### PR TITLE
avoid source bundle warning

### DIFF
--- a/tests/org.eclipse.jface.tests.notifications/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.tests.notifications/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Jface notifications tests
 Bundle-SymbolicName: org.eclipse.jface.tests.notifications
+Bundle-Vendor: Eclipse.org
 Bundle-Version: 0.2.0.qualifier
 Automatic-Module-Name: org.eclipse.jface.notifications.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tools/tests/org.eclipse.e4.tools.compatibility.migration.tests/META-INF/MANIFEST.MF
+++ b/tools/tests/org.eclipse.e4.tools.compatibility.migration.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: org.eclipse.e4.tools.compatibility.migration.tests;singleton:=true
+Bundle-Vendor: Eclipse.org
 Bundle-Version: 1.1.0.qualifier
 Automatic-Module-Name: org.eclipse.e4.tools.compatibility.migration.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tools/tests/org.eclipse.e4.tools.persistence.tests/META-INF/MANIFEST.MF
+++ b/tools/tests/org.eclipse.e4.tools.persistence.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: org.eclipse.e4.tools.persistence.tests;singleton:=true
+Bundle-Vendor: Eclipse.org
 Bundle-Version: 1.1.0.qualifier
 Automatic-Module-Name: org.eclipse.e4.tools.persistence.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tools/tests/org.eclipse.e4.tools.test/META-INF/MANIFEST.MF
+++ b/tools/tests/org.eclipse.e4.tools.test/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: org.eclipse.e4.tools.test
+Bundle-Vendor: Eclipse.org
 Bundle-Version: 1.3.0.qualifier
 Fragment-Host: org.eclipse.e4.tools;bundle-version="4.7.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17


### PR DESCRIPTION
Fix a certain warning that appears during the Maven build: Warning:  Bundle-Vendor header not found in
somepath\META-INF\MANIFEST.MF, fallback to 'unknown' for source bundle