### PR TITLE
Make E4 more accessible in org.eclipse.ui to ease migrations

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/PlatformUI.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/PlatformUI.java
@@ -14,8 +14,12 @@
  *******************************************************************************/
 package org.eclipse.ui;
 
+import java.util.Optional;
+import java.util.function.Supplier;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.internal.workbench.swt.DialogSettingsProviderService;
+import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.jface.dialogs.IDialogSettingsProvider;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.widgets.Display;
@@ -27,7 +31,9 @@ import org.eclipse.ui.internal.util.PrefUtil;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
 import org.eclipse.ui.testing.TestableObject;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
 
 /**
  * The central class for access to the Eclipse Platform User Interface. This
@@ -83,6 +89,15 @@ public final class PlatformUI {
 	 * @since 3.0
 	 */
 	public static final int RETURN_EMERGENCY_CLOSE = 3;
+
+	/**
+	 * A supplier that supplies an {@link IllegalStateException} that a Workbench is
+	 * not running.
+	 *
+	 * @since 3.126
+	 */
+	public static final Supplier<RuntimeException> NO_WORKBENCH = () -> new IllegalStateException(
+			WorkbenchMessages.PlatformUI_NoWorkbench);
 
 	/**
 	 * Block instantiation.
@@ -232,5 +247,63 @@ public final class PlatformUI {
 	 */
 	public static IPreferenceStore createPreferenceStore(Class<?> clazz) {
 		return new ScopedPreferenceStore(InstanceScope.INSTANCE, FrameworkUtil.getBundle(clazz).getSymbolicName());
+	}
+
+	/**
+	 * This methods allows code of eclipse.ui to gracefully migrate to E4 as it has
+	 * the following properties:
+	 *
+	 * <ol>
+	 * <li>It does not throw an exception but returns an empty optional if something
+	 * is not ready (yet or anymore) so code can choose how to handle this (e.g. use
+	 * {@link Optional#orElseThrow()} if required or {@link Optional#orElse(Object)}
+	 * if a fallback exits.</li>
+	 * <li>If this is is actually a (ui) Workbench running, this is returned and
+	 * could be used</li>
+	 * <li>If not the service registry is searched for an
+	 * org.eclipse.e4.ui.workbench.IWorkbench so code can run inside a pure E4 (e.g.
+	 * RCP) application as well.</li>
+	 * <li>With the Application at hand, it is possible to get access to the
+	 * {@link IEclipseContext} (see {@link MApplication#getContext()} to further
+	 * interact with the plain E4 Application Model.</li>
+	 * </ol>
+	 *
+	 * The following example fails if run inside an E4 Application: <code>
+	 *  PlatformUI.getWorkbench().getExtensionTracker()
+	 *  </code> and could be rewritten as: <code>
+	 *  PlatformUI.getApplication().map(MApplication::getContext).map(ctx->ctx.get(IExtensionTracker)).orElseThrow(PlatformUI.NO_WORKBENCH);
+	 *  </code>
+	 *
+	 * @return a reference to the {@link MApplication} running the Workbench or an
+	 *         empty optional if currently no Workbench is available.
+	 * @since 3.126
+	 */
+	public static Optional<MApplication> getApplication() {
+
+		Workbench instance = Workbench.getInstance();
+		if (instance != null && instance.isRunning()) {
+			return Optional.of((instance.getApplication()));
+		}
+		WorkbenchPlugin plugin = WorkbenchPlugin.getDefault();
+		if (plugin == null) {
+			return Optional.empty();
+		}
+		// We intentionally do not use a tracker here to not bind it to much to the
+		// service in case E4 is used
+		BundleContext bundleContext = plugin.getBundleContext();
+		if (bundleContext == null) {
+			return Optional.empty();
+		}
+		ServiceReference<org.eclipse.e4.ui.workbench.IWorkbench> reference = bundleContext
+				.getServiceReference(org.eclipse.e4.ui.workbench.IWorkbench.class);
+		if (reference == null) {
+			return Optional.empty();
+		}
+		org.eclipse.e4.ui.workbench.IWorkbench service = bundleContext.getService(reference);
+		if (service == null) {
+			return Optional.empty();
+		}
+		bundleContext.ungetService(reference);
+		return Optional.ofNullable(service.getApplication());
 	}
 }

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/ObjectContributorManager.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/ObjectContributorManager.java
@@ -34,6 +34,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.dynamichelpers.ExtensionTracker;
 import org.eclipse.core.runtime.dynamichelpers.IExtensionChangeHandler;
 import org.eclipse.core.runtime.dynamichelpers.IExtensionTracker;
+import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.PlatformUI;
 
@@ -112,8 +113,9 @@ public abstract class ObjectContributorManager implements IExtensionChangeHandle
 		if (extensionPointId != null) {
 			IExtensionPoint extensionPoint = Platform.getExtensionRegistry().getExtensionPoint(PlatformUI.PLUGIN_ID,
 					extensionPointId);
-			IExtensionTracker tracker = PlatformUI.getWorkbench().getExtensionTracker();
-			tracker.registerHandler(this, ExtensionTracker.createExtensionPointFilter(extensionPoint));
+			PlatformUI.getApplication().map(MApplication::getContext).map(ctx -> ctx.get(IExtensionTracker.class))
+					.orElseThrow(PlatformUI.NO_WORKBENCH)
+					.registerHandler(this, ExtensionTracker.createExtensionPointFilter(extensionPoint));
 		}
 	}
 
@@ -325,7 +327,9 @@ public abstract class ObjectContributorManager implements IExtensionChangeHandle
 		if (element != null) {
 			ContributorRecord contributorRecord = new ContributorRecord(contributor, targetType);
 			contributorRecordSet.add(contributorRecord);
-			PlatformUI.getWorkbench().getExtensionTracker().registerObject(element.getDeclaringExtension(),
+			PlatformUI.getApplication().map(MApplication::getContext).map(ctx -> ctx.get(IExtensionTracker.class))
+					.orElseThrow(PlatformUI.NO_WORKBENCH)
+					.registerObject(element.getDeclaringExtension(),
 					contributorRecord, IExtensionTracker.REF_WEAK);
 		}
 	}

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.125.200.qualifier
+Bundle-Version: 3.126.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Currently it is very hard to migrate parts of the code, there is only
all or nothing and migration feels stuck for years now.

One culprit is the exhaustive use of PlatformUI.getWorkBench() and the
inability for code to easily "join" the E4 ecosystem without major
rewrites.

This change proposes a new API in PlatformUI that allows a migration
path from old Workbench API to E4 without creating an immediate
requirement to refactor all components. As an example
ObjectContributorManager is refactored to use the new API so it could
access the IExtensionTracker in both worlds.

### Disclaimer

Yes **it adds new API,** please still consider this so we can finally get some more spin on E4 migration :-)