### PR TITLE
Fixes #30: Close the dialog if test fails

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/DialogCheck.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/DialogCheck.java
@@ -87,10 +87,13 @@ public class DialogCheck {
 		dialog.open();
 		Shell shell = dialog.getShell();
 		UITestCase.processEvents();
-		verifyCompositeText(shell);
-		dialog.close();
-		// close "verify results" dialog, it makes other tests unhappy
-		_verifyDialog.buttonPressed(IDialogConstants.YES_ID);
+		try {
+			verifyCompositeText(shell);
+		} finally {
+			dialog.close();
+			// close "verify results" dialog, it makes other tests unhappy
+			_verifyDialog.buttonPressed(IDialogConstants.YES_ID);
+		}
 	}
 
 	/**


### PR DESCRIPTION
The individual checks in this class do "button.getShell().dispose();"
to close the dialog when an assertion fails. That closes the UI
resources, but it does not dispose the non-UI resources/references.

In this particular case when
UIComparePreferencesAuto.testCompareViewersPref failed, it left
org.eclipse.jface.preference.PreferenceNode.page
set to the now disposed General preference page. So when a later
test tries to open the dialog, the test fails due to disposed widget
error.

By calling dialog.close() it makes sure that
org.eclipse.jface.preference.PreferenceNode.disposeResources()
is called, which releases the reference in PreferenceNode.page