### PR TITLE
Strings in the plugin org.eclipse.e4.tools.jdt.templates need to be externalized for translation

### DIFF
--- a/tools/bundles/org.eclipse.e4.tools.jdt.templates/plugin.xml
+++ b/tools/bundles/org.eclipse.e4.tools.jdt.templates/plugin.xml
@@ -39,7 +39,7 @@
       </contextType>
       <include
             file="templates/default-e4templates.xml"
-            translations="templates/default-e4templates.properties">
+            translations="$nl$/templates/default-e4templates.properties">
       </include>
             <resolver
             class="org.eclipse.jdt.internal.corext.template.java.FieldResolver"


### PR DESCRIPTION
File Changed:
plugin.xml
Refer :https://github.com/eclipse-platform/eclipse.platform.ui/issues/638
cc @noopur2507 