### PR TITLE
Workbench should not init various manages on shutdown (#240)

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/ObjectActionContributorManager.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/ObjectActionContributorManager.java
@@ -113,11 +113,20 @@ public class ObjectActionContributorManager extends ObjectContributorManager {
 	 *
 	 * @return the shared instance of this manager
 	 */
-	public static ObjectActionContributorManager getManager() {
+	public static synchronized ObjectActionContributorManager getManager() {
 		if (sharedInstance == null) {
 			sharedInstance = new ObjectActionContributorManager();
 		}
 		return sharedInstance;
+	}
+
+	/**
+	 * Disposes instance if it was created
+	 */
+	public static synchronized void disposeManager() {
+		if (sharedInstance != null) {
+			sharedInstance.dispose();
+		}
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/Workbench.java
@@ -2966,9 +2966,9 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 		if (WorkbenchPlugin.getDefault() != null) {
 			WorkbenchPlugin.getDefault().reset();
 		}
-		WorkbenchThemeManager.getInstance().dispose();
-		PropertyPageContributorManager.getManager().dispose();
-		ObjectActionContributorManager.getManager().dispose();
+		WorkbenchThemeManager.disposeManager();
+		PropertyPageContributorManager.disposeManager();
+		ObjectActionContributorManager.disposeManager();
 		statusManager.unregister();
 	}
 

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/PropertyPageContributorManager.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/PropertyPageContributorManager.java
@@ -180,11 +180,20 @@ public class PropertyPageContributorManager extends ObjectContributorManager {
 	 *
 	 * @return PropertyPageContributorManager
 	 */
-	public static PropertyPageContributorManager getManager() {
+	public static synchronized PropertyPageContributorManager getManager() {
 		if (sharedInstance == null) {
 			sharedInstance = new PropertyPageContributorManager();
 		}
 		return sharedInstance;
+	}
+
+	/**
+	 * Disposes instance if it was created
+	 */
+	public static synchronized void disposeManager() {
+		if (sharedInstance != null) {
+			sharedInstance.dispose();
+		}
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/themes/WorkbenchThemeManager.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/themes/WorkbenchThemeManager.java
@@ -84,6 +84,15 @@ public class WorkbenchThemeManager extends EventManager implements IThemeManager
 		return instance;
 	}
 
+	/**
+	 * Disposes instance if it was created
+	 */
+	public static synchronized void disposeManager() {
+		if (instance != null) {
+			instance.dispose();
+		}
+	}
+
 	private ITheme currentTheme;
 
 	private IPropertyChangeListener currentThemeListener = event -> {


### PR DESCRIPTION
- fixed init of managers on shutdown if they were not initialized before
- fixed getInstance() not being properly synchronized

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/240