### PR TITLE
Add system property to override inheritance of OS dark theme. #185

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt.theme/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.css.swt.theme;singleton:=true
-Bundle-Version: 0.13.100.qualifier
+Bundle-Version: 0.13.101.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.css.swt.theme/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.css.swt.theme;singleton:=true
-Bundle-Version: 0.13.101.qualifier
+Bundle-Version: 0.13.200.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/ThemeEngine.java
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/ThemeEngine.java
@@ -87,6 +87,8 @@ public class ThemeEngine implements IThemeEngine {
 
 	public static final String E4_DARK_THEME_ID = "org.eclipse.e4.ui.css.theme.e4_dark";
 
+	public static final String DISABLE_OS_DARK_THEME_INHERIT = "org.eclipse.e4.ui.css.theme.disableOSDarkThemeInherit";
+
 	public ThemeEngine(Display display) {
 		this.display = display;
 
@@ -612,11 +614,12 @@ public class ThemeEngine implements IThemeEngine {
 		/*
 		 * Any Platform: if the system has Dark appearance set and Eclipse is using the
 		 * default settings, then start Eclipse in Dark theme. Check that there is a
-		 * dark theme present.
+		 * dark theme present. Can be disabled using a system property.
 		 */
 		boolean hasDarkTheme = getThemes().stream().anyMatch(t -> t.getId().startsWith(E4_DARK_THEME_ID));
 		String themeToRestore = Display.isSystemDarkTheme() && hasDarkTheme ? E4_DARK_THEME_ID : alternateTheme;
-		if (themeToRestore != null && flag) {
+		boolean disableOSDarkThemeInherit = "true".equalsIgnoreCase(System.getProperty(DISABLE_OS_DARK_THEME_INHERIT));
+		if (themeToRestore != null && flag && !disableOSDarkThemeInherit) {
 			setTheme(themeToRestore, false);
 		}
 	}

--- a/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/ThemeEngine.java
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/ThemeEngine.java
@@ -617,9 +617,10 @@ public class ThemeEngine implements IThemeEngine {
 		 * dark theme present. Can be disabled using a system property.
 		 */
 		boolean hasDarkTheme = getThemes().stream().anyMatch(t -> t.getId().startsWith(E4_DARK_THEME_ID));
-		String themeToRestore = Display.isSystemDarkTheme() && hasDarkTheme ? E4_DARK_THEME_ID : alternateTheme;
 		boolean disableOSDarkThemeInherit = "true".equalsIgnoreCase(System.getProperty(DISABLE_OS_DARK_THEME_INHERIT));
-		if (themeToRestore != null && flag && !disableOSDarkThemeInherit) {
+		boolean overrideWithDarkTheme = Display.isSystemDarkTheme() && hasDarkTheme && !disableOSDarkThemeInherit;
+		String themeToRestore = overrideWithDarkTheme ? E4_DARK_THEME_ID : alternateTheme;
+		if (themeToRestore != null && flag) {
 			setTheme(themeToRestore, false);
 		}
 	}


### PR DESCRIPTION
- Still enabled by default, for backward compatibility.
- To disable, set the new property: `org.eclipse.e4.ui.css.theme.disableOSDarkThemeInherit=true`