### PR TITLE
Re-parent the toolbar to the new composite when shown on a tab #230

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/LazyStackRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/LazyStackRenderer.java
@@ -14,6 +14,7 @@
  *     Fabio Zadrozny (fabiofz@gmail.com) - Bug 436763
  *     Dirk Fauth <dirk.fauth@googlemail.com> - Bug 457939
  *     Rolf Theunissen <rolf.theunissen@gmail.com> - Bug 564561
+ *     Ole Osterhagen <ole@osterhagen.info> - Issue 230
  *******************************************************************************/
 package org.eclipse.e4.ui.workbench.renderers.swt;
 
@@ -26,6 +27,7 @@ import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.core.services.events.IEventBroker;
 import org.eclipse.e4.ui.di.UIEventTopic;
+import org.eclipse.e4.ui.internal.workbench.swt.AbstractPartRenderer;
 import org.eclipse.e4.ui.model.application.ui.MContext;
 import org.eclipse.e4.ui.model.application.ui.MElementContainer;
 import org.eclipse.e4.ui.model.application.ui.MGenericStack;
@@ -313,6 +315,13 @@ public abstract class LazyStackRenderer extends SWTPartRenderer {
 			MToolBar toolbar = ((MPart) element).getToolbar();
 			if (toolbar != null) {
 				toolbar.setVisible(true);
+
+				// Ensure that the toolbar control is under its 'real' parent
+				AbstractPartRenderer renderer = (AbstractPartRenderer) element.getRenderer();
+				if (renderer != null && renderer.getUIContainer(toolbar) instanceof Composite composite
+						&& toolbar.getWidget() instanceof Control control && control.getParent() != composite) {
+					control.setParent(composite);
+				}
 			}
 		}
 

--- a/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.ui.tests;singleton:=true
-Bundle-Version: 0.15.100.qualifier
+Bundle-Version: 0.15.200.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
While resetting a perspective, tab folders are recreated. These tab folders also have a new composite for the toolbars on the top right corner. The existing toolbar from the old tab folder has to be re-parented to this new composite.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/230