### PR TITLE
Bug 546115: show editor guiding text

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.renderers.swt;singleton:=true
-Bundle-Version: 0.15.800.qualifier
+Bundle-Version: 0.15.900.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
First draft of showing some guiding text in the editor area.

Open: where to put the actual code, at the moment it is in StackRenderer.
Also at the moment there is a leak with on of the images. But let's first discuss whether it should be done like this or the whether the image and text should come from a new extension point.

