### PR TITLE
Do not open key assist dialog again if already open for the same matches

### DIFF
--- a/bundles/org.eclipse.e4.ui.bindings/src/org/eclipse/e4/ui/bindings/internal/KeyAssistDialog.java
+++ b/bundles/org.eclipse.e4.ui.bindings/src/org/eclipse/e4/ui/bindings/internal/KeyAssistDialog.java
@@ -16,6 +16,7 @@ package org.eclipse.e4.ui.bindings.internal;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.TreeSet;
@@ -518,6 +519,21 @@ public class KeyAssistDialog extends PopupDialog {
 	@Override
 	public void setParentShell(Shell newParentShell) {
 		super.setParentShell(newParentShell);
+	}
+
+	/**
+	 * Tests whether the key assist dialog is currently showing a set of bindings.
+	 *
+	 * @param bindings A set of conflicts or partial matches.
+	 * @return Whether the key assist dialog shows the bindings.
+	 */
+	public boolean isShowingBindings(Collection<Binding> bindings) {
+		if (matches == null || !matches.equals(new HashSet<>(bindings))) {
+			return false;
+		}
+
+		Shell shell = getShell();
+		return shell != null && !shell.isDisposed() && shell.isVisible();
 	}
 
 	/**

--- a/bundles/org.eclipse.e4.ui.bindings/src/org/eclipse/e4/ui/bindings/keys/KeyBindingDispatcher.java
+++ b/bundles/org.eclipse.e4.ui.bindings/src/org/eclipse/e4/ui/bindings/keys/KeyBindingDispatcher.java
@@ -607,6 +607,14 @@ public class KeyBindingDispatcher {
 						if (isTracingEnabled()) {
 							logger.trace("Error matches for key: " + sequenceAfterKeyStroke + ", :" + errorMatches); //$NON-NLS-1$//$NON-NLS-2$
 						}
+
+						if (sequenceBeforeKeyStroke.isEmpty() && keyAssistDialog != null
+								&& keyAssistDialog.isShowingBindings(errorMatches)) {
+							if (isTracingEnabled()) {
+								logger.trace("Key assist dialog is already showing error matches: " + errorMatches); //$NON-NLS-1$
+							}
+							return false;
+						}
 					} else if (isTracingEnabled() && !Character.isLetterOrDigit(event.character)) {
 						logger.trace("No binding for keys: " + sequenceBeforeKeyStroke + " " //$NON-NLS-1$//$NON-NLS-2$
 								+ sequenceAfterKeyStroke + " in " + describe(context)); //$NON-NLS-1$

--- a/tests/org.eclipse.e4.ui.bindings.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.bindings.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.e4.ui.bindings.tests
-Bundle-Version: 0.14.0.qualifier
+Bundle-Version: 0.14.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: javax.inject;version="1.0.0",
  org.eclipse.e4.core.commands,
@@ -19,7 +19,8 @@ Require-Bundle: org.eclipse.core.commands;bundle-version="3.5.0",
  org.eclipse.e4.ui.bindings;bundle-version="0.9.0",
  org.eclipse.swt;bundle-version="3.6.0",
  org.eclipse.e4.core.contexts,
- org.eclipse.e4.core.di
+ org.eclipse.e4.core.di,
+ org.mockito.mockito-core
 Eclipse-BundleShape: dir
 Export-Package: org.eclipse.e4.ui.bindings.tests;x-internal:=true
 Automatic-Module-Name: org.eclipse.e4.ui.bindings.tests

--- a/tests/org.eclipse.e4.ui.bindings.tests/src/org/eclipse/e4/ui/bindings/tests/KeyAssistDialogTest.java
+++ b/tests/org.eclipse.e4.ui.bindings.tests/src/org/eclipse/e4/ui/bindings/tests/KeyAssistDialogTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+* Copyright (c) 2023 Ole Osterhagen and others.
+*
+* This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Ole Osterhagen - Issue 654
+*******************************************************************************/
+package org.eclipse.e4.ui.bindings.tests;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.eclipse.core.commands.ParameterizedCommand;
+import org.eclipse.core.commands.common.NotDefinedException;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.ui.bindings.internal.KeyAssistDialog;
+import org.eclipse.e4.ui.bindings.keys.KeyBindingDispatcher;
+import org.eclipse.jface.bindings.Binding;
+import org.eclipse.jface.bindings.keys.KeySequence;
+import org.junit.Test;
+
+@SuppressWarnings("restriction")
+public class KeyAssistDialogTest {
+
+	private final Binding binding1 = mockBinding("Command 1");
+	private final Binding binding2 = mockBinding("Command 2");
+	private final Binding binding3 = mockBinding("Command 3");
+
+	@Test
+	public void testIsShowingBindings() throws Exception {
+		KeyAssistDialog keyAssistDialog = new KeyAssistDialog(mock(IEclipseContext.class), new KeyBindingDispatcher());
+		keyAssistDialog.open(List.of(binding1, binding2));
+
+		// the order is not important
+		assertTrue(keyAssistDialog.isShowingBindings(List.of(binding2, binding1)));
+
+		// different bindings
+		assertFalse(keyAssistDialog.isShowingBindings(List.of(binding2, binding3)));
+
+		keyAssistDialog.close();
+		assertFalse(keyAssistDialog.isShowingBindings(List.of(binding2, binding1)));
+	}
+
+	private Binding mockBinding(String commandName) {
+		ParameterizedCommand command = mock(ParameterizedCommand.class);
+		try {
+			when(command.getName()).thenReturn(commandName);
+		} catch (NotDefinedException e) {
+			throw new RuntimeException(e);
+		}
+
+		Binding binding = mock(Binding.class);
+		when(binding.getParameterizedCommand()).thenReturn(command);
+		when(binding.getTriggerSequence()).thenReturn(KeySequence.getInstance());
+		return binding;
+	}
+
+}


### PR DESCRIPTION
Fixes #654 

While searching for matching mnemonics the key binding dispatcher may be invoked for many widgets and their children. Closing and re-opening the key binding conflict dialog on every invocation otherwise leads to flickering, delays and sometimes to a wrong positioning of the window.