### PR TITLE
Do not list felix.scr expliictly in e4.rcp feature.

### DIFF
--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -238,13 +238,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.apache.felix.scr"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.equinox.event"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
It should be pulled in as a provider of
osgi.extender;filter:="(&(osgi.extender=osgi.component)(version>=1.0)(!(version>=2.0)))"

Change is an effort to reduce the need to "touch" features everytime 3rd party dependency is being updated.
This is the 5th place to "touch" for update to felix.scr in the old way. https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/832