### PR TITLE
Set explicit project encoding to UTF-8

### DIFF
--- a/bundles/org.eclipse.core.commands/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.core.commands/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.core.databinding.beans/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.core.databinding.beans/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.core.databinding.observable/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.core.databinding.observable/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.core.databinding.property/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.core.databinding.property/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.core.databinding/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.core.databinding/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.core.commands/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.core.commands/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.emf.xpath/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.emf.xpath/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.ui.bindings/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.ui.bindings/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.ui.css.core/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.ui.css.core/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.ui.css.swt.theme/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.ui.css.swt/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.ui.css.swt/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.ui.di/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.ui.di/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.ui.dialogs/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.ui.dialogs/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.ui.ide/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.ui.ide/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.ui.progress/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.ui.progress/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.ui.services/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.ui.services/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.ui.swt.win32/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.ui.swt.win32/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.ui.widgets/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.ui.widgets/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.ui.workbench.swt/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.ui.workbench/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.ui.workbench/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.e4.ui.workbench3/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.e4.ui.workbench3/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.jface.databinding/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.jface.databinding/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.jface.notifications/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.jface.notifications/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.ui.browser/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.ui.browser/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,3 @@
-#Thu Mar 31 17:23:30 EST 2005
 eclipse.preferences.version=1
 encoding//src/org/eclipse/ui/internal/browser/Messages.properties=8859_1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.ui.forms/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.ui.forms/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.ui.ide.application/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.ui.ide.application/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.ui.ide/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.ui.ide/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.ui.monitoring/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.ui.monitoring/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.ui.navigator.resources/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.ui.navigator.resources/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,3 @@
-#Tue Feb 21 13:59:06 EST 2006
 eclipse.preferences.version=1
 encoding//src/org/eclipse/ui/internal/navigator/resources/plugin/messages.properties=8859_1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.ui.navigator/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.ui.navigator/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.ui.themes/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.ui.themes/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.ui.views.properties.tabbed/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.ui.views.properties.tabbed/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.ui.views/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.ui.views/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.ui.win32/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.ui.win32/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.ui.workbench/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.ui.workbench/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.ui/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/bundles/org.eclipse.urischeme/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.urischeme/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.e4.demo.cssbridge/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.e4.demo.cssbridge/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.e4.ui.examples.job/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.e4.ui.examples.job/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.jface.examples.databinding/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.jface.examples.databinding/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.jface.snippets/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.jface.snippets/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.ui.examples.adapterservice/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.ui.examples.adapterservice/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.ui.examples.contributions/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.ui.examples.contributions/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.ui.examples.fieldassist/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.ui.examples.fieldassist/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.ui.examples.job/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.ui.examples.job/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.ui.examples.markerHelp/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.ui.examples.markerHelp/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.ui.examples.multipageeditor/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.ui.examples.multipageeditor/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.ui.examples.navigator/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.ui.examples.navigator/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.ui.examples.propertysheet/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.ui.examples.propertysheet/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.ui.examples.readmetool/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.ui.examples.readmetool/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.ui.examples.undo/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.ui.examples.undo/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.ui.examples.uriSchemeHandler/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.ui.examples.uriSchemeHandler/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.ui.examples.views.properties.tabbed.article/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.ui.examples.views.properties.tabbed.article/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/examples/org.eclipse.ui.forms.examples/.settings/org.eclipse.core.resources.prefs
+++ b/examples/org.eclipse.ui.forms.examples/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/features/org.eclipse.e4.rcp/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.eclipse.e4.rcp/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/features/org.eclipse.e4.ui.progress.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.eclipse.e4.ui.progress.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/features/org.eclipse.ui.tests.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.eclipse.ui.tests.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/releng/org.eclipse.ui.releng/.settings/org.eclipse.core.resources.prefs
+++ b/releng/org.eclipse.ui.releng/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.e4.core.commands.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.e4.core.commands.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.e4.emf.xpath.test/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.e4.emf.xpath.test/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.e4.ui.bindings.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.e4.ui.bindings.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.e4.ui.tests.css.core/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.e4.ui.tests.css.core/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.e4.ui.tests.css.swt/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.e4.ui.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.e4.ui.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.e4.ui.workbench.addons.swt.test/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.e4.ui.workbench.addons.swt.test/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.jface.tests.databinding.conformance/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.jface.tests.databinding.conformance/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.jface.tests.databinding/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.jface.tests.databinding/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.jface.tests.notifications/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.jface.tests.notifications/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.jface.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.jface.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.tests.urischeme/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.tests.urischeme/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.ui.monitoring.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.ui.monitoring.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.ui.tests.browser/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.ui.tests.browser/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.ui.tests.forms/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.ui.tests.forms/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.ui.tests.harness/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.ui.tests.harness/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.ui.tests.navigator/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.ui.tests.navigator/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.ui.tests.performance/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.ui.tests.performance/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.ui.tests.pluginchecks/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.ui.tests.pluginchecks/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.ui.tests.rcp/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.ui.tests.rcp/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8

--- a/tests/org.eclipse.ui.tests.views.properties.tabbed/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.eclipse.ui.tests.views.properties.tabbed/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,2 @@
 eclipse.preferences.version=1
-encoding//model/UIElements.ecorediag=UTF-8
 encoding/<project>=UTF-8


### PR DESCRIPTION
Avoid the newly introduced warning in all platform.ui projects.