### PR TITLE
Avoid redraw animation on Windows

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/QuickFixPage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/QuickFixPage.java
@@ -256,8 +256,14 @@ public class QuickFixPage extends WizardPage {
 
 		resolutionsList
 				.addSelectionChangedListener(event -> {
-					markersTable.refresh();
-					setPageComplete(markersTable.getCheckedElements().length > 0);
+					Control tableControl = markersTable.getControl();
+					tableControl.setRedraw(false);
+					try {
+						markersTable.refresh();
+						setPageComplete(markersTable.getCheckedElements().length > 0);
+					} finally {
+						tableControl.setRedraw(true);
+					}
 				});
 	}
 


### PR DESCRIPTION
When the markers table contains a big amount of markers, selecting another resolution leads to the typical "animated removal" of all contained items on Windows, which fully blocks the UI thread due to redrawing after each item removed.

The screen recording doesn't capture how bad it looks with the naked eye, but gives an idea:
![markers refresh](https://github.com/eclipse-platform/eclipse.platform.ui/assets/406876/cb2ed8a7-31f0-48b4-a10f-8e89a819a85c)
