### PR TITLE
Check if the Workbench is running before setting the help

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/PropertyDialogAction.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/PropertyDialogAction.java
@@ -90,7 +90,9 @@ public class PropertyDialogAction extends SelectionProviderAction {
 		Assert.isNotNull(shell);
 		this.shellProvider = shell;
 		setToolTipText(WorkbenchMessages.PropertyDialog_toolTip);
-		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IWorkbenchHelpContextIds.PROPERTY_DIALOG_ACTION);
+		if (PlatformUI.isWorkbenchRunning()) {
+			PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IWorkbenchHelpContextIds.PROPERTY_DIALOG_ACTION);
+		}
 	}
 
 	/**


### PR DESCRIPTION
If this action is constructed when the workbench is not running (e.g. E4
RCP) the constructor throws an exception.

Instead of failing completely, we can gracefully handle the case here by
just not setting the help then. This helps in applications migrating
from E3>E4.