### PR TITLE
Fix "Widget is disposed" error in StackRenderer

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
@@ -253,7 +253,8 @@ public class StackRenderer extends LazyStackRenderer {
 	}
 
 	private void setOnboarding(MPerspective perspective) {
-		if (onboardingImage == null || onboardingText == null) {
+		if (onboardingImage == null || onboardingText == null || onboardingComposite == null
+				|| onboardingComposite.isDisposed()) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/issues/777