### PR TITLE
nullhandling in LightweightLabelDecorator

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/decorators/LightweightDecoratorDefinition.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/decorators/LightweightDecoratorDefinition.java
@@ -122,7 +122,10 @@ class LightweightDecoratorDefinition extends DecoratorDefinition implements IObj
 						try {
 							decorator = (ILightweightLabelDecorator) WorkbenchPlugin.createExtension(definingElement,
 									DecoratorDefinition.ATT_CLASS);
-							decorator.addListener(WorkbenchPlugin.getDefault().getDecoratorManager());
+							DecoratorManager decoratorManager = WorkbenchPlugin.getDefault().getDecoratorManager();
+							if (decoratorManager != null) {
+								decorator.addListener(decoratorManager);
+							}
 						} catch (CoreException exception) {
 							exceptions[0] = exception;
 						}


### PR DESCRIPTION
fixes logged IllegalArgumentException at the end of Junit tests