### PR TITLE
Error after test execution in jenkins/surefire #50

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.swt;singleton:=true
-Bundle-Version: 0.16.400.qualifier
+Bundle-Version: 0.16.500.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/tests/org.eclipse.e4.ui.bindings.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.bindings.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.e4.ui.bindings.tests
-Bundle-Version: 0.13.100.qualifier
+Bundle-Version: 0.13.200.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: javax.inject;version="1.0.0",
  org.eclipse.e4.core.commands,

--- a/tests/org.eclipse.e4.ui.bindings.tests/pom.xml
+++ b/tests/org.eclipse.e4.ui.bindings.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.e4</groupId>
   <artifactId>org.eclipse.e4.ui.bindings.tests</artifactId>
-  <version>0.13.100-SNAPSHOT</version>
+  <version>0.13.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
 </project>

--- a/tests/org.eclipse.e4.ui.bindings.tests/src/org/eclipse/e4/ui/bindings/tests/KeyDispatcherTest.java
+++ b/tests/org.eclipse.e4.ui.bindings.tests/src/org/eclipse/e4/ui/bindings/tests/KeyDispatcherTest.java
@@ -92,6 +92,8 @@ public class KeyDispatcherTest {
 	private IEclipseContext workbenchContext;
 	private CallHandler handler;
 	private CallHandler twoStrokeHandler;
+	private KeyBindingDispatcher dispatcher;
+	private Listener listener;
 
 	private void defineCommands(IEclipseContext context) {
 		ECommandService cs = workbenchContext
@@ -136,6 +138,12 @@ public class KeyDispatcherTest {
 		defineContexts(workbenchContext);
 		defineBindingTables(workbenchContext);
 		defineCommands(workbenchContext);
+
+		dispatcher = new KeyBindingDispatcher();
+		listener = dispatcher.getKeyDownFilter();
+		ContextInjectionFactory.inject(dispatcher, workbenchContext);
+		display.addFilter(SWT.KeyDown, listener);
+		display.addFilter(SWT.Traverse, listener);
 	}
 
 	private void defineContexts(IEclipseContext context) {
@@ -162,17 +170,13 @@ public class KeyDispatcherTest {
 	public void tearDown() {
 		workbenchContext.dispose();
 		workbenchContext = null;
-		display.dispose();
-		display = null;
+		display.removeFilter(SWT.KeyDown, listener);
+		display.removeFilter(SWT.Traverse, listener);
 	}
 
 	@Test
 	public void testExecuteOneCommand() {
-		KeyBindingDispatcher dispatcher = new KeyBindingDispatcher();
 		ContextInjectionFactory.inject(dispatcher, workbenchContext);
-		final Listener listener = dispatcher.getKeyDownFilter();
-		display.addFilter(SWT.KeyDown, listener);
-		display.addFilter(SWT.Traverse, listener);
 
 		assertFalse(handler.q2);
 
@@ -194,12 +198,6 @@ public class KeyDispatcherTest {
 
 	@Test
 	public void testExecuteMultiStrokeBinding() {
-		KeyBindingDispatcher dispatcher = new KeyBindingDispatcher();
-		ContextInjectionFactory.inject(dispatcher, workbenchContext);
-		final Listener listener = dispatcher.getKeyDownFilter();
-		display.addFilter(SWT.KeyDown, listener);
-		display.addFilter(SWT.Traverse, listener);
-
 		assertFalse(twoStrokeHandler.q2);
 
 		Shell shell = new Shell(display, SWT.NONE);
@@ -237,12 +235,6 @@ public class KeyDispatcherTest {
 	@Test
 	@Ignore
 	public void TODOtestKeyDispatcherReset() throws Exception {
-		KeyBindingDispatcher dispatcher = new KeyBindingDispatcher();
-		ContextInjectionFactory.inject(dispatcher, workbenchContext);
-		final Listener listener = dispatcher.getKeyDownFilter();
-		display.addFilter(SWT.KeyDown, listener);
-		display.addFilter(SWT.Traverse, listener);
-
 		assertFalse(twoStrokeHandler.q2);
 
 		Shell shell = new Shell(display, SWT.NONE);
@@ -281,8 +273,11 @@ public class KeyDispatcherTest {
 
 	@Test
 	public void testSendKeyStroke() {
+		display.removeFilter(SWT.KeyDown, listener);
+		display.removeFilter(SWT.Traverse, listener);
+
 		KeyBindingDispatcher dispatcher = ContextInjectionFactory.make(KeyBindingDispatcher.class, workbenchContext);
-		final Listener listener = dispatcher.getKeyDownFilter();
+		listener = dispatcher.getKeyDownFilter();
 		display.addFilter(SWT.KeyDown, listener);
 		display.addFilter(SWT.Traverse, listener);
 		Shell shell = new Shell(display, SWT.NONE);

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTColorHelperTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTColorHelperTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNull;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.css.CSSValue;
@@ -32,13 +31,7 @@ public class CSSSWTColorHelperTest extends CSSSWTHelperTestCase {
 
 	@Before
 	public void setUp() {
-
 		display = Display.getDefault();
-	}
-
-	@After
-	public void tearDown() {
-		display.dispose();
 	}
 
 	@Test

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CSSSWTTestCase.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CSSSWTTestCase.java
@@ -98,12 +98,10 @@ public class CSSSWTTestCase {
 
 	@After
 	public void tearDown() {
-		display = Display.getDefault();
 		if (!display.isDisposed()) {
 			for (Shell shell : display.getShells()) {
 				shell.dispose();
 			}
-			display.dispose();
 		}
 	}
 

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ThemeTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ThemeTest.java
@@ -45,6 +45,7 @@ public class ThemeTest extends CSSSWTTestCase {
 	@Override
 	@Before
 	public void setUp() {
+		super.setUp();
 		Bundle b = FrameworkUtil.getBundle(this.getClass());
 		assertNotNull("Not running in an OSGi environment", b);
 		context = b.getBundleContext();

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/jface/tests/databinding/scenarios/BindingScenariosTestSuite.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/jface/tests/databinding/scenarios/BindingScenariosTestSuite.java
@@ -44,8 +44,6 @@ public class BindingScenariosTestSuite {
 		junit.textui.TestRunner.run(suite());
 	}
 
-	private static Display display;
-
 	private static Shell shell;
 
 	public static junit.framework.Test suite() {
@@ -61,9 +59,6 @@ public class BindingScenariosTestSuite {
 			public void tearDown() throws Exception {
 				shell.close();
 				shell.dispose();
-				if (display != null) {
-					display.dispose();
-				}
 			}
 		};
 	}


### PR DESCRIPTION
Added assertions to find out who disposes the display before the test
application finishes if it runs in in jenkins/surefire.

Execution in IDE doesn't trigger new assertions.

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/50