### PR TITLE
Remove System.out output from CSS test cases

### DIFF
--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CSSSWTTestCase.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CSSSWTTestCase.java
@@ -18,8 +18,6 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.swt.engine.CSSSWTEngineImpl;
@@ -87,12 +85,6 @@ public class CSSSWTTestCase {
 
 	@Before
 	public void setUp() {
-		System.out.println("[" + DateTimeFormatter.ISO_DATE_TIME.format(LocalDateTime.now()) + "] "
-				+ getClass().getName() + "#" + testName.getMethodName());
-		System.out.format("  memory (free/max/total): %s/%s/%s MB%n",
-				Runtime.getRuntime().freeMemory() / 1000000,
-				Runtime.getRuntime().maxMemory() / 1000000,
-				Runtime.getRuntime().totalMemory() / 1000000);
 		display = Display.getDefault();
 	}
 


### PR DESCRIPTION
Currently the CSS test cases printout the memory usage and its start
time. AFAIK this information has not been used in the recent years to
improve performance or memory consumption of the CSS engine and should
be better done with tracing tools.