### PR TITLE
Require bundle junit-jupiter-engine in org.eclipse.e4.ui.tests.css.core

### DIFF
--- a/tests/org.eclipse.e4.ui.tests.css.core/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests.css.core/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.swt,
  org.eclipse.e4.ui.css.core,
  org.eclipse.e4.ui.css.swt,
- org.w3c.css.sac
+ org.w3c.css.sac,
+ junit-jupiter-engine
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Eclipse-BundleShape: dir


### PR DESCRIPTION
The tests appear to fail to run because this engine is missing

https://github.com/eclipse-platform/eclipse.platform.ui/issues/415