### PR TITLE
Decoration is not a question

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
@@ -493,7 +493,7 @@ OpenPerspectiveDialogAction_tooltip=Open Perspective
 PreferencePage_noDescription = (No description available)
 PreferencePageParameterValues_pageLabelSeparator = \ >\ 
 ThemingEnabled = E&nable theming
-ThemeChangeWarningText = Restart for the theme changes to take full effect?
+ThemeChangeWarningText = Restart for the theme changes to take full effect
 ThemeChangeWarningTitle = Theme Changed 
 # --- Workbench -----
 WorkbenchPreference_openMode=Open mode


### PR DESCRIPTION
This decoration when changing a theme is prompted as a question, even though it isn't. It is a warning to tell the user to restart for the theme change to take full effect. They are prompted with a question when pressing "Apply".