### PR TITLE
Adds forRemoval to deprecation annotation for NumberToStringConverter

### DIFF
--- a/bundles/org.eclipse.core.databinding/src/org/eclipse/core/databinding/conversion/NumberToStringConverter.java
+++ b/bundles/org.eclipse.core.databinding/src/org/eclipse/core/databinding/conversion/NumberToStringConverter.java
@@ -35,9 +35,9 @@ import com.ibm.icu.text.NumberFormat;
  * @deprecated Use
  *             {@link org.eclipse.core.databinding.conversion.text.NumberToStringConverter}
  *             instead, which does not use {@code com.ibm.icu} as that package
- *             may be removed in the future from platform.
+ *             is planned to be removed.
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class NumberToStringConverter extends AbstractNumberToStringConverter {
 	private NumberToStringConverter(Format numberFormat, Class<?> fromType) {
 		super(numberFormat, fromType);


### PR DESCRIPTION
This class is planned to be removal and we should also use the
@Deprecated(forRemoval = true) information for such classes.

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/262.
Also see https://github.com/eclipse-platform/.github/issues/22 which
suggests to use the code directly for removal information instead of an
external document.