### PR TITLE
fix #307: Progress View sometimes shows short living jobs twice

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/DetailedProgressViewer.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/DetailedProgressViewer.java
@@ -165,16 +165,23 @@ public class DetailedProgressViewer extends AbstractProgressViewer {
 
 	@Override
 	public void add(JobTreeElement... elements) {
-		ViewerComparator sorter = getComparator();
-
-		// Use a Set in case we are getting something added that exists
-		Set<JobTreeElement> newItems = new LinkedHashSet<>(jobItemControls.keySet());
+		Set<JobTreeElement> items = getItems();
 		for (JobTreeElement element : elements) {
 			if (element != null) {
-				newItems.add(element);
+				items.add(element);
 			}
 		}
+		updateItems(items);
+	}
 
+	private Set<JobTreeElement> getItems() {
+		// Use a Set in case we are getting something added that exists
+		Set<JobTreeElement> newItems = new LinkedHashSet<>(jobItemControls.keySet());
+		return newItems;
+	}
+
+	private void updateItems(Set<JobTreeElement> newItems) {
+		ViewerComparator sorter = getComparator();
 		JobTreeElement[] infos = newItems.toArray(new JobTreeElement[0]);
 		if (sorter != null) {
 			sorter.sort(this, infos);
@@ -369,6 +376,7 @@ public class DetailedProgressViewer extends AbstractProgressViewer {
 	@Override
 	public void remove(JobTreeElement... elements) {
 
+		Set<JobTreeElement> items = getItems();
 		for (Object element : elements) {
 			JobTreeElement treeElement = (JobTreeElement) element;
 			// Make sure we are not keeping this one
@@ -387,19 +395,13 @@ public class DetailedProgressViewer extends AbstractProgressViewer {
 						remove(parent);
 				}
 				if (item != null) {
-					jobItemControls.remove(element);
+					items.remove(element);
 					unmapElement(element);
-					item.dispose();
 				}
 			}
 		}
-
-		Control[] existingChildren = control.getChildren();
-		for (int i = 0; i < existingChildren.length; i++) {
-			ProgressInfoItem item = (ProgressInfoItem) existingChildren[i];
-			item.setColor(i);
-		}
-		updateForShowingProgress();
+		 // also sort again, otherwise removed job may appear at top again:
+		updateItems(items); 
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/JobInfo.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/JobInfo.java
@@ -60,6 +60,19 @@ public class JobInfo extends JobTreeElement {
 		this.taskInfo = Optional.empty();
 	}
 
+	@Override
+	public int hashCode() {
+		return job.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof JobInfo) {
+			return job.equals(((JobInfo) obj).job);
+		}
+		return false;
+	}
+
 	/**
 	 * Adds the subtask to the receiver.
 	 *

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.126.0.qualifier
+Bundle-Version: 3.126.100.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
There is a lot of code to handle equal JobTreeElement, but JobInfo did
not implement equals().
Since the JobInfo is now reliable avoided to be added each time to the
bottom, the sort order has to be maintained also on remove.