### PR TITLE
Propagate the exception that make the image creation fail

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.29.0.qualifier
+Bundle-Version: 3.29.100.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageDescriptor.java
@@ -227,11 +227,23 @@ public abstract class ImageDescriptor extends DeviceResourceDescriptor {
 
 	@Override
 	public Object createResource(Device device) throws DeviceResourceException {
-		Image result = createImage(false, device);
-		if (result == null) {
-			throw new DeviceResourceException(this);
+		try {
+			return new Image(device, new ImageDataProvider() {
+
+				@Override
+				public ImageData getImageData(int zoom) {
+					ImageData imageData = ImageDescriptor.this.getImageData(zoom);
+					if (imageData == null && zoom == 100) {
+						throw new IllegalStateException(String.format(
+								"The ImageDescriptor of type %s returned no image data at zoom=100!", //$NON-NLS-1$
+								getClass().getName()));
+					}
+					return imageData;
+				}
+			});
+		} catch (IllegalStateException | IllegalArgumentException | SWTException e) {
+			throw new DeviceResourceException(this, e);
 		}
-		return result;
 	}
 
 	@Override


### PR DESCRIPTION
Currently if image creation fails, only a very generic "Unable to create resource" exception is thrown and the caller has no clue what is actually going on.

This changes the code that the original exception is propagated as the cause.

See https://github.com/eclipse-platform/eclipse.platform.releng/issues/210