### PR TITLE
Revert reusable ImageFileNameProvider/ImageDataProvider instances of

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FileImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FileImageDescriptor.java
@@ -11,7 +11,8 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Christoph Läubrich - Bug 567898 - [JFace][HiDPI] ImageDescriptor support alternative naming scheme for high dpi
- *     Daniel Kruegler - #375, #376, #378, #396, #398, #401
+ *     Daniel Kruegler - #375, #376, #378, #396, #398, #401,
+ *                       #679: Ensure that a fresh ImageFileNameProvider instance is created to preserve Image#equals invariant.
  *******************************************************************************/
 package org.eclipse.jface.resource;
 
@@ -42,7 +43,34 @@ import org.eclipse.swt.graphics.ImageFileNameProvider;
 /**
  * An image descriptor that loads its image information from a file.
  */
-class FileImageDescriptor extends ImageDescriptor implements IAdaptable, ImageFileNameProvider {
+class FileImageDescriptor extends ImageDescriptor implements IAdaptable {
+
+	private class ImageProvider implements ImageFileNameProvider {
+
+		@Override
+		public String getImagePath(int zoom) {
+			final boolean logIOException = zoom == 100;
+			if (zoom == 100) {
+				return getFilePath(name, logIOException);
+			}
+			String xName = getxName(name, zoom);
+			if (xName != null) {
+				String xResult = getFilePath(xName, logIOException);
+				if (xResult != null) {
+					return xResult;
+				}
+			}
+			String xPath = getxPath(name, zoom);
+			if (xPath != null) {
+				String xResult = getFilePath(xPath, logIOException);
+				if (xResult != null) {
+					return xResult;
+				}
+			}
+			return null;
+		}
+
+	}
 
 	private static final Pattern XPATH_PATTERN = Pattern.compile("(\\d+)x(\\d+)"); //$NON-NLS-1$
 
@@ -214,7 +242,10 @@ class FileImageDescriptor extends ImageDescriptor implements IAdaptable, ImageFi
 	public Image createImage(boolean returnMissingImageOnError, Device device) {
 		if (InternalPolicy.DEBUG_LOAD_URL_IMAGE_DESCRIPTOR_2x) {
 			try {
-				return new Image(device, this);
+				// We really want a fresh ImageFileNameProvider instance to make
+				// sure the code that uses created images can use equals(),
+				// see Image#equals
+				return new Image(device, new ImageProvider());
 			} catch (SWTException | IllegalArgumentException exception) {
 				// If we fail, fall back to the old 1x implementation.
 			}
@@ -281,34 +312,14 @@ class FileImageDescriptor extends ImageDescriptor implements IAdaptable, ImageFi
 	}
 
 	@Override
-	public String getImagePath(int zoom) {
-		final boolean logIOException = zoom == 100;
-		if (zoom == 100) {
-			return getFilePath(name, logIOException);
-		}
-		String xName = getxName(name, zoom);
-		if (xName != null) {
-			String xResult = getFilePath(xName, logIOException);
-			if (xResult != null) {
-				return xResult;
-			}
-		}
-		String xPath = getxPath(name, zoom);
-		if (xPath != null) {
-			String xResult = getFilePath(xPath, logIOException);
-			if (xResult != null) {
-				return xResult;
-			}
-		}
-		return null;
-	}
-
-	@Override
 	public <T> T getAdapter(Class<T> adapter) {
 		if (adapter == URL.class) {
 			if (location != null && name != null) {
 				return adapter.cast(location.getResource(name));
 			}
+		}
+		if (adapter == ImageFileNameProvider.class) {
+			return adapter.cast(new ImageProvider());
 		}
 		return null;
 	}

--- a/tests/org.eclipse.jface.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.jface.tests
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.4.100.qualifier
 Bundle-ClassPath: .
 Automatic-Module-Name: org.eclipse.jface.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/AllImagesTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/AllImagesTests.java
@@ -20,7 +20,7 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({ ImageRegistryTest.class, ResourceManagerTest.class, FileImageDescriptorTest.class,
-		DecorationOverlayIconTest.class, DeferredImageDescriptorTest.class })
+		UrlImageDescriptorTest.class, DecorationOverlayIconTest.class, DeferredImageDescriptorTest.class })
 public class AllImagesTests {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
URLImageDescriptor and FileImageDescriptor

This fixes #679: It restores the Image#equals contract, which depends on non-equal providers per image.

The corresponding tests are modified, too: Now they assert non-sameness of the provider instead of sameness.

To preserve the testability of their underlying providers, the two affected ImageDescriptor classes return them now through their getAdapter methods (And so so similarly by creating fresh instances).