### PR TITLE
Include org.eclipse.e4.ui.progress in org.eclipse.e4.rcp

### DIFF
--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -60,6 +60,13 @@
          unpack="false"/>
 
    <plugin
+         id="org.eclipse.e4.ui.progress"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.e4.ui.services"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
The org.eclipse.equinox.p2.ui bundle requires the
org.eclipse.e4.ui.progress package of the org.eclipse.e4.ui.progress bundle so the bundle is already installed with most applications.

Furthermore, if this bundle is not included in any feature, it will need special case handling for publishing to Maven, which would be best avoided.

https://github.com/eclipse-platform/eclipse.platform.releng/issues/126