### PR TITLE
Enable Chrome and Safari as web browsers in the preference page

### DIFF
--- a/bundles/org.eclipse.ui.browser/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.browser/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.browser; singleton:=true
-Bundle-Version: 3.7.400.qualifier
+Bundle-Version: 3.7.500.qualifier
 Bundle-Activator: org.eclipse.ui.internal.browser.WebBrowserUIPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.ui.browser/plugin.properties
+++ b/bundles/org.eclipse.ui.browser/plugin.properties
@@ -38,5 +38,6 @@ browserKonqueror=Konqueror
 browserEpiphany=Epiphany (Gnome Web)
 browserFirefox=Firefox
 browserCamino=Camino
+browserSafari=Safari
 
 contentType_images=Image

--- a/bundles/org.eclipse.ui.browser/plugin.xml
+++ b/bundles/org.eclipse.ui.browser/plugin.xml
@@ -195,20 +195,27 @@
          <location>Applications/Firefox.app</location>
       </browser>
       <browser
+         id="org.eclipse.ui.browser.chrome"
+         name="%browserChrome"
+         os="MacOSX"
+         executable="Google Chrome">
+         <location>Applications/Google Chrome.app</location>
+      </browser>
+      <browser
          id="org.eclipse.ui.browser.camino"
          name="%browserCamino"
          os="MacOSX"
          executable="Camino">
          <location>Applications/Camino.app/Contents/MacOS/Camino</location>
       </browser>
-<!--      <browser
+      <browser
          id="org.eclipse.ui.browser.safari"
          name="%browserSafari"
          os="MacOSX"
          executable="Safari"
          factoryclass="org.eclipse.ui.internal.browser.macosx.SafariBrowserFactory">
-         <location>Applications/Safari.app/Contents/MacOS/Safari</location>
-      </browser> -->
+         <location>Applications/Safari.app</location>
+      </browser>
       <browser
          id="org.eclipse.ui.browser.ie"
          name="%browserInternetExplorer"


### PR DESCRIPTION
selection of Web Browsers Chrome or Safari in the search tab will result in “No Web Browsers were Found“ error, despite these browsers being present in the system.

Enable them by adding  relevant entries for these browsers in plugin.xml and plugin.properties.

Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/issues/618

Before
<img width="624" alt="Screenshot 2023-02-27 at 10 32 59 PM" src="https://user-images.githubusercontent.com/122080218/221763746-41ebb43c-ecae-4d8b-97c5-d3d6d40ae383.png">

After
<img width="620" alt="Screenshot 2023-02-28 at 10 35 31 AM" src="https://user-images.githubusercontent.com/122080218/221763890-331d2977-33a5-40e3-b73e-80c5b5d3fb59.png">

/cc @lshanmug 