### PR TITLE
Fix WorkbookEditorsHandlerTest breaking under Windows by not verifying editor order

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
@@ -132,14 +132,21 @@ public class WorkbookEditorsHandlerTest extends UITestCase {
 
 		handler.execute(event);
 
-		assertEquals("Text should have folder prepended because of name clash (split editor)",
-				PROJECT_NAME_2 + File.separator + fileName, handler.tableItemTexts.get(0));
-		assertEquals("Text should have folder prepended because of name clash",
-				PROJECT_NAME_1 + File.separator + fileName, handler.tableItemTexts.get(1));
-		assertEquals("Text should have folder prepended because of name clash (split editor)",
-				PROJECT_NAME_2 + File.separator + fileName, handler.tableItemTexts.get(2));
-		assertEquals("Selection should be the editor that was active before the currently active editor",
-				PROJECT_NAME_1 + File.separator + fileName, handler.tableItemTexts.get(1));
+		// Test without verifying order because order after editor split differs between
+		// operating systems right now (only in tests)
+		List<String> tableItemTexts = handler.tableItemTexts;
+		assertTrue("Text should have folder prepended because of name clash (split editor)",
+				tableItemTexts.stream().anyMatch(text -> text.equals(PROJECT_NAME_2 + File.separator + fileName)));
+		assertTrue("Text should have folder prepended because of name clash",
+				tableItemTexts.stream().anyMatch(text -> text.equals(PROJECT_NAME_1 + File.separator + fileName)));
+		long referencesToSplitFile = tableItemTexts.stream()
+				.filter(text -> text.equals(PROJECT_NAME_2 + File.separator + fileName)).count();
+		assertEquals("File in Editor that has been split should show up two times in the popup", 2,
+				referencesToSplitFile);
+		long referencesOtherFile = tableItemTexts.stream()
+				.filter(text -> text.equals(PROJECT_NAME_1 + File.separator + fileName)).count();
+		assertEquals("File in editor that has not been split should show up once in the popup", 1, referencesOtherFile);
+		assertEquals("Popup should contain three editor references", 3, tableItemTexts.size());
 	}
 
 	@Test


### PR DESCRIPTION
Editor order in tests under Linux are different from order observed by splitting an Editor manually.
Tests on Windows show the correct behavior and therefore break the assertions written on Linux.
This commit removes the validation of the editor order to make the test pass on Windows.

see https://github.com/eclipse-platform/eclipse.platform.ui/issues/487#issuecomment-1358966421

works on #487