### PR TITLE
Add support for Microsoft Edge in Mac OS.

### DIFF
--- a/bundles/org.eclipse.ui.browser/plugin.properties
+++ b/bundles/org.eclipse.ui.browser/plugin.properties
@@ -1,3 +1,4 @@
+
 ###############################################################################
 # Copyright (c) 2005, 2011 IBM Corporation and others.
 #
@@ -29,7 +30,7 @@ commandParameter.openBrowser.browserId.name=Browser Id
 commandParameter.openBrowser.name.name=Browser Name
 commandParameter.openBrowser.tooltip.name=Browser Tooltip
 
-browserInternetExplorer=Internet Explorer
+
 browserMicrosoftEdge=Microsoft Edge
 browserOpera=Opera
 browserChrome=Chrome
@@ -37,7 +38,6 @@ browserChromium=Chromium
 browserKonqueror=Konqueror
 browserEpiphany=Epiphany (Gnome Web)
 browserFirefox=Firefox
-browserCamino=Camino
 browserSafari=Safari
 
 contentType_images=Image

--- a/bundles/org.eclipse.ui.browser/plugin.xml
+++ b/bundles/org.eclipse.ui.browser/plugin.xml
@@ -201,13 +201,13 @@
          executable="Google Chrome">
          <location>Applications/Google Chrome.app</location>
       </browser>
-      <browser
+<!--  <browser
          id="org.eclipse.ui.browser.camino"
          name="%browserCamino"
          os="MacOSX"
          executable="Camino">
          <location>Applications/Camino.app/Contents/MacOS/Camino</location>
-      </browser>
+      </browser>   -->
       <browser
          id="org.eclipse.ui.browser.safari"
          name="%browserSafari"
@@ -216,12 +216,19 @@
          factoryclass="org.eclipse.ui.internal.browser.macosx.SafariBrowserFactory">
          <location>Applications/Safari.app</location>
       </browser>
-      <browser
+<!--  <browser
          id="org.eclipse.ui.browser.ie"
          name="%browserInternetExplorer"
          os="MacOSX"
          executable="Internet&#0032;Explorer">
          <location>Applications/Internet Explorer.app/Contents/MacOS/"Internet Explorer"</location>
+      </browser>     -->
+      <browser
+         id="org.eclipse.ui.browser.msedge"
+         name="%browserMicrosoftEdge"
+         os="MacOSX"
+         executable="Microsoft Edge">
+         <location>Applications/Microsoft Edge.app</location>
       </browser>
    </extension>
    <extension

--- a/bundles/org.eclipse.ui.browser/plugin.xml
+++ b/bundles/org.eclipse.ui.browser/plugin.xml
@@ -201,13 +201,6 @@
          executable="Google Chrome">
          <location>Applications/Google Chrome.app</location>
       </browser>
-<!--  <browser
-         id="org.eclipse.ui.browser.camino"
-         name="%browserCamino"
-         os="MacOSX"
-         executable="Camino">
-         <location>Applications/Camino.app/Contents/MacOS/Camino</location>
-      </browser>   -->
       <browser
          id="org.eclipse.ui.browser.safari"
          name="%browserSafari"
@@ -216,13 +209,6 @@
          factoryclass="org.eclipse.ui.internal.browser.macosx.SafariBrowserFactory">
          <location>Applications/Safari.app</location>
       </browser>
-<!--  <browser
-         id="org.eclipse.ui.browser.ie"
-         name="%browserInternetExplorer"
-         os="MacOSX"
-         executable="Internet&#0032;Explorer">
-         <location>Applications/Internet Explorer.app/Contents/MacOS/"Internet Explorer"</location>
-      </browser>     -->
       <browser
          id="org.eclipse.ui.browser.msedge"
          name="%browserMicrosoftEdge"


### PR DESCRIPTION
In Eclipse->Settings->General->Web Browser

1.As cleanup removing browsers Camino and Internet Explorer, as it is no longer supported in Mac OS. 
2.Adding support for Microsoft Edge in Mac OS.



/cc @lshanmug 