### PR TITLE
Not properly disposed SWT resource in ContentTypesPreferencePage

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/ContentTypesPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/ContentTypesPreferencePage.java
@@ -21,10 +21,9 @@ import static org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
@@ -113,7 +112,7 @@ public class ContentTypesPreferencePage extends PreferencePage implements IWorkb
 
 	private Button addEditorAssociationButton;
 
-	private Set<Image> disposableEditorIcons = new HashSet<>();
+	private Collection<Image> disposableEditorIcons = new ArrayList<>();
 
 	private static class Spec {
 		/**


### PR DESCRIPTION
Disposable resources must not be tracked via a set, since that will remove images created multiple times.

java.lang.Error: SWT Resource was not properly disposed
	at org.eclipse.swt.graphics.Resource.initNonDisposeTracking(Resource.java:172)
	at org.eclipse.swt.graphics.Resource.<init>(Resource.java:120)
	at org.eclipse.swt.graphics.Image.<init>(Image.java:668)
	at org.eclipse.jface.resource.URLImageDescriptor.createImage(URLImageDescriptor.java:241)
	at org.eclipse.jface.resource.ImageDescriptor.createImage(ImageDescriptor.java:290)
	at org.eclipse.jface.resource.ImageDescriptor.createImage(ImageDescriptor.java:268)
	at org.eclipse.ui.internal.dialogs.ContentTypesPreferencePage.lambda$2(ContentTypesPreferencePage.java:363)