### PR TITLE
Bug 578871 - prevent UI freeze during UNDO operation + autobuild

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/operations/OperationHistoryActionHandler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/operations/OperationHistoryActionHandler.java
@@ -21,15 +21,20 @@ import org.eclipse.core.commands.operations.IOperationHistoryListener;
 import org.eclipse.core.commands.operations.IUndoContext;
 import org.eclipse.core.commands.operations.IUndoableOperation;
 import org.eclipse.core.commands.operations.OperationHistoryEvent;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.jobs.IJobManager;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.LegacyActionTools;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IPartListener;
@@ -298,7 +303,27 @@ public abstract class OperationHistoryActionHandler extends Action
 			if (getOperation() instanceof IAdvancedUndoableOperation2) {
 				runInBackground = ((IAdvancedUndoableOperation2) getOperation()).runInBackground();
 			}
-			progressDialog.run(runInBackground, true, runnable);
+			if (runInBackground) {
+				progressDialog.run(runInBackground, true, runnable);
+			} else {
+				// prevent UI freeze during AutoBuild as in 
+				// org.eclipse.jdt.internal.ui.refactoring.RefactoringExecutionHelper#perform
+				final IJobManager manager = Job.getJobManager();
+				// pessimistic scheduling rule:
+				final ISchedulingRule rule = ResourcesPlugin.getWorkspace().getRoot(); 
+				try {
+					try {
+						// interrupt autobuild or show Wait/Cancel Dialog:
+						Runnable r = () -> manager.beginRule(rule, null);
+						BusyIndicator.showWhile(parent.getDisplay(), r);
+					} catch (OperationCanceledException e) {
+						throw new InterruptedException(e.getMessage());
+					}
+					progressDialog.run(runInBackground, true, runnable); // <-- actual work
+				} finally {
+					manager.endRule(rule);
+				}
+			}
 		} catch (InvocationTargetException e) {
 			Throwable t = e.getTargetException();
 			if (t == null) {

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -118,7 +118,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.19.0,4.0.0)",
  org.eclipse.emf.ecore;bundle-version="2.7.0",
  org.eclipse.e4.ui.services;bundle-version="1.3.0",
  org.eclipse.emf.ecore.xmi;bundle-version="2.11.0",
- org.eclipse.e4.core.di.extensions;bundle-version="0.13.0"
+ org.eclipse.e4.core.di.extensions;bundle-version="0.13.0",
+ org.eclipse.core.resources;bundle-version="3.17.0"
 Import-Package: com.ibm.icu.util,
  javax.annotation,
  javax.inject;version="1.0.0",


### PR DESCRIPTION
While JDT's refactoring correctly tries to interrupt autobuild the UNDO
of the same operation did not. In general all UNDO Operations did not
try to interrupt autobuild.

This adds dependency from ui to resources to make the History operations
become aware of resource scheduling rule.

from https://git.eclipse.org/r/c/platform/eclipse.platform.ui/+/192458
