### PR TITLE
Reducing the freeze error threshold from 1200ms to 1000 ms

### DIFF
--- a/bundles/org.eclipse.ui.monitoring/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.monitoring/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: %Bundle-Name
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-SymbolicName: org.eclipse.ui.monitoring;singleton:=true
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Export-Package: org.eclipse.ui.internal.monitoring;x-internal:=true,
  org.eclipse.ui.internal.monitoring.preferences;x-internal:=true,
  org.eclipse.ui.monitoring;x-internal:=true

--- a/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/preferences/MonitoringPreferenceInitializer.java
+++ b/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/preferences/MonitoringPreferenceInitializer.java
@@ -30,7 +30,7 @@ public class MonitoringPreferenceInitializer extends AbstractPreferenceInitializ
 
 		store.setDefault(PreferenceConstants.MONITORING_ENABLED, false);
 		store.setDefault(PreferenceConstants.LONG_EVENT_WARNING_THRESHOLD_MILLIS, 500); // 0.5 sec
-		store.setDefault(PreferenceConstants.LONG_EVENT_ERROR_THRESHOLD_MILLIS, 1200); // 2 sec
+		store.setDefault(PreferenceConstants.LONG_EVENT_ERROR_THRESHOLD_MILLIS, 1000); // 2 sec
 		store.setDefault(PreferenceConstants.MAX_STACK_SAMPLES, 3);
 		store.setDefault(PreferenceConstants.DEADLOCK_REPORTING_THRESHOLD_MILLIS,
 				5 * 60 * 1000); // 5 min


### PR DESCRIPTION
Each Eclipse release gets faster so we should reducing the error
threshold for a UI freeze. In general I think 800ms would be good value
but I don't think we are there yet, so "only" reducing the error
threshold to one second.