### PR TITLE
Issue #376: URL/FileImageDescriptor's ImageFileNameProvider...

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FileImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FileImageDescriptor.java
@@ -11,7 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Christoph Läubrich - Bug 567898 - [JFace][HiDPI] ImageDescriptor support alternative naming scheme for high dpi
- *     Daniel Krügler - #375, #378
+ *     Daniel Krügler - #375, #378, #376
  *******************************************************************************/
 package org.eclipse.jface.resource;
 
@@ -51,6 +51,10 @@ class FileImageDescriptor extends ImageDescriptor {
 			String xName = getxName(name, zoom);
 			if (xName != null) {
 				return getFilePath(xName, zoom == 100);
+			}
+			String xPath = getxPath(name, zoom);
+			if (xPath != null) {
+				return getFilePath(xPath, zoom == 100);
 			}
 			return getFilePath(name, zoom == 100);
 		}

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/URLImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/URLImageDescriptor.java
@@ -12,6 +12,8 @@
  *     IBM Corporation - initial API and implementation
  *     Patrik Suzzi <psuzzi@gmail.com> - Bug 483465
  *     Christoph Läubrich - Bug 567898 - [JFace][HiDPI] ImageDescriptor support alternative naming scheme for high dpi
+ *     Daniel Krügler - #376 - jface High-DPI: URL/FileImageDescriptor: ImageFileNameProvider implementation
+ *                             should also test for XPATH_PATTERN
  *******************************************************************************/
 package org.eclipse.jface.resource;
 
@@ -56,6 +58,13 @@ class URLImageDescriptor extends ImageDescriptor {
 				URL xUrl = getxURL(tempURL, zoom);
 				if (xUrl != null) {
 					return getFilePath(xUrl, zoom == 100);
+				}
+				String xpath = FileImageDescriptor.getxPath(url, zoom);
+				if (xpath != null) {
+					URL xPathUrl = getURL(xpath);
+					if (xPathUrl != null) {
+						return getFilePath(xPathUrl, zoom == 100);
+					}
 				}
 			}
 			return null;


### PR DESCRIPTION
...implementation should also test for XPATH_PATTERN

- Extend FileImageDescriptor's and URLImageDescriptor's ImageFileNameProvider implementation to consider as fallback also an "NxM" name pattern.

Signed-off-by: Daniel Krügler <daniel.kruegler@gmail.com>