### PR TITLE
Don't call CTabItem.setControl(null) before disposing it

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.renderers.swt;singleton:=true
-Bundle-Version: 0.15.600.qualifier
+Bundle-Version: 0.15.700.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
@@ -904,7 +904,6 @@ public class StackRenderer extends LazyStackRenderer {
 
 		// find the 'stale' tab for this element and dispose it
 		if (tabItem != null && !tabItem.isDisposed()) {
-			tabItem.setControl(null);
 			tabItem.dispose();
 		}
 	}


### PR DESCRIPTION
If stack renderer wants to remove a part, it may cause the other tab of a multpage editor being focused while closing the editor, because of the extra focus logic inside .

CTabItem.setControl(null) seem to be unneeded here, as the part is being closed anyway.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/351