### PR TITLE
Issue #396: Certain ImageDescriptor classes should be adaptable for...

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FileImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FileImageDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,7 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Christoph Läubrich - Bug 567898 - [JFace][HiDPI] ImageDescriptor support alternative naming scheme for high dpi
- *     Daniel Krügler - #375, #378, #376
+ *     Daniel Krügler - #375, #376, #378, #396
  *******************************************************************************/
 package org.eclipse.jface.resource;
 
@@ -26,6 +26,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
@@ -41,7 +42,7 @@ import org.eclipse.swt.graphics.ImageFileNameProvider;
 /**
  * An image descriptor that loads its image information from a file.
  */
-class FileImageDescriptor extends ImageDescriptor {
+class FileImageDescriptor extends ImageDescriptor implements IAdaptable {
 
 	private static final Pattern XPATH_PATTERN = Pattern.compile("(\\d+)x(\\d+)"); //$NON-NLS-1$
 
@@ -294,5 +295,14 @@ class FileImageDescriptor extends ImageDescriptor {
 			}
 			return null;
 		}
+	}
+
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		if (adapter == ImageFileNameProvider.class) {
+			// Support testing ImageFileNameProvider characteristics, see #396
+			return adapter.cast(new ImageProvider());
+		}
+		return null;
 	}
 }

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FileImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FileImageDescriptor.java
@@ -49,15 +49,25 @@ class FileImageDescriptor extends ImageDescriptor implements IAdaptable {
 	private class ImageProvider implements ImageFileNameProvider {
 		@Override
 		public String getImagePath(int zoom) {
+			final boolean logIOException = zoom == 100;
+			if (zoom == 100) {
+				return getFilePath(name, logIOException);
+			}
 			String xName = getxName(name, zoom);
 			if (xName != null) {
-				return getFilePath(xName, zoom == 100);
+				String xResult = getFilePath(xName, logIOException);
+				if (xResult != null) {
+					return xResult;
+				}
 			}
 			String xPath = getxPath(name, zoom);
 			if (xPath != null) {
-				return getFilePath(xPath, zoom == 100);
+				String xResult = getFilePath(xPath, logIOException);
+				if (xResult != null) {
+					return xResult;
+				}
 			}
-			return getFilePath(name, zoom == 100);
+			return null;
 		}
 	}
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/URLImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/URLImageDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,8 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     Patrik Suzzi <psuzzi@gmail.com> - Bug 483465
  *     Christoph Läubrich - Bug 567898 - [JFace][HiDPI] ImageDescriptor support alternative naming scheme for high dpi
- *     Daniel Krügler - #376 - jface High-DPI: URL/FileImageDescriptor: ImageFileNameProvider implementation
- *                             should also test for XPATH_PATTERN
+ *     Daniel Krügler - #376, #396
  *******************************************************************************/
 package org.eclipse.jface.resource;
 
@@ -24,6 +23,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
@@ -42,7 +42,7 @@ import org.eclipse.swt.graphics.ImageFileNameProvider;
  * public API. Use ImageDescriptor#createFromURL to create a descriptor that
  * uses a URL.
  */
-class URLImageDescriptor extends ImageDescriptor {
+class URLImageDescriptor extends ImageDescriptor implements IAdaptable {
 
 	private static class URLImageFileNameProvider implements ImageFileNameProvider {
 		private String url;
@@ -342,6 +342,15 @@ class URLImageDescriptor extends ImageDescriptor {
 			Policy.getLog().log(new Status(IStatus.ERROR, Policy.JFACE, e.getLocalizedMessage(), e));
 		}
 		return result;
+	}
+
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		if (adapter == ImageFileNameProvider.class) {
+			// Support testing ImageFileNameProvider characteristics, see #396
+			return adapter.cast(new URLImageFileNameProvider(url));
+		}
+		return null;
 	}
 
 }

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/URLImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/URLImageDescriptor.java
@@ -55,15 +55,22 @@ class URLImageDescriptor extends ImageDescriptor implements IAdaptable {
 		public String getImagePath(int zoom) {
 			URL tempURL = getURL(url);
 			if (tempURL != null) {
+				final boolean logIOException = zoom == 100;
+				if (zoom == 100) {
+					return getFilePath(tempURL, logIOException);
+				}
 				URL xUrl = getxURL(tempURL, zoom);
 				if (xUrl != null) {
-					return getFilePath(xUrl, zoom == 100);
+					String xResult = getFilePath(xUrl, logIOException);
+					if (xResult != null) {
+						return xResult;
+					}
 				}
 				String xpath = FileImageDescriptor.getxPath(url, zoom);
 				if (xpath != null) {
 					URL xPathUrl = getURL(xpath);
 					if (xPathUrl != null) {
-						return getFilePath(xPathUrl, zoom == 100);
+						return getFilePath(xPathUrl, logIOException);
 					}
 				}
 			}

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/FileImageDescriptorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/FileImageDescriptorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 IBM Corporation and others.
+ * Copyright (c) 2008, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,7 @@
  *     Karsten Stoeckmann <ngc2997@gmx.net> - Test case for Bug 220766
  *     		[JFace] ImageRegistry.get does not work as expected (crashes with NullPointerException)
  *     Christoph Läubrich - Bug 567898 - [JFace][HiDPI] ImageDescriptor support alternative naming scheme for high dpi
- *     Daniel Kruegler - #375, #378
+ *     Daniel Kruegler - #375, #378, #396
  ******************************************************************************/
 
 package org.eclipse.jface.tests.images;
@@ -25,10 +25,12 @@ import java.util.Enumeration;
 import java.util.Iterator;
 
 import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.ImageFileNameProvider;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
@@ -172,6 +174,24 @@ public class FileImageDescriptorTest extends TestCase {
 		assertNotNull(imageDataZoomed);
 		assertEquals(Math.round(imageData.width * 1.5), imageDataZoomed.width);
 		assertEquals(Math.round(imageData.height * 1.5), imageDataZoomed.height);
+	}
+
+	public void testImageFileNameProviderGetxPath() {
+		ImageDescriptor descriptor = ImageDescriptor.createFromFile(FileImageDescriptorTest.class,
+				"/icons/imagetests/rectangular-57x16.png");
+		assertTrue("FileImageDescriptor does not implement IAdaptable", descriptor instanceof IAdaptable);
+		IAdaptable adaptable = (IAdaptable) descriptor;
+		ImageFileNameProvider fileNameProvider = adaptable.getAdapter(ImageFileNameProvider.class);
+		assertNotNull(fileNameProvider);
+		String imagePath100 = fileNameProvider.getImagePath(100);
+		assertNotNull(imagePath100);
+		assertEquals(Path.fromOSString(imagePath100).lastSegment(), "rectangular-57x16.png");
+		String imagePath200 = fileNameProvider.getImagePath(200);
+		assertNotNull(imagePath200);
+		assertEquals(Path.fromOSString(imagePath200).lastSegment(), "rectangular-114x32.png");
+		String imagePath150 = fileNameProvider.getImagePath(150);
+		assertNotNull(imagePath150);
+		assertEquals(Path.fromOSString(imagePath150).lastSegment(), "rectangular-86x24.png");
 	}
 
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/FileImageDescriptorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/FileImageDescriptorTest.java
@@ -182,16 +182,35 @@ public class FileImageDescriptorTest extends TestCase {
 		assertTrue("FileImageDescriptor does not implement IAdaptable", descriptor instanceof IAdaptable);
 		IAdaptable adaptable = (IAdaptable) descriptor;
 		ImageFileNameProvider fileNameProvider = adaptable.getAdapter(ImageFileNameProvider.class);
-		assertNotNull(fileNameProvider);
+		assertNotNull("FileImageDescriptor does not adapt to ImageFileNameProvider", fileNameProvider);
 		String imagePath100 = fileNameProvider.getImagePath(100);
-		assertNotNull(imagePath100);
+		assertNotNull("FileImageDescriptor's ImageFileNameProvider does not return the 100% path", imagePath100);
 		assertEquals(Path.fromOSString(imagePath100).lastSegment(), "rectangular-57x16.png");
 		String imagePath200 = fileNameProvider.getImagePath(200);
-		assertNotNull(imagePath200);
+		assertNotNull("FileImageDescriptor's ImageFileNameProvider does not return the 200% path", imagePath200);
 		assertEquals(Path.fromOSString(imagePath200).lastSegment(), "rectangular-114x32.png");
 		String imagePath150 = fileNameProvider.getImagePath(150);
-		assertNotNull(imagePath150);
+		assertNotNull("FileImageDescriptor's ImageFileNameProvider does not return the 150% path", imagePath150);
 		assertEquals(Path.fromOSString(imagePath150).lastSegment(), "rectangular-86x24.png");
+		String imagePath250 = fileNameProvider.getImagePath(250);
+		assertNull("FileImageDescriptor's ImageFileNameProvider does return a 250% path", imagePath250);
+	}
+
+	public void testImageFileNameProviderGetxName() {
+		ImageDescriptor descriptor = ImageDescriptor.createFromFile(FileImageDescriptorTest.class,
+				"/icons/imagetests/zoomIn.png");
+		assertTrue("FileImageDescriptor does not implement IAdaptable", descriptor instanceof IAdaptable);
+		IAdaptable adaptable = (IAdaptable) descriptor;
+		ImageFileNameProvider fileNameProvider = adaptable.getAdapter(ImageFileNameProvider.class);
+		assertNotNull("FileImageDescriptor does not adapt to ImageFileNameProvider", fileNameProvider);
+		String imagePath100 = fileNameProvider.getImagePath(100);
+		assertNotNull("FileImageDescriptor's ImageFileNameProvider does not return the 100% path", imagePath100);
+		assertEquals(Path.fromOSString(imagePath100).lastSegment(), "zoomIn.png");
+		String imagePath200 = fileNameProvider.getImagePath(200);
+		assertNotNull("FileImageDescriptor's ImageFileNameProvider does not return the @2x path", imagePath200);
+		assertEquals(Path.fromOSString(imagePath200).lastSegment(), "zoomIn@2x.png");
+		String imagePath150 = fileNameProvider.getImagePath(150);
+		assertNull("FileImageDescriptor's ImageFileNameProvider does return a @1.5x path", imagePath150);
 	}
 
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/UrlImageDescriptorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/UrlImageDescriptorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Christoph Läubrich and others.
+ * Copyright (c) 2020, 2022 Christoph Läubrich and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,11 +10,15 @@
  *
  * Contributors:
  *     Christoph Läubrich - initial API and implementation
+ *     Daniel Kruegler - #396 - [jface] Certain ImageDescriptor classes should be adaptable for some internal properties
  ******************************************************************************/
 package org.eclipse.jface.tests.images;
 
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.ImageFileNameProvider;
 
 import junit.framework.TestCase;
 
@@ -39,4 +43,24 @@ public class UrlImageDescriptorTest extends TestCase {
 		assertNotNull(imageDataZoomed);
 		assertEquals(imageData.width * 2, imageDataZoomed.width);
 	}
+
+	public void testImageFileNameProviderGetxPath() {
+		ImageDescriptor descriptor = ImageDescriptor
+				.createFromURL(FileImageDescriptorTest.class.getResource("/icons/imagetests/rectangular-57x16.png"));
+
+		assertTrue("URLImageDescriptor does not implement IAdaptable", descriptor instanceof IAdaptable);
+		IAdaptable adaptable = (IAdaptable) descriptor;
+		ImageFileNameProvider fileNameProvider = adaptable.getAdapter(ImageFileNameProvider.class);
+		assertNotNull(fileNameProvider);
+		String imagePath100 = fileNameProvider.getImagePath(100);
+		assertNotNull(imagePath100);
+		assertEquals(Path.fromOSString(imagePath100).lastSegment(), "rectangular-57x16.png");
+		String imagePath200 = fileNameProvider.getImagePath(200);
+		assertNotNull(imagePath200);
+		assertEquals(Path.fromOSString(imagePath200).lastSegment(), "rectangular-114x32.png");
+		String imagePath150 = fileNameProvider.getImagePath(150);
+		assertNotNull(imagePath150);
+		assertEquals(Path.fromOSString(imagePath150).lastSegment(), "rectangular-86x24.png");
+	}
+
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/UrlImageDescriptorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/UrlImageDescriptorTest.java
@@ -51,16 +51,36 @@ public class UrlImageDescriptorTest extends TestCase {
 		assertTrue("URLImageDescriptor does not implement IAdaptable", descriptor instanceof IAdaptable);
 		IAdaptable adaptable = (IAdaptable) descriptor;
 		ImageFileNameProvider fileNameProvider = adaptable.getAdapter(ImageFileNameProvider.class);
-		assertNotNull(fileNameProvider);
+		assertNotNull("URLImageDescriptor does not adapt to ImageFileNameProvider", fileNameProvider);
 		String imagePath100 = fileNameProvider.getImagePath(100);
-		assertNotNull(imagePath100);
+		assertNotNull("URLImageDescriptor ImageFileNameProvider does not return the 100% path", imagePath100);
 		assertEquals(Path.fromOSString(imagePath100).lastSegment(), "rectangular-57x16.png");
 		String imagePath200 = fileNameProvider.getImagePath(200);
-		assertNotNull(imagePath200);
+		assertNotNull("URLImageDescriptor ImageFileNameProvider does not return the 200% path", imagePath200);
 		assertEquals(Path.fromOSString(imagePath200).lastSegment(), "rectangular-114x32.png");
 		String imagePath150 = fileNameProvider.getImagePath(150);
-		assertNotNull(imagePath150);
+		assertNotNull("URLImageDescriptor ImageFileNameProvider does not return the 150% path", imagePath150);
 		assertEquals(Path.fromOSString(imagePath150).lastSegment(), "rectangular-86x24.png");
+		String imagePath250 = fileNameProvider.getImagePath(250);
+		assertNull("URLImageDescriptor's ImageFileNameProvider does return a 250% path", imagePath250);
+	}
+
+	public void testImageFileNameProviderGetxName() {
+		ImageDescriptor descriptor = ImageDescriptor
+				.createFromURL(FileImageDescriptorTest.class.getResource("/icons/imagetests/zoomIn.png"));
+
+		assertTrue("URLImageDescriptor does not implement IAdaptable", descriptor instanceof IAdaptable);
+		IAdaptable adaptable = (IAdaptable) descriptor;
+		ImageFileNameProvider fileNameProvider = adaptable.getAdapter(ImageFileNameProvider.class);
+		assertNotNull("URLImageDescriptor does not adapt to ImageFileNameProvider", fileNameProvider);
+		String imagePath100 = fileNameProvider.getImagePath(100);
+		assertNotNull("URLImageDescriptor ImageFileNameProvider does not return the 100% path", imagePath100);
+		assertEquals(Path.fromOSString(imagePath100).lastSegment(), "zoomIn.png");
+		String imagePath200 = fileNameProvider.getImagePath(200);
+		assertNotNull("URLImageDescriptor ImageFileNameProvider does not return the 200% path", imagePath200);
+		assertEquals(Path.fromOSString(imagePath200).lastSegment(), "zoomIn@2x.png");
+		String imagePath150 = fileNameProvider.getImagePath(150);
+		assertNull("URLImageDescriptor's ImageFileNameProvider does return a 150% path", imagePath150);
 	}
 
 }


### PR DESCRIPTION
...some internal properties

- Let FileImageDescriptor and URLImageDescriptor implement IAdaptable and provide adaption to ImageFileNameProvider (for testing purposes)
- Add unit tests that attempt to retrieve the underlying ImageFileNameProvider and validate the expected xPath results.

Signed-off-by: Daniel Krügler <daniel.kruegler@gmail.com>