### PR TITLE
Workaround #342: delete stale jobs from ProgressManager

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/ProgressManager.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/ProgressManager.java
@@ -638,6 +638,7 @@ public class ProgressManager extends ProgressProvider implements IProgressServic
 	 * @param info the updated job info
 	 */
 	public void refreshJobInfo(JobInfo info) {
+		checkForStaleness(info.getJob());
 		synchronized (pendingUpdatesMutex) {
 			Predicate<IJobProgressManagerListener> predicate = listener -> !isNeverDisplaying(info.getJob(), listener.showsDebug());
 			rememberListenersForJob(info, pendingJobUpdates, predicate);


### PR DESCRIPTION
when removed from progress view.
Does not solve the issues that there are undetected finished/canceled jobs but the will not reappear after removing them from the progress view.