### PR TITLE
Escape mnemonics in preference page titles

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/PreferenceDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/PreferenceDialog.java
@@ -29,6 +29,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.core.runtime.SafeRunner;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.action.LegacyActionTools;
 import org.eclipse.jface.dialogs.DialogMessageArea;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IMessageProvider;
@@ -1356,7 +1357,7 @@ public class PreferenceDialog extends TrayDialog implements IPreferencePageConta
 		if(currentPage == null) {
 			return;
 		}
-		messageArea.showTitle(currentPage.getTitle(), currentPage.getImage());
+		messageArea.showTitle(LegacyActionTools.escapeMnemonics(currentPage.getTitle()), currentPage.getImage());
 	}
 
 	/**


### PR DESCRIPTION
The current release of Wild Web Developer uses a preference page "Validation & Resolution". The title is displayed wrongly on the (right hand side) preference page content because the ampersand is interpreted as mnemonic.

reproduced using one of the example plugins:
![grafik](https://user-images.githubusercontent.com/406876/206422811-3a22cdd3-9b84-42b3-8e90-51ceeebb54b8.png)

with the fix applied:
![grafik](https://user-images.githubusercontent.com/406876/206422949-b120f60d-3dd8-4cc8-8082-f088d646e26d.png)
