### PR TITLE
Fix Progress Bar to show progress instead of indeterminate Animation.

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/ProgressIndicator.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/ProgressIndicator.java
@@ -79,6 +79,10 @@ public class ProgressIndicator extends Composite {
 	 * Initialize the progress bar to be animated.
 	 */
 	public void beginAnimatedTask() {
+		if (animated && layout.topControl == indeterminateProgressBar) {
+			// do not restart animation if it was already started
+			return;
+		}
 		done();
 		layout.topControl = indeterminateProgressBar;
 		requestLayout();


### PR DESCRIPTION
The average progress of all non-system Jobs is shown every 100ms.
Note that the Text left to it shows progress of top job in the Progress
View only.
