### PR TITLE
LockManager.handleException errors on shutdown (#56)

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/UILockListener.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/UILockListener.java
@@ -121,7 +121,8 @@ public class UILockListener extends LockListener {
 
 	@Override
 	public void aboutToRelease() {
-		if (isUI()) {
+		Thread uiThread = ui;
+		if (uiThread != null && uiThread == Thread.currentThread()) {
 			ui = null;
 		}
 	}
@@ -185,7 +186,11 @@ public class UILockListener extends LockListener {
 	}
 
 	boolean isUI() {
-		return (!display.isDisposed()) && (display.getThread() == Thread.currentThread());
+		try {
+			return display.getThread() == Thread.currentThread();
+		} catch (Exception e) {
+			return false;
+		}
 	}
 
 	boolean isUIWaiting() {


### PR DESCRIPTION
1) Fixed unneeded calls to display from aboutToRelease(). All what we
want is to "null" "ui" field if we are in UI thread. For that we don't
need to check isUI() and Display because "ui" reference should be either
UI thread (which can be compared directly with current thread) or it is
null and we don't care.

2) Fixed race condition in isUI(), which assumes the display is not
disposed after the display.isDisposed() check. But since we are not
guaranteed to be in UI thread, someone could have disposed Display in
the meantime. So just call Thread.currentThread() that already does this
check for us.

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/56