### PR TITLE
Migrate to Java 17 switch semantics in org.eclipse.ui.views.log

### DIFF
--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogView.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogView.java
@@ -1134,21 +1134,13 @@ public class LogView extends ViewPart implements LogListener {
 	private LogEntry createLogEntry(org.osgi.service.log.LogEntry input) {
 		// create a status from OSGi LogEntry
 		LogLevel logLevel = input.getLogLevel();
-		int severity;
-		switch (logLevel) {
-		case ERROR:
-			severity = IStatus.ERROR;
-			break;
-		case WARN:
-			severity = IStatus.WARNING;
-			break;
-		case INFO:
-			severity = IStatus.INFO;
-			break;
-		case DEBUG:
-		default:
-			severity = IStatus.OK;
-		}
+		int severity = switch (logLevel) {
+		case ERROR -> IStatus.ERROR;
+		case WARN -> IStatus.WARNING;
+		case INFO -> IStatus.INFO;
+		case DEBUG -> IStatus.OK;
+		default -> IStatus.OK;
+		};
 		IStatus status = new Status(severity, input.getBundle().getSymbolicName(), input.getMessage(),
 				input.getException());
 		return createLogEntry(status);

--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogViewLabelProvider.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogViewLabelProvider.java
@@ -64,16 +64,12 @@ public class LogViewLabelProvider extends LabelProvider implements ITableLabelPr
 
 		LogEntry entry = (LogEntry) element;
 		if (columnIndex == 0) {
-			switch (entry.getSeverity()) {
-				case IStatus.INFO :
-					return infoImage;
-				case IStatus.OK :
-					return okImage;
-				case IStatus.WARNING :
-					return warningImage;
-				default :
-					return (entry.getStack() == null ? errorImage : errorWithStackImage);
-			}
+			return switch (entry.getSeverity()) {
+			case IStatus.INFO -> infoImage;
+			case IStatus.OK -> okImage;
+			case IStatus.WARNING -> warningImage;
+			default -> (entry.getStack() == null ? errorImage : errorWithStackImage);
+			};
 		}
 		return null;
 	}


### PR DESCRIPTION
Replace legacy switch block with java 17 semantics in org.eclipse.ui.views.log