### PR TITLE
Remove JUnit 4.x from e4.ui.tests.css.core

### DIFF
--- a/tests/org.eclipse.e4.ui.tests.css.core/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests.css.core/META-INF/MANIFEST.MF
@@ -15,8 +15,7 @@ Export-Package: org.eclipse.e4.ui.tests.css.core;x-internal:=true,
  org.eclipse.e4.ui.tests.css.core.parser;x-internal:=true,
  org.eclipse.e4.ui.tests.css.core.util;x-internal:=true
 Automatic-Module-Name: org.eclipse.e4.ui.tests.css.core
-Import-Package: org.junit.runner;version="4.12.0",
- org.junit.jupiter.api,
+Import-Package: org.junit.jupiter.api,
  org.junit.platform.runner,
  org.junit.platform.suite.api
 Bundle-Vendor: %Bundle-Vendor


### PR DESCRIPTION
It's not needed as the tests are JUnit 5.x style.

Reducing possible issue while investigating https://github.com/eclipse-platform/eclipse.platform.ui/issues/415