### PR TITLE
Removes org.eclipse.e4.tools.jdt.templates from build due to failing

### DIFF
--- a/tools/bundles/pom.xml
+++ b/tools/bundles/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2017 vogella GmbH and others.
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Distribution License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/org/documents/edl-v10.php
+
+  Contributors:
+     Lars Vogel <Lars.Vogel@vogella.com>  - initial implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.platform</groupId>
+    <artifactId>eclipse.platform.ui.tools</artifactId>
+    <version>4.27.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>eclipse.platform.ui.tools.bundles</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+  
+
+
+
+
+
+
+  
+    <module>org.eclipse.e4.tools</module>
+    <module>org.eclipse.e4.tools.compat</module>
+    <module>org.eclipse.e4.tools.compatibility.migration</module>
+    <module>org.eclipse.e4.tools.emf.editor3x</module>
+    <module>org.eclipse.e4.tools.emf.ui</module>
+    <!-- Disabled as it otherwise fails the aggregator build due to its JDT dependency
+    <module>org.eclipse.e4.tools.jdt.templates</module>
+    -->
+    <module>org.eclipse.e4.tools.persistence</module>
+    <module>org.eclipse.e4.tools.services</module>
+  </modules>
+</project>

--- a/tools/features/org.eclipse.e4.core.tools.feature/feature.xml
+++ b/tools/features/org.eclipse.e4.core.tools.feature/feature.xml
@@ -54,11 +54,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.eclipse.e4.tools.jdt.templates"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>


### PR DESCRIPTION
aggregator build

org.eclipse.e4.tools.jdt.templates has a dependency to JDT which fails the build after the repo merge. So removing the plug-in from the build for now to make the aggregator build work again.