### PR TITLE
fix NPE in PartRenderingEngine#subscribeTrimHandler

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.swt;singleton:=true
-Bundle-Version: 0.16.600.qualifier
+Bundle-Version: 0.16.700.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/PartRenderingEngine.java
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/PartRenderingEngine.java
@@ -263,7 +263,7 @@ public class PartRenderingEngine implements IPresentationEngine {
 				}
 			}
 		} else if (UIEvents.isREMOVE(event)) {
-			for (Object o : UIEvents.asIterable(event, UIEvents.EventTags.NEW_VALUE)) {
+			for (Object o : UIEvents.asIterable(event, UIEvents.EventTags.OLD_VALUE)) {
 				MUIElement removed = (MUIElement) o;
 				if (removed.getRenderer() != null) {
 					removeGui(removed);


### PR DESCRIPTION
fixes Issue #321: NPE in PartRenderingEngine#subscribeTrimHandler when removing MTrimBar from MTrimmedWindow.getTrimBars()

When `UIEvents.isREMOVE(event)` is true, the Eclipse code tried to get the `UIEvents.EventTags.NEW_VALUE` which returns `null` and causes `removed.getRenderer()` to throw a NPE.

This pull request looks for the element to **remove** in `OLD_VALUE` instead of `NEW_VALUE`.