### PR TITLE
Log debug information to help fix random failure of tests in PipelineChainTest 

### DIFF
--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/PipelineChainTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/PipelineChainTest.java
@@ -25,8 +25,11 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
+import org.eclipse.ui.tests.harness.util.TestRunLogUtil;
 import org.eclipse.ui.tests.navigator.extension.TestPipelineProvider;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestWatcher;
 
 /**
  * @since 3.3
@@ -34,8 +37,10 @@ import org.junit.Test;
  */
 public class PipelineChainTest extends NavigatorTestBase {
 
-	private static final boolean SLEEP_LONG = false;
+	@Rule
+	public TestWatcher LOG_TESTRUN = TestRunLogUtil.LOG_TESTRUN;
 
+	private static final boolean SLEEP_LONG = false;
 
 	public PipelineChainTest() {
 		_navigatorInstanceId = TEST_VIEWER_PIPELINE;

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestPipelineProvider.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestPipelineProvider.java
@@ -26,6 +26,8 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.navigator.ICommonContentExtensionSite;
@@ -42,6 +44,7 @@ import org.eclipse.ui.tests.navigator.m12.model.ResourceWrapper;
  */
 public class TestPipelineProvider extends ResourceWrapperContentProvider {
 
+	private static final ILog LOGGER = Platform.getLog(TestPipelineProvider.class);
 	public static final Map ELEMENTS = new HashMap(),
 	CHILDREN = new HashMap(),
 	ADDS = new HashMap(),
@@ -49,6 +52,7 @@ public class TestPipelineProvider extends ResourceWrapperContentProvider {
 	UPDATES = new HashMap();
 
 	private String _id;
+
 
 	@Override
 	public void getPipelinedChildren(Object aParent, Set theCurrentChildren) {
@@ -221,16 +225,18 @@ public class TestPipelineProvider extends ResourceWrapperContentProvider {
 		return "??? unknown";
 	}
 
-	/**
-	 *
-	 */
 	public static void reset() {
-		ELEMENTS.clear();
-		CHILDREN.clear();
-		ADDS.clear();
-		REMOVES.clear();
-		UPDATES.clear();
+		LOGGER.info("Clearing all maps!");
+		logAndClear(ELEMENTS);
+		logAndClear(CHILDREN);
+		logAndClear(ADDS);
+		logAndClear(REMOVES);
+		logAndClear(UPDATES);
+	}
 
+	private static void logAndClear(Map m) {
+		LOGGER.info("Clearing " + mapName(m) + " (it had " + m.size() + " entries)");
+		m.clear();
 	}
 
 }


### PR DESCRIPTION
(_This PR supersedes #758_)

Some tests in `PipelineChainTest` fail randomly (see #757). The cause is still not clear, that's why this PR adds some debug information to help find the error.

This PR logs the name of the test method during setup/tear-down and it also logs the name of the map being cleared along with the amount of entries the map had before it was cleared when calling `TestPipelineProvider.reset()` .

This PR does not solve #757, it only provides debug information to help diagnose it. The changes introduced in this PR can safely be reverted after the issue is solved.