### PR TITLE
Apply Remove overridden assignment JDT clean in core.commands

### DIFF
--- a/bundles/org.eclipse.core.commands/src/org/eclipse/core/commands/ParameterizedCommand.java
+++ b/bundles/org.eclipse.core.commands/src/org/eclipse/core/commands/ParameterizedCommand.java
@@ -307,10 +307,8 @@ public final class ParameterizedCommand implements Comparable {
 			ArrayList<Parameterization> parms = new ArrayList<>();
 			for (Entry<?, ?> entry : ((Map<?, ?>) parameters).entrySet()) {
 				String key = (String) entry.getKey();
-				IParameter parameter = null;
 				// get the parameter from the command
-				parameter = command.getParameter(key);
-
+				IParameter parameter = command.getParameter(key);
 				// if the parameter is defined add it to the parameter list
 				if (parameter == null) {
 					return null;


### PR DESCRIPTION
Dogfooding the improve JDT cleanup from Bug 572440 to ensure the JDT
cleanup is stable and functional. Push in small chunks to make review
easier.