### PR TITLE
Ctrl+E: Fix crash when editor without name collision has been split

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbookEditorsHandler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbookEditorsHandler.java
@@ -186,10 +186,8 @@ public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 		});
 
 		for (List<Entry<EditorReference, IPath>> groupedEditorReferences : collisionsMap.values()) {
-			if (groupedEditorReferences.size() == 1) {
-				EditorReference editorReference = groupedEditorReferences.get(0).getKey();
-				editorReferenceLabelTexts.put(editorReference, getWorkbenchPartReferenceText(editorReference));
-			} else if (isSplitEditorWithoutAdditionalCollision(groupedEditorReferences)) {
+			if (groupedEditorReferences.size() == 1
+					|| isSplitEditorWithoutAdditionalCollision(groupedEditorReferences)) {
 				groupedEditorReferences.stream().map(Entry::getKey)
 						.forEach(editorReference -> editorReferenceLabelTexts.put(editorReference,
 								getWorkbenchPartReferenceText(editorReference)));

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbookEditorsHandler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbookEditorsHandler.java
@@ -64,6 +64,7 @@ import org.eclipse.ui.themes.ITheme;
  */
 public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 
+
 	/**
 	 * Preference node for the workbench SWT renderer
 	 */
@@ -89,6 +90,14 @@ public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 	 * file paths.
 	 */
 	private static final String OMMITED_PATH_SEGMENTS_SIGNIFIER = "..."; //$NON-NLS-1$
+
+	/**
+	 * Expected value when all editor references passed to
+	 * {@link #generateColumnLabelTexts(List)} share the same path. Usually it's not
+	 * possible to open a file in multiple editors. But when an editor gets split
+	 * (Toggle Split Editor), the same file shows up in separate editors.
+	 */
+	private static final int ALL_PATHS_FULLY_MATCHING = -1;
 
 	private SearchPattern searchPattern;
 
@@ -193,7 +202,7 @@ public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 				List<Integer> maxMatchingSegmentsList = new ArrayList<>(groupedEditorReferences.size());
 				for (Entry<EditorReference, IPath> entry : groupedEditorReferences) {
 					IPath path = entry.getValue();
-					int maxMatchingSegments = -1;
+					int maxMatchingSegments = ALL_PATHS_FULLY_MATCHING;
 					for (int i = 0; i < groupedEditorReferences.size(); i++) {
 						IPath currentPath = groupedEditorReferences.get(i).getValue();
 						if (currentPath.equals(path)) {
@@ -212,6 +221,10 @@ public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 					Integer maxMatchingSegment = maxMatchingSegmentsList.get(i);
 					IPath path = groupedEditorReferences.get(i).getValue();
 
+					if (maxMatchingSegment == ALL_PATHS_FULLY_MATCHING) {
+						editorReferenceLabelTexts.put(editorReference, getWorkbenchPartReferenceText(editorReference));
+						continue;
+					}
 					String labelText = generateLabelText(editorReference, path, maxMatchingSegment,
 							differingMaxSegmentsCounter.size() == 1 && maxMatchingSegment != 0);
 					editorReferenceLabelTexts.put(editorReference, labelText);
@@ -270,7 +283,7 @@ public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 	 * <br/>
 	 * Example:<br/>
 	 * {@code C:\git\project\file => git\project\file}
-	 * 
+	 *
 	 * @param path Path to remove the Windows drive letter from
 	 * @return path Path without the Windows drive letter segment
 	 */

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbookEditorsHandler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbookEditorsHandler.java
@@ -64,7 +64,6 @@ import org.eclipse.ui.themes.ITheme;
  */
 public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 
-
 	/**
 	 * Preference node for the workbench SWT renderer
 	 */
@@ -289,7 +288,7 @@ public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 	 * <br/>
 	 * Example:<br/>
 	 * {@code C:\git\project\file => git\project\file}
-	 *
+	 * 
 	 * @param path Path to remove the Windows drive letter from
 	 * @return path Path without the Windows drive letter segment
 	 */

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
@@ -116,6 +116,33 @@ public class WorkbookEditorsHandlerTest extends UITestCase {
 	}
 
 	@Test
+	public void testMultipleFilesWithNameCollisionAndEditorSplit() throws Exception {
+		String fileName = "example.txt";
+		IDE.openEditor(activePage, FileUtil.createFile(fileName, project1), true);
+		IDE.openEditor(activePage, FileUtil.createFile(fileName, project2), true);
+		ICommandService cmdService = PlatformUI.getWorkbench().getService(ICommandService.class);
+		IHandlerService handlerService = PlatformUI.getWorkbench().getService(IHandlerService.class);
+		final Command splitCmd = cmdService.getCommand("org.eclipse.ui.window.splitEditor");
+		splitCmd.executeWithChecks(handlerService.createExecutionEvent(splitCmd, null));
+
+		final Command cmd = cmdService.getCommand("org.eclipse.ui.window.openEditorDropDown");
+		WorkbookEditorsHandlerTestable handler = new WorkbookEditorsHandlerTestable();
+		cmd.setHandler(handler);
+		final ExecutionEvent event = handlerService.createExecutionEvent(cmd, null);
+
+		handler.execute(event);
+
+		assertEquals("Text should have folder prepended because of name clash (split editor)",
+				PROJECT_NAME_2 + File.separator + fileName, handler.tableItemTexts.get(0));
+		assertEquals("Text should have folder prepended because of name clash",
+				PROJECT_NAME_1 + File.separator + fileName, handler.tableItemTexts.get(1));
+		assertEquals("Text should have folder prepended because of name clash (split editor)",
+				PROJECT_NAME_2 + File.separator + fileName, handler.tableItemTexts.get(2));
+		assertEquals("Selection should be the editor that was active before the currently active editor",
+				PROJECT_NAME_1 + File.separator + fileName, handler.tableItemTexts.get(1));
+	}
+
+	@Test
 	public void testMultipleFilesWithNoNameConflict() throws Exception {
 		String fileName = "example.txt";
 		IDE.openEditor(activePage, FileUtil.createFile(fileName, project1), true);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
@@ -94,6 +94,28 @@ public class WorkbookEditorsHandlerTest extends UITestCase {
 	}
 
 	@Test
+	public void testSingleFileWithEditorSplit() throws Exception {
+		String fileName = "example.txt";
+		IDE.openEditor(activePage, FileUtil.createFile(fileName, project1), true);
+		ICommandService cmdService = PlatformUI.getWorkbench().getService(ICommandService.class);
+		IHandlerService handlerService = PlatformUI.getWorkbench().getService(IHandlerService.class);
+		final Command splitCmd = cmdService.getCommand("org.eclipse.ui.window.splitEditor");
+		splitCmd.executeWithChecks(handlerService.createExecutionEvent(splitCmd, null));
+
+		final Command cmd = cmdService.getCommand("org.eclipse.ui.window.openEditorDropDown");
+		WorkbookEditorsHandlerTestable handler = new WorkbookEditorsHandlerTestable();
+		cmd.setHandler(handler);
+		final ExecutionEvent event = handlerService.createExecutionEvent(cmd, null);
+
+		handler.execute(event);
+
+		assertEquals("Display text should match file name", fileName, handler.tableItemTexts.get(0));
+		assertEquals("Display text should match file name", fileName, handler.tableItemTexts.get(1));
+		assertEquals("Selection should be the editor that was active before the currently active editor", fileName,
+				handler.tableItemTexts.get(1));
+	}
+
+	@Test
 	public void testMultipleFilesWithNoNameConflict() throws Exception {
 		String fileName = "example.txt";
 		IDE.openEditor(activePage, FileUtil.createFile(fileName, project1), true);


### PR DESCRIPTION
- The previous code expected that the same file can never be opened
  in multiple editors.
- When an editor gets split it shows up twice in the Quick Switch
  Editors popup. These two editors share the exact same path.
- Popup now shows just the editor title in these cases. This is the behavior that existed before the name collision handling was added.

works on #487