### PR TITLE
WIP: POM and product version changes for 4.25 release

### DIFF
--- a/bundles/org.eclipse.core.commands/pom.xml
+++ b/bundles/org.eclipse.core.commands/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.core</groupId>

--- a/bundles/org.eclipse.e4.ui.progress/pom.xml
+++ b/bundles/org.eclipse.e4.ui.progress/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.e4</groupId>

--- a/bundles/org.eclipse.e4.ui.swt.gtk/pom.xml
+++ b/bundles/org.eclipse.e4.ui.swt.gtk/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.e4</groupId>

--- a/bundles/org.eclipse.e4.ui.swt.win32/pom.xml
+++ b/bundles/org.eclipse.e4.ui.swt.win32/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.e4</groupId>

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/pom.xml
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.e4</groupId>

--- a/bundles/org.eclipse.jface.databinding/pom.xml
+++ b/bundles/org.eclipse.jface.databinding/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.jface</groupId>

--- a/bundles/org.eclipse.jface/pom.xml
+++ b/bundles/org.eclipse.jface/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.jface</groupId>

--- a/bundles/org.eclipse.ui.cocoa/pom.xml
+++ b/bundles/org.eclipse.ui.cocoa/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/bundles/org.eclipse.ui.ide/pom.xml
+++ b/bundles/org.eclipse.ui.ide/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/bundles/org.eclipse.ui.navigator/pom.xml
+++ b/bundles/org.eclipse.ui.navigator/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/bundles/org.eclipse.ui.views.log/pom.xml
+++ b/bundles/org.eclipse.ui.views.log/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/bundles/org.eclipse.ui.views.properties.tabbed/pom.xml
+++ b/bundles/org.eclipse.ui.views.properties.tabbed/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/bundles/org.eclipse.ui.views/pom.xml
+++ b/bundles/org.eclipse.ui.views/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/bundles/org.eclipse.ui.win32/pom.xml
+++ b/bundles/org.eclipse.ui.win32/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/bundles/org.eclipse.ui.workbench/pom.xml
+++ b/bundles/org.eclipse.ui.workbench/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.ui</groupId>
     <artifactId>eclipse.platform.ui</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <artifactId>eclipse.platform.ui.bundles</artifactId>
   <packaging>pom</packaging>

--- a/examples/org.eclipse.e4.demo.cssbridge/pom.xml
+++ b/examples/org.eclipse.e4.demo.cssbridge/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui.examples</groupId>

--- a/examples/org.eclipse.e4.ui.examples.job/pom.xml
+++ b/examples/org.eclipse.e4.ui.examples.job/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/examples/org.eclipse.jface.snippets/pom.xml
+++ b/examples/org.eclipse.jface.snippets/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.jface</groupId>

--- a/examples/org.eclipse.ui.examples.job/pom.xml
+++ b/examples/org.eclipse.ui.examples.job/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/examples/org.eclipse.ui.examples.markerHelp/pom.xml
+++ b/examples/org.eclipse.ui.examples.markerHelp/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/examples/org.eclipse.ui.examples.navigator/pom.xml
+++ b/examples/org.eclipse.ui.examples.navigator/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/examples/org.eclipse.ui.examples.views.properties.tabbed.article/pom.xml
+++ b/examples/org.eclipse.ui.examples.views.properties.tabbed.article/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/examples/org.eclipse.ui.forms.examples/pom.xml
+++ b/examples/org.eclipse.ui.forms.examples/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.ui</groupId>
     <artifactId>eclipse.platform.ui</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <artifactId>eclipse.platform.ui.examples</artifactId>
   <packaging>pom</packaging>

--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.e4.rcp"
       label="%featureName"
-      version="4.24.0.qualifier"
+      version="4.25.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.e4.rcp/pom.xml
+++ b/features/org.eclipse.e4.rcp/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.e4.feature</groupId>

--- a/features/org.eclipse.e4.ui.progress.feature/pom.xml
+++ b/features/org.eclipse.e4.ui.progress.feature/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <artifactId>eclipse.platform.ui</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 

--- a/releng/org.eclipse.ui.releng/platformUiTools.p2f
+++ b/releng/org.eclipse.ui.releng/platformUiTools.p2f
@@ -269,12 +269,12 @@
     </iu>
     <iu id='org.eclipse.swt.tools.feature.feature.group' name='SWT Tools' version='0.0.0'>
         <repositories size='1'>
-            <repository location='https://download.eclipse.org/eclipse/updates/4.24-I-builds'/>
+            <repository location='https://download.eclipse.org/eclipse/updates/4.25-I-builds'/>
         </repositories>
     </iu>
     <iu id='org.eclipse.equinox.executable.feature.group' name='Eclipse platform launcher executables' version='0.0.0'>
         <repositories size='1'>
-            <repository location='https://download.eclipse.org/eclipse/updates/4.24-I-builds'/>
+            <repository location='https://download.eclipse.org/eclipse/updates/4.25-I-builds'/>
         </repositories>
     </iu>
   </ius>

--- a/tests/org.eclipse.e4.core.commands.tests/pom.xml
+++ b/tests/org.eclipse.e4.core.commands.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.e4</groupId>
   <artifactId>org.eclipse.e4.core.commands.tests</artifactId>

--- a/tests/org.eclipse.e4.emf.xpath.test/pom.xml
+++ b/tests/org.eclipse.e4.emf.xpath.test/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.e4</groupId>
   <artifactId>org.eclipse.e4.emf.xpath.test</artifactId>

--- a/tests/org.eclipse.e4.ui.bindings.tests/pom.xml
+++ b/tests/org.eclipse.e4.ui.bindings.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.e4</groupId>
   <artifactId>org.eclipse.e4.ui.bindings.tests</artifactId>

--- a/tests/org.eclipse.e4.ui.tests.css.core/pom.xml
+++ b/tests/org.eclipse.e4.ui.tests.css.core/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.e4</groupId>
   <artifactId>org.eclipse.e4.ui.tests.css.core</artifactId>

--- a/tests/org.eclipse.e4.ui.tests.css.swt/pom.xml
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.e4</groupId>
   <artifactId>org.eclipse.e4.ui.tests.css.swt</artifactId>

--- a/tests/org.eclipse.e4.ui.tests/pom.xml
+++ b/tests/org.eclipse.e4.ui.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.e4.ui.tests</artifactId>

--- a/tests/org.eclipse.e4.ui.workbench.addons.swt.test/pom.xml
+++ b/tests/org.eclipse.e4.ui.workbench.addons.swt.test/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.e4</groupId>
   <artifactId>org.eclipse.e4.ui.workbench.addons.swt.test</artifactId>

--- a/tests/org.eclipse.jface.tests.databinding.conformance/pom.xml
+++ b/tests/org.eclipse.jface.tests.databinding.conformance/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jface</groupId>
   <artifactId>org.eclipse.jface.tests.databinding.conformance</artifactId>

--- a/tests/org.eclipse.jface.tests.databinding/pom.xml
+++ b/tests/org.eclipse.jface.tests.databinding/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jface</groupId>
   <artifactId>org.eclipse.jface.tests.databinding</artifactId>

--- a/tests/org.eclipse.jface.tests.notifications/pom.xml
+++ b/tests/org.eclipse.jface.tests.notifications/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jface</groupId>
   <artifactId>org.eclipse.jface.tests.notifications</artifactId>

--- a/tests/org.eclipse.jface.tests/pom.xml
+++ b/tests/org.eclipse.jface.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jface</groupId>
   <artifactId>org.eclipse.jface.tests</artifactId>

--- a/tests/org.eclipse.tests.urischeme/pom.xml
+++ b/tests/org.eclipse.tests.urischeme/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.tests.urischeme</artifactId>

--- a/tests/org.eclipse.ui.ide.application.tests/pom.xml
+++ b/tests/org.eclipse.ui.ide.application.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.ide.application.tests</artifactId>

--- a/tests/org.eclipse.ui.monitoring.tests/pom.xml
+++ b/tests/org.eclipse.ui.monitoring.tests/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.monitoring.tests</artifactId>

--- a/tests/org.eclipse.ui.tests.browser/pom.xml
+++ b/tests/org.eclipse.ui.tests.browser/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.tests.browser</artifactId>

--- a/tests/org.eclipse.ui.tests.forms/pom.xml
+++ b/tests/org.eclipse.ui.tests.forms/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.tests.forms</artifactId>

--- a/tests/org.eclipse.ui.tests.harness/pom.xml
+++ b/tests/org.eclipse.ui.tests.harness/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.tests.harness</artifactId>

--- a/tests/org.eclipse.ui.tests.navigator/pom.xml
+++ b/tests/org.eclipse.ui.tests.navigator/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.tests.navigator</artifactId>

--- a/tests/org.eclipse.ui.tests.performance/pom.xml
+++ b/tests/org.eclipse.ui.tests.performance/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.tests.performance</artifactId>

--- a/tests/org.eclipse.ui.tests.pluginchecks/pom.xml
+++ b/tests/org.eclipse.ui.tests.pluginchecks/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.tests.pluginchecks</artifactId>

--- a/tests/org.eclipse.ui.tests.rcp/pom.xml
+++ b/tests/org.eclipse.ui.tests.rcp/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.tests.rcp</artifactId>

--- a/tests/org.eclipse.ui.tests.views.properties.tabbed/pom.xml
+++ b/tests/org.eclipse.ui.tests.views.properties.tabbed/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.tests.views.properties.tabbed</artifactId>

--- a/tests/org.eclipse.ui.tests/pom.xml
+++ b/tests/org.eclipse.ui.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.ui.tests</artifactId>
     <groupId>eclipse.platform.ui</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.tests</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>eclipse.platform.ui</groupId>
     <artifactId>eclipse.platform.ui</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <artifactId>eclipse.platform.ui.tests</artifactId>
   <packaging>pom</packaging>


### PR DESCRIPTION
Tracked in [eclipse.platform.releng.aggregator#290](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/290) and [eclipse.platform.releng.aggregator#291](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/291)

Need to wait to merge until after 4.24 Release