### PR TITLE
Apply Remove overridden assignment JDT clean in workbench.renderers.swt

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
@@ -363,7 +363,6 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 			int circY = bounds.y + radius;
 
 			// Body
-			index = 0;
 			int[] ltt = drawCircle(circX, circY, radius, CirclePart.LEFT_TOP);
 			System.arraycopy(ltt, 0, points, index, ltt.length);
 			index += ltt.length;

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/ToolBarManagerRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/ToolBarManagerRenderer.java
@@ -425,9 +425,8 @@ public class ToolBarManagerRenderer extends SWTPartRenderer {
 			setCSSInfo(element, newTB);
 
 
-			boolean vertical = false;
 			MTrimBar bar = (MTrimBar) parentElement;
-			vertical = bar.getSide() == SideValue.LEFT || bar.getSide() == SideValue.RIGHT;
+			boolean vertical = bar.getSide() == SideValue.LEFT || bar.getSide() == SideValue.RIGHT;
 			IEclipseContext parentContext = getContextForParent(element);
 
 			CSSRenderingUtils cssUtils = parentContext.get(CSSRenderingUtils.class);


### PR DESCRIPTION
Dogfooding the improve JDT cleanup from Bug 572440 to ensure the JDT
cleanup is stable and functional. Push in small chunks to make review
easier.