### PR TITLE
Bug 531785 - Auto infix search in Open Resource

### DIFF
--- a/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide; singleton:=true
-Bundle-Version: 3.20.0.qualifier
+Bundle-Version: 3.20.100.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.internal.ide.IDEWorkbenchPlugin
 Bundle-ActivationPolicy: lazy
@@ -50,7 +50,7 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="[3.17.0,4.0.0)";resol
  org.eclipse.core.runtime;bundle-version="[3.18.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.help;bundle-version="[3.2.0,4.0.0)",
- org.eclipse.ui;bundle-version="[3.106.0,4.0.0)",
+ org.eclipse.ui;bundle-version="[3.202.0,4.0.0)",
  org.eclipse.ui.views;bundle-version="[3.2.0,4.0.0)";resolution:=optional,
  org.eclipse.jface.text;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.ui.forms;bundle-version="[3.3.0,4.0.0)";resolution:=optional,

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/FilteredResourcesSelectionDialog.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/FilteredResourcesSelectionDialog.java
@@ -102,6 +102,19 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 	private static final String SHOW_DERIVED = "ShowDerived"; //$NON-NLS-1$
 	private static final String FILTER_BY_LOCATION = "FilterByLocation"; //$NON-NLS-1$
 
+	private static final char START_SYMBOL = '>';
+
+	private static final char END_SYMBOL = '<';
+
+	private static final char BLANK = ' ';
+
+	// this is hard-coded, as a UI option is most probably not necessary
+	private final boolean autoInfixSearch = true;
+
+	private int getDefaultMatchRules() {
+		return SearchPattern.DEFAULT_MATCH_RULES | (autoInfixSearch ? SearchPattern.RULE_SUBSTRING_MATCH : 0);
+	}
+
 	private ShowDerivedResourcesAction showDerivedResourcesAction;
 
 	private ResourceItemLabelProvider resourceItemLabelProvider;
@@ -443,6 +456,7 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 
 			if (pattern != null) {
 				int patternDot = pattern.lastIndexOf('.');
+				// Prioritize names matching the whole pattern
 				String patternNoExtension = patternDot == -1 ? pattern : pattern.substring(0, patternDot);
 				boolean m1 = patternNoExtension.equals(n1);
 				boolean m2 = patternNoExtension.equals(n2);
@@ -452,6 +466,21 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 					}
 					if (m2) {
 						return 1;
+					}
+				}
+				// Prioritize names starting with the pattern
+				char patternFirstChar = getFirstFileNameChar(pattern);
+				if (patternFirstChar != 0) {
+					patternFirstChar = Character.toLowerCase(patternFirstChar);
+					m1 = patternFirstChar == Character.toLowerCase(s1.charAt(0));
+					m2 = patternFirstChar == Character.toLowerCase(s2.charAt(0));
+					if (!m1 || !m2) {
+						if (m1) {
+							return -1;
+						}
+						if (m2) {
+							return 1;
+						}
 					}
 				}
 			}
@@ -493,6 +522,22 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 
 			return comparability;
 		};
+	}
+
+	/**
+	 * @param pattern
+	 * @return the first character from the given string which <em>could</em> be
+	 *         considered a part of a file name. Returns <code>0</code> if there is
+	 *         no such character found.
+	 */
+	private char getFirstFileNameChar(String pattern) {
+		for (int i = 0; i < pattern.length(); i++) {
+			char ch = pattern.charAt(i);
+			if (ch != '*') {
+				return ch;
+			}
+		}
+		return 0;
 	}
 
 	/**
@@ -722,6 +767,9 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 			}
 
 			// Pre-process the matching pattern
+			if (matching.charAt(0) == '>') {
+				matching = matching.substring(1);
+			}
 			char lastChar = matching.charAt(matching.length() - 1);
 			if (lastChar == ' ' || lastChar == '<') {
 				matching = matching.substring(0, matching.length() - 1);
@@ -756,8 +804,11 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 			if (regionsDontMatch) {
 				// We should get here only when CamelCase nor wildcard matching succeeded
 				// A simple comparison of the whole strings should succeed instead
-				if (string.toLowerCase().startsWith(matching.toLowerCase())) {
-					positions.add(new Position(0, matching.length()));
+				int matchingIndex = autoInfixSearch
+						? string.toLowerCase().indexOf(matching.toLowerCase())
+						: (string.toLowerCase().startsWith(matching.toLowerCase()) ? 0 : -1);
+				if (matchingIndex > -1) {
+					positions.add(new Position(matchingIndex, matching.length()));
 				}
 			}
 			return positions;
@@ -959,7 +1010,7 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 		 * @param typeMask    filter type mask. See {@link IResource#getType()} types.
 		 */
 		public ResourceFilter(IContainer container, boolean showDerived, int typeMask) {
-			super();
+			super(new SearchPattern(getDefaultMatchRules()));
 			this.filterContainer = container;
 			this.showDerived = showDerived;
 			this.filterTypeMask = typeMask;
@@ -977,21 +1028,22 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 		private ResourceFilter(IContainer container, IContainer searchContainer, boolean showDerived, int typeMask) {
 			this(container, showDerived, typeMask);
 
-			String stringPattern = getPattern();
-			int matchRule = getMatchRule();
+			final String stringPattern = patternMatcher.getInitialPattern();
 			String filenamePattern;
 
 			int sep = stringPattern.lastIndexOf(IPath.SEPARATOR);
 			if (sep != -1) {
+				// This means that we primarily check (via `patternMatcher`) just the resource
+				// _name_ part and when there is some actual _container_ part (`sep > 0`), we
+				// also do checks for that part (via `containerPattern` and optional
+				// `relativeContainerPattern`).
 				filenamePattern = stringPattern.substring(sep + 1, stringPattern.length());
-				if ("*".equals(filenamePattern)) //$NON-NLS-1$
-					filenamePattern = "**"; //$NON-NLS-1$
 
 				if (sep > 0) {
 					if (filenamePattern.isEmpty()) // relative patterns don't need a file name
 						filenamePattern = "**"; //$NON-NLS-1$
 
-					String containerPattern = stringPattern.substring(0, sep);
+					String containerPattern = stringPattern.substring(isMatchPrefix(stringPattern) ? 1 : 0, sep);
 
 					if (searchContainer != null) {
 						relativeContainerPattern = new SearchPattern(
@@ -1001,6 +1053,8 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 					}
 
 					if (!containerPattern.startsWith(Character.toString('*'))) {
+						// bug 552418 - make the search always "root less", so that users don't need to
+						// type the initial "*/"
 						if (!containerPattern.startsWith(Character.toString(IPath.SEPARATOR))) {
 							containerPattern = IPath.SEPARATOR + containerPattern;
 						}
@@ -1010,35 +1064,29 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 							| SearchPattern.RULE_PREFIX_MATCH | SearchPattern.RULE_PATTERN_MATCH);
 					this.containerPattern.setPattern(containerPattern);
 				}
-				boolean isPrefixPattern = matchRule == SearchPattern.RULE_PREFIX_MATCH
-						|| (matchRule == SearchPattern.RULE_PATTERN_MATCH && filenamePattern.endsWith("*")); //$NON-NLS-1$
-				if (!isPrefixPattern)
-					// Add '<' again as it was removed by SearchPattern
-					filenamePattern += '<';
-				else if (filenamePattern.endsWith("*") && !filenamePattern.equals("**")) //$NON-NLS-1$ //$NON-NLS-2$
-					// Remove added '*' as the filename pattern might be a camel case pattern
-					filenamePattern = filenamePattern.substring(0, filenamePattern.length() - 1);
+				if (isMatchPrefix(stringPattern)) {
+					filenamePattern = '>' + filenamePattern;
+				}
 				patternMatcher.setPattern(filenamePattern);
-				// Update filenamePattern and matchRule as they might have changed
-				filenamePattern = getPattern();
-				matchRule = getMatchRule();
 			} else {
 				filenamePattern = stringPattern;
 			}
 
 			int lastPatternDot = filenamePattern.lastIndexOf('.');
 			if (lastPatternDot != -1) {
-				if (matchRule != SearchPattern.RULE_EXACT_MATCH) {
-					namePattern = new SearchPattern();
-					namePattern.setPattern(filenamePattern.substring(0, lastPatternDot));
-					String extensionPatternStr = filenamePattern.substring(lastPatternDot + 1);
-					// Add a '<' except this is a camel case pattern or a prefix pattern
-					if (matchRule != SearchPattern.RULE_CAMELCASE_MATCH && matchRule != SearchPattern.RULE_PREFIX_MATCH
-							&& !extensionPatternStr.endsWith("*")) //$NON-NLS-1$
-						extensionPatternStr += '<';
-					extensionPattern = new SearchPattern();
-					extensionPattern.setPattern(extensionPatternStr);
+				// This means we primarily check resource name as _name_ and _extension_ part
+				// and only when we don't succeed, we try the default whole-name check (via
+				// `patternMatcher`).
+				namePattern = new SearchPattern(getDefaultMatchRules());
+				String namePatternStr = filenamePattern.substring(0, lastPatternDot);
+				if (isMatchSuffix(stringPattern) && !namePatternStr.endsWith("*")) { //$NON-NLS-1$
+					// This means extension part will end with '<' (or ' ')
+					// and we should apply the same for the name part.
+					namePatternStr += "<"; //$NON-NLS-1$
 				}
+				namePattern.setPattern(namePatternStr);
+				extensionPattern = new SearchPattern();
+				extensionPattern.setPattern(filenamePattern.substring(lastPatternDot + 1));
 			}
 
 		}
@@ -1216,6 +1264,31 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 			resourceFactory.saveState(element);
 		}
 
+	}
+
+	/**
+	 * Returns whether prefix matching is enforced in the given search pattern.
+	 */
+	private static boolean isMatchPrefix(String pattern) {
+		if (pattern.length() == 0) {
+			return false;
+		}
+
+		char first = pattern.charAt(0);
+		return pattern.length() > 1 && first == START_SYMBOL;
+	}
+
+	/**
+	 * Returns whether suffix matching is enforced in the given search pattern.
+	 */
+	private static boolean isMatchSuffix(String pattern) {
+		if (pattern.length() <= 1) {
+			return false;
+		}
+
+		char last = pattern.charAt(pattern.length() - 1);
+		boolean matchPrefix = isMatchPrefix(pattern);
+		return pattern.length() > (matchPrefix ? 2 : 1) && (last == END_SYMBOL || last == BLANK);
 	}
 
 }

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
@@ -865,7 +865,7 @@ ResourceSelectionDialog_folders = In &folders:
 ResourceSelectionDialog_showDerived=Show &derived resources
 
 OpenResourceDialog_title = Open Resource
-OpenResourceDialog_message = &Enter resource name prefix, path prefix or pattern (?, * or camel case):
+OpenResourceDialog_message = &Enter resource name, path or pattern (?, * or camel case):
 OpenResourceDialog_openButton_text = &Open
 OpenResourceDialog_openWithButton_text=Open Wit&h
 OpenResourceDialog_openWithMenu_label=Open Wit&h

--- a/bundles/org.eclipse.ui.workbench/.settings/.api_filters
+++ b/bundles/org.eclipse.ui.workbench/.settings/.api_filters
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.ui.workbench" version="2">
+    <resource path="Eclipse UI/org/eclipse/ui/dialogs/SearchPattern.java" type="org.eclipse.ui.dialogs.SearchPattern">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.dialogs.SearchPattern"/>
+                <message_argument value="DEFAULT_MATCH_RULES"/>
+            </message_arguments>
+        </filter>
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.dialogs.SearchPattern"/>
+                <message_argument value="RULE_SUBSTRING_MATCH"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/SearchPattern.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/SearchPattern.java
@@ -46,6 +46,9 @@ public class SearchPattern {
 	 * <p>
 	 * Unless the pattern ends with ' ' or '>', search is performed as if '*' was
 	 * specified at the end of the pattern.
+	 * <p>
+	 * When {@link #RULE_SUBSTRING_MATCH} is in effect, search is performed as if
+	 * '*' was specified at the start of the pattern.
 	 */
 	public static final int RULE_PATTERN_MATCH = 0x0002;
 
@@ -84,8 +87,32 @@ public class SearchPattern {
 	 * <code>"NPE"</code> string pattern, search will only use Camel Case match
 	 * rule, but with <code>N*P*E*</code> string pattern, it will use only Pattern
 	 * match rule.
+	 * <p>
+	 * Unless {@link #RULE_SUBSTRING_MATCH} is in effect, it is required that
+	 * the 1st pattern's char must match the very 1st char of the search result.
 	 */
 	public static final int RULE_CAMELCASE_MATCH = 0x0080;
+
+	/**
+	 * Match rule: The search pattern is a string placed anywhere in the search
+	 * result. When in effect, this flag also affects some of the other match rules
+	 * (see their documentation for details).
+	 * <p>
+	 * Prefix search may still be enforced by placing '>' at the beginning of the
+	 * pattern. Analogically, suffix search may be enforced by placing ' ' or '&lt;'
+	 * at the end of the pattern.
+	 *
+	 * @since 3.128
+	 */
+	public static final int RULE_SUBSTRING_MATCH = 0x0200;
+
+	/**
+	 * The default set of match rules as used by the no-argument constructor.
+	 *
+	 * @since 3.128
+	 */
+	public static final int DEFAULT_MATCH_RULES = RULE_EXACT_MATCH | RULE_PREFIX_MATCH | RULE_PATTERN_MATCH
+			| RULE_CAMELCASE_MATCH | RULE_BLANK_MATCH;
 
 	private int matchRule;
 
@@ -95,6 +122,8 @@ public class SearchPattern {
 
 	private TextMatcher stringMatcher;
 
+	private static final char START_SYMBOL = '>';
+
 	private static final char END_SYMBOL = '<';
 
 	private static final char ANY_STRING = '*';
@@ -103,26 +132,33 @@ public class SearchPattern {
 
 	private int allowedRules;
 
+	private boolean substringSearch;
+
+	private boolean matchPrefix;
+
+	private boolean matchSuffix;
+
 	/**
-	 * Creates a new instance of SearchPattern with the following match rules
-	 * configured: {@link #RULE_EXACT_MATCH} | {@link #RULE_PREFIX_MATCH} |
-	 * {@link #RULE_PATTERN_MATCH} | {@link #RULE_CAMELCASE_MATCH} |
-	 * {@link #RULE_BLANK_MATCH}.
+	 * Creates a new instance of SearchPattern with {@link #DEFAULT_MATCH_RULES
+	 * default set of rules} configured.
 	 */
 	public SearchPattern() {
-		this(RULE_EXACT_MATCH | RULE_PREFIX_MATCH | RULE_PATTERN_MATCH | RULE_CAMELCASE_MATCH | RULE_BLANK_MATCH);
+		this(DEFAULT_MATCH_RULES);
 	}
 
 	/**
 	 * Creates a search pattern with a rule or rules to apply for matching index keys.
 	 *
 	 * @param allowedRules one of {@link #RULE_EXACT_MATCH},
-	 *                     {@link #RULE_PREFIX_MATCH}, {@link #RULE_PATTERN_MATCH},
+	 *                     {@link #RULE_PREFIX_MATCH},
+	 *                     {@link #RULE_SUBSTRING_MATCH},
+	 *                     {@link #RULE_PATTERN_MATCH},
 	 *                     {@link #RULE_CAMELCASE_MATCH},
 	 *                     {@link #RULE_CASE_SENSITIVE}, or their combination in
-	 *                     order to enable more types of matching. Note that
-	 *                     {@link #RULE_CASE_SENSITIVE} is special in that it
-	 *                     just affects how the other match rules
+	 *                     order to enable more types of matching. Note that rules
+	 *                     {@link #RULE_CASE_SENSITIVE} and
+	 *                     {@link #RULE_SUBSTRING_MATCH} are special in that they
+	 *                     generally just affect how the other match rules
 	 *                     behave.<br>
 	 *                     Examples: {@link #RULE_EXACT_MATCH} |
 	 *                     {@link #RULE_CASE_SENSITIVE} if an exact and case
@@ -133,6 +169,7 @@ public class SearchPattern {
 	 */
 	public SearchPattern(int allowedRules) {
 		this.allowedRules = allowedRules;
+		this.substringSearch = (allowedRules & RULE_SUBSTRING_MATCH) != 0;
 	}
 
 	/**
@@ -142,6 +179,16 @@ public class SearchPattern {
 	 */
 	public String getPattern() {
 		return this.stringPattern;
+	}
+
+	/**
+	 * Gets the initial (input) string pattern.
+	 *
+	 * @return pattern
+	 * @since 3.128
+	 */
+	public String getInitialPattern() {
+		return this.initialPattern;
 	}
 
 	/**
@@ -181,50 +228,65 @@ public class SearchPattern {
 			}
 			//$FALL-THROUGH$
 		default:
-			return startsWithIgnoreCase(text, stringPattern);
+			// apply RULE_PREFIX_MATCH / RULE_SUBSTRING_MATCH
+			boolean doMatchPrefix = matchPrefix || !substringSearch;
+			if (doMatchPrefix && !matchSuffix) {
+				return startsWithIgnoreCase(text, stringPattern);
+			}
+			if (!doMatchPrefix && matchSuffix) {
+				return endsWithIgnoreCase(text, stringPattern);
+			}
+			if (doMatchPrefix && matchSuffix) {
+				// the same as RULE_EXACT_MATCH
+				return stringPattern.equalsIgnoreCase(text);
+			}
+			return text.toLowerCase().contains(stringPattern.toLowerCase());
 		}
 	}
 
 	private void initializePatternAndMatchRule(String pattern) {
-		int length = pattern.length();
-		if (length == 0) {
+		if (pattern.length() == 0) {
 			matchRule = RULE_BLANK_MATCH;
 			stringPattern = pattern;
 			return;
 		}
-		char last = pattern.charAt(length - 1);
+
+		// pre-process the string pattern
+		char first = pattern.charAt(0);
+		char last = pattern.charAt(pattern.length() - 1);
+		// note: a file name might start with a space => we can't use it for enforcing prefix match
+		matchPrefix = pattern.length() > 1 && first == START_SYMBOL;
+		matchSuffix = pattern.length() > (matchPrefix ? 2 : 1) && (last == END_SYMBOL || last == BLANK);
+		stringPattern = pattern;
+		if (matchPrefix) {
+			stringPattern = stringPattern.substring(1);
+		}
+		if (matchSuffix) {
+			stringPattern = stringPattern.substring(0, stringPattern.length() - 1);
+		}
 
 		if (pattern.indexOf('*') != -1 || pattern.indexOf('?') != -1) {
 			matchRule = RULE_PATTERN_MATCH;
-			switch (last) {
-			case END_SYMBOL:
-			case BLANK:
-				stringPattern = pattern.substring(0, length - 1);
-				break;
-			case ANY_STRING:
-				stringPattern = pattern;
-				break;
-			default:
-				stringPattern = pattern + ANY_STRING;
+			if (substringSearch && !matchPrefix && first != ANY_STRING) {
+				stringPattern = ANY_STRING + stringPattern;
+			}
+			if (!matchSuffix && last != ANY_STRING) {
+				stringPattern += ANY_STRING;
 			}
 			return;
 		}
 
-		if (validateMatchRule(pattern, RULE_CAMELCASE_MATCH) == RULE_CAMELCASE_MATCH) {
+		if (validateMatchRule(stringPattern, RULE_CAMELCASE_MATCH) == RULE_CAMELCASE_MATCH) {
 			matchRule = RULE_CAMELCASE_MATCH;
-			stringPattern = pattern;
 			return;
 		}
 
-		if (last == END_SYMBOL || last == BLANK) {
+		if ((!substringSearch || matchPrefix) && matchSuffix) {
 			matchRule = RULE_EXACT_MATCH;
-			stringPattern = pattern.substring(0, length - 1);
 			return;
 		}
 
 		matchRule = RULE_PREFIX_MATCH;
-		stringPattern = pattern;
-
 	}
 
 	/**
@@ -242,6 +304,20 @@ public class SearchPattern {
 				return false;
 		}
 		return true;
+	}
+
+	/**
+	 * @param text
+	 * @param suffix
+	 * @return true if text ends with given suffix, ignoring case; false in other
+	 *         way
+	 */
+	private boolean endsWithIgnoreCase(String text, String suffix) {
+		int textLength = text.length();
+		int suffixLength = suffix.length();
+		if (textLength < suffixLength)
+			return false;
+		return startsWithIgnoreCase(text.substring(textLength - suffixLength), suffix);
 	}
 
 	/**
@@ -425,32 +501,41 @@ public class SearchPattern {
 		// check first pattern char
 		if (name.charAt(nameStart) != pattern.charAt(patternStart)) {
 			// first char must strictly match (upper/lower)
-			return false;
+			if (!this.substringSearch || this.matchPrefix) {
+				return false;
+			}
+			nameStart = name.indexOf(pattern.charAt(patternStart), nameStart + 1);
+			if (nameStart < 0) {
+				return false;
+			}
 		}
-
-		int patternLength = patternEnd;
-
-		if (pattern.charAt(patternEnd - 1) == END_SYMBOL || pattern.charAt(patternEnd - 1) == BLANK)
-			patternLength = patternEnd - 1;
 
 		char patternChar, nameChar;
 		int iPattern = patternStart;
 		int iName = nameStart;
 
-		// Main loop is on pattern characters
+		// Main loop starts from the 2nd characters...
 		while (true) {
 
 			iPattern++;
 			iName++;
 
 			if (iPattern == patternEnd) {
-				// We have exhausted pattern, so it's a match
+				// We have exhausted pattern, so it might be a match
+				if (!this.matchSuffix) {
+					return true;
+				}
+				for (int i = iName; i < nameEnd; i++) {
+					if (isNameCharAllowed(name.charAt(i))) {
+						// There is another uppercase further in the name, but the pattern doesn't allow
+						// this
+						return false;
+					}
+				}
 				return true;
 			}
 
 			if (iName == nameEnd) {
-				if (iPattern == patternLength)
-					return true;
 				// We have exhausted name (and not pattern), so it's not a match
 				return false;
 			}
@@ -466,24 +551,15 @@ public class SearchPattern {
 			if (!isPatternCharAllowed(patternChar))
 				return false;
 
-			// patternChar is uppercase, so let's find the next uppercase in
+			// patternChar is uppercase, so let's find the next patternChar-matching uppercase in
 			// name
 			while (true) {
 				if (iName == nameEnd) {
-					if ((iPattern == patternLength) && (patternChar == END_SYMBOL || patternChar == BLANK))
-						return true;
+					// We have exhausted name (and not pattern), so it's not a match
 					return false;
 				}
 
 				nameChar = name.charAt(iName);
-
-				if ((iPattern == patternLength) && (patternChar == END_SYMBOL || patternChar == BLANK)) {
-					if (isNameCharAllowed(nameChar)) {
-						return false;
-					}
-					iName++;
-					continue;
-				}
 
 				if (Character.isDigit(nameChar)) {
 					// nameChar is digit => break if the digit is current pattern character
@@ -653,6 +729,9 @@ public class SearchPattern {
 	 * @return true if the given pattern is a sub pattern of this search pattern
 	 */
 	public boolean isSubPattern(SearchPattern pattern) {
+		if (this.initialPattern.length() == 1 && this.initialPattern.charAt(0) == START_SYMBOL) {
+			return false;
+		}
 		return trimWildcardCharacters(pattern.initialPattern).startsWith(trimWildcardCharacters(this.initialPattern));
 	}
 

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.127.100.qualifier
+Bundle-Version: 3.128.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui; singleton:=true
-Bundle-Version: 3.201.300.qualifier
+Bundle-Version: 3.202.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.internal.UIPlugin
 Bundle-ActivationPolicy: lazy
@@ -12,7 +12,7 @@ Export-Package: org.eclipse.ui.internal;x-internal:=true
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.swt;bundle-version="[3.103.0,4.0.0)";visibility:=reexport,
  org.eclipse.jface;bundle-version="[3.19.0,4.0.0)";visibility:=reexport,
- org.eclipse.ui.workbench;bundle-version="[3.125.0,4.0.0)";visibility:=reexport,
+ org.eclipse.ui.workbench;bundle-version="[3.128.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.expressions;bundle-version="[3.4.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.ui

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/AbstractSearchPatternAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/AbstractSearchPatternAuto.java
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2017 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Petr Bodnar - common ancestor for SearchPattern test classes
+ *******************************************************************************/
+
+package org.eclipse.ui.tests.dialogs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.eclipse.ui.dialogs.SearchPattern;
+import org.junit.Test;
+
+/**
+ * Common ancestor for tests of the SearchPattern's match functionality.
+ */
+public abstract class AbstractSearchPatternAuto {
+
+	/**
+	 * Items to be filtered.
+	 */
+	protected static List<String> resources = new ArrayList<>();
+
+	static {
+		generateResourcesTestCases('A', 'C', 8, "");
+		generateResourcesTestCases('A', 'C', 4, "");
+		// add some explicit testing samples:
+		resources.addAll(
+				Arrays.asList("BC", "BCD", "AiBiCiDi", "BiCiDi", "BijCiDi", "BICI", "abc", "bcd", "abcd", "ab cd"));
+		// in practice, there should be no resources with such names, but for
+		// completeness:
+		resources.addAll(Arrays.asList(" ", "AB ", ">", "<"));
+		// ... while this might exist:
+		resources.add(" BC");
+	}
+
+	/**
+	 * Generates strings data for match test cases.
+	 *
+	 * @param startChar
+	 * @param endChar
+	 * @param length
+	 * @param resource
+	 */
+	protected static void generateResourcesTestCases(char startChar, char endChar, int length, String resource) {
+		for (char ch = startChar; ch <= endChar; ch++) {
+			String res = resource + ch;
+			if (length == res.length()) {
+				resources.add(res);
+			} else if ((res.trim().length() % 2) == 0) {
+				generateResourcesTestCases(Character.toUpperCase((char) (startChar + 1)),
+						Character.toUpperCase((char) (endChar + 1)), length, res);
+			} else {
+				generateResourcesTestCases(Character.toLowerCase((char) (startChar + 1)),
+						Character.toLowerCase((char) (endChar + 1)), length, res);
+			}
+		}
+	}
+
+	/**
+	 * Empty pattern matches everything. In practice, no search is done in this case
+	 * though.
+	 */
+	@Test
+	public void testBlankMatch() {
+		Pattern pattern = Pattern.compile(".*", Pattern.CASE_INSENSITIVE);
+		assertMatches("", SearchPattern.RULE_BLANK_MATCH, pattern);
+	}
+
+	/**
+	 * Tests that a single "&lt;" is taken as a plain character. For simplicity, we
+	 * emulate just a perfect match here.
+	 */
+	@Test
+	public void testJustEndCharPattern() {
+		Pattern pattern = Pattern.compile("<", Pattern.CASE_INSENSITIVE);
+		assertMatches("<", SearchPattern.RULE_PREFIX_MATCH, pattern);
+	}
+
+	/**
+	 * Tests that a single "&gt;" is taken as a plain character. For simplicity, we
+	 * emulate just a perfect match here.
+	 */
+	@Test
+	public void testJustStartCharPattern() {
+		Pattern pattern = Pattern.compile(">", Pattern.CASE_INSENSITIVE);
+		assertMatches(">", SearchPattern.RULE_PREFIX_MATCH, pattern);
+	}
+
+	@Test
+	public void testIsSubPattern_BasicCases() {
+		SearchPattern prevPattern = createSearchPattern("a");
+		SearchPattern nextPattern = createSearchPattern("ab");
+		assertTrue("[ab] has to be a sub-pattern of [a]", prevPattern.isSubPattern(nextPattern));
+		assertFalse("[a] must not be a sub-pattern of [ab]", nextPattern.isSubPattern(prevPattern));
+	}
+
+	/**
+	 * Tests this scenario: user types in ">" and then "a" - the resulting ">a"
+	 * pattern must NOT be evaluated as a sub-pattern of ">", because searching just
+	 * by ">" should normally return an empty set - and filtering just that empty
+	 * set would find nothing.
+	 */
+	@Test
+	public void testIsSubPattern_WhenPrevIsJustStartChar_ReturnFalse() {
+		SearchPattern prevPattern = createSearchPattern(">");
+		SearchPattern nextPattern = createSearchPattern(">a");
+		assertFalse(prevPattern.isSubPattern(nextPattern));
+	}
+
+	protected abstract SearchPattern createSearchPattern();
+
+	protected SearchPattern createSearchPattern(String inputPattern) {
+		SearchPattern pattern = createSearchPattern();
+		pattern.setPattern(inputPattern);
+		return pattern;
+	}
+
+	protected void assertMatches(String patternText, int expectedMatchRule, Pattern... matchingPatterns) {
+		SearchPattern patternMatcher = createSearchPattern();
+		patternMatcher.setPattern(patternText);
+		assertEquals("Inferred match rule must match", expectedMatchRule, patternMatcher.getMatchRule());
+		boolean someMatch = false;
+		for (String res : resources) {
+			boolean anyMatches = anyMatches(res, matchingPatterns);
+			boolean patternMatches = patternMatcher.matches(res);
+			if (patternMatches) {
+				assertTrue("Pattern '" + patternText + "' matches '" + res + "', but it shouldn't.", anyMatches);
+			} else {
+				assertFalse("Pattern '" + patternText + "' doesn't match '" + res + "', but it should.", anyMatches);
+			}
+			if (anyMatches) {
+				someMatch = true;
+			}
+		}
+		if (!someMatch) {
+			fail("Invalid test setup: no item matches any of the supplied matchingPatterns");
+		}
+	}
+
+	protected static boolean anyMatches(String res, Pattern... patterns) {
+		for (Pattern pattern : patterns) {
+			if (pattern.matcher(res).matches()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourceItemLabelTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourceItemLabelTest.java
@@ -82,6 +82,19 @@ public class ResourceItemLabelTest extends UITestCase {
 	}
 
 	/**
+	 * Tests that the highlighting matches basic substrings when infix search is
+	 * automatically performed.
+	 */
+	@Test
+	public void testSubstringMatch_withAutoInfix() throws Exception {
+		Position[] atEnd = { new Position(2, 6) };
+		compareStyleRanges(atEnd, getStyleRanges("st.txt", "test.txt"), "test.txt", "");
+
+		Position[] atEndDifferentCase = { new Position(2, 6) };
+		compareStyleRanges(atEndDifferentCase, getStyleRanges("ST.txt", "test.txt"), "test.txt", "");
+	}
+
+	/**
 	 * Tests that the highlighting matches CamelCase searches
 	 *
 	 * @throws Exception
@@ -102,6 +115,17 @@ public class ResourceItemLabelTest extends UITestCase {
 
 		Position[] skippingDigit = { new Position(0, 2), new Position(5, 1) };
 		compareStyleRanges(skippingDigit, getStyleRanges("ThT", "This3Test.txt"), "This3Test.txt", "");
+
+	}
+
+	/**
+	 * Tests that the highlighting matches CamelCase searches when infix search is
+	 * automatically performed.
+	 */
+	@Test
+	public void testCamelCaseMatch_withAutoInfix() throws Exception {
+		Position[] atEnd = { new Position(4, 1), new Position(6, 1) };
+		compareStyleRanges(atEnd, getStyleRanges("IT", "ThisIsTest.txt"), "ThisIsTest.txt", "");
 	}
 
 	/**
@@ -122,6 +146,16 @@ public class ResourceItemLabelTest extends UITestCase {
 
 		Position[] withDigits = { new Position(0, 1), new Position(2, 2), new Position(7, 3) };
 		compareStyleRanges(withDigits, getStyleRanges("t?s3*x3t", "tes3t.tx3t"), "tes3t.tx3t", "");
+	}
+
+	/**
+	 * Tests that the highlighting matches searches using '*' and '?' when infix
+	 * search is automatically performed.
+	 */
+	@Test
+	public void testPatternMatch_withAutoInfix() throws Exception {
+		Position[] atEnd = { new Position(1, 1), new Position(3, 2) };
+		compareStyleRanges(atEnd, getStyleRanges("t?st", "atest.txt"), "atest.txt", "");
 	}
 
 	/**
@@ -153,6 +187,21 @@ public class ResourceItemLabelTest extends UITestCase {
 
 		Position[] both = { new Position(0, 3), new Position(6, 1) };
 		compareStyleRanges(both, getStyleRanges("CreS<", "CreateStuff.java"), "CreateStuff.java", "");
+	}
+
+	/**
+	 * Tests that the highlighting matches searches using '&lt;'.
+	 */
+	@Test
+	public void testDisableAutoInfixMatching() throws Exception {
+		Position[] substring = { new Position(0, 4) };
+		compareStyleRanges(substring, getStyleRanges(">make", "Makefile"), "Makefile", "");
+
+		Position[] pattern = { new Position(0, 1), new Position(4, 4) };
+		compareStyleRanges(pattern, getStyleRanges(">M*file", "Makefile"), "Makefile", "");
+
+		Position[] camelCase = { new Position(0, 3), new Position(6, 1) };
+		compareStyleRanges(camelCase, getStyleRanges(">CreS", "CreateStuff.java"), "CreateStuff.java", "");
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIAutomatedSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIAutomatedSuite.java
@@ -22,7 +22,8 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({ UIDialogsAuto.class, DeprecatedUIDialogsAuto.class, UIWizardsAuto.class,
 		DeprecatedUIWizardsAuto.class, UIPreferencesAuto.class, UIComparePreferencesAuto.class,
 		DeprecatedUIPreferencesAuto.class, UIMessageDialogsAuto.class, UINewWorkingSetWizardAuto.class,
-		UIEditWorkingSetWizardAuto.class, SearchPatternAuto.class, UIFilteredResourcesSelectionDialogAuto.class,
+		UIEditWorkingSetWizardAuto.class, SearchPatternAuto.class, InfixSearchPatternAuto.class,
+		UIFilteredResourcesSelectionDialogAuto.class,
 		TreeManagerTest.class, ContainerCheckedTreeViewerTest.class })
 public class UIAutomatedSuite {
 


### PR DESCRIPTION
## Basic feature description

A new match rule `RULE_SUBSTRING_MATCH` is introduced in the
`SearchPattern`. The constant itself is copied as-is from JDT's variant
of `SearchPattern`, yet its usage and purpose differs.

When used and prefix search is not enforced, then:

* search is done as if "*" was specified at the pattern start
* CamelCase search doesn't require the 1st pattern char to be the very
1st char of the matched string

Use this in Resource search dialogs for the default and file name
pattern, while also list "prefix matches" firstly and extend the matched
characters highlighting to still work correctly.
Path (container) and extension searches should not be affected by this.

Further changes:

* users can start a search pattern with ">" to enforce the old
prefix-only search

For seeing how autoInfixSearch differs from the old one, one can compare "SearchPatternAuto.java" with "InfixSearchPatternAuto.java".

## Yet to be investigated / implemented

* [x] present the SearchPattern's autoInfixSearch feature on UI layer: change the Open Resource dialog label
* [x] API: introduce `SearchPattern.RULE_SUBSTRING_MATCH` or similar instead of `SearchPattern.autoInfixSearch`
* [x] update corresponding user documentation (see eclipse-platform/eclipse.platform.common#89)

## Historical issues identified that could / should be solved later on

1. `SearchPattern.RULE_CASE_SENSITIVE` - this flag seems to be ignored by the actual SearchPattern implementation
2. `SearchPattern.camelCaseMatch()` could be optimized to check strings' lengths firstly. Something like:

		int patternLength = patternEnd - patternStart;
		int nameLength = nameEnd - nameStart;
		if (nameLength < patternLength) {
			return false;
		}

3. Constants like `SearchPattern.END_SYMBOL` are just private and special chars checking is hard-coded in dependent classes like `FilteredResourcesSelectionDialog`
4. Inefficient matches highlighting: `ResourceItemLabelProvider.getMatchPositions()` and related seem to contain some tricky code and logic. -> see #184