### PR TITLE
Issue #398: FileImageDescriptor and URLImageDescriptor should hold...

### DIFF
--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/FileImageDescriptorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/FileImageDescriptorTest.java
@@ -13,7 +13,7 @@
  *     Karsten Stoeckmann <ngc2997@gmx.net> - Test case for Bug 220766
  *     		[JFace] ImageRegistry.get does not work as expected (crashes with NullPointerException)
  *     Christoph Läubrich - Bug 567898 - [JFace][HiDPI] ImageDescriptor support alternative naming scheme for high dpi
- *     Daniel Kruegler - #375, #378, #396
+ *     Daniel Kruegler - #375, #378, #396, #398
  ******************************************************************************/
 
 package org.eclipse.jface.tests.images;
@@ -183,6 +183,9 @@ public class FileImageDescriptorTest extends TestCase {
 		IAdaptable adaptable = (IAdaptable) descriptor;
 		ImageFileNameProvider fileNameProvider = adaptable.getAdapter(ImageFileNameProvider.class);
 		assertNotNull("FileImageDescriptor does not adapt to ImageFileNameProvider", fileNameProvider);
+		ImageFileNameProvider fileNameProvider2nd = adaptable.getAdapter(ImageFileNameProvider.class);
+		assertSame("FileImageDescriptor does not return unique ImageFileNameProvider", fileNameProvider,
+				fileNameProvider2nd);
 		String imagePath100 = fileNameProvider.getImagePath(100);
 		assertNotNull("FileImageDescriptor's ImageFileNameProvider does not return the 100% path", imagePath100);
 		assertEquals(Path.fromOSString(imagePath100).lastSegment(), "rectangular-57x16.png");

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/FileImageDescriptorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/FileImageDescriptorTest.java
@@ -24,8 +24,8 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
 
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
@@ -179,11 +179,9 @@ public class FileImageDescriptorTest extends TestCase {
 	public void testImageFileNameProviderGetxPath() {
 		ImageDescriptor descriptor = ImageDescriptor.createFromFile(FileImageDescriptorTest.class,
 				"/icons/imagetests/rectangular-57x16.png");
-		assertTrue("FileImageDescriptor does not implement IAdaptable", descriptor instanceof IAdaptable);
-		IAdaptable adaptable = (IAdaptable) descriptor;
-		ImageFileNameProvider fileNameProvider = adaptable.getAdapter(ImageFileNameProvider.class);
+		ImageFileNameProvider fileNameProvider = Adapters.adapt(descriptor, ImageFileNameProvider.class);
 		assertNotNull("FileImageDescriptor does not adapt to ImageFileNameProvider", fileNameProvider);
-		ImageFileNameProvider fileNameProvider2nd = adaptable.getAdapter(ImageFileNameProvider.class);
+		ImageFileNameProvider fileNameProvider2nd = Adapters.adapt(descriptor, ImageFileNameProvider.class);
 		assertSame("FileImageDescriptor does not return unique ImageFileNameProvider", fileNameProvider,
 				fileNameProvider2nd);
 		String imagePath100 = fileNameProvider.getImagePath(100);
@@ -202,9 +200,7 @@ public class FileImageDescriptorTest extends TestCase {
 	public void testImageFileNameProviderGetxName() {
 		ImageDescriptor descriptor = ImageDescriptor.createFromFile(FileImageDescriptorTest.class,
 				"/icons/imagetests/zoomIn.png");
-		assertTrue("FileImageDescriptor does not implement IAdaptable", descriptor instanceof IAdaptable);
-		IAdaptable adaptable = (IAdaptable) descriptor;
-		ImageFileNameProvider fileNameProvider = adaptable.getAdapter(ImageFileNameProvider.class);
+		ImageFileNameProvider fileNameProvider = Adapters.adapt(descriptor, ImageFileNameProvider.class);
 		assertNotNull("FileImageDescriptor does not adapt to ImageFileNameProvider", fileNameProvider);
 		String imagePath100 = fileNameProvider.getImagePath(100);
 		assertNotNull("FileImageDescriptor's ImageFileNameProvider does not return the 100% path", imagePath100);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/UrlImageDescriptorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/UrlImageDescriptorTest.java
@@ -14,7 +14,7 @@
  ******************************************************************************/
 package org.eclipse.jface.tests.images;
 
-import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.ImageData;
@@ -48,11 +48,9 @@ public class UrlImageDescriptorTest extends TestCase {
 		ImageDescriptor descriptor = ImageDescriptor
 				.createFromURL(FileImageDescriptorTest.class.getResource("/icons/imagetests/rectangular-57x16.png"));
 
-		assertTrue("URLImageDescriptor does not implement IAdaptable", descriptor instanceof IAdaptable);
-		IAdaptable adaptable = (IAdaptable) descriptor;
-		ImageFileNameProvider fileNameProvider = adaptable.getAdapter(ImageFileNameProvider.class);
+		ImageFileNameProvider fileNameProvider = Adapters.adapt(descriptor, ImageFileNameProvider.class);
 		assertNotNull("URLImageDescriptor does not adapt to ImageFileNameProvider", fileNameProvider);
-		ImageFileNameProvider fileNameProvider2nd = adaptable.getAdapter(ImageFileNameProvider.class);
+		ImageFileNameProvider fileNameProvider2nd = Adapters.adapt(descriptor, ImageFileNameProvider.class);
 		assertSame("URLImageDescriptor does not return unique ImageFileNameProvider", fileNameProvider,
 				fileNameProvider2nd);
 		String imagePath100 = fileNameProvider.getImagePath(100);
@@ -72,9 +70,7 @@ public class UrlImageDescriptorTest extends TestCase {
 		ImageDescriptor descriptor = ImageDescriptor
 				.createFromURL(FileImageDescriptorTest.class.getResource("/icons/imagetests/zoomIn.png"));
 
-		assertTrue("URLImageDescriptor does not implement IAdaptable", descriptor instanceof IAdaptable);
-		IAdaptable adaptable = (IAdaptable) descriptor;
-		ImageFileNameProvider fileNameProvider = adaptable.getAdapter(ImageFileNameProvider.class);
+		ImageFileNameProvider fileNameProvider = Adapters.adapt(descriptor, ImageFileNameProvider.class);
 		assertNotNull("URLImageDescriptor does not adapt to ImageFileNameProvider", fileNameProvider);
 		String imagePath100 = fileNameProvider.getImagePath(100);
 		assertNotNull("URLImageDescriptor ImageFileNameProvider does not return the 100% path", imagePath100);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/UrlImageDescriptorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/UrlImageDescriptorTest.java
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Christoph Läubrich - initial API and implementation
- *     Daniel Kruegler - #396 - [jface] Certain ImageDescriptor classes should be adaptable for some internal properties
+ *     Daniel Kruegler - #396, #398
  ******************************************************************************/
 package org.eclipse.jface.tests.images;
 
@@ -52,6 +52,9 @@ public class UrlImageDescriptorTest extends TestCase {
 		IAdaptable adaptable = (IAdaptable) descriptor;
 		ImageFileNameProvider fileNameProvider = adaptable.getAdapter(ImageFileNameProvider.class);
 		assertNotNull("URLImageDescriptor does not adapt to ImageFileNameProvider", fileNameProvider);
+		ImageFileNameProvider fileNameProvider2nd = adaptable.getAdapter(ImageFileNameProvider.class);
+		assertSame("URLImageDescriptor does not return unique ImageFileNameProvider", fileNameProvider,
+				fileNameProvider2nd);
 		String imagePath100 = fileNameProvider.getImagePath(100);
 		assertNotNull("URLImageDescriptor ImageFileNameProvider does not return the 100% path", imagePath100);
 		assertEquals(Path.fromOSString(imagePath100).lastSegment(), "rectangular-57x16.png");
@@ -77,10 +80,10 @@ public class UrlImageDescriptorTest extends TestCase {
 		assertNotNull("URLImageDescriptor ImageFileNameProvider does not return the 100% path", imagePath100);
 		assertEquals(Path.fromOSString(imagePath100).lastSegment(), "zoomIn.png");
 		String imagePath200 = fileNameProvider.getImagePath(200);
-		assertNotNull("URLImageDescriptor ImageFileNameProvider does not return the 200% path", imagePath200);
+		assertNotNull("URLImageDescriptor ImageFileNameProvider does not return the @2x path", imagePath200);
 		assertEquals(Path.fromOSString(imagePath200).lastSegment(), "zoomIn@2x.png");
 		String imagePath150 = fileNameProvider.getImagePath(150);
-		assertNull("URLImageDescriptor's ImageFileNameProvider does return a 150% path", imagePath150);
+		assertNull("URLImageDescriptor's ImageFileNameProvider does return a @1.5x path", imagePath150);
 	}
 
 }


### PR DESCRIPTION
... only a single ImageFileNameProvider instance

- Introduce a lazily generated ImageFileNameProvider in FileImageDescriptor and URLImageDescriptor.
- Make the pre-existing fields of FileImageDescriptor and URLImageDescriptor final as an additional guarantee that these are effectively immutable, justifying the usage of an only once generated ImageFileNameProvider.
- Extend existing tests for FileImageDescriptor and URLImageDescriptor that getAdapter returns a unique instance of ImageFileNameProvider.

Signed-off-by: Daniel Krügler <daniel.kruegler@gmail.com>