### PR TITLE
QuickAccessDialogTest improvements

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2017 IBM Corporation and others.
+ * Copyright (c) 2008, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -63,6 +63,18 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class QuickAccessDialogTest {
 
+	private class TestQuickAccessDialog extends QuickAccessDialog {
+
+		public TestQuickAccessDialog(IWorkbenchWindow activeWorkbenchWindow, Command command) {
+			super(activeWorkbenchWindow, command);
+		}
+
+		@Override
+		protected IDialogSettings getDialogSettings() {
+			return dialogSettings;
+		}
+	}
+
 	@Rule
 	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
@@ -118,17 +130,12 @@ public class QuickAccessDialogTest {
 	 */
 	@Test
 	public void testTextFilter(){
-		QuickAccessDialog dialog = new QuickAccessDialog(activeWorkbenchWindow, null) {
-			@Override
-			protected IDialogSettings getDialogSettings() {
-				return dialogSettings;
-			}
-		};
+		QuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		dialog.open();
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		Table table = dialog.getQuickAccessContents().getTable();
 		assertTrue("Quick access filter should be empty", text.getText().isEmpty());
-		assertTrue("Quick access table should be empty", table.getItemCount() == 0);
+		assertEquals("Quick access table should be empty", 0, table.getItemCount());
 
 		text.setText("T");
 		UITestCase.processEventsUntil(() -> table.getItemCount() > 1, TIMEOUT);
@@ -148,17 +155,12 @@ public class QuickAccessDialogTest {
 
 	@Test
 	public void testContributedElement() {
-		QuickAccessDialog dialog = new QuickAccessDialog(activeWorkbenchWindow, null) {
-			@Override
-			protected IDialogSettings getDialogSettings() {
-				return dialogSettings;
-			}
-		};
+		QuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		dialog.open();
 		final Table table = dialog.getQuickAccessContents().getTable();
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		assertTrue("Quick access filter should be empty", text.getText().isEmpty());
-		assertTrue("Quick access table should be empty", table.getItemCount() == 0);
+		assertEquals("Quick access table should be empty", 0, table.getItemCount());
 
 		text.setText(TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL);
 		assertTrue("Missing contributed element", DisplayHelper.waitForCondition(dialog.getShell().getDisplay(), TIMEOUT, () ->
@@ -168,12 +170,7 @@ public class QuickAccessDialogTest {
 
 	@Test
 	public void testLongRunningComputerDoesntFreezeUI() {
-		QuickAccessDialog dialog = new QuickAccessDialog(activeWorkbenchWindow, null) {
-			@Override
-			protected IDialogSettings getDialogSettings() {
-				return dialogSettings;
-			}
-		};
+		QuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		dialog.open();
 		final Table table = dialog.getQuickAccessContents().getTable();
 		Text text = dialog.getQuickAccessContents().getFilterText();
@@ -187,12 +184,7 @@ public class QuickAccessDialogTest {
 		table.select(0);
 		activateCurrentElement(dialog);
 		duration = System.currentTimeMillis();
-		QuickAccessDialog secondDialog = new QuickAccessDialog(activeWorkbenchWindow, null) {
-			@Override
-			protected IDialogSettings getDialogSettings() {
-				return dialogSettings;
-			}
-		};
+		QuickAccessDialog secondDialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		secondDialog.open();
 		assertTrue(System.currentTimeMillis() - duration < TestLongRunningQuickAccessComputer.DELAY);
 		AtomicLong tick = new AtomicLong(System.currentTimeMillis());
@@ -216,17 +208,12 @@ public class QuickAccessDialogTest {
 	@Test
 	public void testShowAll() throws Exception {
 		// Open the shell
-		QuickAccessDialog dialog = new QuickAccessDialog(activeWorkbenchWindow, null) {
-			@Override
-			protected IDialogSettings getDialogSettings() {
-				return dialogSettings;
-			}
-		};
+		QuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		dialog.open();
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		final Table table = dialog.getQuickAccessContents().getTable();
 		assertTrue("Quick access filter should be empty", text.getText().isEmpty());
-		assertTrue("Quick access table should be empty", table.getItemCount() == 0);
+		assertEquals("Quick access table should be empty", 0, table.getItemCount());
 
 		// Set a filter to get some items
 		text.setText("T");
@@ -274,12 +261,7 @@ public class QuickAccessDialogTest {
 	@Test
 	public void testPreviousChoicesAvailable() {
 		// add one selection to history
-		QuickAccessDialog dialog = new QuickAccessDialog(activeWorkbenchWindow, null) {
-			@Override
-			protected IDialogSettings getDialogSettings() {
-				return dialogSettings;
-			}
-		};
+		QuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		dialog.open();
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		Table firstTable = dialog.getQuickAccessContents().getTable();
@@ -298,12 +280,7 @@ public class QuickAccessDialogTest {
 								.equalsIgnoreCase(activeWorkbenchWindow.getActivePage().getActivePart().getTitle()),
 				TIMEOUT);
 		// then try in a new SearchField
-		QuickAccessDialog secondDialog = new QuickAccessDialog(activeWorkbenchWindow, null) {
-			@Override
-			protected IDialogSettings getDialogSettings() {
-				return dialogSettings;
-			}
-		};
+		QuickAccessDialog secondDialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		secondDialog.open();
 		assertTrue("Missing entry in previous pick",
 				DisplayHelper.waitForCondition(secondDialog.getShell().getDisplay(), TIMEOUT,
@@ -321,12 +298,7 @@ public class QuickAccessDialogTest {
 	@Test
 	public void testPreviousChoicesAvailableForExtension() {
 		// add one selection to history
-		QuickAccessDialog dialog = new QuickAccessDialog(activeWorkbenchWindow, null) {
-			@Override
-			protected IDialogSettings getDialogSettings() {
-				return dialogSettings;
-			}
-		};
+		QuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		dialog.open();
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		text.setText(TestQuickAccessComputer.TEST_QUICK_ACCESS_PROPOSAL_LABEL);
@@ -336,13 +308,7 @@ public class QuickAccessDialogTest {
 		firstTable.select(0);
 		activateCurrentElement(dialog);
 		// then try in a new SearchField
-		QuickAccessDialog secondDialog = new QuickAccessDialog(activeWorkbenchWindow,
-				null) {
-			@Override
-			protected IDialogSettings getDialogSettings() {
-				return dialogSettings;
-			}
-		};
+		QuickAccessDialog secondDialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		secondDialog.open();
 		assertTrue("Contributed item not found in previous choices",
 				DisplayHelper.waitForCondition(secondDialog.getShell().getDisplay(), TIMEOUT,
@@ -352,12 +318,7 @@ public class QuickAccessDialogTest {
 
 	@Test
 	public void testPreviousChoicesAvailableForIncrementalExtension() {
-		QuickAccessDialog dialog = new QuickAccessDialog(activeWorkbenchWindow, null) {
-			@Override
-			protected IDialogSettings getDialogSettings() {
-				return dialogSettings;
-			}
-		};
+		QuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		dialog.open();
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		text.setText(TestIncrementalQuickAccessComputer.ENABLEMENT_QUERY);
@@ -370,12 +331,7 @@ public class QuickAccessDialogTest {
 		firstTable.select(0);
 		activateCurrentElement(dialog);
 		// then try in a new SearchField
-		dialog = new QuickAccessDialog(activeWorkbenchWindow, null) {
-			@Override
-			protected IDialogSettings getDialogSettings() {
-				return dialogSettings;
-			}
-		};
+		dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		dialog.open();
 		final Table secondTable = dialog.getQuickAccessContents().getTable();
 		assertTrue("Contributed item not found in previous choices",
@@ -387,12 +343,7 @@ public class QuickAccessDialogTest {
 
 	@Test
 	public void testPrefixMatchHavePriority() {
-		QuickAccessDialog dialog = new QuickAccessDialog(activeWorkbenchWindow, null) {
-			@Override
-			protected IDialogSettings getDialogSettings() {
-				return dialogSettings;
-			}
-		};
+		QuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		dialog.open();
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		Table table = dialog.getQuickAccessContents().getTable();
@@ -413,12 +364,7 @@ public class QuickAccessDialogTest {
 		IDE.openEditor(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), tmpFile.toURI(),
 				"org.eclipse.ui.DefaultTextEditor", true);
 
-		QuickAccessDialog dialog = new QuickAccessDialog(activeWorkbenchWindow, null) {
-			@Override
-			protected IDialogSettings getDialogSettings() {
-				return dialogSettings;
-			}
-		};
+		QuickAccessDialog dialog = new TestQuickAccessDialog(activeWorkbenchWindow, null);
 		dialog.open();
 		Text text = dialog.getQuickAccessContents().getFilterText();
 		Table table = dialog.getQuickAccessContents().getTable();

--- a/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse UI Tests
 Bundle-SymbolicName: org.eclipse.ui.tests; singleton:=true
-Bundle-Version: 3.15.900.qualifier
+Bundle-Version: 3.15.1000.qualifier
 Eclipse-BundleShape: dir
 Bundle-Activator: org.eclipse.ui.tests.TestPlugin
 Bundle-Vendor: Eclipse.org


### PR DESCRIPTION
* create private class instead of having dozen of anonymous same classes
* improve asserts by using assertEquals instead of assertTrue to get better fail messages

First step towards looking into unstable test https://download.eclipse.org/eclipse/downloads/drops4/I20221207-1800/testresults/html/org.eclipse.ui.tests_ep427I-unit-cen64-gtk3-java17_linux.gtk.x86_64_17.html