### PR TITLE
ProgressManager: add Test for rescheduled Jobs #327

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/FinishedJobs.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/FinishedJobs.java
@@ -164,7 +164,7 @@ public final class FinishedJobs extends EventManager {
 	 *
 	 * @param l listener to remove. Not {@code null}.
 	 */
-	void removeListener(KeptJobsListener l) {
+	public void removeListener(KeptJobsListener l) {
 		removeListenerObject(l);
 	}
 


### PR DESCRIPTION
Shows reschedules jobs have a a regression: they are currently not properly removed from ProgressManager.getJobInfos() anymore.