### PR TITLE
ChooseWorkspaceDialog is now resizable

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceDialog.java
@@ -591,4 +591,9 @@ public class ChooseWorkspaceDialog extends TitleAreaDialog {
 	public Button getDefaultButton() {
 		return defaultButton;
 	}
+
+	@Override
+	protected boolean isResizable() {
+		return true;
+	}
 }


### PR DESCRIPTION
Allows to resize the ChooseWorkspaceDialog. We have OS / users which
cannot use Eclipse due to an incorrectly sized launcher. This allows
these users to adjust the workspace dialog.

Fixes #165