### PR TITLE
Fix access to the UISynchronize

### DIFF
--- a/bundles/org.eclipse.e4.ui.progress/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.progress/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.progress;singleton:=true
-Bundle-Version: 0.3.400.qualifier
+Bundle-Version: 0.3.500.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.progress/pom.xml
+++ b/bundles/org.eclipse.e4.ui.progress/pom.xml
@@ -16,7 +16,7 @@
   </parent>
   <groupId>org.eclipse.e4</groupId>
   <artifactId>org.eclipse.e4.ui.progress</artifactId>
-  <version>0.3.400-SNAPSHOT</version>
+  <version>0.3.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <properties>

--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/UIJob.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/UIJob.java
@@ -24,6 +24,7 @@ import org.eclipse.e4.ui.progress.internal.ProgressMessages;
 import org.eclipse.e4.ui.progress.internal.Services;
 import org.eclipse.e4.ui.progress.internal.legacy.PlatformUI;
 import org.eclipse.e4.ui.progress.internal.legacy.StatusUtil;
+import org.eclipse.e4.ui.workbench.swt.DisplayUISynchronize;
 import org.eclipse.swt.widgets.Display;
 
 /**
@@ -148,7 +149,10 @@ public abstract class UIJob extends Job {
 	 */
 	public Display getDisplay() {
 		if (cachedDisplay == null) {
-			cachedDisplay = Services.getInstance().getDisplay();
+			Services instance = Services.getInstance();
+			if (instance != null) {
+				cachedDisplay = instance.getDisplay();
+			}
 		}
 		if (cachedDisplay == null) {
 			cachedDisplay = Display.getCurrent();
@@ -200,7 +204,11 @@ public abstract class UIJob extends Job {
 	 * @return UI synchronizer
 	 */
 	protected UISynchronize getUiSynchronize() {
-		return Services.getInstance().getUISynchronize();
+		Services instance = Services.getInstance();
+		if (instance == null) {
+			return new DisplayUISynchronize(getDisplay());
+		}
+		return instance.getUISynchronize();
 	}
 
 }


### PR DESCRIPTION
Currently the code assumes that the Services is always there, what is
not true. Beside that, it ignores if a users sets a Display for
execution completely.

This is now fixed, by first check if there is a user display, then if
the addon is active and can supply required objects, and as a last
resort fall back to the swt displays.