### PR TITLE
Avoid race conditions and AssertionFailedException in LogView (#317)

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.27.0.qualifier
+Bundle-Version: 3.27.100.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.ui.views.log;singleton:=true
-Bundle-Version: 1.3.300.qualifier
+Bundle-Version: 1.3.400.qualifier
 Bundle-Activator: org.eclipse.ui.internal.views.log.Activator
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",

--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogView.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogView.java
@@ -830,7 +830,7 @@ public class LogView extends ViewPart implements LogListener {
 	}
 
 	public AbstractEntry[] getElements() {
-		return elements.toArray(new AbstractEntry[elements.size()]);
+		return elements.toArray(new AbstractEntry[0]);
 	}
 
 	public void handleClear() {


### PR DESCRIPTION
Between calls to elements.size() and elements.toArray() the list might reduce the size so the resulting array will contain null slots.

As a result, the array returned by LogViewContentProvider.getElements(Object) is checked by StructuredViewer.assertElementsNotNull() and fails with AssertionFailedException.


Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/317