### PR TITLE
Limit based table and tree viewer implementation.

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.30.100.qualifier
+Bundle-Version: 3.31.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,
@@ -29,6 +29,7 @@ Export-Package: org.eclipse.jface,
  org.eclipse.jface.util,
  org.eclipse.jface.viewers,
  org.eclipse.jface.viewers.deferred,
+ org.eclipse.jface.viewers.internal;x-friends:="org.eclipse.ui.tests,org.eclipse.jface.tests",
  org.eclipse.jface.widgets,
  org.eclipse.jface.window,
  org.eclipse.jface.wizard,

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/messages.properties
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/messages.properties
@@ -230,3 +230,6 @@ ConfigureColumnsDialog_Title=Configure Columns
 ConfigureColumnsDialog_WidthOfSelectedColumn=&Width of selected column:
 ConfigureColumnsDialog_up = &Up
 ConfigureColumnsDialog_down = Dow&n
+
+# org.eclipse.jface.viewers.internal.ExpandableNode
+ExpandableNode.defaultLabel = Show {0}...{1} ({2})

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTableViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTableViewer.java
@@ -1502,4 +1502,28 @@ public abstract class AbstractTableViewer extends ColumnViewer {
 	 */
 	protected abstract void doSelect(int[] indices);
 
+	/**
+	 * Returns true if the element is present in the viewer. If the viewer has
+	 * incremental display set then the element is searched inside expandable node
+	 * also. i.e. it searches inside the remaining elements to be populated.
+	 *
+	 * @param element model element
+	 * @return if given model element is contained in the viewer
+	 * @since 3.31
+	 */
+	public boolean contains(Object element) {
+		if (findItem(element) != null) {
+			return true;
+		}
+
+		if (getItemsLimit() <= 0) {
+			return false;
+		}
+
+		if (getLastElement() instanceof ExpandableNode node) {
+			return node.contains(element);
+		}
+		return false;
+	}
+
 }

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
@@ -24,6 +24,7 @@ package org.eclipse.jface.viewers;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -34,6 +35,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.internal.InternalPolicy;
 import org.eclipse.jface.util.Policy;
 import org.eclipse.jface.util.SafeRunnable;
+import org.eclipse.jface.viewers.internal.ExpandableNode;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.events.SelectionEvent;
@@ -43,6 +45,7 @@ import org.eclipse.swt.events.TreeListener;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Item;
+import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.swt.widgets.Widget;
 
 /**
@@ -286,6 +289,15 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 					comparator.sort(this, filtered);
 				}
 			}
+			// there are elements to be shown and viewer is showing limited items.
+			// newly added element can be inside expandable node or can be visible item.
+			// Assumption that user has already updated the model and needs addition of
+			// item.
+			if (getItemsLimit() > 0 && hasLimitedChildrenItems(widget)) {
+				internalRefreshStruct(widget, parent, false);
+				return;
+			}
+
 			createAddedElements(widget, filtered);
 			if (InternalPolicy.DEBUG_LOG_EQUAL_VIEWER_ELEMENTS) {
 				Item[] children = getChildren(widget);
@@ -635,10 +647,11 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 
 	@Override
 	protected Object[] getSortedChildren(Object parentElementOrTreePath) {
-		Object[] result = getFilteredChildren(parentElementOrTreePath);
+		Object[] result = null;
 		ViewerComparator comparator = getComparator();
 		if (parentElementOrTreePath != null
 				&& comparator instanceof TreePathViewerSorter) {
+			result = getFilteredChildren(parentElementOrTreePath);
 			TreePathViewerSorter tpvs = (TreePathViewerSorter) comparator;
 
 			// be sure we're not modifying the original array from the model
@@ -655,10 +668,9 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 				}
 			}
 			tpvs.sort(this, path, result);
-		} else if (comparator != null) {
-			// be sure we're not modifying the original array from the model
-			result = result.clone();
-			comparator.sort(this, result);
+			result = applyItemsLimit(parentElementOrTreePath, result);
+		} else {
+			return super.getSortedChildren(parentElementOrTreePath);
 		}
 		return result;
 	}
@@ -958,6 +970,12 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 		}
 
 		for (int column = 0; column < columnCount; column++) {
+
+			// ExpandableNode is shown in first column only.
+			if (element instanceof ExpandableNode && column != 0) {
+				continue;
+			}
+
 			ViewerColumn columnViewer = getViewerColumn(column);
 			ViewerCell cellToUpdate = updateCell(viewerRowFromItem, column,
 					element);
@@ -1422,6 +1440,9 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 					return super.getRawChildren(parent);
 				}
 				IContentProvider cp = getContentProvider();
+				if (getItemsLimit() > 0 && parent instanceof ExpandableNode expNode) {
+					return expNode.getRemainingElements();
+				}
 				if (cp instanceof ITreePathContentProvider) {
 					ITreePathContentProvider tpcp = (ITreePathContentProvider) cp;
 					if (path == null) {
@@ -1518,6 +1539,13 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 	 */
 	@Override
 	protected void handleDoubleSelect(SelectionEvent event) {
+		// expand ExpandableNode for default selection.
+		if (event.item != null && event.item.getData() instanceof ExpandableNode node) {
+			handleExpandableNodeClicked(event.item);
+			// do not notify client listeners for this item.
+			return;
+		}
+		
 		// handle case where an earlier selection listener disposed the control.
 		Control control = getControl();
 		if (control != null && !control.isDisposed()) {
@@ -1968,7 +1996,14 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 	 */
 	/* package */void internalRefreshStruct(Widget widget, Object element,
 			boolean updateLabels) {
-		updateChildren(widget, element, null, updateLabels);
+
+		// updateChildren will ask getSortedChildren for items to be populated.
+		// getSortedChildren always returns the limited items doesn't matter if there
+		// were any items expanded. We need to fetch exactly same number of
+		// elements which were shown in the viewer.
+		Object[] updatedChildren = getChildrenWithLimitApplied(element, getChildren(widget));
+
+		updateChildren(widget, element, updatedChildren, updateLabels);
 		Item[] children = getChildren(widget);
 		if (children != null) {
 			for (Item item : children) {
@@ -1999,6 +2034,27 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 			if (equals(element, input)) {
 				setInput(null);
 				return;
+			}
+
+			boolean continueOuter = false;
+			if (getItemsLimit() > 0) {
+				Widget[] itemsOfElement = internalFindItems(element);
+				for (Widget item : itemsOfElement) {
+					if (item instanceof TreeItem) {
+						TreeItem parentItem = ((TreeItem) item).getParentItem();
+						if (parentItem == null) {
+							internalRefreshStruct(((TreeItem) item).getParent(), getInput(), false);
+							continueOuter = true;
+							break;
+						}
+						// refresh parent item with the latest model.
+						internalRefreshStruct(parentItem, parentItem.getData(), false);
+						continueOuter = true;
+					}
+				}
+			}
+			if (continueOuter) {
+				continue;
 			}
 			Widget[] childItems = internalFindItems(element);
 			if (childItems.length > 0) {
@@ -2052,6 +2108,15 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 
 			// Iterate over the child items and remove each one
 			Item[] children = getChildren(parentItem);
+
+			// there are elements to be shown and viewer is showing limited items.
+			// newly added element can be inside expandable node or can be visible item.
+			// Assumption that user has already updated the model and needs removal of
+			// an item.
+			if (getItemsLimit() > 0 && hasLimitedChildrenItems(parentItem)) {
+				internalRefreshStruct(parentItem, parentItem.getData(), false);
+				continue;
+			}
 
 			if (children.length == 1 && children[0].getData() == null &&
 					parentItem instanceof Item) { // dummy node
@@ -2579,6 +2644,41 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 				}
 			}
 		}
+
+		// there can be some items inside expandable node and not populated yet. In this
+		// case try to find the item to select inside all the visible expandable nodes.
+		if (newSelection.size() < v.size() && getItemsLimit() > 0) {
+			// make out still not found items
+			List<Object> notFound = new ArrayList<>();
+			for (Object toSelect : v) {
+				boolean bFound = false;
+				for (Item found : newSelection) {
+					if (equals(toSelect, found.getData())) {
+						bFound = true;
+						break;
+					}
+				}
+				if (!bFound) {
+					notFound.add(toSelect);
+				}
+			}
+
+			// find out all visible expandable nodes
+			Collection<ExpandableNode> expandItems = getExpandableNodes();
+
+			// search for still missing items inside expandable nodes
+			for (Object nFound : notFound) {
+				for (ExpandableNode expNode : expandItems) {
+					if (findElementInExpandableNode(expNode, nFound)) {
+						Widget w = findItem(expNode);
+						if (w instanceof Item item) {
+							newSelection.add(item);
+						}
+					}
+				}
+			}
+		}
+
 		setSelection(newSelection);
 
 		// Although setting the selection in the control should reveal it,
@@ -2592,6 +2692,16 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 				showItem(newSelection.get(i));
 			}
 		}
+	}
+
+	private boolean findElementInExpandableNode(ExpandableNode expNode, Object toFind) {
+		Object[] remEles = getFilteredChildren(expNode);
+		for (Object element : remEles) {
+			if (equals(element, toFind)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -3251,6 +3361,18 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 			this.isExpandableCheckFilters = checkFilters;
 			refresh();
 		}
+	}
+
+	/**
+	 * @param widget
+	 * @return if the given widget's children has an expandable node at the end.
+	 */
+	boolean hasLimitedChildrenItems(Widget widget) {
+		Item[] items = getChildren(widget);
+		if (items.length == 0) {
+			return false;
+		}
+		return items[items.length - 1].getData() instanceof ExpandableNode;
 	}
 
 }

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
@@ -1545,7 +1545,7 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 			// do not notify client listeners for this item.
 			return;
 		}
-		
+
 		// handle case where an earlier selection listener disposed the control.
 		Control control = getControl();
 		if (control != null && !control.isDisposed()) {
@@ -3373,6 +3373,41 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 			return false;
 		}
 		return items[items.length - 1].getData() instanceof ExpandableNode;
+	}
+
+	/**
+	 * Returns true if the element is present in the viewer. If the viewer has
+	 * incremental display set then the element is searched inside expandable node
+	 * also. i.e. it searches inside the remaining elements to be populated.
+	 *
+	 * @param parent  model element which corresponds to any visible widget on the
+	 *                viewer
+	 * @param element model element
+	 * @return if given model element is contained in the viewer
+	 * @since 3.31
+	 */
+	public boolean contains(Object parent, Object element) {
+		if (findItem(element) != null) {
+			return true;
+		}
+
+		if (getItemsLimit() <= 0) {
+			return false;
+		}
+
+		Widget parentWideget = findItem(parent);
+		if (parentWideget == null) {
+			return false;
+		}
+
+		Item[] items = getChildren(parentWideget);
+		if (items.length == 0) {
+			return false;
+		}
+		if (items[items.length - 1].getData() instanceof ExpandableNode node) {
+			return node.contains(element);
+		}
+		return false;
 	}
 
 }

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ViewerColumn.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ViewerColumn.java
@@ -19,7 +19,9 @@
 package org.eclipse.jface.viewers;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.util.Policy;
+import org.eclipse.jface.viewers.internal.ExpandableNode;
 import org.eclipse.swt.widgets.Widget;
 
 /**
@@ -142,6 +144,16 @@ public abstract class ViewerColumn {
 			" has no label provider."); //$NON-NLS-1$
 		}
 		labelProvider.update(cell);
+
+		// check if client has updated the label for this element. Otherwise use default
+		// label provided
+		if (cell.getElement() instanceof ExpandableNode expNode) {
+			cell.setFont(JFaceResources.getFontRegistry().getItalic(JFaceResources.DEFAULT_FONT));
+			String text = cell.getText();
+			if (text.isEmpty() || text.equals(expNode.toString())) {
+				cell.setText(expNode.getLabel());
+			}
+		}
 	}
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/internal/ExpandableNode.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/internal/ExpandableNode.java
@@ -14,6 +14,7 @@
 package org.eclipse.jface.viewers.internal;
 
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
 
 import org.eclipse.core.runtime.Assert;
@@ -46,6 +47,10 @@ public class ExpandableNode {
 	private final int startOffSet;
 	private final int limit;
 	/**
+	 * This is a dummy object placed as a value for each unique item.
+	 */
+	private static Object VALUE = new Object();
+	/**
 	 * These elements are added into expandable node. will be rendered in the next
 	 * iterations.
 	 */
@@ -56,6 +61,12 @@ public class ExpandableNode {
 	private final int start;
 
 	private final StructuredViewer viewer;
+
+	/**
+	 * This maintains all the unique children of the parent node. It is needed for
+	 * supporting adding new elements.
+	 */
+	private final IdentityHashMap<Object, Object> uniqueElementsMap;
 
 	/**
 	 * @param children    non null list of children
@@ -73,6 +84,7 @@ public class ExpandableNode {
 		this.limit = limit;
 		this.viewer = viewer;
 		this.addedElements = new ArrayList<>();
+		this.uniqueElementsMap = new IdentityHashMap<>();
 	}
 
 	/**
@@ -165,6 +177,28 @@ public class ExpandableNode {
 	 * @param element
 	 */
 	public void addElement(Object element) {
+		initializeUniqueMap();
+		uniqueElementsMap.put(element, VALUE);
 		addedElements.add(element);
+	}
+
+	private void initializeUniqueMap() {
+		if (uniqueElementsMap.isEmpty()) {
+			// add all the existing elements.
+			for (Object element : orginalArray) {
+				uniqueElementsMap.put(element, VALUE);
+			}
+		}
+	}
+
+	/**
+	 * Returns true if the given element is present in the all elements.
+	 *
+	 * @param element
+	 * @return returns if it finds in all the elements.
+	 */
+	public boolean contains(Object element) {
+		initializeUniqueMap();
+		return uniqueElementsMap.containsKey(element);
 	}
 }

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/internal/ExpandableNode.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/internal/ExpandableNode.java
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Advantest Europe GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * 				Raghunandana Murthappa
+ *******************************************************************************/
+package org.eclipse.jface.viewers.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.jface.viewers.TableViewer;
+
+/**
+ * The expandable placeholder element to be used for viewer items that represent
+ * an expandable tree or table element.
+ * <p>
+ * The idea of {@link ExpandableNode} is to allow viewers to show only some
+ * subset of children that would otherwise all appear below parent element. The
+ * main purpose of this is to prevent UI freezes with viewers that can offer lot
+ * of elements but can't efficiently handle such amount using SWT.
+ * <p>
+ * The node consists of a parent element, list of all children of this parent
+ * and the offset to which child elements are supposed to be created and shown
+ * in the viewer.
+ *
+ * @noextend This class is not intended to be subclassed by clients.
+ */
+public class ExpandableNode {
+
+	/**
+	 * This array must be sorted always because we will populate elements
+	 * from offset onwards.
+	 */
+	private Object[] orginalArray;
+	private final int startOffSet;
+	private final int limit;
+	/**
+	 * These elements are added into expandable node. will be rendered in the next
+	 * iterations.
+	 */
+	private final List<Object> addedElements;
+	/**
+	 * a cursor only used for labeling to point to starting point of next block.
+	 */
+	private final int start;
+
+	private final StructuredViewer viewer;
+
+	/**
+	 * @param children    non null list of children
+	 * @param startOffSet first not shown item index
+	 * @param limit       current child limit of the viewer
+	 * @param viewer      owner of the node
+	 */
+	public ExpandableNode(Object[] children, int startOffSet, int limit, StructuredViewer viewer) {
+		Assert.isNotNull(children, "children of an ExpandableNode cannot be null"); //$NON-NLS-1$
+		Assert.isTrue(startOffSet >= 0 && startOffSet < children.length,
+				"startOffSet must be within the range of children: " + startOffSet); //$NON-NLS-1$
+		this.orginalArray = children;
+		this.startOffSet = startOffSet;
+		this.start = startOffSet;
+		this.limit = limit;
+		this.viewer = viewer;
+		this.addedElements = new ArrayList<>();
+	}
+
+	/**
+	 * The viewer is supposed to show subset of original elements as children of
+	 * this node up to this offset (but not including it). In other worlds, this is
+	 * the index of first invisible element under this node.
+	 *
+	 * {@return current offset in the original list of elements}
+	 */
+	public int getOffset() {
+		return startOffSet;
+	}
+
+	/**
+	 * This method returns those children of the current node which are supposed to
+	 * be not created / shown yet in the viewer.
+	 *
+	 * {@return all remaining elements from original array starting with the element
+	 * at offset index}
+	 */
+	public Object[] getRemainingElements() {
+		if (addedElements.size() > 0) {
+			Object[] children = updateChildrenWithAddedElements();
+			return children;
+		}
+		Object[] children = new Object[orginalArray.length - startOffSet];
+		System.arraycopy(orginalArray, startOffSet, children, 0, children.length);
+		return children;
+	}
+
+	/**
+	 * This will grow the original array with added elements. And it clears the
+	 * added elements. Also sort the newly added elements along with remaining
+	 * elements from offset.
+	 *
+	 * @return Returns the remaining elements from offset. returned array is sorted
+	 *         if viewer has comparator.
+	 */
+	private Object[] updateChildrenWithAddedElements() {
+		// sub array from offset + newly added elements
+		Object[] children = new Object[orginalArray.length - startOffSet + addedElements.size()];
+
+		System.arraycopy(orginalArray, startOffSet, children, 0, orginalArray.length - startOffSet);
+		System.arraycopy(addedElements.toArray(), 0, children, orginalArray.length - startOffSet, addedElements.size());
+
+		if (viewer.getComparator() != null) {
+			viewer.getComparator().sort(viewer, children);
+		}
+
+		// grow the original array with newly added elements.
+		Object[] newOriginalArray = new Object[orginalArray.length + addedElements.size()];
+		System.arraycopy(orginalArray, 0, newOriginalArray, 0, startOffSet);
+		System.arraycopy(children, 0, newOriginalArray, startOffSet, children.length);
+		this.orginalArray = newOriginalArray;
+		addedElements.clear();
+		return children;
+	}
+
+	/**
+	 * {@return original list of elements of the parent}
+	 */
+	public Object[] getAllElements() {
+		if (addedElements.size() > 0) {
+			updateChildrenWithAddedElements();
+			return this.orginalArray;
+		}
+		return orginalArray;
+	}
+
+	/**
+	 * {@return label shown for the node in the viewer}
+	 */
+	public String getLabel() {
+		Integer start = Integer.valueOf(this.start + 1);
+		Integer length = Integer.valueOf(orginalArray.length + addedElements.size());
+		int next = this.start + this.limit;
+		if (next > orginalArray.length + addedElements.size()) {
+			next = orginalArray.length + addedElements.size();
+		}
+		Integer nextBlock = Integer.valueOf(next);
+		String label = JFaceResources.format("ExpandableNode.defaultLabel", start, nextBlock, length); //$NON-NLS-1$
+		return label;
+	}
+
+	/**
+	 * Client can use {@link TableViewer#add(Object[])} to add an element beyond
+	 * visible range. It must be tracked to render when {@link ExpandableNode} node
+	 * is clicked.
+	 *
+	 * @param element
+	 */
+	public void addElement(Object element) {
+		addedElements.add(element);
+	}
+}

--- a/bundles/org.eclipse.search/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search; singleton:=true
-Bundle-Version: 3.15.100.qualifier
+Bundle-Version: 3.15.200.qualifier
 Bundle-Activator: org.eclipse.search.internal.ui.SearchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.search/new search/org/eclipse/search/ui/text/AbstractTextSearchViewPage.java
+++ b/bundles/org.eclipse.search/new search/org/eclipse/search/ui/text/AbstractTextSearchViewPage.java
@@ -84,6 +84,7 @@ import org.eclipse.ui.part.IPageSite;
 import org.eclipse.ui.part.Page;
 import org.eclipse.ui.part.PageBook;
 import org.eclipse.ui.progress.UIJob;
+import org.eclipse.ui.views.WorkbenchViewerSetup;
 
 import org.eclipse.ui.texteditor.IUpdate;
 
@@ -724,10 +725,12 @@ public abstract class AbstractTextSearchViewPage extends Page implements ISearch
 			TableViewer viewer = createTableViewer(parent);
 			fViewer = viewer;
 			configureTableViewer(viewer);
+			WorkbenchViewerSetup.setupViewer(viewer);
 		} else if ((layout & FLAG_LAYOUT_TREE) != 0) {
 			TreeViewer viewer = createTreeViewer(parent);
 			fViewer = viewer;
 			configureTreeViewer(viewer);
+			WorkbenchViewerSetup.setupViewer(viewer);
 			fCollapseAllAction.setViewer(viewer);
 			fExpandAllAction.setViewer(viewer);
 		}

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/text/FileTableContentProvider.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/text/FileTableContentProvider.java
@@ -85,7 +85,7 @@ public class FileTableContentProvider implements IStructuredContentProvider, IFi
 		boolean tableLimited= elementLimit != -1;
 		for (Object updatedElement : updatedElements) {
 			if (fPage.getDisplayedMatchCount(updatedElement) > 0) {
-				if (viewer.testFindItem(updatedElement) != null)
+				if (viewer.contains(updatedElement))
 					viewer.update(updatedElement, null);
 				else {
 					if (!tableLimited || viewer.getTable().getItemCount() < elementLimit)

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerProblemSeverityAndMessageField.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerProblemSeverityAndMessageField.java
@@ -76,7 +76,8 @@ public class MarkerProblemSeverityAndMessageField extends
 	public void update(ViewerCell cell) {
 		super.update(cell);
 
-		MarkerItem item = (MarkerItem) cell.getElement();
-		cell.setImage(annotateImage(item, getImage(item)));
+		if (cell.getElement() instanceof MarkerItem item) {
+			cell.setImage(annotateImage(item, getImage(item)));
+		}
 	}
 }

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerViewerContentProvider.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerViewerContentProvider.java
@@ -82,7 +82,10 @@ class MarkerViewerContentProvider implements ITreeContentProvider {
 
 	@Override
 	public Object getParent(Object element) {
-		Object parent = ((MarkerSupportItem) element).getParent();
+		Object parent = null;
+		if (element instanceof MarkerSupportItem markerItem) {
+			parent = markerItem.getParent();
+		}
 		if (parent == null)
 			return input;
 		return parent;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkersTreeViewer.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkersTreeViewer.java
@@ -71,9 +71,10 @@ public class MarkersTreeViewer extends TreeViewer {
 		/*
 		 * For performance reasons clear cache of the item used in updating UI.
 		 */
-		MarkerSupportItem cellItem = (MarkerSupportItem) element;
-		if (cellItem.isConcrete())
-			cellItem.clearCache();
+		if (element instanceof MarkerSupportItem cellItem) {
+			if (cellItem.isConcrete())
+				cellItem.clearCache();
+		}
 	}
 
 }

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/MarkerField.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/MarkerField.java
@@ -252,8 +252,10 @@ public abstract class MarkerField {
 	 * @param cell cell to update; not <code>null</code>
 	 */
 	public void update(ViewerCell cell) {
-		cell.setText(getValue((MarkerItem) cell.getElement()));
-		cell.setImage(null);
+		if (cell.getElement() instanceof MarkerItem element) {
+			cell.setText(getValue(element));
+			cell.setImage(null);
+		}
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.navigator.resources/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.navigator.resources/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Export-Package: org.eclipse.ui.internal.navigator.resources;x-internal:=true,
  org.eclipse.ui.navigator.resources
 Require-Bundle: org.eclipse.ui.ide;bundle-version="[3.15.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.6.0,4.0.0)",
- org.eclipse.jface;bundle-version="[3.18.0,4.0.0)",
+ org.eclipse.jface;bundle-version="[3.31.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.ui.navigator;bundle-version="[3.9.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/navigator/resources/ProjectExplorer.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/navigator/resources/ProjectExplorer.java
@@ -73,6 +73,7 @@ import org.eclipse.ui.model.IWorkbenchAdapter;
 import org.eclipse.ui.navigator.CommonNavigator;
 import org.eclipse.ui.navigator.CommonViewer;
 import org.eclipse.ui.navigator.INavigatorContentService;
+import org.eclipse.ui.views.WorkbenchViewerSetup;
 
 /**
  *
@@ -335,6 +336,7 @@ public final class ProjectExplorer extends CommonNavigator implements ISecondary
 	protected CommonViewer createCommonViewer(Composite aParent) {
 		CommonViewer viewer = super.createCommonViewer(aParent);
 		emptyWorkspaceHelper.setNonEmptyControl(viewer.getControl());
+		WorkbenchViewerSetup.setupViewer(viewer);
 		return viewer;
 	}
 

--- a/bundles/org.eclipse.ui.views/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views/META-INF/MANIFEST.MF
@@ -12,6 +12,6 @@ Export-Package: org.eclipse.ui.internal.views.contentoutline;x-internal:=true,
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.help;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.5.0,4.0.0)",
- org.eclipse.jface;bundle-version="[3.18.0,4.0.0)"
+ org.eclipse.jface;bundle-version="[3.31.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.ui.views

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IWorkbenchPreferenceConstants.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IWorkbenchPreferenceConstants.java
@@ -685,4 +685,17 @@ public interface IWorkbenchPreferenceConstants {
 	 * @since 3.129
 	 */
 	String DISPOSE_CLOSED_BROWSER_HOVER_TIMEOUT = "disposeClosedBrowserHoverTimeout"; //$NON-NLS-1$
+
+	/**
+	 * This preference specifies the limit for number of children that can be shown
+	 * per parent element without expanding.
+	 * <p>
+	 * This preference is an <code>int</code> value that defines how many child
+	 * elements a parent viewer element can show before workbench will create
+	 * "expand" item that hides all remaining child elements.
+	 * </p>
+	 *
+	 * @since 3.130
+	 */
+	String LARGE_VIEW_LIMIT = "largeViewLimit"; //$NON-NLS-1$
 }

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchMessages.java
@@ -730,6 +730,8 @@ public class WorkbenchMessages extends NLS {
 	public static String WorkbenchPreference_recentFilesError;
 	public static String WorkbenchPreference_workbenchSaveInterval;
 	public static String WorkbenchPreference_workbenchSaveIntervalError;
+	public static String WorkbenchPreference_largeViewLimit;
+	public static String WorkbenchPreference_largeViewLimitError;
 	public static String WorkbenchEditorsAction_label;
 	public static String WorkbookEditorsAction_label;
 

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchPreferenceInitializer.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchPreferenceInitializer.java
@@ -126,6 +126,9 @@ public class WorkbenchPreferenceInitializer extends AbstractPreferenceInitialize
 
 		node.putInt(IWorkbenchPreferenceConstants.DISPOSE_CLOSED_BROWSER_HOVER_TIMEOUT, -1);
 
+		// Don't show more than 10.000 child elements per parent by default
+		node.putInt(IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT, 1000);
+
 		node.put(IWorkbenchPreferenceConstants.RESOURCE_RENAME_MODE,
 				IWorkbenchPreferenceConstants.RESOURCE_RENAME_MODE_INLINE);
 

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/WorkbenchPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/WorkbenchPreferencePage.java
@@ -67,6 +67,8 @@ public class WorkbenchPreferencePage extends PreferencePage implements IWorkbenc
 
 	private IntegerFieldEditor saveInterval;
 
+	private IntegerFieldEditor largeViewLimit;
+
 	private boolean openOnSingleClick;
 
 	private boolean selectOnHover;
@@ -78,6 +80,7 @@ public class WorkbenchPreferencePage extends PreferencePage implements IWorkbenc
 	private Button showInlineRenameButton;
 
 	protected static int MAX_SAVE_INTERVAL = 9999;
+	protected static int MAX_VIEW_LIMIT = 1_000_000;
 
 	private boolean renameModeInline;
 
@@ -109,6 +112,7 @@ public class WorkbenchPreferencePage extends PreferencePage implements IWorkbenc
 		createShowUserDialogPref(composite);
 		createStickyCyclePref(composite);
 		createHeapStatusPref(composite);
+		createLargeViewLimitPref(composite);
 	}
 
 	/**
@@ -136,6 +140,41 @@ public class WorkbenchPreferencePage extends PreferencePage implements IWorkbenc
 
 		showHeapStatusButton.setSelection(
 				PrefUtil.getAPIPreferenceStore().getBoolean(IWorkbenchPreferenceConstants.SHOW_MEMORY_MONITOR));
+	}
+
+	/**
+	 * Create the widget for the max number of elements in the view
+	 *
+	 * @param composite
+	 */
+	protected void createLargeViewLimitPref(Composite composite) {
+		Composite groupComposite = new Composite(composite, SWT.LEFT);
+		GridLayout layout = new GridLayout();
+		layout.numColumns = 2;
+		groupComposite.setLayout(layout);
+		GridData gd = new GridData();
+		gd.horizontalAlignment = GridData.FILL;
+		gd.grabExcessHorizontalSpace = true;
+		groupComposite.setLayoutData(gd);
+
+		largeViewLimit = new IntegerFieldEditor(IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT,
+				WorkbenchMessages.WorkbenchPreference_largeViewLimit, groupComposite);
+
+		largeViewLimit.setPreferenceStore(getPreferenceStore());
+		largeViewLimit.setPage(this);
+		largeViewLimit.setTextLimit(7);
+		largeViewLimit.setErrorMessage(
+				NLS.bind(WorkbenchMessages.WorkbenchPreference_largeViewLimitError, Integer.valueOf(MAX_VIEW_LIMIT)));
+		largeViewLimit.setValidateStrategy(StringFieldEditor.VALIDATE_ON_KEY_STROKE);
+		largeViewLimit.setValidRange(0, MAX_VIEW_LIMIT);
+
+		largeViewLimit.load();
+
+		largeViewLimit.setPropertyChangeListener(event -> {
+			if (event.getProperty().equals(FieldEditor.IS_VALID)) {
+				setValid(largeViewLimit.isValid());
+			}
+		});
 	}
 
 	/**
@@ -359,6 +398,7 @@ public class WorkbenchPreferencePage extends PreferencePage implements IWorkbenc
 	protected void performDefaults() {
 		IPreferenceStore store = getPreferenceStore();
 		saveInterval.loadDefault();
+		largeViewLimit.loadDefault();
 		stickyCycleButton.setSelection(store.getBoolean(IPreferenceConstants.STICKY_CYCLE));
 		openOnSingleClick = store.getDefaultBoolean(IPreferenceConstants.OPEN_ON_SINGLE_CLICK);
 		selectOnHover = store.getDefaultBoolean(IPreferenceConstants.SELECT_ON_HOVER);
@@ -395,6 +435,7 @@ public class WorkbenchPreferencePage extends PreferencePage implements IWorkbenc
 		store.setValue(IPreferenceConstants.OPEN_AFTER_DELAY, openAfterDelay);
 		store.setValue(IPreferenceConstants.RUN_IN_BACKGROUND, showUserDialogButton.getSelection());
 		store.setValue(IPreferenceConstants.WORKBENCH_SAVE_INTERVAL, saveInterval.getIntValue());
+		store.setValue(IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT, largeViewLimit.getIntValue());
 
 		String renameModeValue = IWorkbenchPreferenceConstants.RESOURCE_RENAME_MODE_INLINE;
 		if (!renameModeInline) {

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
@@ -711,6 +711,9 @@ WorkbenchPreference_workbenchSaveIntervalError=The workbench save interval shoul
 WorkbenchEditorsAction_label=S&witch to Editor...
 WorkbookEditorsAction_label=&Quick Switch Editor
 
+WorkbenchPreference_largeViewLimit=Default increment for displaying elements in UI:
+WorkbenchPreference_largeViewLimitError=The limit should be an integer between 0 and {0}.
+
 WorkbenchEditorsDialog_title=Switch to Editor
 WorkbenchEditorsDialog_label=Select an &editor to switch to:
 WorkbenchEditorsDialog_closeSelected=&Close Selected Editors

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/views/WorkbenchViewerSetup.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/views/WorkbenchViewerSetup.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Advantest Europe GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov (loskutov@gmx.de) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.views;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.util.IPropertyChangeListener;
+import org.eclipse.jface.util.PropertyChangeEvent;
+import org.eclipse.jface.viewers.ColumnViewer;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.swt.events.DisposeEvent;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.ui.IWorkbenchPreferenceConstants;
+import org.eclipse.ui.internal.WorkbenchPlugin;
+
+/**
+ * @since 3.130
+ */
+public class WorkbenchViewerSetup {
+
+	static Map<DisposeListener, ColumnViewer> registeredViewers = new ConcurrentHashMap<>();
+
+	static final IPropertyChangeListener propertyChangeListener = new IPropertyChangeListener() {
+
+		@Override
+		public void propertyChange(PropertyChangeEvent event) {
+			if (!IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT.equals(event.getProperty())) {
+				return;
+			}
+			int itemsLimit = getItemsLimit();
+			registeredViewers.values().forEach(v -> {
+				v.setDisplayIncrementally(itemsLimit);
+				v.refresh();
+			});
+		}
+	};
+
+	static {
+		getPreferenceStore().addPropertyChangeListener(propertyChangeListener);
+	}
+
+	/**
+	 * Returns the current viewer limit set in the {@code General} preference page.
+	 * Default value is set to {@code 10000}
+	 *
+	 * @return {@link IWorkbenchPreferenceConstants#LARGE_VIEW_LIMIT}
+	 */
+	public static int getItemsLimit() {
+		return getPreferenceStore().getInt(IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT);
+	}
+
+	private static IPreferenceStore getPreferenceStore() {
+		return WorkbenchPlugin.getDefault().getPreferenceStore();
+	}
+
+	/**
+	 * Configure a {@link ColumnViewer} to show limited items per parent before
+	 * showing an ExpandableNode. Limit used is read from preference
+	 * {@link IWorkbenchPreferenceConstants#LARGE_VIEW_LIMIT}. Client must call this
+	 * before {@link Viewer#setInput(Object)}
+	 * <p>
+	 * User can change the viewer limit on preference page any time in the lifetime
+	 * of the viewer. This setup takes care of refreshing the viewer with the new
+	 * limit set.
+	 * </p>
+	 *
+	 * @param viewer {@link ColumnViewer} which has to configured for showing
+	 *               limited items.
+	 */
+	public static void setupViewer(ColumnViewer viewer) {
+		viewer.setDisplayIncrementally(getItemsLimit());
+		Control control = viewer.getControl();
+		if (control != null) {
+			control.addDisposeListener(new DisposeListener(viewer));
+		}
+	}
+
+	private static class DisposeListener implements org.eclipse.swt.events.DisposeListener {
+
+		public DisposeListener(ColumnViewer viewer) {
+			registeredViewers.put(this, viewer);
+		}
+
+		@Override
+		public void widgetDisposed(DisposeEvent e) {
+			registeredViewers.remove(this);
+		}
+
+	}
+}

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.129.100.qualifier
+Bundle-Version: 3.130.0.qualifier
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
@@ -95,7 +95,7 @@ Export-Package: org.eclipse.e4.ui.workbench.addons.perspectiveswitcher;x-interna
  org.eclipse.ui.wizards
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.help;bundle-version="[3.2.0,4.0.0)",
- org.eclipse.jface;bundle-version="[3.18.0,4.0.0)",
+ org.eclipse.jface;bundle-version="[3.31.0,4.0.0)",
  org.eclipse.jface.databinding;bundle-version="[1.3.0,2.0.0)",
  org.eclipse.core.databinding.property;bundle-version="[1.2.0,2.0.0)",
  org.eclipse.core.databinding.observable;bundle-version="[1.2.0,2.0.0)",

--- a/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet068TableViewerWithLimit.java
+++ b/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet068TableViewerWithLimit.java
@@ -1,0 +1,169 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Advantest Europe GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * 				Raghunandana Murthappa
+ *******************************************************************************/
+
+package org.eclipse.jface.snippets.viewers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jface.viewers.IStructuredContentProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableColumn;
+
+/**
+ * Table viewer with limits
+ */
+public class Snippet068TableViewerWithLimit {
+	List<MyModel> model;
+	final TableViewer viewer;
+
+	private SelectionListener listener = new SelectionListener() {
+
+		@Override
+		public void widgetSelected(SelectionEvent e) {
+			String data = (String) e.widget.getData();
+			MyModel element = null;
+			switch (data) {
+			case "refresh":
+				viewer.refresh();
+				break;
+			case "add":
+				element = new MyModel();
+				model.add(element);
+				viewer.add(element);
+				break;
+			case "remove":
+				viewer.remove(model.remove(model.size() - 1));
+				break;
+			case "setSelection":
+				viewer.setSelection(
+						new StructuredSelection(Arrays.asList(model.get(0), "test_Data", model.get(model.size() - 2))));
+			default:
+				break;
+			}
+		}
+
+		@Override
+		public void widgetDefaultSelected(SelectionEvent e) {
+
+		}
+	};
+
+	private static class MyContentProvider implements IStructuredContentProvider {
+
+		@Override
+		public Object[] getElements(Object inputElement) {
+			return ((ArrayList<?>) inputElement).toArray();
+		}
+
+	}
+
+	public static class MyModel {
+		static int counter;
+		int id;
+
+		public MyModel() {
+			this.id = counter++;
+		}
+
+		@Override
+		public String toString() {
+			return "Item " + id;
+		}
+	}
+
+	public Snippet068TableViewerWithLimit(Shell shell) {
+		Composite tableComp = new Composite(shell, SWT.BORDER);
+		tableComp.setLayout(new FillLayout(SWT.VERTICAL));
+		tableComp.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		viewer = new TableViewer(tableComp, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL);
+		viewer.setLabelProvider(new LabelProvider());
+		viewer.setDisplayIncrementally(3);
+		viewer.setContentProvider(new MyContentProvider());
+		createColumn(viewer.getTable(), "column1");
+		model = createModel();
+		viewer.setInput(model);
+		viewer.getTable().setLinesVisible(true);
+
+		Composite buttons = new Composite(shell, SWT.BORDER);
+		buttons.setLayout(new FillLayout(SWT.VERTICAL));
+		buttons.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true));
+
+		Button refresh = new Button(buttons, SWT.PUSH);
+		refresh.setData("refresh");
+		refresh.setText("refresh");
+		refresh.addSelectionListener(listener);
+
+		Button add = new Button(buttons, SWT.PUSH);
+		add.setText("add");
+		add.setData("add");
+		add.addSelectionListener(listener);
+
+		Button remove = new Button(buttons, SWT.PUSH);
+		remove.setText("remove");
+		remove.setData("remove");
+		remove.addSelectionListener(listener);
+
+		Button setSel = new Button(buttons, SWT.PUSH);
+		setSel.setText("setSelection");
+		setSel.setData("setSelection");
+		setSel.addSelectionListener(listener);
+	}
+
+	public void createColumn(Table tb, String text) {
+		TableColumn column = new TableColumn(tb, SWT.NONE);
+		column.setWidth(100);
+		column.setText(text);
+		tb.setHeaderVisible(true);
+	}
+
+	private List<MyModel> createModel() {
+		List<MyModel> model = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			model.add(new MyModel());
+		}
+		return model;
+	}
+
+	public static void main(String[] args) {
+		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setLayout(new GridLayout(2, false));
+		new Snippet068TableViewerWithLimit(shell);
+		shell.open();
+
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch())
+				display.sleep();
+		}
+
+		display.dispose();
+
+	}
+
+}

--- a/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet069TreeViewerWithLimit.java
+++ b/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet069TreeViewerWithLimit.java
@@ -1,0 +1,300 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Advantest Europe GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * 				Raghunandana Murthappa
+ *******************************************************************************/
+
+package org.eclipse.jface.snippets.viewers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.TreeSelection;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swt.widgets.TreeColumn;
+
+/**
+ * A simple TreeViewer to demonstrate the usage of limits
+ */
+
+public class Snippet069TreeViewerWithLimit {
+
+	final TreeViewer viewer;
+	MyModel root;
+	private Object curSel;
+
+	private SelectionListener listener = new SelectionListener() {
+
+		@Override
+		public void widgetSelected(SelectionEvent e) {
+			String data = (String) e.widget.getData();
+			switch (data) {
+			case "refresh":
+				if (curSel instanceof MyModel current) {
+					viewer.refresh(current, false);
+				} else {
+					viewer.refresh();
+				}
+				break;
+			case "add":
+				if (curSel instanceof MyModel) {
+					MyModel current = (MyModel) curSel;
+					MyModel eleToAdd = new MyModel(current, 100);
+					current.addChild(eleToAdd);
+					viewer.add(curSel, eleToAdd);
+				}
+				break;
+			case "remove":
+				if (curSel instanceof MyModel current) {
+					current.getParent().getChildren().remove(current);
+					viewer.remove(current);
+				}
+				break;
+			case "setSelection":
+				IStructuredSelection sel = new StructuredSelection(
+						root.getChildren().get(2).getChildren().get(7).getChildren().get(7));
+				viewer.setSelection(sel, true);
+				break;
+			case "expandAll":
+				viewer.expandAll();
+				break;
+			case "expandToLevel":
+				if (curSel instanceof MyModel) {
+					viewer.expandToLevel(curSel, 2, false);
+				}
+				break;
+			case "collapseAll":
+				if (curSel instanceof MyModel) {
+					viewer.collapseAll();
+				}
+				break;
+			case "collapseToLevel":
+				if (curSel instanceof MyModel) {
+					viewer.collapseToLevel(curSel, 3);
+				}
+				break;
+			default:
+				break;
+			}
+		}
+
+		@Override
+		public void widgetDefaultSelected(SelectionEvent e) {
+
+		}
+	};
+
+	private static class MyContentProvider implements ITreeContentProvider {
+
+		@Override
+		public Object[] getElements(Object inputElement) {
+			return ((MyModel) inputElement).children.toArray();
+		}
+
+		@Override
+		public Object[] getChildren(Object parentElement) {
+			if (!(parentElement instanceof MyModel)) {
+				return null;
+			}
+			return getElements(parentElement);
+		}
+
+		@Override
+		public Object getParent(Object element) {
+			if (!(element instanceof MyModel)) {
+				return null;
+			}
+
+			return ((MyModel) element).parent;
+		}
+
+		@Override
+		public boolean hasChildren(Object element) {
+			if (!(element instanceof MyModel)) {
+				return false;
+			}
+			MyModel myModel = (MyModel) element;
+			return myModel.children.size() > 0;
+		}
+
+	}
+
+	public static class MyModel {
+		private MyModel parent;
+
+		public MyModel getParent() {
+			return parent;
+		}
+
+		private List<MyModel> children = new ArrayList<>();
+
+		public List<MyModel> getChildren() {
+			return children;
+		}
+
+		static int counter;
+		int id;
+
+		public MyModel(MyModel parent, int id) {
+			this.parent = parent;
+			this.id = id;
+		}
+
+		@Override
+		public String toString() {
+			String rv = "Item ";
+			if (parent != null) {
+				rv = parent + ".";
+			}
+
+			rv += id;
+
+			return rv;
+		}
+
+		public boolean removeChild(MyModel child) {
+			return children.remove(child);
+		}
+
+		public boolean addChild(MyModel child) {
+			return children.add(child);
+		}
+	}
+
+	public Snippet069TreeViewerWithLimit(Shell shell) {
+		Composite tableComp = new Composite(shell, SWT.BORDER);
+		tableComp.setLayout(new FillLayout(SWT.VERTICAL));
+		tableComp.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		viewer = new TreeViewer(tableComp, SWT.MULTI);
+		viewer.setLabelProvider(new LabelProvider());
+		viewer.setDisplayIncrementally(3);
+		viewer.setContentProvider(new MyContentProvider());
+		createColumn(viewer.getTree(), "Column1");
+		createColumn(viewer.getTree(), "Column2");
+		root = createModel();
+		viewer.setInput(root);
+
+		viewer.addSelectionChangedListener(new ISelectionChangedListener() {
+
+			@Override
+			public void selectionChanged(SelectionChangedEvent event) {
+				if (event.getSelection() instanceof TreeSelection) {
+					curSel = ((TreeSelection) event.getSelection()).getFirstElement();
+				}
+			}
+		});
+
+		Composite buttons = new Composite(shell, SWT.BORDER);
+		buttons.setLayout(new FillLayout(SWT.VERTICAL));
+		buttons.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true));
+
+		Button refresh = new Button(buttons, SWT.PUSH);
+		refresh.setData("refresh");
+		refresh.setText("refresh");
+		refresh.addSelectionListener(listener);
+
+		Button add = new Button(buttons, SWT.PUSH);
+		add.setText("add");
+		add.setData("add");
+		add.addSelectionListener(listener);
+
+		Button remove = new Button(buttons, SWT.PUSH);
+		remove.setText("remove");
+		remove.setData("remove");
+		remove.addSelectionListener(listener);
+
+		Button setSel = new Button(buttons, SWT.PUSH);
+		setSel.setText("setSelection");
+		setSel.setData("setSelection");
+		setSel.addSelectionListener(listener);
+
+		Button expAll = new Button(buttons, SWT.PUSH);
+		expAll.setText("expandAll");
+		expAll.setData("expandAll");
+		expAll.addSelectionListener(listener);
+
+		Button expandToLevel = new Button(buttons, SWT.PUSH);
+		expandToLevel.setText("expandToLevel");
+		expandToLevel.setData("expandToLevel");
+		expandToLevel.addSelectionListener(listener);
+
+		Button collapseAll = new Button(buttons, SWT.PUSH);
+		collapseAll.setText("collapseAll");
+		collapseAll.setData("collapseAll");
+		collapseAll.addSelectionListener(listener);
+
+		Button collapseToLevel = new Button(buttons, SWT.PUSH);
+		collapseToLevel.setText("collapseToLevel");
+		collapseToLevel.setData("collapseToLevel");
+		collapseToLevel.addSelectionListener(listener);
+
+	}
+
+	public void createColumn(Tree tr, String text) {
+		TreeColumn column = new TreeColumn(tr, SWT.NONE);
+		column.setWidth(200);
+		column.setText(text);
+		tr.setHeaderVisible(true);
+	}
+
+	private MyModel createModel() {
+
+		MyModel root = new MyModel(null, 0);
+
+		for (int i = 0; i < 15; i++) {
+			MyModel l1 = new MyModel(root, i);
+			root.addChild(l1);
+			for (int j = 0; j < 10; j++) {
+				MyModel l2 = new MyModel(l1, j);
+				l1.addChild(l2);
+				for (int j2 = 0; j2 < 10; j2++) {
+					MyModel l3 = new MyModel(l2, j2);
+					l2.addChild(l3);
+
+				}
+			}
+		}
+
+		return root;
+	}
+
+	public static void main(String[] args) {
+		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setLayout(new GridLayout(2, false));
+		new Snippet069TreeViewerWithLimit(shell);
+		shell.open();
+
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch())
+				display.sleep();
+		}
+
+		display.dispose();
+	}
+}

--- a/examples/org.eclipse.jface.snippets/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.jface.snippets/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JFace Snippets Plug-in
 Bundle-SymbolicName: org.eclipse.jface.snippets
-Bundle-Version: 3.6.0.qualifier
+Bundle-Version: 3.6.100.qualifier
 Bundle-Vendor: Eclipse.org
-Require-Bundle: org.eclipse.jface;bundle-version="[3.18.0,4.0.0)",
+Require-Bundle: org.eclipse.jface;bundle-version="[3.31.0,4.0.0)",
  org.eclipse.jface.databinding,
  org.eclipse.core.runtime,
  org.eclipse.core.databinding,

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/AbstractTreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/AbstractTreeViewerTest.java
@@ -310,6 +310,26 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 		assertEquals("Same element added to parent twice.", 3, tree.getItems().length);
 	}
 
+	public void testContains() {
+		// some random element.
+		assertFalse("element must not be available on the viewer", fTreeViewer.contains(fRootElement, ""));
+
+		// first child of root.
+		assertTrue("element must be available on the viewer",
+				fTreeViewer.contains(fRootElement, fRootElement.getFirstChild()));
+
+		// last child of the root
+		assertTrue("element must be available on the viewer",
+				fTreeViewer.contains(fRootElement, fRootElement.getLastChild()));
+		// child of first element is not expanded
+		assertFalse("element must not be available on the viewer",
+				fTreeViewer.contains(fRootElement.getFirstChild(), fRootElement.getFirstChild().getFirstChild()));
+		fTreeViewer.expandAll();
+		// child of first element when expanded.
+		assertTrue("element must be available on the viewer",
+				fTreeViewer.contains(fRootElement.getFirstChild(), fRootElement.getFirstChild().getFirstChild()));
+	}
+
 	@Override
 	public void tearDown() {
 		super.tearDown();

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/AllViewersTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/AllViewersTests.java
@@ -30,7 +30,9 @@ import org.junit.runners.Suite;
 		ListViewerRefreshTest.class, Bug200558Test.class, Bug201002TableViewerTest.class, Bug201002TreeViewerTest.class,
 		Bug200337TableViewerTest.class, Bug203657TreeViewerTest.class, Bug203657TableViewerTest.class,
 		Bug205700TreeViewerTest.class, Bug180504TableViewerTest.class, Bug180504TreeViewerTest.class,
-		Bug256889TableViewerTest.class, Bug287765Test.class, Bug242231Test.class, StyledStringBuilderTest.class })
+		Bug256889TableViewerTest.class, Bug287765Test.class, Bug242231Test.class, StyledStringBuilderTest.class,
+		TreeViewerWithLimitTest.class, TreeViewerWithLimitCompatibilityTest.class, TableViewerWithLimitTest.class,
+		TableViewerWithLimitCompatibilityTest.class })
 public class AllViewersTests {
 
 	public static void main(String[] args) {

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/BaseLimitBasedViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/BaseLimitBasedViewerTest.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Advantest Europe GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * 				Raghunandana Murthappa
+ *******************************************************************************/
+
+package org.eclipse.jface.tests.viewers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerComparator;
+import org.eclipse.jface.viewers.ViewerFilter;
+import org.eclipse.swt.widgets.Composite;
+
+public class BaseLimitBasedViewerTest extends ViewerTestCase {
+
+	List<DataModel> rootModel;
+	protected static final int VIEWER_LIMIT = 4;
+
+	public BaseLimitBasedViewerTest(String name) {
+		super(name);
+	}
+
+	@Override
+	protected StructuredViewer createViewer(Composite parent) {
+		return null;
+	}
+
+	protected static List<DataModel> createModel() {
+		List<DataModel> rootModel = new ArrayList<>();
+		for (int i = 0; i < 40; i++) {
+			if (i % 2 == 0) {
+				DataModel rootLevel = new DataModel(Integer.valueOf(i));
+				for (int j = 0; j < 40; j++) {
+					if (j % 2 == 0) {
+						DataModel level1 = new DataModel(Integer.valueOf(j));
+						level1.parent = rootLevel;
+						for (int k = 0; k < 40; k++) {
+							if (k % 2 == 0) {
+								DataModel level2 = new DataModel(Integer.valueOf(k));
+								level2.parent = level1;
+								level1.addChild(level2);
+							}
+
+						}
+						rootLevel.addChild(level1);
+					}
+
+				}
+				rootModel.add(rootLevel);
+			}
+		}
+		return rootModel;
+	}
+
+	protected static class DataModel {
+		public Integer id;
+		public List<DataModel> children;
+		public DataModel parent;
+
+		public DataModel(Integer id) {
+			this.id = id;
+			children = new ArrayList<>();
+		}
+
+		public void addChild(DataModel child) {
+			children.add(child);
+		}
+
+		@Override
+		public String toString() {
+			return "Item " + id;
+		}
+	}
+
+	protected static class TestComparator extends ViewerComparator {
+		@Override
+		public int compare(Viewer viewer, Object e1, Object e2) {
+			if (e1 instanceof DataModel mod1 && e2 instanceof DataModel mod2) {
+				return mod1.id.compareTo(mod2.id);
+			}
+			return super.compare(viewer, e1, e2);
+		}
+	}
+
+	public static class TestViewerFilter extends ViewerFilter {
+		@Override
+		public boolean select(Viewer viewer, Object parent, Object element) {
+			return ((DataModel) element).id.intValue() > 10;
+		}
+	}
+
+}

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerTest.java
@@ -191,4 +191,16 @@ public class TableViewerTest extends StructuredItemViewerTest {
 
 	}
 
+	public void testContains() {
+		TableViewer tViewer = (TableViewer) fViewer;
+		// some random element.
+		assertFalse("element must not be available on the viewer", tViewer.contains(""));
+
+		// first child of root.
+		assertTrue("element must be available on the viewer", tViewer.contains(fRootElement.getFirstChild()));
+
+		// last child of the root
+		assertTrue("element must be available on the viewer", tViewer.contains(fRootElement.getLastChild()));
+	}
+
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerWithLimitCompatibilityTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerWithLimitCompatibilityTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Advantest Europe GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * 				Raghunandana Murthappa
+ *******************************************************************************/
+
+package org.eclipse.jface.tests.viewers;
+
+import org.eclipse.jface.viewers.ColumnViewer;
+import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.swt.widgets.Composite;
+
+public class TableViewerWithLimitCompatibilityTest extends TableViewerTest {
+
+	public TableViewerWithLimitCompatibilityTest(String name) {
+		super(name);
+	}
+
+	@Override
+	protected StructuredViewer createViewer(Composite parent) {
+		ColumnViewer viewer = (ColumnViewer) super.createViewer(parent);
+		viewer.setDisplayIncrementally(Integer.MAX_VALUE);
+		return viewer;
+	}
+
+	public static void main(String args[]) {
+		junit.textui.TestRunner.run(TableViewerWithLimitCompatibilityTest.class);
+	}
+}

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerWithLimitTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerWithLimitTest.java
@@ -1,0 +1,326 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Advantest Europe GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * 				Raghunandana Murthappa
+ *******************************************************************************/
+
+package org.eclipse.jface.tests.viewers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredContentProvider;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Item;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableItem;
+
+public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
+
+	public TableViewerWithLimitTest(String name) {
+		super(name);
+	}
+
+	TestTableViewer tableViewer;
+
+	public void testLimitedItemsCreatedWithExpansionNode() {
+		Table table = tableViewer.getTable();
+		TableItem[] items = table.getItems();
+		assertLimitedItems(items);
+	}
+
+	public void testAddElement() {
+		Table table = tableViewer.getTable();
+		assertLimitedItems(table.getItems());
+		DataModel data = (DataModel) table.getItems()[2].getData();
+		assertEquals("wrong item is found at given location", Integer.valueOf(4), data.id);
+
+		// this element must be visible
+		DataModel newEle = new DataModel(Integer.valueOf(3));
+		rootModel.add(newEle);
+		tableViewer.add(newEle);
+		processEvents();
+		// check items and label after addition.
+		assertLimitedItems(table.getItems());
+		data = (DataModel) table.getItems()[2].getData();
+		assertEquals("wrong item is found at given location", Integer.valueOf(3), data.id);
+
+		// this element must not be visible only expandable node label must be updated.
+		DataModel newEle1 = new DataModel(Integer.valueOf(9));
+		rootModel.add(newEle1);
+		tableViewer.add(newEle1);
+		processEvents();
+		// check items and label after addition.
+		assertLimitedItems(table.getItems());
+		data = (DataModel) table.getItems()[2].getData();
+		assertEquals("wrong item is found at given location", Integer.valueOf(3), data.id);
+	}
+
+	public void testRemoveElement() {
+		Table table = tableViewer.getTable();
+		assertLimitedItems(table.getItems());
+		DataModel data = (DataModel) table.getItems()[2].getData();
+		assertEquals("wrong item is found at given location", Integer.valueOf(4), data.id);
+
+		// this element must be visible
+		DataModel removed = rootModel.remove(2);
+		tableViewer.remove(removed);
+		processEvents();
+		// check items and label after addition.
+		assertLimitedItems(table.getItems());
+		data = (DataModel) table.getItems()[2].getData();
+		assertEquals("wrong item is found at given location", Integer.valueOf(6), data.id);
+
+		// this element must not be visible only expandable node label must be updated.
+		DataModel removed1 = rootModel.remove(7);
+		tableViewer.remove(removed1);
+		processEvents();
+		// check items and label after addition.
+		assertLimitedItems(table.getItems());
+		data = (DataModel) table.getItems()[2].getData();
+		assertEquals("wrong item is found at given location", Integer.valueOf(6), data.id);
+	}
+
+	public void testClickExpandableNode() {
+		Table table = tableViewer.getTable();
+		assertLimitedItems(table.getItems());
+		TableItem lastItem = table.getItems()[table.getItems().length - 1];
+		clickTableItem(table, lastItem);
+		processEvents();
+		Item[] itemsBefore = table.getItems();
+		assertEquals("There are more/less items rendered than viewer limit", VIEWER_LIMIT * 2 + 1, itemsBefore.length);
+		Item item = itemsBefore[itemsBefore.length - 1];
+		assertTrue("Last node must be an Expandable Node", tableViewer.isExpandableNode(item.getData()));
+
+		String expected = JFaceResources.format("ExpandableNode.defaultLabel", Integer.valueOf(VIEWER_LIMIT * 2 + 1),
+				Integer.valueOf(VIEWER_LIMIT * 3), Integer.valueOf(rootModel.size()));
+		assertEquals("Expandable node has an incorrect text", expected, item.getText());
+
+		// click until all expandable nodes are expanded.
+		clickUntilAllExpandableNodes(table);
+
+		// all the elements of the model should be visible
+		Item[] itemsAfterExp = table.getItems();
+		assertEquals("There are more/less items rendered than viewer limit", rootModel.size(), itemsAfterExp.length);
+		assertEquals("Last node must be an DataModel after all the elements expanded",
+				itemsAfterExp[itemsAfterExp.length - 1].getData().getClass(), DataModel.class);
+	}
+
+	public void testApplyFilter() {
+		Table table = tableViewer.getTable();
+		clickUntilAllExpandableNodes(table);
+
+		// all the elements of the model should be visible
+		assertEquals("There are more/less items rendered than viewer limit", rootModel.size(), table.getItems().length);
+		DataModel data = (DataModel) table.getItems()[2].getData();
+		assertEquals("wrong item is found at given location", Integer.valueOf(4), data.id);
+
+		tableViewer.setFilters(new TestViewerFilter());
+		processEvents();
+
+		clickUntilAllExpandableNodes(table);
+
+		// only filtered items are visible
+		assertEquals("There are more/less items rendered than viewer limit", 14, table.getItems().length);
+		data = (DataModel) table.getItems()[2].getData();
+		assertEquals("wrong item is found at given location", Integer.valueOf(16), data.id);
+	}
+
+	private void clickUntilAllExpandableNodes(Table table) {
+		TableItem lastItem = table.getItems()[table.getItems().length - 1];
+		processEvents();
+		while (tableViewer.isExpandableNode(lastItem.getData())) {
+			clickTableItem(table, lastItem);
+			processEvents();
+			lastItem = table.getItems()[table.getItems().length - 1];
+		}
+		processEvents();
+	}
+
+	public void testResetComparator() {
+		Table table = tableViewer.getTable();
+		// add an element at the end of the model. comparator will add it to right
+		// location
+		DataModel newEle1 = new DataModel(Integer.valueOf(3));
+		rootModel.add(newEle1);
+		tableViewer.add(newEle1);
+		processEvents();
+		DataModel data = (DataModel) table.getItems()[2].getData();
+		assertEquals("wrong item is found at given location", Integer.valueOf(3), data.id);
+		// reset comparator
+		tableViewer.setComparator(null);
+		processEvents();
+		data = (DataModel) table.getItems()[2].getData();
+		assertEquals("wrong item is found at given location", Integer.valueOf(4), data.id);
+	}
+
+	public void testSelection() {
+		// select an element which is not visible
+		DataModel toSelect = rootModel.get(rootModel.size() - VIEWER_LIMIT);
+		tableViewer.setSelection(new StructuredSelection(toSelect));
+		processEvents();
+		ISelection selection = tableViewer.getSelection();
+		assertTrue("Selection must not be empty", selection instanceof IStructuredSelection);
+		Object selEle = ((IStructuredSelection) selection).getFirstElement();
+		assertTrue("Selection must be ExpandableNode", tableViewer.isExpandableNode(selEle));
+
+		// select an element which is visible
+		toSelect = rootModel.get(VIEWER_LIMIT / 2);
+		tableViewer.setSelection(new StructuredSelection(toSelect));
+		processEvents();
+		selection = tableViewer.getSelection();
+		assertTrue("Selection must not be empty", selection instanceof IStructuredSelection);
+		selEle = ((IStructuredSelection) selection).getFirstElement();
+		assertEquals("selection must be desired element which is visible", toSelect, selEle);
+
+		// select something not present in model.
+		tableViewer.setSelection(new StructuredSelection("dummy"));
+		processEvents();
+		selection = tableViewer.getSelection();
+		assertTrue("Selection must not be empty", selection.isEmpty());
+	}
+
+	public void testRefresh() {
+		Table table = tableViewer.getTable();
+		assertLimitedItems(table.getItems());
+		assertEquals("third element must be third element of the input", rootModel.get(2), table.getItem(2).getData());
+		DataModel ele1 = new DataModel(Integer.valueOf(100));
+		rootModel.add(ele1);
+		tableViewer.add(ele1);
+		processEvents();
+		assertLimitedItems(table.getItems());
+		assertEquals("third element must be third element of the input", rootModel.get(2), table.getItem(2).getData());
+		DataModel newEle = new DataModel(Integer.valueOf(3));
+		rootModel.add(newEle);
+		tableViewer.add(newEle);
+		processEvents();
+		assertLimitedItems(table.getItems());
+		assertEquals("third element must be newly added element", newEle, table.getItem(2).getData());
+	}
+
+	private void assertLimitedItems(TableItem[] itemsBefore) {
+		assertEquals("There are more/less items rendered than viewer limit", VIEWER_LIMIT + 1, itemsBefore.length);
+		TableItem tableItem = itemsBefore[itemsBefore.length - 1];
+		assertTrue("Last node must be an Expandable Node", tableViewer.isExpandableNode(tableItem.getData()));
+
+		String expectedLabel = JFaceResources.format("ExpandableNode.defaultLabel", Integer.valueOf(VIEWER_LIMIT + 1),
+				Integer.valueOf(VIEWER_LIMIT + VIEWER_LIMIT), Integer.valueOf(rootModel.size()));
+		assertEquals("Expandable node has an incorrect text", expectedLabel, tableItem.getText());
+	}
+
+	public void testSetInput() {
+		List<DataModel> rootModel = new ArrayList<>();
+		DataModel rootLevel = new DataModel(Integer.valueOf(100));
+		rootModel.add(rootLevel);
+		tableViewer.setInput(rootModel);
+		processEvents();
+		assertEquals("there must be only one item", 1, tableViewer.getTable().getItems().length);
+		tableViewer.setInput(createModel());
+		processEvents();
+		assertLimitedItems(tableViewer.getTable().getItems());
+	}
+
+	public void testBoundaryConditions() {
+		List<DataModel> dummy = new ArrayList<>();
+		dummy.add(new DataModel(Integer.valueOf(100)));
+		tableViewer.setInput(dummy);
+		int numOfEle = 7;
+		int limit = 2;
+		tableViewer.setDisplayIncrementally(limit);
+		processEvents();
+		List<DataModel> newInput = new ArrayList<>();
+		for (int i = 0; i < numOfEle; i++) {
+			DataModel rootLevel = new DataModel(Integer.valueOf(i));
+			newInput.add(rootLevel);
+		}
+		tableViewer.setInput(newInput);
+		processEvents();
+		assertEquals("visible items length should be " + (limit + 1), limit + 1,
+				tableViewer.getTable().getItems().length);
+
+		tableViewer.setDisplayIncrementally(limit = 4);
+		tableViewer.refresh();
+		processEvents();
+		assertEquals("visible items length should be " + (limit + 1), limit + 1,
+				tableViewer.getTable().getItems().length);
+
+		tableViewer.setDisplayIncrementally(limit = 6);
+		tableViewer.refresh();
+		processEvents();
+		assertEquals("visible items length should be " + (limit + 1), limit + 1,
+				tableViewer.getTable().getItems().length);
+
+		tableViewer.setDisplayIncrementally(limit = 8);
+		tableViewer.refresh();
+		processEvents();
+		assertEquals("visible items length should be " + newInput.size(), newInput.size(),
+				tableViewer.getTable().getItems().length);
+
+	}
+
+	private static class TestContentProvider implements IStructuredContentProvider {
+		@Override
+		public Object[] getElements(Object inputElement) {
+			return ((ArrayList<?>) inputElement).toArray();
+		}
+	}
+
+	@Override
+	protected StructuredViewer createViewer(Composite parent) {
+		tableViewer = new TestTableViewer(parent);
+		tableViewer.setDisplayIncrementally(VIEWER_LIMIT);
+		tableViewer.setLabelProvider(new LabelProvider());
+		tableViewer.setContentProvider(new TestContentProvider());
+		tableViewer.setComparator(new TestComparator());
+		return tableViewer;
+	}
+
+	@Override
+	protected void setInput() {
+		rootModel = createModel();
+		fViewer.setInput(rootModel);
+	}
+
+	public static void main(String args[]) {
+		junit.textui.TestRunner.run(TableViewerWithLimitTest.class);
+	}
+
+	private static void clickTableItem(Control viewerControl, TableItem item) {
+		Rectangle bounds = item.getBounds();
+		Event event = new Event();
+		event.x = bounds.x + 5;
+		event.y = bounds.y + 5;
+		viewerControl.notifyListeners(SWT.MouseDown, event);
+	}
+
+	class TestTableViewer extends TableViewer {
+		public TestTableViewer(Composite parent) {
+			super(parent);
+		}
+
+		@Override
+		public boolean isExpandableNode(Object element) {
+			return super.isExpandableNode(element);
+		}
+	}
+
+}

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerWithLimitTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerWithLimitTest.java
@@ -277,6 +277,19 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 
 	}
 
+	public void testContains() {
+		// some random element.
+		assertFalse("element must not be available on the viewer", tableViewer.contains(""));
+
+		// first child of root.
+		assertTrue("element must be available on the viewer", tableViewer.contains(rootModel.get(0)));
+
+		// last child of the root. It should be true even if it shows limited items.
+		assertTrue("element must be available on the viewer",
+				tableViewer.contains(rootModel.get(rootModel.size() - 1)));
+
+	}
+
 	private static class TestContentProvider implements IStructuredContentProvider {
 		@Override
 		public Object[] getElements(Object inputElement) {

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitCompatibilityTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitCompatibilityTest.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Advantest Europe GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * 				Raghunandana Murthappa
+ *******************************************************************************/
+
+package org.eclipse.jface.tests.viewers;
+
+import org.eclipse.jface.viewers.ColumnViewer;
+import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.swt.widgets.Composite;
+
+public class TreeViewerWithLimitCompatibilityTest extends TreeViewerTest {
+
+	public TreeViewerWithLimitCompatibilityTest(String name) {
+		super(name);
+	}
+
+	@Override
+	protected StructuredViewer createViewer(Composite parent) {
+		ColumnViewer viewer = (ColumnViewer) super.createViewer(parent);
+		// set higher limit than number of items in the input.
+		// this should not break any existing tests.
+		viewer.setDisplayIncrementally(Integer.MAX_VALUE);
+		return viewer;
+	}
+
+	public static void main(String args[]) {
+		junit.textui.TestRunner.run(TreeViewerWithLimitCompatibilityTest.class);
+	}
+
+}

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitTest.java
@@ -248,6 +248,25 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertLimitedItems();
 	}
 
+	public void testContains() {
+		// some random element.
+		assertFalse("element must not be available on the viewer", treeViewer.contains(fRootElement, ""));
+
+		// first child of root.
+		assertTrue("element must be available on the viewer", treeViewer.contains(rootModel, rootModel.get(0)));
+
+		// last child of the root
+		assertTrue("element must be available on the viewer",
+				treeViewer.contains(rootModel, rootModel.get(rootModel.size() - 1)));
+		// child of first element is not expanded
+		assertFalse("element must not be available on the viewer",
+				treeViewer.contains(rootModel, rootModel.get(0).children.get(0)));
+		treeViewer.expandAll();
+		// child of first element when expanded.
+		assertTrue("element must be available on the viewer",
+				treeViewer.contains(rootModel, rootModel.get(0).children.get(0)));
+	}
+
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
 		treeViewer = new TestTreeViewer(parent);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitTest.java
@@ -1,0 +1,318 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Advantest Europe GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * 				Raghunandana Murthappa
+ *******************************************************************************/
+
+package org.eclipse.jface.tests.viewers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.internal.ExpandableNode;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.TreeItem;
+
+public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
+
+	private TestTreeViewer treeViewer;
+
+	public TreeViewerWithLimitTest(String name) {
+		super(name);
+	}
+
+	public void testSetSelection() {
+		DataModel firstEle = rootModel.get(0);
+		assertSetSelection(firstEle);
+
+		DataModel invisible = rootModel.get(rootModel.size() - VIEWER_LIMIT);
+		assertSetSelectionExpNode(invisible);
+	}
+
+	private void assertSetSelectionExpNode(DataModel invisible) {
+		treeViewer.setSelection(new StructuredSelection(invisible), true);
+		processEvents();
+		IStructuredSelection selection = treeViewer.getStructuredSelection();
+		assertFalse("Selection must not be empty", selection.isEmpty());
+		Object firstElement = selection.getFirstElement();
+		assertTrue("Selection must be expandable node: " + firstElement, treeViewer.isExpandableNode(firstElement));
+	}
+
+	private void assertSetSelection(DataModel firstEle) {
+		treeViewer.setSelection(new StructuredSelection(firstEle));
+		processEvents();
+		IStructuredSelection selection = treeViewer.getStructuredSelection();
+		assertFalse("Selection must not be empty", selection.isEmpty());
+		assertEquals("incorrect element is selected", firstEle, selection.getFirstElement());
+	}
+
+	public void testReveal() throws Exception {
+		DataModel firstEle = rootModel.get(0);
+		DataModel toReveal = firstEle.children.get(2).children.get(2);
+		treeViewer.reveal(toReveal);
+		// selection works if the element was revealed. selection don't try to create
+		// item but reveal does.
+		assertSetSelection(toReveal);
+
+		// now try to reveal non expanded item. it should not reveal anything because in
+		// case of limit based tree we don't create an item if it hidden.
+		DataModel inVisible = firstEle.children.get(2).children.get(VIEWER_LIMIT + 2);
+		assertSetSelectionExpNode(inVisible);
+		ExpandableNode selected = (ExpandableNode) treeViewer.getStructuredSelection().getFirstElement();
+		Object[] remaining = selected.getRemainingElements();
+		boolean found = false;
+		for (Object object : remaining) {
+			if (object == inVisible) {
+				found = true;
+				break;
+			}
+		}
+		assertTrue("item to select must be inside expandable node", found);
+	}
+
+	public void testCollapseAll() {
+		treeViewer.expandAll();
+		processEvents();
+		DataModel l2ThirdEle = rootModel.get(0).children.get(2).children.get(2);
+		assertSetSelection(l2ThirdEle);
+
+		treeViewer.collapseAll();
+		processEvents();
+		TreeItem[] items = assertLimitedItems();
+		for (int i = 0; i < VIEWER_LIMIT; i++) {
+			TreeItem treeItem = items[i];
+			assertFalse("expansion must be false", treeItem.getExpanded());
+		}
+	}
+
+	public void testCollapseToLevel() {
+	}
+
+	public void testExpandAll() {
+		treeViewer.expandAll();
+		processEvents();
+		TreeItem[] rootLevelItems = assertLimitedItems();
+		for (int i = 0; i < VIEWER_LIMIT; i++) {
+			TreeItem[] items = assertLimitedItems(rootLevelItems[i]);
+			for (int j = 0; j < VIEWER_LIMIT; j++) {
+				TreeItem treeItem2 = items[j];
+				assertLimitedItems(treeItem2);
+			}
+		}
+	}
+
+	private TreeItem[] assertLimitedItems(TreeItem treeItem) {
+		TreeItem[] items = treeItem.getItems();
+		assertEquals("There should be only limited items", VIEWER_LIMIT + 1, items.length);
+		Object data = items[VIEWER_LIMIT].getData();
+		assertTrue("last item must be expandable node", treeViewer.isExpandableNode(data));
+		return items;
+	}
+
+	private TreeItem[] assertLimitedItems() {
+		TreeItem[] rootLevelItems = treeViewer.getTree().getItems();
+		assertEquals("There should be only limited items", VIEWER_LIMIT + 1, rootLevelItems.length);
+		Object data = rootLevelItems[VIEWER_LIMIT].getData();
+		assertTrue("last item must be expandable node", treeViewer.isExpandableNode(data));
+		return rootLevelItems;
+	}
+
+	public void testExpandToLevelInt() {
+		treeViewer.expandToLevel(2, true);
+		processEvents();
+		TreeItem[] rootLevelItems = assertLimitedItems();
+		for (int i = 0; i < VIEWER_LIMIT; i++) {
+			TreeItem[] items = assertLimitedItems(rootLevelItems[i]);
+			for (int j = 0; j < VIEWER_LIMIT; j++) {
+				assertDummyItem(items[j]);
+			}
+		}
+	}
+
+	private static void assertDummyItem(TreeItem treeItem) {
+		TreeItem[] items = treeItem.getItems();
+		assertEquals("Item must not be expanded", 1, items.length);
+		assertNull("Dummy tree item data must be null", items[0].getData());
+	}
+
+	public void testExpandToLevelObjectInt() {
+		DataModel firstEle = rootModel.get(0);
+		treeViewer.expandToLevel(firstEle, 3, true);
+		processEvents();
+		TreeItem[] topLevelItems = assertLimitedItems();
+		TreeItem firstItem = topLevelItems[0];
+		TreeItem[] children = assertLimitedItems(firstItem);
+		for (int i = 1; i < VIEWER_LIMIT; i++) {
+			assertLimitedItems(children[i]);
+		}
+		// no other items are expanded
+		for (int i = 1; i < VIEWER_LIMIT; i++) {
+			assertDummyItem(topLevelItems[i]);
+		}
+	}
+
+	public void testRemoveItemsAtParent() {
+		treeViewer.expandAll();
+		processEvents();
+		DataModel firstEle = rootModel.get(0);
+		DataModel thirdOfFirst = firstEle.children.get(2).children.remove(2);
+		TreeItem visItem = treeViewer.getTree().getItem(0).getItem(2).getItem(2);
+		assertEquals("element contains unexpected data", thirdOfFirst, visItem.getData());
+		treeViewer.remove(firstEle, new Object[] { thirdOfFirst });
+		processEvents();
+		thirdOfFirst = firstEle.children.get(2).children.get(2);
+		visItem = treeViewer.getTree().getItem(0).getItem(2).getItem(2);
+		assertEquals("element contains unexpected data", thirdOfFirst, visItem.getData());
+	}
+
+	public void testRemoveItem() {
+		DataModel firstEle = rootModel.remove(0);
+		TreeItem firstItem = treeViewer.getTree().getItem(0);
+		assertEquals("element contains unexpected data", firstEle, firstItem.getData());
+		treeViewer.remove(firstEle);
+		firstEle = rootModel.get(0);
+		firstItem = treeViewer.getTree().getItem(0);
+		assertEquals("element contains unexpected data", firstEle, firstItem.getData());
+	}
+
+	public void testSetAutoExpandLevel() {
+		treeViewer.setInput(new DataModel(Integer.valueOf(100)));
+		treeViewer.setAutoExpandLevel(2);
+		treeViewer.setInput(rootModel);
+		processEvents();
+		TreeItem[] rootLevelItems = assertLimitedItems();
+		for (int i = 0; i < VIEWER_LIMIT; i++) {
+			TreeItem[] items = assertLimitedItems(rootLevelItems[i]);
+			for (int j = 0; j < VIEWER_LIMIT; j++) {
+				assertDummyItem(items[j]);
+			}
+		}
+	}
+
+	public void testInsert() {
+		TreeItem thirdItem = treeViewer.getTree().getItem(2);
+		assertEquals("unexpected element found at position 2", rootModel.get(2), thirdItem.getData());
+		DataModel newElement = new DataModel(Integer.valueOf(3));
+		rootModel.add(newElement);
+		treeViewer.insert(rootModel, newElement, 2);
+		processEvents();
+		thirdItem = treeViewer.getTree().getItem(2);
+		assertEquals("unexpected element found at position 2", newElement, thirdItem.getData());
+	}
+
+	public void testRefresh() {
+		DataModel firstEle = rootModel.remove(0);
+		TreeItem firstItem = treeViewer.getTree().getItem(0);
+		assertEquals("element contains unexpected data", firstEle, firstItem.getData());
+		treeViewer.refresh();
+		processEvents();
+		firstEle = rootModel.get(0);
+		firstItem = treeViewer.getTree().getItem(0);
+		assertEquals("element contains unexpected data", firstEle, firstItem.getData());
+	}
+
+	public void testSetFilters() {
+		DataModel firstEle = rootModel.get(0);
+		TreeItem firstItem = treeViewer.getTree().getItem(0);
+		assertEquals("element contains unexpected data", firstEle, firstItem.getData());
+		treeViewer.setFilters(new TestViewerFilter());
+		processEvents();
+		firstEle = rootModel.get(6);
+		firstItem = treeViewer.getTree().getItem(0);
+		assertEquals("element contains unexpected data", firstEle, firstItem.getData());
+	}
+
+	public void testSetInput() {
+		List<DataModel> rootModel = new ArrayList<>();
+		DataModel rootLevel = new DataModel(Integer.valueOf(100));
+		rootModel.add(rootLevel);
+		treeViewer.setInput(rootModel);
+		processEvents();
+		assertEquals("there must be only one item", 1, treeViewer.getTree().getItems().length);
+		treeViewer.setInput(createModel());
+		processEvents();
+		assertLimitedItems();
+	}
+
+	@Override
+	protected StructuredViewer createViewer(Composite parent) {
+		treeViewer = new TestTreeViewer(parent);
+		treeViewer.setDisplayIncrementally(VIEWER_LIMIT);
+		treeViewer.setContentProvider(new TestTreeContentProvider());
+		treeViewer.setLabelProvider(new LabelProvider());
+		treeViewer.setComparator(new TestComparator());
+		return treeViewer;
+	}
+
+	@Override
+	protected void setInput() {
+		rootModel = createModel();
+		treeViewer.setInput(rootModel);
+	}
+
+	public static void main(String args[]) {
+		junit.textui.TestRunner.run(TreeViewerWithLimitTest.class);
+	}
+
+	private static class TestTreeContentProvider implements ITreeContentProvider {
+
+		@Override
+		public Object[] getElements(Object inputElement) {
+			if (inputElement instanceof ArrayList<?>) {
+				return ((ArrayList<?>) inputElement).toArray();
+			}
+			return ((DataModel) inputElement).children.toArray();
+		}
+
+		@Override
+		public Object[] getChildren(Object parentElement) {
+			if (!(parentElement instanceof DataModel)) {
+				return null;
+			}
+			return getElements(parentElement);
+		}
+
+		@Override
+		public Object getParent(Object element) {
+			if (!(element instanceof DataModel)) {
+				return null;
+			}
+			return ((DataModel) element).parent;
+		}
+
+		@Override
+		public boolean hasChildren(Object element) {
+			if (element instanceof ArrayList<?>) {
+				return !((ArrayList<?>) element).isEmpty();
+			}
+			DataModel myModel = (DataModel) element;
+			return myModel.children.size() > 0;
+		}
+	}
+
+	class TestTreeViewer extends TreeViewer {
+		public TestTreeViewer(Composite parent) {
+			super(parent);
+		}
+
+		@Override
+		public boolean isExpandableNode(Object element) {
+			return super.isExpandableNode(element);
+		}
+	}
+
+}

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/ViewerTestCase.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/ViewerTestCase.java
@@ -100,6 +100,10 @@ public abstract class ViewerTestCase extends TestCase {
 			if (display != null) {
 				while (display.readAndDispatch()) {
 					// loop until there are no more events to dispatch
+					try {
+						Thread.sleep(50);
+					} catch (InterruptedException e) {
+					}
 				}
 			}
 		}

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualLazyTableViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualLazyTableViewerTest.java
@@ -165,4 +165,11 @@ public class VirtualLazyTableViewerTest extends VirtualTableViewerTest {
 		// based on the assumption that all items
 		// are created.
 	}
+
+	@Override
+	public void testContains() {
+		// This test is no use here as it is
+		// based on the assumption that all items
+		// are created.
+	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/UiTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/UiTestSuite.java
@@ -48,6 +48,7 @@ import org.eclipse.ui.tests.multipageeditor.MultiPageEditorTestSuite;
 import org.eclipse.ui.tests.navigator.NavigatorTestSuite;
 import org.eclipse.ui.tests.operations.OperationsTestSuite;
 import org.eclipse.ui.tests.preferences.PreferencesTestSuite;
+import org.eclipse.ui.tests.preferences.ViewerItemsLimitTest;
 import org.eclipse.ui.tests.progress.ProgressTestSuite;
 import org.eclipse.ui.tests.propertysheet.PropertySheetTestSuite;
 import org.eclipse.ui.tests.quickaccess.QuickAccessTestSuite;
@@ -106,6 +107,7 @@ import org.junit.runners.Suite;
 	OpenSystemInPlaceEditorTest.class,
 	WorkbenchDatabindingTest.class,
 	ChooseWorkspaceDialogTests.class,
+	ViewerItemsLimitTest.class
 })
 public class UiTestSuite {
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ViewerItemsLimitTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ViewerItemsLimitTest.java
@@ -1,0 +1,472 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Advantest Europe GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * 				Raghunandana Murthappa
+ *******************************************************************************/
+package org.eclipse.ui.tests.preferences;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.internal.ExpandableNode;
+import org.eclipse.search.internal.ui.text.FileSearchPage;
+import org.eclipse.search.internal.ui.text.FileSearchQuery;
+import org.eclipse.search.ui.NewSearchUI;
+import org.eclipse.search.ui.text.AbstractTextSearchViewPage;
+import org.eclipse.search.ui.text.FileTextSearchScope;
+import org.eclipse.search2.internal.ui.SearchView;
+import org.eclipse.swt.widgets.Item;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swt.widgets.TreeItem;
+import org.eclipse.ui.IPageLayout;
+import org.eclipse.ui.IPerspectiveDescriptor;
+import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchPreferenceConstants;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.WorkbenchPlugin;
+import org.eclipse.ui.internal.views.markers.MarkersTreeViewer;
+import org.eclipse.ui.intro.IIntroPart;
+import org.eclipse.ui.navigator.CommonViewer;
+import org.eclipse.ui.tests.harness.util.EmptyPerspective;
+import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ViewerItemsLimitTest extends UITestCase {
+
+	private IPreferenceStore preferenceStore;
+
+	private static final int DEFAULT_VIEW_LIMIT = 1000;
+
+	private static final int VIEW_LIMIT_3 = 3;
+
+	private static final int VIEW_LIMIT_DOUBLE = VIEW_LIMIT_3 + VIEW_LIMIT_3;
+
+	private static String SEARCH_VIEW_ID = "org.eclipse.search.ui.views.SearchView";
+
+	private IPerspectiveDescriptor defaultPerspective;
+
+	private IWorkbenchWindow window;
+
+	private IWorkbenchPage activePage;
+
+	public ViewerItemsLimitTest() {
+		super(ViewerItemsLimitTest.class.getSimpleName());
+	}
+
+	@Override
+	protected void doSetUp() throws Exception {
+		super.doSetUp();
+		cleanUp();
+		preferenceStore = WorkbenchPlugin.getDefault().getPreferenceStore();
+		int viewLimit = preferenceStore.getInt(IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT);
+		assertEquals("Default viewer limit must be " + DEFAULT_VIEW_LIMIT, DEFAULT_VIEW_LIMIT, viewLimit);
+		window = getActiveWindow();
+		activePage = window.getActivePage();
+		defaultPerspective = activePage.getPerspective();
+		activePage.closeAllPerspectives(false, false);
+		getWorkbench().showPerspective(EmptyPerspective.PERSP_ID, window);
+	}
+
+	@Override
+	protected void doTearDown() throws Exception {
+		cleanUp();
+		preferenceStore.setValue(IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT, DEFAULT_VIEW_LIMIT);
+		activePage.closeAllPerspectives(false, false);
+		if (defaultPerspective != null) {
+			getWorkbench().showPerspective(defaultPerspective.getId(), window);
+		}
+		super.doTearDown();
+	}
+
+	/**
+	 * Create some projects and open the ProjectExplorer and check if limited
+	 * projects are shown. Add one more project and check if newly added project
+	 * added to it's position as per the sorting order. Add one more project and
+	 * check it goes inside ExpandbaleNode. Delete the newly added project and check
+	 * the projects order is as expected. Reset the viewer limit to default and
+	 * check if all the project are visible.
+	 *
+	 * @throws CoreException
+	 */
+	@Test
+	public void testProjectExplorerLimitedProjects() throws CoreException {
+		closeView(IPageLayout.ID_PROJECT_EXPLORER);
+
+		setNewViewerLimit(VIEW_LIMIT_3);
+		int numberOfProjects = 8;
+		for (int i = 0; i < numberOfProjects; i++) {
+			IProject javaProj = createProject("javap" + i);
+			assertNotNull(javaProj);
+		}
+		// open project explorer
+		IViewPart navigator = activePage.showView(IPageLayout.ID_PROJECT_EXPLORER);
+		assertNotNull("failed to open project explorer", navigator);
+		processEvents();
+
+		CommonViewer commonViewer = navigator.getAdapter(CommonViewer.class);
+		Tree tree = commonViewer.getTree();
+		assertLimitedItems(VIEW_LIMIT_3, numberOfProjects, tree.getItems());
+
+		// at second posting `javap1` must be present
+		assertEquals("at second position javap1 must be present", "javap1", tree.getItems()[1].getText());
+
+		// create a project which will be inserted at second position as per sorting
+		IProject javap = createProject("javap01");
+		ResourcesPlugin.getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
+		numberOfProjects++;
+
+		processBackgroundUpdates(100);
+
+		// still it must show limited items.
+		processEventsUntil(() -> tree.getItems().length > VIEW_LIMIT_3, 30_000);
+		assertLimitedItems(VIEW_LIMIT_3, numberOfProjects, tree.getItems());
+		// Now at second posting newly created project `javap01` must appear
+		assertEquals("at second position javap01 must be present", "javap01", tree.getItems()[1].getText());
+
+		// create a project which will be inserted inside expandable node
+		javap = createProject("javap20");
+		ResourcesPlugin.getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
+		numberOfProjects++;
+
+		processBackgroundUpdates(100);
+		// still it must show limited items.
+		processEventsUntil(() -> tree.getItems().length > VIEW_LIMIT_3, 30_000);
+		assertLimitedItems(VIEW_LIMIT_3, numberOfProjects, tree.getItems());
+
+		// change the viewer limit to 4
+		setNewViewerLimit(VIEW_LIMIT_DOUBLE);
+
+		processBackgroundUpdates(100);
+		processEventsUntil(() -> tree.getItems().length > VIEW_LIMIT_DOUBLE, 30_000);
+		assertLimitedItems(VIEW_LIMIT_DOUBLE, numberOfProjects, tree.getItems());
+		// Now at fourth posting previously added project `javap20` must appear
+		assertEquals("at fourth position javap20 must be present", "javap20", tree.getItems()[4].getText());
+
+		// delete the last added project
+		javap.delete(true, null);
+		ResourcesPlugin.getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
+		numberOfProjects--;
+
+		processBackgroundUpdates(100);
+		processEventsUntil(() -> tree.getItems().length > VIEW_LIMIT_DOUBLE, 30_000);
+		assertLimitedItems(VIEW_LIMIT_DOUBLE, numberOfProjects, tree.getItems());
+		assertEquals("at fourth position javap3 must be present", "javap3", tree.getItems()[4].getText());
+
+		setNewViewerLimit(DEFAULT_VIEW_LIMIT);
+
+		processBackgroundUpdates(100);
+		assertEquals("all the items must be visible with limit more than input", numberOfProjects,
+				tree.getItems().length);
+	}
+
+	private IWorkbenchWindow getActiveWindow() {
+		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		assertNotNull("Should get one window", window);
+		return window;
+	}
+
+	private static void processBackgroundUpdates(int minWaitTime) {
+		processEvents();
+		waitForJobs(minWaitTime, 10_000);
+		processEvents();
+	}
+
+	/**
+	 * 1. close Intro part. 2. Delete any projects exist. 3. Close the view of our
+	 * choice
+	 */
+	private void cleanUp() throws CoreException {
+		deleteAllProjects();
+		closeIntro();
+		processBackgroundUpdates(100);
+	}
+
+	private void closeView(String viewId) {
+		IViewPart myView = activePage.findView(viewId);
+		activePage.hideView(myView);
+	}
+
+	private static void deleteAllProjects() throws CoreException {
+		IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
+		for (IProject proj : workspaceRoot.getProjects()) {
+			proj.delete(true, null);
+		}
+		workspaceRoot.refreshLocal(IResource.DEPTH_INFINITE, null);
+	}
+
+	private static IWorkbench closeIntro() {
+		IWorkbench workbench = PlatformUI.getWorkbench();
+		IIntroPart introPart = workbench.getIntroManager().getIntro();
+		if (introPart != null) {
+			workbench.getIntroManager().closeIntro(introPart);
+		}
+		return workbench;
+	}
+
+	private void assertLimitedItems(int currentLimit, int realInputSize, Item[] items) {
+		assertEquals("items length mist be limit plus one", currentLimit + 1, items.length);
+		int nextBlock = currentLimit * 2;
+		Item lastItem = items[items.length - 1];
+		if (nextBlock > realInputSize) {
+			nextBlock = realInputSize;
+		}
+		String expLabel = JFaceResources.format("ExpandableNode.defaultLabel", currentLimit + 1, nextBlock,
+				realInputSize);
+
+		assertEquals("Incorrect text for expand node", expLabel, lastItem.getText().trim());
+		ExpandableNode node = (ExpandableNode) lastItem.getData();
+		assertEquals(expLabel, node.getLabel());
+	}
+
+	private void setNewViewerLimit(int viewerLimit) {
+		preferenceStore.setValue(IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT, viewerLimit);
+		int readViewLimit = preferenceStore.getInt(IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT);
+		assertEquals("Default viewer limit must be " + viewerLimit, viewerLimit, readViewLimit);
+		processEvents();
+	}
+
+	/**
+	 * Create some markers on the project and check if limited Markers are shown.
+	 * Add one more marker which is at top of items. Check if it appears properly.
+	 * Add one more marker check which will go inside expandable node. Delete the
+	 * last added marker and check it refreshes properly. Set the viewer limit to
+	 * default and check if all the markers are visible.
+	 *
+	 * @throws CoreException
+	 */
+	@Test
+	public void testMarkersViewLimitedMarkers() throws CoreException {
+		closeView(IPageLayout.ID_PROBLEM_VIEW);
+		setNewViewerLimit(VIEW_LIMIT_3);
+		IProject project = createProject("jp" + 0);
+		assertNotNull(project);
+		int numberOfMarkers = 8;
+		for (int i = 0; i < numberOfMarkers; i++) {
+			Map<String, Object> attributes = new HashMap<>();
+			attributes.put(IMarker.SEVERITY, Integer.valueOf(IMarker.SEVERITY_ERROR));
+			attributes.put(IMarker.MESSAGE, i + " project error has occured");
+			attributes.put(IMarker.LOCATION, project.getFullPath().toOSString());
+			project.createMarker(IMarker.PROBLEM, attributes);
+		}
+
+		IViewPart probView = activePage.showView(IPageLayout.ID_PROBLEM_VIEW);
+		// job may take some time to create marker.
+		processBackgroundUpdates(1000);
+		MarkersTreeViewer commonViewer = probView.getAdapter(MarkersTreeViewer.class);
+
+		processEventsUntil(() -> getFirstItem(commonViewer) != null, 30_000);
+		assertNotNull("There must be one problems root element", getFirstItem(commonViewer));
+		commonViewer.expandAll();
+
+		processEventsUntil(() -> getFirstItem(commonViewer).getItems().length > VIEW_LIMIT_3, 30_000);
+		TreeItem firstItem = getFirstItem(commonViewer);
+		assertLimitedItems(VIEW_LIMIT_3, numberOfMarkers, firstItem.getItems());
+		assertEquals("0 project error has occured", firstItem.getItems()[0].getText());
+
+		// create one more marker which will appear at first location of error markers.
+		Map<String, Object> attributes = new HashMap<>();
+		attributes.put(IMarker.SEVERITY, Integer.valueOf(IMarker.SEVERITY_ERROR));
+		attributes.put(IMarker.MESSAGE, "01 project error has occured");
+		attributes.put(IMarker.LOCATION, project.getFullPath().toOSString());
+		IMarker errorMarker = project.createMarker(IMarker.PROBLEM, attributes);
+		numberOfMarkers++;
+		processBackgroundUpdates(1000);
+
+		firstItem = getFirstItem(commonViewer);
+		assertLimitedItems(VIEW_LIMIT_3, numberOfMarkers, getFirstItem(commonViewer).getItems());
+		assertEquals("01 project error has occured", getFirstItem(commonViewer).getItems()[0].getText());
+
+		// create one more marker which will appear inside expandable node.
+		attributes = new HashMap<>();
+		attributes.put(IMarker.SEVERITY, Integer.valueOf(IMarker.SEVERITY_ERROR));
+		attributes.put(IMarker.MESSAGE, "30 project error has occured");
+		attributes.put(IMarker.LOCATION, project.getFullPath().toOSString());
+		errorMarker = project.createMarker(IMarker.PROBLEM, attributes);
+		numberOfMarkers++;
+		processBackgroundUpdates(1000);
+
+		firstItem = getFirstItem(commonViewer);
+		assertLimitedItems(VIEW_LIMIT_3, numberOfMarkers, getFirstItem(commonViewer).getItems());
+
+		// change the viewer limit
+		setNewViewerLimit(VIEW_LIMIT_DOUBLE);
+		processBackgroundUpdates(100);
+		processEventsUntil(() -> getFirstItem(commonViewer).getItems().length > VIEW_LIMIT_DOUBLE, 30_000);
+
+		firstItem = getFirstItem(commonViewer);
+		assertLimitedItems(VIEW_LIMIT_DOUBLE, numberOfMarkers, firstItem.getItems());
+		assertEquals("30 project error has occured", firstItem.getItems()[4].getText());
+
+		errorMarker.delete();
+		numberOfMarkers--;
+		processBackgroundUpdates(1000);
+
+		firstItem = getFirstItem(commonViewer);
+		assertLimitedItems(VIEW_LIMIT_DOUBLE, numberOfMarkers, firstItem.getItems());
+		assertEquals("3 project error has occured", firstItem.getItems()[4].getText());
+
+		setNewViewerLimit(DEFAULT_VIEW_LIMIT);
+
+		// job may take some time to create marker.
+		processBackgroundUpdates(100);
+
+		firstItem = getFirstItem(commonViewer);
+		assertEquals("all the items must be visible with limit more than input", numberOfMarkers,
+				firstItem.getItems().length);
+	}
+
+	private TreeItem getFirstItem(MarkersTreeViewer commonViewer) {
+		TreeItem[] items = commonViewer.getTree().getItems();
+		return items.length > 0 ? items[0] : null;
+	}
+
+	/**
+	 * Create some projects and some search data. Create some query and execute the
+	 * search. Check limited search results. Add new search data onto workspace and
+	 * refresh search to see if search results updated properly.
+	 *
+	 * @throws CoreException
+	 */
+	@Ignore
+	@Test
+	public void testLimitedSearchResult() throws CoreException {
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		IWorkspaceRoot workspaceRoot = workspace.getRoot();
+		setNewViewerLimit(VIEW_LIMIT_3);
+		int numOfProj = 9;
+		for (int i = 1; i <= numOfProj; i++) {
+			createProjectWithFile(workspaceRoot, i);
+		}
+		processBackgroundUpdates(100);
+
+		SearchView searchView = (SearchView) activePage.showView(SEARCH_VIEW_ID);
+		FileTextSearchScope scope = FileTextSearchScope.newWorkspaceScope(new String[] { "*" }, false);
+		FileSearchQuery searchQuery = new FileSearchQuery("some", false, false, false, false, scope);
+		NewSearchUI.runQueryInBackground(searchQuery);
+
+		// job may take some time to create marker.
+		processBackgroundUpdates(1000);
+
+		FileSearchPage searchPage = (FileSearchPage) searchView.getActivePage();
+		assertNotNull("Search page should be shown", searchPage);
+		TreeViewer viewer = (TreeViewer) searchPage.getViewer();
+		Tree tree = viewer.getTree();
+		processEventsUntil(() -> tree.getItems().length > VIEW_LIMIT_3, 30_000);
+
+		TreeItem[] items = tree.getItems();
+		assertLimitedItems(VIEW_LIMIT_3, numOfProj, items);
+		assertFirstSearchResultExpanded(items, "jp1", VIEW_LIMIT_3);
+
+		// this is equal to refresh of search results.
+		createProjectWithFile(workspaceRoot, 0);
+		processBackgroundUpdates(1000);
+
+		numOfProj++;
+		NewSearchUI.runQueryInBackground(searchQuery);
+		processBackgroundUpdates(1000);
+
+		processEventsUntil(() -> tree.getItems().length > VIEW_LIMIT_3, 30_000);
+		items = tree.getItems();
+		assertLimitedItems(VIEW_LIMIT_3, numOfProj, items);
+		assertFirstSearchResultExpanded(items, "jp0", VIEW_LIMIT_3);
+
+		// this is equal to refresh of search results.
+		createProjectWithFile(workspaceRoot, 50);
+		processBackgroundUpdates(1000);
+
+		numOfProj++;
+		NewSearchUI.runQueryInBackground(searchQuery);
+		processBackgroundUpdates(1000);
+
+		processEventsUntil(() -> tree.getItems().length > VIEW_LIMIT_3, 30_000);
+		items = tree.getItems();
+		assertLimitedItems(VIEW_LIMIT_3, numOfProj, items);
+		assertFirstSearchResultExpanded(items, "jp0", VIEW_LIMIT_3);
+
+		setNewViewerLimit(VIEW_LIMIT_DOUBLE);
+		processBackgroundUpdates(100);
+
+		processEventsUntil(() -> tree.getItems().length > VIEW_LIMIT_DOUBLE, 30_000);
+		items = tree.getItems();
+		assertLimitedItems(VIEW_LIMIT_DOUBLE, numOfProj, items);
+
+		searchPage.setLayout(AbstractTextSearchViewPage.FLAG_LAYOUT_FLAT);
+		processBackgroundUpdates(100);
+
+		Table table = ((TableViewer) searchPage.getViewer()).getTable();
+		processEventsUntil(() -> table.getItems().length > VIEW_LIMIT_DOUBLE, 30_000);
+		assertLimitedItems(VIEW_LIMIT_DOUBLE, numOfProj, table.getItems());
+
+		setNewViewerLimit(DEFAULT_VIEW_LIMIT);
+		processBackgroundUpdates(100);
+
+		assertEquals("all the items must be visible with limit more than input", numOfProj, table.getItems().length);
+	}
+
+	private void assertFirstSearchResultExpanded(TreeItem[] items, String projName, int viewerLimit) {
+		assertEquals(projName, items[0].getText());
+		assertEquals(1, items[0].getItems().length);
+		TreeItem rootItem = items[0].getItems()[0];
+		assertEquals("test_file.text (6 matches)", rootItem.getText().trim());
+		// here limited results must populate
+		TreeItem[] matches = rootItem.getItems();
+		assertLimitedItems(viewerLimit, 6, matches);
+		assertEquals("1: some line 1", matches[0].getText().trim());
+	}
+
+	private void createProjectWithFile(IWorkspaceRoot workspaceRoot, int projNameSuf) throws CoreException {
+		IProject testProject = createProject("jp" + projNameSuf);
+		testProject.open(null);
+		IPath path = IPath.fromOSString("/" + testProject.getName() + "/test_file" + "." + "text");
+		IFile temporaryFile = workspaceRoot.getFile(path);
+		String content = String.join(System.lineSeparator(), "some line 1", "some line 2", "some line 3", "some line 4",
+				"some line 5", "some line 6");
+		boolean force = true;
+		temporaryFile.create(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)), force, null);
+	}
+
+	private IProject createProject(String pname) throws CoreException {
+		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+		IProject project = root.getProject(pname);
+		if (!project.exists()) {
+			project.create(null);
+		} else {
+			project.refreshLocal(IResource.DEPTH_INFINITE, null);
+		}
+		if (!project.isOpen()) {
+			project.open(null);
+		}
+		return project;
+	}
+}

--- a/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -40,7 +40,9 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="3.14.0",
  org.eclipse.e4.ui.workbench.renderers.swt;bundle-version="0.10.0",
  org.mockito.mockito-core;bundle-version="2.13.0",
  org.eclipse.ui.views.log;bundle-version="1.2.1300",
- org.eclipse.jdt.ui
+ org.eclipse.jdt.ui,
+ org.eclipse.ui.navigator;bundle-version="3.12.100",
+ org.eclipse.search
 Import-Package: javax.annotation,
  javax.inject,
  org.osgi.service.event


### PR DESCRIPTION
New org.eclipse.jface.viewers.ColumnViewer#setDisplayIncrementally(int) API has been introduced. This API will limit the number of direct children rendered per parent by the viewers by introducing an intermediate `ExpandableNode` element which will then render a subset of original children and show more elements on demand (user click).

This API is introduced to solve UI freezes caused by viewers when they try to render large number of items at a given level. The changes made for the new API should not affect any existing clients, because new behavior has to be explicitly enabled by using new ColumnViewer.setItemsLimit(int) API.

For the clients using this new API the change should be mostly backwards compatible. Clients might need to adopt label provider and viewer code to make them safe for receiving `ExpandableNode` from viewer.

Note: clients that extended (not allowed to be extended) TreeViewer should make sure that `isExpandable()` returns "false" for `ExpandableNode`.

A new workbench preference is introduced to provide a default viewer limit suitable for most of the clients. Current default value for this limit is 1000. The preference can be changed in "General" section:

![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/964108/6bd559f3-d546-43c3-9484-e912101e7f0f)

Clients that adopt new API can use this preference to configure their viewer with a single line of code by using new
`WorkbenchViewerSetup.setupViewer(ColumnViewer)` API.

Project Explorer,  Markers, Problems and Search views has been adopted to the new API and use the new preference to show limited number of items. Package Explorer and Java Outline view adoption for JDT follows in a [separated commit](https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/632).

**How to test**

Use three extra branches on "[Java project generator](https://github.com/iloveeclipse/java-project-generator/)" project that generate code for 3 use cases that show different ways to "hang up" IDE as of today:

- 10 Java classes with 18.000 methods each. (https://github.com/iloveeclipse/java-project-generator/tree/bigMethodsCount)
- 3 Java packages with 20.000 classes each. (https://github.com/iloveeclipse/java-project-generator/tree/manySmalllClasses)
- 11000 classes with 4 warnings each. (https://github.com/iloveeclipse/java-project-generator/tree/manyWarnings)

Steps in the test workspace:

- Clone "[bigMethodsCount](https://github.com/iloveeclipse/java-project-generator/tree/bigMethodsCount)" branch from https://github.com/iloveeclipse/java-project-generator/
- Import Java project
- Run Main
- refresh `target/generated` source folder in the project
- open `Foo9` java in Java editor

Same as above but with 3 Java packages containing each 20000 classes: clone "[manySmalllClasses](https://github.com/iloveeclipse/java-project-generator/tree/manySmalllClasses)" 

Same as above but with 11000 classes with 4 warnings each: clone "[manyWarnings](https://github.com/iloveeclipse/java-project-generator/tree/manyWarnings)" 

**Without patch**:

- wait some seconds till editor is opened (Outline view hangs)
- try to expand subtree under Foo9 type in Package Explorer (UI hangs)
- try to expand subtree under Foo9 type in Project Explorer (UI hangs)
- try to expand Java editor breadcrumb (UI hangs)
- on the `manyWarnings` branch try to unset "Use limits" in the Problems view filter (default is 100 which basically disallows to see warnings for most of the code).

**With latest patches** (this one  plus [one small for JDT UI](https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/632)) and limit set to **1000** UI doesn't hang or has barely noticeable hangs. All remaining CPU intensive tasks I've still noticed (like decorators) are only executed in the background and do not block UI anymore.

---------

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/818

**See also** https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/632 for additional changes in JDT UI.
