### PR TITLE
Various fixes for warnings in I-build

### DIFF
--- a/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/Tracer.java
+++ b/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/Tracer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2014 Google Inc.
+ * Copyright (C) 2014, 2023 Google Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,6 @@ import java.io.StringWriter;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Date;
 
 import org.eclipse.core.runtime.Platform;
 
@@ -33,7 +32,6 @@ import org.eclipse.core.runtime.Platform;
  */
 public class Tracer {
 	private static final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS").withZone(ZoneId.systemDefault()); //$NON-NLS-1$
-	private final Date date = new Date();
 	private final String prefix;
 	private static final PrintStream out = System.out;
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ZipSlipTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ZipSlipTests.java
@@ -66,10 +66,10 @@ public class ZipSlipTests extends UITestCase {
 	}
 
 	@Test
-	public void testZipLeveledStructureProvider() throws ZipException, IOException {
+	public void testZipLeveledStructureProvider() throws Exception {
 		IPath path = getLocalPath(new Path(ZIPSLIP_FILE));
-		try (ZipFile zipFile = new ZipFile(path.toFile())) {
-			ZipLeveledStructureProvider zipLeveledStructureProvider = new ZipLeveledStructureProvider(zipFile);
+		try (ZipFile zipFile = new ZipFile(path.toFile());
+				ZipLeveledStructureProvider zipLeveledStructureProvider = new ZipLeveledStructureProvider(zipFile)) {
 			List<?> children = zipLeveledStructureProvider.getChildren(zipLeveledStructureProvider.getRoot());
 			Assert.assertEquals(1, children.size());
 			Enumeration<? extends ZipEntry> entries = zipFile.entries();

--- a/tools/bundles/org.eclipse.e4.tools.emf.editor3x/src/org/eclipse/e4/tools/emf/editor3x/PDEClassContributionProvider.java
+++ b/tools/bundles/org.eclipse.e4.tools.emf.editor3x/src/org/eclipse/e4/tools/emf/editor3x/PDEClassContributionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 BestSolution.at and others.
+ * Copyright (c) 2010, 2023 BestSolution.at and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -25,8 +25,6 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.e4.tools.emf.ui.common.IClassContributionProvider;
 import org.eclipse.e4.tools.emf.ui.common.ResourceSearchScope;
-import org.eclipse.e4.tools.emf.ui.common.IClassContributionProvider.ContributionData;
-import org.eclipse.e4.tools.emf.ui.common.IClassContributionProvider.ContributionResultHandler;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaCore;


### PR DESCRIPTION
First one reported at
https://download.eclipse.org/eclipse/downloads/drops4/I20230615-1800/compilelogs/plugins/org.eclipse.ui.monitoring_1.3.100.v20230615-0548/@dot.html .
Introduced via
https://github.com/eclipse-platform/eclipse.platform.ui/pull/826
For the rest I just went and fixed them.