### PR TITLE
Remove the help icon from the restart Eclipse due to theme changes

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
@@ -314,7 +314,7 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 	 */
 	private void showRestartDialog() {
 		if (new MessageDialog(null, WorkbenchMessages.ThemeChangeWarningTitle, null,
-				WorkbenchMessages.ThemeChangeWarningText, MessageDialog.QUESTION, 2,
+				WorkbenchMessages.ThemeChangeWarningText, MessageDialog.NONE, 2,
 				WorkbenchMessages.Workbench_RestartButton, WorkbenchMessages.Workbench_DontRestartButton)
 						.open() == Window.OK) {
 			Display.getDefault().asyncExec(() -> PlatformUI.getWorkbench().restart());


### PR DESCRIPTION
Operating system Ui guidelines do not recommend the usage of the help
icon in a dialog. For example check the screenshots in the Windows
guidelines for dialogs.

Operating System UI Guidelines

Windows UI guidence
https://docs.microsoft.com/en-us/windows/apps/design/controls/dialogs-and-flyouts/dialogs

Gnome UI guidence
https://developer.gnome.org/hig/patterns/feedback/dialogs.html

Mac UI guidence
https://developer.apple.com/design/human-interface-guidelines/components/presentation/alerts/