### PR TITLE
Add static UIJob-factories similiar to Job factories

### DIFF
--- a/bundles/org.eclipse.e4.ui.progress/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.progress/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.progress;singleton:=true
-Bundle-Version: 0.3.500.qualifier
+Bundle-Version: 0.3.600.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/AnimationManager.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/AnimationManager.java
@@ -23,9 +23,6 @@ import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.e4.core.di.annotations.Creatable;
 import org.eclipse.e4.ui.progress.UIJob;
@@ -68,19 +65,13 @@ public class AnimationManager {
 
 		animationProcessor = new ProgressAnimationProcessor(this);
 
-		animationUpdateJob = new UIJob(ProgressMessages.AnimationManager_AnimationStart) {
-
-			@Override
-			public IStatus runInUIThread(IProgressMonitor monitor) {
-
-				if (animated) {
-					animationProcessor.animationStarted();
-				} else {
-					animationProcessor.animationFinished();
-				}
-				return Status.OK_STATUS;
+		animationUpdateJob = UIJob.create(ProgressMessages.AnimationManager_AnimationStart, monitor -> {
+			if (animated) {
+				animationProcessor.animationStarted();
+			} else {
+				animationProcessor.animationFinished();
 			}
-		};
+		});
 		animationUpdateJob.setSystem(true);
 
 		listener = getProgressListener();

--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressManager.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressManager.java
@@ -33,11 +33,11 @@ import java.util.Map.Entry;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
+import org.eclipse.core.runtime.ICoreRunnable;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.core.runtime.QualifiedName;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.IJobChangeListener;
 import org.eclipse.core.runtime.jobs.Job;
@@ -436,18 +436,10 @@ public class ProgressManager extends ProgressProvider {
 					boolean noDialog = shouldRunInBackground();
 					if (!noDialog) {
 						final IJobChangeEvent finalEvent = event;
-						Job showJob = new UIJob(
-								ProgressMessages.ProgressManager_showInDialogName) {
-							@Override
-							public IStatus runInUIThread(
-									IProgressMonitor monitor) {
-								progressService.showInDialog(null, finalEvent.getJob());
-								return Status.OK_STATUS;
-							}
-						};
+						Job showJob = UIJob.create(ProgressMessages.ProgressManager_showInDialogName,
+								(ICoreRunnable) m -> progressService.showInDialog(null, finalEvent.getJob()));
 						showJob.setSystem(true);
 						showJob.schedule();
-						return;
 					}
 				}
 			}

--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressMonitorFocusJobDialog.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressMonitorFocusJobDialog.java
@@ -134,18 +134,14 @@ class ProgressMonitorFocusJobDialog extends ProgressMonitorJobsDialog {
 				if (getShell() == null) {
 					return;
 				}
-				Job closeJob = new UIJob(
-						ProgressMessages.ProgressMonitorFocusJobDialog_CLoseDialogJob) {
-					@Override
-					public IStatus runInUIThread(IProgressMonitor monitor) {
-						Shell currentShell = getShell();
-						if (currentShell == null || currentShell.isDisposed()) {
-							return Status.CANCEL_STATUS;
-						}
-						finishedRun();
-						return Status.OK_STATUS;
+				Job closeJob = UIJob.create(ProgressMessages.ProgressMonitorFocusJobDialog_CLoseDialogJob, monitor -> {
+					Shell currentShell = getShell();
+					if (currentShell == null || currentShell.isDisposed()) {
+						return Status.CANCEL_STATUS;
 					}
-				};
+					finishedRun();
+					return Status.OK_STATUS;
+				});
 				closeJob.setSystem(true);
 				closeJob.schedule();
 			}
@@ -316,34 +312,28 @@ class ProgressMonitorFocusJobDialog extends ProgressMonitorJobsDialog {
 				});
 		job.removeJobChangeListener(jobListener);
 
-		Job openJob = new UIJob(
-				ProgressMessages.ProgressMonitorFocusJobDialog_UserDialogJob) {
-			@Override
-			public IStatus runInUIThread(IProgressMonitor monitor) {
-
-				// if the job is done at this point, we don't need the dialog
-				if (job.getState() == Job.NONE) {
-					finishedRun();
-					cleanUpFinishedJob();
-					return Status.CANCEL_STATUS;
-				}
-
-				// now open the progress dialog if nothing else is
-				if (!ProgressManagerUtil.safeToOpen(
-						ProgressMonitorFocusJobDialog.this, originatingShell)) {
-					return Status.CANCEL_STATUS;
-				}
-
-				// Do not bother if the parent is disposed
-				if (getParentShell() != null && getParentShell().isDisposed()) {
-					return Status.CANCEL_STATUS;
-				}
-
-				open();
-
-				return Status.OK_STATUS;
+		Job openJob = UIJob.create(ProgressMessages.ProgressMonitorFocusJobDialog_UserDialogJob, m -> {
+			// if the job is done at this point, we don't need the dialog
+			if (job.getState() == Job.NONE) {
+				finishedRun();
+				cleanUpFinishedJob();
+				return Status.CANCEL_STATUS;
 			}
-		};
+
+			// now open the progress dialog if nothing else is
+			if (!ProgressManagerUtil.safeToOpen(ProgressMonitorFocusJobDialog.this, originatingShell)) {
+				return Status.CANCEL_STATUS;
+			}
+
+			// Do not bother if the parent is disposed
+			if (getParentShell() != null && getParentShell().isDisposed()) {
+				return Status.CANCEL_STATUS;
+			}
+
+			open();
+
+			return Status.OK_STATUS;
+		});
 		openJob.setSystem(true);
 		openJob.schedule();
 

--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressServiceImpl.java
@@ -277,17 +277,12 @@ public class ProgressServiceImpl implements IProgressService {
 	private void scheduleProgressMonitorJob(
 			final ProgressMonitorJobsDialog dialog) {
 
-		final Job updateJob = new UIJob(
-				ProgressMessages.ProgressManager_openJobName) {
-			@Override
-			public IStatus runInUIThread(IProgressMonitor monitor) {
-				setUserInterfaceActive(true);
-				if (ProgressManagerUtil.safeToOpen(dialog, null)) {
-					dialog.open();
-				}
-				return Status.OK_STATUS;
+		Job updateJob = UIJob.create(ProgressMessages.ProgressManager_openJobName, monitor -> {
+			setUserInterfaceActive(true);
+			if (ProgressManagerUtil.safeToOpen(dialog, null)) {
+				dialog.open();
 			}
-		};
+		});
 		updateJob.setSystem(true);
 		updateJob.schedule(getLongOperationTime());
 

--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressViewerContentProvider.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressViewerContentProvider.java
@@ -96,23 +96,16 @@ public class ProgressViewerContentProvider extends ProgressContentProvider {
 			}
 
 			@Override
-			public void removed(JobTreeElement jte) {
-				final JobTreeElement element = jte;
-				Job updateJob = new UIJob("Remove finished") {//$NON-NLS-1$
-					@Override
-					public IStatus runInUIThread(IProgressMonitor monitor) {
-						if (element == null) {
-							refresh();
-						} else {
-							ProgressViewerContentProvider.this
-									.remove(new Object[] { element });
-						}
-						return Status.OK_STATUS;
+			public void removed(JobTreeElement element) {
+				Job updateJob = UIJob.create("Remove finished", monitor -> {
+					if (element == null) {
+						refresh();
+					} else {
+						ProgressViewerContentProvider.this.remove(new Object[] { element });
 					}
-				};
+				});
 				updateJob.setSystem(true);
 				updateJob.schedule();
-
 			}
 
 		};

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchErrorHandler.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchErrorHandler.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 
-import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.IDialogConstants;
@@ -108,18 +107,11 @@ public class IDEWorkbenchErrorHandler extends WorkbenchErrorHandler {
 
 		// if fatal error occurs, we will ask to close the workbench
 		if (isFatal(statusAdapter)) {
-			UIJob handlingExceptionJob = new UIJob("IDE Exception Handler") //$NON-NLS-1$
-			{
-				@Override
-				public IStatus runInUIThread(IProgressMonitor monitor) {
-					handleException(statusAdapter.getStatus().getException());
-					return new Status(
-							IStatus.OK,
-							IDEWorkbenchPlugin.IDE_WORKBENCH,
-							IDEWorkbenchMessages.IDEExceptionHandler_ExceptionHandledMessage);
-				}
-
-			};
+			UIJob handlingExceptionJob = UIJob.create("IDE Exception Handler", m -> { //$NON-NLS-1$
+				handleException(statusAdapter.getStatus().getException());
+				return new Status(IStatus.OK, IDEWorkbenchPlugin.IDE_WORKBENCH,
+						IDEWorkbenchMessages.IDEExceptionHandler_ExceptionHandledMessage);
+			});
 
 			handlingExceptionJob.setSystem(true);
 			handlingExceptionJob.schedule();

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/OpenFilesystemQuickAccessComputer.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/OpenFilesystemQuickAccessComputer.java
@@ -18,14 +18,11 @@ import java.util.Optional;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ICoreRunnable;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
-import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
 import org.eclipse.ui.internal.ide.dialogs.OpenResourceQuickAccessComputer.ResourceElement;
 import org.eclipse.ui.model.WorkbenchLabelProvider;
 import org.eclipse.ui.progress.UIJob;
@@ -62,18 +59,11 @@ public class OpenFilesystemQuickAccessComputer implements IQuickAccessComputerEx
 
 		@Override
 		public void execute() {
-			new UIJob(getLabel()) {
-				@Override
-				public IStatus runInUIThread(IProgressMonitor monitor) {
-					try {
-						IDE.openEditorOnFileStore(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(),
-								EFS.getStore(file.toURI()));
-					} catch (CoreException e) {
-						return new Status(IStatus.ERROR, IDEWorkbenchPlugin.IDE_WORKBENCH, e.getMessage(), e);
-					}
-					return Status.OK_STATUS;
-				}
-			}.schedule();
+			UIJob.create(getLabel(),
+					(ICoreRunnable) m -> IDE.openEditorOnFileStore(
+							PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(),
+							EFS.getStore(file.toURI())))
+					.schedule();
 		}
 
 	}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/activities/MutableActivityManager.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/activities/MutableActivityManager.java
@@ -29,8 +29,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import org.eclipse.core.expressions.Expression;
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.ICoreRunnable;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.IJobFunction;
@@ -832,13 +831,8 @@ public final class MutableActivityManager extends AbstractActivityManager
 					}
 				}
 				if (!identifierEventsByIdentifierId.isEmpty()) {
-					UIJob notifyJob = new UIJob("Activity Identifier Update UI") { //$NON-NLS-1$
-						@Override
-						public IStatus runInUIThread(IProgressMonitor monitor) {
-							notifyIdentifiers(identifierEventsByIdentifierId);
-							return Status.OK_STATUS;
-						}
-					};
+					UIJob notifyJob = UIJob.create("Activity Identifier Update UI", //$NON-NLS-1$
+							(ICoreRunnable) m -> notifyIdentifiers(identifierEventsByIdentifierId));
 					notifyJob.setSystem(true);
 					notifyJob.schedule();
 				}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/QuickMenuHandler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/QuickMenuHandler.java
@@ -18,9 +18,6 @@ package org.eclipse.ui.internal.handlers;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.action.ContributionManager;
 import org.eclipse.jface.action.IMenuListener2;
 import org.eclipse.jface.action.IMenuManager;
@@ -75,16 +72,10 @@ public class QuickMenuHandler extends AbstractHandler implements IMenuListener2 
 
 	@Override
 	public void menuAboutToHide(final IMenuManager managerM) {
-		new UIJob("quickMenuCleanup") { //$NON-NLS-1$
-
-			@Override
-			public IStatus runInUIThread(IProgressMonitor monitor) {
+		UIJob.create("quickMenuCleanup", m -> { //$NON-NLS-1$
 				IMenuService service = PlatformUI.getWorkbench().getService(IMenuService.class);
 				service.releaseContributions((ContributionManager) managerM);
-				return Status.OK_STATUS;
-			}
-
-		}.schedule();
+		}).schedule();
 	}
 
 	@Override

--- a/examples/org.eclipse.ui.examples.navigator/src/org/eclipse/ui/examples/navigator/PropertiesContentProvider.java
+++ b/examples/org.eclipse.ui.examples.navigator/src/org/eclipse/ui/examples/navigator/PropertiesContentProvider.java
@@ -25,9 +25,6 @@ import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IResourceDeltaVisitor;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jface.viewers.Viewer;
@@ -171,14 +168,11 @@ public class PropertiesContentProvider implements ITreeContentProvider,
 			final IFile file = (IFile) source;
 			if (PROPERTIES_EXT.equals(file.getFileExtension())) {
 				updateModel(file);
-				new UIJob("Update Properties Model in CommonViewer") {  //$NON-NLS-1$
-					@Override
-					public IStatus runInUIThread(IProgressMonitor monitor) {
-						if (viewer != null && !viewer.getControl().isDisposed())
-							viewer.refresh(file);
-						return Status.OK_STATUS;
+				UIJob.create("Update Properties Model in CommonViewer", m -> { //$NON-NLS-1$
+					if (viewer != null && !viewer.getControl().isDisposed()) {
+						viewer.refresh(file);
 					}
-				}.schedule();
+				}).schedule();
 			}
 			return false;
 		}

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestContentProvider.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestContentProvider.java
@@ -31,11 +31,8 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jface.viewers.Viewer;
@@ -187,16 +184,13 @@ public class TestContentProvider implements ITreeContentProvider,
 			return true;
 		case IResource.FILE:
 			final IFile file = (IFile) source;
-				if ("model.properties".equals(file.getName())) {
+			if ("model.properties".equals(file.getName())) {
 				updateModel(file);
-				new UIJob("Update Test Model in CommonViewer") {
-					@Override
-					public IStatus runInUIThread(IProgressMonitor monitor) {
-						if (viewer != null && !viewer.getControl().isDisposed())
-							viewer.refresh(file.getParent());
-						return Status.OK_STATUS;
+				UIJob.create("Update Test Model in CommonViewer", m -> {
+					if (viewer != null && !viewer.getControl().isDisposed()) {
+						viewer.refresh(file.getParent());
 					}
-				}.schedule();
+				}).schedule();
 			}
 			return false;
 		}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/UIJobTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/UIJobTest.java
@@ -75,15 +75,10 @@ public class UIJobTest extends UITestCase {
 		backgroundThreadInterrupted = false;
 		uiJobFinishedBeforeBackgroundThread = false;
 
-		final UIJob testJob = new UIJob("blah blah blah") {
-			@Override
-			public IStatus runInUIThread(IProgressMonitor monitor) {
-				backgroundThreadFinishedBeforeUIJob = backgroundThreadFinished;
-				uiJobFinished = true;
-
-				return Status.OK_STATUS;
-			}
-		};
+		final UIJob testJob = UIJob.create("blah blah blah", m -> {
+			backgroundThreadFinishedBeforeUIJob = backgroundThreadFinished;
+			uiJobFinished = true;
+		});
 
 		testJob.setPriority(Job.INTERACTIVE);
 


### PR DESCRIPTION
The Job class has convenient factory methods `create()` and `createSystem()` to create a job that executes a given `ICoreRunnable` or `IJobFunction`.
This PR proposes to add similar factories for the subclass `UIJob` named `UIJob.createUI()`. The name `createUI` was chosen to not clash with the super-class.