### PR TITLE
4.26 version increase for org.eclipse.e4.ui.css.swt

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.css.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.css.swt;singleton:=true
-Bundle-Version: 0.14.600.qualifier
+Bundle-Version: 0.14.700.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
Required for pending work.