### PR TITLE
When updating the image from the workbench part currently a trivial put

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/e4/compatibility/CompatibilityPart.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/e4/compatibility/CompatibilityPart.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.ui.internal.e4.compatibility;
 
+import java.util.Map;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
@@ -383,9 +384,21 @@ public abstract class CompatibilityPart implements ISelectionChangedListener {
 			case IWorkbenchPartConstants.PROP_TITLE:
 				part.setLabel(computeLabel());
 
-				if (wrapped.getTitleImage() != null) {
-					Image newImage = wrapped.getTitleImage();
-					part.getTransientData().put(IPresentationEngine.OVERRIDE_ICON_IMAGE_KEY, newImage);
+				Image titleImage = wrapped.getTitleImage();
+				if (titleImage != null) {
+					Map<String, Object> data = part.getTransientData();
+					// we need to do an identity compare here, because images are considered equal
+					// when there imageproviders are equal, but the native image instance might be
+					// different and therefore disposed indivually!
+					Object object = data.get(IPresentationEngine.OVERRIDE_ICON_IMAGE_KEY);
+					if (titleImage != object) {
+						if (titleImage.equals(object)) {
+							// to trigger a change, we need to perform a remove/add instead of a simple put
+							// operation
+							data.remove(IPresentationEngine.OVERRIDE_ICON_IMAGE_KEY);
+						}
+						data.put(IPresentationEngine.OVERRIDE_ICON_IMAGE_KEY, titleImage);
+					}
 				}
 				String titleToolTip = wrapped.getTitleToolTip();
 				if (titleToolTip != null) {


### PR DESCRIPTION
When updating the image from the workbench part currently a trivial put operation is used, but because of how the transient data map works it only triggers a change if the value is not equal to the previous one.

It can now happen that two images are considered equal because they are created from the same imagedescriptor, but one of them is disposed afterwards in which case the value in the transient data is stale even though it was tried to being updated.

This is now changed in the following:
- first the current value is compared with the update value using identity comparison
- if it is not the same object, a remove/put operation is performed to enforce an update of the value in the map

Fix https://github.com/eclipse-platform/eclipse.platform.ui/issues/679
FYI @Dani-Hub