### PR TITLE
[TVT] Strings in the plugin org.eclipse.e4.tools.jdt.templates need to be externalized for translation support

### DIFF
--- a/tools/bundles/org.eclipse.e4.tools.jdt.templates/plugin.properties
+++ b/tools/bundles/org.eclipse.e4.tools.jdt.templates/plugin.properties
@@ -14,3 +14,32 @@
 
 pluginName = e4 JDT code templates
 providerName = Eclipse.org
+
+
+#--- templates
+templates.e4.contextType.name= e4
+templates.e4.statements.contextType.name= e4 statements
+templates.e4.members.contextType.name= e4 members
+
+templates.java.resolvers.Field.name= Field
+templates.java.resolvers.Field.description= <b>${<i>id</i>:field(type[,type]*)}</b><br>Evaluates to a field in the current scope that is a subtype of any of the given types. If no type is specified, any non-primitive field matches.<br><br><b>Example:</b><br><code>${counter:field(int)}</code>
+templates.java.resolvers.Link.name= Linked Mode
+templates.java.resolvers.Link.description= <b>${<i>id</i>:link([proposal[,proposal]*])}</b><br>Evaluates to <i>id</i> if the list of proposals is empty, evaluates to the first proposal otherwise. The evaluated value is put into linked mode. A proposal window shows all the given proposals.<br><br><b>Example1:</b><br><code>java.util.Collections.${kind:link(EMPTY_SET, EMPTY_LIST, 'EMPTY_MAP.entrySet()')}</code><br><br><b>Example2:</b><br><code>int ${integer:link}; ${integer}= 0;</code>
+templates.java.resolvers.Imports.name= Import
+templates.java.resolvers.Imports.description= <b>${:import([type[,type]*])}</b><br>Adds an import statement for each type that is not already imported. Does nothing if a conflicting import exists. Evaluates to nothing.<br><br><b>Example:</b><br><code>${:import(java.util.List, java.util.Collection)}</code>
+templates.java.resolvers.ImportStatic.name= Import Static
+templates.java.resolvers.ImportStatic.description= <b>${:importStatic([qualifiedName[,qualifiedName]*])}</b><br>Adds a static import statement for each qualified name that is not already imported. The <code>qualifiedName</code> is the fully qualified name of a static field or method, or it is the qualified name of a type plus a <code>.*</code> suffix, enclosed in single quotes <code>'\u0027</code>. Does nothing if a conflicting import exists. Evaluates to nothing.<br><br><b>Example:</b><br><code>${:importStatic(java.util.Collections.EMPTY_SET, 'java.lang.System.*')}</code>
+templates.java.resolvers.Var.name= Variable
+templates.java.resolvers.Var.description= <b>${<i>id</i>:var(type[,type]*)}</b><br>Evaluates to a field, local variable or parameter visible in the current scope that is a subtype of any of the given types. If no type is specified, any non-primitive variable matches.<br><br><b>Example:</b><br><code>${array:var('java.lang.Object[]')}</code>
+templates.java.resolvers.LocalVar.name= Local Variable
+templates.java.resolvers.LocalVar.description= <b>${<i>id</i>:localVar(type[,type]*)}</b><br>Evaluates to a local variable or parameter visible in the current scope that is a subtype of any of the given types. If no type is specified, any non-primitive local variable matches.<br><br><b>Example:</b><br><code>${iterable:localVar(java.lang.Iterable)}</code>
+templates.java.resolvers.Name.name= New Name
+templates.java.resolvers.Name.description= <b>${<i>id</i>:newName(reference)}</b><br>Evaluates to an non-conflicting name for a new local variable of the type specified by the reference. The reference may either be a Java type name or the name of another template variable. The generated name respects the code style settings.<br><br><b>Example:</b><br><code>${index:newName(int)}</code>
+templates.java.resolvers.Type.name= New Type
+templates.java.resolvers.Type.description= <b>${<i>id</i>:newType(fullyQualifiedType)}</b><br>Evaluates to a type name given the fully qualified Java type name. Evaluates to a simple type name and an import if no conflicting type exists. Evaluates to a fully qualified type name otherwise.<br><br><b>Example:</b><br><code>${type:newType(java.util.Iterator)}</code>
+templates.java.resolvers.ElementType.name= Element Type
+templates.java.resolvers.ElementType.description= <b>${<i>id</i>:elemType(variable)}</b><br>Evaluates to the element type of the referenced template variable. The reference should be the name of another template variable that resolves to an array or an instance of <code>java.lang.Iterable</code>.<br><br><b>Example:</b><br><code>${t:elemType(a)} elem = ${a:array};</code>
+templates.java.resolvers.ArgumentType.name= Argument Type
+templates.java.resolvers.ArgumentType.description= <b>${<i>id</i>:argType(variable, n)}</b><br> Evaluates to the <em>nth</em> type argument of the referenced template variable. The reference should be the name of another template variable. Resolves to <code>java.lang.Object</code> if the referenced variable cannot be found or is not a parameterized type.<br><br><b>Example:</b><br><code>${type:argType(vector, 0)} ${first:name(type)} = ${vector:var(java.util.Vector)}.get(0);</code>;
+templates.java.resolvers.ExceptionVariableName.name= Exception Variable Name
+templates.java.resolvers.ExceptionVariableName.description= Exception variable name in catch blocks

--- a/tools/bundles/org.eclipse.e4.tools.jdt.templates/plugin.xml
+++ b/tools/bundles/org.eclipse.e4.tools.jdt.templates/plugin.xml
@@ -20,25 +20,26 @@
    <extension
          point="org.eclipse.ui.editors.templates">
       <contextType
-            name="e4"
+            name="%templates.e4.contextType.name"
             class="org.eclipse.e4.internal.tools.jdt.templates.E4ContextType"
             id="e4"
             registryId="org.eclipse.jdt.ui.CompilationUnitEditor">
       </contextType>
       <contextType
-            name="e4 statements"
+            name="%templates.e4.statements.contextType.name"
             class="org.eclipse.e4.internal.tools.jdt.templates.E4ContextType"
             id="e4-statements"
             registryId="org.eclipse.jdt.ui.CompilationUnitEditor">
       </contextType>
       <contextType
-            name="e4 members"
+            name="%templates.e4.members.contextType.name"
             class="org.eclipse.e4.internal.tools.jdt.templates.E4ContextType"
             id="e4-members"
             registryId="org.eclipse.jdt.ui.CompilationUnitEditor">
       </contextType>
       <include
-            file="templates/default-e4templates.xml">
+            file="templates/default-e4templates.xml"
+            translations="templates/default-e4templates.properties">
       </include>
             <resolver
             class="org.eclipse.jdt.internal.corext.template.java.FieldResolver"
@@ -50,61 +51,61 @@
             class="org.eclipse.jdt.internal.corext.template.java.LocalVarResolver"
             contextTypeId="e4-members"
             description="%templates.java.resolvers.LocalVar.description"
-            name="Local Variable"
+            name="%templates.java.resolvers.LocalVar.name"
             type="localVar"/>
       <resolver
             class="org.eclipse.jdt.internal.corext.template.java.VarResolver"
             contextTypeId="e4-members"
             description="%templates.java.resolvers.Var.description"
-            name="Variable"
+            name="%templates.java.resolvers.Var.name"
             type="var"/>
       <resolver
             class="org.eclipse.jdt.internal.corext.template.java.NameResolver"
             contextTypeId="e4-members"
             description="%templates.java.resolvers.Name.description"
-            name="New Name"
+            name="%templates.java.resolvers.Name.name"
             type="newName"/>
       <resolver
             class="org.eclipse.jdt.internal.corext.template.java.TypeResolver"
             contextTypeId="e4-members"
             description="%templates.java.resolvers.Type.description"
-            name="New Type"
+            name="%templates.java.resolvers.Type.name"
             type="newType"/>
       <resolver
             class="org.eclipse.jdt.internal.corext.template.java.ElementTypeResolver"
             contextTypeId="e4-members"
             description="%templates.java.resolvers.ElementType.description"
-            name="Element Type"
+            name="%templates.java.resolvers.ElementType.name"
             type="elemType"/>
       <resolver
             class="org.eclipse.jdt.internal.corext.template.java.TypeVariableResolver"
             contextTypeId="e4-members"
             description="%templates.java.resolvers.ArgumentType.description"
-            name="Argument Type"
+            name="%templates.java.resolvers.ArgumentType.name"
             type="argType"/>
 	  <resolver
             class="org.eclipse.jdt.internal.corext.template.java.LinkResolver"
             contextTypeId="e4-members"
             description="%templates.java.resolvers.Link.description"
-            name="Linked Mode"
+            name="%templates.java.resolvers.Link.name"
             type="link"/>
       <resolver
             class="org.eclipse.jdt.internal.corext.template.java.ImportsResolver"
             contextTypeId="e4-members"
             description="%templates.java.resolvers.Imports.description"
-            name="Import"
+            name="%templates.java.resolvers.Imports.name"
             type="import"/>
       <resolver
             class="org.eclipse.jdt.internal.corext.template.java.StaticImportResolver"
             contextTypeId="e4-members"
             description="%templates.java.resolvers.ImportStatic.description"
-            name="Import Static"
+            name="%templates.java.resolvers.ImportStatic.name"
             type="importStatic"/>
       <resolver
             class="org.eclipse.jdt.internal.corext.template.java.ExceptionVariableNameResolver"
             contextTypeId="e4-members"
             description="%templates.java.resolvers.ExceptionVariableName.description"
-            name="Exception Variable Name"
+            name="%templates.java.resolvers.ExceptionVariableName.name"
             type="exception_variable_name">
       </resolver>
    </extension>

--- a/tools/bundles/org.eclipse.e4.tools.jdt.templates/templates/default-e4templates.properties
+++ b/tools/bundles/org.eclipse.e4.tools.jdt.templates/templates/default-e4templates.properties
@@ -1,0 +1,27 @@
+###############################################################################
+# Copyright (c) 2010, 2018 IBM Corporation and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#       Boris Bokowski, IBM Corporation - initial API and implementation
+#        Lars Vogel <Lars.Vogel@vogella.com> - Ongoing maintenance
+################################################################################
+
+Templates.preference_value=Injected Preference Value
+Templates.preference_field=Injected Preferences Service
+Templates.logger=Injected Logger
+Templates.eventbroker=Injected Event Broker
+Templates.selectionservice=Injected ESEectionService
+Templates.eventhandler=Event Handler Method
+Templates.stylingengine=Injected Styling Engine
+Templates.init=Creates @PostConstruct method
+Templates.focus=Creates @Focus method 
+Templates.dispose=Creates @PreDestroy method
+Templates.execute=Creates Execute method
+Templates.canexecute=Creates CanExecute method

--- a/tools/bundles/org.eclipse.e4.tools.jdt.templates/templates/default-e4templates.xml
+++ b/tools/bundles/org.eclipse.e4.tools.jdt.templates/templates/default-e4templates.xml
@@ -19,28 +19,28 @@
 
 <templates>
 
-<template name="Inject -  Preference value as method injection" description="Injected Preference Value" id="org.eclipse.e4.tools.jdt.templates.preference" context="e4-members" enabled="true" autoinsert="false">@Inject
+<template name="preference" description="%Templates.preference_value" id="org.eclipse.e4.tools.jdt.templates.preference" context="e4-members" enabled="true" autoinsert="false">@Inject
 void setPreferenceValue(@Named("preference-PREFERENCE_KEY") String preferenceValue) {
 	${cursor}
 }</template>
 
-<template name="Inject - Preferences service as field" description="Injected Preferences Service" id="org.eclipse.e4.tools.jdt.templates.preferences" context="e4-members" enabled="true" autoinsert="false">@Inject
+<template name="preference" description="%Templates.preference_field" id="org.eclipse.e4.tools.jdt.templates.preferences" context="e4-members" enabled="true" autoinsert="false">@Inject
 IEclipsePreferences preferences;</template>
 
-<template name="Inject - Logger service as field" description="Injected Logger" id="org.eclipse.e4.tools.jdt.templates.logger" context="e4-members" enabled="true" autoinsert="false">@Inject
+<template name="logger" description="%Templates.logger" id="org.eclipse.e4.tools.jdt.templates.logger" context="e4-members" enabled="true" autoinsert="false">@Inject
 Logger logger;</template>
 
-<template name="Inject - Eventbroker service as field" description="Injected Event Broker" id="org.eclipse.e4.tools.jdt.templates.eventbroker" context="e4-members" enabled="true" autoinsert="false">@Inject
+<template name="eventbroker" description="%Templates.eventbroker" id="org.eclipse.e4.tools.jdt.templates.eventbroker" context="e4-members" enabled="true" autoinsert="false">@Inject
 IEventBroker eventBroker;
 ${imp:import(org.eclipse.e4.core.services.events.IEventBroker)}
 </template>
 
-<template name="Inject - ESelection service as field" description="Injected ESEectionService" id="org.eclipse.e4.tools.jdt.templates.selectionservice" context="e4-members" enabled="true" autoinsert="false">@Inject
+<template name="selectionservice" description="%Templates.selectionservice" id="org.eclipse.e4.tools.jdt.templates.selectionservice" context="e4-members" enabled="true" autoinsert="false">@Inject
 ESelectionService selectionService;
 ${imp:import(org.eclipse.e4.ui.workbench.modeling.ESelectionService)}
 </template>
 
-<template name="Inject -  Subscribe to event topic via method" description="Event Handler Method" id="org.eclipse.e4.tools.jdt.templates.eventhandler" context="e4-members" enabled="true" autoinsert="false"> @Inject
+<template name="eventhandler" description="%Templates.eventhandler" id="org.eclipse.e4.tools.jdt.templates.eventhandler" context="e4-members" enabled="true" autoinsert="false"> @Inject
     @Optional
     private void subscribeApplicationCompleted
             (@UIEventTopic(UIEvents.UILifeCycle.APP_STARTUP_COMPLETE)
@@ -49,39 +49,39 @@ ${imp:import(org.eclipse.e4.ui.workbench.modeling.ESelectionService)}
 	${cursor}
 }</template>
 
-<template name="Inject - IStylingEngine service as field" description="Injected Styling Engine" id="org.eclipse.e4.tools.jdt.templates.stylingengine" context="e4-members" enabled="true" autoinsert="false">@Inject
+<template name="stylingengine" description="%Templates.stylingengine" id="org.eclipse.e4.tools.jdt.templates.stylingengine" context="e4-members" enabled="true" autoinsert="false">@Inject
 IStylingEngine stylingEngine;</template>
 
 
-<template name="PostConstruct" description="Creates @PostConstruct method" id="org.eclipse.e4.tools.jdt.templates.init" context="e4-members" enabled="true" autoinsert="false">@PostConstruct
+<template name="init" description="%Templates.init" id="org.eclipse.e4.tools.jdt.templates.init" context="e4-members" enabled="true" autoinsert="false">@PostConstruct
 public void postConstruct(${type:newType(org.eclipse.swt.widgets.Composite)} parent) { 
 	${cursor}
 }
 ${imp:import(javax.annotation.PostConstruct)}
 </template>
 
-<template name="Focus" description="Creates @Focus method" id="org.eclipse.e4.tools.jdt.templates.focus" context="e4-members" enabled="true" autoinsert="false">@Focus
+<template name="focus" description="%Templates.focus" id="org.eclipse.e4.tools.jdt.templates.focus" context="e4-members" enabled="true" autoinsert="false">@Focus
 public void onFocus() {
 	${cursor}
 }
 ${imp:import(org.eclipse.e4.ui.di.Focus)}
 </template>
 
-<template name="PreDestroy" description="Creates @PreDestroy method" id="org.eclipse.e4.tools.jdt.templates.dispose" context="e4-members" enabled="true" autoinsert="false">@PreDestroy
+<template name="dispose" description="%Templates.dispose" id="org.eclipse.e4.tools.jdt.templates.dispose" context="e4-members" enabled="true" autoinsert="false">@PreDestroy
 public void preDestroy() {
 	${cursor}
 }
 ${imp:import(javax.annotation.PreDestroy)}
 </template>
 
-<template name="Execute" description="Creates Execute method" id="org.eclipse.e4.tools.jdt.templates.execute" context="e4-members" enabled="true" autoinsert="false">@Execute
+<template name="execute" description="%Templates.execute" id="org.eclipse.e4.tools.jdt.templates.execute" context="e4-members" enabled="true" autoinsert="false">@Execute
 public void execute() {
 	${cursor}
 }
 ${imp:import(org.eclipse.e4.core.di.annotations.Execute)}
 </template>
 
-<template name="CanExecute" description="Creates CanExecute method" id="org.eclipse.e4.tools.jdt.templates.canexecute" context="e4-members" enabled="true" autoinsert="false">@CanExecute
+<template name="canExecute" description="%Templates.canexecute" id="org.eclipse.e4.tools.jdt.templates.canexecute" context="e4-members" enabled="true" autoinsert="false">@CanExecute
 public boolean canExecute() {
 	return true;
 }


### PR DESCRIPTION
Fixes #638. 
Strings in the plugin org.eclipse.e4.tools.jdt.templates need to be externalized for translation support