### PR TITLE
Remove org.apache.commons.logging from o.e.e4.rcp feature

### DIFF
--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -186,13 +186,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.apache.commons.logging"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.e4.core.di.extensions"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
If a Feature includes a Plugin, it usually includes it with a specific name and the version that was in the TP when the feature was build. This prevents consumers from using 'logging-bridges' in their TP or product, for example a slf4j-bridge that provides binary compatible packages and classes but redirects all events to slf4j.

Although not directly related to the move to slf4j from Maven-Central or slf4j-2, this is similar like https://github.com/eclipse-platform/eclipse.platform.releng/pull/118.

Besides some test classes I cannot se any code that `org.apache.commons.logging`.

@mickaelistria any objections? You added it back then.