### PR TITLE
Add OSGi-util bundles to features

### DIFF
--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -662,4 +662,39 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.osgi.util.function"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.util.promise"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.util.measurement"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.util.position"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.util.xml"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
This PR adds the OSGi-bundles that replace the formerly embedded OSGi source-code in `org.eclipse.osgi.util` to those Features that contain the `org.eclipse.osgi.util` plugin.
The motivation to add the OSGi-bundles to the features is mainly to also have their sources included into the p2-repos of the Eclipse-SDK.

This is part of https://github.com/eclipse-equinox/equinox/issues/18 and should be submitted after https://github.com/eclipse-equinox/equinox.framework/pull/41 is merged.