### PR TITLE
Fix LegacyHandlerService to use IEvaluationService to resolve handler

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/LegacyHandlerService.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/LegacyHandlerService.java
@@ -112,7 +112,8 @@ public class LegacyHandlerService implements IHandlerService {
 
 			HandlerActivation bestActivation = null;
 
-			ExpressionContext legacyEvalContext = new ExpressionContext(context);
+			IEvaluationService evaluationService = context.get(IEvaluationService.class);
+			IEvaluationContext legacyEvalContext = evaluationService.getCurrentState();
 
 			HandlerActivation conflictBest = null;
 			HandlerActivation conflictOther = null;

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/services/EvaluationService.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/services/EvaluationService.java
@@ -130,7 +130,7 @@ public final class EvaluationService implements IEvaluationService {
 				ISources.ACTIVE_WORKBENCH_WINDOW_SHELL_NAME, ISources.ACTIVE_EDITOR_ID_NAME,
 				ISources.ACTIVE_EDITOR_INPUT_NAME, ISources.SHOW_IN_INPUT, ISources.SHOW_IN_SELECTION,
 				ISources.ACTIVE_PART_NAME, ISources.ACTIVE_PART_ID_NAME, ISources.ACTIVE_SITE_NAME,
-				ISources.ACTIVE_CONTEXT_NAME, ISources.ACTIVE_CURRENT_SELECTION_NAME }));
+				ISources.ACTIVE_CONTEXT_NAME }));
 		context.runAndTrack(ratUpdater);
 	}
 

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/services/EvaluationService.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/services/EvaluationService.java
@@ -21,8 +21,10 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import org.eclipse.core.expressions.Expression;
 import org.eclipse.core.expressions.ExpressionInfo;
 import org.eclipse.core.expressions.IEvaluationContext;
@@ -54,10 +56,16 @@ import org.eclipse.ui.services.IEvaluationService;
 public final class EvaluationService implements IEvaluationService {
 	public static final String DEFAULT_VAR = "org.eclipse.ui.internal.services.EvaluationService.default_var"; //$NON-NLS-1$
 	private static final String RE_EVAL = "org.eclipse.ui.internal.services.EvaluationService.evaluate"; //$NON-NLS-1$
+
+	private static final List<String> LEGACY_WORKBENCH_VARIABLES = Arrays.asList(ISources.ACTIVE_WORKBENCH_WINDOW_NAME,
+			ISources.ACTIVE_WORKBENCH_WINDOW_SHELL_NAME, ISources.ACTIVE_EDITOR_ID_NAME,
+			ISources.ACTIVE_EDITOR_INPUT_NAME, ISources.SHOW_IN_INPUT, ISources.SHOW_IN_SELECTION,
+			ISources.ACTIVE_PART_NAME, ISources.ACTIVE_PART_ID_NAME, ISources.ACTIVE_SITE_NAME,
+			ISources.ACTIVE_CONTEXT_NAME, ISources.ACTIVE_CURRENT_SELECTION_NAME);
+
 	private boolean evaluate = false;
 	private ExpressionContext legacyContext;
 	private IEclipseContext context;
-	private IEclipseContext ratContext;
 	private int notifying = 0;
 
 	private ListenerList<IPropertyChangeListener> serviceListeners = new ListenerList<>(ListenerList.IDENTITY);
@@ -65,19 +73,18 @@ public final class EvaluationService implements IEvaluationService {
 	LinkedList<EvaluationReference> refs = new LinkedList<>();
 	private ISourceProviderListener contextUpdater;
 
-	private HashSet<String> ratVariables = new HashSet<>();
-	private RunAndTrack ratUpdater = new RunAndTrack() {
+	private Set<String> knownReferencedVariables = new HashSet<>();
+	// Keeps the local/hidden legacyContext variables pool up-to-date.
+	private RunAndTrack legacyContextUpdater = new RunAndTrack() {
 		@Override
 		public boolean changed(IEclipseContext context) {
 			context.get(RE_EVAL);
-			String[] vars = ratVariables.toArray(new String[ratVariables.size()]);
-			for (String var : vars) {
+			List<String> allVars = new ArrayList<>(LEGACY_WORKBENCH_VARIABLES);
+			allVars.addAll(knownReferencedVariables);
+			for (String var : allVars) {
+				// pipe from originating context into legacy context
 				Object value = context.getActive(var);
-				if (value == null) {
-					ratContext.remove(var);
-				} else {
-					ratContext.set(var, value);
-				}
+				changeVariable(var, value);
 			}
 			// This ties tool item enablement to variable changes that can
 			// effect the enablement.
@@ -86,13 +93,12 @@ public final class EvaluationService implements IEvaluationService {
 		}
 	};
 
-	private HashSet<String> variableFilter = new HashSet<>();
 	private IEventBroker eventBroker;
 
 	public EvaluationService(IEclipseContext c) {
 		context = c;
-		ratContext = context.getParent().createChild(getClass().getName());
-		legacyContext = new ExpressionContext(context);
+		IEclipseContext legacyContextEclipseContext = context.getParent().createChild(getClass().getName());
+		legacyContext = new ExpressionContext(legacyContextEclipseContext);
 		ExpressionContext.defaultVariableConverter = new ContextFunction() {
 			@Override
 			public Object compute(IEclipseContext context, String contextKey) {
@@ -126,12 +132,7 @@ public final class EvaluationService implements IEvaluationService {
 				}
 			}
 		};
-		variableFilter.addAll(Arrays.asList(new String[] { ISources.ACTIVE_WORKBENCH_WINDOW_NAME,
-				ISources.ACTIVE_WORKBENCH_WINDOW_SHELL_NAME, ISources.ACTIVE_EDITOR_ID_NAME,
-				ISources.ACTIVE_EDITOR_INPUT_NAME, ISources.SHOW_IN_INPUT, ISources.SHOW_IN_SELECTION,
-				ISources.ACTIVE_PART_NAME, ISources.ACTIVE_PART_ID_NAME, ISources.ACTIVE_SITE_NAME,
-				ISources.ACTIVE_CONTEXT_NAME }));
-		context.runAndTrack(ratUpdater);
+		context.runAndTrack(legacyContextUpdater);
 	}
 
 	private void contextEvaluate() {
@@ -140,7 +141,7 @@ public final class EvaluationService implements IEvaluationService {
 	}
 
 	protected void changeVariable(final String name, final Object value) {
-		if (name == null || variableFilter.contains(name)) {
+		if (name == null) {
 			return;
 		}
 		if (value == null) {
@@ -209,7 +210,7 @@ public final class EvaluationService implements IEvaluationService {
 	@Override
 	public IEvaluationReference addEvaluationListener(Expression expression, IPropertyChangeListener listener,
 			String property) {
-		EvaluationReference ref = new EvaluationReference(ratContext, expression, listener, property);
+		EvaluationReference ref = new EvaluationReference(legacyContext.eclipseContext, expression, listener, property);
 		addEvaluationReference(ref);
 		return ref;
 	}
@@ -223,12 +224,12 @@ public final class EvaluationService implements IEvaluationService {
 			ExpressionInfo info = new ExpressionInfo();
 			eref.getExpression().collectExpressionInfo(info);
 			for (String varName : info.getAccessedVariableNames()) {
-				if (ratVariables.add(varName)) {
+				if (knownReferencedVariables.add(varName)) {
 					changed = true;
 				}
 			}
 
-			if (info.hasDefaultVariableAccess() && ratVariables.add(IServiceConstants.ACTIVE_SELECTION)) {
+			if (info.hasDefaultVariableAccess() && knownReferencedVariables.add(IServiceConstants.ACTIVE_SELECTION)) {
 				changed = true;
 			}
 		}
@@ -236,7 +237,7 @@ public final class EvaluationService implements IEvaluationService {
 			contextEvaluate();
 		}
 		eref.participating = true;
-		ratContext.runAndTrack(eref);
+		legacyContext.eclipseContext.runAndTrack(eref);
 	}
 
 	private void invalidate(IEvaluationReference ref, boolean remove) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/DispatcherTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/DispatcherTest.java
@@ -21,11 +21,17 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.bindings.keys.KeyBindingDispatcher;
 import org.eclipse.jface.bindings.keys.KeyStroke;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IPageLayout;
+import org.eclipse.ui.ISources;
+import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.tests.commands.CheckInvokedHandler;
@@ -91,4 +97,44 @@ public class DispatcherTest {
 		}
 	}
 
+	@Test
+	public void testSelectionVariableHandlerConflicts() throws Exception {
+		IFile file = p.getFile("test.whatever");
+		try (ByteArrayInputStream stream = new ByteArrayInputStream("hello".getBytes())) {
+			file.create(stream, true, new NullProgressMonitor());
+		}
+		CheckInvokedHandler.invoked = false;
+		IViewPart projectExplorer = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage()
+				.showView(IPageLayout.ID_PROJECT_EXPLORER);
+
+		// select a file in the project explorer and assert that CTRL+C invokes our test
+		// handler
+		{
+			projectExplorer.getSite().getSelectionProvider().setSelection(new StructuredSelection(file));
+			dispatcher.press(Arrays.asList(KeyStroke.getInstance(SWT.CTRL, 'C')), null);
+			// in the Project Explorer, the custom copy handler should have been called
+			Assert.assertTrue("Handler should have been invoked", CheckInvokedHandler.invoked);
+		}
+
+		// invalidate the 'selection' variable and trigger copy operation again
+		{
+			// simulate that some user or platform code triggered a change in the evaluation
+			// context
+			// in real scenario, this would be opening a new Shell, for example
+			{
+				IEclipseContext ectx = projectExplorer.getSite().getService(IEclipseContext.class);
+				ectx.set(ISources.ACTIVE_CURRENT_SELECTION_NAME, null);
+			}
+
+			ISelection selection = projectExplorer.getSite().getSelectionProvider().getSelection();
+			Assert.assertNotNull(selection);
+
+			CheckInvokedHandler.invoked = false;
+			dispatcher.press(Arrays.asList(KeyStroke.getInstance(SWT.CTRL, 'C')), null);
+
+			// our handler was not called, assume the key binding has been dispatched to
+			// another handler
+			Assert.assertFalse("Handler should NOT have been invoked", CheckInvokedHandler.invoked);
+		}
+	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/DispatcherTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/DispatcherTest.java
@@ -106,11 +106,12 @@ public class DispatcherTest {
 		CheckInvokedHandler.invoked = false;
 		IViewPart projectExplorer = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage()
 				.showView(IPageLayout.ID_PROJECT_EXPLORER);
+		projectExplorer.getSite().getSelectionProvider().setSelection(new StructuredSelection(file));
+		ISelection selection = projectExplorer.getSite().getSelectionProvider().getSelection();
 
 		// select a file in the project explorer and assert that CTRL+C invokes our test
 		// handler
 		{
-			projectExplorer.getSite().getSelectionProvider().setSelection(new StructuredSelection(file));
 			dispatcher.press(Arrays.asList(KeyStroke.getInstance(SWT.CTRL, 'C')), null);
 			// in the Project Explorer, the custom copy handler should have been called
 			Assert.assertTrue("Handler should have been invoked", CheckInvokedHandler.invoked);
@@ -126,8 +127,8 @@ public class DispatcherTest {
 				ectx.set(ISources.ACTIVE_CURRENT_SELECTION_NAME, null);
 			}
 
-			ISelection selection = projectExplorer.getSite().getSelectionProvider().getSelection();
-			Assert.assertNotNull(selection);
+			// the original selection should not have changed
+			Assert.assertSame(selection, projectExplorer.getSite().getSelectionProvider().getSelection());
 
 			CheckInvokedHandler.invoked = false;
 			dispatcher.press(Arrays.asList(KeyStroke.getInstance(SWT.CTRL, 'C')), null);

--- a/tests/org.eclipse.ui.tests/plugin.xml
+++ b/tests/org.eclipse.ui.tests/plugin.xml
@@ -4664,4 +4664,23 @@
           <run class="org.eclipse.ui.tests.datatransfer.ImportTestUtils$TestBuilder"/>
     </builder>
  </extension>
+ <extension
+       point="org.eclipse.ui.handlers">
+    <handler
+          class="org.eclipse.ui.tests.commands.CheckInvokedHandler"
+          commandId="org.eclipse.ui.edit.copy">
+       <activeWhen>
+          <with
+                variable="selection">
+             <iterate
+                   ifEmpty="false"
+                   operator="or">
+                <instanceof
+                      value="org.eclipse.core.resources.IFile">
+                </instanceof>
+             </iterate>
+          </with>
+       </activeWhen>
+    </handler>
+ </extension>
 </plugin>


### PR DESCRIPTION
This fix is important as Eclipse registers listeners (Display filters) which keep handler activation states in sync the way E3 did when:
- a new Shell is activated
- a Menu is about to be shown

In E4 (as-is) handler activation state is determined by consuming the IEclipseContext which might not be proper for Menus/Shells.