### PR TITLE
Use https for zipeditor update site

### DIFF
--- a/releng/org.eclipse.ui.releng/platformUiTools.p2f
+++ b/releng/org.eclipse.ui.releng/platformUiTools.p2f
@@ -234,7 +234,7 @@
     </iu>
     <iu id='zipeditor.feature.group' name='ZipEditor' version='0.0.0'>
         <repositories size='1'>
-            <repository location='http://zipeditor.sourceforge.net/update'/>
+            <repository location='https://zipeditor.sourceforge.net/update'/>
         </repositories>
     </iu>
     <iu id='com.yourkit.profiler.feature.group' name='Yourkit' version='0.0.0'>


### PR DESCRIPTION
See
- https://github.com/uvoigt/zipeditor/issues/1
- https://github.com/eclipse-platform/.github/issues/55