### PR TITLE
sBug 576213: Create Shell in Display

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.27.100.qualifier
+Bundle-Version: 3.28.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/widgets/AbstractWidgetFactory.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/widgets/AbstractWidgetFactory.java
@@ -65,8 +65,12 @@ public abstract class AbstractWidgetFactory<F extends AbstractWidgetFactory<?, ?
 	 */
 	public final W create(P parent) {
 		W widget = widgetCreator.create(parent);
-		properties.forEach(p -> p.apply(widget));
+		applyProperties(widget);
 		return widget;
+	}
+
+	void applyProperties(W widget) {
+		properties.forEach(p -> p.apply(widget));
 	}
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/widgets/ShellFactory.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/widgets/ShellFactory.java
@@ -20,6 +20,7 @@ import org.eclipse.swt.events.ShellEvent;
 import org.eclipse.swt.events.ShellListener;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Decorations;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Shell;
 
@@ -70,6 +71,20 @@ public final class ShellFactory extends AbstractCompositeFactory<ShellFactory, S
 	 */
 	private ShellFactory(int style) {
 		super(ShellFactory.class, (Composite parent) -> new Shell((Shell) parent, style));
+	}
+
+	/**
+	 * Creates the shell in the given display.
+	 *
+	 * @param display
+	 * @return the created shell
+	 *
+	 * @since 3.28
+	 */
+	public final Shell create(Display display) {
+		Shell shell = new Shell(display);
+		applyProperties(shell);
+		return shell;
 	}
 
 	/**

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitShellFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitShellFactory.java
@@ -16,11 +16,13 @@ package org.eclipse.jface.tests.widgets;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.eclipse.jface.widgets.ShellFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ShellEvent;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Shell;
@@ -32,6 +34,15 @@ public class TestUnitShellFactory extends AbstractFactoryTest {
 	public void createsShell() {
 		Shell myShell = ShellFactory.newShell(SWT.BORDER).create(shell);
 		assertEquals(shell, myShell.getParent());
+	}
+
+	@Test
+	public void createsShellInDisplayWithText() {
+		Display display = Display.getDefault();
+		Shell myShell = ShellFactory.newShell(SWT.BORDER).text("Test").create(display);
+		assertEquals("Test", myShell.getText());
+		assertNull(myShell.getParent());
+		assertEquals(display, myShell.getDisplay());
 	}
 
 	@Test


### PR DESCRIPTION
A new method in ShellFactory to create the shell not only i a parent control but also in a Display (which is the most common use case).

Signed-off-by: Marcus Hoepfner <marcus.hoepfner@sap.com>