### PR TITLE
[WIP] Allow plugin fragments to supply alternate icons

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/JFacePreferences.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/JFacePreferences.java
@@ -111,6 +111,13 @@ public final class JFacePreferences {
 	 */
 	public static final String REVISION_OLDEST_COLOR = "org.eclipse.jface.REVISION_OLDEST_COLOR"; //$NON-NLS-1$
 
+	/**
+	 * TODO: Add javadoc
+	 *
+	 * @since 3.26
+	 */
+	public static final String CUSTOM_RESOURCE_THEME = "org.eclipse.jface.CUSTOM_RESOURCE_THEME"; //$NON-NLS-1$
+
 	private static IPreferenceStore preferenceStore;
 
 	/**


### PR DESCRIPTION
Fix #13 

Allow plugin fragments to contribute alternate icons that will be loaded
through the URLImageDescriptor class.

The icons must be placed within a directory titled "theme"
located at the root of the plugin fragment, ie. "/theme/"

The file path of the replacement icons must match the file path of the
icon to be replaced.

For example, in order to replace an icon used by plugin org.eclipse.xxx
where the path of the icon is "/path/To/icon.png" in the plugin's bundle
one must:
- Create a plugin fragment with org.eclipse.xxx as the Host Plug-in
- Create a directory "/theme/" at the root of the plugin
fragment
- Place an alternate icon with the correct file path in the theme
directory, ie. "/theme/path/To/icon.png"

