### PR TITLE
Ctrl+E: Handle 3 or more references to the same path

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbookEditorsHandler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbookEditorsHandler.java
@@ -190,8 +190,7 @@ public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 		});
 
 		for (List<Entry<EditorReference, IPath>> groupedEditorReferences : collisionsMap.values()) {
-			if (groupedEditorReferences.size() == 1
-					|| isSplitEditorWithoutAdditionalCollision(groupedEditorReferences)) {
+			if (groupedEditorReferences.size() == 1 || allReferencesToSamePath(groupedEditorReferences)) {
 				groupedEditorReferences.stream().map(Entry::getKey)
 						.forEach(editorReference -> editorReferenceLabelTexts.put(editorReference,
 								getWorkbenchPartReferenceText(editorReference)));
@@ -227,17 +226,15 @@ public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 
 	/**
 	 * Usually it's not possible to open a file in multiple editors. But when an
-	 * editor gets split (Toggle Split Editor), the same file shows up in separate
-	 * editors. The size of the list can be used as an indicator because an editor
-	 * can only be split once.
+	 * editor gets split (Toggle Split Editor) or cloned (Clone Editor) then
+	 * multiples editor references can point to the same path.
 	 *
 	 * @param groupedEditorReferences the editor references grouped by matching file
 	 *                                name
-	 * @return if the passed references are a split editor without any additional
+	 * @return if all references point to the same path
 	 */
-	private boolean isSplitEditorWithoutAdditionalCollision(
-			List<Entry<EditorReference, IPath>> groupedEditorReferences) {
-		return groupedEditorReferences.size() == 2 && groupedEditorReferences.stream().map(Entry::getValue)
+	private boolean allReferencesToSamePath(List<Entry<EditorReference, IPath>> groupedEditorReferences) {
+		return groupedEditorReferences.stream().map(Entry::getValue)
 				.allMatch(groupedEditorReferences.get(0).getValue()::equals);
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
@@ -143,6 +143,60 @@ public class WorkbookEditorsHandlerTest extends UITestCase {
 	}
 
 	@Test
+	public void testSingleFileWithEditorClonedTwice() throws Exception {
+		String fileName = "example.txt";
+		IDE.openEditor(activePage, FileUtil.createFile(fileName, project1), true);
+		ICommandService cmdService = PlatformUI.getWorkbench().getService(ICommandService.class);
+		IHandlerService handlerService = PlatformUI.getWorkbench().getService(IHandlerService.class);
+		final Command splitCmd = cmdService.getCommand("org.eclipse.ui.window.newEditor");
+		splitCmd.executeWithChecks(handlerService.createExecutionEvent(splitCmd, null));
+		splitCmd.executeWithChecks(handlerService.createExecutionEvent(splitCmd, null));
+
+		final Command cmd = cmdService.getCommand("org.eclipse.ui.window.openEditorDropDown");
+		WorkbookEditorsHandlerTestable handler = new WorkbookEditorsHandlerTestable();
+		cmd.setHandler(handler);
+		final ExecutionEvent event = handlerService.createExecutionEvent(cmd, null);
+
+		handler.execute(event);
+
+		assertEquals("Display text should match file name", fileName, handler.tableItemTexts.get(0));
+		assertEquals("Display text should match file name", fileName, handler.tableItemTexts.get(1));
+		assertEquals("Display text should match file name", fileName, handler.tableItemTexts.get(2));
+		assertEquals("Selection should be the editor that was active before the currently active editor", fileName,
+				handler.tableItemTexts.get(1));
+	}
+
+	@Test
+	public void testFileWithNameConflictWithEditorClonedTwice() throws Exception {
+		String fileName = "example.txt";
+		IDE.openEditor(activePage, FileUtil.createFile(fileName, project1), true);
+		IDE.openEditor(activePage, FileUtil.createFile(fileName, project2), true);
+		ICommandService cmdService = PlatformUI.getWorkbench().getService(ICommandService.class);
+		IHandlerService handlerService = PlatformUI.getWorkbench().getService(IHandlerService.class);
+		final Command splitCmd = cmdService.getCommand("org.eclipse.ui.window.newEditor");
+		splitCmd.executeWithChecks(handlerService.createExecutionEvent(splitCmd, null));
+		splitCmd.executeWithChecks(handlerService.createExecutionEvent(splitCmd, null));
+
+		final Command cmd = cmdService.getCommand("org.eclipse.ui.window.openEditorDropDown");
+		WorkbookEditorsHandlerTestable handler = new WorkbookEditorsHandlerTestable();
+		cmd.setHandler(handler);
+		final ExecutionEvent event = handlerService.createExecutionEvent(cmd, null);
+
+		handler.execute(event);
+
+		assertEquals("Display text should match file name", PROJECT_NAME_2 + File.separator + fileName,
+				handler.tableItemTexts.get(0));
+		assertEquals("Display text should match file name", PROJECT_NAME_2 + File.separator + fileName,
+				handler.tableItemTexts.get(1));
+		assertEquals("Display text should match file name", PROJECT_NAME_2 + File.separator + fileName,
+				handler.tableItemTexts.get(2));
+		assertEquals("Display text should match file name", PROJECT_NAME_1 + File.separator + fileName,
+				handler.tableItemTexts.get(3));
+		assertEquals("Selection should be the editor that was active before the currently active editor",
+				PROJECT_NAME_2 + File.separator + fileName, handler.tableItemTexts.get(1));
+	}
+
+	@Test
 	public void testMultipleFilesWithNoNameConflict() throws Exception {
 		String fileName = "example.txt";
 		IDE.openEditor(activePage, FileUtil.createFile(fileName, project1), true);


### PR DESCRIPTION
Previously the code expected that there can be two references to the same path max, because split editor is a toggle.
As @harawata pointed out[0], it is possible to have more than two references to the same path because editor cloning can be done without any limits.
This commit therefore removes the check for the reference list length.

[0] https://github.com/eclipse-platform/eclipse.platform.ui/issues/487#issuecomment-1357466836