### PR TITLE
Wizard pages should be able to specify their minimum size.

### DIFF
--- a/bundles/org.eclipse.jface/.settings/.api_filters
+++ b/bundles/org.eclipse.jface/.settings/.api_filters
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.jface" version="2">
+    <resource path="src/org/eclipse/jface/wizard/IWizard.java" type="org.eclipse.jface.wizard.IWizard">
+        <filter comment="https://github.com/eclipse-platform/eclipse.platform.ui/issues/516" id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.wizard.IWizard"/>
+                <message_argument value="getMinimumWizardSize()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/jface/wizard/IWizardPage.java" type="org.eclipse.jface.wizard.IWizardPage">
+        <filter comment="https://github.com/eclipse-platform/eclipse.platform.ui/issues/516" id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.wizard.IWizardPage"/>
+                <message_argument value="getMinimumPageSize()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/IWizard.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/IWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@ package org.eclipse.jface.wizard;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.dialogs.TrayDialog;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Composite;
 
@@ -111,6 +112,19 @@ public interface IWizard {
 	 * @return the next page, or <code>null</code> if none
 	 */
 	IWizardPage getNextPage(IWizardPage page);
+
+	/**
+	 * Returns the minimum size of this wizard. The minimum size is calculated using
+	 * the minimum page sizes of all wizard pages. May return {@code null} if none
+	 * of the wizard pages specify a minimum size.
+	 *
+	 * @see IWizardPage#getMinimumPageSize()
+	 * @return the minimum size encoded as {@code new Point(width,height)}
+	 * @since 3.30
+	 */
+	default Point getMinimumWizardSize() {
+		return null;
+	}
 
 	/**
 	 * Returns the wizard page with the given name belonging to this wizard.

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/IWizardPage.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/IWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,7 @@
 package org.eclipse.jface.wizard;
 
 import org.eclipse.jface.dialogs.IDialogPage;
+import org.eclipse.swt.graphics.Point;
 
 /**
  * Interface for a wizard page.
@@ -31,6 +32,18 @@ public interface IWizardPage extends IDialogPage {
 	 *   and <code>false</code> otherwise
 	 */
 	public boolean canFlipToNextPage();
+
+	/**
+	 * Returns the minimum page size used of this page. May return {@code null} if
+	 * this page doesn't specify a minimum size..
+	 *
+	 * @see IWizard#getMinimumWizardSize()
+	 * @return the minimum page size encoded as <code>new Point(width,height)</code>
+	 * @since 3.30
+	 */
+	default Point getMinimumPageSize() {
+		return null;
+	}
 
 	/**
 	 * Returns this page's name.

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/Wizard.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/Wizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -26,7 +26,9 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.util.Policy;
 import org.eclipse.jface.window.IShellProvider;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
@@ -299,6 +301,27 @@ public abstract class Wizard implements IWizard, IShellProvider {
 	@Override
 	public String getWindowTitle() {
 		return windowTitle;
+	}
+
+	@Override
+	public Point getMinimumWizardSize() {
+		int minWidth = SWT.DEFAULT;
+		int minHeight = SWT.DEFAULT;
+
+		for (IWizardPage page : pages) {
+			Point minPageSize = page.getMinimumPageSize();
+
+			if (minPageSize != null) {
+				minWidth = Math.max(minWidth, minPageSize.x);
+				minHeight = Math.max(minHeight, minPageSize.y);
+			}
+		}
+
+		if (minWidth == SWT.DEFAULT || minHeight == SWT.DEFAULT) {
+			return null;
+		}
+
+		return new Point(minWidth, minHeight);
 	}
 
 	@Override

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/WizardDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/WizardDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -748,6 +748,10 @@ public class WizardDialog extends TitleAreaDialog implements IWizardContainer2, 
 			if (page.getControl() != null) {
 				page.getControl().setVisible(false);
 			}
+		}
+		Point minWizardSize = wizard.getMinimumWizardSize();
+		if (minWizardSize != null) {
+			getShell().setMinimumSize(minWizardSize);
 		}
 	}
 


### PR DESCRIPTION
Subclasses of WizardPage can overwrite the getMinimumPageSize() method in order to set a minimal size for the wizard shell. By default, no such minimum size is set.

For the sake of backwards-compatibility, I've moved this logic into "supplement" interfaces, similar to how it's done for the IWizardContainer. Because there are already several classes implementing IWizardPage directly and would otherwise have to implement a dummy method.

If getMinimumPageSize() is not overwritten, then the minimum size of the shell is not set. This corresponds to the current behavior. Otherwise the minimum size is of the shell is calculated to be equal or larger than the minimum sizes of all wizard pages.

Resolves #516