### PR TITLE
Mark ShowViewHandler(boolean makeFast) for deletion

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/handlers/ShowViewHandler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/handlers/ShowViewHandler.java
@@ -55,14 +55,9 @@ public final class ShowViewHandler extends AbstractHandler {
 	}
 
 	/**
-	 * Creates a new ShowViewHandler that will optionally force the view to become a
-	 * fast view.
-	 *
-	 * @param makeFast if true, the view will be moved to the fast view bar (even if
-	 *                 it already exists elsewhere). If false, the view will be
-	 *                 shown in its default location. Calling with false is
-	 *                 equivalent to using the default constructor.
+	 * fast views are not supported since a while in the Eclipse IDE
 	 */
+	@Deprecated(forRemoval = true)
 	public ShowViewHandler(boolean makeFast) {
 
 	}


### PR DESCRIPTION
Fast views are not supported since multiple years in the Eclipse IDE,
hence lets mark the constructur for this for removal.