### PR TITLE
Project wizards should be shown in "new project" category

### DIFF
--- a/bundles/org.eclipse.ui.navigator.resources/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.navigator.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.navigator.resources; singleton:=true
-Bundle-Version: 3.8.500.qualifier
+Bundle-Version: 3.8.600.qualifier
 Bundle-Activator: org.eclipse.ui.internal.navigator.resources.plugin.WorkbenchNavigatorPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.ui.navigator/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.navigator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.navigator; singleton:=true
-Bundle-Version: 3.10.400.qualifier
+Bundle-Version: 3.11.0.qualifier
 Bundle-Activator: org.eclipse.ui.internal.navigator.NavigatorPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
Currently wizard that are marked with project=true are shown with other generic ones instead of in the "new project" section of the navigator.

This adds them to the "new project" category so they are easier identified by a user that they create a new project.

Fix https://github.com/eclipse-platform/eclipse.platform.ui/issues/502