### PR TITLE
Bug 578581 - MarkerSupportView custom groupings requires use of internal GroupsContribution

### DIFF
--- a/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide; singleton:=true
-Bundle-Version: 3.22.400.qualifier
+Bundle-Version: 3.23.0.qualifier
 Bundle-Activator: org.eclipse.ui.internal.ide.IDEWorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/GroupsContribution.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/GroupsContribution.java
@@ -40,7 +40,7 @@ public class GroupsContribution extends MarkersContribution {
 	}
 
 	@Override
-	protected IContributionItem[] getContributionItems() {
+	public IContributionItem[] getContributionItems() {
 		ExtendedMarkersView view = getView();
 		if (view == null) {
 			return new IContributionItem[0];

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/MarkerGroupsContribution.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/MarkerGroupsContribution.java
@@ -1,0 +1,19 @@
+package org.eclipse.ui.views.markers;
+
+import org.eclipse.jface.action.IContributionItem;
+import org.eclipse.ui.actions.CompoundContributionItem;
+import org.eclipse.ui.internal.views.markers.GroupsContribution;
+
+/**
+ * @since 3.23
+ *
+ */
+public class MarkerGroupsContribution extends CompoundContributionItem {
+
+	@Override
+	protected IContributionItem[] getContributionItems() {
+		GroupsContribution gc = new GroupsContribution();
+		return gc.getContributionItems();
+	}
+
+}


### PR DESCRIPTION
This is a patch submission for the bugzilla issue here: https://bugs.eclipse.org/bugs/show_bug.cgi?id=578581

The proposal is to have an API equivalent of the ContributionItem for Marker groups.
This will allow clients to create their own custom groupings.

Note: Creating the custom groupings was always possible but relied on referencing the internal GroupsContribution in the xml definition.
