### PR TITLE
Update to temurin jvm

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
 	}
 	tools {
 		maven 'apache-maven-latest'
-		jdk 'openjdk-jdk17-latest'
+		jdk 'temurin-jdk17-latest'
 	}
 	stages {
 		stage('Build') {


### PR DESCRIPTION
As the openjdk-jdk17-latest is no longer updated to latest 17.0.x