### PR TITLE
NPE on MAC on TreeViewerFocusCellManager - fixes #174

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.26.0.qualifier
+Bundle-Version: 3.26.100.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.jface/pom.xml
+++ b/bundles/org.eclipse.jface/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.jface</groupId>
   <artifactId>org.eclipse.jface</artifactId>
-  <version>3.26.0-SNAPSHOT</version>
+  <version>3.26.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewerFocusCellManager.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewerFocusCellManager.java
@@ -119,7 +119,8 @@ public class TreeViewerFocusCellManager extends SWTFocusCellManager {
 	ViewerCell getInitialFocusCell() {
 		Tree tree = (Tree) getViewer().getControl();
 
-		if (! tree.isDisposed() && tree.getItemCount() > 0 && ! tree.getTopItem().isDisposed()) {
+		if (!tree.isDisposed() && tree.getItemCount() > 0 && tree.getTopItem() != null
+				&& !tree.getTopItem().isDisposed()) {
 			ViewerRow aViewerRow = getViewer().getViewerRowFromItem(tree.getTopItem());
 			if (tree.getColumnCount() == 0) {
 				return aViewerRow.getCell(0);


### PR DESCRIPTION
In TreeViewerFocusCellManager.getInitialFocusCell() the
tree.getTopItem() can return a null element, since the tree can be in
process (expanded, collapsed, scrolled or new items are added or
removed). So a null check must be added.

Change-Id: Icdc9b44b3ace1cc385e2a6e8cf43f04622c31020
Signed-off-by: Denis Ungemach <denis.ungemach@sap.com>