### PR TITLE
[a11y] Accessibility - EnablementDialog Enable the required activity? cannot be read by JAWS

### DIFF
--- a/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.themes;singleton:=true
-Bundle-Version: 1.2.1700.qualifier
+Bundle-Version: 1.2.1701.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.e4.ui.css.swt.theme

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/activities/ws/EnablementDialog.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/activities/ws/EnablementDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2018 IBM Corporation and others.
+ * Copyright (c) 2004, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -113,7 +113,19 @@ public class EnablementDialog extends Dialog {
 			text.setText(MessageFormat.format(RESOURCE_BUNDLE.getString("requiresSingle"), //$NON-NLS-1$
 					activityText));
 
-			text = new Label(composite, SWT.NONE);
+			/*
+			 * Label doesn't grab tab focus, hence is not read by Accessible tools like
+			 * JAWS. Hence nesting it inside a composite and setting an explicit TabList
+			 * works. For more details :
+			 * https://github.com/eclipse-platform/eclipse.platform.ui/issues/272
+			 */
+			Composite tabStopComposite = (Composite) super.createDialogArea(composite);
+			tabStopComposite.setFont(dialogFont);
+			GridLayout gridLayout = (GridLayout) tabStopComposite.getLayout();
+			gridLayout.marginWidth = 0;
+			gridLayout.marginHeight = 0;
+			text = new Label(tabStopComposite, SWT.NONE);
+			tabStopComposite.setTabList(new Control[] { text });
 			text.setText(strings.getProperty(WorkbenchTriggerPointAdvisor.PROCEED_SINGLE,
 					RESOURCE_BUNDLE.getString(WorkbenchTriggerPointAdvisor.PROCEED_SINGLE)));
 			text.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
@@ -145,7 +157,19 @@ public class EnablementDialog extends Dialog {
 			viewer.getControl().setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 			viewer.getControl().setFont(dialogFont);
 
-			text = new Label(composite, SWT.NONE);
+			/*
+			 * Label doesn't grab tab focus, hence is not read by Accessible tools like
+			 * JAWS. Hence nesting it inside a composite and setting an explicit TabList
+			 * works. For more details :
+			 * https://github.com/eclipse-platform/eclipse.platform.ui/issues/272
+			 */
+			Composite tabStopComposite = (Composite) super.createDialogArea(composite);
+			tabStopComposite.setFont(dialogFont);
+			GridLayout gridLayout = (GridLayout) tabStopComposite.getLayout();
+			gridLayout.marginWidth = 0;
+			gridLayout.marginHeight = 0;
+			text = new Label(tabStopComposite, SWT.NONE);
+			tabStopComposite.setTabList(new Control[] { text });
 			text.setText(strings.getProperty(WorkbenchTriggerPointAdvisor.PROCEED_MULTI,
 					RESOURCE_BUNDLE.getString(WorkbenchTriggerPointAdvisor.PROCEED_MULTI)));
 			text.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.125.0.qualifier
+Bundle-Version: 3.125.1.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.ui.workbench/pom.xml
+++ b/bundles/org.eclipse.ui.workbench/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.workbench</artifactId>
-  <version>3.125.0-SNAPSHOT</version>
+  <version>3.125.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
- Back-port #272 to R4_23_maintenance branch.

Signed-off-by: Niraj Modi <niraj.modi@in.ibm.com>