### PR TITLE
Remove javax bundles from org.eclipse.e4.rcp Feature

### DIFF
--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -144,20 +144,6 @@
          unpack="false"/>
 
    <plugin
-         id="javax.inject"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="javax.annotation"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.e4.core.di"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
During builds these annotation providing bundles are pulled in as transitive dependencies any ways. Removing them from this features simplifies the exchange of the atucally providing bundle and therefore the migration to Jakarta.

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1056