### PR TITLE
Remove getDocument from AbstractCSSEngine

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/AbstractCSSEngine.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/engine/AbstractCSSEngine.java
@@ -914,10 +914,6 @@ public abstract class AbstractCSSEngine implements CSSEngine {
 		}
 	}
 
-	public Object getDocument() {
-		return null;
-	}
-
 	@Override
 	public CSSElementContext getCSSElementContext(Object element) {
 		Object o = getNativeWidget(element);


### PR DESCRIPTION
Always returns null and it is never called, so remove the method.