### PR TITLE
Fix SorterTest

### DIFF
--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/LabelProviderTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/LabelProviderTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.jface.viewers.IToolTipProvider;
@@ -432,11 +434,24 @@ public class LabelProviderTest extends NavigatorTestBase {
 		_contentService.getActivationService().activateExtensions(
 				new String[] { TEST_CONTENT_EMPTY, COMMON_NAVIGATOR_RESOURCE_EXT }, true);
 
-		TestLabelProvider._throw = true;
-		TestEmptyContentProvider._throw = true;
+		AtomicBoolean labelProviderThrewException = new AtomicBoolean(false);
+		AtomicBoolean contentProviderThrewException = new AtomicBoolean(false);
+
+		TestEmptyContentProvider._runnable = () -> {
+			contentProviderThrewException.set(true);
+			throw new RuntimeException("Throwing... " + LabelProviderTest.class + " threw this exception!");
+
+		};
+		TestLabelProvider._runnable = () -> {
+			labelProviderThrewException.set(true);
+			throw new RuntimeException("Throwing... " + LabelProviderTest.class + " threw this exception!");
+		};
 
 		refreshViewer();
 		// Have to look at the log to see a bunch of stuff thrown
+
+		assertTrue(labelProviderThrewException.get());
+		assertTrue(contentProviderThrewException.get());
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestEmptyContentProvider.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestEmptyContentProvider.java
@@ -21,37 +21,37 @@ public class TestEmptyContentProvider implements ITreeContentProvider {
 
 	private static final Object[] NO_CHILDREN = new Object[0];
 
-	public static boolean _throw;
+	public static Runnable _runnable;
 
 	public static void resetTest() {
-		_throw = false;
+		_runnable = null;
 	}
 
 	@Override
 	public Object[] getChildren(Object parentElement) {
-		if (_throw)
-			throw new RuntimeException("Throwing...");
+		if (_runnable != null)
+			_runnable.run();
 		return NO_CHILDREN;
 	}
 
 	@Override
 	public Object getParent(Object element) {
-		if (_throw)
-			throw new RuntimeException("Throwing...");
+		if (_runnable != null)
+			_runnable.run();
 		return null;
 	}
 
 	@Override
 	public boolean hasChildren(Object element) {
-		if (_throw)
-			throw new RuntimeException("Throwing...");
+		if (_runnable != null)
+			_runnable.run();
 		return false;
 	}
 
 	@Override
 	public Object[] getElements(Object inputElement) {
-		if (_throw)
-			throw new RuntimeException("Throwing...");
+		if (_runnable != null)
+			_runnable.run();
 		return NO_CHILDREN;
 	}
 

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProvider.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProvider.java
@@ -49,10 +49,10 @@ public abstract class TestLabelProvider extends LabelProvider implements
 	public boolean _blank;
 	public boolean _null;
 
-	public static boolean _throw;
+	public static Runnable _runnable;
 
 	public static void resetTest() {
-		_throw = false;
+		_runnable = null;
 	}
 
 	static {
@@ -85,8 +85,8 @@ public abstract class TestLabelProvider extends LabelProvider implements
 
 	@Override
 	public Image getImage(Object element) {
-		if (_throw)
-			throw new RuntimeException("Throwing...");
+		if (_runnable != null)
+			_runnable.run();
 		if (element instanceof TestExtensionTreeData)
 			return PlatformUI.getWorkbench().getSharedImages().getImage(
 					ISharedImages.IMG_OBJ_ELEMENT);
@@ -95,8 +95,8 @@ public abstract class TestLabelProvider extends LabelProvider implements
 
 	@Override
 	public String getText(Object element) {
-		if (_throw)
-			throw new RuntimeException("Throwing...");
+		if (_runnable != null)
+			_runnable.run();
 		if (_blank)
 			return "";
 		if (_null)
@@ -114,8 +114,8 @@ public abstract class TestLabelProvider extends LabelProvider implements
 
 	@Override
 	public String getDescription(Object anElement) {
-		if (_throw)
-			throw new RuntimeException("Throwing...");
+		if (_runnable != null)
+			_runnable.run();
 		if (anElement instanceof TestExtensionTreeData) {
 			TestExtensionTreeData data = (TestExtensionTreeData) anElement;
 			return "TestItem: " + data.getName();
@@ -125,36 +125,36 @@ public abstract class TestLabelProvider extends LabelProvider implements
 
 	@Override
 	public void restoreState(IMemento aMemento) {
-		if (_throw)
-			throw new RuntimeException("Throwing...");
+		if (_runnable != null)
+			_runnable.run();
 
 	}
 
 	@Override
 	public void saveState(IMemento aMemento) {
-		if (_throw)
-			throw new RuntimeException("Throwing...");
+		if (_runnable != null)
+			_runnable.run();
 
 	}
 
 	@Override
 	public Color getForeground(Object element) {
-		if (_throw)
-			throw new RuntimeException("Throwing...");
+		if (_runnable != null)
+			_runnable.run();
 		return toForegroundColor(getTestColor());
 	}
 
 	@Override
 	public Color getBackground(Object element) {
-		if (_throw)
-			throw new RuntimeException("Throwing...");
+		if (_runnable != null)
+			_runnable.run();
 		return getTestColor();
 	}
 
 	@Override
 	public Font getFont(Object element) {
-		if (_throw)
-			throw new RuntimeException("Throwing...");
+		if (_runnable != null)
+			_runnable.run();
 		if (element instanceof TestExtensionTreeData) {
 			TestExtensionTreeData data = (TestExtensionTreeData) element;
 			if (data.getParent() != null
@@ -166,9 +166,13 @@ public abstract class TestLabelProvider extends LabelProvider implements
 
 	@Override
 	public void dispose() {
-		if (_throw)
-			throw new RuntimeException("Throwing...");
+		if (_runnable != null)
+			_runnable.run();
+		boldFont.dispose();
 		boldFont = null;
+
+//		font.dispose();
+//		font = null;
 	}
 
 }

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProviderTooltips.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProviderTooltips.java
@@ -14,11 +14,19 @@
 package org.eclipse.ui.tests.navigator.extension;
 
 import org.eclipse.jface.viewers.IToolTipProvider;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Display;
 
 /**
  * @since 3.3
  */
 public class TestLabelProviderTooltips extends TestLabelProvider implements IToolTipProvider {
+
+	@Override
+	protected void initSubclass() {
+		backgroundColor = Display.getCurrent().getSystemColor(SWT.COLOR_BLACK);
+		backgroundColorName = "Black";
+	}
 	@Override
 	public String getToolTipText(Object element) {
 		return "ToolTip " + getText(element);


### PR DESCRIPTION
Fix TestLabelProviderTooltips which might influence the SorterTest. TestLabelProviderTooltips caused an NPE because it did not have a backGroundColor. This NPE could just be seen in the console.

Fix TestLabelProvider which did not dispose the boldFont correctly. Also could be seen in the console.

Issue: https://github.com/eclipse-platform/eclipse.platform.ui/issues/809