### PR TITLE
Bug 577923 - Allow hiding scope items in marker support filter dialog

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/FiltersConfigurationDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/FiltersConfigurationDialog.java
@@ -96,7 +96,7 @@ public class FiltersConfigurationDialog extends TrayDialog {
 	private Button limitButton;
 	private Text limitText;
 
-	private GroupFilterConfigurationArea scopeArea = new ScopeArea();
+	private GroupFilterConfigurationArea scopeArea = createScopeArea();
 	private ScrolledForm form;
 
 	private Collection<FilterConfigurationArea> configAreas;
@@ -174,6 +174,15 @@ public class FiltersConfigurationDialog extends TrayDialog {
 		initUI();
 
 		return container;
+	}
+
+	/**
+	 * Create a new ScopeArea for the receiver.
+	 *
+	 * @return ScopeArea
+	 */
+	protected ScopeArea createScopeArea() {
+		return new ScopeArea();
 	}
 
 	private void initUI() {

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerFieldFilterGroup.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerFieldFilterGroup.java
@@ -55,7 +55,7 @@ import org.eclipse.ui.views.markers.internal.MarkerType;
  *
  * @since 3.4
  */
-class MarkerFieldFilterGroup {
+public class MarkerFieldFilterGroup {
 
 	private static final String ATTRIBUTE_ON_ANY_IN_SAME_CONTAINER = "ON_ANY_IN_SAME_CONTAINER";//$NON-NLS-1$
 	private static final String ATTRIBUTE_ON_SELECTED_AND_CHILDREN = "ON_SELECTED_AND_CHILDREN";//$NON-NLS-1$
@@ -73,25 +73,25 @@ class MarkerFieldFilterGroup {
 	/**
 	 * Constant for any element.
 	 */
-	static final int ON_ANY = 0;
+	public static final int ON_ANY = 0;
 
 	/**
 	 * Constant for any element in same container.
 	 */
-	static final int ON_ANY_IN_SAME_CONTAINER = 3;
+	public static final int ON_ANY_IN_SAME_CONTAINER = 3;
 
 	/**
 	 * Constant for selected element and children.
 	 */
-	static final int ON_SELECTED_AND_CHILDREN = 2;
+	public static final int ON_SELECTED_AND_CHILDREN = 2;
 	/**
 	 * Constant for any selected element only.
 	 */
-	static final int ON_SELECTED_ONLY = 1;
+	public static final int ON_SELECTED_ONLY = 1;
 	/**
 	 * Constant for on working set.
 	 */
-	static final int ON_WORKING_SET = 4;
+	public static final int ON_WORKING_SET = 4;
 
 	static final String TAG_ENABLED = "enabled"; //$NON-NLS-1$
 	private static final String TAG_SCOPE = "scope"; //$NON-NLS-1$
@@ -274,7 +274,6 @@ class MarkerFieldFilterGroup {
 	 * @see #ON_SELECTED_ONLY
 	 * @see #ON_WORKING_SET
 	 */
-	@SuppressWarnings("javadoc")
 	public int getScope() {
 		return scope;
 	}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ScopeArea.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ScopeArea.java
@@ -18,7 +18,6 @@ import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.window.Window;
 import org.eclipse.osgi.util.NLS;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -38,10 +37,10 @@ import org.eclipse.ui.views.markers.internal.MarkerMessages;
  *
  * @since 3.4
  */
-class ScopeArea extends GroupFilterConfigurationArea {
+public class ScopeArea extends GroupFilterConfigurationArea {
 
-	private Button[] buttons;
-	int scope;
+	protected Button[] buttons;
+	protected int scope;
 	private WorkingSetArea workingSetArea;
 
 	private class WorkingSetArea {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/CustomScopeArea.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/CustomScopeArea.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Enda O'Brien and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors: IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.tests;
+
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.internal.views.markers.MarkerFieldFilterGroup;
+import org.eclipse.ui.internal.views.markers.ScopeArea;
+import org.eclipse.ui.views.markers.internal.MarkerMessages;
+
+/**
+ * CustomScopeArea is a custom implementation of ScopeArea that handles the
+ * scope of the filter in FiltersConfigurationDialog.
+ *
+ * @since 3.5
+ */
+
+public class CustomScopeArea extends ScopeArea {
+
+	/**
+	 * Create a new instance of the receiver.
+	 */
+	public CustomScopeArea() {
+		super();
+	}
+
+	@Override
+	public void applyToGroup(MarkerFieldFilterGroup group) {
+		group.setScope(scope);
+	}
+
+	@Override
+	public void createContents(Composite parent) {
+
+		buttons = new Button[5];
+
+		buttons[MarkerFieldFilterGroup.ON_ANY] = createRadioButton(parent, MarkerMessages.filtersDialog_anyResource,
+				MarkerFieldFilterGroup.ON_ANY);
+		buttons[MarkerFieldFilterGroup.ON_SELECTED_ONLY] = createRadioButton(parent,
+				MarkerMessages.filtersDialog_selectedResource, MarkerFieldFilterGroup.ON_SELECTED_ONLY);
+	}
+
+	@Override
+	public String getTitle() {
+		return MarkerMessages.filtersDialog_scopeTitle;
+	}
+
+	@Override
+	public void initializeFromGroup(MarkerFieldFilterGroup group) {
+		buttons[scope].setSelection(false);
+		scope = group.getScope();
+		buttons[scope].setSelection(true);
+	}
+
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/ScopeAreaTestView.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/ScopeAreaTestView.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Enda O'Brien and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors: IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.tests;
+
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.internal.views.markers.FiltersConfigurationDialog;
+import org.eclipse.ui.internal.views.markers.MarkerContentGenerator;
+import org.eclipse.ui.internal.views.markers.ScopeArea;
+import org.eclipse.ui.views.markers.MarkerSupportView;
+
+/**
+ * @since 3.5
+ *
+ */
+public class ScopeAreaTestView extends MarkerSupportView {
+	public static final String ID = "org.eclipse.ui.tests.customScopeTestView";
+
+	static final String CONTENT_GEN_ID = "org.eclipse.ui.tests.customScopeContentGenerator";
+
+	Composite scopeAreaParent;
+
+	FiltersConfigurationDialog dialog;
+
+	public FiltersConfigurationDialog getDialog() {
+		return dialog;
+	}
+
+	public ScopeAreaTestView() {
+		super(CONTENT_GEN_ID);
+	}
+
+	public Composite getScopeArea() {
+		return scopeAreaParent;
+	}
+
+	@Override
+	protected FiltersConfigurationDialog createFilterConfigurationDialog(MarkerContentGenerator gen) {
+		dialog = new FiltersConfigurationDialogWithMyScope(
+				getSite().getWorkbenchWindow().getShell(), gen);
+
+		// don't block for test purposes
+		dialog.setBlockOnOpen(false);
+		return dialog;
+	}
+
+	class FiltersConfigurationDialogWithMyScope extends FiltersConfigurationDialog {
+		/**
+		 * @param parentShell
+		 * @param generator
+		 */
+		public FiltersConfigurationDialogWithMyScope(Shell parentShell, MarkerContentGenerator generator) {
+			super(parentShell, generator);
+		}
+
+		@Override
+		public ScopeArea createScopeArea() {
+
+			CustomScopeArea myScopeArea = new CustomScopeArea() {
+				@Override
+				public void createContents(Composite parent) {
+					super.createContents(parent);
+					scopeAreaParent = parent;
+				}
+			};
+
+			return myScopeArea;
+
+		}
+	}
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/InternalTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/InternalTestSuite.java
@@ -28,6 +28,7 @@ import org.eclipse.ui.tests.markers.MarkerTesterTest;
 import org.eclipse.ui.tests.markers.MarkerViewTests;
 import org.eclipse.ui.tests.markers.MarkerViewUtilTest;
 import org.eclipse.ui.tests.markers.ResourceMappingMarkersTest;
+import org.eclipse.ui.tests.markers.ScopeAreaTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -66,5 +67,6 @@ import org.junit.runners.Suite;
 	Bug549139Test.class,
 	LargeFileLimitsPreferenceHandlerTest.class,
 	WorkbookEditorsHandlerTest.class,
+	ScopeAreaTest.class,
 })
 public class InternalTestSuite {}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/ScopeAreaTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/ScopeAreaTest.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Enda O'Brien and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors: IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.ui.tests.markers;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.views.markers.ExtendedMarkersView;
+import org.eclipse.ui.tests.ScopeAreaTestView;
+import org.eclipse.ui.views.markers.MarkerSupportView;
+import org.eclipse.ui.views.markers.internal.MarkerMessages;
+import org.junit.After;
+import org.junit.Test;
+
+public class ScopeAreaTest {
+	ScopeAreaTestView view;
+	Composite composite;
+
+	@After
+	public void cleanup() {
+		if (view.getDialog() != null) {
+			view.getDialog().close();
+		}
+	}
+
+	@Test
+	public void canCreateCustomScopeArea() throws Exception {
+		view = (ScopeAreaTestView) PlatformUI.getWorkbench().getActiveWorkbenchWindow()
+				.getActivePage().showView(ScopeAreaTestView.ID);
+
+		openFiltersDialog(view);
+
+		assertTrue(MarkerMessages.filtersDialog_anyResource,
+				isButtonAvailable(view.getScopeArea(), MarkerMessages.filtersDialog_anyResource));
+		assertFalse(MarkerMessages.filtersDialog_anyResourceInSameProject,
+				isButtonAvailable(view.getScopeArea(), MarkerMessages.filtersDialog_anyResourceInSameProject));
+		assertFalse(MarkerMessages.filtersDialog_anyResourceInSameProject,
+				isButtonAvailable(view.getScopeArea(), MarkerMessages.filtersDialog_anyResourceInSameProject));
+		assertFalse(MarkerMessages.filtersDialog_selectedAndChildren,
+				isButtonAvailable(view.getScopeArea(), MarkerMessages.filtersDialog_selectedAndChildren));
+		assertTrue(MarkerMessages.filtersDialog_selectedResource,
+				isButtonAvailable(view.getScopeArea(), MarkerMessages.filtersDialog_selectedResource));
+	}
+
+	void openFiltersDialog(MarkerSupportView view) {
+		Method openFiltersDialog;
+		try {
+			openFiltersDialog = ExtendedMarkersView.class.getDeclaredMethod("openFiltersDialog");
+			openFiltersDialog.setAccessible(true);
+			openFiltersDialog.invoke(view);
+		} catch (NoSuchMethodException | SecurityException | IllegalArgumentException | IllegalAccessException
+				| InvocationTargetException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	boolean isButtonAvailable(Composite composite, String buttonText) {
+		Control[] children = composite.getChildren();
+		for (Control ctrl : children) {
+			if (ctrl instanceof Button) {
+				if (((Button) ctrl).getText().contains(buttonText)) {
+					return true;
+				}
+			} else if (ctrl instanceof Composite && isButtonAvailable((Composite) ctrl, buttonText)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/tests/org.eclipse.ui.tests/plugin.xml
+++ b/tests/org.eclipse.ui.tests/plugin.xml
@@ -3409,6 +3409,9 @@
         <markerContentGenerator
              id="org.eclipse.ui.tests.filterHelpContentGenerator">
        </markerContentGenerator>
+        <markerContentGenerator
+             id="org.eclipse.ui.tests.customScopeContentGenerator">
+       </markerContentGenerator>       
    </extension>
    <extension
          id="categoryTestMarker"
@@ -3923,7 +3926,12 @@
             class="org.eclipse.ui.tests.FilterHelpTestView"
             id="org.eclipse.ui.tests.filterHelpTestView"
             name="Marker Filter Help View">
-      </view>      
+      </view>
+      <view
+            class="org.eclipse.ui.tests.ScopeAreaTestView"
+            id="org.eclipse.ui.tests.customScopeTestView"
+            name="Custom Scope Area View">
+      </view>
    </extension>
    <extension
          point="org.eclipse.ui.statusHandlers">


### PR DESCRIPTION
Moving patch from Gerrit: https://git.eclipse.org/r/c/platform/eclipse.platform.ui/+/191618

Bug 577923 - Irrelevant items cannot be removed/hidden from scope area
in the filter used by MarkerSupportView.

- Added the possibility to make radio buttons hidden using the
markerContentGenerator.

- Added 2 tests that items can be hidden and a second that default
behavour is to show all items.

- Rebased branch to see if it helps fix build fail.

Change-Id: Ied05d59195d58bc96b2e41ee5499a4fa164da837
Signed-off-by: Enda O Brien <E.OBrien@pilz.ie>