### PR TITLE
FileSystemExporter: Handle virtual resources without local location

### DIFF
--- a/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide; singleton:=true
-Bundle-Version: 3.20.100.qualifier
+Bundle-Version: 3.20.200.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.internal.ide.IDEWorkbenchPlugin
 Bundle-ActivationPolicy: lazy

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/VirtualTestFileStore.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/VirtualTestFileStore.java
@@ -1,0 +1,163 @@
+package org.eclipse.ui.tests.internal;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileInfo;
+import org.eclipse.core.filesystem.IFileStore;
+import org.eclipse.core.filesystem.provider.FileInfo;
+import org.eclipse.core.filesystem.provider.FileStore;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Status;
+
+/**
+ * Based on org.eclipse.debug.tests.launching.DebugFileStore
+ */
+public class VirtualTestFileStore extends FileStore {
+
+	private final URI uri;
+
+	public VirtualTestFileStore(URI uri) {
+		this.uri = uri;
+	}
+
+	@Override
+	public String[] childNames(int options, IProgressMonitor monitor) {
+		URI[] uris = VirtualTestFileSystem.getDefault().getFileURIs();
+		List<String> children = new ArrayList<>();
+		IPath me = getPath();
+		for (URI id : uris) {
+			Path path = new Path(id.getPath());
+			if (path.segmentCount() > 0) {
+				if (path.removeLastSegments(1).equals(me)) {
+					children.add(path.lastSegment());
+				}
+			}
+		}
+		return children.toArray(new String[children.size()]);
+	}
+
+	@Override
+	public IFileInfo fetchInfo(int options, IProgressMonitor monitor) {
+		byte[] contents = VirtualTestFileSystem.getDefault().getContents(toURI());
+		FileInfo info = new FileInfo();
+		info.setName(getName());
+		info.setAttribute(EFS.ATTRIBUTE_READ_ONLY, false);
+		if (contents == null) {
+			info.setExists(false);
+			info.setLength(0L);
+		} else {
+			info.setExists(true);
+			info.setLength(contents.length);
+			info.setDirectory(contents == VirtualTestFileSystem.DIRECTORY_BYTES);
+			if (info.isDirectory()) {
+				info.setAttribute(EFS.ATTRIBUTE_EXECUTABLE, true);
+			}
+		}
+		return info;
+	}
+
+	@Override
+	public IFileStore getChild(String name) {
+		try {
+			return new VirtualTestFileStore(
+					new URI(getFileSystem().getScheme(), getPath().append(name).toString(), null));
+		} catch (URISyntaxException e) {
+		}
+		return null;
+	}
+
+	@Override
+	public String getName() {
+		IPath path = getPath();
+		if (path.segmentCount() > 0) {
+			return path.lastSegment();
+		}
+		return ""; //$NON-NLS-1$
+	}
+
+	private IPath getPath() {
+		URI me = toURI();
+		IPath path = new Path(me.getPath());
+		return path;
+	}
+
+	@Override
+	public IFileStore getParent() {
+		IPath path = getPath();
+		if (path.segmentCount() > 0) {
+			try {
+				return new VirtualTestFileStore(
+						new URI(getFileSystem().getScheme(), path.removeLastSegments(1).toString(), null));
+			} catch (URISyntaxException e) {
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public InputStream openInputStream(int options, IProgressMonitor monitor) throws CoreException {
+		byte[] contents = VirtualTestFileSystem.getDefault().getContents(toURI());
+		if (contents != null) {
+			return new ByteArrayInputStream(contents);
+		}
+		throw new CoreException(new Status(IStatus.ERROR, "org.eclipse.ui.tests", //$NON-NLS-1$
+				"File does not exist: " + toURI())); //$NON-NLS-1$
+	}
+
+	@Override
+	public OutputStream openOutputStream(int options, IProgressMonitor monitor) {
+		return new ByteArrayOutputStream() {
+
+			@Override
+			public void close() throws IOException {
+				super.close();
+				VirtualTestFileSystem.getDefault().setContents(toURI(), toByteArray());
+			}
+		};
+	}
+
+	@Override
+	public IFileStore mkdir(int options, IProgressMonitor monitor) throws CoreException {
+		IFileInfo info = fetchInfo();
+		if (info.exists()) {
+			if (!info.isDirectory()) {
+				throw new CoreException(new Status(IStatus.ERROR, "org.eclipse.ui.tests", //$NON-NLS-1$
+						"mkdir failed - file already exists with name: " + toURI())); //$NON-NLS-1$
+			}
+		} else {
+			IFileStore parent = getParent();
+			if (parent.fetchInfo().exists()) {
+				VirtualTestFileSystem.getDefault().setContents(toURI(), VirtualTestFileSystem.DIRECTORY_BYTES);
+			} else if ((options & EFS.SHALLOW) > 0) {
+				throw new CoreException(new Status(IStatus.ERROR, "org.eclipse.ui.tests", //$NON-NLS-1$
+						"mkdir failed - parent does not exist: " + toURI())); //$NON-NLS-1$
+			} else {
+				parent.mkdir(EFS.NONE, null);
+			}
+		}
+		return this;
+	}
+
+	@Override
+	public URI toURI() {
+		return uri;
+	}
+
+	@Override
+	public void delete(int options, IProgressMonitor monitor) {
+		VirtualTestFileSystem.getDefault().delete(toURI());
+	}
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/VirtualTestFileSystem.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/VirtualTestFileSystem.java
@@ -1,0 +1,102 @@
+package org.eclipse.ui.tests.internal;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.core.filesystem.IFileStore;
+import org.eclipse.core.filesystem.provider.FileSystem;
+import org.eclipse.core.runtime.Path;
+
+/**
+ * Based on org.eclipse.debug.tests.launching.DebugFileSystem
+ */
+public class VirtualTestFileSystem extends FileSystem {
+
+	public static final String SCHEME = "virtual-test";
+
+	/**
+	 * represents a directory
+	 */
+	public static final byte[] DIRECTORY_BYTES = new byte[] { 1, 2, 3, 4 };
+
+	private static VirtualTestFileSystem system;
+
+	/**
+	 * Keys URIs to file stores for existing files
+	 */
+	private final Map<URI, byte[]> files = new HashMap<>();
+
+	public VirtualTestFileSystem() {
+		system = this;
+		// create root of the file system
+		try {
+			setContents(new URI(SCHEME, Path.ROOT.toString(), null), DIRECTORY_BYTES); // $NON-NLS-1$
+		} catch (URISyntaxException e) {
+		}
+	}
+
+	/**
+	 * Returns the Debug files system.
+	 *
+	 * @return file system
+	 */
+	public static VirtualTestFileSystem getDefault() {
+		return system;
+	}
+
+	@Override
+	public IFileStore getStore(URI uri) {
+		return new VirtualTestFileStore(uri);
+	}
+
+	@Override
+	public boolean canDelete() {
+		return true;
+	}
+
+	@Override
+	public boolean canWrite() {
+		return true;
+	}
+
+	/**
+	 * Returns whether contents of the file or <code>null</code> if none.
+	 *
+	 * @param uri
+	 * @return bytes or <code>null</code>
+	 */
+	public byte[] getContents(URI uri) {
+		return files.get(uri);
+	}
+
+	/**
+	 * Deletes the file.
+	 *
+	 * @param uri
+	 */
+	public void delete(URI uri) {
+		files.remove(uri);
+	}
+
+	/**
+	 * Sets the content of the given file.
+	 *
+	 * @param uri
+	 * @param bytes
+	 */
+	public void setContents(URI uri, byte[] bytes) {
+		files.put(uri, bytes);
+	}
+
+	/**
+	 * Returns URIs of all existing files.
+	 *
+	 * @return
+	 */
+	public URI[] getFileURIs() {
+		return files.keySet().toArray(new URI[files.size()]);
+	}
+
+}

--- a/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse UI Tests
 Bundle-SymbolicName: org.eclipse.ui.tests; singleton:=true
-Bundle-Version: 3.15.1000.qualifier
+Bundle-Version: 3.15.1100.qualifier
 Eclipse-BundleShape: dir
 Bundle-Activator: org.eclipse.ui.tests.TestPlugin
 Bundle-Vendor: Eclipse.org

--- a/tests/org.eclipse.ui.tests/plugin.xml
+++ b/tests/org.eclipse.ui.tests/plugin.xml
@@ -4664,4 +4664,15 @@
           <run class="org.eclipse.ui.tests.datatransfer.ImportTestUtils$TestBuilder"/>
     </builder>
  </extension>
+ <extension
+       id="virtual-test"
+       name="virtual-test"
+       point="org.eclipse.core.filesystem.filesystems">
+    <filesystem
+          scheme="virtual-test">
+       <run
+             class="org.eclipse.ui.tests.internal.VirtualTestFileSystem">
+       </run>
+    </filesystem>
+ </extension>
 </plugin>


### PR DESCRIPTION
`IResource#getLocation()` returns null for virtual resources that do not exist in the local file system.

Fall back to copying input to output stream like before 9c6c5519dfb245b2b1c9bf5b3686cf9c324bd67e [1] in this case.

Fixes #615.

[1] https://bugs.eclipse.org/bugs/show_bug.cgi?id=549486