### PR TITLE
Enable searchable tree for the e4 model editor

### DIFF
--- a/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/tabs/XmiTab.java
+++ b/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/tabs/XmiTab.java
@@ -134,7 +134,7 @@ public class XmiTab extends Composite {
 
 		final String property = System
 				.getProperty(ORG_ECLIPSE_E4_TOOLS_MODELEDITOR_FILTEREDTREE_ENABLED_XMITAB_DISABLED);
-		if (property != null || preferences.getBoolean("tab-form-search-show", false)) { //$NON-NLS-1$
+		if (property != null || preferences.getBoolean("tab-form-search-show", true)) { //$NON-NLS-1$
 			sourceViewer.setEditable(false);
 			sourceViewer.getTextWidget().setEnabled(false);
 		}


### PR DESCRIPTION
Setting is relatively hidden for new users (or existing ones) and it is really useful. The readonly tab is not a big functionality loss as this text is rarely modified directly.