### PR TITLE
Avoid duplicate quick access entry (fixes #152)

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
@@ -527,6 +527,14 @@ public abstract class QuickAccessContents {
 					QuickAccessEntry.MATCH_PERFECT)));
 		}
 		res.addAll(entriesPerProvider.values());
+
+		// if one category provides the same single entry like "previous", we can avoid
+		// showing the duplicate second list
+		if (res.size() >= 2 && res.get(0).size() == 1 && res.get(1).size() == 1
+				&& (res.get(0).get(0).element.equals(res.get(1).get(0).element))) {
+			res.remove(1);
+		}
+
 		return (List<QuickAccessEntry>[]) res.toArray(new List<?>[res.size()]);
 	}
 


### PR DESCRIPTION
When you have used quick access previously, the dialog adds matching
entries from "previous" at the top. Afterwards the same entries may
appear from their "normal" provider (e.q. views, commands, ...).

Since the logic of adding entries seems quite complex, this change fixes
the duplicate entry by detecting the exact situation (same single entry
in first and second provider list), and then removes the duplicate entry
list.