### PR TITLE
Add support for Windows on Arm64 (WoA) build

### DIFF
--- a/bundles/org.eclipse.e4.ui.swt.win32/pom.xml
+++ b/bundles/org.eclipse.e4.ui.swt.win32/pom.xml
@@ -42,6 +42,11 @@
               <ws>win32</ws>
               <arch>x86_64</arch>
             </environment>
+            <environment>
+              <os>win32</os>
+              <ws>win32</ws>
+              <arch>aarch64</arch>
+            </environment>
           </environments>
         </configuration>
       </plugin>

--- a/bundles/org.eclipse.ui.win32/pom.xml
+++ b/bundles/org.eclipse.ui.win32/pom.xml
@@ -42,6 +42,11 @@
               <ws>win32</ws>
               <arch>x86_64</arch>
             </environment>
+            <environment>
+              <os>win32</os>
+              <ws>win32</ws>
+              <arch>aarch64</arch>
+            </environment>
           </environments>
           <dependency-resolution>
             <extraRequirements>

--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -436,6 +436,16 @@
          fragment="true"/>
 
    <plugin
+         id="org.eclipse.equinox.launcher.win32.win32.aarch64"
+         os="win32"
+         ws="win32"
+         arch="aarch64"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"/>
+
+   <plugin
          id="org.eclipse.equinox.launcher.win32.win32.x86_64"
          os="win32"
          ws="win32"
@@ -450,6 +460,17 @@
          download-size="0"
          install-size="0"
          version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.swt.win32.win32.aarch64"
+         os="win32"
+         ws="win32"
+         arch="aarch64"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
          unpack="false"/>
 
    <plugin

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
                     <plugin id="org.eclipse.equinox.launcher.gtk.linux.ppc64le" />
                     <plugin id="org.eclipse.equinox.launcher.gtk.linux.aarch64" />
                     <plugin id="org.eclipse.equinox.launcher.gtk.linux.x86_64" />
+                    <plugin id="org.eclipse.equinox.launcher.win32.win32.aarch64" />
                     <plugin id="org.eclipse.equinox.launcher.win32.win32.x86_64" />
                   </excludes>
                 </configuration>


### PR DESCRIPTION
by adding the `win32/win32/aarch64` environment triplet and including the new fragments for WoA in the 'org.eclipse.e4.rcp' feature.