### PR TITLE
Avoid animated refresh of markers table

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/QuickFixPage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/QuickFixPage.java
@@ -256,8 +256,13 @@ public class QuickFixPage extends WizardPage {
 
 		resolutionsList
 				.addSelectionChangedListener(event -> {
-					markersTable.refresh();
-					setPageComplete(markersTable.getCheckedElements().length > 0);
+					markersTable.getControl().setRedraw(false);
+					try {
+						markersTable.refresh();
+						setPageComplete(markersTable.getCheckedElements().length > 0);
+					} finally {
+						markersTable.getControl().setRedraw(true);
+					}
 				});
 	}
 


### PR DESCRIPTION
When switching between different resolutions in the quick fix dialog, the marker list is refreshed with animation (e.g. after each item being removed/added there is a redraw of the control). That looks bad and blocks the UI thread for quite some time (with a bigger number of markers).