### PR TITLE
Regression - deadlock on undo (#15)

### DIFF
--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -118,8 +118,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.19.0,4.0.0)",
  org.eclipse.emf.ecore;bundle-version="2.7.0",
  org.eclipse.e4.ui.services;bundle-version="1.3.0",
  org.eclipse.emf.ecore.xmi;bundle-version="2.11.0",
- org.eclipse.e4.core.di.extensions;bundle-version="0.13.0",
- org.eclipse.core.resources;bundle-version="3.17.0"
+ org.eclipse.e4.core.di.extensions;bundle-version="0.13.0"
 Import-Package: com.ibm.icu.util,
  javax.annotation,
  javax.inject;version="1.0.0",


### PR DESCRIPTION
Reverted commit d610ff274b9a755fe33c73fbd74c914b8d3acacf as it caused
deadlock during undo if the undo operation also wants to use workspace
rule.

This fixes issue
https://github.com/eclipse-platform/eclipse.platform.ui/issues/15