### PR TITLE
Issue #401: MenuHelper#getIconURI should be improved

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FileImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FileImageDescriptor.java
@@ -11,7 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Christoph Läubrich - Bug 567898 - [JFace][HiDPI] ImageDescriptor support alternative naming scheme for high dpi
- *     Daniel Krügler - #375, #376, #378, #396, #398
+ *     Daniel Kruegler - #375, #376, #378, #396, #398, #401
  *******************************************************************************/
 package org.eclipse.jface.resource;
 
@@ -264,7 +264,6 @@ class FileImageDescriptor extends ImageDescriptor implements IAdaptable, ImageFi
 			return null;
 		try {
 			if (!InternalPolicy.OSGI_AVAILABLE) {// Stand-alone case
-
 				return new Path(resource.getFile()).toOSString();
 			}
 			return new Path(FileLocator.toFileURL(resource).getPath()).toOSString();
@@ -306,10 +305,12 @@ class FileImageDescriptor extends ImageDescriptor implements IAdaptable, ImageFi
 
 	@Override
 	public <T> T getAdapter(Class<T> adapter) {
-		if (adapter == ImageFileNameProvider.class) {
-			// Support testing ImageFileNameProvider characteristics, see #396
-			return adapter.cast(this);
+		if (adapter == URL.class) {
+			if (location != null && name != null) {
+				return adapter.cast(location.getResource(name));
+			}
 		}
 		return null;
 	}
+
 }

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/URLImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/URLImageDescriptor.java
@@ -12,7 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     Patrik Suzzi <psuzzi@gmail.com> - Bug 483465
  *     Christoph Läubrich - Bug 567898 - [JFace][HiDPI] ImageDescriptor support alternative naming scheme for high dpi
- *     Daniel Krügler - #376, #396, #398, #399
+ *     Daniel Kruegler - #376, #396, #398, #399, #401
  *******************************************************************************/
 package org.eclipse.jface.resource;
 
@@ -328,9 +328,8 @@ class URLImageDescriptor extends ImageDescriptor implements IAdaptable, ImageFil
 
 	@Override
 	public <T> T getAdapter(Class<T> adapter) {
-		if (adapter == ImageFileNameProvider.class) {
-			// Support testing ImageFileNameProvider characteristics, see #396
-			return adapter.cast(this);
+		if (adapter == URL.class) {
+			return adapter.cast(getURL(url));
 		}
 		return null;
 	}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/menus/MenuHelper.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/menus/MenuHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2019 IBM Corporation and others.
+ * Copyright (c) 2010, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,10 +11,10 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 180308, 472654
+ *     Daniel Kruegler - #399, #401
  *******************************************************************************/
 package org.eclipse.ui.internal.menus;
 
-import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -22,7 +22,6 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.ParameterizedCommand;
@@ -30,15 +29,14 @@ import org.eclipse.core.expressions.EvaluationResult;
 import org.eclipse.core.expressions.Expression;
 import org.eclipse.core.expressions.ExpressionConverter;
 import org.eclipse.core.expressions.IEvaluationContext;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.core.runtime.IAdapterManager;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.InvalidRegistryObjectException;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.e4.core.commands.EHandlerService;
 import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.core.services.adapter.Adapter;
 import org.eclipse.e4.ui.internal.workbench.swt.Policy;
 import org.eclipse.e4.ui.internal.workbench.swt.WorkbenchSWTActivator;
 import org.eclipse.e4.ui.model.application.MApplication;
@@ -74,86 +72,9 @@ public class MenuHelper {
 	}
 
 	private static final Pattern SCHEME_PATTERN = Pattern.compile("\\p{Alpha}[\\p{Alnum}+.-]*:.*"); //$NON-NLS-1$
-	private static Field urlField;
-	private static Field urlSupplierField;
-
-	/**
-	 * The private 'location' field that is defined in the FileImageDescriptor.
-	 *
-	 * @see #getLocation(ImageDescriptor)
-	 */
-	private static Field locationField;
-
-	/**
-	 * The private 'name' field that is defined in the FileImageDescriptor.
-	 *
-	 * @see #getName(ImageDescriptor)
-	 */
-	private static Field nameField;
 
 	public static String getImageUrl(ImageDescriptor imageDescriptor) {
 		return getIconURI(imageDescriptor, null);
-	}
-
-	private static String getUrl(Class<? extends ImageDescriptor> idc, ImageDescriptor imageDescriptor) {
-		try {
-			if (urlField == null) {
-				urlField = idc.getDeclaredField("url"); //$NON-NLS-1$
-				urlField.setAccessible(true);
-			}
-			Object value = urlField.get(imageDescriptor);
-			if (value != null) {
-				return value.toString();
-			}
-		} catch (SecurityException | NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
-			WorkbenchPlugin.log(e);
-		}
-		return null;
-	}
-
-	private static String getUrlSupplier(Class<? extends ImageDescriptor> idc, ImageDescriptor imageDescriptor) {
-		try {
-			if (urlSupplierField == null) {
-				urlSupplierField = idc.getDeclaredField("supplier"); //$NON-NLS-1$
-				urlSupplierField.setAccessible(true);
-			}
-			Object value = urlSupplierField.get(imageDescriptor);
-			if (value != null && value instanceof Supplier) {
-				@SuppressWarnings("unchecked")
-				Supplier<URL> supplier = (Supplier<URL>) value;
-				URL url = supplier.get();
-				return url == null ? null : url.toString();
-			}
-		} catch (SecurityException | NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
-			WorkbenchPlugin.log(e);
-		}
-		return null;
-	}
-
-	private static Class<?> getLocation(ImageDescriptor imageDescriptor) {
-		try {
-			if (locationField == null) {
-				locationField = imageDescriptor.getClass().getDeclaredField("location"); //$NON-NLS-1$
-				locationField.setAccessible(true);
-			}
-			return (Class<?>) locationField.get(imageDescriptor);
-		} catch (SecurityException | NoSuchFieldException | IllegalAccessException e) {
-			WorkbenchPlugin.log(e);
-		}
-		return null;
-	}
-
-	private static String getName(ImageDescriptor imageDescriptor) {
-		try {
-			if (nameField == null) {
-				nameField = imageDescriptor.getClass().getDeclaredField("name"); //$NON-NLS-1$
-				nameField.setAccessible(true);
-			}
-			return (String) nameField.get(imageDescriptor);
-		} catch (SecurityException | NoSuchFieldException | IllegalAccessException e) {
-			WorkbenchPlugin.log(e);
-		}
-		return null;
 	}
 
 	static MExpression getVisibleWhen(final IConfigurationElement commandAddition) {
@@ -460,54 +381,25 @@ public class MenuHelper {
 
 		// Attempt to retrieve URIs from the descriptor and convert into a more
 		// durable form in case it's to be persisted
-		if (descriptor.getClass().toString().endsWith("URLImageDescriptor")) { //$NON-NLS-1$
-			String url = getUrl(descriptor.getClass(), descriptor);
-			return rewriteDurableURL(url);
-		} else if (descriptor.getClass().toString().endsWith("DeferredImageDescriptor")) { //$NON-NLS-1$
-			String url = getUrlSupplier(descriptor.getClass(), descriptor);
-			return rewriteDurableURL(url);
-		} else if (descriptor.getClass().toString().endsWith("FileImageDescriptor")) { //$NON-NLS-1$
-			Class<?> sourceClass = getLocation(descriptor);
-			if (sourceClass == null) {
-				return null;
-			}
-
-			String path = getName(descriptor);
-			if (path == null) {
-				return null;
-			}
-
-			Bundle bundle = FrameworkUtil.getBundle(sourceClass);
-			// get the fully qualified class name
-			String parentPath = sourceClass.getName();
-			// remove the class's name
-			parentPath = parentPath.substring(0, parentPath.lastIndexOf('.'));
-			// swap '.' with '/' so that it becomes a path
-			parentPath = parentPath.replace('.', '/');
-
-			// construct the URL
-			URL url = FileLocator.find(bundle, new Path(parentPath).append(path), null);
-			return url == null ? null : rewriteDurableURL(url.toString());
-		} else if (descriptor instanceof IAdaptable) {
-			Object o = ((IAdaptable) descriptor).getAdapter(URL.class);
+		Adapter adapter = context != null ? context.get(Adapter.class) : null;
+		if (adapter != null) {
+			Object o = adapter.adapt(descriptor, URL.class);
 			if (o != null) {
 				return rewriteDurableURL(o.toString());
 			}
-			o = ((IAdaptable) descriptor).getAdapter(URI.class);
+			o = adapter.adapt(descriptor, URI.class);
 			if (o != null) {
 				return rewriteDurableURL(o.toString());
 			}
-		} else if (context != null) {
-			IAdapterManager adapter = context.get(IAdapterManager.class);
-			if (adapter != null) {
-				Object o = adapter.getAdapter(descriptor, URL.class);
-				if (o != null) {
-					return rewriteDurableURL(o.toString());
-				}
-				o = adapter.getAdapter(descriptor, URI.class);
-				if (o != null) {
-					return rewriteDurableURL(o.toString());
-				}
+		}
+		else {
+			Object o = Adapters.adapt(descriptor, URL.class);
+			if (o != null) {
+				return rewriteDurableURL(o.toString());
+			}
+			o = Adapters.adapt(descriptor, URI.class);
+			if (o != null) {
+				return rewriteDurableURL(o.toString());
 			}
 		}
 		return null;

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/DeferredImageDescriptorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/DeferredImageDescriptorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, Alex Blewitt and others
+ * Copyright (c) 2020, 2022, Alex Blewitt and others
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,10 +10,14 @@
  *
  * Contributors:
  *     Alex Blewitt - initial API and implementation
+ *     Daniel Kruegler - #399, #401
  ******************************************************************************/
 
 package org.eclipse.jface.tests.images;
 
+import java.net.URL;
+
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.ImageData;
 
@@ -23,6 +27,7 @@ import junit.framework.TestCase;
  * Test loading ImageDescriptors from a URL calculated on demand.
  */
 public class DeferredImageDescriptorTest extends TestCase {
+
 	public void testDeferredLoading() {
 		ImageData empty = ImageDescriptor.getMissingImageDescriptor().getImageData(100);
 		assertEquals(empty, ImageDescriptor.createFromURLSupplier(true, () -> null).getImageData(100));
@@ -40,4 +45,23 @@ public class DeferredImageDescriptorTest extends TestCase {
 				.createFromURLSupplier(true, () -> DeferredImageDescriptorTest.class.getResource("anything.gif"))
 				.createImage());
 	}
+
+	public void testAdaptToURL() {
+		ImageDescriptor descriptor = ImageDescriptor.createFromURLSupplier(false,
+				() -> DeferredImageDescriptorTest.class.getResource("anything.gif"));
+
+		URL url = Adapters.adapt(descriptor, URL.class);
+		assertNotNull("DeferredImageDescriptor does not adapt to URL", url);
+
+		ImageDescriptor descriptorFromUrl = ImageDescriptor.createFromURL(url);
+
+		ImageData imageDataOrig = descriptor.getImageData(100);
+		assertNotNull("Original URL does not return 100% image data", imageDataOrig);
+
+		ImageData imageDataURL = descriptorFromUrl.getImageData(100);
+		assertNotNull("Adapted URL does not return 100% image data", imageDataURL);
+		assertEquals(imageDataOrig.width, imageDataURL.width);
+		assertEquals(imageDataOrig.height, imageDataURL.height);
+	}
+
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/FileImageDescriptorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/FileImageDescriptorTest.java
@@ -13,7 +13,7 @@
  *     Karsten Stoeckmann <ngc2997@gmx.net> - Test case for Bug 220766
  *     		[JFace] ImageRegistry.get does not work as expected (crashes with NullPointerException)
  *     Christoph Läubrich - Bug 567898 - [JFace][HiDPI] ImageDescriptor support alternative naming scheme for high dpi
- *     Daniel Kruegler - #375, #378, #396, #398
+ *     Daniel Kruegler - #375, #378, #396, #398, #399, #401
  ******************************************************************************/
 
 package org.eclipse.jface.tests.images;
@@ -210,6 +210,31 @@ public class FileImageDescriptorTest extends TestCase {
 		assertEquals(Path.fromOSString(imagePath200).lastSegment(), "zoomIn@2x.png");
 		String imagePath150 = fileNameProvider.getImagePath(150);
 		assertNull("FileImageDescriptor's ImageFileNameProvider does return a @1.5x path", imagePath150);
+	}
+
+	public void testAdaptToURL() {
+		ImageDescriptor descriptor = ImageDescriptor.createFromFile(FileImageDescriptorTest.class,
+				"/icons/imagetests/rectangular-57x16.png");
+
+		URL url = Adapters.adapt(descriptor, URL.class);
+		assertNotNull("FileImageDescriptor does not adapt to URL", url);
+
+		ImageDescriptor descriptorFromUrl = ImageDescriptor.createFromURL(url);
+
+		ImageData imageDataOrig = descriptor.getImageData(100);
+		assertNotNull("Original URL does not return 100% image data", imageDataOrig);
+
+		ImageData imageDataURL = descriptorFromUrl.getImageData(100);
+		assertNotNull("Adapted URL does not return 100% image data", imageDataURL);
+		assertEquals(imageDataOrig.width, imageDataURL.width);
+		assertEquals(imageDataOrig.height, imageDataURL.height);
+
+		ImageData imageDataOrig200 = descriptor.getImageData(200);
+		assertNotNull("Original URL does not return 200% image data", imageDataOrig200);
+
+		ImageData imageDataURL200 = descriptorFromUrl.getImageData(200);
+		assertEquals(imageDataOrig200.width, imageDataURL200.width);
+		assertEquals(imageDataOrig200.height, imageDataURL200.height);
 	}
 
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/UrlImageDescriptorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/UrlImageDescriptorTest.java
@@ -10,9 +10,11 @@
  *
  * Contributors:
  *     Christoph Läubrich - initial API and implementation
- *     Daniel Kruegler - #396, #398
+ *     Daniel Kruegler - #396, #398, #399, #401
  ******************************************************************************/
 package org.eclipse.jface.tests.images;
+
+import java.net.URL;
 
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.Path;
@@ -80,6 +82,31 @@ public class UrlImageDescriptorTest extends TestCase {
 		assertEquals(Path.fromOSString(imagePath200).lastSegment(), "zoomIn@2x.png");
 		String imagePath150 = fileNameProvider.getImagePath(150);
 		assertNull("URLImageDescriptor's ImageFileNameProvider does return a @1.5x path", imagePath150);
+	}
+
+	public void testAdaptToURL() {
+		ImageDescriptor descriptor = ImageDescriptor
+				.createFromURL(FileImageDescriptorTest.class.getResource("/icons/imagetests/rectangular-57x16.png"));
+
+		URL url = Adapters.adapt(descriptor, URL.class);
+		assertNotNull("URLImageDescriptor does not adapt to URL", url);
+
+		ImageDescriptor descriptorFromUrl = ImageDescriptor.createFromURL(url);
+
+		ImageData imageDataOrig = descriptor.getImageData(100);
+		assertNotNull("Original URL does not return 100% image data", imageDataOrig);
+
+		ImageData imageDataURL = descriptorFromUrl.getImageData(100);
+		assertNotNull("Adapted URL does not return 100% image data", imageDataURL);
+		assertEquals(imageDataOrig.width, imageDataURL.width);
+		assertEquals(imageDataOrig.height, imageDataURL.height);
+
+		ImageData imageDataOrig200 = descriptor.getImageData(200);
+		assertNotNull("Original URL does not return 200% image data", imageDataOrig200);
+
+		ImageData imageDataURL200 = descriptorFromUrl.getImageData(200);
+		assertEquals(imageDataOrig200.width, imageDataURL200.width);
+		assertEquals(imageDataOrig200.height, imageDataURL200.height);
 	}
 
 }


### PR DESCRIPTION
- Make DeferredImageDescriptor, FileImageDescriptor, and URLImageDescriptor adaptable to URL
- For FileImageDescriptor and URLImageDescriptor remove explicit adaption to ImageFileNameProvider, since Adapters.adapt will also find the inherited one
- Add new ImageDescriptor tests that validate URL adaption
- Refactor DeferredImageDescriptor to hold as field the URL from the Supplier and get it only once
- Refactor MenuHelper#getIconURI by eliminating the reflection-based part and by replacing the IAdaptable+IAdapterManager pattern by Adapters.adapt, if no context is available, otherwise use the org.eclipse.e4.core.services.adapter.Adapter as adapter.

Signed-off-by: Daniel Krügler <daniel.kruegler@gmail.com>