### PR TITLE
Add preference for disposing closed browser hovers after some time

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IWorkbenchPreferenceConstants.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IWorkbenchPreferenceConstants.java
@@ -674,4 +674,15 @@ public interface IWorkbenchPreferenceConstants {
 	 */
 	String RESOURCE_RENAME_MODE_DIALOG = "dialog"; //$NON-NLS-1$
 
+	/**
+	 * Preference for the <i>advised</i> time (in ms) after a closed browser hover
+	 * is to be disposed.
+	 * <p>
+	 * The integer default value for this preference is: <code>-1</code>.
+	 * Non-positive values indicate closed hovers are not disposed automatically.
+	 * </p>
+	 *
+	 * @since 3.129
+	 */
+	String DISPOSE_CLOSED_BROWSER_HOVER_TIMEOUT = "disposeClosedBrowserHoverTimeout"; //$NON-NLS-1$
 }

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchPreferenceInitializer.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchPreferenceInitializer.java
@@ -124,6 +124,8 @@ public class WorkbenchPreferenceInitializer extends AbstractPreferenceInitialize
 		node.putBoolean(IPreferenceConstants.SHOW_KEYS_ENABLED_FOR_MOUSE_EVENTS, false);
 		node.putInt(IPreferenceConstants.SHOW_KEYS_TIME_TO_CLOSE, 3000);
 
+		node.putInt(IWorkbenchPreferenceConstants.DISPOSE_CLOSED_BROWSER_HOVER_TIMEOUT, -1);
+
 		node.put(IWorkbenchPreferenceConstants.RESOURCE_RENAME_MODE,
 				IWorkbenchPreferenceConstants.RESOURCE_RENAME_MODE_INLINE);
 


### PR DESCRIPTION
Add a preference for disposing closed browser hovers after some time.

The preference can be used by client code, combined with the fix for: https://github.com/eclipse-platform/eclipse.platform.text/issues/191

Fixes: #742