### PR TITLE
Alignment of onboarding information (#796)

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
@@ -711,9 +711,11 @@ public class StackRenderer extends LazyStackRenderer {
 		GridDataFactory.create(GridData.VERTICAL_ALIGN_CENTER | GridData.HORIZONTAL_ALIGN_CENTER).grab(true, true)
 				.applyTo(onboardingComposite);
 
-		GridLayoutFactory.swtDefaults().numColumns(2).equalWidth(true).applyTo(onboardingComposite);
+		GridLayoutFactory.swtDefaults().numColumns(2).equalWidth(true).spacing(10, SWT.DEFAULT)
+				.applyTo(onboardingComposite);
 
-		GridDataFactory gridDataFactory = GridDataFactory.swtDefaults().indent(SWT.DEFAULT, 10).span(2, 1);
+		GridDataFactory gridDataFactory = GridDataFactory.swtDefaults().align(SWT.CENTER, SWT.CENTER)
+				.indent(SWT.DEFAULT, 10).span(2, 1);
 
 		onboardingImage = WidgetFactory.label(SWT.NONE).supplyLayoutData(gridDataFactory::create)
 				.create(onboardingComposite);


### PR DESCRIPTION
Align all onboarding information centered.
Space between onboarding command text and short cut.

Issue: https://github.com/eclipse-platform/eclipse.platform.ui/issues/788