### PR TITLE
Catch contribution factory exceptions (#718)

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/menus/ContributionFactoryGenerator.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/menus/ContributionFactoryGenerator.java
@@ -70,7 +70,11 @@ public class ContributionFactoryGenerator extends ContextFunction {
 		final ContributionRoot root = new ContributionRoot(menuService, new HashSet<>(), null, factory);
 		ServiceLocator sl = new ServiceLocator();
 		sl.setContext(context);
-		factory.createContributionItems(sl, root);
+		try {
+			factory.createContributionItems(sl, root);
+		} catch (Throwable ex) {
+			WorkbenchPlugin.log(ex);
+		}
 		final List contributionItems = root.getItems();
 		final Map<IContributionItem, Expression> itemsToExpression = root.getVisibleWhen();
 		List<MUIElement> menuElements = new ArrayList<>();


### PR DESCRIPTION
Avoid that exceptions in contribution factories (which are contributed by extension points) break the complete context menu or view part using that factory.