### PR TITLE
Reuse color constants from parent in TreeTest

### DIFF
--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/TreeTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/TreeTest.java
@@ -16,7 +16,6 @@ package org.eclipse.e4.ui.tests.css.swt;
 import static org.junit.Assert.assertEquals;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
@@ -24,10 +23,6 @@ import org.eclipse.swt.widgets.Tree;
 import org.junit.Test;
 
 public class TreeTest extends CSSSWTTestCase {
-
-	static final RGB RED = new RGB(255, 0, 0);
-	static final RGB GREEN = new RGB(0, 255, 0);
-	static final RGB BLUE = new RGB(0, 0, 255);
 
 	protected Tree createTestTree(String styleSheet) {
 		engine = createEngine(styleSheet, display);


### PR DESCRIPTION
CSSSWTTestCase already defines the color constants, lets reuse them
instead of declaring them again.