### PR TITLE
Fix endless loop with duplicates in recent workspaces #312

### DIFF
--- a/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide; singleton:=true
-Bundle-Version: 3.19.100.qualifier
+Bundle-Version: 3.19.200.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.internal.ide.IDEWorkbenchPlugin
 Bundle-ActivationPolicy: lazy

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/internal/ide/ChooseWorkspaceDialogTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/internal/ide/ChooseWorkspaceDialogTests.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Simeon Andreev and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Simeon Andreev - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.internal.ide;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+public class ChooseWorkspaceDialogTests {
+
+	/**
+	 * Validates that {@link ChooseWorkspaceDialog#filterDuplicatedPaths(String[])}
+	 * filters out non-unique paths.
+	 *
+	 * @see <a href=
+	 *      "https://github.com/eclipse-platform/eclipse.platform.ui/issues/312">GitHub
+	 *      issue 312</a>
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=531611">Eclipse
+	 *      bug 531611</a>
+	 */
+	@Test
+	public void testFilterDuplicatedPaths() {
+		String[] testPaths = {
+				"some/location1/",
+				"/some/location1/",
+				"/some/location1",
+				"/some/location2/",
+				"/some///location1",
+				"//some//location1//",
+		};
+		String[] expectedFilteredPaths = { "some/location1/", "/some/location1/", "/some/location2/", };
+		List<String> actualFilteredPaths = ChooseWorkspaceDialog.filterDuplicatedPaths(testPaths);
+		assertEquals("Non-unique paths were not filtered as expected", Arrays.asList(expectedFilteredPaths),
+				actualFilteredPaths);
+	}
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/UiTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/UiTestSuite.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests;
 
+import org.eclipse.ui.internal.ide.ChooseWorkspaceDialogTests;
 import org.eclipse.ui.internal.ide.DirectoryProposalContentAssistTestSuite;
 import org.eclipse.ui.tests.activities.ActivitiesTestSuite;
 import org.eclipse.ui.tests.adaptable.AdaptableTestSuite;
@@ -104,6 +105,7 @@ import org.junit.runners.Suite;
 	MultiEditorTestSuite.class,
 	OpenSystemInPlaceEditorTest.class,
 	WorkbenchDatabindingTest.class,
+	ChooseWorkspaceDialogTests.class,
 })
 public class UiTestSuite {
 }


### PR DESCRIPTION
ChooseWorkspaceDialog.createUniqueWorkspaceNameMap() finds a unique
short name for a recent workspace path, based on the last segments of
the workspace path. If the recent workspace paths contain duplicates,
the method loops endlessly - the exit condition of the method is that a
unique name is found for each recent workspace.

This change filters duplicates from recent workspace paths in
ChooseWorkspaceDialog. Duplicates in this context are workspace paths
that represent the same location, but are different string-wise due to
superfluous separators.

In addition, an extra exit condition is added to the loop in
ChooseWorkspaceDialog.createUniqueWorkspaceNameMap(), to prevent endless
loops in future.

Fixes: #312
Signed-off-by: Simeon Andreev <simeon.danailov.andreev@gmail.com>