### PR TITLE
[TVT] Strings in the plugin org.eclipse.e4.tools.jdt.templates need to be externalized for translation support

### DIFF
--- a/tools/bundles/org.eclipse.e4.tools.jdt.templates/META-INF/MANIFEST.MF
+++ b/tools/bundles/org.eclipse.e4.tools.jdt.templates/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.e4.tools.jdt.templates;singleton:=true
-Bundle-Version: 4.9.100.qualifier
+Bundle-Version: 4.9.101.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.jdt.ui;bundle-version="3.20.0",
  org.eclipse.ui.editors;bundle-version="3.6.0",

--- a/tools/bundles/org.eclipse.e4.tools.jdt.templates/plugin.properties
+++ b/tools/bundles/org.eclipse.e4.tools.jdt.templates/plugin.properties
@@ -14,3 +14,8 @@
 
 pluginName = e4 JDT code templates
 providerName = Eclipse.org
+
+#--- templates
+templates.e4.contextType.name= e4
+templates.e4.statements.contextType.name= e4 statements
+templates.e4.members.contextType.name= e4 members

--- a/tools/bundles/org.eclipse.e4.tools.jdt.templates/plugin.xml
+++ b/tools/bundles/org.eclipse.e4.tools.jdt.templates/plugin.xml
@@ -20,25 +20,26 @@
    <extension
          point="org.eclipse.ui.editors.templates">
       <contextType
-            name="e4"
+            name="%templates.e4.contextType.name"
             class="org.eclipse.e4.internal.tools.jdt.templates.E4ContextType"
             id="e4"
             registryId="org.eclipse.jdt.ui.CompilationUnitEditor">
       </contextType>
       <contextType
-            name="e4 statements"
+            name="%templates.e4.statements.contextType.name"
             class="org.eclipse.e4.internal.tools.jdt.templates.E4ContextType"
             id="e4-statements"
             registryId="org.eclipse.jdt.ui.CompilationUnitEditor">
       </contextType>
       <contextType
-            name="e4 members"
+            name="%templates.e4.members.contextType.name"
             class="org.eclipse.e4.internal.tools.jdt.templates.E4ContextType"
             id="e4-members"
             registryId="org.eclipse.jdt.ui.CompilationUnitEditor">
       </contextType>
       <include
-            file="templates/default-e4templates.xml">
+            file="templates/default-e4templates.xml"
+            translations="templates/default-e4templates.properties">
       </include>
             <resolver
             class="org.eclipse.jdt.internal.corext.template.java.FieldResolver"

--- a/tools/bundles/org.eclipse.e4.tools.jdt.templates/templates/default-e4templates.properties
+++ b/tools/bundles/org.eclipse.e4.tools.jdt.templates/templates/default-e4templates.properties
@@ -1,0 +1,26 @@
+###############################################################################
+# Copyright (c) 2010, 2023 IBM Corporation and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#       Sheena, IBM Corporation 
+################################################################################
+
+Templates.injected_preference_value=Injected Preference Value
+Templates.injected_preference_field=Injected Preferences Service
+Templates.injected_logger=Injected Logger
+Templates.injected_eventbroker=Injected Event Broker
+Templates.injected_eselectionservice=Injected ESEectionService
+Templates.injected_eventhandler_method=Event Handler Method
+Templates.injected_stylingengine=Injected Styling Engine
+Templates.postconstruct_method=Creates @PostConstruct method
+Templates.focus_method=Creates @Focus method 
+Templates.predestroy_method=Creates @PreDestroy method
+Templates.execute_method=Creates Execute method
+Templates.canexecute_method=Creates CanExecute method 

--- a/tools/bundles/org.eclipse.e4.tools.jdt.templates/templates/default-e4templates.xml
+++ b/tools/bundles/org.eclipse.e4.tools.jdt.templates/templates/default-e4templates.xml
@@ -19,28 +19,28 @@
 
 <templates>
 
-<template name="Inject -  Preference value as method injection" description="Injected Preference Value" id="org.eclipse.e4.tools.jdt.templates.preference" context="e4-members" enabled="true" autoinsert="false">@Inject
+<template name="Inject -  Preference value as method injection" description="%Templates.injected_preference_value" id="org.eclipse.e4.tools.jdt.templates.preference" context="e4-members" enabled="true" autoinsert="false">@Inject
 void setPreferenceValue(@Named("preference-PREFERENCE_KEY") String preferenceValue) {
 	${cursor}
 }</template>
 
-<template name="Inject - Preferences service as field" description="Injected Preferences Service" id="org.eclipse.e4.tools.jdt.templates.preferences" context="e4-members" enabled="true" autoinsert="false">@Inject
+<template name="Inject - Preferences service as field" description="%Templates.injected_preference_field" id="org.eclipse.e4.tools.jdt.templates.preferences" context="e4-members" enabled="true" autoinsert="false">@Inject
 IEclipsePreferences preferences;</template>
 
-<template name="Inject - Logger service as field" description="Injected Logger" id="org.eclipse.e4.tools.jdt.templates.logger" context="e4-members" enabled="true" autoinsert="false">@Inject
+<template name="Inject - Logger service as field" description="%Templates.injected_logger" id="org.eclipse.e4.tools.jdt.templates.logger" context="e4-members" enabled="true" autoinsert="false">@Inject
 Logger logger;</template>
 
-<template name="Inject - Eventbroker service as field" description="Injected Event Broker" id="org.eclipse.e4.tools.jdt.templates.eventbroker" context="e4-members" enabled="true" autoinsert="false">@Inject
+<template name="Inject - Eventbroker service as field" description="%Templates.injected_eventbroker" id="org.eclipse.e4.tools.jdt.templates.eventbroker" context="e4-members" enabled="true" autoinsert="false">@Inject
 IEventBroker eventBroker;
 ${imp:import(org.eclipse.e4.core.services.events.IEventBroker)}
 </template>
 
-<template name="Inject - ESelection service as field" description="Injected ESEectionService" id="org.eclipse.e4.tools.jdt.templates.selectionservice" context="e4-members" enabled="true" autoinsert="false">@Inject
+<template name="Inject - ESelection service as field" description="%Templates.injected_eselectionservice" id="org.eclipse.e4.tools.jdt.templates.selectionservice" context="e4-members" enabled="true" autoinsert="false">@Inject
 ESelectionService selectionService;
 ${imp:import(org.eclipse.e4.ui.workbench.modeling.ESelectionService)}
 </template>
 
-<template name="Inject -  Subscribe to event topic via method" description="Event Handler Method" id="org.eclipse.e4.tools.jdt.templates.eventhandler" context="e4-members" enabled="true" autoinsert="false"> @Inject
+<template name="Inject -  Subscribe to event topic via method" description="%Templates.injected_eventhandler_method" id="org.eclipse.e4.tools.jdt.templates.eventhandler" context="e4-members" enabled="true" autoinsert="false"> @Inject
     @Optional
     private void subscribeApplicationCompleted
             (@UIEventTopic(UIEvents.UILifeCycle.APP_STARTUP_COMPLETE)
@@ -49,39 +49,39 @@ ${imp:import(org.eclipse.e4.ui.workbench.modeling.ESelectionService)}
 	${cursor}
 }</template>
 
-<template name="Inject - IStylingEngine service as field" description="Injected Styling Engine" id="org.eclipse.e4.tools.jdt.templates.stylingengine" context="e4-members" enabled="true" autoinsert="false">@Inject
+<template name="Inject - IStylingEngine service as field" description="%Templates.injected_stylingengine" id="org.eclipse.e4.tools.jdt.templates.stylingengine" context="e4-members" enabled="true" autoinsert="false">@Inject
 IStylingEngine stylingEngine;</template>
 
 
-<template name="PostConstruct" description="Creates @PostConstruct method" id="org.eclipse.e4.tools.jdt.templates.init" context="e4-members" enabled="true" autoinsert="false">@PostConstruct
+<template name="PostConstruct" description="%Templates.postconstruct_method" id="org.eclipse.e4.tools.jdt.templates.init" context="e4-members" enabled="true" autoinsert="false">@PostConstruct
 public void postConstruct(${type:newType(org.eclipse.swt.widgets.Composite)} parent) { 
 	${cursor}
 }
 ${imp:import(javax.annotation.PostConstruct)}
 </template>
 
-<template name="Focus" description="Creates @Focus method" id="org.eclipse.e4.tools.jdt.templates.focus" context="e4-members" enabled="true" autoinsert="false">@Focus
+<template name="Focus" description="%Templates.focus_method" id="org.eclipse.e4.tools.jdt.templates.focus" context="e4-members" enabled="true" autoinsert="false">@Focus
 public void onFocus() {
 	${cursor}
 }
 ${imp:import(org.eclipse.e4.ui.di.Focus)}
 </template>
 
-<template name="PreDestroy" description="Creates @PreDestroy method" id="org.eclipse.e4.tools.jdt.templates.dispose" context="e4-members" enabled="true" autoinsert="false">@PreDestroy
+<template name="PreDestroy" description="%Templates.predestroy_method" id="org.eclipse.e4.tools.jdt.templates.dispose" context="e4-members" enabled="true" autoinsert="false">@PreDestroy
 public void preDestroy() {
 	${cursor}
 }
 ${imp:import(javax.annotation.PreDestroy)}
 </template>
 
-<template name="Execute" description="Creates Execute method" id="org.eclipse.e4.tools.jdt.templates.execute" context="e4-members" enabled="true" autoinsert="false">@Execute
+<template name="Execute" description="%Templates.execute_method" id="org.eclipse.e4.tools.jdt.templates.execute" context="e4-members" enabled="true" autoinsert="false">@Execute
 public void execute() {
 	${cursor}
 }
 ${imp:import(org.eclipse.e4.core.di.annotations.Execute)}
 </template>
 
-<template name="CanExecute" description="Creates CanExecute method" id="org.eclipse.e4.tools.jdt.templates.canexecute" context="e4-members" enabled="true" autoinsert="false">@CanExecute
+<template name="CanExecute" description="%Templates.canexecute_method" id="org.eclipse.e4.tools.jdt.templates.canexecute" context="e4-members" enabled="true" autoinsert="false">@CanExecute
 public boolean canExecute() {
 	return true;
 }

--- a/tools/features/org.eclipse.e4.core.tools.feature/feature.xml
+++ b/tools/features/org.eclipse.e4.core.tools.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.e4.core.tools.feature"
       label="%featureName"
-      version="4.27.0.qualifier"
+      version="4.27.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/638

These files are changed:
1.default-e4templates.xml
2.plugin.properties
3.plugin.xml

And one file is added:
1.default-e4templates.properties

Please review @ktatavarthi 