### PR TITLE
Fix FileLocationDetailsTest and NotificationPopupTest failing on windows

### DIFF
--- a/tests/org.eclipse.jface.tests.notifications/src/org/eclipse/jface/tests/notifications/NotificationPopupTest.java
+++ b/tests/org.eclipse.jface.tests.notifications/src/org/eclipse/jface/tests/notifications/NotificationPopupTest.java
@@ -67,7 +67,7 @@ public class NotificationPopupTest {
 	public void createsWithTextAndTitle() {
 		NotificationPopup notication = this.builder.text("This is a test").title("Hello World", false).delay(1).build();
 		notication.open();
-		List<Control> controls = getNotificationPopupControls();
+		List<Control> controls = getNotificationPopupControls(notication);
 
 		assertThat(controls, hasItem(aLabelWith("Hello World")));
 		assertThat(controls, hasItem(aLabelWith("This is a test")));
@@ -78,7 +78,7 @@ public class NotificationPopupTest {
 	public void createsWithCloseButton() {
 		NotificationPopup notication = this.builder.text("This is a test").title("Hello World", true).delay(1).build();
 		notication.open();
-		List<Control> controls = getNotificationPopupControls();
+		List<Control> controls = getNotificationPopupControls(notication);
 
 		assertThat(controls, hasItem(aLabelWith(CommonImages.getImage(CommonImages.NOTIFICATION_CLOSE))));
 		notication.close();
@@ -95,7 +95,7 @@ public class NotificationPopupTest {
 		}).delay(1).build();
 
 		notication.open();
-		List<Control> controls = getNotificationPopupControls();
+		List<Control> controls = getNotificationPopupControls(notication);
 
 		assertThat(controls, hasItem(is(text[0])));
 		notication.close();
@@ -111,14 +111,13 @@ public class NotificationPopupTest {
 		}, false).delay(1).build();
 
 		notication.open();
-		List<Control> controls = getNotificationPopupControls();
+		List<Control> controls = getNotificationPopupControls(notication);
 		notication.close();
 		assertThat(controls, hasItem(is(text[0])));
 	}
 
-	private List<Control> getNotificationPopupControls() {
-		Shell[] shells = this.display.getShells();
-		Shell shell = shells[shells.length - 1];
+	private List<Control> getNotificationPopupControls(NotificationPopup notication) {
+		Shell shell = notication.getShell();
 		return getChildrenStream(shell).toList();
 	}
 

--- a/tests/org.eclipse.ui.ide.application.tests/src/org/eclipse/ui/internal/ide/application/FileLocationDetailsTest.java
+++ b/tests/org.eclipse.ui.ide.application.tests/src/org/eclipse/ui/internal/ide/application/FileLocationDetailsTest.java
@@ -36,7 +36,7 @@ public class FileLocationDetailsTest {
 	@Before
 	public void setUp() throws IOException {
 		tempFile = File.createTempFile(getClass().getSimpleName(), "java");
-		path = tempFile.getAbsolutePath();
+		path = tempFile.getAbsolutePath().replace('\\', '/');
 	}
 
 	@After


### PR DESCRIPTION
On windows the array returned by `Display.getShells()` does not have a stable order over different runs and therefore `NotificationPopupTest` fails intermittently.