### PR TITLE
Add CTabFolder support to tests

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.harness/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Harness Plug-in
 Bundle-SymbolicName: org.eclipse.ui.tests.harness;singleton:=true
-Bundle-Version: 1.8.100.qualifier
+Bundle-Version: 1.8.200.qualifier
 Eclipse-BundleShape: dir
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.eclipse.ui.tests.harness/pom.xml
+++ b/tests/org.eclipse.ui.tests.harness/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.tests.harness</artifactId>
-  <version>1.8.100-SNAPSHOT</version>
+  <version>1.8.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
 </project>

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/DialogCheck.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/DialogCheck.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertTrue;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -118,6 +119,12 @@ public class DialogCheck {
 		for (Control child : children) {
 			if (child instanceof TabFolder) {
 				TabFolder folder = (TabFolder) child;
+				int numPages = folder.getItemCount();
+				for (int j = 0; j < numPages; j++) {
+					folder.setSelection(j);
+				}
+			} else if (child instanceof CTabFolder) {
+				CTabFolder folder = (CTabFolder) child;
 				int numPages = folder.getItemCount();
 				for (int j = 0; j < numPages; j++) {
 					folder.setSelection(j);


### PR DESCRIPTION
The method verifyCompositeText in DialogCheck verifies various aspects
of composites, with
https://github.com/eclipse-platform/eclipse.platform.team/pull/14 this
now needs to understand CTabFolder (in addition to TabFolder)

This fixes UIComparePreferencesAuto.testCompareViewersPref failures reported in #30 