### PR TITLE
Fix toolbar render problems in dark mode on resizing #536

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/dark/e4-dark_globalstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/dark/e4-dark_globalstyle.css
@@ -57,9 +57,9 @@ TabFolder > Composite > * > * { /* [style~='SWT.NO_BACKGROUND'] <- generate E4 n
 	color:'#org-eclipse-ui-workbench-DARK_FOREGROUND'; 
 }
 
+/* Toolbar should inherit the colors of its container to avoid drawing artifacts*/
 ToolBar {
-    /* Because resizing leads to a change in style inheritance we do not use 'inherit', but define an explicit background color here */
-    background-color: '#org-eclipse-ui-workbench-DARK_BACKGROUND';
+	background-color:inherit;	
 }
 
 Combo,

--- a/bundles/org.eclipse.ui.themes/css/dark/e4-dark_globalstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/dark/e4-dark_globalstyle.css
@@ -57,9 +57,9 @@ TabFolder > Composite > * > * { /* [style~='SWT.NO_BACKGROUND'] <- generate E4 n
 	color:'#org-eclipse-ui-workbench-DARK_FOREGROUND'; 
 }
 
-/* Toolbar should inherit the colors of its container to avoid drawing artifacts*/
 ToolBar {
-	background-color:inherit;	
+    /* Because resizing leads to a change in style inheritance we do not use 'inherit', but define an explicit background color here */
+    background-color: '#org-eclipse-ui-workbench-DARK_BACKGROUND';
 }
 
 Combo,

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ToolItemTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ToolItemTest.java
@@ -51,6 +51,7 @@ public class ToolItemTest extends CSSSWTTestCase {
 	}
 
 	@Test
+	@Disabled("Implementation was removed because problems when parent toolbar inside CTabFolder")
 	void testBackgroundColor() {
 		var toolItemToTest = createTestToolItem("ToolItem { background-color: #FF0000;}",
 				SWT.PUSH);
@@ -75,6 +76,7 @@ public class ToolItemTest extends CSSSWTTestCase {
 	}
 
 	@Test
+	@Disabled("Implementation was removed because problems when parent toolbar inside CTabFolder")
 	void ensurePseudoAttributeAllowsToSelectionPushButton() {
 		var toolItemToTest = createTestToolItem(
 				"ToolItem[style~='SWT.CHECK'] { background-color: #FF0000; color: #0000FF }", SWT.CHECK);
@@ -86,6 +88,20 @@ public class ToolItemTest extends CSSSWTTestCase {
 				"ToolItem[style~='SWT.PUSH'] { background-color: #FF0000; color: #0000FF }", SWT.CHECK);
 
 		assertNotEquals(RED, unStyledBToolItem.getBackground().getRGB());
+		assertNotEquals(BLUE, unStyledBToolItem.getForeground().getRGB());
+
+	}
+
+	@Test
+	void ensurePseudoAttributeAllowsToSelectionPushButtonOnlyForeground() {
+		var toolItemToTest = createTestToolItem(
+				"ToolItem[style~='SWT.CHECK'] { color: #0000FF }", SWT.CHECK);
+
+		assertEquals(BLUE, toolItemToTest.getForeground().getRGB());
+
+		var unStyledBToolItem = createTestToolItem(
+				"ToolItem[style~='SWT.PUSH'] { color: #0000FF }", SWT.CHECK);
+
 		assertNotEquals(BLUE, unStyledBToolItem.getForeground().getRGB());
 
 	}


### PR DESCRIPTION
This PR
- closes #536

### Details
- Toolbar has in dark mode now a dedicated color instead of css inheritance. A parent container change by resizing does not change the toolbar color any longer
- The color is choosen in way that the main toolbar looks as expected before. Also the toggle border is now visible again, which could address #467 as well.

Signed-off-by: Albert Tregnaghi <albert.tregnaghi@gmail.com>