### PR TITLE
Wait for extensions to be activated in PipelineChainTest #757

### DIFF
--- a/tests/org.eclipse.ui.tests.navigator/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.navigator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundlename
 Bundle-SymbolicName: org.eclipse.ui.tests.navigator;singleton:=true
-Bundle-Version: 3.7.100.qualifier
+Bundle-Version: 3.7.200.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.runtime,

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/NavigatorTestBase.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/NavigatorTestBase.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.fail;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -248,6 +249,25 @@ public class NavigatorTestBase {
 		_project.findMember(TestContentProvider.MODEL_FILE_PATH).touch(null);
 		// Let build run to load the model objects
 		DisplayHelper.sleep(50);
+	}
+
+	/**
+	 * Wait for up to 1 minute for a condition to be met.
+	 *
+	 * @param description A description of the condition (for debugging purposes).
+	 * @param condition   The condition to be met.
+	 */
+	protected void waitForCondition(String description, BooleanSupplier condition) {
+		for (int i = 1; i <= 1200; i++) {
+
+			if (condition.getAsBoolean()) {
+				System.out.println("The condition '" + description + "' was met in " + (i * 50) + " ms or less");
+				return;
+			}
+			DisplayHelper.sleep(50);
+		}
+
+		fail("The condition '" + description + "' was never met");
 	}
 
 	protected void showNavigator() {

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/PipelineChainTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/PipelineChainTest.java
@@ -52,8 +52,7 @@ public class PipelineChainTest extends NavigatorTestBase {
 				TEST_CONTENT_PIPELINE + ".F",
 				TEST_CONTENT_PIPELINE + ".G"
 		};
-		_contentService.bindExtensions(EXTENSIONS, false);
-		_contentService.getActivationService().activateExtensions(EXTENSIONS, true);
+		activateAndWait(EXTENSIONS);
 	}
 
 	private void _initContentWithLabel() {
@@ -68,8 +67,17 @@ public class PipelineChainTest extends NavigatorTestBase {
 				TEST_CONTENT_PIPELINE + ".G",
 				TEST_CONTENT_PIPELINE + ".label"
 		};
-		_contentService.bindExtensions(EXTENSIONS, false);
-		_contentService.getActivationService().activateExtensions(EXTENSIONS, true);
+		activateAndWait(EXTENSIONS);
+	}
+
+	private void activateAndWait(String[] extensionIds) {
+		_contentService.bindExtensions(extensionIds, false);
+		_contentService.getActivationService().activateExtensions(extensionIds, true);
+
+		for (String extensionId : extensionIds) {
+			waitForCondition("Wait for content pipelines",
+					() -> _contentService.getActivationService().isNavigatorExtensionActive(extensionId));
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Let all tests in `PipelineChainTest` wait for up to 1 minute for the proper extensions to be activated before running. 

This PR makes sure that the necessary interceptors are present before running the tests and keeps the test from failing randomly. If the proper interceptors are not active by the time the tests run then the tests fail with this error: `Wrong query sequence for interceptAdd expected:<ACGFBDE> but was:<null>` (the `null` means that there were no interceptors in play).

Waiting for extensions to be loaded seems to be a common and accepted pattern since some other tests in the plugin also need to wait for extensions to be loaded (I also mentioned this in #800).

Solves #757 