### PR TITLE
Enable the setting of command icons for e4 commands

### DIFF
--- a/bundles/org.eclipse.e4.ui.model.workbench/model/UIElements.ecore
+++ b/bundles/org.eclipse.e4.ui.model.workbench/model/UIElements.ecore
@@ -208,6 +208,11 @@
           <details key="documentation" value="&lt;p>&#xD;&#xA;&lt;strong>Developers&lt;/strong>:&#xD;&#xA;Add more detailed documentation by editing this comment in&#xD;&#xA;org.eclipse.ui.model.workbench/model/UIElements.ecore.&#xD;&#xA;There is a GenModel/documentation node under each type and attribute.&#xD;&#xA;&lt;/p>"/>
         </eAnnotations>
       </eStructuralFeatures>
+      <eStructuralFeatures xsi:type="ecore:EAttribute" name="commandIconURI" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
+        <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+          <details key="documentation" value="&lt;p>&#xD;&#xA;This field contains a fully qualified URL defining the path to an Image to display&#xD;&#xA;for this element.&#xD;&#xA;&lt;/p>&#xD;&#xA;@since 2.4"/>
+        </eAnnotations>
+      </eStructuralFeatures>
       <eStructuralFeatures xsi:type="ecore:EAttribute" name="localizedCommandName"
           eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
           changeable="false" volatile="true" transient="true" derived="true">

--- a/bundles/org.eclipse.e4.ui.model.workbench/model/UIElements.genmodel
+++ b/bundles/org.eclipse.e4.ui.model.workbench/model/UIElements.genmodel
@@ -67,6 +67,7 @@
         <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference UIElements.ecore#//commands/Command/parameters"/>
         <genFeatures notify="false" createChild="false" propertySortChoices="true"
             ecoreFeature="ecore:EReference UIElements.ecore#//commands/Command/category"/>
+        <genFeatures createChild="false" ecoreFeature="ecore:EAttribute UIElements.ecore#//commands/Command/commandIconURI"/>
         <genFeatures property="Readonly" createChild="false" ecoreFeature="ecore:EAttribute UIElements.ecore#//commands/Command/localizedCommandName"
             get="return &lt;%org.eclipse.e4.ui.model.LocalizationHelper%>.getLocalizedFeature(CommandsPackageImpl.Literals.COMMAND__COMMAND_NAME, this);"/>
         <genFeatures property="Readonly" createChild="false" ecoreFeature="ecore:EAttribute UIElements.ecore#//commands/Command/localizedDescription"

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/commands/MCommand.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/commands/MCommand.java
@@ -39,6 +39,7 @@ import org.eclipse.e4.ui.model.application.ui.MLocalizable;
  *   <li>{@link org.eclipse.e4.ui.model.application.commands.MCommand#getDescription <em>Description</em>}</li>
  *   <li>{@link org.eclipse.e4.ui.model.application.commands.MCommand#getParameters <em>Parameters</em>}</li>
  *   <li>{@link org.eclipse.e4.ui.model.application.commands.MCommand#getCategory <em>Category</em>}</li>
+ *   <li>{@link org.eclipse.e4.ui.model.application.commands.MCommand#getCommandIconURI <em>Command Icon URI</em>}</li>
  *   <li>{@link org.eclipse.e4.ui.model.application.commands.MCommand#getLocalizedCommandName <em>Localized Command Name</em>}</li>
  *   <li>{@link org.eclipse.e4.ui.model.application.commands.MCommand#getLocalizedDescription <em>Localized Description</em>}</li>
  * </ul>
@@ -146,6 +147,35 @@ public interface MCommand extends MApplicationElement, MLocalizable {
 	 * @generated
 	 */
 	void setCategory(MCategory value);
+
+	/**
+	 * Returns the value of the '<em><b>Command Icon URI</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * <p>
+	 * This field contains a fully qualified URL defining the path to an Image to display
+	 * for this element.
+	 * </p>
+	 * @since 2.4
+	 * <!-- end-model-doc -->
+	 * @return the value of the '<em>Command Icon URI</em>' attribute.
+	 * @see #setCommandIconURI(String)
+	 * @model
+	 * @generated
+	 */
+	String getCommandIconURI();
+
+	/**
+	 * Sets the value of the '{@link org.eclipse.e4.ui.model.application.commands.MCommand#getCommandIconURI <em>Command Icon URI</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Command Icon URI</em>' attribute.
+	 * @see #getCommandIconURI()
+	 * @since 2.4
+	 * @generated
+	 */
+	void setCommandIconURI(String value);
 
 	/**
 	 * Returns the value of the '<em><b>Localized Command Name</b></em>' attribute.

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/commands/impl/BindingContextImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/commands/impl/BindingContextImpl.java
@@ -168,7 +168,7 @@ public class BindingContextImpl extends ApplicationElementImpl implements MBindi
 	@Override
 	public List<MBindingContext> getChildren() {
 		if (children == null) {
-			children = new EObjectContainmentEList<MBindingContext>(MBindingContext.class, this,
+			children = new EObjectContainmentEList<>(MBindingContext.class, this,
 					CommandsPackageImpl.BINDING_CONTEXT__CHILDREN);
 		}
 		return children;

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/commands/impl/BindingTableImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/commands/impl/BindingTableImpl.java
@@ -92,7 +92,7 @@ public class BindingTableImpl extends ApplicationElementImpl implements MBinding
 	@Override
 	public List<MKeyBinding> getBindings() {
 		if (bindings == null) {
-			bindings = new EObjectContainmentEList<MKeyBinding>(MKeyBinding.class, this,
+			bindings = new EObjectContainmentEList<>(MKeyBinding.class, this,
 					CommandsPackageImpl.BINDING_TABLE__BINDINGS);
 		}
 		return bindings;

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/commands/impl/CommandImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/commands/impl/CommandImpl.java
@@ -45,6 +45,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
  *   <li>{@link org.eclipse.e4.ui.model.application.commands.impl.CommandImpl#getDescription <em>Description</em>}</li>
  *   <li>{@link org.eclipse.e4.ui.model.application.commands.impl.CommandImpl#getParameters <em>Parameters</em>}</li>
  *   <li>{@link org.eclipse.e4.ui.model.application.commands.impl.CommandImpl#getCategory <em>Category</em>}</li>
+ *   <li>{@link org.eclipse.e4.ui.model.application.commands.impl.CommandImpl#getCommandIconURI <em>Command Icon URI</em>}</li>
  *   <li>{@link org.eclipse.e4.ui.model.application.commands.impl.CommandImpl#getLocalizedCommandName <em>Localized Command Name</em>}</li>
  *   <li>{@link org.eclipse.e4.ui.model.application.commands.impl.CommandImpl#getLocalizedDescription <em>Localized Description</em>}</li>
  * </ul>
@@ -112,6 +113,28 @@ public class CommandImpl extends ApplicationElementImpl implements MCommand {
 	 * @ordered
 	 */
 	protected MCategory category;
+
+	/**
+	 * The default value of the '{@link #getCommandIconURI() <em>Command Icon URI</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getCommandIconURI()
+	 * @since 2.4
+	 * @generated
+	 * @ordered
+	 */
+	protected static final String COMMAND_ICON_URI_EDEFAULT = null;
+
+	/**
+	 * The cached value of the '{@link #getCommandIconURI() <em>Command Icon URI</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getCommandIconURI()
+	 * @since 2.4
+	 * @generated
+	 * @ordered
+	 */
+	protected String commandIconURI = COMMAND_ICON_URI_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #getLocalizedCommandName() <em>Localized Command Name</em>}' attribute.
@@ -208,7 +231,7 @@ public class CommandImpl extends ApplicationElementImpl implements MCommand {
 	@Override
 	public List<MCommandParameter> getParameters() {
 		if (parameters == null) {
-			parameters = new EObjectContainmentEList<MCommandParameter>(MCommandParameter.class, this,
+			parameters = new EObjectContainmentEList<>(MCommandParameter.class, this,
 					CommandsPackageImpl.COMMAND__PARAMETERS);
 		}
 		return parameters;
@@ -254,6 +277,32 @@ public class CommandImpl extends ApplicationElementImpl implements MCommand {
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, CommandsPackageImpl.COMMAND__CATEGORY, oldCategory,
 					category));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @since 2.4
+	 * @generated
+	 */
+	@Override
+	public String getCommandIconURI() {
+		return commandIconURI;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @since 2.4
+	 * @generated
+	 */
+	@Override
+	public void setCommandIconURI(String newCommandIconURI) {
+		String oldCommandIconURI = commandIconURI;
+		commandIconURI = newCommandIconURI;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CommandsPackageImpl.COMMAND__COMMAND_ICON_URI,
+					oldCommandIconURI, commandIconURI));
 	}
 
 	/**
@@ -325,6 +374,8 @@ public class CommandImpl extends ApplicationElementImpl implements MCommand {
 			if (resolve)
 				return getCategory();
 			return basicGetCategory();
+		case CommandsPackageImpl.COMMAND__COMMAND_ICON_URI:
+			return getCommandIconURI();
 		case CommandsPackageImpl.COMMAND__LOCALIZED_COMMAND_NAME:
 			return getLocalizedCommandName();
 		case CommandsPackageImpl.COMMAND__LOCALIZED_DESCRIPTION:
@@ -356,6 +407,9 @@ public class CommandImpl extends ApplicationElementImpl implements MCommand {
 		case CommandsPackageImpl.COMMAND__CATEGORY:
 			setCategory((MCategory) newValue);
 			return;
+		case CommandsPackageImpl.COMMAND__COMMAND_ICON_URI:
+			setCommandIconURI((String) newValue);
+			return;
 		default:
 			super.eSet(featureID, newValue);
 			return;
@@ -382,6 +436,9 @@ public class CommandImpl extends ApplicationElementImpl implements MCommand {
 		case CommandsPackageImpl.COMMAND__CATEGORY:
 			setCategory((MCategory) null);
 			return;
+		case CommandsPackageImpl.COMMAND__COMMAND_ICON_URI:
+			setCommandIconURI(COMMAND_ICON_URI_EDEFAULT);
+			return;
 		default:
 			super.eUnset(featureID);
 			return;
@@ -404,6 +461,9 @@ public class CommandImpl extends ApplicationElementImpl implements MCommand {
 			return parameters != null && !parameters.isEmpty();
 		case CommandsPackageImpl.COMMAND__CATEGORY:
 			return category != null;
+		case CommandsPackageImpl.COMMAND__COMMAND_ICON_URI:
+			return COMMAND_ICON_URI_EDEFAULT == null ? commandIconURI != null
+					: !COMMAND_ICON_URI_EDEFAULT.equals(commandIconURI);
 		case CommandsPackageImpl.COMMAND__LOCALIZED_COMMAND_NAME:
 			return LOCALIZED_COMMAND_NAME_EDEFAULT == null ? getLocalizedCommandName() != null
 					: !LOCALIZED_COMMAND_NAME_EDEFAULT.equals(getLocalizedCommandName());
@@ -464,6 +524,8 @@ public class CommandImpl extends ApplicationElementImpl implements MCommand {
 		result.append(commandName);
 		result.append(", description: "); //$NON-NLS-1$
 		result.append(description);
+		result.append(", commandIconURI: "); //$NON-NLS-1$
+		result.append(commandIconURI);
 		result.append(')');
 		return result.toString();
 	}

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/commands/impl/CommandsPackageImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/commands/impl/CommandsPackageImpl.java
@@ -501,6 +501,16 @@ public class CommandsPackageImpl extends EPackageImpl {
 	public static final int COMMAND__CATEGORY = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 3;
 
 	/**
+	 * The feature id for the '<em><b>Command Icon URI</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @since 2.4
+	 * @generated
+	 * @ordered
+	 */
+	public static final int COMMAND__COMMAND_ICON_URI = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 4;
+
+	/**
 	 * The feature id for the '<em><b>Localized Command Name</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -509,7 +519,7 @@ public class CommandsPackageImpl extends EPackageImpl {
 	 * @ordered
 	 */
 	public static final int COMMAND__LOCALIZED_COMMAND_NAME = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT
-			+ 4;
+			+ 5;
 
 	/**
 	 * The feature id for the '<em><b>Localized Description</b></em>' attribute.
@@ -520,7 +530,7 @@ public class CommandsPackageImpl extends EPackageImpl {
 	 * @ordered
 	 */
 	public static final int COMMAND__LOCALIZED_DESCRIPTION = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT
-			+ 5;
+			+ 6;
 
 	/**
 	 * The number of structural features of the '<em>Command</em>' class.
@@ -530,7 +540,7 @@ public class CommandsPackageImpl extends EPackageImpl {
 	 * @generated
 	 * @ordered
 	 */
-	public static final int COMMAND_FEATURE_COUNT = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 6;
+	public static final int COMMAND_FEATURE_COUNT = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 7;
 
 	/**
 	 * The operation id for the '<em>Update Localization</em>' operation.
@@ -1654,6 +1664,20 @@ public class CommandsPackageImpl extends EPackageImpl {
 	}
 
 	/**
+	 * Returns the meta object for the attribute '{@link org.eclipse.e4.ui.model.application.commands.MCommand#getCommandIconURI <em>Command Icon URI</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Command Icon URI</em>'.
+	 * @see org.eclipse.e4.ui.model.application.commands.MCommand#getCommandIconURI()
+	 * @see #getCommand()
+	 * @since 2.4
+	 * @generated
+	 */
+	public EAttribute getCommand_CommandIconURI() {
+		return (EAttribute) commandEClass.getEStructuralFeatures().get(4);
+	}
+
+	/**
 	 * Returns the meta object for the attribute '{@link org.eclipse.e4.ui.model.application.commands.MCommand#getLocalizedCommandName <em>Localized Command Name</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -1664,7 +1688,7 @@ public class CommandsPackageImpl extends EPackageImpl {
 	 * @generated
 	 */
 	public EAttribute getCommand_LocalizedCommandName() {
-		return (EAttribute) commandEClass.getEStructuralFeatures().get(4);
+		return (EAttribute) commandEClass.getEStructuralFeatures().get(5);
 	}
 
 	/**
@@ -1678,7 +1702,7 @@ public class CommandsPackageImpl extends EPackageImpl {
 	 * @generated
 	 */
 	public EAttribute getCommand_LocalizedDescription() {
-		return (EAttribute) commandEClass.getEStructuralFeatures().get(5);
+		return (EAttribute) commandEClass.getEStructuralFeatures().get(6);
 	}
 
 	/**
@@ -2059,6 +2083,7 @@ public class CommandsPackageImpl extends EPackageImpl {
 		createEAttribute(commandEClass, COMMAND__DESCRIPTION);
 		createEReference(commandEClass, COMMAND__PARAMETERS);
 		createEReference(commandEClass, COMMAND__CATEGORY);
+		createEAttribute(commandEClass, COMMAND__COMMAND_ICON_URI);
 		createEAttribute(commandEClass, COMMAND__LOCALIZED_COMMAND_NAME);
 		createEAttribute(commandEClass, COMMAND__LOCALIZED_DESCRIPTION);
 		createEOperation(commandEClass, COMMAND___UPDATE_LOCALIZATION);
@@ -2188,6 +2213,9 @@ public class CommandsPackageImpl extends EPackageImpl {
 		initEReference(getCommand_Category(), this.getCategory(), null, "category", null, 0, 1, MCommand.class, //$NON-NLS-1$
 				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
 				IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getCommand_CommandIconURI(), ecorePackage.getEString(), "commandIconURI", null, 0, 1, //$NON-NLS-1$
+				MCommand.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
+				!IS_DERIVED, IS_ORDERED);
 		initEAttribute(getCommand_LocalizedCommandName(), ecorePackage.getEString(), "localizedCommandName", null, 0, 1, //$NON-NLS-1$
 				MCommand.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
 				IS_DERIVED, IS_ORDERED);
@@ -2440,6 +2468,15 @@ public class CommandsPackageImpl extends EPackageImpl {
 		 * @generated
 		 */
 		public static final EReference COMMAND__CATEGORY = eINSTANCE.getCommand_Category();
+
+		/**
+		 * The meta object literal for the '<em><b>Command Icon URI</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @since 2.4
+		 * @generated
+		 */
+		public static final EAttribute COMMAND__COMMAND_ICON_URI = eINSTANCE.getCommand_CommandIconURI();
 
 		/**
 		 * The meta object literal for the '<em><b>Localized Command Name</b></em>' attribute feature.

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/commands/impl/KeyBindingImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/commands/impl/KeyBindingImpl.java
@@ -180,7 +180,7 @@ public class KeyBindingImpl extends ApplicationElementImpl implements MKeyBindin
 	@Override
 	public List<MParameter> getParameters() {
 		if (parameters == null) {
-			parameters = new EObjectContainmentEList<MParameter>(MParameter.class, this,
+			parameters = new EObjectContainmentEList<>(MParameter.class, this,
 					CommandsPackageImpl.KEY_BINDING__PARAMETERS);
 		}
 		return parameters;

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/impl/ApplicationElementImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/impl/ApplicationElementImpl.java
@@ -170,7 +170,7 @@ public abstract class ApplicationElementImpl extends org.eclipse.emf.ecore.impl.
 	@Override
 	public Map<String, String> getPersistedState() {
 		if (persistedState == null) {
-			persistedState = new EcoreEMap<String, String>(ApplicationPackageImpl.Literals.STRING_TO_STRING_MAP,
+			persistedState = new EcoreEMap<>(ApplicationPackageImpl.Literals.STRING_TO_STRING_MAP,
 					StringToStringMapImpl.class, this, ApplicationPackageImpl.APPLICATION_ELEMENT__PERSISTED_STATE);
 		}
 		return persistedState.map();
@@ -184,7 +184,7 @@ public abstract class ApplicationElementImpl extends org.eclipse.emf.ecore.impl.
 	@Override
 	public List<String> getTags() {
 		if (tags == null) {
-			tags = new EDataTypeUniqueEList<String>(String.class, this,
+			tags = new EDataTypeUniqueEList<>(String.class, this,
 					ApplicationPackageImpl.APPLICATION_ELEMENT__TAGS);
 		}
 		return tags;
@@ -226,7 +226,7 @@ public abstract class ApplicationElementImpl extends org.eclipse.emf.ecore.impl.
 	@Override
 	public Map<String, Object> getTransientData() {
 		if (transientData == null) {
-			transientData = new EcoreEMap<String, Object>(ApplicationPackageImpl.Literals.STRING_TO_OBJECT_MAP,
+			transientData = new EcoreEMap<>(ApplicationPackageImpl.Literals.STRING_TO_OBJECT_MAP,
 					StringToObjectMapImpl.class, this, ApplicationPackageImpl.APPLICATION_ELEMENT__TRANSIENT_DATA);
 		}
 		return transientData.map();

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/impl/ApplicationImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/impl/ApplicationImpl.java
@@ -280,7 +280,7 @@ public class ApplicationImpl extends ElementContainerImpl<MWindow> implements MA
 	@Override
 	public List<MWindow> getChildren() {
 		if (children == null) {
-			children = new EObjectContainmentWithInverseEList<MWindow>(MWindow.class, this,
+			children = new EObjectContainmentWithInverseEList<>(MWindow.class, this,
 					ApplicationPackageImpl.APPLICATION__CHILDREN, UiPackageImpl.UI_ELEMENT__PARENT) {
 				private static final long serialVersionUID = 1L;
 
@@ -336,7 +336,7 @@ public class ApplicationImpl extends ElementContainerImpl<MWindow> implements MA
 	@Override
 	public List<String> getVariables() {
 		if (variables == null) {
-			variables = new EDataTypeUniqueEList<String>(String.class, this,
+			variables = new EDataTypeUniqueEList<>(String.class, this,
 					ApplicationPackageImpl.APPLICATION__VARIABLES);
 		}
 		return variables;
@@ -350,7 +350,7 @@ public class ApplicationImpl extends ElementContainerImpl<MWindow> implements MA
 	@Override
 	public Map<String, String> getProperties() {
 		if (properties == null) {
-			properties = new EcoreEMap<String, String>(ApplicationPackageImpl.Literals.STRING_TO_STRING_MAP,
+			properties = new EcoreEMap<>(ApplicationPackageImpl.Literals.STRING_TO_STRING_MAP,
 					StringToStringMapImpl.class, this, ApplicationPackageImpl.APPLICATION__PROPERTIES);
 		}
 		return properties.map();
@@ -364,7 +364,7 @@ public class ApplicationImpl extends ElementContainerImpl<MWindow> implements MA
 	@Override
 	public List<MHandler> getHandlers() {
 		if (handlers == null) {
-			handlers = new EObjectContainmentEList<MHandler>(MHandler.class, this,
+			handlers = new EObjectContainmentEList<>(MHandler.class, this,
 					ApplicationPackageImpl.APPLICATION__HANDLERS);
 		}
 		return handlers;
@@ -378,7 +378,7 @@ public class ApplicationImpl extends ElementContainerImpl<MWindow> implements MA
 	@Override
 	public List<MBindingTable> getBindingTables() {
 		if (bindingTables == null) {
-			bindingTables = new EObjectContainmentEList<MBindingTable>(MBindingTable.class, this,
+			bindingTables = new EObjectContainmentEList<>(MBindingTable.class, this,
 					ApplicationPackageImpl.APPLICATION__BINDING_TABLES);
 		}
 		return bindingTables;
@@ -392,7 +392,7 @@ public class ApplicationImpl extends ElementContainerImpl<MWindow> implements MA
 	@Override
 	public List<MBindingContext> getRootContext() {
 		if (rootContext == null) {
-			rootContext = new EObjectContainmentEList<MBindingContext>(MBindingContext.class, this,
+			rootContext = new EObjectContainmentEList<>(MBindingContext.class, this,
 					ApplicationPackageImpl.APPLICATION__ROOT_CONTEXT);
 		}
 		return rootContext;
@@ -406,7 +406,7 @@ public class ApplicationImpl extends ElementContainerImpl<MWindow> implements MA
 	@Override
 	public List<MPartDescriptor> getDescriptors() {
 		if (descriptors == null) {
-			descriptors = new EObjectContainmentEList<MPartDescriptor>(MPartDescriptor.class, this,
+			descriptors = new EObjectContainmentEList<>(MPartDescriptor.class, this,
 					ApplicationPackageImpl.APPLICATION__DESCRIPTORS);
 		}
 		return descriptors;
@@ -420,7 +420,7 @@ public class ApplicationImpl extends ElementContainerImpl<MWindow> implements MA
 	@Override
 	public List<MBindingContext> getBindingContexts() {
 		if (bindingContexts == null) {
-			bindingContexts = new EObjectResolvingEList<MBindingContext>(MBindingContext.class, this,
+			bindingContexts = new EObjectResolvingEList<>(MBindingContext.class, this,
 					ApplicationPackageImpl.APPLICATION__BINDING_CONTEXTS);
 		}
 		return bindingContexts;
@@ -434,7 +434,7 @@ public class ApplicationImpl extends ElementContainerImpl<MWindow> implements MA
 	@Override
 	public List<MMenuContribution> getMenuContributions() {
 		if (menuContributions == null) {
-			menuContributions = new EObjectContainmentEList<MMenuContribution>(MMenuContribution.class, this,
+			menuContributions = new EObjectContainmentEList<>(MMenuContribution.class, this,
 					ApplicationPackageImpl.APPLICATION__MENU_CONTRIBUTIONS);
 		}
 		return menuContributions;
@@ -448,7 +448,7 @@ public class ApplicationImpl extends ElementContainerImpl<MWindow> implements MA
 	@Override
 	public List<MToolBarContribution> getToolBarContributions() {
 		if (toolBarContributions == null) {
-			toolBarContributions = new EObjectContainmentEList<MToolBarContribution>(MToolBarContribution.class, this,
+			toolBarContributions = new EObjectContainmentEList<>(MToolBarContribution.class, this,
 					ApplicationPackageImpl.APPLICATION__TOOL_BAR_CONTRIBUTIONS);
 		}
 		return toolBarContributions;
@@ -462,7 +462,7 @@ public class ApplicationImpl extends ElementContainerImpl<MWindow> implements MA
 	@Override
 	public List<MTrimContribution> getTrimContributions() {
 		if (trimContributions == null) {
-			trimContributions = new EObjectContainmentEList<MTrimContribution>(MTrimContribution.class, this,
+			trimContributions = new EObjectContainmentEList<>(MTrimContribution.class, this,
 					ApplicationPackageImpl.APPLICATION__TRIM_CONTRIBUTIONS);
 		}
 		return trimContributions;
@@ -476,7 +476,7 @@ public class ApplicationImpl extends ElementContainerImpl<MWindow> implements MA
 	@Override
 	public List<MUIElement> getSnippets() {
 		if (snippets == null) {
-			snippets = new EObjectContainmentEList<MUIElement>(MUIElement.class, this,
+			snippets = new EObjectContainmentEList<>(MUIElement.class, this,
 					ApplicationPackageImpl.APPLICATION__SNIPPETS);
 		}
 		return snippets;
@@ -490,7 +490,7 @@ public class ApplicationImpl extends ElementContainerImpl<MWindow> implements MA
 	@Override
 	public List<MCommand> getCommands() {
 		if (commands == null) {
-			commands = new EObjectContainmentEList<MCommand>(MCommand.class, this,
+			commands = new EObjectContainmentEList<>(MCommand.class, this,
 					ApplicationPackageImpl.APPLICATION__COMMANDS) {
 
 				private static final long serialVersionUID = 1L;
@@ -513,7 +513,7 @@ public class ApplicationImpl extends ElementContainerImpl<MWindow> implements MA
 	@Override
 	public List<MAddon> getAddons() {
 		if (addons == null) {
-			addons = new EObjectContainmentEList<MAddon>(MAddon.class, this,
+			addons = new EObjectContainmentEList<>(MAddon.class, this,
 					ApplicationPackageImpl.APPLICATION__ADDONS);
 		}
 		return addons;
@@ -527,7 +527,7 @@ public class ApplicationImpl extends ElementContainerImpl<MWindow> implements MA
 	@Override
 	public List<MCategory> getCategories() {
 		if (categories == null) {
-			categories = new EObjectContainmentEList<MCategory>(MCategory.class, this,
+			categories = new EObjectContainmentEList<>(MCategory.class, this,
 					ApplicationPackageImpl.APPLICATION__CATEGORIES);
 		}
 		return categories;
@@ -542,7 +542,7 @@ public class ApplicationImpl extends ElementContainerImpl<MWindow> implements MA
 	@Override
 	public MCommand getCommand(final String elementId) {
 		if (elementIdToCommandMap == null) {
-			Map<String, MCommand> result = new HashMap<String, MCommand>();
+			Map<String, MCommand> result = new HashMap<>();
 			for (MCommand command : getCommands()) {
 				MCommand otherCommand = result.put(command.getElementId(), command);
 				if (otherCommand != null) {

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/SideValue.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/SideValue.java
@@ -143,8 +143,7 @@ public enum SideValue implements InternalSideValue {
 	 * @generated
 	 */
 	public static SideValue get(String literal) {
-		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
-			SideValue result = VALUES_ARRAY[i];
+		for (SideValue result : VALUES_ARRAY) {
 			if (result.toString().equals(literal)) {
 				return result;
 			}
@@ -161,8 +160,7 @@ public enum SideValue implements InternalSideValue {
 	 * @generated
 	 */
 	public static SideValue getByName(String name) {
-		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
-			SideValue result = VALUES_ARRAY[i];
+		for (SideValue result : VALUES_ARRAY) {
 			if (result.getName().equals(name)) {
 				return result;
 			}

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/basic/impl/CompositePartImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/basic/impl/CompositePartImpl.java
@@ -115,7 +115,7 @@ public class CompositePartImpl extends PartImpl implements MCompositePart {
 	@Override
 	public List<MPartSashContainerElement> getChildren() {
 		if (children == null) {
-			children = new EObjectContainmentWithInverseEList<MPartSashContainerElement>(
+			children = new EObjectContainmentWithInverseEList<>(
 					MPartSashContainerElement.class, this, BasicPackageImpl.COMPOSITE_PART__CHILDREN,
 					UiPackageImpl.UI_ELEMENT__PARENT) {
 				private static final long serialVersionUID = 1L;

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/basic/impl/TrimBarImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/basic/impl/TrimBarImpl.java
@@ -76,7 +76,7 @@ public class TrimBarImpl extends GenericTrimContainerImpl<MTrimElement> implemen
 	@Override
 	public List<MTrimElement> getPendingCleanup() {
 		if (pendingCleanup == null) {
-			pendingCleanup = new EObjectResolvingEList<MTrimElement>(MTrimElement.class, this,
+			pendingCleanup = new EObjectResolvingEList<>(MTrimElement.class, this,
 					BasicPackageImpl.TRIM_BAR__PENDING_CLEANUP);
 		}
 		return pendingCleanup;

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/basic/impl/TrimmedWindowImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/basic/impl/TrimmedWindowImpl.java
@@ -76,7 +76,7 @@ public class TrimmedWindowImpl extends WindowImpl implements MTrimmedWindow {
 	@Override
 	public List<MTrimBar> getTrimBars() {
 		if (trimBars == null) {
-			trimBars = new EObjectContainmentEList<MTrimBar>(MTrimBar.class, this,
+			trimBars = new EObjectContainmentEList<>(MTrimBar.class, this,
 					BasicPackageImpl.TRIMMED_WINDOW__TRIM_BARS);
 		}
 		return trimBars;

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/basic/impl/WindowImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/basic/impl/WindowImpl.java
@@ -413,7 +413,7 @@ public class WindowImpl extends ElementContainerImpl<MWindowElement> implements 
 	@Override
 	public List<MWindowElement> getChildren() {
 		if (children == null) {
-			children = new EObjectContainmentWithInverseEList<MWindowElement>(MWindowElement.class, this,
+			children = new EObjectContainmentWithInverseEList<>(MWindowElement.class, this,
 					BasicPackageImpl.WINDOW__CHILDREN, UiPackageImpl.UI_ELEMENT__PARENT) {
 				private static final long serialVersionUID = 1L;
 
@@ -566,7 +566,7 @@ public class WindowImpl extends ElementContainerImpl<MWindowElement> implements 
 	@Override
 	public List<String> getVariables() {
 		if (variables == null) {
-			variables = new EDataTypeUniqueEList<String>(String.class, this, BasicPackageImpl.WINDOW__VARIABLES);
+			variables = new EDataTypeUniqueEList<>(String.class, this, BasicPackageImpl.WINDOW__VARIABLES);
 		}
 		return variables;
 	}
@@ -579,7 +579,7 @@ public class WindowImpl extends ElementContainerImpl<MWindowElement> implements 
 	@Override
 	public Map<String, String> getProperties() {
 		if (properties == null) {
-			properties = new EcoreEMap<String, String>(ApplicationPackageImpl.Literals.STRING_TO_STRING_MAP,
+			properties = new EcoreEMap<>(ApplicationPackageImpl.Literals.STRING_TO_STRING_MAP,
 					StringToStringMapImpl.class, this, BasicPackageImpl.WINDOW__PROPERTIES);
 		}
 		return properties.map();
@@ -593,7 +593,7 @@ public class WindowImpl extends ElementContainerImpl<MWindowElement> implements 
 	@Override
 	public List<MHandler> getHandlers() {
 		if (handlers == null) {
-			handlers = new EObjectContainmentEList<MHandler>(MHandler.class, this, BasicPackageImpl.WINDOW__HANDLERS);
+			handlers = new EObjectContainmentEList<>(MHandler.class, this, BasicPackageImpl.WINDOW__HANDLERS);
 		}
 		return handlers;
 	}
@@ -606,7 +606,7 @@ public class WindowImpl extends ElementContainerImpl<MWindowElement> implements 
 	@Override
 	public List<MBindingContext> getBindingContexts() {
 		if (bindingContexts == null) {
-			bindingContexts = new EObjectResolvingEList<MBindingContext>(MBindingContext.class, this,
+			bindingContexts = new EObjectResolvingEList<>(MBindingContext.class, this,
 					BasicPackageImpl.WINDOW__BINDING_CONTEXTS);
 		}
 		return bindingContexts;
@@ -620,7 +620,7 @@ public class WindowImpl extends ElementContainerImpl<MWindowElement> implements 
 	@Override
 	public List<MUIElement> getSnippets() {
 		if (snippets == null) {
-			snippets = new EObjectContainmentEList<MUIElement>(MUIElement.class, this,
+			snippets = new EObjectContainmentEList<>(MUIElement.class, this,
 					BasicPackageImpl.WINDOW__SNIPPETS);
 		}
 		return snippets;
@@ -892,7 +892,7 @@ public class WindowImpl extends ElementContainerImpl<MWindowElement> implements 
 	@Override
 	public List<MWindow> getWindows() {
 		if (windows == null) {
-			windows = new EObjectContainmentEList<MWindow>(MWindow.class, this, BasicPackageImpl.WINDOW__WINDOWS);
+			windows = new EObjectContainmentEList<>(MWindow.class, this, BasicPackageImpl.WINDOW__WINDOWS);
 		}
 		return windows;
 	}
@@ -905,7 +905,7 @@ public class WindowImpl extends ElementContainerImpl<MWindowElement> implements 
 	@Override
 	public List<MUIElement> getSharedElements() {
 		if (sharedElements == null) {
-			sharedElements = new EObjectContainmentEList<MUIElement>(MUIElement.class, this,
+			sharedElements = new EObjectContainmentEList<>(MUIElement.class, this,
 					BasicPackageImpl.WINDOW__SHARED_ELEMENTS);
 		}
 		return sharedElements;

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/impl/ElementContainerImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/impl/ElementContainerImpl.java
@@ -102,7 +102,7 @@ public abstract class ElementContainerImpl<T extends MUIElement> extends UIEleme
 				clazz = null;
 			}
 
-			children = new EObjectContainmentWithInverseEList<T>(MUIElement.class, this,
+			children = new EObjectContainmentWithInverseEList<>(MUIElement.class, this,
 					UiPackageImpl.ELEMENT_CONTAINER__CHILDREN, UiPackageImpl.UI_ELEMENT__PARENT) {
 
 				/**

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/ItemType.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/ItemType.java
@@ -121,8 +121,7 @@ public enum ItemType implements InternalItemType {
 	 * @generated
 	 */
 	public static ItemType get(String literal) {
-		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
-			ItemType result = VALUES_ARRAY[i];
+		for (ItemType result : VALUES_ARRAY) {
 			if (result.toString().equals(literal)) {
 				return result;
 			}
@@ -139,8 +138,7 @@ public enum ItemType implements InternalItemType {
 	 * @generated
 	 */
 	public static ItemType getByName(String name) {
-		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
-			ItemType result = VALUES_ARRAY[i];
+		for (ItemType result : VALUES_ARRAY) {
 			if (result.getName().equals(name)) {
 				return result;
 			}

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/impl/HandledItemImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/impl/HandledItemImpl.java
@@ -183,7 +183,7 @@ public abstract class HandledItemImpl extends ItemImpl implements MHandledItem {
 	@Override
 	public List<MParameter> getParameters() {
 		if (parameters == null) {
-			parameters = new EObjectContainmentEList<MParameter>(MParameter.class, this,
+			parameters = new EObjectContainmentEList<>(MParameter.class, this,
 					MenuPackageImpl.HANDLED_ITEM__PARAMETERS);
 		}
 		return parameters;

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/impl/HandledMenuItemImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/impl/HandledMenuItemImpl.java
@@ -184,7 +184,7 @@ public class HandledMenuItemImpl extends MenuItemImpl implements MHandledMenuIte
 	@Override
 	public List<MParameter> getParameters() {
 		if (parameters == null) {
-			parameters = new EObjectContainmentEList<MParameter>(MParameter.class, this,
+			parameters = new EObjectContainmentEList<>(MParameter.class, this,
 					MenuPackageImpl.HANDLED_MENU_ITEM__PARAMETERS);
 		}
 		return parameters;

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/impl/HandledToolItemImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/impl/HandledToolItemImpl.java
@@ -184,7 +184,7 @@ public class HandledToolItemImpl extends ToolItemImpl implements MHandledToolIte
 	@Override
 	public List<MParameter> getParameters() {
 		if (parameters == null) {
-			parameters = new EObjectContainmentEList<MParameter>(MParameter.class, this,
+			parameters = new EObjectContainmentEList<>(MParameter.class, this,
 					MenuPackageImpl.HANDLED_TOOL_ITEM__PARAMETERS);
 		}
 		return parameters;

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/impl/MenuContributionImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/impl/MenuContributionImpl.java
@@ -109,7 +109,7 @@ public class MenuContributionImpl extends ElementContainerImpl<MMenuElement> imp
 	@Override
 	public List<MMenuElement> getChildren() {
 		if (children == null) {
-			children = new EObjectContainmentWithInverseEList<MMenuElement>(MMenuElement.class, this,
+			children = new EObjectContainmentWithInverseEList<>(MMenuElement.class, this,
 					MenuPackageImpl.MENU_CONTRIBUTION__CHILDREN, UiPackageImpl.UI_ELEMENT__PARENT) {
 				private static final long serialVersionUID = 1L;
 

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/impl/MenuImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/impl/MenuImpl.java
@@ -114,7 +114,7 @@ public class MenuImpl extends MenuElementImpl implements MMenu {
 	@Override
 	public List<MMenuElement> getChildren() {
 		if (children == null) {
-			children = new EObjectContainmentWithInverseEList<MMenuElement>(MMenuElement.class, this,
+			children = new EObjectContainmentWithInverseEList<>(MMenuElement.class, this,
 					MenuPackageImpl.MENU__CHILDREN, UiPackageImpl.UI_ELEMENT__PARENT) {
 				private static final long serialVersionUID = 1L;
 

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/impl/PopupMenuImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/impl/PopupMenuImpl.java
@@ -142,7 +142,7 @@ public class PopupMenuImpl extends MenuImpl implements MPopupMenu {
 	@Override
 	public List<String> getVariables() {
 		if (variables == null) {
-			variables = new EDataTypeUniqueEList<String>(String.class, this, MenuPackageImpl.POPUP_MENU__VARIABLES);
+			variables = new EDataTypeUniqueEList<>(String.class, this, MenuPackageImpl.POPUP_MENU__VARIABLES);
 		}
 		return variables;
 	}
@@ -155,7 +155,7 @@ public class PopupMenuImpl extends MenuImpl implements MPopupMenu {
 	@Override
 	public Map<String, String> getProperties() {
 		if (properties == null) {
-			properties = new EcoreEMap<String, String>(ApplicationPackageImpl.Literals.STRING_TO_STRING_MAP,
+			properties = new EcoreEMap<>(ApplicationPackageImpl.Literals.STRING_TO_STRING_MAP,
 					StringToStringMapImpl.class, this, MenuPackageImpl.POPUP_MENU__PROPERTIES);
 		}
 		return properties.map();

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/impl/ToolBarContributionImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/impl/ToolBarContributionImpl.java
@@ -109,7 +109,7 @@ public class ToolBarContributionImpl extends ElementContainerImpl<MToolBarElemen
 	@Override
 	public List<MToolBarElement> getChildren() {
 		if (children == null) {
-			children = new EObjectContainmentWithInverseEList<MToolBarElement>(MToolBarElement.class, this,
+			children = new EObjectContainmentWithInverseEList<>(MToolBarElement.class, this,
 					MenuPackageImpl.TOOL_BAR_CONTRIBUTION__CHILDREN, UiPackageImpl.UI_ELEMENT__PARENT) {
 				private static final long serialVersionUID = 1L;
 

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/impl/TrimContributionImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/menu/impl/TrimContributionImpl.java
@@ -109,7 +109,7 @@ public class TrimContributionImpl extends ElementContainerImpl<MTrimElement> imp
 	@Override
 	public List<MTrimElement> getChildren() {
 		if (children == null) {
-			children = new EObjectContainmentWithInverseEList<MTrimElement>(MTrimElement.class, this,
+			children = new EObjectContainmentWithInverseEList<>(MTrimElement.class, this,
 					MenuPackageImpl.TRIM_CONTRIBUTION__CHILDREN, UiPackageImpl.UI_ELEMENT__PARENT) {
 				private static final long serialVersionUID = 1L;
 

--- a/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.ui.tests;singleton:=true
-Bundle-Version: 0.15.0.qualifier
+Bundle-Version: 0.15.100.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/model/test/MTestPackage.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/model/test/MTestPackage.java
@@ -148,6 +148,16 @@ public interface MTestPackage extends EPackage {
 	int TEST_HARNESS__CATEGORY = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 3;
 
 	/**
+	 * The feature id for the '<em><b>Command Icon URI</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @since 2.4
+	 * @generated
+	 * @ordered
+	 */
+	int TEST_HARNESS__COMMAND_ICON_URI = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 4;
+
+	/**
 	 * The feature id for the '<em><b>Localized Command Name</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -155,7 +165,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__LOCALIZED_COMMAND_NAME = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 4;
+	int TEST_HARNESS__LOCALIZED_COMMAND_NAME = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 5;
 
 	/**
 	 * The feature id for the '<em><b>Localized Description</b></em>' attribute.
@@ -165,7 +175,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__LOCALIZED_DESCRIPTION = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 5;
+	int TEST_HARNESS__LOCALIZED_DESCRIPTION = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 6;
 
 	/**
 	 * The feature id for the '<em><b>Context</b></em>' attribute. <!--
@@ -174,7 +184,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__CONTEXT = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 6;
+	int TEST_HARNESS__CONTEXT = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 7;
 
 	/**
 	 * The feature id for the '<em><b>Variables</b></em>' attribute list. <!--
@@ -183,7 +193,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__VARIABLES = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 7;
+	int TEST_HARNESS__VARIABLES = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 8;
 
 	/**
 	 * The feature id for the '<em><b>Properties</b></em>' map. <!--
@@ -192,7 +202,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__PROPERTIES = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 8;
+	int TEST_HARNESS__PROPERTIES = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 9;
 
 	/**
 	 * The feature id for the '<em><b>Contribution URI</b></em>' attribute. <!--
@@ -201,7 +211,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__CONTRIBUTION_URI = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 9;
+	int TEST_HARNESS__CONTRIBUTION_URI = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 10;
 
 	/**
 	 * The feature id for the '<em><b>Object</b></em>' attribute. <!--
@@ -210,7 +220,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__OBJECT = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 10;
+	int TEST_HARNESS__OBJECT = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 11;
 
 	/**
 	 * The feature id for the '<em><b>Widget</b></em>' attribute. <!--
@@ -219,7 +229,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__WIDGET = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 11;
+	int TEST_HARNESS__WIDGET = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 12;
 
 	/**
 	 * The feature id for the '<em><b>Renderer</b></em>' attribute. <!--
@@ -228,7 +238,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__RENDERER = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 12;
+	int TEST_HARNESS__RENDERER = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 13;
 
 	/**
 	 * The feature id for the '<em><b>To Be Rendered</b></em>' attribute. <!--
@@ -237,7 +247,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__TO_BE_RENDERED = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 13;
+	int TEST_HARNESS__TO_BE_RENDERED = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 14;
 
 	/**
 	 * The feature id for the '<em><b>On Top</b></em>' attribute. <!--
@@ -246,7 +256,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__ON_TOP = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 14;
+	int TEST_HARNESS__ON_TOP = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 15;
 
 	/**
 	 * The feature id for the '<em><b>Visible</b></em>' attribute. <!--
@@ -255,7 +265,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__VISIBLE = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 15;
+	int TEST_HARNESS__VISIBLE = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 16;
 
 	/**
 	 * The feature id for the '<em><b>Parent</b></em>' container reference. <!--
@@ -264,7 +274,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__PARENT = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 16;
+	int TEST_HARNESS__PARENT = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 17;
 
 	/**
 	 * The feature id for the '<em><b>Container Data</b></em>' attribute. <!--
@@ -273,7 +283,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__CONTAINER_DATA = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 17;
+	int TEST_HARNESS__CONTAINER_DATA = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 18;
 
 	/**
 	 * The feature id for the '<em><b>Cur Shared Ref</b></em>' reference.
@@ -283,7 +293,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__CUR_SHARED_REF = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 18;
+	int TEST_HARNESS__CUR_SHARED_REF = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 19;
 
 	/**
 	 * The feature id for the '<em><b>Visible When</b></em>' containment reference.
@@ -293,7 +303,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__VISIBLE_WHEN = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 19;
+	int TEST_HARNESS__VISIBLE_WHEN = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 20;
 
 	/**
 	 * The feature id for the '<em><b>Accessibility Phrase</b></em>' attribute.
@@ -303,7 +313,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__ACCESSIBILITY_PHRASE = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 20;
+	int TEST_HARNESS__ACCESSIBILITY_PHRASE = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 21;
 
 	/**
 	 * The feature id for the '<em><b>Localized Accessibility Phrase</b></em>' attribute.
@@ -313,7 +323,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__LOCALIZED_ACCESSIBILITY_PHRASE = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 21;
+	int TEST_HARNESS__LOCALIZED_ACCESSIBILITY_PHRASE = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 22;
 
 	/**
 	 * The feature id for the '<em><b>Children</b></em>' containment reference list.
@@ -322,7 +332,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__CHILDREN = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 22;
+	int TEST_HARNESS__CHILDREN = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 23;
 
 	/**
 	 * The feature id for the '<em><b>Selected Element</b></em>' reference. <!--
@@ -331,7 +341,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__SELECTED_ELEMENT = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 23;
+	int TEST_HARNESS__SELECTED_ELEMENT = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 24;
 
 	/**
 	 * The feature id for the '<em><b>Name</b></em>' attribute. <!--
@@ -340,7 +350,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__NAME = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 24;
+	int TEST_HARNESS__NAME = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 25;
 
 	/**
 	 * The feature id for the '<em><b>Value</b></em>' attribute. <!--
@@ -349,7 +359,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__VALUE = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 25;
+	int TEST_HARNESS__VALUE = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 26;
 
 	/**
 	 * The feature id for the '<em><b>Label</b></em>' attribute. <!--
@@ -358,7 +368,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__LABEL = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 26;
+	int TEST_HARNESS__LABEL = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 27;
 
 	/**
 	 * The feature id for the '<em><b>Icon URI</b></em>' attribute. <!--
@@ -367,7 +377,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__ICON_URI = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 27;
+	int TEST_HARNESS__ICON_URI = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 28;
 
 	/**
 	 * The feature id for the '<em><b>Tooltip</b></em>' attribute. <!--
@@ -376,7 +386,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__TOOLTIP = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 28;
+	int TEST_HARNESS__TOOLTIP = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 29;
 
 	/**
 	 * The feature id for the '<em><b>Localized Label</b></em>' attribute.
@@ -386,7 +396,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__LOCALIZED_LABEL = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 29;
+	int TEST_HARNESS__LOCALIZED_LABEL = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 30;
 
 	/**
 	 * The feature id for the '<em><b>Localized Tooltip</b></em>' attribute.
@@ -396,7 +406,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__LOCALIZED_TOOLTIP = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 30;
+	int TEST_HARNESS__LOCALIZED_TOOLTIP = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 31;
 
 	/**
 	 * The feature id for the '<em><b>Dirty</b></em>' attribute. <!--
@@ -405,7 +415,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__DIRTY = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 31;
+	int TEST_HARNESS__DIRTY = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 32;
 
 	/**
 	 * The feature id for the '<em><b>Snippets</b></em>' containment reference list.
@@ -415,7 +425,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS__SNIPPETS = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 32;
+	int TEST_HARNESS__SNIPPETS = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 33;
 
 	/**
 	 * The number of structural features of the '<em>Harness</em>' class. <!--
@@ -424,7 +434,7 @@ public interface MTestPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TEST_HARNESS_FEATURE_COUNT = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 33;
+	int TEST_HARNESS_FEATURE_COUNT = ApplicationPackageImpl.APPLICATION_ELEMENT_FEATURE_COUNT + 34;
 
 	/**
 	 * The operation id for the '<em>Update Localization</em>' operation.

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/model/test/impl/TestHarnessImpl.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/model/test/impl/TestHarnessImpl.java
@@ -60,6 +60,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
  *   <li>{@link org.eclipse.e4.ui.tests.model.test.impl.TestHarnessImpl#getDescription <em>Description</em>}</li>
  *   <li>{@link org.eclipse.e4.ui.tests.model.test.impl.TestHarnessImpl#getParameters <em>Parameters</em>}</li>
  *   <li>{@link org.eclipse.e4.ui.tests.model.test.impl.TestHarnessImpl#getCategory <em>Category</em>}</li>
+ *   <li>{@link org.eclipse.e4.ui.tests.model.test.impl.TestHarnessImpl#getCommandIconURI <em>Command Icon URI</em>}</li>
  *   <li>{@link org.eclipse.e4.ui.tests.model.test.impl.TestHarnessImpl#getLocalizedCommandName <em>Localized Command Name</em>}</li>
  *   <li>{@link org.eclipse.e4.ui.tests.model.test.impl.TestHarnessImpl#getLocalizedDescription <em>Localized Description</em>}</li>
  *   <li>{@link org.eclipse.e4.ui.tests.model.test.impl.TestHarnessImpl#getContext <em>Context</em>}</li>
@@ -143,6 +144,26 @@ public class TestHarnessImpl extends ApplicationElementImpl implements
 	 * @ordered
 	 */
 	protected MCategory category;
+	/**
+	 * The default value of the '{@link #getCommandIconURI() <em>Command Icon URI</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getCommandIconURI()
+	 * @since 2.4
+	 * @generated
+	 * @ordered
+	 */
+	protected static final String COMMAND_ICON_URI_EDEFAULT = null;
+	/**
+	 * The cached value of the '{@link #getCommandIconURI() <em>Command Icon URI</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getCommandIconURI()
+	 * @since 2.4
+	 * @generated
+	 * @ordered
+	 */
+	protected String commandIconURI = COMMAND_ICON_URI_EDEFAULT;
 	/**
 	 * The default value of the '{@link #getLocalizedCommandName() <em>Localized Command Name</em>}' attribute.
 	 * <!-- begin-user-doc -->
@@ -587,7 +608,7 @@ public class TestHarnessImpl extends ApplicationElementImpl implements
 	@Override
 	public List<MCommandParameter> getParameters() {
 		if (parameters == null) {
-			parameters = new EObjectContainmentEList<MCommandParameter>(MCommandParameter.class, this, MTestPackage.TEST_HARNESS__PARAMETERS);
+			parameters = new EObjectContainmentEList<>(MCommandParameter.class, this, MTestPackage.TEST_HARNESS__PARAMETERS);
 		}
 		return parameters;
 	}
@@ -630,6 +651,31 @@ public class TestHarnessImpl extends ApplicationElementImpl implements
 	}
 
 	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @since 2.4
+	 * @generated
+	 */
+	@Override
+	public String getCommandIconURI() {
+		return commandIconURI;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @since 2.4
+	 * @generated
+	 */
+	@Override
+	public void setCommandIconURI(String newCommandIconURI) {
+		String oldCommandIconURI = commandIconURI;
+		commandIconURI = newCommandIconURI;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, MTestPackage.TEST_HARNESS__COMMAND_ICON_URI, oldCommandIconURI, commandIconURI));
+	}
+
+	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
@@ -657,7 +703,7 @@ public class TestHarnessImpl extends ApplicationElementImpl implements
 	@Override
 	public List<String> getVariables() {
 		if (variables == null) {
-			variables = new EDataTypeUniqueEList<String>(String.class, this, MTestPackage.TEST_HARNESS__VARIABLES);
+			variables = new EDataTypeUniqueEList<>(String.class, this, MTestPackage.TEST_HARNESS__VARIABLES);
 		}
 		return variables;
 	}
@@ -669,7 +715,7 @@ public class TestHarnessImpl extends ApplicationElementImpl implements
 	@Override
 	public Map<String, String> getProperties() {
 		if (properties == null) {
-			properties = new EcoreEMap<String,String>(ApplicationPackageImpl.Literals.STRING_TO_STRING_MAP, StringToStringMapImpl.class, this, MTestPackage.TEST_HARNESS__PROPERTIES);
+			properties = new EcoreEMap<>(ApplicationPackageImpl.Literals.STRING_TO_STRING_MAP, StringToStringMapImpl.class, this, MTestPackage.TEST_HARNESS__PROPERTIES);
 		}
 		return properties.map();
 	}
@@ -994,7 +1040,7 @@ public class TestHarnessImpl extends ApplicationElementImpl implements
 	@Override
 	public List<MUIElement> getChildren() {
 		if (children == null) {
-			children = new EObjectContainmentWithInverseEList<MUIElement>(MUIElement.class, this, MTestPackage.TEST_HARNESS__CHILDREN, UiPackageImpl.UI_ELEMENT__PARENT);
+			children = new EObjectContainmentWithInverseEList<>(MUIElement.class, this, MTestPackage.TEST_HARNESS__CHILDREN, UiPackageImpl.UI_ELEMENT__PARENT);
 		}
 		return children;
 	}
@@ -1176,7 +1222,7 @@ public class TestHarnessImpl extends ApplicationElementImpl implements
 	@Override
 	public List<MUIElement> getSnippets() {
 		if (snippets == null) {
-			snippets = new EObjectContainmentEList<MUIElement>(MUIElement.class, this, MTestPackage.TEST_HARNESS__SNIPPETS);
+			snippets = new EObjectContainmentEList<>(MUIElement.class, this, MTestPackage.TEST_HARNESS__SNIPPETS);
 		}
 		return snippets;
 	}
@@ -1318,6 +1364,8 @@ public class TestHarnessImpl extends ApplicationElementImpl implements
 			case MTestPackage.TEST_HARNESS__CATEGORY:
 				if (resolve) return getCategory();
 				return basicGetCategory();
+			case MTestPackage.TEST_HARNESS__COMMAND_ICON_URI:
+				return getCommandIconURI();
 			case MTestPackage.TEST_HARNESS__LOCALIZED_COMMAND_NAME:
 				return getLocalizedCommandName();
 			case MTestPackage.TEST_HARNESS__LOCALIZED_DESCRIPTION:
@@ -1403,6 +1451,9 @@ public class TestHarnessImpl extends ApplicationElementImpl implements
 				return;
 			case MTestPackage.TEST_HARNESS__CATEGORY:
 				setCategory((MCategory)newValue);
+				return;
+			case MTestPackage.TEST_HARNESS__COMMAND_ICON_URI:
+				setCommandIconURI((String)newValue);
 				return;
 			case MTestPackage.TEST_HARNESS__CONTEXT:
 				setContext((IEclipseContext)newValue);
@@ -1502,6 +1553,9 @@ public class TestHarnessImpl extends ApplicationElementImpl implements
 			case MTestPackage.TEST_HARNESS__CATEGORY:
 				setCategory((MCategory)null);
 				return;
+			case MTestPackage.TEST_HARNESS__COMMAND_ICON_URI:
+				setCommandIconURI(COMMAND_ICON_URI_EDEFAULT);
+				return;
 			case MTestPackage.TEST_HARNESS__CONTEXT:
 				setContext(CONTEXT_EDEFAULT);
 				return;
@@ -1593,6 +1647,8 @@ public class TestHarnessImpl extends ApplicationElementImpl implements
 				return parameters != null && !parameters.isEmpty();
 			case MTestPackage.TEST_HARNESS__CATEGORY:
 				return category != null;
+			case MTestPackage.TEST_HARNESS__COMMAND_ICON_URI:
+				return COMMAND_ICON_URI_EDEFAULT == null ? commandIconURI != null : !COMMAND_ICON_URI_EDEFAULT.equals(commandIconURI);
 			case MTestPackage.TEST_HARNESS__LOCALIZED_COMMAND_NAME:
 				return LOCALIZED_COMMAND_NAME_EDEFAULT == null ? getLocalizedCommandName() != null : !LOCALIZED_COMMAND_NAME_EDEFAULT.equals(getLocalizedCommandName());
 			case MTestPackage.TEST_HARNESS__LOCALIZED_DESCRIPTION:
@@ -1672,6 +1728,7 @@ public class TestHarnessImpl extends ApplicationElementImpl implements
 				case MTestPackage.TEST_HARNESS__DESCRIPTION: return CommandsPackageImpl.COMMAND__DESCRIPTION;
 				case MTestPackage.TEST_HARNESS__PARAMETERS: return CommandsPackageImpl.COMMAND__PARAMETERS;
 				case MTestPackage.TEST_HARNESS__CATEGORY: return CommandsPackageImpl.COMMAND__CATEGORY;
+				case MTestPackage.TEST_HARNESS__COMMAND_ICON_URI: return CommandsPackageImpl.COMMAND__COMMAND_ICON_URI;
 				case MTestPackage.TEST_HARNESS__LOCALIZED_COMMAND_NAME: return CommandsPackageImpl.COMMAND__LOCALIZED_COMMAND_NAME;
 				case MTestPackage.TEST_HARNESS__LOCALIZED_DESCRIPTION: return CommandsPackageImpl.COMMAND__LOCALIZED_DESCRIPTION;
 				default: return -1;
@@ -1764,6 +1821,7 @@ public class TestHarnessImpl extends ApplicationElementImpl implements
 				case CommandsPackageImpl.COMMAND__DESCRIPTION: return MTestPackage.TEST_HARNESS__DESCRIPTION;
 				case CommandsPackageImpl.COMMAND__PARAMETERS: return MTestPackage.TEST_HARNESS__PARAMETERS;
 				case CommandsPackageImpl.COMMAND__CATEGORY: return MTestPackage.TEST_HARNESS__CATEGORY;
+				case CommandsPackageImpl.COMMAND__COMMAND_ICON_URI: return MTestPackage.TEST_HARNESS__COMMAND_ICON_URI;
 				case CommandsPackageImpl.COMMAND__LOCALIZED_COMMAND_NAME: return MTestPackage.TEST_HARNESS__LOCALIZED_COMMAND_NAME;
 				case CommandsPackageImpl.COMMAND__LOCALIZED_DESCRIPTION: return MTestPackage.TEST_HARNESS__LOCALIZED_DESCRIPTION;
 				default: return -1;
@@ -1930,6 +1988,8 @@ public class TestHarnessImpl extends ApplicationElementImpl implements
 		result.append(commandName);
 		result.append(", description: ");
 		result.append(description);
+		result.append(", commandIconURI: ");
+		result.append(commandIconURI);
 		result.append(", context: ");
 		result.append(context);
 		result.append(", variables: ");

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandsTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandsTestSuite.java
@@ -43,6 +43,7 @@ import org.junit.runners.Suite;
 	ActionDelegateProxyTest.class,
 	ToggleStateTest.class,
 	RadioStateTest.class,
+	E4CommandImageTest.class
 })
 public final class CommandsTestSuite {
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/E4CommandImageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/E4CommandImageTest.java
@@ -1,0 +1,26 @@
+package org.eclipse.ui.tests.commands;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.commands.ICommandImageService;
+import org.junit.Test;
+
+/**
+ * @since 3.5
+ *
+ */
+public class E4CommandImageTest {
+
+	@Test
+	public void testE4CommandImage() {
+
+		ICommandImageService commandImageService = PlatformUI.getWorkbench().getService(ICommandImageService.class);
+
+		ImageDescriptor imageDescriptor = commandImageService
+				.getImageDescriptor("org.eclipse.ui.tests.command.iconTest");
+
+		assertNotNull(imageDescriptor);
+	}
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/EmptyE4CommandHandler.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/EmptyE4CommandHandler.java
@@ -1,0 +1,15 @@
+package org.eclipse.ui.tests.commands;
+
+import org.eclipse.e4.core.di.annotations.Execute;
+
+/**
+ * @since 3.5
+ *
+ */
+public class EmptyE4CommandHandler {
+
+	@Execute
+	public void execute() {
+		System.out.println("Executed Command Handler");
+	}
+}

--- a/tests/org.eclipse.ui.tests/build.properties
+++ b/tests/org.eclipse.ui.tests/build.properties
@@ -24,7 +24,8 @@ bin.includes = icons/,\
                test.xml,\
                META-INF/,\
                dialog_settings.xml,\
-               CSS/
+               CSS/,\
+               fragment.e4xmi
 src.includes = about.html
 
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless

--- a/tests/org.eclipse.ui.tests/fragment.e4xmi
+++ b/tests/org.eclipse.ui.tests/fragment.e4xmi
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="ASCII"?>
+<fragment:ModelFragments xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:commands="http://www.eclipse.org/ui/2010/UIModel/application/commands" xmlns:fragment="http://www.eclipse.org/ui/2010/UIModel/fragment" xmi:id="_zPmxwL5fEe2xycAdAs49Bg">
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_2DG0IL5fEe2xycAdAs49Bg" featurename="commands" parentElementId="org.eclipse.e4.legacy.ide.application">
+    <elements xsi:type="commands:Command" xmi:id="__OUmgL5fEe2xycAdAs49Bg" elementId="org.eclipse.ui.tests.command.iconTest" commandName="Test Icon Command" commandIconURI="platform:/plugin/org.eclipse.ui.tests/icons/view.gif"/>
+  </fragments>
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_MALdgL5iEe2xycAdAs49Bg" featurename="handlers" parentElementId="org.eclipse.e4.legacy.ide.application">
+    <elements xsi:type="commands:Handler" xmi:id="_NTEBsL5iEe2xycAdAs49Bg" elementId="org.eclipse.ui.tests.handler.iconTest" contributionURI="bundleclass://org.eclipse.ui.tests/org.eclipse.ui.tests.commands.EmptyE4CommandHandler" command="__OUmgL5fEe2xycAdAs49Bg"/>
+  </fragments>
+</fragment:ModelFragments>

--- a/tests/org.eclipse.ui.tests/plugin.xml
+++ b/tests/org.eclipse.ui.tests/plugin.xml
@@ -4675,4 +4675,12 @@
        </run>
     </filesystem>
  </extension>
+ <extension
+       id="org.eclipse.ui.tests.fragment"
+       point="org.eclipse.e4.workbench.model">
+    <fragment
+          uri="fragment.e4xmi"
+          apply="always">
+    </fragment>
+ </extension>
 </plugin>

--- a/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/E4Properties.java
+++ b/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/E4Properties.java
@@ -549,6 +549,11 @@ public class E4Properties {
 	}
 
 	@SuppressWarnings("unchecked")
+	public static IValueProperty<MCommand, String> commandIcon(EditingDomain editingDomain) {
+		return EMFEditProperties.value(editingDomain, CommandsPackageImpl.Literals.COMMAND__COMMAND_ICON_URI);
+	}
+
+	@SuppressWarnings("unchecked")
 	public static IValueProperty<MCommand, MCategory> category() {
 		return EMFProperties.value(CommandsPackageImpl.Literals.COMMAND__CATEGORY);
 	}

--- a/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/Messages.java
+++ b/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/Messages.java
@@ -166,6 +166,8 @@ public class Messages {
 	public String CommandEditor_LabelDescription;
 	public String CommandEditor_Parameters;
 	public String CommandEditor_Category;
+	public String CommandEditor_IconURI;
+	public String CommandEditor_IconURI_Tooltip;
 	public String CommandEditor_AddCommandParameter;
 	public String CommandEditor_NewCommandParameter;
 
@@ -646,6 +648,10 @@ public class Messages {
 	public String KeyBindingCommandSelectionDialog_ShellTitle;
 	public String KeyBindingCommandSelectionDialog_DialogTitle;
 	public String KeyBindingCommandSelectionDialog_DialogMessage;
+
+	public String CommandIconDialogEditor_ShellTitle;
+	public String CommandIconDialogEditor_DialogTitle;
+	public String CommandIconDialogEditor_DialogMessage;
 
 	public String MenuIconDialogEditor_ShellTitle;
 	public String MenuIconDialogEditor_DialogTitle;

--- a/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/Messages.properties
+++ b/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/Messages.properties
@@ -127,6 +127,8 @@ CommandEditor_Name=&Name\:
 CommandEditor_LabelDescription=&Description\:
 CommandEditor_Parameters=Parameters
 CommandEditor_Category=C&ategory\:
+CommandEditor_IconURI=&Icon URI\:
+CommandEditor_IconURI_Tooltip=Choose the icon of your command here
 CommandEditor_AddCommandParameter=Command Parameter
 CommandEditor_NewCommandParameter=Command Parameter {0}
 
@@ -654,6 +656,10 @@ HandlerCommandSelectionDialog_DialogMessage=Connect the handler to a command
 KeyBindingCommandSelectionDialog_ShellTitle=Keybinding Command
 KeyBindingCommandSelectionDialog_DialogTitle=Keybinding-Command
 KeyBindingCommandSelectionDialog_DialogMessage=Connect the keybinding to a command
+
+CommandIconDialogEditor_ShellTitle=Command Icon Search
+CommandIconDialogEditor_DialogTitle=Command Icon Search
+CommandIconDialogEditor_DialogMessage=Search for GIF, PNG and JPG icons in the current project
 
 MenuIconDialogEditor_ShellTitle=Menu Icon Search
 MenuIconDialogEditor_DialogTitle=Menu Icon Search

--- a/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/CommandEditor.java
+++ b/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/CommandEditor.java
@@ -25,6 +25,8 @@ import javax.inject.Inject;
 
 import org.eclipse.core.databinding.observable.list.IObservableList;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.tools.emf.ui.common.ImageTooltip;
 import org.eclipse.e4.tools.emf.ui.common.Util;
 import org.eclipse.e4.tools.emf.ui.common.component.AbstractComponentEditor;
 import org.eclipse.e4.tools.emf.ui.internal.E4Properties;
@@ -33,6 +35,7 @@ import org.eclipse.e4.tools.emf.ui.internal.common.AbstractPickList.PickListFeat
 import org.eclipse.e4.tools.emf.ui.internal.common.E4PickList;
 import org.eclipse.e4.tools.emf.ui.internal.common.component.ControlFactory.TextPasteHandler;
 import org.eclipse.e4.tools.emf.ui.internal.common.component.dialogs.CommandCategorySelectionDialog;
+import org.eclipse.e4.tools.emf.ui.internal.common.component.dialogs.CommandIconDialogEditor;
 import org.eclipse.e4.ui.model.application.commands.MCommand;
 import org.eclipse.e4.ui.model.application.commands.MCommandParameter;
 import org.eclipse.e4.ui.model.application.commands.MCommandsFactory;
@@ -68,6 +71,9 @@ public class CommandEditor extends AbstractComponentEditor<MCommand> {
 	private StackLayout stackLayout;
 	private final List<Action> actions = new ArrayList<>();
 	private MessageFormat newCommandParameterName;
+
+	@Inject
+	private IEclipseContext eclipseContext;
 
 	@Inject
 	public CommandEditor() {
@@ -171,7 +177,7 @@ public class CommandEditor extends AbstractComponentEditor<MCommand> {
 		{
 			final Label l = new Label(parent, SWT.NONE);
 			l.setText(Messages.CommandEditor_Category);
-			l.setLayoutData(new GridData(GridData.BEGINNING, GridData.BEGINNING, false, false));
+			l.setLayoutData(new GridData());
 
 			final Text t = new Text(parent, SWT.BORDER);
 			TextPasteHandler.createFor(t);
@@ -188,6 +194,33 @@ public class CommandEditor extends AbstractComponentEditor<MCommand> {
 				public void widgetSelected(SelectionEvent e) {
 					final CommandCategorySelectionDialog dialog = new CommandCategorySelectionDialog(b.getShell(),
 							getEditor().getModelProvider(), getMaster().getValue(), Messages);
+					dialog.open();
+				}
+			});
+		}
+
+		// ------------------------------------------------------------
+		{
+			final Label l = new Label(parent, SWT.NONE);
+			l.setText(Messages.CommandEditor_IconURI);
+			l.setLayoutData(new GridData());
+			l.setToolTipText(Messages.CommandEditor_IconURI_Tooltip);
+
+			final Text t = new Text(parent, SWT.BORDER);
+			TextPasteHandler.createFor(t);
+			t.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+			context.bindValue(textProp.observeDelayed(200, t),
+					E4Properties.commandIcon(getEditingDomain()).observeDetail(getMaster()));
+
+			new ImageTooltip(t, Messages, this);
+
+			Button b = ControlFactory.createFindButton(parent, resourcePool);
+			b.addSelectionListener(new SelectionAdapter() {
+				@Override
+				public void widgetSelected(SelectionEvent e) {
+					final CommandIconDialogEditor dialog = new CommandIconDialogEditor(b.getShell(), eclipseContext,
+							project,
+							getEditingDomain(), getMaster().getValue(), Messages);
 					dialog.open();
 				}
 			});

--- a/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/dialogs/CommandIconDialogEditor.java
+++ b/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/dialogs/CommandIconDialogEditor.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2010 BestSolution.at and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Tom Schindl <tom.schindl@bestsolution.at> - initial API and implementation
+ *     Steven Spungin <steven@spungin.tv> - Bug 424730
+ ******************************************************************************/
+package org.eclipse.e4.tools.emf.ui.internal.common.component.dialogs;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.tools.emf.ui.internal.Messages;
+import org.eclipse.e4.ui.model.application.commands.MCommand;
+import org.eclipse.e4.ui.model.application.commands.impl.CommandsPackageImpl;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.swt.widgets.Shell;
+
+public class CommandIconDialogEditor extends AbstractIconDialog {
+
+	public CommandIconDialogEditor(Shell parentShell, IEclipseContext context, IProject project,
+			EditingDomain editingDomain, MCommand element, Messages Messages) {
+		super(parentShell, context, project, editingDomain, element,
+				CommandsPackageImpl.Literals.COMMAND__COMMAND_ICON_URI,
+				Messages);
+	}
+
+	@Override
+	protected String getShellTitle() {
+		return Messages.CommandIconDialogEditor_ShellTitle;
+	}
+
+	@Override
+	protected String getDialogTitle() {
+		return Messages.CommandIconDialogEditor_DialogTitle;
+	}
+
+	@Override
+	protected String getDialogMessage() {
+		return Messages.CommandIconDialogEditor_DialogMessage;
+	}
+
+}


### PR DESCRIPTION
Solves #614 

Previously it was only possible to define command icons using the extensions point org.eclipse.ui.commandImages
It was not possible to define images for e4 commands without creating a warning in the plugin.xml.
Now it is possible to define a command icon in the e4 application model by setting the "image" key in the persisted state of the command.