### PR TITLE
Remove the help icon from the save dialog

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/SaveablesList.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/SaveablesList.java
@@ -687,7 +687,7 @@ public class SaveablesList implements ISaveablesLifecycleListener {
 					String message = NLS.bind(WorkbenchMessages.EditorManager_saveChangesOptionallyQuestion,
 							model.getName());
 					MessageDialogWithToggle dialogWithToggle = new MessageDialogWithToggle(shellProvider.getShell(),
-							WorkbenchMessages.Save_Resource, null, message, MessageDialog.QUESTION, buttonLabelToIdMap,
+							WorkbenchMessages.Save_Resource, null, message, MessageDialog.NONE, buttonLabelToIdMap,
 							0, WorkbenchMessages.EditorManager_closeWithoutPromptingOption, false) {
 						@Override
 						protected int getShellStyle() {
@@ -708,7 +708,7 @@ public class SaveablesList implements ISaveablesLifecycleListener {
 
 					String message = NLS.bind(WorkbenchMessages.EditorManager_saveChangesQuestion, model.getName());
 					dialog = new MessageDialog(shellProvider.getShell(), WorkbenchMessages.Save_Resource, null, message,
-							MessageDialog.QUESTION, 0, buttons) {
+							MessageDialog.NONE, 0, buttons) {
 						@Override
 						protected int getShellStyle() {
 							return (canCancel ? SWT.CLOSE : SWT.NONE) | SWT.TITLE | SWT.BORDER | SWT.APPLICATION_MODAL


### PR DESCRIPTION
Operating system Ui guidelines do not recommend the usage of the help
icon in a dialog. For example check the screenshots in the Windows
guidelines for dialogs.

Operating System UI Guidelines

Windows UI guidence
https://docs.microsoft.com/en-us/windows/apps/design/controls/dialogs-and-flyouts/dialogs

Gnome UI guidence
https://developer.gnome.org/hig/patterns/feedback/dialogs.html

Mac UI guidence
https://developer.apple.com/design/human-interface-guidelines/components/presentation/alerts/