### PR TITLE
MessageDialog should support AUTOMATED_MODE (#255)

### DIFF
--- a/bundles/org.eclipse.jface/.settings/.api_filters
+++ b/bundles/org.eclipse.jface/.settings/.api_filters
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.jface" version="2">
+    <resource path="META-INF/MANIFEST.MF">
+        <filter comment="Added MessageDialog.AUTOMATED_MODE" id="926941240">
+            <message_arguments>
+                <message_argument value="3.27.0"/>
+                <message_argument value="3.26.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/jface/dialogs/MessageDialog.java" type="org.eclipse.jface.dialogs.MessageDialog">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.dialogs.MessageDialog"/>
+                <message_argument value="AUTOMATED_MODE"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.26.100.qualifier
+Bundle-Version: 3.27.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/MessageDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/MessageDialog.java
@@ -14,6 +14,9 @@
  *******************************************************************************/
 package org.eclipse.jface.dialogs;
 
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.util.Policy;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.graphics.Image;
@@ -38,6 +41,14 @@ import org.eclipse.swt.widgets.Shell;
  * </p>
  */
 public class MessageDialog extends IconAndMessageDialog {
+
+	/**
+	 * Flag to prevent opening of message dialogs for automated testing.
+	 *
+	 * @since 3.27
+	 */
+	public static boolean AUTOMATED_MODE = false;
+
 	/**
 	 * Constant for no image (value 0).
 	 *
@@ -590,5 +601,17 @@ public class MessageDialog extends IconAndMessageDialog {
 			throw new NullPointerException("The array of button labels cannot be null."); //$NON-NLS-1$
 		}
 		this.buttonLabels = buttonLabels;
+	}
+
+	@Override
+	public int open() {
+		if (!AUTOMATED_MODE) {
+			return super.open();
+		}
+		IllegalStateException e = new IllegalStateException("Message dialog is supposed to be shown now"); //$NON-NLS-1$
+		IStatus ms = Status.warning(title + " : " + message, e); //$NON-NLS-1$
+		Policy.getLog().log(ms);
+		setReturnCode(OK);
+		return OK;
 	}
 }


### PR DESCRIPTION
The test can now set MessageDialog.AUTOMATED_MODE so
MessageDialog.open() and handle that similar how ErrorDialog.open()
it does (log warning to the log with the dialog title/message/stack
trace and return "OK").

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/255