### PR TITLE
Match quick access input against command categories (#127)

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/providers/CommandElement.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/providers/CommandElement.java
@@ -150,6 +150,16 @@ public class CommandElement extends QuickAccessElement {
 	}
 
 	@Override
+	public String getMatchLabel() {
+		String defaultMatchLabel = super.getMatchLabel();
+		try {
+			return defaultMatchLabel + ' ' + command.getCommand().getCategory().getName();
+		} catch (NotDefinedException e) {
+			return defaultMatchLabel;
+		}
+	}
+
+	@Override
 	public int hashCode() {
 		return Objects.hashCode(command);
 	}


### PR DESCRIPTION
Quick access inputs like "Project", "Git" etc. should show all commands
of those categories, not only those that have these terms in their
labels.

When testing, the difference can be seen by using "project" (or other
command category names) as quick access input. Without the change only
commands with "project" in their label are shown. With this change also
commands like "Build Clean - Discard old build state" are shown, which
don't contain "Project" in the label, but in are in that category.

before:
![image](https://user-images.githubusercontent.com/406876/174252029-600f61d2-3ed4-4b87-846f-a783fdc3db7c.png)

after:
![image](https://user-images.githubusercontent.com/406876/174251995-5bffb034-94dc-4e81-9380-2cc0abd319eb.png)

In the second image commands are visible that do not have "project" in their label, but are in that category.