### PR TITLE
NPE in ResourceFilterGroup (fixes #143)

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ResourceFilterGroup.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ResourceFilterGroup.java
@@ -1181,11 +1181,10 @@ public class ResourceFilterGroup {
 	 * @return true if the filters changed
 	 */
 	public boolean performOk() {
-
+		if (resource == null || filters == null) {
+			return true;
+		}
 		if (filters.hasChanged()) {
-			if (resource == null)
-				return true;
-
 			try {
 				if (resource != nonExistantResource) {
 					IResourceFilterDescription[] oldFilters = resource.getFilters();


### PR DESCRIPTION
filters is null, if the resource has been null during
ResourceFilterGroup.createContents(Composite), see line 573.

Therefore the NPE should already be avoided by moving the "resource ==
null" check to the begin of the method. To be sure, also check "filters
== null" explicitly.