### PR TITLE
579498 filter dialog types

### DIFF
--- a/bundles/org.eclipse.ui.ide/schema/markerSupport.exsd
+++ b/bundles/org.eclipse.ui.ide/schema/markerSupport.exsd
@@ -192,6 +192,26 @@ ON_ANY_IN_SAME_CONTAINER: on any item with the same top level container as the s
                </appinfo>
             </annotation>
          </attribute>
+         <attribute name="application">
+            <annotation>
+               <documentation>
+                  The application attribute describes how the reference should be applied.
+                  i.e. Does it refer to type only, type and subtypes or subtypes only.
+                  It is optionally included.
+                  If it is not specified it defaults to typeAndSubTypes.
+               </documentation>
+            </annotation>
+            <simpleType>
+               <restriction base="string">
+                  <enumeration value="subTypesOnly">
+                  </enumeration>
+                  <enumeration value="typeOnly">
+                  </enumeration>
+                  <enumeration value="typeAndSubTypes">
+                  </enumeration>
+               </restriction>
+            </simpleType>
+         </attribute>
       </complexType>
    </element>
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerSupportInternalUtilities.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerSupportInternalUtilities.java
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Lars Vogel <Lars.Vogel@gmail.com> - Bug 430694
+ *     Enda O'Brien, Pilz Ireland - PR #144
  ******************************************************************************/
 
 package org.eclipse.ui.internal.views.markers;
@@ -70,6 +71,26 @@ public class MarkerSupportInternalUtilities {
 	 * The id attribute name from a configuration element.
 	 */
 	public static final String ATTRIBUTE_ID = "id"; //$NON-NLS-1$
+
+	/**
+	 * The application attribute from a configuration element.
+	 */
+	public static final String APPLICATION = "application"; //$NON-NLS-1$
+
+	/**
+	 * The sub type only attribute value from the application attribute.
+	 */
+	public static final String SUB_TYPES_ONLY = "subTypesOnly"; //$NON-NLS-1$
+
+	/**
+	 * The type only attribute value from the application attribute.
+	 */
+	public static final String TYPE_ONLY = "typeOnly"; //$NON-NLS-1$
+
+	/**
+	 * The type and subtype attribute value from the application attribute.
+	 */
+	public static final String TYPE_AND_SUBTYPE = "typeAndSubTypes"; //$NON-NLS-1$
 
 	/**
 	 * The name attribute name from a configuration element.

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/internal/ContentGeneratorDescriptor.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/internal/ContentGeneratorDescriptor.java
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Enda O'Brien, Pilz Ireland - PR #144
  ******************************************************************************/
 
 package org.eclipse.ui.views.markers.internal;
@@ -190,9 +191,25 @@ public class ContentGeneratorDescriptor {
 			IConfigurationElement[] markerTypeElements = configurationElement.getChildren(MarkerSupportRegistry.MARKER_TYPE_REFERENCE);
 			for (IConfigurationElement configElement : markerTypeElements) {
 				String elementName = configElement.getAttribute(MarkerSupportInternalUtilities.ATTRIBUTE_ID);
-				MarkerType[] types = MarkerTypesModel.getInstance().getType(elementName).getAllSubTypes();
-				markerTypes.addAll(Arrays.asList(types));
-				markerTypes.add(MarkerTypesModel.getInstance().getType(elementName));
+
+				String application = configElement.getAttribute(MarkerSupportInternalUtilities.APPLICATION) == null
+						? MarkerSupportInternalUtilities.TYPE_AND_SUBTYPE
+						: configElement.getAttribute(MarkerSupportInternalUtilities.APPLICATION);
+
+				switch (application) {
+				case MarkerSupportInternalUtilities.TYPE_ONLY:
+					markerTypes.add(MarkerTypesModel.getInstance().getType(elementName));
+					break;
+				case MarkerSupportInternalUtilities.SUB_TYPES_ONLY:
+					markerTypes.addAll(
+							Arrays.asList(MarkerTypesModel.getInstance().getType(elementName).getAllSubTypes()));
+					break;
+				case MarkerSupportInternalUtilities.TYPE_AND_SUBTYPE:
+				default:
+					markerTypes.addAll(
+							Arrays.asList(MarkerTypesModel.getInstance().getType(elementName).getAllSubTypes()));
+					markerTypes.add(MarkerTypesModel.getInstance().getType(elementName));
+				}
 			}
 			if (markerTypes.isEmpty()) {
 				MarkerType[] types = MarkerTypesModel.getInstance().getType(IMarker.PROBLEM).getAllSubTypes();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/NoApplicationAttribTestView.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/NoApplicationAttribTestView.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Enda O'Brien and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors: Enda O'Brien, Pilz Ireland - PR #144
+ *******************************************************************************/
+package org.eclipse.ui.tests;
+
+import org.eclipse.ui.views.markers.MarkerSupportView;
+
+/**
+ * A test view that does not define the markerTypeReference application
+ * attribute in its content generator (CONTENT_GEN_ID).
+ *
+ */
+public class NoApplicationAttribTestView extends MarkerSupportView {
+	public static final String ID = "org.eclipse.ui.tests.noApplicationAttribTestView";
+
+	static final String CONTENT_GEN_ID = "org.eclipse.ui.tests.noApplicationAttribTestViewContentGenerator";
+
+	public NoApplicationAttribTestView() {
+		super(CONTENT_GEN_ID);
+	}
+
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/SubTypeOnlyTestView.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/SubTypeOnlyTestView.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Enda O'Brien and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors: Enda O'Brien, Pilz Ireland - PR #144
+ *******************************************************************************/
+package org.eclipse.ui.tests;
+
+import org.eclipse.ui.views.markers.MarkerSupportView;
+
+/**
+ * A test view that defines a markerTypeReference application attribute of
+ * subTypesOnly in it content generator (CONTENT_GEN_ID).
+ */
+public class SubTypeOnlyTestView extends MarkerSupportView {
+	public static final String ID = "org.eclipse.ui.tests.subTypeOnlyTestView";
+
+	static final String CONTENT_GEN_ID = "org.eclipse.ui.tests.subTypeOnlyTestViewContentGenerator";
+
+	public SubTypeOnlyTestView() {
+		super(CONTENT_GEN_ID);
+	}
+
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/TypeAndSubTypeTestView.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/TypeAndSubTypeTestView.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Enda O'Brien and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors: Enda O'Brien, Pilz Ireland - PR #144
+ *******************************************************************************/
+package org.eclipse.ui.tests;
+
+import org.eclipse.ui.views.markers.MarkerSupportView;
+
+/**
+ * A test view that defines a markerTypeReference application attribute of
+ * typeAndSubTypes in it content generator (CONTENT_GEN_ID).
+ */
+public class TypeAndSubTypeTestView extends MarkerSupportView {
+	public static final String ID = "org.eclipse.ui.tests.typeAndSubTypeTestView";
+
+	static final String CONTENT_GEN_ID = "org.eclipse.ui.tests.typeAndSubTypeTestViewContentGenerator";
+
+	public TypeAndSubTypeTestView() {
+		super(CONTENT_GEN_ID);
+	}
+
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/TypeOnlyTestView.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/TypeOnlyTestView.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Enda O'Brien and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors: Enda O'Brien, Pilz Ireland - PR #144
+ *******************************************************************************/
+package org.eclipse.ui.tests;
+
+import org.eclipse.ui.views.markers.MarkerSupportView;
+
+/**
+ * A test view that defines a markerTypeReference application attribute of
+ * typeOnly in it content generator (CONTENT_GEN_ID).
+ *
+ */
+public class TypeOnlyTestView extends MarkerSupportView {
+
+	public static final String ID = "org.eclipse.ui.tests.typeOnlyTestView";
+
+	static final String CONTENT_GEN_ID = "org.eclipse.ui.tests.typeOnlyTestViewContentGenerator";
+
+	public TypeOnlyTestView() {
+		super(CONTENT_GEN_ID);
+	}
+
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/InternalTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/InternalTestSuite.java
@@ -25,6 +25,7 @@ import org.eclipse.ui.tests.markers.MarkerSortUtilTest;
 import org.eclipse.ui.tests.markers.MarkerSupportRegistryTests;
 import org.eclipse.ui.tests.markers.MarkerSupportViewTest;
 import org.eclipse.ui.tests.markers.MarkerTesterTest;
+import org.eclipse.ui.tests.markers.MarkerTypeTests;
 import org.eclipse.ui.tests.markers.MarkerViewTests;
 import org.eclipse.ui.tests.markers.MarkerViewUtilTest;
 import org.eclipse.ui.tests.markers.ResourceMappingMarkersTest;
@@ -68,5 +69,6 @@ import org.junit.runners.Suite;
 	LargeFileLimitsPreferenceHandlerTest.class,
 	WorkbookEditorsHandlerTest.class,
 	ScopeAreaTest.class,
+		MarkerTypeTests.class
 })
 public class InternalTestSuite {}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/MarkerTypeTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/MarkerTypeTests.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Enda O'Brien and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors: Enda O'Brien, Pilz Ireland - PR #144
+ *******************************************************************************/
+package org.eclipse.ui.tests.markers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.views.markers.ExtendedMarkersView;
+import org.eclipse.ui.internal.views.markers.MarkerContentGenerator;
+import org.eclipse.ui.tests.NoApplicationAttribTestView;
+import org.eclipse.ui.tests.SubTypeOnlyTestView;
+import org.eclipse.ui.tests.TypeAndSubTypeTestView;
+import org.eclipse.ui.tests.TypeOnlyTestView;
+import org.eclipse.ui.views.markers.MarkerSupportView;
+import org.eclipse.ui.views.markers.internal.ContentGeneratorDescriptor;
+import org.eclipse.ui.views.markers.internal.MarkerType;
+import org.eclipse.ui.views.markers.internal.MarkerTypesModel;
+import org.junit.Test;
+
+public class MarkerTypeTests {
+
+	static final String PROBLEM_MARKER = "org.eclipse.core.resources.problemmarker";
+
+	@Test
+	public void canIncludeTypeOnly() throws Exception {
+		MarkerSupportView view = (MarkerSupportView) PlatformUI.getWorkbench().getActiveWorkbenchWindow()
+				.getActivePage().showView(TypeOnlyTestView.ID);
+
+		MarkerContentGenerator generator = getMarkerContentGenerator(view);
+		Collection<MarkerType> filterDialogTypes = getMarkerTypes(generator);
+
+		assertEquals(1, filterDialogTypes.size());
+		assertEquals(PROBLEM_MARKER, filterDialogTypes.stream().map(type -> type.getId()).findFirst().get());
+	}
+
+	@Test
+	public void canIncludeTypeAndSubTypes() throws Exception {
+		MarkerSupportView view = (MarkerSupportView) PlatformUI.getWorkbench().getActiveWorkbenchWindow()
+				.getActivePage().showView(TypeAndSubTypeTestView.ID);
+
+		MarkerContentGenerator generator = getMarkerContentGenerator(view);
+		Collection<MarkerType> filterDialogTypes = getMarkerTypes(generator);
+
+		Collection<MarkerType> markerTypes = new HashSet<>();
+		markerTypes.add(MarkerTypesModel.getInstance().getType(PROBLEM_MARKER));
+		markerTypes.addAll(Arrays.asList(MarkerTypesModel.getInstance().getType(PROBLEM_MARKER).getAllSubTypes()));
+
+		assertEquals(markerTypes.size(), filterDialogTypes.size());
+		assertEquals(PROBLEM_MARKER, filterDialogTypes.stream().map(type -> type.getId())
+				.filter(s -> s.equals(PROBLEM_MARKER)).findFirst().get());
+
+		for (MarkerType type : markerTypes) {
+			assertTrue(filterDialogTypes.contains(type));
+		}
+	}
+
+	@Test
+	public void canIncludeSubtypesOnly() throws Exception {
+		MarkerSupportView view = (MarkerSupportView) PlatformUI.getWorkbench().getActiveWorkbenchWindow()
+				.getActivePage().showView(SubTypeOnlyTestView.ID);
+
+		MarkerContentGenerator generator = getMarkerContentGenerator(view);
+		Collection<MarkerType> filterDialogTypes = getMarkerTypes(generator);
+
+		Collection<MarkerType> markerTypes = new HashSet<>();
+		markerTypes.addAll(Arrays.asList(MarkerTypesModel.getInstance().getType(PROBLEM_MARKER).getAllSubTypes()));
+
+		assertEquals(markerTypes.size(), filterDialogTypes.size());
+		assertTrue(PROBLEM_MARKER, filterDialogTypes.stream().map(type -> type.getId())
+				.filter(s -> s.equals(PROBLEM_MARKER)).findFirst().isEmpty());
+		for (MarkerType type : markerTypes) {
+			assertTrue(filterDialogTypes.contains(type));
+		}
+	}
+
+	@Test
+	public void typeAndSubTypesIsDefault() throws Exception {
+		MarkerSupportView view = (MarkerSupportView) PlatformUI.getWorkbench().getActiveWorkbenchWindow()
+				.getActivePage().showView(NoApplicationAttribTestView.ID);
+
+		MarkerContentGenerator generator = getMarkerContentGenerator(view);
+		Collection<MarkerType> filterDialogTypes = getMarkerTypes(generator);
+
+		Collection<MarkerType> markerTypes = new HashSet<>();
+		markerTypes.add(MarkerTypesModel.getInstance().getType(PROBLEM_MARKER));
+		markerTypes.addAll(Arrays.asList(MarkerTypesModel.getInstance().getType(PROBLEM_MARKER).getAllSubTypes()));
+
+		assertEquals(markerTypes.size(), filterDialogTypes.size());
+		assertEquals(PROBLEM_MARKER, filterDialogTypes.stream().map(type -> type.getId())
+				.filter(s -> s.equals(PROBLEM_MARKER)).findFirst().get());
+
+		for (MarkerType type : markerTypes) {
+			assertTrue(filterDialogTypes.contains(type));
+		}
+	}
+
+	public static MarkerContentGenerator getMarkerContentGenerator(MarkerSupportView view) {
+		MarkerContentGenerator generator = null;
+		try {
+			Field fieldGenerator = ExtendedMarkersView.class.getDeclaredField("generator");
+			fieldGenerator.setAccessible(true);
+			generator = (MarkerContentGenerator) fieldGenerator.get(view);
+		} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+		}
+		return generator;
+	}
+
+	@SuppressWarnings("unchecked")
+	public static Collection<MarkerType> getMarkerTypes(MarkerContentGenerator generator) {
+		Collection<MarkerType> selectedTypesCollection = null;
+		try {
+			Field generatorDescriptor = MarkerContentGenerator.class.getDeclaredField("generatorDescriptor");
+			generatorDescriptor.setAccessible(true);
+
+			ContentGeneratorDescriptor contentGeneratorDescriptor = (ContentGeneratorDescriptor) generatorDescriptor
+					.get(generator);
+
+			Field markerTypesField = ContentGeneratorDescriptor.class.getDeclaredField("markerTypes");
+			markerTypesField.setAccessible(true);
+
+			selectedTypesCollection = (Collection<MarkerType>) markerTypesField.get(contentGeneratorDescriptor);
+		} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+		}
+		return selectedTypesCollection;
+	}
+}

--- a/tests/org.eclipse.ui.tests/plugin.xml
+++ b/tests/org.eclipse.ui.tests/plugin.xml
@@ -190,7 +190,26 @@
        		class="org.eclipse.ui.tests.api.workbenchpart.ViewWithCreateControlsException"
        		id="org.eclipse.ui.tests.api.workbenchpart.ViewWithCreateControlsException">
       </view>
-
+      <view
+            class="org.eclipse.ui.tests.TypeOnlyTestView"
+            id="org.eclipse.ui.tests.typeOnlyTestView"
+            name="TypeOnlyTestView">
+      </view>
+      <view
+            class="org.eclipse.ui.tests.SubTypeOnlyTestView"
+            id="org.eclipse.ui.tests.subTypeOnlyTestView"
+            name="SubTypeOnlyTestView">
+      </view>
+      <view
+            class="org.eclipse.ui.tests.TypeAndSubTypeTestView"
+            id="org.eclipse.ui.tests.typeAndSubTypeTestView"
+            name="TypeAndSubTypeTestView">
+      </view>
+      <view
+            class="org.eclipse.ui.tests.NoApplicationAttribTestView"
+            id="org.eclipse.ui.tests.noApplicationAttribTestView"
+            name="NoApplicationAttribTestView">
+      </view>
    </extension>
    
    <extension
@@ -3408,6 +3427,37 @@
        </markerContentGeneratorExtension>
         <markerContentGenerator
              id="org.eclipse.ui.tests.filterHelpContentGenerator">
+       </markerContentGenerator>
+       <markerContentGenerator
+              id="org.eclipse.ui.tests.typeAndSubTypeTestViewContentGenerator"
+              name="typeAndSubTypeTestViewContentGenerator">
+          <markerTypeReference
+                application="typeAndSubTypes"
+                id="org.eclipse.core.resources.problemmarker">
+          </markerTypeReference>
+       </markerContentGenerator>
+       <markerContentGenerator
+             id="org.eclipse.ui.tests.typeOnlyTestViewContentGenerator"
+             name="typeOnlyTestViewContentGenerator">
+          <markerTypeReference
+                application="typeOnly"
+                id="org.eclipse.core.resources.problemmarker">
+          </markerTypeReference>
+       </markerContentGenerator>
+       <markerContentGenerator
+             id="org.eclipse.ui.tests.subTypeOnlyTestViewContentGenerator"
+             name="subTypeOnlyTestViewContentGenerator">
+          <markerTypeReference
+                application="subTypesOnly"
+                id="org.eclipse.core.resources.problemmarker">
+          </markerTypeReference>
+       </markerContentGenerator>
+       <markerContentGenerator
+             id="org.eclipse.ui.tests.noApplicationAttribTestViewContentGenerator"
+             name="noApplicationAttribTestViewContentGenerator">
+          <markerTypeReference
+                id="org.eclipse.core.resources.problemmarker">
+          </markerTypeReference>
        </markerContentGenerator>
         <markerContentGenerator
              id="org.eclipse.ui.tests.customScopeContentGenerator">


### PR DESCRIPTION
![filterDialog](https://user-images.githubusercontent.com/58333578/186390333-1eb3394f-0111-4c2e-b2a9-1f138b05ae11.png)
![ProblemView](https://user-images.githubusercontent.com/58333578/186390339-21b742f2-3404-4457-9ebe-305fbdff125e.png)

We have a customized problem view for our application.
It displays markers of our own type pilzproblemmarker

i.e.

Defined like this.
`
       <extension point="org.eclipse.core.resources.markers"
        id="pilzproblemmarker"
		name="pilz problem marker">
        	<super
                type="org.eclipse.core.resources.problemmarker">
          	</super>
		.......
`

We associate it with the problem view like this.
`
      <extension point="org.eclipse.ui.ide.markerSupport">
      	id="com.pilz.pas.platform.gui.pilzproblemmarker"/>
 `

We create our markers like this with our custom marker as a super.
`    <extension point="org.eclipse.core.resources.markers"
          id="com.pilz.pas.hal.errorhandling.ErrorCodes.STATEMENT_INDEX_OUT_OF_BOUNDS"
          name="%SUPPRESSION_MSG_STATEMENT_INDEX_OUT_OF_BOUNDS">
          <super
                type="com.pilz.pas.platform.gui.pilzproblemmarker">
          </super>
		.......`

This works well with the filter dialog. 
1) All our markers get displayed in the type section of the filter dialog.
2) Other problem markers that we don't care about (e.g. Java problems) are not displayed.

Only issue is that the supertype pilzproblemmarker is shown : see the screenshot
We need to hide it.
