### PR TITLE
Make matches highlighting in Resource dialog more simple and efficient

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourceItemLabelTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourceItemLabelTest.java
@@ -192,6 +192,15 @@ public class ResourceItemLabelTest extends UITestCase {
 		compareStyleRanges(withDigits, getStyleRanges("AB5C", "Ab5cBz5zCz.txt"), "Ab5cBz5zCz.txt", "");
 	}
 
+	@Test
+	public void testBug528301_withConsecutiveWildcards() throws Exception {
+		Position[] questionMarkStar = { new Position(0, 1), new Position(5, 2) };
+		compareStyleRanges(questionMarkStar, getStyleRanges("a?*fg", "abcdefg.txt"), "abcdefg.txt", "");
+
+		Position[] starQuestionMark = { new Position(0, 1), new Position(5, 2) };
+		compareStyleRanges(starQuestionMark, getStyleRanges("a*?fg", "abcdefg.txt"), "abcdefg.txt", "");
+	}
+
 	/**
 	 * Tests for Bug 531610: Open Resource dialog doesn't show paths for duplicated
 	 * files


### PR DESCRIPTION
This effectively removes and/or replaces most of the code introduced
within the solutions of bug 520250 "Open resource should use highlight
matches based on CamelCase" and follow-up bugs 528301 and 529451. The
goal is more maintainable and readable code, while also having the
implementation more efficient.

1. Remove redundant conditions, escaping and usage of regex (from top to
bottom):

   * Remove `escapeRegexCharacters()` and follow-up de-escaping of
characters, as treating the search string as a plain string seems to be
sufficient.
   * Remove `searchFieldString.lastIndexOf('.') != -1`, as this is
implied when `str.getStyleRanges().length > 0` is true.
   * Remove ` + resource.getFileExtension()`, as passing just `'.'` to
`lastIndexOf()` should do the very same job in a simpler fashion.
   * Every matching string `region` is used as a simple string. It is
unclear why handling it as a regex instead was introduced.
   * Remove the `restart` flag and do-while around it. It is unclear
what exact scenarios this should have covered. Also, incrementing
`currentIndex` just by 1 lead to repeated failing `indexOf()` lookups
being performed in loop for simple search strings.

2. Choose simpler ways of calculations (from top to bottom):

   * `resource.getName().lastIndexOf(resourceExtension)` seems to be a
less efficient variant of `resource.getName().length() -
resourceExtension.length()`.
   * rename: `lastDotIndex` -> `matchingExtensionIndex` for consistency
   * `(\\?)|\\*` replaced by a less cryptic `[?*]`

3. Add explanatory comments