### PR TITLE
fix MarkerPathField.compare nulls last

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerPathField.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerPathField.java
@@ -29,8 +29,12 @@ public class MarkerPathField extends MarkerField {
 
 	@Override
 	public int compare(MarkerItem item1, MarkerItem item2) {
-		if (item1.getMarker() == null || item2.getMarker() == null)
+		if (item1.getMarker() == null && item2.getMarker() == null)
 			return 0;
+		if (item1.getMarker() == null)
+			return 1;
+		if (item2.getMarker() == null)
+			return -1;
 
 		return item1.getPath().compareTo(item2.getPath());
 	}


### PR DESCRIPTION
If a user sorts by a field he expects either nulls first or nulls last, but not null values unsorted.