### PR TITLE
Ctrl+E: Handle file name collisions where one file is in root

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
@@ -211,15 +211,15 @@ public class WorkbookEditorsHandlerTest extends UITestCase {
 
 		assertEquals("Text should have parent folder prepended", "bar" + File.separator + fileName,
 				handler.tableItemTexts.get(0));
-		assertEquals("Text should have full folder chain until differing folder prepended",
-				String.join(File.separator, "test2", "foo", "bar", "baz", fileName),
+		assertEquals("Text should have first differing folder and the mark for collapsed matching folders prepended",
+				String.join(File.separator, "test2", "...", fileName),
 				handler.tableItemTexts.get(1));
-		assertEquals("Text should have full folder chain until differing folder prepended",
-				String.join(File.separator, "test1", "foo", "bar", "baz", fileName),
+		assertEquals("Text should have first differing folder and the mark for collapsed matching folders prepended",
+				String.join(File.separator, "test1", "...", fileName),
 				handler.tableItemTexts.get(2));
 		assertEquals("There should only ever be one selected editor", 1, handler.selectionTexts.size());
 		assertEquals("Selection should be the editor that was active before the currently active editor",
-				String.join(File.separator, "test2", "foo", "bar", "baz", fileName),
+				String.join(File.separator, "test2", "...", fileName),
 				handler.tableItemTexts.get(1));
 	}
 


### PR DESCRIPTION
- handle name collisions where one file is located in root by prepending the root path ('/' on Unix systems, '<drive letter>:\' on Windows systems)
- remove special handling when not all colliding files share the same parent folder structure
  - this simplifies the code
  - removes the need to also handle the special case where a file is located in root

might be related to #487

---

Regarding the change in the naming pattern I looked at other editors and IDEs and they all seem to handle those cases somewhat differently. The approach taken in this PR, always collapsing if there are files that have common parents, works for me quite well, but I'm curious what other people think.

I sadly don't know how I would write a regression test for the bug fixed in this PR. I don't know of a way to place a file into the root directory in a test without something like Jimfs. Also happy to hear suggestions.