### PR TITLE
ArrayIndexOutOfBoundsException in RenameResourceAction #460

### DIFF
--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/RenameResourceAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/RenameResourceAction.java
@@ -241,7 +241,9 @@ public class RenameResourceAction extends WorkspaceAction {
 		TreeItem[] selectedItems = tree.getSelection();
 		treeEditor.horizontalAlignment = SWT.LEFT;
 		treeEditor.grabHorizontal = true;
-		treeEditor.setEditor(result, selectedItems[0]);
+		if (selectedItems.length != 0) {
+			treeEditor.setEditor(result, selectedItems[0]);
+		}
 		return result;
 	}
 


### PR DESCRIPTION
When trying to rename a resource in Project Explorer there is no check whether the current selection is empty. This is probably some race condition and occurs rarely. This change adds a missing security check.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/460