### PR TITLE
Ctrl-E: Do not handle name collisions in case of custom editor input

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbookEditorsHandler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbookEditorsHandler.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.core.runtime.Adapters;
@@ -161,50 +162,56 @@ public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 	 */
 	private Map<EditorReference, String> generateColumnLabelTexts(List<EditorReference> editorReferences) {
 		Map<EditorReference, String> editorReferenceLabelTexts = new HashMap<>(editorReferences.size());
-		Map<String, List<Entry<EditorReference, IPath>>> collisionsMap = new HashMap<>(editorReferences.size());
-		editorReferences.forEach(editorReference -> {
-			try {
-				IPathEditorInput iPathEditorInput = Adapters.adapt(editorReference.getEditorInput(),
-						IPathEditorInput.class);
-				IPath path;
-				// we only detect collisions for IPathEditorInput and only if the name used by
-				// the editor reference is the filename. Otherwise, this would break scenarios
-				// where editors override the name used, e.g. for virtual file systems using
-				// org.eclipse.core.internal.filesystem.FileCache
-				if (iPathEditorInput != null && (path = iPathEditorInput.getPath()) != null
-						&& editorReference.getName().equals(path.lastSegment())) {
+		Map<String, List<EditorReference>> collisionsMap = editorReferences.stream()
+				.collect(Collectors.groupingBy(r -> r.getName()));
 
-					List<Entry<EditorReference, IPath>> referencesWithSameTitle = collisionsMap
-							.get(editorReference.getTitle());
-					if (referencesWithSameTitle == null) {
-						referencesWithSameTitle = new ArrayList<>();
-						collisionsMap.put(editorReference.getTitle(), referencesWithSameTitle);
-					}
-
-					referencesWithSameTitle.add(Map.entry(editorReference, path));
-				} else {
-					editorReferenceLabelTexts.put(editorReference, getWorkbenchPartReferenceText(editorReference));
-				}
-			} catch (PartInitException e) {
-				// This should never happen as all the parts are initialized?
-				String message = "Expected parts to be initialized"; //$NON-NLS-1$
-				final IStatus status = new Status(IStatus.ERROR, WorkbenchPlugin.PI_WORKBENCH, 0, message, e);
-				WorkbenchPlugin.log(message, status);
-			}
-		});
-
-		for (List<Entry<EditorReference, IPath>> groupedEditorReferences : collisionsMap.values()) {
-			if (groupedEditorReferences.size() == 1 || allReferencesToSamePath(groupedEditorReferences)) {
-				groupedEditorReferences.stream().map(Entry::getKey)
-						.forEach(editorReference -> editorReferenceLabelTexts.put(editorReference,
-								getWorkbenchPartReferenceText(editorReference)));
+		for (Entry<String, List<EditorReference>> groupedEditorReferences : collisionsMap.entrySet()) {
+			if (groupedEditorReferences.getValue().size() == 1) {
+				groupedEditorReferences.getValue().stream().forEach(editorReference -> editorReferenceLabelTexts
+						.put(editorReference, getWorkbenchPartReferenceText(editorReference)));
 			} else {
-				List<Integer> maxMatchingSegmentsList = new ArrayList<>(groupedEditorReferences.size());
-				for (Entry<EditorReference, IPath> entry : groupedEditorReferences) {
+				List<Entry<EditorReference, IPath>> refsToMakeDistinguishableViaPathSegments = new ArrayList<>();
+				for (EditorReference editorReference : groupedEditorReferences.getValue()) {
+					try {
+						// we only detect collisions for IPathEditorInput and only if the name used by
+						// the editor reference is the filename. Otherwise, this would break scenarios
+						// where editors override the name used, e.g. for virtual file systems using
+						// org.eclipse.core.internal.filesystem.FileCache
+						IPathEditorInput iPathEditorInput = Adapters.adapt(editorReference.getEditorInput(),
+								IPathEditorInput.class);
+						IPath path;
+						if (iPathEditorInput != null && (path = iPathEditorInput.getPath()) != null
+								&& groupedEditorReferences.getKey().equals(path.lastSegment())) {
+							refsToMakeDistinguishableViaPathSegments.add(Map.entry(editorReference, path));
+						} else {
+							editorReferenceLabelTexts.put(editorReference,
+									getWorkbenchPartReferenceText(editorReference));
+						}
+					} catch (PartInitException e) {
+						// This should never happen as all the parts are initialized?
+						String message = "Expected parts to be initialized"; //$NON-NLS-1$
+						final IStatus status = new Status(IStatus.ERROR, WorkbenchPlugin.PI_WORKBENCH, 0, message, e);
+						WorkbenchPlugin.log(message, status);
+					}
+				}
+
+				if (refsToMakeDistinguishableViaPathSegments.isEmpty()) {
+					continue;
+				}
+
+				if (allReferencesToSamePath(refsToMakeDistinguishableViaPathSegments)) {
+					refsToMakeDistinguishableViaPathSegments.stream().forEach(
+							e -> editorReferenceLabelTexts.put(e.getKey(), getWorkbenchPartReferenceText(e.getKey())));
+					continue;
+				}
+
+				List<Integer> maxMatchingSegmentsList = new ArrayList<>(
+						refsToMakeDistinguishableViaPathSegments.size());
+				for (Entry<EditorReference, IPath> entry : refsToMakeDistinguishableViaPathSegments) {
 					IPath path = entry.getValue();
 					int maxMatchingSegments = -1;
-					for (int i = 0; i < groupedEditorReferences.size(); i++) {
-						IPath currentPath = groupedEditorReferences.get(i).getValue();
+					for (int i = 0; i < refsToMakeDistinguishableViaPathSegments.size(); i++) {
+						IPath currentPath = refsToMakeDistinguishableViaPathSegments.get(i).getValue();
 						if (currentPath.equals(path)) {
 							continue;
 						}
@@ -216,9 +223,9 @@ public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 				}
 
 				for (int i = 0; i < maxMatchingSegmentsList.size(); i++) {
-					EditorReference editorReference = groupedEditorReferences.get(i).getKey();
+					EditorReference editorReference = refsToMakeDistinguishableViaPathSegments.get(i).getKey();
 					Integer maxMatchingSegment = maxMatchingSegmentsList.get(i);
-					IPath path = groupedEditorReferences.get(i).getValue();
+					IPath path = refsToMakeDistinguishableViaPathSegments.get(i).getValue();
 
 					String labelText = generateLabelText(editorReference, path, maxMatchingSegment);
 					editorReferenceLabelTexts.put(editorReference, labelText);

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbookEditorsHandler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbookEditorsHandler.java
@@ -166,8 +166,13 @@ public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 			try {
 				IPathEditorInput iPathEditorInput = Adapters.adapt(editorReference.getEditorInput(),
 						IPathEditorInput.class);
-				if (iPathEditorInput != null && iPathEditorInput.getPath() != null) {
-					IPath path = iPathEditorInput.getPath();
+				IPath path;
+				// we only detect collisions for IPathEditorInput and only if the name used by
+				// the editor reference is the filename. Otherwise, this would break scenarios
+				// where editors override the name used, e.g. for virtual file systems using
+				// org.eclipse.core.internal.filesystem.FileCache
+				if (iPathEditorInput != null && (path = iPathEditorInput.getPath()) != null
+						&& editorReference.getName().equals(path.lastSegment())) {
 
 					List<Entry<EditorReference, IPath>> referencesWithSameTitle = collisionsMap
 							.get(editorReference.getTitle());
@@ -178,7 +183,6 @@ public class WorkbookEditorsHandler extends FilteredTableBaseHandler {
 
 					referencesWithSameTitle.add(Map.entry(editorReference, path));
 				} else {
-					// we only detect collisions for IPathEditorInput
 					editorReferenceLabelTexts.put(editorReference, getWorkbenchPartReferenceText(editorReference));
 				}
 			} catch (PartInitException e) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.swt.widgets.Display;
@@ -33,6 +34,7 @@ import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.WorkbookEditorsHandler;
+import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Test;
@@ -329,6 +331,41 @@ public class WorkbookEditorsHandlerTest extends UITestCase {
 		assertEquals("Selection should be the editor that was active before the currently active editor",
 				String.join(File.separator, "test2", "...", fileName),
 				handler.tableItemTexts.get(1));
+	}
+
+	@Test
+	public void testTwoFilesWithNameClashButEditorInputNameIsDiffereentThanFileName() throws Exception {
+		String fileName = "example.txt";
+		String editorInputName = "Example";
+		class EditorInputWithCustomName extends FileEditorInput {
+
+			public EditorInputWithCustomName(IFile file) {
+				super(file);
+			}
+
+			@Override
+			public String getName() {
+				return editorInputName;
+			}
+		}
+
+		IFile file1 = FileUtil.createFile(fileName, project1);
+		IFile file2 = FileUtil.createFile(fileName, project2);
+		IDE.openEditor(activePage, new EditorInputWithCustomName(file1),
+				IDE.getEditorDescriptor(file1, true, true).getId(), true);
+		IDE.openEditor(activePage, new EditorInputWithCustomName(file2),
+				IDE.getEditorDescriptor(file2, true, true).getId(), true);
+		ICommandService cmdService = PlatformUI.getWorkbench().getService(ICommandService.class);
+		final Command cmd = cmdService.getCommand("org.eclipse.ui.window.openEditorDropDown");
+		WorkbookEditorsHandlerTestable handler = new WorkbookEditorsHandlerTestable();
+		cmd.setHandler(handler);
+		IHandlerService handlerService = PlatformUI.getWorkbench().getService(IHandlerService.class);
+		final ExecutionEvent event = handlerService.createExecutionEvent(cmd, null);
+
+		handler.execute(event);
+
+		assertEquals("Display text should match name of editor input", editorInputName, handler.tableItemTexts.get(0));
+		assertEquals("Display text should match name of editor input", editorInputName, handler.tableItemTexts.get(1));
 	}
 
 	class WorkbookEditorsHandlerTestable extends WorkbookEditorsHandler {


### PR DESCRIPTION
In case the editor input returns a 'name' that is not the actual file name, do not apply the collision resolving logic based on file path segments.

In such cases we need to assume that the editor input is custom-built and such files might be virtual, in which case showing a path is not the intended behavior.

Fixes #547.