### PR TITLE
MarkerEntry.marker is final

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerEntry.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerEntry.java
@@ -82,7 +82,7 @@ class MarkerEntry extends MarkerSupportItem implements IAdaptable {
 	 * access to these fields must be via methods, they must be in sync and their
 	 * values should reflect correctly the state of the other
 	 */
-	private IMarker marker;
+	private final IMarker marker;
 
 	/**
 	 * Create a new instance of the receiver.
@@ -355,19 +355,6 @@ class MarkerEntry extends MarkerSupportItem implements IAdaptable {
 	 */
 	void setCategory(MarkerCategory markerCategory) {
 		category = markerCategory;
-	}
-
-	/**
-	 * Set the marker for the receiver.
-	 *
-	 * @param marker
-	 *            The marker to set.
-	 */
-	void setMarker(IMarker marker) {
-		this.marker = marker;
-		// reset stale
-		stale = false;
-		clearCache();
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerFieldFilterGroup.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerFieldFilterGroup.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -117,10 +116,6 @@ class MarkerFieldFilterGroup {
 	private String name;
 	private String id;
 
-	/**
-	 * The entry for testing filters. Cached to prevent garbage.
-	 */
-	private MarkerEntry testEntry = new MarkerEntry(null);
 	private IWorkingSet workingSet;
 	private IResource[] wSetResources;
 
@@ -572,17 +567,6 @@ class MarkerFieldFilterGroup {
 					MarkerSupportInternalUtilities.getId(filter.getField()));
 			filter.saveSettings(child);
 		}
-	}
-
-	/**
-	 * Return whether or not this IMarker is being shown.
-	 *
-	 * @param marker
-	 * @return <code>true</code> if it is being shown
-	 */
-	public boolean select(IMarker marker) {
-		testEntry.setMarker(marker);
-		return select(testEntry);
 	}
 
 	/**


### PR DESCRIPTION
The only re-assignment was by an not referenced
MarkerFieldFilterGroup.select() method.