### PR TITLE
Don't use "file.encoding", use Platform.getSystemCharset() instead

### DIFF
--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -95,7 +95,7 @@ Export-Package: org.eclipse.e4.ui.workbench.addons.perspectiveswitcher;x-interna
  org.eclipse.ui.themes,
  org.eclipse.ui.views,
  org.eclipse.ui.wizards
-Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.25.0,4.0.0)",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.26.0,4.0.0)",
  org.eclipse.help;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.jface;bundle-version="[3.18.0,4.0.0)",
  org.eclipse.swt;bundle-version="[3.107.0,4.0.0)",


### PR DESCRIPTION
With https://openjdk.java.net/jeps/400 implemented in Java 18,
"file.encoding" system property became meaningless and can't be used
anymore to determine system native encoding.

Instead, use new Platform.getNativeEncoding() API that tries to provide
a suitable replacement compatible with Java 18+ and previous Java
versions.

Note: this PR requires https://github.com/eclipse-platform/eclipse.platform.runtime/pull/63 to be merged first.

This PR fixes
https://github.com/eclipse-platform/eclipse.platform.resources/issues/154