### PR TITLE
Add KeyAssistDialogTest to test suite

### DIFF
--- a/tests/org.eclipse.e4.ui.bindings.tests/src/org/eclipse/e4/ui/bindings/tests/BindingTestSuite.java
+++ b/tests/org.eclipse.e4.ui.bindings.tests/src/org/eclipse/e4/ui/bindings/tests/BindingTestSuite.java
@@ -22,7 +22,8 @@ import org.junit.runners.Suite;
 	BindingLookupTest.class,
 	KeyDispatcherTest.class,
 	BindingTableTests.class,
-	BindingCreateTest.class })
+	BindingCreateTest.class,
+	KeyAssistDialogTest.class })
 
 public class BindingTestSuite {
 }

--- a/tests/org.eclipse.ui.monitoring.tests/src/org/eclipse/ui/internal/monitoring/EventLoopMonitorThreadTests.java
+++ b/tests/org.eclipse.ui.monitoring.tests/src/org/eclipse/ui/internal/monitoring/EventLoopMonitorThreadTests.java
@@ -79,27 +79,22 @@ public class EventLoopMonitorThreadTests {
 		 */
 		@Override
 		protected void sleepForMillis(long nanoseconds) {
-			synchronized (sleepLock) {
-				++numSleeps;
-				sleepLock.notifyAll();
-			}
+			monitorThreadControl.pauseThreadAndWaitForResume();
 		}
 	}
 
 	private MockEventLoopMonitorThread monitoringThread;
 	private MockUiFreezeEventLogger logger;
 	private List<UiFreezeEvent> loggedEvents;
-	private static Object sleepLock;
-	private static long numSleeps;
-	private static volatile long timestamp;
+	private static ThreadControl monitorThreadControl;
+	private static long timestamp;
 
 	@Before
 	public void setUp() {
 		MonitoringPlugin.getPreferenceStore().setValue(PreferenceConstants.MONITORING_ENABLED, false);
 		logger = new MockUiFreezeEventLogger();
 		loggedEvents = logger.getLoggedEvents();
-		sleepLock = new Object();
-		numSleeps = 0;
+		monitorThreadControl = new ThreadControl(MAX_TIMEOUT_MS);
 		timestamp = 1;
 	}
 
@@ -135,7 +130,9 @@ public class EventLoopMonitorThreadTests {
 	private void shutdownMonitoringThread() throws Exception {
 		sendEvent(SWT.PostExternalEventDispatch);
 		sendEvent(SWT.PostEvent);
+		monitorThreadControl.waitUntilThreadIsPaused();
 		monitoringThread.shutdown();
+		monitorThreadControl.resumeThread();
 		monitoringThread.join();
 	}
 
@@ -150,19 +147,14 @@ public class EventLoopMonitorThreadTests {
 	 * Runs the current thread for a specified amount of time in milliseconds.
 	 */
 	private static void runForTime(long millis) throws Exception {
-		synchronized (sleepLock) {
-			while (millis > 0) {
-				long next = Math.min(millis, SAMPLE_INTERVAL_MS);
-				timestamp += next;
+		while (millis > 0) {
+			monitorThreadControl.waitUntilThreadIsPaused();
 
-				long sleeps = numSleeps;
-				long endTime = System.currentTimeMillis() + MAX_TIMEOUT_MS;
-				do {
-					sleepLock.wait(MAX_TIMEOUT_MS);
-				} while (sleeps == numSleeps && endTime - System.currentTimeMillis() > 0);
+			long next = Math.min(millis, SAMPLE_INTERVAL_MS);
+			timestamp += next;
+			millis -= next;
 
-				millis -= next;
-			}
+			monitorThreadControl.resumeThread();
 		}
 	}
 
@@ -174,9 +166,13 @@ public class EventLoopMonitorThreadTests {
 	}
 
 	private void sendEvent(int eventType) {
+		monitorThreadControl.waitUntilThreadIsPaused();
+
 		Event event = new Event();
 		event.type = eventType;
 		monitoringThread.handleEvent(event);
+
+		monitorThreadControl.resumeThread();
 	}
 
 	/**
@@ -200,22 +196,18 @@ public class EventLoopMonitorThreadTests {
 		sendEvent(SWT.PreEvent);
 
 		// Cycle a few events
-		synchronized (sleepLock) {
-			for (int i = 0; i < 3; ++i) {
-				sendEvent(SWT.PreEvent);
-				runForCycles(1);
-				sendEvent(SWT.PostEvent);
-			}
+		for (int i = 0; i < 3; ++i) {
+			sendEvent(SWT.PreEvent);
+			runForCycles(1);
+			sendEvent(SWT.PostEvent);
 		}
 
 		// Test going one beyond the MAX_STACK_TRACES count to see that the count is decimated.
 		int eventLength = MAX_STACK_TRACES + 2;
-		synchronized (sleepLock) {
-			sendEvent(SWT.PreEvent);
-			runForCycles(eventLength);
-			sendEvent(SWT.PostEvent);
-			runForCycles(3);
-		}
+		sendEvent(SWT.PreEvent);
+		runForCycles(eventLength);
+		sendEvent(SWT.PostEvent);
+		runForCycles(3);
 
 		UiFreezeEvent event = loggedEvents.get(0);
 		assertNotNull("A freeze event was not automatically published", event);
@@ -224,12 +216,10 @@ public class EventLoopMonitorThreadTests {
 
 		// Decimation slows down the sampling rate by a factor of 2, so test the resampling reduction.
 		eventLength = MAX_STACK_TRACES + (MIN_MAX_STACK_TRACE_DELTA - 1) * 2;
-		synchronized (sleepLock) {
-			sendEvent(SWT.PreEvent);
-			runForCycles(eventLength);
-			sendEvent(SWT.PostEvent);
-			runForCycles(3);
-		}
+		sendEvent(SWT.PreEvent);
+		runForCycles(eventLength);
+		sendEvent(SWT.PostEvent);
+		runForCycles(3);
 
 		event = loggedEvents.get(1);
 		assertNotNull("A freeze event was not automatically published", event);
@@ -239,12 +229,10 @@ public class EventLoopMonitorThreadTests {
 		// Test the resampling reduction after two decimations.
 		eventLength =
 				MAX_STACK_TRACES + (MIN_MAX_STACK_TRACE_DELTA) * 2 + (MIN_MAX_STACK_TRACE_DELTA - 2) * 4;
-		synchronized (sleepLock) {
-			sendEvent(SWT.PreEvent);
-			runForCycles(eventLength);
-			sendEvent(SWT.PostEvent);
-			runForCycles(3);
-		}
+		sendEvent(SWT.PreEvent);
+		runForCycles(eventLength);
+		sendEvent(SWT.PostEvent);
+		runForCycles(3);
 
 		event = loggedEvents.get(2);
 		assertNotNull("A freeze event was not automatically published", event);
@@ -259,34 +247,32 @@ public class EventLoopMonitorThreadTests {
 		long maxDeadlock = FORCE_DEADLOCK_LOG_TIME_MS;
 		sendEvent(SWT.PreEvent);
 
-		synchronized (sleepLock) {
-			// Cycle a few events to make sure the monitoring event thread is running.
-			for (int i = 0; i < 3; ++i) {
-				sendEvent(SWT.PreEvent);
-				runForCycles(1);
-				sendEvent(SWT.PostEvent);
-			}
-			long startTime = timestamp;
-
-			// Wait for the end of the event to propagate to the deadlock tracker.
+		// Cycle a few events to make sure the monitoring event thread is running.
+		for (int i = 0; i < 3; ++i) {
+			sendEvent(SWT.PreEvent);
 			runForCycles(1);
-
-			long remaining = maxDeadlock - (timestamp - startTime);
-			runForTime(remaining - 1);
-			assertTrue("No deadlock should get logged before its time", loggedEvents.isEmpty());
-
-			// March time forward to trigger the possible deadlock logging.
-			runForCycles(4);
-
-			assertEquals("Incorrect number of events was logged", 1, loggedEvents.size());
-			UiFreezeEvent event = loggedEvents.get(0);
-			assertTrue("Possible deadlock logging should have a valid number of stack traces",
-					event.getStackTraceSamples().length >= MIN_STACK_TRACES);
-
-			// Extending the UI freeze shouldn't log any more events.
-			runForTime(maxDeadlock * 2);
-			runForCycles(3);
+			sendEvent(SWT.PostEvent);
 		}
+		long startTime = timestamp;
+
+		// Wait for the end of the event to propagate to the deadlock tracker.
+		runForCycles(1);
+
+		long remaining = maxDeadlock - (timestamp - startTime);
+		runForTime(remaining - 1);
+		assertTrue("No deadlock should get logged before its time", loggedEvents.isEmpty());
+
+		// March time forward to trigger the possible deadlock logging.
+		runForCycles(4);
+
+		assertEquals("Incorrect number of events was logged", 1, loggedEvents.size());
+		UiFreezeEvent event = loggedEvents.get(0);
+		assertTrue("Possible deadlock logging should have a valid number of stack traces",
+				event.getStackTraceSamples().length >= MIN_STACK_TRACES);
+
+		// Extending the UI freeze shouldn't log any more events.
+		runForTime(maxDeadlock * 2);
+		runForCycles(3);
 
 		assertEquals("No more deadlock events should get logged", 1, loggedEvents.size());
 	}
@@ -297,19 +283,17 @@ public class EventLoopMonitorThreadTests {
 		monitoringThread.start();
 		sendEvent(SWT.PreEvent);
 
-		synchronized (sleepLock) {
-			// Cycle a few events to make sure the monitoring event thread is running.
-			for (int i = 0; i < 3; ++i) {
-				sendEvent(SWT.PreEvent);
-				runForCycles(1);
-				sendEvent(SWT.PostEvent);
-			}
-			sendEvent(SWT.PreExternalEventDispatch);
-
-			// Wait for the end of the event to propagate to the deadlock tracker.
-			runForTime(FORCE_DEADLOCK_LOG_TIME_MS * 2);
-			runForCycles(3);
+		// Cycle a few events to make sure the monitoring event thread is running.
+		for (int i = 0; i < 3; ++i) {
+			sendEvent(SWT.PreEvent);
+			runForCycles(1);
+			sendEvent(SWT.PostEvent);
 		}
+		sendEvent(SWT.PreExternalEventDispatch);
+
+		// Wait for the end of the event to propagate to the deadlock tracker.
+		runForTime(FORCE_DEADLOCK_LOG_TIME_MS * 2);
+		runForCycles(3);
 
 		assertTrue("No deadlock events should get logged", loggedEvents.isEmpty());
 	}
@@ -321,12 +305,10 @@ public class EventLoopMonitorThreadTests {
 		monitoringThread.start();
 
 		// One level deep
-		synchronized (sleepLock) {
-			sendEvent(SWT.PreExternalEventDispatch);
-			runForTime(FREEZE_THRESHOLD_MS * freezeDurationFactor);
-			sendEvent(SWT.PostExternalEventDispatch);
-			runForCycles(3);
-		}
+		sendEvent(SWT.PreExternalEventDispatch);
+		runForTime(FREEZE_THRESHOLD_MS * freezeDurationFactor);
+		sendEvent(SWT.PostExternalEventDispatch);
+		runForCycles(3);
 
 		assertTrue("Sleeping should not trigger a freeze event", loggedEvents.isEmpty());
 	}
@@ -340,14 +322,12 @@ public class EventLoopMonitorThreadTests {
 		long freezeDuration;
 
 		// One level deep
-		synchronized (sleepLock) {
-			sendEvent(SWT.PreEvent); // level 1
-			eventStartTime = timestamp;
-			runForTime(FREEZE_THRESHOLD_MS * freezeDurationFactor);
-			freezeDuration = timestamp - eventStartTime;
-			sendEvent(SWT.PostEvent);
-			runForCycles(3);
-		}
+		sendEvent(SWT.PreEvent); // level 1
+		eventStartTime = timestamp;
+		runForTime(FREEZE_THRESHOLD_MS * freezeDurationFactor);
+		freezeDuration = timestamp - eventStartTime;
+		sendEvent(SWT.PostEvent);
+		runForCycles(3);
 
 		assertEquals("Incorrect number of freeze events was logged", 1, loggedEvents.size());
 		UiFreezeEvent event = loggedEvents.get(0);
@@ -369,17 +349,15 @@ public class EventLoopMonitorThreadTests {
 		long freezeDuration;
 
 		// Two levels deep
-		synchronized (sleepLock) {
-			sendEvent(SWT.PreEvent); // level 1
-			runForCycles(1);
-			sendEvent(SWT.PreEvent); // level 2
-			eventStartTime = timestamp;
-			runForTime(FREEZE_THRESHOLD_MS * freezeDurationFactor);
-			freezeDuration = timestamp - eventStartTime;
-			sendEvent(SWT.PostEvent);
-			sendEvent(SWT.PostEvent);
-			runForCycles(3);
-		}
+		sendEvent(SWT.PreEvent); // level 1
+		runForCycles(1);
+		sendEvent(SWT.PreEvent); // level 2
+		eventStartTime = timestamp;
+		runForTime(FREEZE_THRESHOLD_MS * freezeDurationFactor);
+		freezeDuration = timestamp - eventStartTime;
+		sendEvent(SWT.PostEvent);
+		sendEvent(SWT.PostEvent);
+		runForCycles(3);
 
 		assertEquals("Incorrect number of freeze events was logged", 1, loggedEvents.size());
 		UiFreezeEvent event = loggedEvents.get(0);
@@ -401,20 +379,18 @@ public class EventLoopMonitorThreadTests {
 		long freezeDuration;
 
 		// Three levels deep
-		synchronized (sleepLock) {
-			sendEvent(SWT.PreEvent); // level 1
-			runForCycles(1);
-			sendEvent(SWT.PreEvent); // level 2
-			runForCycles(1);
-			sendEvent(SWT.PreEvent); // level 3
-			eventStartTime = timestamp;
-			runForTime(FREEZE_THRESHOLD_MS * freezeDurationFactor);
-			freezeDuration = timestamp - eventStartTime;
-			sendEvent(SWT.PostEvent);
-			sendEvent(SWT.PostEvent);
-			sendEvent(SWT.PostEvent);
-			runForCycles(3);
-		}
+		sendEvent(SWT.PreEvent); // level 1
+		runForCycles(1);
+		sendEvent(SWT.PreEvent); // level 2
+		runForCycles(1);
+		sendEvent(SWT.PreEvent); // level 3
+		eventStartTime = timestamp;
+		runForTime(FREEZE_THRESHOLD_MS * freezeDurationFactor);
+		freezeDuration = timestamp - eventStartTime;
+		sendEvent(SWT.PostEvent);
+		sendEvent(SWT.PostEvent);
+		sendEvent(SWT.PostEvent);
+		runForCycles(3);
 
 		assertEquals("Incorrect number of freeze events was logged", 1, loggedEvents.size());
 		UiFreezeEvent event = loggedEvents.get(0);
@@ -437,21 +413,19 @@ public class EventLoopMonitorThreadTests {
 
 		// Exceed the threshold after the thread is started in the middle of an event, then end
 		// the event and validate that no freeze event was logged.
-		synchronized (sleepLock) {
+		sendEvent(SWT.PreEvent);
+		// Initially the outer thread is invoking nested events that are responsive.
+		for (int i = 0; i < 4; i++) {
+			runForCycles(1);
 			sendEvent(SWT.PreEvent);
-			// Initially the outer thread is invoking nested events that are responsive.
-			for (int i = 0; i < 4; i++) {
-				runForCycles(1);
-				sendEvent(SWT.PreEvent);
-				sendEvent(SWT.PostEvent);
-			}
-
-			eventResumeTime = timestamp;
-			runForTime(FREEZE_THRESHOLD_MS * freezeDurationFactor);
 			sendEvent(SWT.PostEvent);
-			freezeDuration = timestamp - eventResumeTime;
-			runForCycles(3);
 		}
+
+		eventResumeTime = timestamp;
+		runForTime(FREEZE_THRESHOLD_MS * freezeDurationFactor);
+		sendEvent(SWT.PostEvent);
+		freezeDuration = timestamp - eventResumeTime;
+		runForCycles(3);
 
 		assertEquals("Incorrect number of freeze events was logged", 1, loggedEvents.size());
 		UiFreezeEvent event = loggedEvents.get(0);
@@ -474,30 +448,28 @@ public class EventLoopMonitorThreadTests {
 
 		// Exceed the threshold after the thread is started in the middle of an event, then end
 		// the event and validate that no freeze event was logged.
-		synchronized (sleepLock) {
+		sendEvent(SWT.PreEvent);
+		// Initially the outer thread is invoking nested events that are responsive.
+		for (int i = 0; i < 3; i++) {
+			runForCycles(1);
 			sendEvent(SWT.PreEvent);
-			// Initially the outer thread is invoking nested events that are responsive.
-			for (int i = 0; i < 3; i++) {
-				runForCycles(1);
-				sendEvent(SWT.PreEvent);
-				sendEvent(SWT.PostEvent);
-			}
-
-			// This is the nested event UI freeze
-			eventResumeTime = timestamp;
-			runForTime(FREEZE_THRESHOLD_MS * freezeDurationFactor);
-			freezeDuration = timestamp - eventResumeTime;
-
-			// Before exiting the outer thread is invoking nested events that are responsive.
-			for (int i = 0; i < 3; i++) {
-				sendEvent(SWT.PreEvent);
-				sendEvent(SWT.PostEvent);
-				runForCycles(1);
-			}
-
 			sendEvent(SWT.PostEvent);
-			runForCycles(3);
 		}
+
+		// This is the nested event UI freeze
+		eventResumeTime = timestamp;
+		runForTime(FREEZE_THRESHOLD_MS * freezeDurationFactor);
+		freezeDuration = timestamp - eventResumeTime;
+
+		// Before exiting the outer thread is invoking nested events that are responsive.
+		for (int i = 0; i < 3; i++) {
+			sendEvent(SWT.PreEvent);
+			sendEvent(SWT.PostEvent);
+			runForCycles(1);
+		}
+
+		sendEvent(SWT.PostEvent);
+		runForCycles(3);
 
 		assertEquals("Incorrect number of freeze events was logged", 1, loggedEvents.size());
 		UiFreezeEvent event = loggedEvents.get(0);
@@ -518,31 +490,29 @@ public class EventLoopMonitorThreadTests {
 
 		// Exceed the threshold after the thread is started in the middle of an event, then end
 		// the event and validate that no freeze event was logged.
-		synchronized (sleepLock) {
+		sendEvent(SWT.PreEvent);
+		// Initially the outer thread is invoking nested events that are responsive.
+		for (int i = 0; i < 3; i++) {
+			runForCycles(1);
 			sendEvent(SWT.PreEvent);
-			// Initially the outer thread is invoking nested events that are responsive.
-			for (int i = 0; i < 3; i++) {
-				runForCycles(1);
-				sendEvent(SWT.PreEvent);
-				sendEvent(SWT.PostEvent);
-			}
-
-			// Nested events
-			for (int i = 0; i < freezeDurationFactor; ++i) {
-				runForCycles(1);
-				sendEvent(SWT.PreExternalEventDispatch);
-				sendEvent(SWT.PostExternalEventDispatch);
-			}
-
-			// Before exiting the outer thread is invoking nested events that are responsive.
-			for (int i = 0; i < 3; i++) {
-				sendEvent(SWT.PreEvent);
-				sendEvent(SWT.PostEvent);
-				runForCycles(1);
-			}
 			sendEvent(SWT.PostEvent);
-			runForCycles(3);
 		}
+
+		// Nested events
+		for (int i = 0; i < freezeDurationFactor; ++i) {
+			runForCycles(1);
+			sendEvent(SWT.PreExternalEventDispatch);
+			sendEvent(SWT.PostExternalEventDispatch);
+		}
+
+		// Before exiting the outer thread is invoking nested events that are responsive.
+		for (int i = 0; i < 3; i++) {
+			sendEvent(SWT.PreEvent);
+			sendEvent(SWT.PostEvent);
+			runForCycles(1);
+		}
+		sendEvent(SWT.PostEvent);
+		runForCycles(3);
 
 		assertTrue("A freeze event should not be published during an external event dispatch",
 				loggedEvents.isEmpty());
@@ -556,28 +526,24 @@ public class EventLoopMonitorThreadTests {
 		long eventStartTime;
 		long eventDuration;
 
-		synchronized (sleepLock) {
-			sendEvent(SWT.PreEvent);
-			sendEvent(SWT.PreExternalEventDispatch);
-			runForTime(FREEZE_THRESHOLD_MS);
-			sendEvent(SWT.PostExternalEventDispatch);
-			eventStartTime = timestamp;
-			runForCycles(3);
-		}
+		sendEvent(SWT.PreEvent);
+		sendEvent(SWT.PreExternalEventDispatch);
+		runForTime(FREEZE_THRESHOLD_MS);
+		sendEvent(SWT.PostExternalEventDispatch);
+		eventStartTime = timestamp;
+		runForCycles(3);
 
 		assertTrue("A freeze event shold not be published during an external event dispatch",
 				loggedEvents.isEmpty());
 
 		// Let a long time elapse between the last PostExternalEventDispatch and the next
 		// PreExternalEventDispatch.
-		synchronized (sleepLock) {
-			runForTime(FREEZE_THRESHOLD_MS * freezeDurationFactor);
-			eventDuration = timestamp - eventStartTime;
-			sendEvent(SWT.PreExternalEventDispatch);
-			sendEvent(SWT.PostExternalEventDispatch);
-			sendEvent(SWT.PostEvent);
-			runForCycles(3);
-		}
+		runForTime(FREEZE_THRESHOLD_MS * freezeDurationFactor);
+		eventDuration = timestamp - eventStartTime;
+		sendEvent(SWT.PreExternalEventDispatch);
+		sendEvent(SWT.PostExternalEventDispatch);
+		sendEvent(SWT.PostEvent);
+		runForCycles(3);
 
 		assertEquals("Incorrect number of freeze events was logged", 1, loggedEvents.size());
 		UiFreezeEvent event = loggedEvents.get(0);

--- a/tests/org.eclipse.ui.monitoring.tests/src/org/eclipse/ui/internal/monitoring/ThreadControl.java
+++ b/tests/org.eclipse.ui.monitoring.tests/src/org/eclipse/ui/internal/monitoring/ThreadControl.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+* Copyright (c) 2023 Ole Osterhagen and others.
+*
+* This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Ole Osterhagen - initial API and implementation
+*******************************************************************************/
+package org.eclipse.ui.internal.monitoring;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * This test helper class coordinates the execution between a main thread and a
+ * secondary thread.
+ *
+ * <ol>
+ * <li>On start both threads a running.</li>
+ * <li>At some point the main thread decides to wait until the secondary thread
+ * is paused: {@link #waitUntilThreadIsPaused()}</li>
+ * <li>The secondary thread pauses execution, notifies the main thread and waits
+ * until it is resumed: {@link #pauseThreadAndWaitForResume()}</li>
+ * <li>The waiting main thread continues execution.</li>
+ * <li>Later the main thread may resume the paused secondary thread:
+ * {@link #resumeThread()}</li>
+ * </ol>
+ */
+class ThreadControl {
+
+	private final long timeoutMillis;
+
+	private final CyclicBarrier barrier = new CyclicBarrier(2);
+
+	/**
+	 * Creates a {@code ThreadControl} class with the specified timeout.
+	 *
+	 * @param timeoutMillis The maximum time in milliseconds to wait for thread
+	 *                      status changes. This prevents a broken test from running
+	 *                      forever.
+	 */
+	public ThreadControl(long timeoutMillis) {
+		this.timeoutMillis = timeoutMillis;
+	}
+
+	/**
+	 * Called from the main thread to wait until the secondary thread pauses
+	 * execution with a call to {@link #pauseThreadAndWaitForResume()}.
+	 */
+	public void waitUntilThreadIsPaused() {
+		await();
+	}
+
+	/**
+	 * Called from the secondary thread to inform a waiting main thread that it can
+	 * continue. The secondary thread waits until it is resumed with a call to
+	 * {@link #resumeThread()} from the main thread.
+	 */
+	public void pauseThreadAndWaitForResume() {
+		// the other thread (main thread) can continue
+		await();
+
+		// this thread (secondary thread) is paused
+		await();
+	}
+
+	/**
+	 * Called from the main thread to resume the paused secondary thread.
+	 */
+	public void resumeThread() {
+		await();
+	}
+
+	private void await() {
+		try {
+			barrier.await(timeoutMillis, TimeUnit.MILLISECONDS);
+		} catch (InterruptedException | BrokenBarrierException | TimeoutException e) {
+			throw new RuntimeException("Error while waiting for threads to synchronize.", e);
+		}
+	}
+
+}


### PR DESCRIPTION
Sorry, with PR #655 I forgot to add a newly introduced test to the test suite in the Java package.

The test was already found and invoked by the Tycho Surefire Plugin during the Maven build. But it is missing from the [published test reports](https://download.eclipse.org/eclipse/downloads/) since these are produced by a separate Ant build using manually created test suites.