### PR TITLE
Ctrl+E: Prepend parent directories for file name collisions

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/FilteredTableBaseHandler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/FilteredTableBaseHandler.java
@@ -302,16 +302,24 @@ public abstract class FilteredTableBaseHandler extends AbstractHandler implement
 			addKeyListener(table, dialog);
 			addTraverseListener(table);
 
-			while (!dialog.isDisposed()) {
-				if (!display.readAndDispatch()) {
-					display.sleep();
-				}
-			}
+			keepOpen(display, dialog);
 		} finally {
 			if (!dialog.isDisposed()) {
 				cancel(dialog);
 			}
 			contextService.unregisterShell(dialog);
+		}
+	}
+
+	/**
+	 * Intended to be overwritten by test classes so the handler won't block the UI
+	 * thread
+	 */
+	protected void keepOpen(Display display, Shell dialog) {
+		while (!dialog.isDisposed()) {
+			if (!display.readAndDispatch()) {
+				display.sleep();
+			}
 		}
 	}
 

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbookEditorsHandler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbookEditorsHandler.java
@@ -77,6 +77,11 @@ public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 	 */
 	private static final String TAG_ACTIVE = "active"; //$NON-NLS-1$
 
+	/**
+	 * Prefix used to mark Editors that are dirty (unsaved changes).
+	 */
+	private static final String DIRTY_PREFIX = "*"; //$NON-NLS-1$
+
 	private SearchPattern searchPattern;
 
 	private Map<EditorReference, String> editorReferenceColumnLabelTexts;
@@ -248,7 +253,7 @@ public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 	 */
 	private String prependDirtyIndicationIfDirty(EditorReference editorReference, String labelText) {
 		if (editorReference.isDirty()) {
-			return "*" + labelText; //$NON-NLS-1$
+			return DIRTY_PREFIX + labelText;
 		}
 		return labelText;
 	}
@@ -398,18 +403,27 @@ public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 				if (matcher == null || !(viewer instanceof TableViewer)) {
 					return true;
 				}
-				String matchName = null;
+				String editorTitle = null;
+				String editorLabel = null;
 				if (element instanceof EditorReference) {
-					matchName = ((EditorReference) element).getTitle();
-					// skips dirty editor prefix
-					if (matchName.startsWith("*")) { //$NON-NLS-1$
-						matchName = matchName.substring(1);
-					}
+					editorTitle = removeDirtyPrefix(((EditorReference) element).getTitle());
+					editorLabel = removeDirtyPrefix(editorReferenceColumnLabelTexts.get(element));
 				}
+				return (editorTitle != null && matcher.matches(editorTitle))
+						|| (editorLabel != null && matcher.matches(editorLabel));
+			}
+
+			/**
+			 * Removes the dirty prefix if the input is not null and starts with the dirty
+			 * prefix. Otherwise returns the input unchanged.
+			 */
+			private String removeDirtyPrefix(String matchName) {
 				if (matchName == null) {
-					return false;
+					return null;
+				} else if (matchName.startsWith(DIRTY_PREFIX)) {
+					return matchName.substring(1);
 				}
-				return matcher.matches(matchName);
+				return matchName;
 			}
 		};
 	}

--- a/tests/org.eclipse.ui.tests.harness/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.harness/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Harness Plug-in
 Bundle-SymbolicName: org.eclipse.ui.tests.harness;singleton:=true
-Bundle-Version: 1.8.300.qualifier
+Bundle-Version: 1.9.0.qualifier
 Eclipse-BundleShape: dir
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/FileUtil.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/FileUtil.java
@@ -16,13 +16,16 @@ package org.eclipse.ui.tests.harness.util;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
 
 /**
  * <code>FileUtil</code> contains methods to create and
@@ -58,6 +61,34 @@ public class FileUtil {
 		proj.delete(true, null);
 	}
 
+    /**
+	 * Creates a folder and all parent folders if not existing. Project must exist.
+	 * <code> org.eclipse.ui.dialogs.ContainerGenerator</code> is too heavy (creates
+	 * a runnable)<br/>
+	 * <br/>
+	 * This method was copied from
+	 * {@link org.eclipse.jdt.internal.ui.util.CoreUtility#createFolder(IFolder, boolean, boolean, IProgressMonitor)
+	 * CoreUtility#createFolder}.
+	 *
+	 * @param folder  the folder to create
+	 * @param force   a flag controlling how to deal with resources that are not in
+	 *                sync with the local file system
+	 * @param local   a flag controlling whether or not the folder will be local
+	 *                after the creation
+	 * @param monitor the progress monitor
+	 * @throws CoreException thrown if the creation failed
+	 */
+	public static void createFolder(IFolder folder, boolean force, boolean local, IProgressMonitor monitor)
+			throws CoreException {
+		if (!folder.exists()) {
+			IContainer parent = folder.getParent();
+			if (parent instanceof IFolder) {
+				createFolder((IFolder) parent, force, local, null);
+			}
+			folder.create(force, local, monitor);
+		}
+	}
+
 	/**
 	 * Creates a new file in a project.
 	 *
@@ -65,8 +96,7 @@ public class FileUtil {
 	 * @param proj the existing project
 	 * @return the new file
 	 */
-	public static IFile createFile(String name, IProject proj)
-			throws CoreException {
+	public static IFile createFile(String name, IProject proj) throws CoreException {
 		IFile file = proj.getFile(name);
 		if (!file.exists()) {
 			String str = " ";

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/InternalTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/InternalTestSuite.java
@@ -63,5 +63,6 @@ import org.junit.runners.Suite;
 	Bug540297WorkbenchPageFindViewTest.class,
 	Bug549139Test.class,
 	LargeFileLimitsPreferenceHandlerTest.class,
+	WorkbookEditorsHandlerTest.class,
 })
 public class InternalTestSuite {}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
@@ -1,0 +1,237 @@
+package org.eclipse.ui.tests.internal;
+
+import static java.util.stream.Collectors.toList;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.core.commands.Command;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableItem;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.commands.ICommandService;
+import org.eclipse.ui.handlers.IHandlerService;
+import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.internal.WorkbookEditorsHandler;
+import org.eclipse.ui.tests.harness.util.FileUtil;
+import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.Test;
+
+/**
+ * @since 3.5
+ *
+ */
+public class WorkbookEditorsHandlerTest extends UITestCase {
+
+
+	public WorkbookEditorsHandlerTest(String testName) {
+		super(testName);
+	}
+
+	private static final String PROJECT_NAME = "WorkbookEditorsHandlerTest";
+	private static final String PROJECT_NAME_1 = PROJECT_NAME + 1;
+	private static final String PROJECT_NAME_2 = PROJECT_NAME + 2;
+	private IWorkbenchWindow activeWindow;
+	private IWorkbenchPage activePage;
+	private IProject project1;
+	private IProject project2;
+
+	@Override
+	public void doSetUp() throws CoreException {
+		activeWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		activePage = activeWindow.getActivePage();
+		project1 = FileUtil.createProject(PROJECT_NAME_1);
+		project2 = FileUtil.createProject(PROJECT_NAME_2);
+	}
+
+	@Override
+	public void doTearDown() throws Exception {
+		if (project1 != null) {
+			project1.delete(true, true, null);
+			project1 = null;
+		}
+		if (project2 != null) {
+			project2.delete(true, true, null);
+			project2 = null;
+		}
+		activePage.closeAllEditors(false);
+	}
+
+	@Test
+	public void testSingleFile() throws Exception {
+		String fileName = "example.txt";
+		IDE.openEditor(activePage, FileUtil.createFile(fileName, project1), true);
+		ICommandService cmdService = PlatformUI.getWorkbench().getService(ICommandService.class);
+		final Command cmd = cmdService.getCommand("org.eclipse.ui.window.openEditorDropDown");
+		WorkbookEditorsHandlerTestable handler = new WorkbookEditorsHandlerTestable();
+		cmd.setHandler(handler);
+		IHandlerService handlerService = PlatformUI.getWorkbench().getService(IHandlerService.class);
+		final ExecutionEvent event = handlerService.createExecutionEvent(cmd, null);
+
+		handler.execute(event);
+
+		assertEquals("Display text should match file name", fileName, handler.tableItemTexts.get(0));
+		assertEquals("Selection should be on current editor if only one editor is open", fileName,
+				handler.tableItemTexts.get(0));
+	}
+
+	@Test
+	public void testMultipleFilesWithNoNameConflict() throws Exception {
+		String fileName = "example.txt";
+		IDE.openEditor(activePage, FileUtil.createFile(fileName, project1), true);
+		String fileName2 = "example2.txt";
+		IDE.openEditor(activePage, FileUtil.createFile(fileName2, project1), true);
+		ICommandService cmdService = PlatformUI.getWorkbench().getService(ICommandService.class);
+		final Command cmd = cmdService.getCommand("org.eclipse.ui.window.openEditorDropDown");
+		WorkbookEditorsHandlerTestable handler = new WorkbookEditorsHandlerTestable();
+		cmd.setHandler(handler);
+		IHandlerService handlerService = PlatformUI.getWorkbench().getService(IHandlerService.class);
+		final ExecutionEvent event = handlerService.createExecutionEvent(cmd, null);
+
+		handler.execute(event);
+
+		assertEquals("Display text should match file name", fileName2, handler.tableItemTexts.get(0));
+		assertEquals("Display text should match file name", fileName, handler.tableItemTexts.get(1));
+		assertEquals("Selection should be the editor that was active before the currently active editor", fileName,
+				handler.tableItemTexts.get(1));
+	}
+
+	@Test
+	public void testTwoFilesWithNameClash() throws Exception {
+		String fileName = "example.txt";
+		IDE.openEditor(activePage, FileUtil.createFile(fileName, project1), true);
+		IDE.openEditor(activePage, FileUtil.createFile(fileName, project2), true);
+		ICommandService cmdService = PlatformUI.getWorkbench().getService(ICommandService.class);
+		final Command cmd = cmdService.getCommand("org.eclipse.ui.window.openEditorDropDown");
+		WorkbookEditorsHandlerTestable handler = new WorkbookEditorsHandlerTestable();
+		cmd.setHandler(handler);
+		IHandlerService handlerService = PlatformUI.getWorkbench().getService(IHandlerService.class);
+		final ExecutionEvent event = handlerService.createExecutionEvent(cmd, null);
+
+		handler.execute(event);
+
+		assertEquals("Text should have folder prepended because of name clash",
+				PROJECT_NAME_2 + File.separator + fileName, handler.tableItemTexts.get(0));
+		assertEquals("Text should have folder prepended because of name clash",
+				PROJECT_NAME_1 + File.separator + fileName, handler.tableItemTexts.get(1));
+		assertEquals("Selection should be the editor that was active before the currently active editor",
+				PROJECT_NAME_1 + File.separator + fileName, handler.tableItemTexts.get(1));
+	}
+
+	@Test
+	public void testMultipleFilesWithOneNameClash() throws Exception {
+		String fileName = "example.txt";
+		String otherFileName = "other.txt";
+		IDE.openEditor(activePage, FileUtil.createFile(otherFileName, project1), true);
+		IDE.openEditor(activePage, FileUtil.createFile(fileName, project1), true);
+		IDE.openEditor(activePage, FileUtil.createFile(fileName, project2), true);
+		ICommandService cmdService = PlatformUI.getWorkbench().getService(ICommandService.class);
+		final Command cmd = cmdService.getCommand("org.eclipse.ui.window.openEditorDropDown");
+		WorkbookEditorsHandlerTestable handler = new WorkbookEditorsHandlerTestable();
+		cmd.setHandler(handler);
+		IHandlerService handlerService = PlatformUI.getWorkbench().getService(IHandlerService.class);
+		final ExecutionEvent event = handlerService.createExecutionEvent(cmd, null);
+
+		handler.execute(event);
+
+		assertEquals("Text should have folder prepended because of name clash",
+				PROJECT_NAME_2 + File.separator + fileName, handler.tableItemTexts.get(0));
+		assertEquals("Text should have folder prepended because of name clash",
+				PROJECT_NAME_1 + File.separator + fileName, handler.tableItemTexts.get(1));
+		assertEquals("Display name should equal to file name", otherFileName, handler.tableItemTexts.get(2));
+		assertEquals("Selection should be the editor that was active before the currently active editor",
+				PROJECT_NAME_1 + File.separator + fileName, handler.tableItemTexts.get(1));
+	}
+
+	@Test
+	public void testMultipleFilesWithSharedParentFolders() throws Exception {
+		String fileName = "example.txt";
+		String path1 = "test1/foo/bar/baz/";
+		String path2 = "test2/foo/bar/baz/";
+		FileUtil.createFolder(project1.getFolder(path1), true, false, null);
+		FileUtil.createFolder(project1.getFolder(path2), true, false, null);
+		IDE.openEditor(activePage, FileUtil.createFile(path1 + fileName, project1), true);
+		IDE.openEditor(activePage, FileUtil.createFile(path2 + fileName, project1), true);
+		ICommandService cmdService = PlatformUI.getWorkbench().getService(ICommandService.class);
+		final Command cmd = cmdService.getCommand("org.eclipse.ui.window.openEditorDropDown");
+		WorkbookEditorsHandlerTestable handler = new WorkbookEditorsHandlerTestable();
+		cmd.setHandler(handler);
+		IHandlerService handlerService = PlatformUI.getWorkbench().getService(IHandlerService.class);
+		final ExecutionEvent event = handlerService.createExecutionEvent(cmd, null);
+
+		handler.execute(event);
+
+		assertEquals("Text should have first differing folder prepended", "test2/" + fileName,
+				handler.tableItemTexts.get(0));
+		assertEquals("Text should have first differing folder prepended", "test1/" + fileName,
+				handler.tableItemTexts.get(1));
+		assertEquals("Selection should be the editor that was active before the currently active editor",
+				"test1/" + fileName, handler.tableItemTexts.get(1));
+	}
+
+	@Test
+	public void testMultipleFilesWithSharedParentFoldersButNotAllShareTheSameParentFolders() throws Exception {
+		String fileName = "example.txt";
+		String path1 = "test1/foo/bar/baz/";
+		String path2 = "test2/foo/bar/baz/";
+		String path3 = "test2/foo/bar/";
+		FileUtil.createFolder(project1.getFolder(path1), true, false, null);
+		FileUtil.createFolder(project1.getFolder(path2), true, false, null);
+		IDE.openEditor(activePage, FileUtil.createFile(path1 + fileName, project1),
+				true);
+		IDE.openEditor(activePage, FileUtil.createFile(path2 + fileName, project1),
+				true);
+		IDE.openEditor(activePage, FileUtil.createFile(path3 + fileName, project1), true);
+		ICommandService cmdService = PlatformUI.getWorkbench().getService(ICommandService.class);
+		final Command cmd = cmdService.getCommand("org.eclipse.ui.window.openEditorDropDown");
+		WorkbookEditorsHandlerTestable handler = new WorkbookEditorsHandlerTestable();
+		cmd.setHandler(handler);
+		IHandlerService handlerService = PlatformUI.getWorkbench().getService(IHandlerService.class);
+		final ExecutionEvent event = handlerService.createExecutionEvent(cmd, null);
+
+		handler.execute(event);
+
+		assertEquals("Text should have parent folder prepended", "bar/" + fileName,
+				handler.tableItemTexts.get(0));
+		assertEquals("Text should have full folder chain until differing folder prepended", path2 + fileName,
+				handler.tableItemTexts.get(1));
+		assertEquals("Text should have full folder chain until differing folder prepended", path1 + fileName,
+				handler.tableItemTexts.get(2));
+		assertEquals("There should only ever be one selected editor", 1, handler.selectionTexts.size());
+		assertEquals("Selection should be the editor that was active before the currently active editor",
+				path2 + fileName, handler.tableItemTexts.get(1));
+	}
+
+	class WorkbookEditorsHandlerTestable extends WorkbookEditorsHandler {
+		List<String> selectionTexts;
+		List<String> tableItemTexts;
+
+		/**
+		 * This method was solely chosen as an overwrite target because it gets passed
+		 * the Table, which we need to get the relevant data for our assertions.
+		 */
+		@Override
+		protected void addKeyListener(Table table, Shell dialog) {
+			super.addKeyListener(table, dialog);
+			tableItemTexts = Arrays.stream(table.getItems()).map(TableItem::getText).collect(toList());
+			selectionTexts = Arrays.stream(table.getSelection()).map(TableItem::getText).collect(toList());
+		}
+
+		/**
+		 * Don't block the UI thread. Otherwise our tests would hang indefinitely.
+		 */
+		@Override
+		protected void keepOpen(Display display, Shell dialog) {
+			dialog.close();
+		}
+	}
+
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022 vogella GmbH.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Fabian Pfaff (vogella GmbH) - initial API and implementation
+ ******************************************************************************/
+
 package org.eclipse.ui.tests.internal;
 
 import static java.util.stream.Collectors.toList;
@@ -25,10 +39,6 @@ import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Test;
 
-/**
- * @since 3.5
- *
- */
 public class WorkbookEditorsHandlerTest extends UITestCase {
 
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
@@ -179,12 +179,12 @@ public class WorkbookEditorsHandlerTest extends UITestCase {
 
 		handler.execute(event);
 
-		assertEquals("Text should have first differing folder prepended", "test2/" + fileName,
-				handler.tableItemTexts.get(0));
-		assertEquals("Text should have first differing folder prepended", "test1/" + fileName,
-				handler.tableItemTexts.get(1));
+		assertEquals("Text should have first differing folder and the mark for collapsed matching folders prepended",
+				"test2/.../" + fileName, handler.tableItemTexts.get(0));
+		assertEquals("Text should have first differing folder and the mark for collapsed matching folders prepended",
+				"test1/.../" + fileName, handler.tableItemTexts.get(1));
 		assertEquals("Selection should be the editor that was active before the currently active editor",
-				"test1/" + fileName, handler.tableItemTexts.get(1));
+				"test1/.../" + fileName, handler.tableItemTexts.get(1));
 	}
 
 	@Test


### PR DESCRIPTION
If multiple EditorReferences share the same file name the user can't
differentiate between them without hovering on the table item.
By prepending parent directories when necessary the files
are distinguishable immediately and the user can filter for the
parent directory.

closes #301