### PR TITLE
[trivial] disconnectFromWorkspace() unconditionally opens error dialog

### DIFF
--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
@@ -569,10 +569,10 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 					IDEWorkbenchPlugin.IDE_WORKBENCH, 1,
 					IDEWorkbenchMessages.InternalError, e));
 		}
-		ErrorDialog.openError(null,
-				IDEWorkbenchMessages.ProblemsSavingWorkspace, null, status,
-				IStatus.ERROR | IStatus.WARNING);
 		if (!status.isOK()) {
+			ErrorDialog.openError(null,
+					IDEWorkbenchMessages.ProblemsSavingWorkspace, null, status,
+					IStatus.ERROR | IStatus.WARNING);
 			IDEWorkbenchPlugin.log(
 					IDEWorkbenchMessages.ProblemsSavingWorkspace, status);
 		}


### PR DESCRIPTION
The code in IDEWorkbenchAdvisor.disconnectFromWorkspace() relies on the
fact that ErrorDialog.openError() "will only be displayed if there is at
least one child status matching the mask".

While that is technically OK, it surprises a lot to see the code outside
of the if(status is bad) block trying to open an error dialog. If we
check for errors anyway, let open the error dialog only in that case.