### PR TITLE
Close resource actions should use the property tooltip property

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/ide/IDEActionFactory.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/ide/IDEActionFactory.java
@@ -206,7 +206,7 @@ public final class IDEActionFactory {
 				throw new IllegalArgumentException();
 			}
 			RetargetAction action = new RetargetAction(getId(), IDEWorkbenchMessages.CloseResourceAction_text);
-			action.setToolTipText(IDEWorkbenchMessages.CloseResourceAction_text);
+			action.setToolTipText(IDEWorkbenchMessages.CloseResourceAction_toolTip);
 			window.getPartService().addPartListener(action);
 			action.setActionDefinitionId(getCommandId());
 			return action;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/WorkbenchActionBuilder.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/WorkbenchActionBuilder.java
@@ -1525,7 +1525,7 @@ public class WorkbenchActionBuilder extends ActionBarAdvisor {
 
 	private IContributionItem getCloseProjectItem() {
 		return getItem(IDEActionFactory.CLOSE_PROJECT.getId(), IDEActionFactory.CLOSE_PROJECT.getCommandId(), null,
-				null, IDEWorkbenchMessages.CloseResourceAction_text, IDEWorkbenchMessages.CloseResourceAction_text);
+				null, IDEWorkbenchMessages.CloseResourceAction_text, IDEWorkbenchMessages.CloseResourceAction_toolTip);
 	}
 
 	private IContributionItem getItem(String actionId, String commandId,


### PR DESCRIPTION
Where IDEWorkbenchMessages.CloseResourceAction_text is used to create an action, IDEWorkbenchMessages.CloseResourceAction_toolTip should be used for the tooltip of that action.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/304