### PR TITLE
Disable theming by default on Linux/GTK

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/build.properties
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/build.properties
@@ -17,5 +17,6 @@ bin.includes = META-INF/,\
                .,\
                about.html,\
                plugin.properties,\
-               icons/
+               icons/,\
+               plugin.xml
 src.includes = about.html

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/plugin.xml
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/plugin.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.core.runtime.preferences">
+      <initializer
+            class="org.eclipse.e4.ui.internal.workbench.renderers.swt.ThemePreferenceInitializer">
+      </initializer>
+   </extension>
+
+</plugin>

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/internal/workbench/renderers/swt/ThemePreferenceInitializer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/internal/workbench/renderers/swt/ThemePreferenceInitializer.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package org.eclipse.e4.ui.internal.workbench.renderers.swt;
+
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+import org.eclipse.core.runtime.preferences.DefaultScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine;
+
+public class ThemePreferenceInitializer extends AbstractPreferenceInitializer {
+
+	@Override
+	public void initializeDefaultPreferences() {
+		IEclipsePreferences preferences = DefaultScope.INSTANCE.getNode("org.eclipse.e4.ui.workbench.renderers.swt"); //$NON-NLS-1$
+		if (Platform.WS_GTK.equals(Platform.getWS())) {
+			preferences.putBoolean(PartRenderingEngine.ENABLED_THEME_KEY, false);
+		}
+	}
+
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/themes/JFaceThemeTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/themes/JFaceThemeTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.themes;
 
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine;
 import org.eclipse.jface.resource.ColorDescriptor;
 import org.eclipse.jface.resource.ColorRegistry;
 import org.eclipse.jface.resource.FontRegistry;
@@ -22,6 +24,7 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.ui.themes.ITheme;
 import org.eclipse.ui.themes.IThemeManager;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -36,6 +39,12 @@ public class JFaceThemeTest extends ThemeTest {
 
 	public JFaceThemeTest() {
 		super(JFaceThemeTest.class.getSimpleName());
+	}
+
+	@BeforeClass
+	public static void enableTheme() {
+		InstanceScope.INSTANCE.getNode("org.eclipse.e4.ui.workbench.renderers.swt")
+				.putBoolean(PartRenderingEngine.ENABLED_THEME_KEY, true);
 	}
 
 	private void setAndTest(String themeId, IPropertyChangeListener listener) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/themes/ThemeAPITest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/themes/ThemeAPITest.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceConverter;
 import org.eclipse.jface.resource.ColorRegistry;
@@ -31,6 +33,7 @@ import org.eclipse.ui.internal.themes.ThemeElementHelper;
 import org.eclipse.ui.internal.util.PrefUtil;
 import org.eclipse.ui.themes.ITheme;
 import org.eclipse.ui.themes.IThemeManager;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -160,6 +163,11 @@ public class ThemeAPITest extends ThemeTest {
 		super(ThemeAPITest.class.getSimpleName());
 	}
 
+	@BeforeClass
+	public static void enableTheme() {
+		InstanceScope.INSTANCE.getNode("org.eclipse.e4.ui.workbench.renderers.swt").putBoolean(PartRenderingEngine.ENABLED_THEME_KEY, true);
+	}
+	
 	private void checkEvents(ThemePropertyListener listener, Object source,
 			Object oldObject, Object newObject) {
 		boolean array = oldObject instanceof Object[];


### PR DESCRIPTION
The light theme shows no clear value over no theme on Linux, so let's switch to no theme by default on Linux.