### PR TITLE
Fix random failure of test in PipelinChainTest #757

### DIFF
--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/PipelineChainTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/PipelineChainTest.java
@@ -55,6 +55,7 @@ public class PipelineChainTest extends NavigatorTestBase {
 		activateAndWait(EXTENSIONS);
 	}
 
+
 	private void _initContentWithLabel() {
 		String[] EXTENSIONS = new String[] {
 				COMMON_NAVIGATOR_RESOURCE_EXT,
@@ -84,22 +85,22 @@ public class PipelineChainTest extends NavigatorTestBase {
 	public void testPipelinedChildren() throws Exception
 	{
 		_initContent();
-		_testPipelinedChildren();
+		_testPipelinedChildren("testPipelinedChildren");
 	}
 
 	@Test
 	public void testPipelinedChildrenWithLabel() throws Exception
 	{
 		_initContentWithLabel();
-		_testPipelinedChildren();
+		_testPipelinedChildren("testPipelinedChildrenWithLabel");
 	}
 
-	private void _testPipelinedChildren() throws CoreException {
+	private void _testPipelinedChildren(String testName) throws CoreException {
 		final String NEW_FOLDER = "newFolder_" + System.currentTimeMillis();
 
 		IFolder newFolder = _p1.getFolder(NEW_FOLDER);
 
-		TestPipelineProvider.reset();
+		TestPipelineProvider.reset(testName);
 		newFolder.create(true, true, new NullProgressMonitor());
 		TreeItem[] rootItems = _viewer.getTree().getItems();
 
@@ -118,7 +119,7 @@ public class PipelineChainTest extends NavigatorTestBase {
 	public void testInterceptAdd() throws CoreException
 	{
 		_initContent();
-		_testInterceptAdd();
+		_testInterceptAdd("testInterceptAdd");
 	}
 
 	/** Verifies that interceptAdd is called in the right sequence */
@@ -126,10 +127,10 @@ public class PipelineChainTest extends NavigatorTestBase {
 	public void testInterceptAddWithLabel() throws CoreException
 	{
 		_initContentWithLabel();
-		_testInterceptAdd();
+		_testInterceptAdd("testInterceptAddWithLabel");
 	}
 
-	private void _testInterceptAdd() throws CoreException {
+	private void _testInterceptAdd(String testName) throws CoreException {
 		final String NEW_FOLDER_1 = "newFolder1";
 
 
@@ -138,7 +139,7 @@ public class PipelineChainTest extends NavigatorTestBase {
 		_expand(rootItems);
 
 		IFolder newFolder1 = _p1.getFolder(NEW_FOLDER_1);
-		TestPipelineProvider.reset();
+		TestPipelineProvider.reset(testName);
 		newFolder1.create(true, true, new NullProgressMonitor());
 
 		assertEquals("Wrong query sequence for interceptAdd", "ACGFBDE",
@@ -151,7 +152,7 @@ public class PipelineChainTest extends NavigatorTestBase {
 	public void testInterceptRemove() throws CoreException
 	{
 		_initContent();
-		_testInterceptRemove();
+		_testInterceptRemove("testInterceptRemove");
 	}
 
 	/** Verifies that interceptRemove is called in the right sequence */
@@ -160,10 +161,10 @@ public class PipelineChainTest extends NavigatorTestBase {
 	public void testInterceptRemoveWithLabel() throws CoreException
 	{
 		_initContentWithLabel();
-		_testInterceptRemove();
+		_testInterceptRemove("testInterceptRemoveWithLabel");
 	}
 
-	private void _testInterceptRemove() throws CoreException {
+	private void _testInterceptRemove(String testName) throws CoreException {
 		final String NEW_FOLDER_1 = "newFolder1";
 
 
@@ -176,7 +177,7 @@ public class PipelineChainTest extends NavigatorTestBase {
 			newFolder1.create(true, true, new NullProgressMonitor());
 		}
 
-		TestPipelineProvider.reset();
+		TestPipelineProvider.reset(testName);
 		newFolder1.delete(true, new NullProgressMonitor());
 
 		assertEquals("Wrong query sequence for interceptRemove", "ACGFBDE",
@@ -189,7 +190,7 @@ public class PipelineChainTest extends NavigatorTestBase {
 	public void testInterceptRefreshOnChildTypeChange() throws CoreException
 	{
 		_initContent();
-		_testInterceptRefreshOnChildTypeChange();
+		_testInterceptRefreshOnChildTypeChange("testInterceptRefreshOnChildTypeChange");
 	}
 
 	/** Verifies that interceptRefresh or interceptUpdate is called in the right sequence */
@@ -198,10 +199,10 @@ public class PipelineChainTest extends NavigatorTestBase {
 	public void testInterceptRefreshOnChildTypeChangeWithLabel() throws CoreException
 	{
 		_initContentWithLabel();
-		_testInterceptRefreshOnChildTypeChange();
+		_testInterceptRefreshOnChildTypeChange("testInterceptRefreshOnChildTypeChangeWithLabel");
 	}
 
-	private void _testInterceptRefreshOnChildTypeChange() throws CoreException {
+	private void _testInterceptRefreshOnChildTypeChange(String testName) throws CoreException {
 
 		final IFile file2 = _p2.getFile("file2.txt");
 
@@ -210,7 +211,7 @@ public class PipelineChainTest extends NavigatorTestBase {
 			file2.create(null, true, null);
 		};
 
-		TestPipelineProvider.reset();
+		TestPipelineProvider.reset(testName);
 		ResourcesPlugin.getWorkspace().run(runnable, new NullProgressMonitor());
 
 		assertEquals("Wrong query sequence for interceptRefresh/update", "ACGFBDE",
@@ -223,7 +224,7 @@ public class PipelineChainTest extends NavigatorTestBase {
 	public void testInterceptUpdate() throws CoreException
 	{
 		_initContent();
-		_testInterceptUpdate();
+		_testInterceptUpdate("testInterceptUpdate");
 	}
 
 	// Bug 285529 Incorrect pipeline logic for interceptXXX methods
@@ -231,10 +232,10 @@ public class PipelineChainTest extends NavigatorTestBase {
 	public void testInterceptUpdateWithLabel() throws CoreException
 	{
 		_initContentWithLabel();
-		_testInterceptUpdate();
+		_testInterceptUpdate("testInterceptUpdateWithLabel");
 	}
 
-	private void _testInterceptUpdate() throws CoreException {
+	private void _testInterceptUpdate(String testName) throws CoreException {
 		final String NEW_FOLDER_1 = "newFolder1";
 
 
@@ -247,13 +248,10 @@ public class PipelineChainTest extends NavigatorTestBase {
 			newFolder1.create(true, true, new NullProgressMonitor());
 		}
 
-		TestPipelineProvider.reset();
+		TestPipelineProvider.reset(testName);
 		newFolder1.move(newFolder1.getFullPath().removeLastSegments(1).append("newFolderRenamed"), true, null);
 
 		assertEquals("Wrong query sequence for interceptUpdate", "ACGFBDE",
 				TestPipelineProvider.REMOVES.get(newFolder1));
 	}
-
-
-
 }

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestPipelineProvider.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestPipelineProvider.java
@@ -42,11 +42,8 @@ import org.eclipse.ui.tests.navigator.m12.model.ResourceWrapper;
  */
 public class TestPipelineProvider extends ResourceWrapperContentProvider {
 
-	public static final Map ELEMENTS = new HashMap(),
-	CHILDREN = new HashMap(),
-	ADDS = new HashMap(),
-	REMOVES = new HashMap(),
-	UPDATES = new HashMap();
+	public static final Map ELEMENTS = new HashMap(), CHILDREN = new HashMap(), ADDS = new HashMap(),
+			REMOVES = new HashMap(), UPDATES = new HashMap();
 
 	private String _id;
 
@@ -71,7 +68,6 @@ public class TestPipelineProvider extends ResourceWrapperContentProvider {
 		_track(ELEMENTS, anInput, _id);
 	}
 
-
 	@Override
 	public boolean hasPipelinedChildren(Object anInput, boolean currentHasChildren) {
 		return currentHasChildren;
@@ -94,13 +90,13 @@ public class TestPipelineProvider extends ResourceWrapperContentProvider {
 	 */
 	private void _track(Map map, Object key, String id) {
 		if (key instanceof ResourceWrapper) {
-			key = ((ResourceWrapper)key).getResource();
+			key = ((ResourceWrapper) key).getResource();
 		}
 
 		System.out.println("track:  " + mapName(map) + " " + key + " id: " + id);
 
 		String queries = (String) map.get(key);
-		StringBuilder buf = new StringBuilder(queries==null ? "" : queries);
+		StringBuilder buf = new StringBuilder(queries == null ? "" : queries);
 		buf.append(id);
 		map.put(key, buf.toString());
 	}
@@ -108,7 +104,7 @@ public class TestPipelineProvider extends ResourceWrapperContentProvider {
 	@Override
 	public PipelinedShapeModification interceptAdd(PipelinedShapeModification anAddModification) {
 		Set children = anAddModification.getChildren();
-		for (Iterator it = children.iterator(); it.hasNext(); ) {
+		for (Iterator it = children.iterator(); it.hasNext();) {
 			_track(ADDS, it.next(), _id);
 		}
 		return super.interceptAdd(anAddModification);
@@ -117,7 +113,7 @@ public class TestPipelineProvider extends ResourceWrapperContentProvider {
 	@Override
 	public boolean interceptRefresh(PipelinedViewerUpdate update) {
 		Set targets = update.getRefreshTargets();
-		for (Iterator it = targets.iterator(); it.hasNext(); ) {
+		for (Iterator it = targets.iterator(); it.hasNext();) {
 			_track(UPDATES, it.next(), _id);
 		}
 		return super.interceptRefresh(update);
@@ -126,7 +122,7 @@ public class TestPipelineProvider extends ResourceWrapperContentProvider {
 	@Override
 	public PipelinedShapeModification interceptRemove(PipelinedShapeModification aRemoveModification) {
 		Set children = aRemoveModification.getChildren();
-		for (Iterator it = children.iterator(); it.hasNext(); ) {
+		for (Iterator it = children.iterator(); it.hasNext();) {
 			_track(REMOVES, it.next(), _id);
 		}
 		return super.interceptRemove(aRemoveModification);
@@ -135,7 +131,7 @@ public class TestPipelineProvider extends ResourceWrapperContentProvider {
 	@Override
 	public boolean interceptUpdate(PipelinedViewerUpdate update) {
 		Set targets = update.getRefreshTargets();
-		for (Iterator it = targets.iterator(); it.hasNext(); ) {
+		for (Iterator it = targets.iterator(); it.hasNext();) {
 			_track(UPDATES, it.next(), _id);
 		}
 		return super.interceptUpdate(update);
@@ -146,7 +142,7 @@ public class TestPipelineProvider extends ResourceWrapperContentProvider {
 		_id = config.getExtension().getId();
 		int i = _id.lastIndexOf('.');
 		if (i >= 0) {
-			_id = _id.substring(i+1);
+			_id = _id.substring(i + 1);
 		}
 
 	}
@@ -155,7 +151,7 @@ public class TestPipelineProvider extends ResourceWrapperContentProvider {
 	public Object[] getChildren(Object parentElement) {
 		try {
 			_track(CHILDREN, parentElement, _id + "1");
-			return ((ResourceWrapper)parentElement).getChildren();
+			return ((ResourceWrapper) parentElement).getChildren();
 		} catch (CoreException e) {
 			e.printStackTrace();
 			return NO_CHILDREN;
@@ -199,10 +195,9 @@ public class TestPipelineProvider extends ResourceWrapperContentProvider {
 	}
 
 	@Override
-	protected Object _convertToModelObject(Object object)
-	{
+	protected Object _convertToModelObject(Object object) {
 		if (object instanceof IResource) {
-			return M1Core.getModelObject((IResource)object);
+			return M1Core.getModelObject((IResource) object);
 		}
 		return null;
 	}
@@ -221,16 +216,18 @@ public class TestPipelineProvider extends ResourceWrapperContentProvider {
 		return "??? unknown";
 	}
 
-	/**
-	 *
-	 */
-	public static void reset() {
-		ELEMENTS.clear();
-		CHILDREN.clear();
-		ADDS.clear();
-		REMOVES.clear();
-		UPDATES.clear();
+	public static void reset(String hint) {
+		System.out.println(hint + ": Clearing all maps!");
+		logAndClear(ELEMENTS);
+		logAndClear(CHILDREN);
+		logAndClear(ADDS);
+		logAndClear(REMOVES);
+		logAndClear(UPDATES);
+	}
 
+	private static void logAndClear(Map m) {
+		System.out.println("Clearing " + mapName(m) + " (it had " + m.size() + " entries)");
+		m.clear();
 	}
 
 }


### PR DESCRIPTION
Some tests in `PipelineChainTest` fail randomly. This happens because all tests share the `Map`s in `TestPipelineProvider` and they clear them at will.

This is a typical race condition and it looks like this: 
* Test "A" fills the map
* Test "B" clears the map 
* Test "A" `assert`s that the map has some key --> **FAIL**

One example of this is:
* `testInterceptAdd()` fills `TestPipelineProvider.ADDS`
* `testInterceptRemove()` clears all maps by calling `TestPipelineProvider.clear()`
* `testInterceptAdd()` asserts that `TestPipelineProvider.ADDS` has some entry --> **FAIL**

This avoids the race condition by only removing the entries (of all maps) that are relevant to the test itself.

Solves Bug #757 