### PR TITLE
Revert "Remove dispose check from ButtonElement"

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/dom/ButtonElement.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/dom/ButtonElement.java
@@ -34,8 +34,10 @@ public class ButtonElement extends ControlElement {
 	private SelectionListener selectionListener = new SelectionAdapter() {
 		@Override
 		public void widgetSelected(SelectionEvent e) {
-			ButtonElement.this.isSelected = getButton().getSelection();
-			doApplyStyles();
+			if (!e.widget.isDisposed()) {
+				ButtonElement.this.isSelected = getButton().getSelection();
+				doApplyStyles();
+			}
 		}
 	};
 


### PR DESCRIPTION
The assumption that this is not needed because SWT handles it was wrong, see https://github.com/eclipse-platform/eclipse.platform.ui/pull/164#issuecomment-1229193596

This reverts commit 46b1d61bc8bc812514f2d71c8b1c9fbce3b96c47.