### PR TITLE
Disable MarkerSortUtil batch sorting. (closes #53)

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerEntry.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerEntry.java
@@ -21,6 +21,7 @@ import java.text.Collator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.CoreException;
@@ -68,6 +69,7 @@ class MarkerEntry extends MarkerSupportItem implements IAdaptable {
 	private static final String LOCATION_STRING = "LOCATION_STRING"; //$NON-NLS-1$
 	private MarkerCategory category;
 	private Map<String, Object> cache;
+	private static Map<String, CollationKey> collationCache = new ConcurrentHashMap<>();
 
 	/**
 	 * Set the MarkerEntry to be stale, if discovered at any point of time
@@ -219,7 +221,8 @@ class MarkerEntry extends MarkerSupportItem implements IAdaptable {
 		if (attributeValue.isEmpty()) {
 			return MarkerSupportInternalUtilities.EMPTY_COLLATION_KEY;
 		}
-		CollationKey key = Collator.getInstance().getCollationKey(attributeValue);
+		CollationKey key = collationCache.computeIfAbsent(attributeValue,
+				k -> Collator.getInstance().getCollationKey(attributeValue));
 		getCache().put(attribute, key);
 		return key;
 	}
@@ -385,6 +388,7 @@ class MarkerEntry extends MarkerSupportItem implements IAdaptable {
 	@Override
 	void clearCache() {
 		cache = null;
+		collationCache = new ConcurrentHashMap<>();
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerEntry.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerEntry.java
@@ -388,6 +388,9 @@ class MarkerEntry extends MarkerSupportItem implements IAdaptable {
 	@Override
 	void clearCache() {
 		cache = null;
+	}
+
+	static void clearCollationCache() {
 		collationCache = new ConcurrentHashMap<>();
 	}
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerSortUtil.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerSortUtil.java
@@ -115,6 +115,7 @@ public class MarkerSortUtil {
 
 			++current;
 		}
+		MarkerEntry.clearCollationCache();
 	}
 
 	/**
@@ -333,6 +334,7 @@ public class MarkerSortUtil {
 			for (int i = from; i <= to; i++) {
 				entries[i].clearCache();
 			}
+			MarkerEntry.clearCollationCache();
 			return;
 		}
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerSortUtil.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerSortUtil.java
@@ -50,11 +50,13 @@ public class MarkerSortUtil {
 	 */
 
 	/*
-	 * Increasing BATCH_SIZE increases memory consumption but increases speed,
-	 * and vice-versa.This indirectly controls the number of active caches in
-	 * MarkerEntry[] array passed for sorting.
+	 * Increasing BATCH_SIZE increases memory consumption but increases speed, and
+	 * vice-versa.This indirectly controls the number of active caches in
+	 * MarkerEntry[] array passed for sorting. Batching is disabled by default.
+	 * Batching can be enabled with system property
+	 * org.eclipse.ui.MarkerSortUtil.batchSize=10000
 	 */
-	private static int BATCH_SIZE = 10000;
+	private static int BATCH_SIZE = Integer.getInteger("org.eclipse.ui.MarkerSortUtil.batchSize", Integer.MAX_VALUE); //$NON-NLS-1$
 
 	/*
 	 * For n/k ratios less than this , we will use Arrays.Sort(). The heapsort
@@ -323,7 +325,7 @@ public class MarkerSortUtil {
 				|| last > to || to > entries.length - 1 || to < 0)
 			return;
 		int n=to-from+1;
-		if (n <= BATCH_SIZE && (((float) n / k) <= MERGE_OR_HEAP_SWITCH)
+		if (BATCH_SIZE == Integer.MAX_VALUE || (n <= BATCH_SIZE && (((float) n / k) <= MERGE_OR_HEAP_SWITCH))
 				/*|| ((float) n / k) <= MERGE_OR_HEAP_SWITCH*/) {
 			// use arrays sort
 			Arrays.sort(entries, from, to + 1, comparator);


### PR DESCRIPTION
Can be reenabled with org.eclipse.ui.MarkerSortUtil.batchSize=10000

Batch sorting was intended to decrease memory consumption during sorting
Marker View. But it is very slow especially when CollationKeys are
calculated. Today temporary memory consumption is not as much an issue
any more, but performance is.

Performance difference is visible with MarkerSortUtilTest especially
when increasing ARRAYSIZE to a million (22sec vs 2sec) - even without
CollationKeys.