### PR TITLE
Remove explicit requirement to jxpath in feature

### DIFF
--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -596,13 +596,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.apache.commons.jxpath"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.e4.emf.xpath"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
jxpath version is changing and having feature specifying an exact version is not helpful. Removing the explicit reference to jxpath would come as a transitive dependency.