### PR TITLE
Fix random failure of SorterTest.testSorterContentAdd()

### DIFF
--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/LabelProviderTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/LabelProviderTest.java
@@ -338,15 +338,8 @@ public class LabelProviderTest extends NavigatorTestBase {
 
 		//System.out.println(System.currentTimeMillis() + " after expand");
 
-		// Let the label provider refresh - wait up to 60 seconds
-		for (int i = 0; i < 1200; i++) {
-			rootItems = _viewer.getTree().getItems();
-			//System.out.println("checking text: " + rootItems[0].getText());
-			if (rootItems[0].getBackground(0).equals(TestLabelProviderCyan.instance.backgroundColor))
-				break;
-			//System.out.println(System.currentTimeMillis() + " before sleep " + i);
-			DisplayHelper.sleep(50);
-		}
+		// Let the label provider refresh
+		waitForInitialization(TestLabelProviderCyan.instance);
 
 		//System.out.println(System.currentTimeMillis() + " after sleep");
 

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/NavigatorTestBase.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/NavigatorTestBase.java
@@ -431,5 +431,27 @@ public class NavigatorTestBase {
 		}
 	}
 
+	/**
+	 * Wait up to 60 seconds for a test label provider to be initialized.
+	 *
+	 * @param tlp the label provider.
+	 */
+	protected void waitForInitialization(TestLabelProvider tlp) {
+
+		for (int i = 0; i < 1200; i++) {
+			TreeItem[] rootItems = _viewer.getTree().getItems();
+
+			if (tlp != null && rootItems[0].getBackground(0).equals(tlp.backgroundColor)) {
+				System.out.println("The label provider '" + tlp.getClass().getCanonicalName()
+						+ "' was initialized after "
+						+ (i * 50) + " ms");
+				return;
+			}
+
+			DisplayHelper.sleep(50);
+		}
+
+		fail("The label provider was not initialized.");
+	}
 
 }

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/SorterTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/SorterTest.java
@@ -39,6 +39,7 @@ import org.eclipse.ui.tests.navigator.extension.TestComparatorData;
 import org.eclipse.ui.tests.navigator.extension.TestContentProvider;
 import org.eclipse.ui.tests.navigator.extension.TestContentProviderResource;
 import org.eclipse.ui.tests.navigator.extension.TestExtensionTreeData;
+import org.eclipse.ui.tests.navigator.extension.TestLabelProviderBlue;
 import org.eclipse.ui.tests.navigator.extension.TestSorterDataAndResource;
 import org.eclipse.ui.tests.navigator.extension.TestSorterResource;
 import org.junit.Test;
@@ -282,6 +283,9 @@ public class SorterTest extends NavigatorTestBase {
 				new String[] { TEST_CONTENT_SORTER_MODEL }, false);
 		_contentService.getActivationService().activateExtensions(
 				new String[] { TEST_CONTENT_SORTER_MODEL }, false);
+
+		// Let the label provider refresh
+		waitForInitialization(TestLabelProviderBlue.instance);
 
 		dynamicAddModelObjects();
 


### PR DESCRIPTION
The test relies on `TestLabelProviderBlue`, which is not being instantly initialized. This behavior seems to be known and accepted since the test `LabelProviderTest.testChangeActivation()` was already using a busy wait.

This PR extracts a new method into `NavigatorTestBase` and uses it in both tests. The method also asserts that the required label provider has been initialized, which helps debugging.

fixes #794 