### PR TITLE
WelcomeContentHandler can be static in WelcomeParser

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/WelcomeParser.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/WelcomeParser.java
@@ -78,7 +78,7 @@ public class WelcomeParser extends DefaultHandler {
 
 	private String format;
 
-	private class WelcomeContentHandler implements ContentHandler {
+	private static class WelcomeContentHandler implements ContentHandler {
 		protected ContentHandler parent;
 
 		public void setParent(ContentHandler p) {


### PR DESCRIPTION
Done via a JDT clean-up action for optimizing performance.