### PR TITLE
After 1st opening of Error Log, selection change in other views/editor does not work #792

### DIFF
--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogView.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogView.java
@@ -1215,16 +1215,25 @@ public class LogView extends ViewPart implements LogListener {
 
 	@Override
 	public void setFocus() {
-		if (!isDisposed()) {
-			if (fMemento.getBoolean(P_SHOW_FILTER_TEXT).booleanValue()) {
-				Text filterControl = fFilteredTree.getFilterControl();
-				if (filterControl != null && !filterControl.isDisposed()) {
-					filterControl.setFocus();
+		if (isDisposed()) {
+			return;
+		}
+		if (fMemento.getBoolean(P_SHOW_FILTER_TEXT).booleanValue()) {
+			Text filterControl = fFilteredTree.getFilterControl();
+			if (filterControl != null && !filterControl.isDisposed()) {
+				if (!filterControl.setFocus()) {
+					setFocusToParentComposite();
 				}
-			} else if (!fFilteredTree.isDisposed()) {
-				fFilteredTree.setFocus();
+			}
+		} else if (!fFilteredTree.isDisposed()) {
+			if (!fFilteredTree.setFocus()) {
+				setFocusToParentComposite();
 			}
 		}
+	}
+
+	private void setFocusToParentComposite() {
+		fFilteredTree.getParent().setFocus();
 	}
 
 	private void handleSelectionChanged(IStructuredSelection selection) {


### PR DESCRIPTION
On the first opening of the view the fFilteredTree is disabled. It is disabled right after creation and will become enabled later after reading log file. Because filterControl is disabled, it is not able to gain focus by calling forceFocus() during call of setFocus(). Fix is to set the focus to the parent composite if setFocus() of filtered tree returns false.