### PR TITLE
Enhance deprecation notice for Navigator

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/CollapseAllAction.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/CollapseAllAction.java
@@ -28,7 +28,7 @@ import org.eclipse.ui.handlers.CollapseAllHandler;
  *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=549953
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class CollapseAllAction extends ResourceNavigatorAction {
 
 	/**

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/CopyAction.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/CopyAction.java
@@ -50,7 +50,7 @@ import org.eclipse.ui.part.ResourceTransfer;
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  * @since 2.0
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 /* package */class CopyAction extends SelectionListenerAction {
 
 	/**

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/FilterSelectionAction.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/FilterSelectionAction.java
@@ -32,7 +32,7 @@ import org.eclipse.ui.internal.views.navigator.ResourceNavigatorMessages;
  *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=549953
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class FilterSelectionAction extends ResourceNavigatorAction {
 	private static final String FILTER_TOOL_TIP = ResourceNavigatorMessages.FilterSelection_toolTip;
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/FiltersContentProvider.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/FiltersContentProvider.java
@@ -36,7 +36,7 @@ import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
  *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=549953
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 /* package */class FiltersContentProvider implements IStructuredContentProvider {
 
 	private static List<String> definedFilters;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/GotoActionGroup.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/GotoActionGroup.java
@@ -41,7 +41,7 @@ import org.eclipse.ui.views.framelist.UpAction;
  *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=549953
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class GotoActionGroup extends ResourceNavigatorActionGroup {
 
 	private BackAction backAction;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/GotoResourceAction.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/GotoResourceAction.java
@@ -30,7 +30,7 @@ import org.eclipse.ui.PlatformUI;
  *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=549953
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class GotoResourceAction extends ResourceNavigatorAction {
 	/**
 	 * Creates a new instance of the class.

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/GotoResourceDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/GotoResourceDialog.java
@@ -31,7 +31,7 @@ import org.eclipse.ui.internal.views.navigator.ResourceNavigatorMessages;
  *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=549953
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 /* package */class GotoResourceDialog extends FilteredResourcesSelectionDialog {
 
 	/**

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/IResourceNavigator.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/IResourceNavigator.java
@@ -30,7 +30,7 @@ import org.eclipse.ui.views.framelist.FrameList;
  * @noimplement This interface is not intended to be implemented by clients.
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public interface IResourceNavigator extends IViewPart {
 
 	/**

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/LocalSelectionTransfer.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/LocalSelectionTransfer.java
@@ -29,7 +29,7 @@ import org.eclipse.swt.dnd.TransferData;
  * @deprecated as of 3.5, use
  *             {@link org.eclipse.jface.util.LocalSelectionTransfer} instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class LocalSelectionTransfer extends org.eclipse.jface.util.LocalSelectionTransfer {
 
 	private static final LocalSelectionTransfer INSTANCE = new LocalSelectionTransfer();

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/MainActionGroup.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/MainActionGroup.java
@@ -57,7 +57,7 @@ import org.eclipse.ui.operations.UndoRedoActionGroup;
  *
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class MainActionGroup extends ResourceNavigatorActionGroup {
 
 	protected AddBookmarkAction addBookmarkAction;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/NavigatorDragAdapter.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/NavigatorDragAdapter.java
@@ -46,7 +46,7 @@ import org.eclipse.ui.statushandlers.StatusManager;
  * @since 2.0
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class NavigatorDragAdapter extends DragSourceAdapter {
 	private static final String CHECK_MOVE_TITLE = ResourceNavigatorMessages.DragAdapter_title;
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/NavigatorDropAdapter.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/NavigatorDropAdapter.java
@@ -56,7 +56,7 @@ import org.eclipse.ui.part.ResourceTransfer;
  * @since 2.0
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class NavigatorDropAdapter extends PluginDropAdapter implements IOverwriteQuery {
 
 	/**

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/NavigatorFrameSource.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/NavigatorFrameSource.java
@@ -26,7 +26,7 @@ import org.eclipse.ui.views.framelist.TreeViewerFrameSource;
  *
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class NavigatorFrameSource extends TreeViewerFrameSource {
 
 	private ResourceNavigator navigator;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/OpenActionGroup.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/OpenActionGroup.java
@@ -17,11 +17,9 @@ import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
-
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.viewers.IStructuredSelection;
-
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.OpenFileAction;
 import org.eclipse.ui.actions.OpenInNewWindowAction;
@@ -33,7 +31,7 @@ import org.eclipse.ui.internal.views.navigator.ResourceNavigatorMessages;
  *
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class OpenActionGroup extends ResourceNavigatorActionGroup {
 
 	private OpenFileAction openFileAction;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/PasteAction.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/PasteAction.java
@@ -44,7 +44,7 @@ import org.eclipse.ui.part.ResourceTransfer;
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  * @since 2.0
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 /* package */class PasteAction extends SelectionListenerAction {
 
 	/**

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/RefactorActionGroup.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/RefactorActionGroup.java
@@ -36,7 +36,7 @@ import org.eclipse.ui.actions.TextActionHandler;
  * @since 2.0
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class RefactorActionGroup extends ResourceNavigatorActionGroup {
 
 	private Clipboard clipboard;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourceNavigator.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourceNavigator.java
@@ -114,7 +114,7 @@ import org.osgi.framework.FrameworkUtil;
  *
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class ResourceNavigator extends ViewPart implements ISetSelectionTarget, IResourceNavigator {
 
 	private TreeViewer viewer;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourceNavigatorAction.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourceNavigatorAction.java
@@ -32,7 +32,7 @@ import org.eclipse.ui.actions.SelectionProviderAction;
  *
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public abstract class ResourceNavigatorAction extends SelectionProviderAction {
 
 	private IResourceNavigator navigator;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourceNavigatorActionGroup.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourceNavigatorActionGroup.java
@@ -41,7 +41,7 @@ import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
  *
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public abstract class ResourceNavigatorActionGroup extends ActionGroup {
 
 	/**

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourceNavigatorMessages.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourceNavigatorMessages.java
@@ -30,7 +30,7 @@ package org.eclipse.ui.views.navigator;
  *
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class ResourceNavigatorMessages {
 
 	private ResourceNavigatorMessages() {

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourceNavigatorMoveAction.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourceNavigatorMoveAction.java
@@ -44,7 +44,7 @@ import org.eclipse.ui.actions.MoveResourceAction;
  * @since 2.0
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class ResourceNavigatorMoveAction extends MoveResourceAction {
 	private StructuredViewer viewer;
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourceNavigatorRenameAction.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourceNavigatorRenameAction.java
@@ -39,7 +39,7 @@ import org.eclipse.ui.actions.RenameResourceAction;
  *
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class ResourceNavigatorRenameAction extends RenameResourceAction {
 	private TreeViewer viewer;
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourcePatternFilter.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourcePatternFilter.java
@@ -39,7 +39,7 @@ import org.eclipse.ui.internal.util.PrefUtil;
  *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=549953
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class ResourcePatternFilter extends ViewerFilter {
 	private String[] patterns;
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourceSelectionUtil.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourceSelectionUtil.java
@@ -40,7 +40,7 @@ import org.eclipse.jface.viewers.StructuredSelection;
  * @deprecated as of 3.5, use {@link org.eclipse.ui.ide.ResourceSelectionUtil}
  *             instead.
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class ResourceSelectionUtil {
 	private ResourceSelectionUtil() {
 	}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourceSorter.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ResourceSorter.java
@@ -44,7 +44,7 @@ import org.eclipse.jface.viewers.ViewerSorter;
  * @deprecated as of 3.3, use {@link ResourceComparator} instead
  * @noextend This class is not intended to be subclassed by clients.
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class ResourceSorter extends ViewerSorter {
 
 	/**

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ShowInNavigatorAction.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ShowInNavigatorAction.java
@@ -48,7 +48,7 @@ import org.eclipse.ui.part.ISetSelectionTarget;
  *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=549953
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class ShowInNavigatorAction extends SelectionProviderAction {
 	private IWorkbenchPage page;
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/SortAndFilterActionGroup.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/SortAndFilterActionGroup.java
@@ -31,7 +31,7 @@ import org.eclipse.ui.internal.views.navigator.ResourceNavigatorMessages;
  *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=549953
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class SortAndFilterActionGroup extends ResourceNavigatorActionGroup {
 
 	private SortViewAction sortByTypeAction;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/SortViewAction.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/SortViewAction.java
@@ -29,7 +29,7 @@ import org.eclipse.ui.internal.views.navigator.ResourceNavigatorMessages;
  *
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class SortViewAction extends ResourceNavigatorAction {
 	private int sortCriteria;
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ToggleLinkingAction.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/ToggleLinkingAction.java
@@ -30,7 +30,7 @@ import org.eclipse.ui.IWorkbenchCommandConstants;
  *
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class ToggleLinkingAction extends ResourceNavigatorAction {
 
 	/**

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/WorkspaceActionGroup.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/navigator/WorkspaceActionGroup.java
@@ -61,7 +61,7 @@ import org.eclipse.ui.internal.ide.StatusUtil;
  *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=549953
  * @deprecated as of 3.5, use the Common Navigator Framework classes instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class WorkspaceActionGroup extends ResourceNavigatorActionGroup {
 
 	private BuildAction buildAction;

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IPageLayout.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IPageLayout.java
@@ -90,7 +90,7 @@ public interface IPageLayout {
 	 * @deprecated this has been replaced by the Common Navigator Framework as of
 	 *             release 3.5.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	String ID_RES_NAV = "org.eclipse.ui.views.ResourceNavigator"; //$NON-NLS-1$
 
 	/**


### PR DESCRIPTION
It's been deprecated since 2019 and could have been removed already but this will happen for 2022-06 (or at least part of it) thus make the deprecation annotation forRemoval=true.