### PR TITLE
Remove IWorkbenchWindowConfigurer methods marked for deletion

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/application/IWorkbenchWindowConfigurer.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/application/IWorkbenchWindowConfigurer.java
@@ -19,9 +19,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.swt.dnd.DropTargetListener;
 import org.eclipse.swt.dnd.Transfer;
 import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Menu;
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.IWorkbenchWindow;
 
@@ -160,35 +157,6 @@ public interface IWorkbenchWindowConfigurer {
 	void setShowPerspectiveBar(boolean show);
 
 	/**
-	 * No longer used by the platform
-	 *
-	 * @return <code>true</code> for fast view bars, and <code>false</code> for no
-	 *         fast view bars
-	 * @noreference This method is not intended to be referenced by clients.
-	 *
-	 *              This method is planned to be deleted, see
-	 *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=485835
-	 * @deprecated discontinued support for fast views
-	 */
-	@Deprecated
-	boolean getShowFastViewBars();
-
-	/**
-	 * No longer used by the platform
-	 *
-	 * @param enable <code>true</code> for fast view bars, and <code>false</code>
-	 *               for no fast view bars
-	 * @noreference This method is not intended to be referenced by clients.
-	 *
-	 *              This method is planned to be deleted, see
-	 *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=485835
-	 *
-	 * @deprecated discontinued support for fast views
-	 */
-	@Deprecated
-	void setShowFastViewBars(boolean enable);
-
-	/**
 	 * Returns whether the underlying workbench window has a progress indicator.
 	 * <p>
 	 * The initial value is <code>false</code>.
@@ -307,65 +275,6 @@ public interface IWorkbenchWindowConfigurer {
 	 */
 	void configureEditorAreaDropListener(DropTargetListener dropTargetListener);
 
-	/**
-	 * No longer used by the platform
-	 *
-	 * @return the menu bar, suitable for setting in the shell extended by clients.
-	 * @noreference This method is not intended to be referenced by clients.
-	 *
-	 *              This method is planned to be deleted, see (
-	 *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=485835
-	 * @deprecated This method is no longer used. Applications now define workbench
-	 *             window contents in their application model.
-	 */
-	@Deprecated
-	Menu createMenuBar();
-
-	/**
-	 * No longer used by the platform
-	 *
-	 * @param parent the parent composite
-	 * @return the cool bar control, suitable for laying out in the parent
-	 * @noreference This method is not intended to be referenced by clients.
-	 *
-	 *              This method is planned to be deleted, see
-	 *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=485835
-	 * @deprecated This method is no longer used. Applications now define workbench
-	 *             window contents in their application model.
-	 */
-	@Deprecated
-	Control createCoolBarControl(Composite parent);
-
-	/**
-	 * No longer used by the platform
-	 *
-	 * @param parent the parent composite
-	 * @return the status line control, suitable for laying out in the parent
-	 * @noreference This method is not intended to be referenced by clients.
-	 *
-	 *              This method is planned to be deleted, see
-	 *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=485835
-	 * @deprecated This method is no longer used. Applications now define workbench
-	 *             window contents in their application model.
-	 */
-	@Deprecated
-	Control createStatusLineControl(Composite parent);
-
-	/**
-	 * No longer used by the platform
-	 *
-	 * @param parent the parent composite
-	 * @return the page composite, suitable for laying out in the parent
-	 *
-	 * @noreference This method is not intended to be referenced by clients.
-	 *
-	 *              This method is planned to be deleted, see
-	 *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=485835
-	 * @deprecated This method is no longer used. Applications now define workbench
-	 *             window contents in their application model.
-	 */
-	@Deprecated
-	Control createPageComposite(Composite parent);
 
 	/**
 	 * Saves the current state of the window using the specified memento.

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchWindowConfigurer.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchWindowConfigurer.java
@@ -34,9 +34,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.DropTargetListener;
 import org.eclipse.swt.dnd.Transfer;
 import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -318,16 +315,6 @@ public final class WorkbenchWindowConfigurer implements IWorkbenchWindowConfigur
 		// @issue need to be able to reconfigure after window's controls created
 	}
 
-	@Override
-	public boolean getShowFastViewBars() {
-		// not supported anymore
-		return false;
-	}
-
-	@Override
-	public void setShowFastViewBars(boolean show) {
-		// not supported anymore
-	}
 
 	@Override
 	public boolean getShowPerspectiveBar() {
@@ -462,26 +449,6 @@ public final class WorkbenchWindowConfigurer implements IWorkbenchWindowConfigur
 
 	}
 
-	@Override
-	public Menu createMenuBar() {
-		return null;
-	}
-
-	@Override
-	public Control createCoolBarControl(Composite parent) {
-
-		return null;
-	}
-
-	@Override
-	public Control createStatusLineControl(Composite parent) {
-		return null;
-	}
-
-	@Override
-	public Control createPageComposite(Composite parent) {
-		return null;
-	}
 
 	@Override
 	public IStatus saveState(IMemento memento) {

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchWindowConfigurerTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchWindowConfigurerTest.java
@@ -154,12 +154,6 @@ public class WorkbenchWindowConfigurerTest {
 						getWindowConfigurer().setShowPerspectiveBar(showPerspectiveBar);
 					}
 
-					@Override
-					@SuppressWarnings("deprecation")
-					public void createWindowContents(Shell shell) {
-						IWorkbenchWindowConfigurer configurer = getWindowConfigurer();
-						configurer.createPageComposite(shell);
-					}
 				};
 			}
 

--- a/tests/org.eclipse.ui.tests.rcp/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.rcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.tests.rcp; singleton:=true
-Bundle-Version: 3.5.100.qualifier
+Bundle-Version: 3.5.200.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,


### PR DESCRIPTION
The following methods are not used anymore by the platform and deleted. createMenuBar
createCoolBarControl
createStatusLineControl
createPageComposite
setShowFastViewBars
getShowFastViewBars

Originally planned for June 2017.