### PR TITLE
Declare JupiterTestEngine as service

### DIFF
--- a/tests/org.eclipse.e4.ui.tests.css.core/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests.css.core/META-INF/MANIFEST.MF
@@ -16,6 +16,7 @@ Export-Package: org.eclipse.e4.ui.tests.css.core;x-internal:=true,
  org.eclipse.e4.ui.tests.css.core.util;x-internal:=true
 Automatic-Module-Name: org.eclipse.e4.ui.tests.css.core
 Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api
+ org.junit.platform.suite.api,
+ org.junit.jupiter.engine
 Bundle-Vendor: %Bundle-Vendor
 

--- a/tests/org.eclipse.e4.ui.tests.css.core/META-INF/services/org.junit.platform.engine.TestEngine
+++ b/tests/org.eclipse.e4.ui.tests.css.core/META-INF/services/org.junit.platform.engine.TestEngine
@@ -1,0 +1,1 @@
+org.junit.jupiter.engine.JupiterTestEngine


### PR DESCRIPTION
So it's available when SuiteLauncher will call ServiceLoader using this bundle classloader.
(service declarations from dependencies are not visible from this classloader)

See discussion
https://github.com/eclipse-platform/eclipse.platform.ui/issues/415#issuecomment-1303323652