### PR TITLE
Remove the help icon from the save perspective dialog

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/SavePerspectiveDialog.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/SavePerspectiveDialog.java
@@ -248,7 +248,7 @@ public class SavePerspectiveDialog extends org.eclipse.jface.dialogs.Dialog
 			String[] buttons = new String[] { IDialogConstants.YES_LABEL, IDialogConstants.NO_LABEL,
 					IDialogConstants.CANCEL_LABEL };
 			MessageDialog d = new MessageDialog(this.getShell(), WorkbenchMessages.SavePerspective_overwriteTitle, null,
-					message, MessageDialog.QUESTION, 0, buttons) {
+					message, MessageDialog.NONE, 0, buttons) {
 				@Override
 				protected int getShellStyle() {
 					return super.getShellStyle() | SWT.SHEET;


### PR DESCRIPTION
Operating system Ui guidelines do not recommend the usage of the help
icon in a dialog. For example check the screenshots in the Windows
guidelines for dialogs.

Operating System UI Guidelines

Windows UI guidence
https://docs.microsoft.com/en-us/windows/apps/design/controls/dialogs-and-flyouts/dialogs

Gnome UI guidence
https://developer.gnome.org/hig/patterns/feedback/dialogs.html

Mac UI guidence
https://developer.apple.com/design/human-interface-guidelines/components/presentation/alerts/