### PR TITLE
Revert "Revert "Remove explicit requirement to jxpath in feature""

### DIFF
--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -596,13 +596,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.apache.commons.jxpath"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.e4.emf.xpath"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
This reverts commit c4135cf4ee86c08b85e71314fa0f62d3e1012e89. The former commit was reverted because of a bug in Tycho and because the build was still consuming jxpath from Maven instead of Orbit. Now that 1 build succeeded, there should be nothing left of the jxpath from Maven Central, and removing this transtive dependency from the feature should simplify further maintenance and evolution.