### PR TITLE
Disable again failing test on MacOS

### DIFF
--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/ProgrammaticOpenTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/ProgrammaticOpenTest.java
@@ -15,10 +15,9 @@
 package org.eclipse.ui.tests.navigator;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
-import java.util.Iterator;
 import java.util.Map;
 
 import org.eclipse.core.runtime.Platform;
@@ -120,8 +119,8 @@ public class ProgrammaticOpenTest extends NavigatorTestBase {
 
 		assertEquals(1, sorters.size());
 
-		for (Iterator iter = sorters.entrySet().iterator(); iter.hasNext();) {
-			Map.Entry entry = (Map.Entry) iter.next();
+		for (Object element : sorters.entrySet()) {
+			Map.Entry entry = (Map.Entry) element;
 			assertTrue(entry.getValue() instanceof TestSorterData);
 		}
 
@@ -156,7 +155,7 @@ public class ProgrammaticOpenTest extends NavigatorTestBase {
 	// bug 296728 expression evaluation does not support with
 	@Test
 	public void testEvaluateWith() throws Exception {
-		assertNotEquals("Test fails on Mac: Bug 537641", Platform.OS_MACOSX, Platform.getOS());
+		assumeFalse("Test fails on Mac: Bug 537641", Platform.OS_MACOSX.equals(Platform.getOS()));
 
 		_contentService.bindExtensions(new String[] { COMMON_NAVIGATOR_RESOURCE_EXT,
 				TEST_CONTENT_WITH, }, false);


### PR DESCRIPTION
Broken by dacc55a0fd2c865142478d301c2bde5f31149918 where assume was changed to assert by mistake.