### PR TITLE
NPE in ProjectNaturesPage (fixes #145)

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ProjectNaturesPage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ProjectNaturesPage.java
@@ -26,8 +26,8 @@ import java.util.Map;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IProjectNatureDescriptor;
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -300,7 +300,7 @@ public class ProjectNaturesPage extends PropertyPage {
 	 * Initializes a ProjectNaturesPage.
 	 */
 	private void initialize() {
-		project = (IProject) getElement().getAdapter(IResource.class);
+		project = Adapters.adapt(getElement(), IProject.class);
 		noDefaultAndApplyButton();
 	}
 


### PR DESCRIPTION
The page is meant for elements that adapt to IProject (see plugin.xml).
However, the code adapts to IResource and casts to IProject, probably by
accident. This leads to NPE for objects that adapt to IProject, but not
to IResource.

Change to adapt to IProject directly, to have plugin.xml and code in
sync.