### PR TITLE
Check for disposed widged in CSS styling for ToolItemElement

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/dom/ToolItemElement.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/dom/ToolItemElement.java
@@ -38,8 +38,11 @@ public class ToolItemElement extends ItemElement {
 	private SelectionListener selectionListener = new SelectionAdapter() {
 		@Override
 		public void widgetSelected(SelectionEvent e) {
-			ToolItemElement.this.isSelected = getToolItem().getSelection();
-			doApplyStyles();
+			ToolItem toolItem = getToolItem();
+			if (toolItem != null && !toolItem.isDisposed()) {
+				ToolItemElement.this.isSelected = getToolItem().getSelection();
+				doApplyStyles();
+			}
 		}
 	};
 


### PR DESCRIPTION
If dynamic styling is used via boolean dynamicEnabled = Boolean.getBoolean("org.eclipse.e4.ui.css.dynamic"); I sometimes get the following stacktrace.

org.eclipse.swt.SWTException: Widget is disposed
	at org.eclipse.swt.SWT.error(SWT.java:4918)
	at org.eclipse.swt.SWT.error(SWT.java:4833)
	at org.eclipse.swt.SWT.error(SWT.java:4804)
	at org.eclipse.swt.widgets.Widget.error(Widget.java:565)
	at org.eclipse.swt.widgets.Widget.checkWidget(Widget.java:480)
	at org.eclipse.swt.widgets.ToolItem.getSelection(ToolItem.java:574)
	at org.eclipse.e4.ui.css.swt.dom.ToolItemElement$1.widgetSelected(ToolItemElement.java:41)

This commit ensures that the toolitem is not yet disposed before applying the CSS styles.