### PR TITLE
Avoid reusing of not thread-safe SimpleDateFormat

### DIFF
--- a/bundles/org.eclipse.ui.browser/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.browser/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.browser; singleton:=true
-Bundle-Version: 3.8.0.qualifier
+Bundle-Version: 3.8.100.qualifier
 Bundle-Activator: org.eclipse.ui.internal.browser.WebBrowserUIPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/browsers/BrowserLog.java
+++ b/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/browsers/BrowserLog.java
@@ -19,9 +19,9 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 import org.eclipse.ui.internal.browser.WebBrowserUIPlugin;
 /**
@@ -31,7 +31,8 @@ public class BrowserLog {
 	private static BrowserLog instance;
 	private String logFileName;
 	private boolean newSession;
-	DateFormat formatter = new SimpleDateFormat("MMM dd, yyyy kk:mm:ss.SS"); //$NON-NLS-1$
+	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMM dd, yyyy kk:mm:ss.SS") //$NON-NLS-1$
+			.withZone(ZoneId.systemDefault());
 	String LN = System.lineSeparator();
 	/**
 	 * Constructor
@@ -68,10 +69,10 @@ public class BrowserLog {
 
 			if (newSession) {
 				newSession = false;
-				outWriter.write(LN + formatter.format(new Date())
+				outWriter.write(LN + formatter.format(Instant.now())
 						+ " NEW SESSION" + LN); //$NON-NLS-1$
 			}
-			outWriter.write(formatter.format(new Date()) + " " + message + LN); //$NON-NLS-1$
+			outWriter.write(formatter.format(Instant.now()) + " " + message + LN); //$NON-NLS-1$
 			outWriter.flush();
 		} catch (IOException e) {
 		}

--- a/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/DefaultUiFreezeEventLogger.java
+++ b/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/DefaultUiFreezeEventLogger.java
@@ -17,7 +17,9 @@ package org.eclipse.ui.internal.monitoring;
 
 import java.lang.management.LockInfo;
 import java.lang.management.ThreadInfo;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 import org.eclipse.core.runtime.IStatus;
@@ -34,7 +36,7 @@ import org.eclipse.ui.monitoring.UiFreezeEvent;
  * Writes {@link UiFreezeEvent}s to the Eclipse error log.
  */
 public class DefaultUiFreezeEventLogger implements IUiFreezeEventLogger {
-	private static final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss.SSS"); //$NON-NLS-1$
+	private static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("HH:mm:ss.SSS").withZone(ZoneId.systemDefault()); //$NON-NLS-1$
 	private final long longEventErrorThresholdMillis;
 
 	private static class StackTrace extends Throwable {
@@ -69,7 +71,7 @@ public class DefaultUiFreezeEventLogger implements IUiFreezeEventLogger {
 	@Override
 	public void log(UiFreezeEvent event) {
 		long lastTimestamp = event.getStartTimestamp();
-		String startTime = dateFormat.format(new Date(lastTimestamp));
+		String startTime = dateFormat.format(new Date(lastTimestamp).toInstant());
 
 		String template = event.isStillRunning()
 				? Messages.DefaultUiFreezeEventLogger_ui_freeze_ongoing_header_2
@@ -102,7 +104,7 @@ public class DefaultUiFreezeEventLogger implements IUiFreezeEventLogger {
 			Throwable stackTrace = new StackTrace(threads[0].getStackTrace());
 			String traceText = NLS.bind(
 					Messages.DefaultUiFreezeEventLogger_sample_header_2,
-					dateFormat.format(sample.getTimestamp()),
+					dateFormat.format(Instant.ofEpochMilli(sample.getTimestamp())),
 					String.format("%.3f", deltaInSeconds)); //$NON-NLS-1$
 			MultiStatus traceStatus = new SeverityMultiStatus(IStatus.INFO,
 					PreferenceConstants.PLUGIN_ID,

--- a/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/EventLoopMonitorThread.java
+++ b/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/EventLoopMonitorThread.java
@@ -18,10 +18,11 @@ package org.eclipse.ui.internal.monitoring;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -251,7 +252,7 @@ public class EventLoopMonitorThread extends Thread {
 	 * Circular buffer recording SWT events. Used for tracing.
 	 */
 	private static class EventHistory {
-		private static final SimpleDateFormat TIME_FORMAT = new SimpleDateFormat("HH:mm:ss.SSS"); //$NON-NLS-1$
+		private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSS").withZone(ZoneId.systemDefault()); //$NON-NLS-1$
 
 		private static class EventInfo {
 			long timestamp;
@@ -290,7 +291,7 @@ public class EventLoopMonitorThread extends Thread {
 			for (int i = 0; i < size; i++) {
 				int j = (start + i) % buffer.length;
 				EventInfo eventInfo = buffer[j];
-				buf.append(TIME_FORMAT.format(new Date(eventInfo.timestamp)));
+				buf.append(TIME_FORMAT.format(Instant.ofEpochMilli(eventInfo.timestamp)));
 				buf.append(": "); //$NON-NLS-1$
 				switch (eventInfo.eventType) {
 				case SWT.PreEvent:

--- a/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/Tracer.java
+++ b/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/Tracer.java
@@ -18,7 +18,9 @@ package org.eclipse.ui.internal.monitoring;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 import org.eclipse.core.runtime.Platform;
@@ -30,7 +32,7 @@ import org.eclipse.core.runtime.Platform;
  *      >Eclipse Wiki: FAQ How do I use the platform debug tracing facility?</a>
  */
 public class Tracer {
-	private static final SimpleDateFormat timeFormatter = new SimpleDateFormat("HH:mm:ss.SSS"); //$NON-NLS-1$
+	private static final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS").withZone(ZoneId.systemDefault()); //$NON-NLS-1$
 	private final Date date = new Date();
 	private final String prefix;
 	private static final PrintStream out = System.out;
@@ -90,7 +92,6 @@ public class Tracer {
 	}
 
 	private String getTimestamp() {
-		date.setTime(System.currentTimeMillis());
-		return timeFormatter.format(date);
+		return timeFormatter.format(Instant.now());
 	}
 }

--- a/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.ui.views.log;singleton:=true
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.4.100.qualifier
 Bundle-Activator: org.eclipse.ui.internal.views.log.Activator
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",

--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/EventDetailsDialog.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/EventDetailsDialog.java
@@ -17,7 +17,11 @@
 package org.eclipse.ui.internal.views.log;
 
 import java.io.*;
-import java.text.*;
+import java.text.Collator;
+import java.text.MessageFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.*;
 import java.util.List;
 import org.eclipse.core.runtime.IAdaptable;
@@ -92,8 +96,10 @@ public class EventDetailsDialog extends TrayDialog {
 	private Point dialogSize;
 	private int[] sashWeights;
 
-	private DateFormat dateFormat = DateFormat.getDateInstance(DateFormat.SHORT);
-	private DateFormat timeFormat = new SimpleDateFormat("HH:mm:ss.SSS"); //$NON-NLS-1$
+	private static final DateTimeFormatter dateFormat = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)
+			.withZone(ZoneId.systemDefault());
+	private static final DateTimeFormatter timeFormat = DateTimeFormatter.ofPattern("HH:mm:ss.SSS") //$NON-NLS-1$
+			.withZone(ZoneId.systemDefault());
 
 	/**
 	 *
@@ -356,8 +362,8 @@ public class EventDetailsDialog extends TrayDialog {
 			LogEntry logEntry = (LogEntry) entry;
 
 			String strDate = MessageFormat.format("{0}, {1}", //$NON-NLS-1$
-					dateFormat.format(logEntry.getDate()), //
-					timeFormat.format(logEntry.getDate()));
+					dateFormat.format(logEntry.getDate().toInstant()), //
+					timeFormat.format(logEntry.getDate().toInstant()));
 			dateLabel.setText(strDate);
 			plugInIdLabel.setText(logEntry.getPluginId());
 			severityImageLabel.setImage(labelProvider.getColumnImage(entry, 0));

--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogEntry.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogEntry.java
@@ -18,7 +18,10 @@ package org.eclipse.ui.internal.views.log;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.text.*;
+import java.text.ParseException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import org.eclipse.core.runtime.IStatus;
 
@@ -29,8 +32,10 @@ public class LogEntry extends AbstractEntry {
 
 	public static final String SPACE = " "; //$NON-NLS-1$
 	public static final String F_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS"; //$NON-NLS-1$
-	private static final DateFormat GREGORIAN_SDF = new SimpleDateFormat(F_DATE_FORMAT, Locale.ENGLISH);
-	private static final DateFormat LOCAL_SDF = new SimpleDateFormat(F_DATE_FORMAT);
+	private static final DateTimeFormatter GREGORIAN_SDF = DateTimeFormatter.ofPattern(F_DATE_FORMAT, Locale.ENGLISH)
+			.withZone(ZoneId.systemDefault());
+	private static final DateTimeFormatter LOCAL_SDF = DateTimeFormatter.ofPattern(F_DATE_FORMAT)
+			.withZone(ZoneId.systemDefault());
 
 	private String pluginId;
 	private int severity;
@@ -146,7 +151,7 @@ public class LogEntry extends AbstractEntry {
 	 */
 	public String getFormattedDate() {
 		if (fDateString == null) {
-			fDateString = LOCAL_SDF.format(getDate());
+			fDateString = LOCAL_SDF.format(getDate().toInstant());
 		}
 		return fDateString;
 	}
@@ -240,10 +245,10 @@ public class LogEntry extends AbstractEntry {
 				}
 			}
 		}
-		Date date = GREGORIAN_SDF.parse(dateBuffer.toString());
+		Date date = Date.from(Instant.from(GREGORIAN_SDF.parse(dateBuffer.toString())));
 		if (date != null) {
 			fDate = date;
-			fDateString = LOCAL_SDF.format(fDate);
+			fDateString = LOCAL_SDF.format(fDate.toInstant());
 		}
 	}
 
@@ -310,10 +315,10 @@ public class LogEntry extends AbstractEntry {
 				}
 			}
 		}
-		Date date = GREGORIAN_SDF.parse(dateBuffer.toString());
+		Date date = Date.from(Instant.from(GREGORIAN_SDF.parse(dateBuffer.toString())));
 		if (date != null) {
 			fDate = date;
-			fDateString = LOCAL_SDF.format(fDate);
+			fDateString = LOCAL_SDF.format(fDate.toInstant());
 		}
 		return depth;
 	}
@@ -345,7 +350,7 @@ public class LogEntry extends AbstractEntry {
 		severity = status.getSeverity();
 		code = status.getCode();
 		fDate = new Date();
-		fDateString = LOCAL_SDF.format(fDate);
+		fDateString = LOCAL_SDF.format(fDate.toInstant());
 		message = status.getMessage();
 		this.session = session;
 		Throwable throwable = status.getException();

--- a/examples/org.eclipse.e4.demo.cssbridge/src/org/eclipse/e4/demo/cssbridge/util/DateUtils.java
+++ b/examples/org.eclipse.e4.demo.cssbridge/src/org/eclipse/e4/demo/cssbridge/util/DateUtils.java
@@ -13,26 +13,28 @@
  *******************************************************************************/
 package org.eclipse.e4.demo.cssbridge.util;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 import java.util.Locale;
 
 public class DateUtils {
 	private static final String UNKNOWN_DATE = "unknown";
 
-	private static SimpleDateFormat DATE_FORMATTER = new SimpleDateFormat(
-			"yyyy-MM-dd HH:mm", Locale.ENGLISH);
+	private static DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(
+			"yyyy-MM-dd HH:mm", Locale.ENGLISH).withZone(ZoneId.systemDefault());
 
 	public static Date parse(String dateAsString) {
 		try {
-			return DATE_FORMATTER.parse(dateAsString);
-		} catch (ParseException exc) {
+			return Date.from(Instant.from(DATE_FORMATTER.parse(dateAsString)));
+		} catch (DateTimeParseException exc) {
 			return null;
 		}
 	}
 
 	public static String toString(Date date) {
-		return date == null ? UNKNOWN_DATE : DATE_FORMATTER.format(date);
+		return date == null ? UNKNOWN_DATE : DATE_FORMATTER.format(date.toInstant());
 	}
 }

--- a/examples/org.eclipse.ui.examples.propertysheet/Eclipse UI Examples PropertySheet/org/eclipse/ui/examples/propertysheet/Birthday.java
+++ b/examples/org.eclipse.ui.examples.propertysheet/Eclipse UI Examples PropertySheet/org/eclipse/ui/examples/propertysheet/Birthday.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.examples.propertysheet;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -57,8 +57,8 @@ public class Birthday implements IPropertySource {
 	private static final Integer YEAR_DEFAULT = Integer.valueOf(2000);
 
 	//static date formater
-	private static final DateFormat formatter = new SimpleDateFormat(
-			"EEEE, MMMM d, yyyy"); //$NON-NLS-1$
+	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(
+			"EEEE, MMMM d, yyyy").withZone(ZoneId.systemDefault()); //$NON-NLS-1$
 
 	static private class DayLabelProvider extends LabelProvider {
 		@Override
@@ -282,6 +282,6 @@ public class Birthday implements IPropertySource {
 	public String toString() {
 		Date bday = (new GregorianCalendar(getYear().intValue(), getMonth()
 				.intValue() - 1, getDay().intValue())).getTime();
-		return formatter.format(bday);
+		return formatter.format(bday.toInstant());
 	}
 }

--- a/examples/org.eclipse.ui.examples.propertysheet/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.propertysheet/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.examples.propertysheet; singleton:=true
-Bundle-Version: 3.5.0.qualifier
+Bundle-Version: 3.5.100.qualifier
 Bundle-Activator: org.eclipse.ui.examples.propertysheet.PropertySheetPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/tests/org.eclipse.ui.monitoring.tests/src/org/eclipse/ui/internal/monitoring/DefaultLoggerTests.java
+++ b/tests/org.eclipse.ui.monitoring.tests/src/org/eclipse/ui/internal/monitoring/DefaultLoggerTests.java
@@ -21,7 +21,8 @@ import static org.junit.Assert.assertTrue;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 import org.eclipse.core.runtime.IStatus;
@@ -36,7 +37,7 @@ import org.junit.Test;
  * JUnit test for the {@link DefaultUiFreezeEventLogger}.
  */
 public class DefaultLoggerTests {
-	private static final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss.SSS");
+	private static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("HH:mm:ss.SSS").withZone(ZoneOffset.systemDefault());
 	private static final String RUNTIME_ID = "org.eclipse.core.runtime";
 	private static final long TIME = 120000000;
 	private static final long DURATION = 500;
@@ -69,7 +70,7 @@ public class DefaultLoggerTests {
 	@Test
 	public void testLogEvent() {
 		UiFreezeEvent event = createFreezeEvent();
-		String expectedTime = dateFormat.format(new Date(TIME));
+		String expectedTime = dateFormat.format(new Date(TIME).toInstant());
 		String expectedHeader =
 				String.format("UI freeze of %.2gs at %s", DURATION / 1000.0, expectedTime);
 		String expectedEventMessage = String.format("Sample at %s (+%.3fs)", expectedTime, 0.000);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/WorkbenchSiteProgressServiceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/WorkbenchSiteProgressServiceTest.java
@@ -14,7 +14,8 @@
 
 package org.eclipse.ui.tests.services;
 
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -54,7 +55,8 @@ public class WorkbenchSiteProgressServiceTest extends UITestCase {
 	private WorkbenchSiteProgressService progressService;
 	private IWorkbenchPartSite site;
 
-	private SimpleDateFormat dateFormat;
+	private static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS Z") //$NON-NLS-1$
+			.withZone(ZoneId.systemDefault());
 
 	@Override
 	protected void doSetUp() throws Exception {
@@ -66,8 +68,6 @@ public class WorkbenchSiteProgressServiceTest extends UITestCase {
 		site = activePart.getSite();
 		progressService = (WorkbenchSiteProgressService) site.getService(IWorkbenchSiteProgressService.class);
 		updateJob = progressService.getUpdateJob();
-
-		dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS Z");
 	}
 
 	public void forceUpdate() {
@@ -212,7 +212,7 @@ public class WorkbenchSiteProgressServiceTest extends UITestCase {
 	}
 
 	private void logTime(String message) {
-		System.out.println(message + dateFormat.format(new Date()));
+		System.out.println(message + dateFormat.format(new Date().toInstant()));
 	}
 
 	static class LongJob extends Job{


### PR DESCRIPTION
  SimpleDateFormat.format(new Date());
returns same string as immutable and thread-safe
  DateTimeFormatter.format(new Date().toInstant())