### PR TITLE
Remove dispose check from ButtonElement

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/dom/ButtonElement.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/dom/ButtonElement.java
@@ -34,10 +34,8 @@ public class ButtonElement extends ControlElement {
 	private SelectionListener selectionListener = new SelectionAdapter() {
 		@Override
 		public void widgetSelected(SelectionEvent e) {
-			if (!e.widget.isDisposed()) {
-				ButtonElement.this.isSelected = getButton().getSelection();
-				doApplyStyles();
-			}
+			ButtonElement.this.isSelected = getButton().getSelection();
+			doApplyStyles();
 		}
 	};
 


### PR DESCRIPTION
In https://github.com/eclipse-platform/eclipse.platform.ui/pull/163#discussion_r901669089
I learned that SWT does not deliver events to disposed widgets. Hence we
can remove the check in ButtonElement (used by CSS engine). This way we
will prevent copy and paste errors for new css handlers.