### PR TITLE
Update the static MessageDialog#openQuestion to UX guidelines from the OS

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/MessageDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/MessageDialog.java
@@ -64,8 +64,8 @@ public class MessageDialog extends IconAndMessageDialog {
 	public static final int INFORMATION = 2;
 
 	/**
-	 * Constant for the question image, or a simple dialog with the question
-	 * image and Yes/No buttons (value 3).
+	 * Constant for the question image, or a simple dialog without an icon and
+	 * Yes/No buttons (value 3).
 	 *
 	 * @see #MessageDialog(Shell, String, Image, String, int, int, String...)
 	 * @see #open(int, Shell, String, String, int)
@@ -82,7 +82,7 @@ public class MessageDialog extends IconAndMessageDialog {
 	public static final int WARNING = 4;
 
 	/**
-	 * Constant for a simple dialog with the question image and OK/Cancel buttons (value 5).
+	 * Constant for a simple dialog without an icon and OK/Cancel buttons (value 5).
 	 *
 	 * @see #open(int, Shell, String, String, int)
 	 * @since 3.5
@@ -90,7 +90,8 @@ public class MessageDialog extends IconAndMessageDialog {
 	public static final int CONFIRM = 5;
 
 	/**
-	 * Constant for a simple dialog with the question image and Yes/No/Cancel buttons (value 6).
+	 * Constant for a simple dialog without an icon and Yes/No/Cancel buttons (value
+	 * 6).
 	 *
 	 * @see #open(int, Shell, String, String, int)
 	 * @since 3.5
@@ -163,8 +164,8 @@ public class MessageDialog extends IconAndMessageDialog {
 	 *                           with an error image</li>
 	 *                           <li><code>MessageDialog.INFORMATION</code> for a
 	 *                           dialog with an information image</li>
-	 *                           <li><code>MessageDialog.QUESTION </code> for a
-	 *                           dialog with a question image</li>
+	 *                           <li><code>MessageDialog.QUESTION </code> for a simple
+	 *                           dialog without an icon</li>
 	 *                           <li><code>MessageDialog.WARNING</code> for a dialog
 	 *                           with a warning image</li>
 	 *                           </ul>
@@ -209,8 +210,8 @@ public class MessageDialog extends IconAndMessageDialog {
 	 *                           with an error image</li>
 	 *                           <li><code>MessageDialog.INFORMATION</code> for a
 	 *                           dialog with an information image</li>
-	 *                           <li><code>MessageDialog.QUESTION </code> for a
-	 *                           dialog with a question image</li>
+	 *                           <li><code>MessageDialog.QUESTION </code> for a simple
+	 *                           dialog without an icon</li>
 	 *                           <li><code>MessageDialog.WARNING</code> for a dialog
 	 *                           with a warning image</li>
 	 *                           </ul>
@@ -246,7 +247,6 @@ public class MessageDialog extends IconAndMessageDialog {
 		case QUESTION:
 		case QUESTION_WITH_CANCEL:
 		case CONFIRM: {
-			this.image = getQuestionImage();
 			break;
 		}
 		case WARNING: {


### PR DESCRIPTION
Operating system Ui guidelines do not recommend the usage of the help /
question
icon in a dialog. This change adjusts the MessageDialog#openQuestion
accordingly.As this will affect all callers of this method, it has will
lead a consistency for callers, users which want / need to violate UX
guidelines of the OS can switch to the non static methods or use
PlainMessageDialog to construct their dialog in a way which they want.

The reasoning for this change is that platform is allowed to adjust its
UI to UX changes in the OS and that the UX of Eclipse is not considered
API.

For example check the screenshots in the Windows
guidelines for dialogs.

Operating System UI Guidelines

Windows UI guidence
https://docs.microsoft.com/en-us/windows/apps/design/controls/dialogs-and-flyouts/dialogs

Gnome UI guidence
https://developer.gnome.org/hig/patterns/feedback/dialogs.html

Mac UI guidence
https://developer.apple.com/design/human-interface-guidelines/components/presentation/alerts/