### PR TITLE
Do not explicitly list JNA dependency

### DIFF
--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -649,20 +649,6 @@
          unpack="false"/>
 
    <plugin
-         id="com.sun.jna"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="com.sun.jna.platform"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.osgi.util.function"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
It's not smth e4 rpm feature mandates in anyway but rather an implementation detail and as long as there is a plugin making use of it will be resolved/installed. Additionally with
https://openjdk.org/jeps/434 being integrated in Java 20 and hopefully getting stable in Java 21 there would be no need for JNA dependency. This change is being done now as it's yet another case where releng work require extra "touches" as identified by
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/829 .