### PR TITLE
Avoid potential Threadlocal.set(null) memory leak

### DIFF
--- a/bundles/org.eclipse.core.databinding.observable/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding.observable/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.databinding.observable
-Bundle-Version: 1.13.0.qualifier
+Bundle-Version: 1.13.100.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/ObservableTracker.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/ObservableTracker.java
@@ -108,7 +108,7 @@ public class ObservableTracker {
 		currentGetterCalledSet.set(observableSet);
 		currentChangeListener.set(changeListener);
 		currentStaleListener.set(staleListener);
-		currentIgnoreCount.set(null);
+		currentIgnoreCount.remove();
 		try {
 			runnable.run();
 		} finally {
@@ -147,7 +147,7 @@ public class ObservableTracker {
 		Set<IObservable> observableSet = new IdentitySet<>();
 		// Push the new listeners to the top of the stack
 		currentObservableCreatedSet.set(observableSet);
-		currentIgnoreCount.set(null);
+		currentIgnoreCount.remove();
 		try {
 			runnable.run();
 		} finally {
@@ -201,7 +201,11 @@ public class ObservableTracker {
 		if (newCount < 0)
 			throw new IllegalStateException("Ignore count is already zero"); //$NON-NLS-1$
 
-		currentIgnoreCount.set(newCount == 0 ? null : Integer.valueOf(newCount));
+		if (newCount == 0) {
+			currentIgnoreCount.remove();
+		} else {
+			currentIgnoreCount.set(Integer.valueOf(newCount));
+		}
 	}
 
 	/**

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/Realm.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/Realm.java
@@ -107,7 +107,11 @@ public abstract class Realm {
 	 */
 	protected static Realm setDefault(Realm realm) {
 		Realm oldValue = getDefault();
-		defaultRealm.set(realm);
+		if (realm == null) {
+			defaultRealm.remove();
+		} else {
+			defaultRealm.set(realm);
+		}
 		return oldValue;
 	}
 


### PR DESCRIPTION
Threadlocal.set(null) keeps a reference to ThreadLocal.this see https://rules.sonarsource.com/java/RSPEC-5164