### PR TITLE
Send out an event during perspective switch

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench;singleton:=true
-Bundle-Version: 1.13.300.qualifier
+Bundle-Version: 1.14.0.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartServiceImpl.java
@@ -627,6 +627,7 @@ public class PartServiceImpl implements EPartService {
 
 				modelService.bringToTop(target);
 				activate(target, true, false);
+				UIEvents.publishEvent(UIEvents.UILifeCycle.PERSPECTIVE_SWITCHED, perspective);
 				return;
 			}
 
@@ -637,6 +638,7 @@ public class PartServiceImpl implements EPartService {
 				if (candidate != null) {
 					modelService.bringToTop(candidate);
 					activate(candidate, true, false);
+					UIEvents.publishEvent(UIEvents.UILifeCycle.PERSPECTIVE_SWITCHED, perspective);
 					return;
 				}
 			}
@@ -653,6 +655,7 @@ public class PartServiceImpl implements EPartService {
 					}
 				}
 				activate(newActivePart, true, false);
+				UIEvents.publishEvent(UIEvents.UILifeCycle.PERSPECTIVE_SWITCHED, perspective);
 			}
 		}
 	}

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/workbench/UIEvents.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/workbench/UIEvents.java
@@ -317,6 +317,13 @@ public class UIEvents {
 		String PERSPECTIVE_RESET = TOPIC + TOPIC_SEP + "perspReset"; //$NON-NLS-1$
 
 		/**
+		 * Sent when a perspective is switched
+		 *
+		 * @since 1.14
+		 */
+		String PERSPECTIVE_SWITCHED = TOPIC + TOPIC_SEP + "perspSwitched"; //$NON-NLS-1$
+
+		/**
 		 * Sent when application startup is complete
 		 */
 		String APP_STARTUP_COMPLETE = TOPIC + TOPIC_SEP + "appStartupComplete"; //$NON-NLS-1$


### PR DESCRIPTION
Currrently the system does not send out and event if the part service is used to switch a perspective. Fix this by adding this event and sending it out.