### PR TITLE
Removes the form styling from the Eclipse default light theme

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/light/e4-light_globalstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/light/e4-light_globalstyle.css
@@ -14,33 +14,6 @@
  *******************************************************************************/
 
 
-Form, FormHeading {
-	background-color: #ffffff;
-	background: #ffffff;
-	color: #505050;
-}
-
-Form {
-	/* Bug 465148: Additional styling for the Form */
-	text-background-color: #ffffff;
-
-	tb-toggle-hover-color: #505050;
-	tb-toggle-color: #505050;
-	h-hover-full-color: #505050;
-	h-hover-light-color: #505050;
-	h-bottom-keyline-2-color: #eaeaea;
-	h-bottom-keyline-1-color: #eaeaea;
-}
-
-
-Section {
-	background-color: #ffffff;
-  	color: #505050;
-  	background-color-titlebar: #eaeaea;
-  	background-color-gradient-titlebar: #eaeaea;
-  	border-color-titlebar: #ffffff;
-}
-
 TabbedPropertyTitle > CLabel{
 	color: #505050;
 }


### PR DESCRIPTION
With https://github.com/eclipse-platform/eclipse.platform.ui/pull/121
form default L&F has been updated to have no gradient anymore.