### PR TITLE
Bug 578859 - [MinMaxAddon] NPE on maximize with sub Area

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.addons.swt;singleton:=true
-Bundle-Version: 1.4.400.qualifier
+Bundle-Version: 1.4.500.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/minmax/MinMaxAddon.java
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/minmax/MinMaxAddon.java
@@ -166,7 +166,8 @@ public class MinMaxAddon {
 			}
 
 			MUIElement parentElement = element.getParent();
-			while (parentElement != null && !(parentElement instanceof MArea)) {
+			while (parentElement != null
+					&& (!(parentElement instanceof MArea) || parentElement.getCurSharedRef() == null)) {
 				parentElement = parentElement.getParent();
 			}
 


### PR DESCRIPTION
MinMaxAddon checks now if the found Area has a SharedRef, if this is not the case it searches for the next higher Area.
Eclipse Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=578859

How to test:
Create inside the Editorss Area a Composite Part containing an Area which contains multiple parts (see bug ticket for example). Double click one of the child parts, the editorss area should now be maximized.