### PR TITLE
Make DeviceResourceDescriptor a parameterized type

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/AbstractContributionItem.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/AbstractContributionItem.java
@@ -148,10 +148,10 @@ public abstract class AbstractContributionItem extends ContributionItem {
 			ImageDescriptor iconDescriptor = resUtils.imageDescriptorFromURI(URI.createURI(iconURI));
 			if (iconDescriptor != null) {
 				try {
-					image = resourceManager.createImage(iconDescriptor);
+					image = resourceManager.create(iconDescriptor);
 				} catch (DeviceResourceException e) {
 					iconDescriptor = ImageDescriptor.getMissingImageDescriptor();
-					image = resourceManager.createImage(iconDescriptor);
+					image = resourceManager.create(iconDescriptor);
 					// as we replaced the failed icon, log the message once.
 					if (Policy.DEBUG_MENUS) {
 						WorkbenchSWTActivator.trace(Policy.DEBUG_MENUS_FLAG, "failed to create image " + iconURI, e); //$NON-NLS-1$

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/MenuManager.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/MenuManager.java
@@ -274,7 +274,7 @@ public class MenuManager extends ContributionManager implements IMenuManager {
 
 			if (image != null) {
 				LocalResourceManager localManager = new LocalResourceManager(JFaceResources.getResources());
-				menuItem.setImage(localManager.createImage(image));
+				menuItem.setImage(localManager.create(image));
 				disposeOldImages();
 				imageManager = localManager;
 			}
@@ -889,7 +889,7 @@ public class MenuManager extends ContributionManager implements IMenuManager {
 				}
 			} else if (IAction.IMAGE.equals(property) && image != null) {
 				LocalResourceManager localManager = new LocalResourceManager(JFaceResources.getResources());
-				menu.getParentItem().setImage(localManager.createImage(image));
+				menu.getParentItem().setImage(localManager.create(image));
 				disposeOldImages();
 				imageManager = localManager;
 			}

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/AbstractResourceManager.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/AbstractResourceManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2015 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -29,18 +29,23 @@ abstract class AbstractResourceManager extends ResourceManager {
 	/**
 	 * Map of ResourceDescriptor onto RefCount. (null when empty)
 	 */
-	private Map<DeviceResourceDescriptor, RefCount> map = null;
+	private Map<DeviceResourceDescriptor<?>, RefCount<?>> map = null;
 
 	/**
 	 * Holds a reference count for a previously-allocated resource
 	 */
-	private static class RefCount {
-		final Object resource;
+	private static class RefCount<R> {
+		final R resource;
 		int count = 1;
 
-		RefCount(Object resource) {
+		RefCount(R resource) {
 			this.resource = resource;
 		}
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private <R> RefCount<R> getRefCount(DeviceResourceDescriptor<R> descriptor) {
+		return (RefCount) map.get(descriptor);
 	}
 
 	/**
@@ -53,7 +58,7 @@ abstract class AbstractResourceManager extends ResourceManager {
 	 * @return the newly allocated resource
 	 * @throws DeviceResourceException Thrown when allocation of an SWT device resource fails
 	 */
-	protected abstract Object allocate(DeviceResourceDescriptor descriptor) throws DeviceResourceException;
+	protected abstract <R> R allocate(DeviceResourceDescriptor<R> descriptor) throws DeviceResourceException;
 
 	/**
 	 * Called the last time a resource is dereferenced. Should release any resources reserved by
@@ -64,10 +69,10 @@ abstract class AbstractResourceManager extends ResourceManager {
 	 * @param resource resource being deallocated
 	 * @param descriptor identifier for the resource
 	 */
-	protected abstract void deallocate(Object resource, DeviceResourceDescriptor descriptor);
+	protected abstract <R> void deallocate(Object resource, DeviceResourceDescriptor<R> descriptor);
 
 	@Override
-	public final Object create(DeviceResourceDescriptor descriptor) throws DeviceResourceException {
+	public final <R> R create(DeviceResourceDescriptor<R> descriptor) throws DeviceResourceException {
 
 		// Lazily allocate the map
 		if (map == null) {
@@ -75,7 +80,7 @@ abstract class AbstractResourceManager extends ResourceManager {
 		}
 
 		// Get the current reference count
-		RefCount count = map.get(descriptor);
+		RefCount<R> count = getRefCount(descriptor);
 		if (count != null) {
 			// If this resource already exists, increment the reference count and return
 			// the existing resource.
@@ -84,23 +89,23 @@ abstract class AbstractResourceManager extends ResourceManager {
 		}
 
 		// Allocate and return a new resource (with ref count = 1)
-		Object resource = allocate(descriptor);
+		R resource = allocate(descriptor);
 
-		count = new RefCount(resource);
+		count = new RefCount<>(resource);
 		map.put(descriptor, count);
 
 		return resource;
 	}
 
 	@Override
-	public final void destroy(DeviceResourceDescriptor descriptor) {
+	public final <R> void destroy(DeviceResourceDescriptor<R> descriptor) {
 		// If the map is empty (null) then there are no resources to dispose
 		if (map == null) {
 			return;
 		}
 
 		// Find the existing resource
-		RefCount count = map.get(descriptor);
+		RefCount<R> count = getRefCount(descriptor);
 		if (count != null) {
 			// If the resource exists, decrement the reference count.
 			count.count--;
@@ -135,11 +140,11 @@ abstract class AbstractResourceManager extends ResourceManager {
 	}
 
 	@Override
-	public Object find(DeviceResourceDescriptor descriptor) {
+	public <R> R find(DeviceResourceDescriptor<R> descriptor) {
 		if (map == null) {
 			return null;
 		}
-		RefCount refCount = map.get(descriptor);
+		RefCount<R> refCount = getRefCount(descriptor);
 		if (refCount == null) {
 			return null;
 		}

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ColorDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ColorDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2015 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -24,7 +24,7 @@ import org.eclipse.swt.graphics.RGB;
  *
  * @since 3.1
  */
-public abstract class ColorDescriptor extends DeviceResourceDescriptor {
+public abstract class ColorDescriptor extends DeviceResourceDescriptor<Color> {
 
 	/**
 	 * Creates a ColorDescriptor from an existing Color, given the Device associated

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/DerivedImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/DerivedImageDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2015 IBM Corporation and others.
+ * Copyright (c) 2005, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -28,8 +28,8 @@ import org.eclipse.swt.widgets.Display;
  */
 final class DerivedImageDescriptor extends ImageDescriptor {
 
-	private ImageDescriptor original;
-	private int flags;
+	private final ImageDescriptor original;
+	private final int flags;
 
 	/**
 	 * Create a new image descriptor

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/DeviceResourceDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/DeviceResourceDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2015 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Hannes Wellmann - Parameterize DeviceResourceDescriptor with the described resource type
  *******************************************************************************/
 package org.eclipse.jface.resource;
 
@@ -25,11 +26,13 @@ import org.eclipse.swt.graphics.Device;
  * two equal descriptors at hand, e.g. decorating an identical object.
  * </p>
  *
+ * @param <R> The resource's type described by this descriptor
+ *
  * @see org.eclipse.jface.resource.ResourceManager
  *
  * @since 3.1
  */
-public abstract class DeviceResourceDescriptor {
+public abstract class DeviceResourceDescriptor<R> {
 	private final boolean shouldBeCached;
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/DeviceResourceException.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/DeviceResourceException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2015 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -35,7 +35,7 @@ public class DeviceResourceException extends RuntimeException {
 	 * @param missingResource the failed resource
 	 * @param cause cause of the exception (or null if none)
 	 */
-	public DeviceResourceException(DeviceResourceDescriptor missingResource, Throwable cause) {
+	public DeviceResourceException(DeviceResourceDescriptor<?> missingResource, Throwable cause) {
 		super("Unable to create resource " + missingResource); //$NON-NLS-1$
 		// don't pass the cause to super, to allow compilation against JCL Foundation (bug 80059)
 		this.cause = cause;
@@ -47,7 +47,7 @@ public class DeviceResourceException extends RuntimeException {
 	 *
 	 * @param missingResource the failed resource
 	 */
-	public DeviceResourceException(DeviceResourceDescriptor missingResource) {
+	public DeviceResourceException(DeviceResourceDescriptor<?> missingResource) {
 		this(missingResource, null);
 	}
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/DeviceResourceManager.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/DeviceResourceManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2015 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -51,12 +51,13 @@ public final class DeviceResourceManager extends AbstractResourceManager {
 	}
 
 	@Override
-	protected Object allocate(DeviceResourceDescriptor descriptor) throws DeviceResourceException {
-		return descriptor.createResource(device);
+	@SuppressWarnings("unchecked")
+	protected <R> R allocate(DeviceResourceDescriptor<R> descriptor) throws DeviceResourceException {
+		return (R) descriptor.createResource(device);
 	}
 
 	@Override
-	protected void deallocate(Object resource, DeviceResourceDescriptor descriptor) {
+	protected <R> void deallocate(Object resource, DeviceResourceDescriptor<R> descriptor) {
 		descriptor.destroyResource(resource);
 	}
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FontDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FontDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2015 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -26,7 +26,7 @@ import org.eclipse.swt.widgets.Display;
  *
  * @since 3.1
  */
-public abstract class FontDescriptor extends DeviceResourceDescriptor {
+public abstract class FontDescriptor extends DeviceResourceDescriptor<Font> {
 
 	/**
 	 * Creates a FontDescriptor that describes an existing font. The resulting

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -59,7 +59,7 @@ import org.eclipse.swt.widgets.Display;
  *
  * @see org.eclipse.swt.graphics.Image
  */
-public abstract class ImageDescriptor extends DeviceResourceDescriptor {
+public abstract class ImageDescriptor extends DeviceResourceDescriptor<Image> {
 
 	/**
 	 * A small red square used to warn that an image cannot be created.

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageRegistry.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageRegistry.java
@@ -333,7 +333,7 @@ public class ImageRegistry {
 		if (table != null) {
 			for (Entry entry : table.values()) {
 				if (entry.image != null) {
-					manager.destroyImage(entry.descriptor);
+					manager.destroy(entry.descriptor);
 				}
 			}
 			table = null;

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/LazyResourceManager.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/LazyResourceManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Joerg Kubitz and others.
+ * Copyright (c) 2021, 2023 Joerg Kubitz and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -31,7 +31,7 @@ public class LazyResourceManager extends ResourceManager {
 	 * referenced otherwise anymore. The Resources itself are only cached by the
 	 * parent ResourceManager.
 	 */
-	private static class LruMap extends LinkedHashMap<DeviceResourceDescriptor, ResourceManager> {
+	private static class LruMap extends LinkedHashMap<DeviceResourceDescriptor<?>, ResourceManager> {
 		private static final long serialVersionUID = 1L;
 		int cacheSize;
 
@@ -41,7 +41,7 @@ public class LazyResourceManager extends ResourceManager {
 		}
 
 		@Override
-		protected boolean removeEldestEntry(java.util.Map.Entry<DeviceResourceDescriptor, ResourceManager> eldest) {
+		protected boolean removeEldestEntry(java.util.Map.Entry<DeviceResourceDescriptor<?>, ResourceManager> eldest) {
 			boolean remove = size() > cacheSize;
 			if (remove) {
 				// destroy resource which was not used recently:
@@ -53,7 +53,7 @@ public class LazyResourceManager extends ResourceManager {
 
 	private final ResourceManager parent;
 	private final LruMap unreferenced;
-	private final Map<DeviceResourceDescriptor, Integer> refCount;
+	private final Map<DeviceResourceDescriptor<?>, Integer> refCount;
 
 	/**
 	 * @param cacheSize the lru cache size
@@ -74,7 +74,7 @@ public class LazyResourceManager extends ResourceManager {
 	 * @param descriptor
 	 * @return if a resource based on this descriptor should be cached.
 	 */
-	private boolean shouldBeCached(DeviceResourceDescriptor descriptor) {
+	private boolean shouldBeCached(DeviceResourceDescriptor<?> descriptor) {
 		return descriptor != null && descriptor.shouldBeCached();
 	}
 
@@ -84,7 +84,7 @@ public class LazyResourceManager extends ResourceManager {
 	}
 
 	@Override
-	public Object create(DeviceResourceDescriptor descriptor) {
+	public <R> R create(DeviceResourceDescriptor<R> descriptor) {
 		if (!shouldBeCached(descriptor)) {
 			return parent.create(descriptor);
 		}
@@ -103,7 +103,7 @@ public class LazyResourceManager extends ResourceManager {
 	}
 
 	@Override
-	public void destroy(DeviceResourceDescriptor descriptor) {
+	public <R> void destroy(DeviceResourceDescriptor<R> descriptor) {
 		if (!shouldBeCached(descriptor)) {
 			parent.destroy(descriptor);
 			return;
@@ -118,7 +118,7 @@ public class LazyResourceManager extends ResourceManager {
 	}
 
 	@Override
-	public Object find(DeviceResourceDescriptor descriptor) {
+	public <R> R find(DeviceResourceDescriptor<R> descriptor) {
 		if (!shouldBeCached(descriptor)) {
 			return parent.find(descriptor);
 		}

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/LocalResourceManager.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/LocalResourceManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2015 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -67,12 +67,12 @@ public final class LocalResourceManager extends AbstractResourceManager {
 	}
 
 	@Override
-	protected Object allocate(DeviceResourceDescriptor descriptor) throws DeviceResourceException {
+	protected <R> R allocate(DeviceResourceDescriptor<R> descriptor) throws DeviceResourceException {
 		return parentRegistry.create(descriptor);
 	}
 
 	@Override
-	protected void deallocate(Object resource, DeviceResourceDescriptor descriptor) {
+	protected <R> void deallocate(Object resource, DeviceResourceDescriptor<R> descriptor) {
 		parentRegistry.destroy(descriptor);
 	}
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ResourceManager.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ResourceManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2015 IBM Corporation and others.
+ * Copyright (c) 2004, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Hannes Wellmann - Parameterize DeviceResourceDescriptor with the described resource type
  *******************************************************************************/
 package org.eclipse.jface.resource;
 
@@ -84,19 +85,13 @@ public abstract class ResourceManager {
 	 * this method.
 	 * </p>
 	 *
-	 * <p>
-	 * Callers may safely downcast the result to the resource type associated with
-	 * the descriptor. For example, when given an ImageDescriptor, the return value
-	 * of this method will always be an Image.
-	 * </p>
-	 *
 	 * @since 3.1
 	 *
 	 * @param descriptor descriptor for the resource to allocate
 	 * @return the newly allocated resource (not null)
 	 * @throws DeviceResourceException if unable to allocate the resource
 	 */
-	public abstract Object create(DeviceResourceDescriptor descriptor);
+	public abstract <R> R create(DeviceResourceDescriptor<R> descriptor);
 
 	/**
 	 * Deallocates a resource previously allocated by {@link #create(DeviceResourceDescriptor)}.
@@ -108,7 +103,7 @@ public abstract class ResourceManager {
 	 *
 	 * @param descriptor identifier for the resource
 	 */
-	public abstract void destroy(DeviceResourceDescriptor descriptor);
+	public abstract <R> void destroy(DeviceResourceDescriptor<R> descriptor);
 
 	/**
 	 * Returns a previously-allocated resource or allocates a new one if none exists
@@ -123,12 +118,6 @@ public abstract class ResourceManager {
 	 * other code that shares them. For example, never call
 	 * {@link org.eclipse.swt.graphics.Resource#dispose()} on anything returned from
 	 * this method.
-	 * </p>
-	 *
-	 * <p>
-	 * Callers may safely downcast the result to the resource type associated with
-	 * the descriptor. For example, when given an ImageDescriptor, the return value
-	 * of this method may be downcast to Image.
 	 * </p>
 	 *
 	 * <p>
@@ -151,8 +140,8 @@ public abstract class ResourceManager {
 	 *
 	 * @since 3.3
 	 */
-	public final Object get(DeviceResourceDescriptor descriptor) {
-		Object cached = find(descriptor);
+	public final <R> R get(DeviceResourceDescriptor<R> descriptor) {
+		R cached = find(descriptor);
 		return cached != null ? cached : create(descriptor);
 	}
 
@@ -171,14 +160,16 @@ public abstract class ResourceManager {
 	 * @since 3.1
 	 *
 	 * @param descriptor descriptor for the image to create
-	 * @return the Image described by this descriptor (possibly shared by other equivalent
-	 * ImageDescriptors)
+	 * @return the Image described by this descriptor (possibly shared by other
+	 *         equivalent ImageDescriptors)
 	 * @throws DeviceResourceException if unable to allocate the Image
+	 * @deprecated use {@link #create(DeviceResourceDescriptor)} instead
 	 */
+	@Deprecated(since = "3.31")
 	public final Image createImage(ImageDescriptor descriptor) {
 		// Assertion added to help diagnose client bugs.  See bug #83711 and bug #90454.
 		Assert.isNotNull(descriptor);
-		return (Image) create(descriptor);
+		return create(descriptor);
 	}
 
 	/**
@@ -198,7 +189,7 @@ public abstract class ResourceManager {
 		}
 
 		try {
-			return (Image) create(descriptor);
+			return create(descriptor);
 		} catch (DeviceResourceException | SWTException e) {
 			Policy.getLog().log(Status.warning("The image could not be loaded: " + descriptor, e)); //$NON-NLS-1$
 			return getDefaultImage();
@@ -222,7 +213,9 @@ public abstract class ResourceManager {
 	 * @since 3.1
 	 *
 	 * @param descriptor identifier for the image to dispose
+	 * @deprecated use {@link #destroy(DeviceResourceDescriptor)} instead
 	 */
+	@Deprecated(since = "3.31")
 	public final void destroyImage(ImageDescriptor descriptor) {
 		destroy(descriptor);
 	}
@@ -238,9 +231,11 @@ public abstract class ResourceManager {
 	 * @param descriptor descriptor for the color to create
 	 * @return the Color described by the given ColorDescriptor (not null)
 	 * @throws DeviceResourceException if unable to create the color
+	 * @deprecated use {@link #create(DeviceResourceDescriptor)} instead
 	 */
+	@Deprecated(since = "3.31")
 	public final Color createColor(ColorDescriptor descriptor) {
-		return (Color)create(descriptor);
+		return create(descriptor);
 	}
 
 	/**
@@ -256,7 +251,7 @@ public abstract class ResourceManager {
 	 * @throws DeviceResourceException if unable to create the color
 	 */
 	public final Color createColor(RGB descriptor) {
-		return createColor(new RGBColorDescriptor(descriptor));
+		return create(new RGBColorDescriptor(descriptor));
 	}
 
 	/**
@@ -267,7 +262,7 @@ public abstract class ResourceManager {
 	 * @param descriptor RGB value of the color to dispose
 	 */
 	public final void destroyColor(RGB descriptor) {
-		destroyColor(new RGBColorDescriptor(descriptor));
+		destroy(new RGBColorDescriptor(descriptor));
 	}
 
 	/**
@@ -277,7 +272,9 @@ public abstract class ResourceManager {
 	 * @since 3.1
 	 *
 	 * @param descriptor identifier for the color to dispose
+	 * @deprecated use {@link #destroy(DeviceResourceDescriptor)} instead
 	 */
+	@Deprecated(since = "3.31")
 	public final void destroyColor(ColorDescriptor descriptor) {
 		destroy(descriptor);
 	}
@@ -293,9 +290,11 @@ public abstract class ResourceManager {
 	 * @param descriptor description of the font to create
 	 * @return the Font described by the given descriptor
 	 * @throws DeviceResourceException if unable to create the font
+	 * @deprecated use {@link #create(DeviceResourceDescriptor)} instead
 	 */
+	@Deprecated(since = "3.31")
 	public final Font createFont(FontDescriptor descriptor) {
-		return (Font)create(descriptor);
+		return create(descriptor);
 	}
 
 	/**
@@ -304,7 +303,9 @@ public abstract class ResourceManager {
 	 * @since 3.1
 	 *
 	 * @param descriptor description of the font to destroy
+	 * @deprecated use {@link #destroy(DeviceResourceDescriptor)} instead
 	 */
+	@Deprecated(since = "3.31")
 	public final void destroyFont(FontDescriptor descriptor) {
 		destroy(descriptor);
 	}
@@ -353,7 +354,7 @@ public abstract class ResourceManager {
 	 * @param descriptor descriptor to find
 	 * @return a previously allocated resource for the given descriptor or null if none.
 	 */
-	public abstract Object find(DeviceResourceDescriptor descriptor);
+	public abstract <R> R find(DeviceResourceDescriptor<R> descriptor);
 
 	/**
 	 * Causes the <code>run()</code> method of the runnable to be invoked just

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/Wizard.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/Wizard.java
@@ -207,7 +207,7 @@ public abstract class Wizard implements IWizard, IShellProvider {
 		}
 		// dispose of image
 		if (defaultImage != null) {
-			JFaceResources.getResources().destroyImage(defaultImageDescriptor);
+			JFaceResources.getResources().destroy(defaultImageDescriptor);
 			defaultImage = null;
 		}
 	}

--- a/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/ImageResourceManager.java
+++ b/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/ImageResourceManager.java
@@ -55,7 +55,7 @@ class ImageResourceManager {
 	 * @return the image
 	 */
 	Image getImage(ImageDescriptor descriptor) {
-		return (Image) manager.get(descriptor);
+		return manager.get(descriptor);
 	}
 }
 

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/FormFonts.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/FormFonts.java
@@ -78,7 +78,7 @@ public class FormFonts {
 	public Font getBoldFont(Display display, Font font) {
 		checkHashMaps();
 		BoldFontDescriptor desc = new BoldFontDescriptor(font);
-		Font result = manager.getResourceManager(display).createFont(desc);
+		Font result = manager.getResourceManager(display).create(desc);
 		descriptors.put(result, desc);
 		return result;
 	}
@@ -88,7 +88,7 @@ public class FormFonts {
 		BoldFontDescriptor desc = descriptors.get(boldFont);
 		if (desc != null) {
 			LocalResourceManager resourceManager = manager.getResourceManager(display);
-			resourceManager.destroyFont(desc);
+			resourceManager.destroy(desc);
 			if (resourceManager.find(desc) == null) {
 				descriptors.remove(boldFont);
 				validateHashMaps();

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/FormImages.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/FormImages.java
@@ -348,7 +348,7 @@ public class FormImages {
 
 	private synchronized Image getGradient(AbstractImageDescriptor desc, Display display) {
 		checkHashMaps();
-		Image result = manager.getResourceManager(display).createImage(desc);
+		Image result = manager.getResourceManager(display).create(desc);
 		descriptors.put(Integer.valueOf(result.hashCode()), desc);
 		return result;
 	}
@@ -359,7 +359,7 @@ public class FormImages {
 		AbstractImageDescriptor desc = descriptors.get(imageHashCode);
 		if (desc != null) {
 			LocalResourceManager resourceManager = manager.getResourceManager(display);
-			resourceManager.destroyImage(desc);
+			resourceManager.destroy(desc);
 			if (resourceManager.find(desc) == null) {
 				descriptors.remove(imageHashCode);
 				validateHashMaps();

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/OpenWithMenu.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/OpenWithMenu.java
@@ -134,7 +134,7 @@ public class OpenWithMenu extends ContributionItem {
 		if (imageDesc == null) {
 			return null;
 		}
-		return IDEWorkbenchPlugin.getDefault().getResourceManager().createImage(imageDesc);
+		return IDEWorkbenchPlugin.getDefault().getResourceManager().create(imageDesc);
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ResourceInfoPage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ResourceInfoPage.java
@@ -330,7 +330,7 @@ public class ResourceInfoPage extends PropertyPage {
 			Bundle bundle = FrameworkUtil.getBundle(getClass());
 			URL goToFolderUrl = FileLocator.find(bundle, IPath.fromOSString("icons/full/obj16/goto_input.png"), //$NON-NLS-1$
 					null);
-			goToLocationButton.setImage(resourceManager.createImage(ImageDescriptor.createFromURL(goToFolderUrl)));
+			goToLocationButton.setImage(resourceManager.create(ImageDescriptor.createFromURL(goToFolderUrl)));
 			goToLocationButton.setToolTipText(LOCATION_BUTTON_TOOLTIP);
 			goToLocationButton.addSelectionListener(new SelectionAdapter() {
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/helpers/EmptyWorkspaceHelper.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/helpers/EmptyWorkspaceHelper.java
@@ -274,7 +274,7 @@ public final class EmptyWorkspaceHelper {
 			ISharedImages images = PlatformUI.getWorkbench().getSharedImages();
 			imageDesc = images.getImageDescriptor(ISharedImages.IMG_TOOL_NEW_WIZARD);
 		}
-		addLabel.setImage(resourceManager.createImage(imageDesc));
+		addLabel.setImage(resourceManager.create(imageDesc));
 
 		Hyperlink addLink = toolkit.createHyperlink(optionsArea, text, SWT.WRAP);
 		addLink.setForeground(linkColor);

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/MarkerField.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/MarkerField.java
@@ -101,7 +101,7 @@ public abstract class MarkerField {
 					}
 				}
 				if (descriptors[IDecoration.TOP_RIGHT] != null || descriptors[IDecoration.BOTTOM_RIGHT] != null)
-					image = getImageManager().createImage(new DecorationOverlayIcon(image, descriptors));
+					image = getImageManager().create(new DecorationOverlayIcon(image, descriptors));
 			}
 		}
 		return image;

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/activities/ActivityCategoryPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/activities/ActivityCategoryPreferencePage.java
@@ -143,7 +143,7 @@ public final class ActivityCategoryPreferencePage extends PreferencePage
 					if (decorate && isLocked(category) && lockDescriptor.isPresent()) {
 						descriptor = new DecorationOverlayIcon(descriptor, lockDescriptor.get(), IDecoration.TOP_RIGHT);
 					}
-					return manager.createImage(descriptor);
+					return manager.create(descriptor);
 				} catch (DeviceResourceException e) {
 					WorkbenchPlugin.log(e);
 				}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/EditorSelectionDialog.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/EditorSelectionDialog.java
@@ -42,7 +42,6 @@ import org.eclipse.osgi.util.NLS;
 import org.eclipse.osgi.util.TextProcessor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.layout.RowLayout;
@@ -279,7 +278,7 @@ public class EditorSelectionDialog extends Dialog {
 			return TextProcessor.process(d.getLabel(), "."); //$NON-NLS-1$
 		}, element -> {
 			IEditorDescriptor d = (IEditorDescriptor) element;
-			return (Image) resourceManager.get(d.getImageDescriptor());
+			return resourceManager.get(d.getImageDescriptor());
 		}));
 
 		browseExternalEditorsButton = new Button(contents, SWT.PUSH);

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/activities/ws/ActivityCategoryLabelProvider.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/activities/ws/ActivityCategoryLabelProvider.java
@@ -49,7 +49,7 @@ public class ActivityCategoryLabelProvider extends LabelProvider {
 		try {
 			ImageDescriptor descriptor = getDescriptor(element);
 			if (descriptor != null) {
-				return manager.createImage(descriptor);
+				return manager.create(descriptor);
 			}
 		} catch (DeviceResourceException e) {
 			// ignore

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/decorators/DecorationResult.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/decorators/DecorationResult.java
@@ -88,7 +88,7 @@ public class DecorationResult {
 		Rectangle bounds = image.getBounds();
 		Point size = new Point(bounds.width, bounds.height);
 		DecorationOverlayIcon icon = new DecorationOverlayIcon(image, descriptors, size);
-		return manager.createImage(icon);
+		return manager.create(icon);
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/WorkingSetLabelProvider.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/WorkingSetLabelProvider.java
@@ -46,7 +46,7 @@ public class WorkingSetLabelProvider extends LabelProvider {
 		IWorkingSet workingSet = (IWorkingSet) object;
 		ImageDescriptor imageDescriptor = workingSet.getImageDescriptor();
 
-		return imageDescriptor == null ? null : (Image) images.get(imageDescriptor);
+		return imageDescriptor == null ? null : images.get(imageDescriptor);
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/WorkingSetTypePage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/WorkingSetTypePage.java
@@ -127,7 +127,7 @@ public class WorkingSetTypePage extends WizardPage {
 			@Override
 			public Image getImage(Object element) {
 				ImageDescriptor imageDescriptor = ((WorkingSetDescriptor) element).getIcon();
-				return imageDescriptor == null ? null : (Image) images.get(imageDescriptor);
+				return imageDescriptor == null ? null : images.get(imageDescriptor);
 			}
 		});
 		typesListViewer.setInput(descriptors);

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/cpd/TreeManager.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/cpd/TreeManager.java
@@ -268,7 +268,7 @@ public class TreeManager {
 				if (imageDescriptor == null) {
 					return null;
 				}
-				image = resourceManager.createImage(imageDescriptor);
+				image = resourceManager.create(imageDescriptor);
 			}
 			return image;
 		}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/CyclePageHandler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/CyclePageHandler.java
@@ -77,7 +77,7 @@ public class CyclePageHandler extends FilteredTableBaseHandler {
 				if (lrm == null) {
 					lrm = new LocalResourceManager(JFaceResources.getResources());
 				}
-				item.setImage(lrm.createImage(imageDescriptor));
+				item.setImage(lrm.create(imageDescriptor));
 			}
 			item.putData(K_PAGE, viewPage);
 			String name = pageSwitcher.getName(viewPage);

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/keys/NewKeysPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/keys/NewKeysPreferencePage.java
@@ -406,7 +406,7 @@ public class NewKeysPreferencePage extends PreferencePage implements IWorkbenchP
 					return null;
 				}
 				try {
-					return localResourceManager.createImage(imageDescriptor);
+					return localResourceManager.create(imageDescriptor);
 				} catch (final DeviceResourceException e) {
 					final String message = "Problem retrieving image for a command '" //$NON-NLS-1$
 							+ commandId + '\'';

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
@@ -743,7 +743,7 @@ public abstract class QuickAccessContents {
 		table = new Table(tableComposite, SWT.SINGLE | SWT.FULL_SELECTION);
 		textLayout = new TextLayout(table.getDisplay());
 		textLayout.setOrientation(defaultOrientation);
-		Font boldFont = resourceManager.createFont(FontDescriptor.createFrom(table.getFont()).setStyle(SWT.BOLD));
+		Font boldFont = resourceManager.create(FontDescriptor.createFrom(table.getFont()).setStyle(SWT.BOLD));
 		textLayout.setFont(table.getFont());
 		textLayout.setText(QuickAccessMessages.QuickAccess_AvailableCategories);
 		int maxProviderWidth = (textLayout.getBounds().width);

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/QuickAccessEntry.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/QuickAccessEntry.java
@@ -129,7 +129,7 @@ public class QuickAccessEntry {
 		if (imageDescriptor == null) {
 			return null;
 		}
-		Image image = (Image) resourceManager.find(imageDescriptor);
+		Image image = resourceManager.find(imageDescriptor);
 		if (image == null) {
 			try {
 				image = resourceManager.createImage(imageDescriptor);

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/QuickAccessEntry.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/QuickAccessEntry.java
@@ -132,7 +132,7 @@ public class QuickAccessEntry {
 		Image image = resourceManager.find(imageDescriptor);
 		if (image == null) {
 			try {
-				image = resourceManager.createImage(imageDescriptor);
+				image = resourceManager.create(imageDescriptor);
 			} catch (DeviceResourceException e) {
 				WorkbenchPlugin.log(e);
 			}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/statushandlers/LabelProviderWrapper.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/statushandlers/LabelProviderWrapper.java
@@ -119,9 +119,9 @@ public class LabelProviderWrapper extends ViewerComparator implements ITableLabe
 
 				// Create an image from the job's icon property or family
 				if (property instanceof ImageDescriptor) {
-					return manager.createImage((ImageDescriptor) property);
+					return manager.create((ImageDescriptor) property);
 				} else if (property instanceof URL) {
-					return manager.createImage(ImageDescriptor.createFromURL((URL) property));
+					return manager.create(ImageDescriptor.createFromURL((URL) property));
 				} else {
 					// Let the progress manager handle the resource management
 					return ProgressManager.getInstance().getIconFor(job);

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/util/Descriptors.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/util/Descriptors.java
@@ -102,10 +102,10 @@ public final class Descriptors {
 		}
 
 		final Method method;
-		DeviceResourceDescriptor oldDescriptor;
+		DeviceResourceDescriptor<?> oldDescriptor;
 		final String id;
 
-		public void invoke(Widget toCall, DeviceResourceDescriptor newDescriptor) {
+		public void invoke(Widget toCall, DeviceResourceDescriptor<?> newDescriptor) {
 			if (newDescriptor == oldDescriptor) {
 				return;
 			}
@@ -272,7 +272,7 @@ public final class Descriptors {
 		return result;
 	}
 
-	private static void callMethod(Widget toCall, String methodName, DeviceResourceDescriptor descriptor,
+	private static void callMethod(Widget toCall, String methodName, DeviceResourceDescriptor<?> descriptor,
 			Class<?> resourceType) {
 		ResourceMethod method;
 		try {

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/menus/CommandContributionItem.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/menus/CommandContributionItem.java
@@ -855,10 +855,10 @@ public class CommandContributionItem extends ContributionItem {
 			MenuItem item = (MenuItem) widget;
 			LocalResourceManager m = new LocalResourceManager(JFaceResources.getResources());
 			try {
-				item.setImage(icon == null ? null : m.createImage(icon));
+				item.setImage(icon == null ? null : m.create(icon));
 			} catch (DeviceResourceException e) {
 				icon = ImageDescriptor.getMissingImageDescriptor();
-				item.setImage(m.createImage(icon));
+				item.setImage(m.create(icon));
 				// as we replaced the failed icon, log the message once.
 				StatusManager.getManager()
 						.handle(new Status(IStatus.ERROR, WorkbenchPlugin.PI_WORKBENCH, "Failed to load image", e)); //$NON-NLS-1$
@@ -868,9 +868,9 @@ public class CommandContributionItem extends ContributionItem {
 		} else if (widget instanceof ToolItem) {
 			ToolItem item = (ToolItem) widget;
 			LocalResourceManager m = new LocalResourceManager(JFaceResources.getResources());
-			item.setDisabledImage(disabledIcon == null ? null : m.createImage(disabledIcon));
-			item.setHotImage(hoverIcon == null ? null : m.createImage(hoverIcon));
-			item.setImage(icon == null ? null : m.createImage(icon));
+			item.setDisabledImage(disabledIcon == null ? null : m.create(disabledIcon));
+			item.setHotImage(hoverIcon == null ? null : m.create(hoverIcon));
+			item.setImage(icon == null ? null : m.create(icon));
 			disposeOldImages();
 			localResourceManager = m;
 		}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/model/WorkbenchLabelProvider.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/model/WorkbenchLabelProvider.java
@@ -182,7 +182,7 @@ public class WorkbenchLabelProvider extends LabelProvider
 		// add any annotations to the image descriptor
 		descriptor = decorateImage(descriptor, element);
 
-		return (Image) getResourceManager().get(descriptor);
+		return getResourceManager().get(descriptor);
 	}
 
 	/**
@@ -263,7 +263,7 @@ public class WorkbenchLabelProvider extends LabelProvider
 			return null;
 		}
 
-		return (Font) getResourceManager().get(FontDescriptor.createFrom(descriptor));
+		return getResourceManager().get(FontDescriptor.createFrom(descriptor));
 	}
 
 	private Color getColor(Object element, boolean forground) {
@@ -276,6 +276,6 @@ public class WorkbenchLabelProvider extends LabelProvider
 			return null;
 		}
 
-		return (Color) getResourceManager().get(ColorDescriptor.createFrom(descriptor));
+		return getResourceManager().get(ColorDescriptor.createFrom(descriptor));
 	}
 }

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/model/WorkbenchPartLabelProvider.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/model/WorkbenchPartLabelProvider.java
@@ -64,7 +64,7 @@ public final class WorkbenchPartLabelProvider extends LabelProvider implements I
 			Image image = (Image) images.get(imageDesc);
 			if (image == null) {
 				try {
-					image = resourceManager.createImage(imageDesc);
+					image = resourceManager.create(imageDesc);
 					images.put(imageDesc, image);
 				} catch (DeviceResourceException e) {
 					WorkbenchPlugin.log(getClass(), "getImage", e); //$NON-NLS-1$

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/part/IntroPart.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/part/IntroPart.java
@@ -96,7 +96,7 @@ public abstract class IntroPart extends EventManager implements IIntroPart, IExe
 	 */
 	@Override
 	public void dispose() {
-		imageDescriptor.ifPresent(JFaceResources.getResources()::destroyImage);
+		imageDescriptor.ifPresent(JFaceResources.getResources()::destroy);
 		titleImage = null;
 		// Clear out the property change listeners as we
 		// should not be notifying anyone after the part

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/part/WorkbenchPart.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/part/WorkbenchPart.java
@@ -105,7 +105,7 @@ public abstract class WorkbenchPart extends EventManager
 	public void dispose() {
 		imageDescriptor.ifPresent(d -> {
 			if (Display.getCurrent() != null) {
-				JFaceResources.getResources().destroyImage(d);
+				JFaceResources.getResources().destroy(d);
 			} // otherwise Device already destroyed => ignore
 		});
 		titleImage = null;
@@ -300,7 +300,7 @@ public abstract class WorkbenchPart extends EventManager
 		}
 		this.titleImage = titleImage;
 		firePropertyChange(IWorkbenchPart.PROP_TITLE);
-		imageDescriptor.ifPresent(JFaceResources.getResources()::destroyImage);
+		imageDescriptor.ifPresent(JFaceResources.getResources()::destroy);
 		imageDescriptor = Optional.empty();
 	}
 

--- a/examples/org.eclipse.jface.examples.databinding/src/org/eclipse/jface/examples/databinding/snippets/Snippet015DelayTextModifyEvents.java
+++ b/examples/org.eclipse.jface.examples.databinding/src/org/eclipse/jface/examples/databinding/snippets/Snippet015DelayTextModifyEvents.java
@@ -79,7 +79,7 @@ public class Snippet015DelayTextModifyEvents {
 		// you are done with it)
 		ResourceManager resourceManager = new LocalResourceManager(JFaceResources.getResources());
 		final Font shellFont = shell.getFont();
-		final Font italicFont = resourceManager.createFont(FontDescriptor.createFrom(shellFont).setStyle(SWT.ITALIC));
+		final Font italicFont = resourceManager.create(FontDescriptor.createFrom(shellFont).setStyle(SWT.ITALIC));
 
 		IObservableValue<Boolean> stale1 = Observables.observeStale(delayed1);
 		IObservableValue<Boolean> stale2 = Observables.observeStale(delayed2);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/LazyResourceManagerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/LazyResourceManagerTest.java
@@ -368,7 +368,7 @@ public class LazyResourceManagerTest extends TestCase {
 		ImageDescriptor nullDescriptor = null;
 
 		// Test with "test" resources manager
-		AtomicReference<DeviceResourceDescriptor> expected = (AtomicReference<DeviceResourceDescriptor>) mgr
+		AtomicReference<DeviceResourceDescriptor> expected = (AtomicReference<DeviceResourceDescriptor>) (Object) mgr
 				.create(nullDescriptor);
 		assertAlife(expected, mgr, tst, nullDescriptor);
 		mgr.destroy(nullDescriptor);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/LazyResourceManagerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/LazyResourceManagerTest.java
@@ -30,8 +30,9 @@ import org.eclipse.swt.graphics.Image;
 
 import junit.framework.TestCase;
 
+@SuppressWarnings({ "rawtypes", "unchecked" })
 public class LazyResourceManagerTest extends TestCase {
-	private static class CachableTestDescriptor extends DeviceResourceDescriptor {
+	private static class CachableTestDescriptor extends DeviceResourceDescriptor<Object> {
 		CachableTestDescriptor() {
 			super(true);
 		}
@@ -46,7 +47,7 @@ public class LazyResourceManagerTest extends TestCase {
 		}
 	}
 
-	private static class UncachableTestDescriptor extends DeviceResourceDescriptor {
+	private static class UncachableTestDescriptor extends DeviceResourceDescriptor<Object> {
 		UncachableTestDescriptor() {
 			super(false);
 		}
@@ -200,7 +201,6 @@ public class LazyResourceManagerTest extends TestCase {
 	/**
 	 * Creates multiple resources for 2 Descriptors. Only 1 of them can be cached
 	 **/
-	@SuppressWarnings("unchecked")
 	public void testLazyResourceManagerRefCounting() {
 		TestResourceManager tst = new TestResourceManager();
 		LazyResourceManager mgr = new LazyResourceManager(1, tst);
@@ -361,7 +361,6 @@ public class LazyResourceManagerTest extends TestCase {
 		assertCached(expected2, mgr, tst, descriptor2); // 2 still cached, because recently used
 	}
 
-	@SuppressWarnings("unchecked")
 	public void testNullDescriptor() {
 		TestResourceManager tst = new TestResourceManager();
 		LazyResourceManager mgr = new LazyResourceManager(2, tst);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/ResourceManagerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/ResourceManagerTest.java
@@ -41,7 +41,7 @@ import junit.framework.TestCase;
  */
 public class ResourceManagerTest extends TestCase {
 
-	private DeviceResourceDescriptor[] descriptors;
+	private DeviceResourceDescriptor<?>[] descriptors;
 	private Image testImage;
 	private Image testImage2;
 	private Color testColor;
@@ -54,11 +54,11 @@ public class ResourceManagerTest extends TestCase {
 		return ResourceLocator.imageDescriptorFromBundle("org.eclipse.jface.tests", path).orElse(null);
 	}
 
-	private static final class TestDescriptor extends DeviceResourceDescriptor {
-		DeviceResourceDescriptor toWrap;
+	private static final class TestDescriptor<R> extends DeviceResourceDescriptor<R> {
+		DeviceResourceDescriptor<R> toWrap;
 		public static int refCount = 0;
 
-		public TestDescriptor(DeviceResourceDescriptor toWrap) {
+		public TestDescriptor(DeviceResourceDescriptor<R> toWrap) {
 			this.toWrap = toWrap;
 		}
 
@@ -77,9 +77,7 @@ public class ResourceManagerTest extends TestCase {
 
 		@Override
 		public boolean equals(Object arg0) {
-			if (arg0 instanceof TestDescriptor description) {
-				TestDescriptor td = description;
-
+			if (arg0 instanceof TestDescriptor td) {
 				return td.toWrap.equals(toWrap);
 			}
 
@@ -107,33 +105,34 @@ public class ResourceManagerTest extends TestCase {
 		// If you modify this array, be sure to adjust numDupes as well. Note that some
 		// tests index the array directly, so it is a good idea to always add to this
 		// array rather than remove from it.
-		descriptors = new DeviceResourceDescriptor[] { new TestDescriptor(getImage("icons/anything.gif")),
-				new TestDescriptor(getImage("icons/anything.gif")), new TestDescriptor(getImage("icons/binary_co.gif")),
-				new TestDescriptor(getImage("icons/binary_co.gif")),
-				new TestDescriptor(getImage("icons/mockeditorpart1.gif")),
+		descriptors = new DeviceResourceDescriptor[] { new TestDescriptor<>(getImage("icons/anything.gif")),
+				new TestDescriptor<>(getImage("icons/anything.gif")),
+				new TestDescriptor<>(getImage("icons/binary_co.gif")),
+				new TestDescriptor<>(getImage("icons/binary_co.gif")),
+				new TestDescriptor<>(getImage("icons/mockeditorpart1.gif")),
 
-				new TestDescriptor(getImage("icons/view.gif")), // 5
-				new TestDescriptor(ImageDescriptor.createFromImage(testImage2)),
-				new TestDescriptor(ImageDescriptor.createFromImage(testImage)),
-				new TestDescriptor(ImageDescriptor.createFromImage(testImage)),
-				new TestDescriptor(ImageDescriptor.createFromImage(testImage)),
+				new TestDescriptor<>(getImage("icons/view.gif")), // 5
+				new TestDescriptor<>(ImageDescriptor.createFromImage(testImage2)),
+				new TestDescriptor<>(ImageDescriptor.createFromImage(testImage)),
+				new TestDescriptor<>(ImageDescriptor.createFromImage(testImage)),
+				new TestDescriptor<>(ImageDescriptor.createFromImage(testImage)),
 
-				new TestDescriptor(ImageDescriptor.createFromImage(testImage)), // 10
-				new TestDescriptor(ImageDescriptor.createFromImage(testImage2)),
-				new TestDescriptor(ColorDescriptor.createFrom(new RGB(10, 200, 54))),
-				new TestDescriptor(ColorDescriptor.createFrom(new RGB(10, 200, 54))),
-				new TestDescriptor(ColorDescriptor.createFrom(new RGB(200, 220, 54))),
+				new TestDescriptor<>(ImageDescriptor.createFromImage(testImage)), // 10
+				new TestDescriptor<>(ImageDescriptor.createFromImage(testImage2)),
+				new TestDescriptor<>(ColorDescriptor.createFrom(new RGB(10, 200, 54))),
+				new TestDescriptor<>(ColorDescriptor.createFrom(new RGB(10, 200, 54))),
+				new TestDescriptor<>(ColorDescriptor.createFrom(new RGB(200, 220, 54))),
 
-				new TestDescriptor(ColorDescriptor.createFrom(testColor)), // 15
-				new TestDescriptor(ColorDescriptor.createFrom(testColor)),
-				new TestDescriptor(ColorDescriptor.createFrom(testColor2)),
-				new TestDescriptor(ColorDescriptor.createFrom(testColor)),
-				new TestDescriptor(ColorDescriptor.createFrom(testColor)),
+				new TestDescriptor<>(ColorDescriptor.createFrom(testColor)), // 15
+				new TestDescriptor<>(ColorDescriptor.createFrom(testColor)),
+				new TestDescriptor<>(ColorDescriptor.createFrom(testColor2)),
+				new TestDescriptor<>(ColorDescriptor.createFrom(testColor)),
+				new TestDescriptor<>(ColorDescriptor.createFrom(testColor)),
 
-				new TestDescriptor(ColorDescriptor.createFrom(testColor2)), // 20
-				new TestDescriptor(ImageDescriptor.createFromImageDataProvider(new MyImageDataProvider("1"))),
-				new TestDescriptor(ImageDescriptor.createFromImageDataProvider(new MyImageDataProvider("1"))),
-				new TestDescriptor(ImageDescriptor.createFromImageDataProvider(new MyImageDataProvider("2"))),
+				new TestDescriptor<>(ColorDescriptor.createFrom(testColor2)), // 20
+				new TestDescriptor<>(ImageDescriptor.createFromImageDataProvider(new MyImageDataProvider("1"))),
+				new TestDescriptor<>(ImageDescriptor.createFromImageDataProvider(new MyImageDataProvider("1"))),
+				new TestDescriptor<>(ImageDescriptor.createFromImageDataProvider(new MyImageDataProvider("2"))),
 
 		};
 
@@ -170,7 +169,7 @@ public class ResourceManagerTest extends TestCase {
 		Object[] resources = new Object[descriptors.length];
 
 		for (int i = 0; i < descriptors.length; i++) {
-			DeviceResourceDescriptor next = descriptors[i];
+			DeviceResourceDescriptor<?> next = descriptors[i];
 
 			Object resource = next.createResource(display);
 			// Ensure that this resource was allocated correctly
@@ -186,7 +185,7 @@ public class ResourceManagerTest extends TestCase {
 
 		// Deallocate resources directly using the descriptors
 		for (int i = 0; i < descriptors.length; i++) {
-			DeviceResourceDescriptor next = descriptors[i];
+			DeviceResourceDescriptor<?> next = descriptors[i];
 
 			next.destroyResource(resources[i]);
 		}
@@ -198,7 +197,7 @@ public class ResourceManagerTest extends TestCase {
 		Object[] resources = new Object[descriptors.length];
 
 		for (int i = 0; i < descriptors.length; i++) {
-			DeviceResourceDescriptor next = descriptors[i];
+			DeviceResourceDescriptor<?> next = descriptors[i];
 
 			Object resource = globalResourceManager.create(next);
 			// Ensure that this resource was allocated correctly
@@ -217,7 +216,7 @@ public class ResourceManagerTest extends TestCase {
 				TestDescriptor.refCount);
 
 		// Deallocate resources directly using the descriptors
-		for (DeviceResourceDescriptor next : descriptors) {
+		for (DeviceResourceDescriptor<?> next : descriptors) {
 			globalResourceManager.destroy(next);
 		}
 	}
@@ -295,7 +294,7 @@ public class ResourceManagerTest extends TestCase {
 	 * See https://bugs.eclipse.org/bugs/show_bug.cgi?id=135088
 	 */
 	public void testResourceManagerFind() throws Exception {
-		DeviceResourceDescriptor descriptor = descriptors[0];
+		DeviceResourceDescriptor<?> descriptor = descriptors[0];
 		Object resource = globalResourceManager.find(descriptor);
 		assertNull("Resource should be null since it is not allocated", resource);
 		resource = globalResourceManager.create(descriptor);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/manual/SaveablesView.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/manual/SaveablesView.java
@@ -100,7 +100,7 @@ public class SaveablesView extends ViewPart {
 		public Image getImage(Object obj) {
 			ImageDescriptor descriptor = ((Saveable) obj)
 					.getImageDescriptor();
-			return resourceManager.createImage(descriptor);
+			return resourceManager.create(descriptor);
 		}
 	}
 

--- a/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/ComponentLabelProvider.java
+++ b/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/ComponentLabelProvider.java
@@ -137,7 +137,7 @@ public class ComponentLabelProvider extends BaseLabelProvider implements IStyled
 	@Override
 	public Font getFont(Object element) {
 		if (element instanceof VirtualEntry) {
-			return resourceManager.createFont(italicFontDescriptor);
+			return resourceManager.create(italicFontDescriptor);
 		}
 		return null;
 	}


### PR DESCRIPTION
This PR adds typed overloads of ResourceManager.get() for images, fonts and colors that return the corresponding specific resource type:
- `Image get(ImageDescriptor descriptor)`
- `Color get(ColorDescriptor descriptor)`
- `Font get(FontDescriptor descriptor)`

This avoids the need to downcast the resource returned by `get(DeviceResourceDescriptor)` and therefore makes caller's code less verbose and more type-safe.

@vogella you have tutorial about this topic, what do you think?