### PR TITLE
Add method to retrieve the IExpansionListeners

### DIFF
--- a/bundles/org.eclipse.ui.forms/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.forms/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.ui.forms;singleton:=true
-Bundle-Version: 3.12.100.qualifier
+Bundle-Version: 3.13.0.qualifier
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.forms,

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/ExpandableComposite.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/ExpandableComposite.java
@@ -885,15 +885,32 @@ public class ExpandableComposite extends Canvas {
 	}
 
 	/**
-	 * Programmatically changes expanded state.
+	 * Changes expanded state.
+	 *
+	 * Equivalent to <code>setExpanded(expanded, false)</code>. @see {@link #setExpanded(boolean, boolean)}.
 	 *
 	 * @param expanded
 	 *            the new expanded state
 	 */
 	public void setExpanded(boolean expanded) {
-		internalSetExpanded(expanded);
-		if (toggle != null)
+		setExpanded(expanded, false);
+	}
+
+	/**
+	 * Changes expanded state.
+	 *
+	 * @param expanded
+	 *            the new expanded state
+	 * @param fireExpanding
+	 *            if true, listeners will be notified
+	 *
+	 * @since 3.13
+	 */
+	public void setExpanded(boolean expanded, boolean fireExpanding) {
+		internalSetExpanded(expanded, fireExpanding);
+		if (toggle != null) {
 			toggle.setExpanded(expanded);
+		}
 	}
 
 	/**
@@ -1083,11 +1100,29 @@ public class ExpandableComposite extends Canvas {
 
 	private void toggleState() {
 		boolean newState = !isExpanded();
-		fireExpanding(newState, true);
-		internalSetExpanded(newState);
-		fireExpanding(newState, false);
+		internalSetExpanded(newState, true);
 		if (newState)
 			FormUtil.ensureVisible(this);
+	}
+
+	/**
+	 * Performs the expanded state change for the expandable control.
+	 *
+	 * @param expanded
+	 *            the new expanded state
+	 * @param fireExpanding
+	 *            if true, listeners will be notified
+	 */
+	private void internalSetExpanded(boolean expanded, boolean fireExpanding) {
+		if (fireExpanding) {
+			fireExpanding(expanded, true);
+		}
+
+		internalSetExpanded(expanded);
+
+		if (fireExpanding) {
+			fireExpanding(expanded, false);
+		}
 	}
 
 	private void fireExpanding(boolean state, boolean before) {


### PR DESCRIPTION
Since `setExpanded` does not fire the listeners, we would like to have access to the listeners to be able to fire them manually.

Alternatively I could change the PR to add a method setExpanded(boolean expanded, boolean fireExpanding) that would do that without exposing the listener list.

Would that be a preferred approach?