### PR TITLE
Endless "Progress message refresh" job re-scheduling (313)

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/FilteredItemsSelectionDialog.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/FilteredItemsSelectionDialog.java
@@ -1333,8 +1333,11 @@ public abstract class FilteredItemsSelectionDialog extends SelectionStatusDialog
 		@Override
 		public IStatus runInUIThread(IProgressMonitor monitor) {
 
-			if (!progressLabel.isDisposed())
+			if (!progressLabel.isDisposed()) {
 				progressLabel.setText(progressMonitor != null ? progressMonitor.getMessage() : EMPTY_STRING);
+			} else {
+				return Status.CANCEL_STATUS;
+			}
 
 			if (progressMonitor == null || progressMonitor.isDone()) {
 				return new Status(IStatus.CANCEL, PlatformUI.PLUGIN_ID, IStatus.CANCEL, EMPTY_STRING, null);


### PR DESCRIPTION
Don't loop forever if the dialog is gone but monitor is not properly
cancelled.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/313