### PR TITLE
Add OSGi-service bundles to features

### DIFF
--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -343,6 +343,13 @@
          unpack="false"/>
 
    <plugin
+         id="org.osgi.service.prefs"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.equinox.registry"
          download-size="0"
          install-size="0"
@@ -692,6 +699,69 @@
 
    <plugin
          id="org.osgi.util.xml"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.cm"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.component"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.device"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.event"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.metatype"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.provisioning"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.upnp"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.useradmin"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.wireadmin"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -43,14 +43,14 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="3.14.0",
  org.eclipse.e4.ui.services;bundle-version="0.10.0",
  org.eclipse.e4.ui.workbench.addons.swt;bundle-version="0.10.0",
  org.eclipse.e4.ui.workbench.renderers.swt;bundle-version="0.10.0",
- org.eclipse.osgi.services;bundle-version="3.3.100",
  org.hamcrest.core;bundle-version="1.3.0",
  org.mockito.mockito-core;bundle-version="2.13.0",
  net.bytebuddy.byte-buddy,
  org.eclipse.jface;bundle-version="[3.18.0,4.0.0)",
  org.eclipse.ui.views.log;bundle-version="1.2.1300"
 Import-Package: javax.annotation,
- javax.inject
+ javax.inject,
+ org.osgi.service.event
 Eclipse-AutoStart: true
 Export-Package: org.eclipse.ui.tests.api,
  org.eclipse.ui.tests.menus


### PR DESCRIPTION
This PR adds the OSGi-bundles that replace the formerly embedded OSGi source-code in `org.eclipse.osgi.service` to those Features that contain the `org.eclipse.osgi.service` plugin.
The motivation to add the OSGi-bundles to the features is mainly to also have their sources included into the p2-repos of the Eclipse-SDK.

This is part of https://github.com/eclipse-equinox/equinox/issues/18 and should be submitted after https://github.com/eclipse-equinox/equinox.framework/pull/44 is merged.