### PR TITLE
Revert "Remove explicit requirement to jxpath in feature"

### DIFF
--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -596,6 +596,13 @@
          unpack="false"/>
 
    <plugin
+         id="org.apache.commons.jxpath"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.e4.emf.xpath"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
This reverts commit f626d1e105179ac01312c204a53340526c764a9d.

This commit breaks SDK building with error

```
Failed to execute goal
org.eclipse.tycho:tycho-p2-repository-plugin:4.0.0-SNAPSHOT:assemble-repository
(default-assemble-repository) on project eclipse.platform.repository:
Could not assemble p2 repository: Mirroring failed: Messages while
mirroring artifact descriptors.: [Failed to transfer artifact packed:
osgi.bundle,org.apache.commons.jxpath.source,1.3.0.v200911051830.:
[Download of osgi.bundle,org.apache.commons.jxpath.source,1.3.0.v200911051830
failed on repository
file:/resolution-context-artifacts@%252Fhome%252Fjenkins%252Fagent%252Fworkspace%252FBuilds%252FI-build-4.27%252Feclipse.platform.releng.aggregator%252Feclipse.platform.releng.aggregator%252Fcje-production%252FgitCache%252Feclipse.platform.releng.aggregator%252Feclipse.platform.releng.tychoeclipsebuilder%252Feclipse.platform.repository.
```

See discussion on
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/773