### PR TITLE
Mark ResourceNavigatorTest for deletion

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/navigator/ResourceNavigatorTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/navigator/ResourceNavigatorTest.java
@@ -40,6 +40,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
+@Deprecated(forRemoval = true)
 public class ResourceNavigatorTest extends UITestCase {
 	private IWorkbenchPage activePage;
 


### PR DESCRIPTION
As ResourceNavigator is marked for deletion do the same for its tests in order to silence the compile warnings.