### PR TITLE
Add convenient static factory methods to create JFace Actions

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.30.100.qualifier
+Bundle-Version: 3.31.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/Action.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/Action.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jface.action;
 
+import java.util.function.Consumer;
+
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.events.HelpListener;
 import org.eclipse.swt.widgets.Control;
@@ -60,6 +62,92 @@ public abstract class Action extends AbstractAction {
 	private static final Boolean VAL_TOGGLE_BTN_OFF = Boolean.FALSE;
 
 	private static final Boolean VAL_TOGGLE_BTN_ON = Boolean.TRUE;
+
+	/**
+	 * Returns an {@code Action} that runs the given runnable when the action runs.
+	 *
+	 * @param runnable the runnable to run
+	 * @return an action that runs the given runnable
+	 * @since 3.31
+	 */
+	public static IAction create(Runnable runnable) {
+		return create(null, runnable);
+	}
+
+	/**
+	 * Returns an {@code Action} that runs the given runnable when the action runs.
+	 *
+	 * @param text     the string used as the text for the action, or
+	 *                 <code>null</code> if there is no text
+	 * @param runnable the runnable to run
+	 * @return an action that runs the given runnable
+	 * @since 3.31
+	 */
+	public static IAction create(String text, Runnable runnable) {
+		return create(text, null, runnable);
+	}
+
+	/**
+	 * Returns an {@code Action} that runs the given runnable when the action runs.
+	 *
+	 * @param text     the string used as the text for the action, or
+	 *                 <code>null</code> if there is no text
+	 * @param image    the action's image, or <code>null</code> if there is no image
+	 * @param runnable the runnable to run
+	 * @return an action that runs the given runnable
+	 * @since 3.31
+	 */
+	public static IAction create(String text, ImageDescriptor image, Runnable runnable) {
+		return new Action(text, image) {
+			@Override
+			public void run() {
+				runnable.run();
+			}
+		};
+	}
+
+	/**
+	 * Returns an {@code Action} that runs the given runnable when the action runs.
+	 *
+	 * @param runnable the runnable to run and accepts the causing event
+	 * @return an action that runs the given runnable
+	 * @since 3.31
+	 */
+	public static IAction create(Consumer<Event> runnable) {
+		return create(null, runnable);
+	}
+
+	/**
+	 * Returns an {@code Action} that runs the given runnable when the action runs.
+	 *
+	 * @param text     the string used as the text for the action, or
+	 *                 <code>null</code> if there is no text
+	 * @param runnable the runnable to run and accepts the causing event
+	 * @return an action that runs the given runnable
+	 * @since 3.31
+	 */
+	public static IAction create(String text, Consumer<Event> runnable) {
+		return create(text, null, runnable);
+	}
+
+	/**
+	 * Returns an {@code Action} that runs the given runnable when the action runs.
+	 *
+	 * @param text     the string used as the text for the action, or
+	 *                 <code>null</code> if there is no text
+	 * @param image    the action's image, or <code>null</code> if there is no image
+	 * @param runnable the runnable to run and accepts the causing event
+	 * @return an action that runs the given runnable
+	 * @since 3.31
+	 */
+	public static IAction create(String text, ImageDescriptor image, Consumer<Event> runnable) {
+		return new Action(text, image) {
+			@Override
+			public void runWithEvent(Event event) {
+				runnable.accept(event);
+			}
+		};
+	}
 
 	/**
 	 * Converts an accelerator key code to a string representation.

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/ProgressView.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/progress/ProgressView.java
@@ -15,6 +15,7 @@
 package org.eclipse.ui.internal.progress;
 
 import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.IToolBarManager;
 import org.eclipse.jface.action.MenuManager;
@@ -45,9 +46,9 @@ public class ProgressView extends ViewPart {
 
 	DetailedProgressViewer viewer;
 
-	Action cancelAction;
+	IAction cancelAction;
 
-	Action clearAllAction;
+	IAction clearAllAction;
 
 	private IPartListener2 partListener;
 
@@ -224,25 +225,15 @@ public class ProgressView extends ViewPart {
 	 * Create the cancel action for the receiver.
 	 */
 	private void createCancelAction() {
-		cancelAction = new Action(ProgressMessages.ProgressView_CancelAction) {
-			@Override
-			public void run() {
-				viewer.cancelSelection();
-			}
-		};
-
+		cancelAction = Action.create(ProgressMessages.ProgressView_CancelAction, () -> viewer.cancelSelection());
 	}
 
 	/**
 	 * Create the clear all action for the receiver.
 	 */
 	private void createClearAllAction() {
-		clearAllAction = new Action(ProgressMessages.ProgressView_ClearAllAction) {
-			@Override
-			public void run() {
-				FinishedJobs.getInstance().clearAll();
-			}
-		};
+		clearAllAction = Action.create(ProgressMessages.ProgressView_ClearAllAction,
+				() -> FinishedJobs.getInstance().clearAll());
 		clearAllAction.setToolTipText(ProgressMessages.NewProgressView_RemoveAllJobsToolTip);
 		ImageDescriptor id = WorkbenchImages.getWorkbenchImageDescriptor("/elcl16/progress_remall.png"); //$NON-NLS-1$
 		if (id != null) {

--- a/examples/org.eclipse.ui.examples.undo/Eclipse UI Examples Undo/org/eclipse/ui/examples/undo/views/UndoHistoryView.java
+++ b/examples/org.eclipse.ui.examples.undo/Eclipse UI Examples Undo/org/eclipse/ui/examples/undo/views/UndoHistoryView.java
@@ -25,6 +25,7 @@ import org.eclipse.core.commands.operations.IUndoableOperation;
 import org.eclipse.core.commands.operations.OperationHistoryEvent;
 import org.eclipse.core.commands.operations.OperationHistoryFactory;
 import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
@@ -75,13 +76,13 @@ public class UndoHistoryView extends ViewPart implements
 		ISelectionChangedListener {
 	private TableViewer viewer;
 
-	private Action filterAction;
+	private IAction filterAction;
 
-	private Action doubleClickAction;
+	private IAction doubleClickAction;
 
-	private Action selectiveUndoAction;
+	private IAction selectiveUndoAction;
 
-	private Action refreshListAction;
+	private IAction refreshListAction;
 
 	private IOperationHistory history = OperationHistoryFactory
 			.getOperationHistory();
@@ -331,67 +332,55 @@ public class UndoHistoryView extends ViewPart implements
 	 * Create the actions for the view.
 	 */
 	private void makeActions() {
-		filterAction = new Action() {
-			@Override
-			public void run() {
-				IUndoContext context = selectContext();
-				if (fContext != context && context != null) {
-					setContext(context);
-				}
+		filterAction = Action.create(() -> {
+			IUndoContext context = selectContext();
+			if (fContext != context && context != null) {
+				setContext(context);
 			}
-		};
+		});
 		filterAction.setText(UndoExampleMessages.UndoHistoryView_FilterText);
 		filterAction.setToolTipText(UndoExampleMessages.UndoHistoryView_FilterToolTipText);
 		filterAction.setImageDescriptor(PlatformUI.getWorkbench()
 				.getSharedImages().getImageDescriptor(
 						ISharedImages.IMG_OBJS_INFO_TSK));
 
-		selectiveUndoAction = new Action() {
-			@Override
-			public void run() {
-				IUndoableOperation operation = (IUndoableOperation) viewer.getStructuredSelection().getFirstElement();
-				if (operation.canUndo()) {
-					try {
-						history.undoOperation(operation, null, undoAction);
-					} catch (ExecutionException e) {
-						showMessage(UndoExampleMessages.UndoHistoryView_OperationException);
-					}
-				} else {
-					showMessage(UndoExampleMessages.UndoHistoryView_OperationInvalid);
+		selectiveUndoAction = Action.create(() -> {
+			IUndoableOperation operation = (IUndoableOperation) viewer.getStructuredSelection().getFirstElement();
+			if (operation.canUndo()) {
+				try {
+					history.undoOperation(operation, null, undoAction);
+				} catch (ExecutionException e) {
+					showMessage(UndoExampleMessages.UndoHistoryView_OperationException);
 				}
+			} else {
+				showMessage(UndoExampleMessages.UndoHistoryView_OperationInvalid);
 			}
-		};
+		});
 		selectiveUndoAction.setText(UndoExampleMessages.UndoHistoryView_UndoSelected);
 		selectiveUndoAction.setToolTipText(UndoExampleMessages.UndoHistoryView_UndoSelectedToolTipText);
 		selectiveUndoAction.setImageDescriptor(PlatformUI.getWorkbench()
 				.getSharedImages().getImageDescriptor(
 						ISharedImages.IMG_TOOL_UNDO));
 
-		refreshListAction = new Action() {
-			@Override
-			public void run() {
-				if (!viewer.getTable().isDisposed()) {
-					viewer.refresh(true);
-				}
+		refreshListAction = Action.create(() -> {
+			if (!viewer.getTable().isDisposed()) {
+				viewer.refresh(true);
 			}
-		};
+		});
 		refreshListAction.setText(UndoExampleMessages.UndoHistoryView_RefreshList);
 		refreshListAction.setToolTipText(UndoExampleMessages.UndoHistoryView_RefreshListToolTipText);
 
-		doubleClickAction = new Action() {
-			@Override
-			public void run() {
-				IUndoableOperation operation = (IUndoableOperation) viewer.getStructuredSelection().getFirstElement();
-				StringBuilder buf = new StringBuilder(operation.getLabel());
-				buf.append("\n");
-				buf.append("Enabled=");	//$NON-NLS-1$
-				buf.append(Boolean.toString(operation.canUndo()));
-				buf.append("\n");
-				buf.append(operation.getClass().toString());
-				showMessage(buf.toString());
+		doubleClickAction = Action.create(() -> {
+			IUndoableOperation operation = (IUndoableOperation) viewer.getStructuredSelection().getFirstElement();
+			StringBuilder buf = new StringBuilder(operation.getLabel());
+			buf.append("\n");
+			buf.append("Enabled="); //$NON-NLS-1$
+			buf.append(Boolean.toString(operation.canUndo()));
+			buf.append("\n");
+			buf.append(operation.getClass().toString());
+			showMessage(buf.toString());
 
-			}
-		};
+		});
 	}
 
 	/*


### PR DESCRIPTION
Creating JFace actions is often cumbersome, especially for simple implementations of the `run` method, because one has to sub-class the Action class and implement at least the run method. Very often this is done using a anonymous class whose `run()` method just calls the desired method.

Similar like `org.eclipse.core.runtime.jobs.Job.create()` jface' Action could provide a static factory method that accepts the runnable to execute (and optionally a text and image). And does the anonymous implementation for the caller.

I also added overloads that uses a Consumer and overwrites `runWithEvent()`. 
Additionally an overload to accepts a text and the style could be added to reflect all Action constructor overloads.

Instead of providing the methods in the `Action` class, they could also be added to the `IAction` interface.

There would be many use-cases in the SDK. I already used it for a few in the second commit, but that could be extended.