### PR TITLE
Add preference combo to change severity of 'missing project encoding'

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
@@ -26,6 +26,7 @@
  * Lucas Bullen (Red Hat Inc.) - Bug 522096
  * Gunnar Wagenknecht - [102527] Project Natures property page
  * Mickael Istria (Red Hat Inc) - [102527] Project Natures property page
+ * Ingo Mohr <tellastory73@gmail.com> - Issue #198
  *******************************************************************************/
 package org.eclipse.ui.internal.ide;
 
@@ -573,6 +574,8 @@ public class IDEWorkbenchMessages extends NLS {
 	public static String IDEWorkbenchPreference_workbenchSystemExplorer;
 	public static String IDEWorkspacePreference_UnknownNatureSeverity;
 	public static String IDEWorkspacePreference_UnknownNatureSeverity_Ignore;
+	public static String IDEWorkspacePreference_UnknownEncodingSeverity;
+	public static String IDEWorkspacePreference_UnknownEncodingSeverity_Ignore;
 
 	// --- Linked Resources ---
 	public static String LinkedResourcesPreference_explanation;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/IDEWorkspacePreferencePage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/IDEWorkspacePreferencePage.java
@@ -17,12 +17,14 @@
 *     Christian Georgi (SAP SE)          -  bug 458811
 *     Mickael Istria (Red Hat Inc.) - Bug 486901
 *     Patrik Suzzi <psuzzi@gmail.com> - Bug 502050
+*     Ingo Mohr <tellastory73@gmail.com> - Issue #198
 *******************************************************************************/
 package org.eclipse.ui.internal.ide.dialogs;
 
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.eclipse.core.internal.resources.ValidateProjectEncoding;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -109,6 +111,7 @@ public class IDEWorkspacePreferencePage extends PreferencePage implements IWorkb
 	private StringFieldEditor systemExplorer;
 
 	private ComboFieldEditor missingNatureSeverityCombo;
+	private ComboFieldEditor missingEncodingSeverityCombo;
 
 	private boolean showLocationIsSetOnCommandLine;
 
@@ -140,6 +143,7 @@ public class IDEWorkspacePreferencePage extends PreferencePage implements IWorkb
 		comboParent.setLayout(new GridLayout(2, false));
 		createOpenPrefControls(comboParent);
 		createMissingNaturePref(comboParent);
+		createMissingEncodingPref(comboParent);
 
 		createSpace(composite);
 		createSystemExplorerGroup(composite);
@@ -195,6 +199,23 @@ public class IDEWorkspacePreferencePage extends PreferencePage implements IWorkb
 				.setPreferenceStore(new ScopedPreferenceStore(InstanceScope.INSTANCE, ResourcesPlugin.PI_RESOURCES));
 		missingNatureSeverityCombo.setPage(this);
 		missingNatureSeverityCombo.load();
+	}
+
+	@SuppressWarnings("restriction")
+	private void createMissingEncodingPref(Composite parent) {
+		missingEncodingSeverityCombo = new ComboFieldEditorInGrid(ResourcesPlugin.PREF_MISSING_ENCODING_MARKER_SEVERITY,
+				IDEWorkbenchMessages.IDEWorkspacePreference_UnknownEncodingSeverity,
+				new String[][] {
+						{ IDEWorkbenchMessages.IDEWorkspacePreference_UnknownEncodingSeverity_Ignore,
+								Integer.toString(ValidateProjectEncoding.SEVERITY_IGNORE) },
+						{ MarkerMessages.propertiesDialog_infoLabel, Integer.toString(IMarker.SEVERITY_INFO) },
+						{ MarkerMessages.propertiesDialog_warningLabel, Integer.toString(IMarker.SEVERITY_WARNING) },
+						{ MarkerMessages.propertiesDialog_errorLabel, Integer.toString(IMarker.SEVERITY_ERROR) }, },
+				parent);
+		missingEncodingSeverityCombo
+				.setPreferenceStore(new ScopedPreferenceStore(InstanceScope.INSTANCE, ResourcesPlugin.PI_RESOURCES));
+		missingEncodingSeverityCombo.setPage(this);
+		missingEncodingSeverityCombo.load();
 	}
 
 	/**
@@ -544,6 +565,7 @@ public class IDEWorkspacePreferencePage extends PreferencePage implements IWorkb
 		lineSeparatorEditor.loadDefault();
 		openReferencesEditor.loadDefault();
 		missingNatureSeverityCombo.loadDefault();
+		missingEncodingSeverityCombo.loadDefault();
 
 		systemExplorer.loadDefault();
 
@@ -608,6 +630,7 @@ public class IDEWorkspacePreferencePage extends PreferencePage implements IWorkb
 		lineSeparatorEditor.store();
 		openReferencesEditor.store();
 		missingNatureSeverityCombo.store();
+		missingEncodingSeverityCombo.store();
 
 		return super.performOk();
 	}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
@@ -35,6 +35,7 @@
 #     Axel Richard <axel.richard@obeo.fr> - Bug 486644
 #     Lucas Bullen (Red Hat Inc.) - Bug 522096
 #     Gunnar Wagenknecht - Bug 102527 Project Natures property page
+#     Ingo Mohr <tellastory73@gmail.com> - Issue #198
 ###############################################################################
 
 # package: org.eclipse.ui.ide
@@ -550,6 +551,8 @@ IDEWorkspacePreference_workspaceName=Wor&kspace name:
 IDEWorkbenchPreference_workbenchSystemExplorer=Command for launching system e&xplorer:
 IDEWorkspacePreference_UnknownNatureSeverity=Report unknown project n&ature as:
 IDEWorkspacePreference_UnknownNatureSeverity_Ignore=Ignore
+IDEWorkspacePreference_UnknownEncodingSeverity=Report missing project en&coding as:
+IDEWorkspacePreference_UnknownEncodingSeverity_Ignore=Ignore
 
 # --- Linked Resources ---
 LinkedResourcesPreference_explanation = Path variables specify locations in the file system. The locations of linked resources\nmay be specified relative to these path variables.

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
@@ -551,7 +551,7 @@ IDEWorkspacePreference_workspaceName=Wor&kspace name:
 IDEWorkbenchPreference_workbenchSystemExplorer=Command for launching system e&xplorer:
 IDEWorkspacePreference_UnknownNatureSeverity=Report unknown project n&ature as:
 IDEWorkspacePreference_UnknownNatureSeverity_Ignore=Ignore
-IDEWorkspacePreference_UnknownEncodingSeverity=Report missing project en&coding as:
+IDEWorkspacePreference_UnknownEncodingSeverity=Rep&ort missing project encoding as:
 IDEWorkspacePreference_UnknownEncodingSeverity_Ignore=Ignore
 
 # --- Linked Resources ---


### PR DESCRIPTION
This introduces a new combo-box entry to the "Workspace" preference page
to modify the severity used for the check for "missing project-specific
encoding".
See issue #198.