### PR TITLE
Make UIExtensionTracker a ServiceContextFunction

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench/.settings/org.eclipse.pde.ds.annotations.prefs
+++ b/bundles/org.eclipse.e4.ui.workbench/.settings/org.eclipse.pde.ds.annotations.prefs
@@ -1,0 +1,8 @@
+classpath=true
+dsVersion=V1_3
+eclipse.preferences.version=1
+enabled=true
+generateBundleActivationPolicyLazy=true
+path=OSGI-INF
+validationErrorLevel=error
+validationErrorLevel.missingImplicitUnbindMethod=error

--- a/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench;singleton:=true
-Bundle-Version: 1.13.100.qualifier
+Bundle-Version: 1.13.200.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -40,13 +40,14 @@ Export-Package: org.eclipse.e4.ui.internal.workbench;
  org.eclipse.e4.ui.workbench.modeling
 Bundle-Activator: org.eclipse.e4.ui.internal.workbench.Activator
 Service-Component: OSGI-INF/org.eclipse.e4.ui.internal.LocaleChangeServiceContextFunction.xml,
+ OSGI-INF/org.eclipse.e4.ui.internal.workbench.ExtensionTrackeContextFunction.xml,
+ OSGI-INF/org.eclipse.e4.ui.internal.workbench.ModelAssembler.xml,
  OSGI-INF/org.eclipse.e4.ui.internal.workbench.PartServiceCreationFunction.xml,
- OSGI-INF/org.eclipse.e4.ui.internal.workbench.ProgressMonitorFunction.xml,
- OSGI-INF/org.eclipse.e4.ui.internal.workbench.ModelAssembler.xml
+ OSGI-INF/org.eclipse.e4.ui.internal.workbench.ProgressMonitorFunction.xml
 Import-Package: javax.annotation,
  javax.inject;version="1.0.0",
  org.apache.commons.jxpath;version="1.3.0",
- org.osgi.service.component.annotations;version="1.2.0";resolution:=optional,
+ org.osgi.service.component.annotations;version="1.3.0";resolution:=optional,
  org.osgi.service.event;version="1.3.0"
 Require-Capability: osgi.extender;
   filter:="(&(osgi.extender=osgi.component)(version>=1.2)(!(version>=2.0)))",

--- a/bundles/org.eclipse.e4.ui.workbench/OSGI-INF/org.eclipse.e4.ui.internal.workbench.ExtensionTrackeContextFunction.xml
+++ b/bundles/org.eclipse.e4.ui.workbench/OSGI-INF/org.eclipse.e4.ui.internal.workbench.ExtensionTrackeContextFunction.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" deactivate="shutdown" name="org.eclipse.e4.ui.internal.workbench.ExtensionTrackeContextFunction">
+   <property name="service.context.key" value="org.eclipse.core.runtime.dynamichelpers.IExtensionTracker"/>
+   <property name="event.topics" value="org/eclipse/e4/core/contexts/IEclipseContext/DISPOSE"/>
+   <service>
+      <provide interface="org.eclipse.e4.core.contexts.IContextFunction"/>
+   </service>
+   <reference cardinality="1..1" field="log" interface="org.eclipse.core.runtime.ILog" name="log"/>
+   <implementation class="org.eclipse.e4.ui.internal.workbench.ExtensionTrackeContextFunction"/>
+</scr:component>

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ExtensionTrackeContextFunction.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ExtensionTrackeContextFunction.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ ******************************************************************************/
+
+package org.eclipse.e4.ui.internal.workbench;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.dynamichelpers.IExtensionTracker;
+import org.eclipse.e4.core.contexts.ContextFunction;
+import org.eclipse.e4.core.contexts.IContextFunction;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.ui.di.UISynchronize;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+
+@Component(service = IContextFunction.class, property = {
+		"service.context.key=org.eclipse.core.runtime.dynamichelpers.IExtensionTracker",
+		"event.topics=" + IEclipseContext.TOPIC_DISPOSE })
+public class ExtensionTrackeContextFunction extends ContextFunction implements EventHandler {
+
+	@Reference
+	private ILog log;
+
+	private Map<IEclipseContext, IExtensionTracker> createdObjects = new ConcurrentHashMap<>();
+
+	@Override
+	public Object compute(IEclipseContext context, String contextKey) {
+		IExtensionTracker tracker = context.getLocal(IExtensionTracker.class);
+		if (tracker == null) {
+			tracker = createdObjects.computeIfAbsent(context, ctx -> {
+				return new UIExtensionTracker(runnable -> {
+					UISynchronize synchronize = ctx.get(UISynchronize.class);
+					if (synchronize != null) {
+						synchronize.asyncExec(runnable);
+					}
+				}, log);
+
+			});
+		}
+		return tracker;
+	}
+
+	@Deactivate
+	void shutdown() {
+		createdObjects.values().forEach(IExtensionTracker::close);
+		createdObjects.clear();
+	}
+
+	@Override
+	public void handleEvent(Event event) {
+		Object property = event.getProperty(IEclipseContext.PROPERTY_CONTEXT);
+		if (property instanceof IEclipseContext) {
+			createdObjects.computeIfPresent((IEclipseContext) property, (k, v) -> {
+				v.close();
+				return null;
+			});
+		}
+	}
+
+}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/Workbench.java
@@ -220,7 +220,6 @@ import org.eclipse.ui.internal.model.ContributionService;
 import org.eclipse.ui.internal.progress.ProgressManager;
 import org.eclipse.ui.internal.progress.ProgressManagerUtil;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
-import org.eclipse.ui.internal.registry.UIExtensionTracker;
 import org.eclipse.ui.internal.registry.ViewDescriptor;
 import org.eclipse.ui.internal.services.EvaluationService;
 import org.eclipse.ui.internal.services.IServiceLocatorCreator;
@@ -2051,16 +2050,6 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 	}
 
 	private void initializeLazyServices() {
-		e4Context.set(IExtensionTracker.class.getName(), new ContextFunction() {
-
-			@Override
-			public Object compute(IEclipseContext context, String contextKey) {
-				if (tracker == null) {
-					tracker = new UIExtensionTracker(getDisplay());
-				}
-				return tracker;
-			}
-		});
 		e4Context.set(IWorkbenchActivitySupport.class.getName(), new ContextFunction() {
 
 			@Override
@@ -2980,9 +2969,6 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 		WorkbenchThemeManager.getInstance().dispose();
 		PropertyPageContributorManager.getManager().dispose();
 		ObjectActionContributorManager.getManager().dispose();
-		if (tracker != null) {
-			tracker.close();
-		}
 		statusManager.unregister();
 	}
 
@@ -3204,8 +3190,6 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 	 * <code>null</code> if none.
 	 */
 	private IntroDescriptor introDescriptor;
-
-	private IExtensionTracker tracker;
 
 	private IRegistryChangeListener startupRegistryListener = event -> {
 		final IExtensionDelta[] deltas = event.getExtensionDeltas(PlatformUI.PLUGIN_ID,

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchPage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchPage.java
@@ -68,6 +68,7 @@ import org.eclipse.e4.core.services.events.IEventBroker;
 import org.eclipse.e4.ui.di.UIEventTopic;
 import org.eclipse.e4.ui.internal.workbench.ModelServiceImpl;
 import org.eclipse.e4.ui.internal.workbench.PartServiceImpl;
+import org.eclipse.e4.ui.internal.workbench.UIExtensionTracker;
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.descriptor.basic.MPartDescriptor;
 import org.eclipse.e4.ui.model.application.ui.MElementContainer;
@@ -176,7 +177,6 @@ import org.eclipse.ui.internal.registry.IActionSetDescriptor;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
 import org.eclipse.ui.internal.registry.PerspectiveDescriptor;
 import org.eclipse.ui.internal.registry.PerspectiveRegistry;
-import org.eclipse.ui.internal.registry.UIExtensionTracker;
 import org.eclipse.ui.internal.registry.ViewDescriptor;
 import org.eclipse.ui.internal.tweaklets.TabBehaviour;
 import org.eclipse.ui.internal.tweaklets.Tweaklets;
@@ -1803,7 +1803,10 @@ public class WorkbenchPage implements IWorkbenchPage {
 		selectionHandler = null;
 		selectionService = null;
 		sortedPerspectives.clear();
-		tracker = null;
+		if (tracker != null) {
+			tracker.close();
+			tracker = null;
+		}
 		widgetHandler = null;
 //		window = null;
 		workingSet = null;
@@ -4474,7 +4477,8 @@ public class WorkbenchPage implements IWorkbenchPage {
 	@Override
 	public IExtensionTracker getExtensionTracker() {
 		if (tracker == null) {
-			tracker = new UIExtensionTracker(getWorkbenchWindow().getWorkbench().getDisplay());
+			tracker = new UIExtensionTracker(getWorkbenchWindow().getWorkbench().getDisplay()::asyncExec,
+					WorkbenchPlugin.getDefault().getLog());
 		}
 		return tracker;
 	}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchWindow.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchWindow.java
@@ -63,6 +63,7 @@ import org.eclipse.e4.core.services.log.Logger;
 import org.eclipse.e4.ui.di.UIEventTopic;
 import org.eclipse.e4.ui.internal.workbench.E4Workbench;
 import org.eclipse.e4.ui.internal.workbench.PartServiceSaveHandler;
+import org.eclipse.e4.ui.internal.workbench.UIExtensionTracker;
 import org.eclipse.e4.ui.internal.workbench.URIHelper;
 import org.eclipse.e4.ui.internal.workbench.renderers.swt.IUpdateService;
 import org.eclipse.e4.ui.model.application.MApplication;
@@ -186,7 +187,6 @@ import org.eclipse.ui.internal.progress.ProgressRegion;
 import org.eclipse.ui.internal.provisional.application.IActionBarConfigurer2;
 import org.eclipse.ui.internal.registry.IActionSetDescriptor;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
-import org.eclipse.ui.internal.registry.UIExtensionTracker;
 import org.eclipse.ui.internal.services.EvaluationReference;
 import org.eclipse.ui.internal.services.IServiceLocatorCreator;
 import org.eclipse.ui.internal.services.IWorkbenchLocationService;
@@ -494,7 +494,8 @@ public class WorkbenchWindow implements IWorkbenchWindow {
 				@Override
 				public Object compute(IEclipseContext context, String contextKey) {
 					if (tracker == null) {
-						tracker = new UIExtensionTracker(getWorkbench().getDisplay());
+						tracker = new UIExtensionTracker(getWorkbench().getDisplay()::asyncExec,
+								WorkbenchPlugin.getDefault().getLog());
 					}
 					return tracker;
 				}


### PR DESCRIPTION
Currently the IExtensionTracker service is only accessible in E3/LegacyWorkbench. As IExtensionTracker has no dependency to the old Workbench and could use the E4 UISyncronize instead of a display this could be extracted to be generally available in E4.

As I'd like to make P2 more E4 aware and some code seems to rely on this... WDYT @vogella? This also clean up some locations where one created/managed some own instance of the UIExtensionTracker ...