### PR TITLE
Add extension point for generic editor content assistant look and feel.

### DIFF
--- a/bundles/org.eclipse.ui.genericeditor/plugin.xml
+++ b/bundles/org.eclipse.ui.genericeditor/plugin.xml
@@ -27,6 +27,7 @@
    <extension-point id="characterPairMatchers" name="%ExtPoint.characterPairMatchers" schema="schema/characterPairMatchers.exsd"/>
    <extension-point id="icons" name="%ExtPoint.iconProviders" schema="schema/icons.exsd"/>
    <extension-point id="quickAssistProcessors" name="%ExtPoint.quickAssistProcessors" schema="schema/quickAssistProcessors.exsd"/>
+   <extension-point id="contentAssistantLookAndFeel" name="%ExtPoint.contentAssistantLookAndFeel" schema="schema/contentAssistantLookAndFeel.exsd"/>
    <extension
          point="org.eclipse.ui.editors">
       <editor

--- a/bundles/org.eclipse.ui.genericeditor/schema/contentAssistantLookAndFeel.exsd
+++ b/bundles/org.eclipse.ui.genericeditor/schema/contentAssistantLookAndFeel.exsd
@@ -1,0 +1,136 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.ui.genericeditor" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="org.eclipse.ui.genericeditor" id="contentAssistantLookAndFeel" name="%ExtPoint.contentAssistantLookAndFeel"/>
+      </appinfo>
+      <documentation>
+         This extension point is used to contribute to the content assistant look and feel for a given content type.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="contentAssistantLookAndFeel"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  a fully qualified identifier of the target extension point
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  an optional identifier of the extension instance
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  an optional name of the extension instance
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="contentAssistantLookAndFeel">
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  The fully qualified class name implementing the interface &lt;code&gt;org.eclipse.ui.internal.genericeditor.IContentAssistantLookAndFeel&lt;/code&gt;
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.ui.internal.genericeditor.IContentAssistantLookAndFeel"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+         <attribute name="contentType" type="string">
+            <annotation>
+               <documentation>
+                  The target content-type for this extension. Content-types are defined as extension to the org.eclipse.core.contenttype.contentTypes extension point. If no content type is given, the extension is applied to all content types.
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="identifier" basedOn="org.eclipse.core.contenttype.contentTypes/content-type/@id"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         1.3
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         This is an example of a default look and feel being registered for the content assistant, and a look and feel being registered for a target definition file type:
+
+&lt;pre&gt;
+&lt;extension point=&quot;org.eclipse.ui.genericeditor.contentAssistantLookAndFeel&quot;&gt;
+   &lt;contentAssistantLookAndFeel
+       class=&quot;org.eclipse.ui.genericeditor.examples.DefaultContentAssistantLookAndFeel&quot;&gt;
+   &lt;/contentAssistantLookAndFeel&gt;
+   &lt;contentAssistantLookAndFeel
+       class=&quot;org.eclipse.ui.genericeditor.examples.TargetDefinitionContentAssistantLookAndFeel&quot;
+       contentType=&quot;org.eclipse.pde.targetFile&quot;&gt;
+   &lt;/contentAssistantLookAndFeel&gt;
+&lt;/extension&gt;
+&lt;/pre&gt;
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="copyright"/>
+      </appinfo>
+      <documentation>
+         Copyright (c) 2023 Avaloq Group AG (http://www.avaloq.com) and others
+
+This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution, and is available at &lt;a href=&quot;https://www.eclipse.org/legal/epl-2.0&quot;&gt;https://www.eclipse.org/legal/epl-v20.html&lt;/a&gt;/
+
+SPDX-License-Identifier: EPL-2.0
+      </documentation>
+   </annotation>
+
+</schema>

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ContentAssistantLookAndFeelRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ContentAssistantLookAndFeelRegistry.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Avaloq Group AG (http://www.avaloq.com).
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Andrew Lamb (Avaloq Group AG) - initial implementation
+ *******************************************************************************/
+package org.eclipse.ui.internal.genericeditor;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.content.IContentType;
+
+/**
+ * A registry of contributions to the content assistant look and feel provided
+ * by extension
+ * <code>org.eclipse.ui.genericeditor.contentAssistantLookAndFeel</code>. Those
+ * extensions may be specific to a given {@link IContentType}.
+ *
+ * @since 1.3
+ */
+public class ContentAssistantLookAndFeelRegistry {
+
+	private static final String EXTENSION_POINT_ID = GenericEditorPlugin.BUNDLE_ID + ".contentAssistantLookAndFeel"; //$NON-NLS-1$
+
+	private Map<IConfigurationElement, GenericContentTypeRelatedExtension<IContentAssistantLookAndFeel>> extensions = new LinkedHashMap<>();
+	private boolean outOfSync = true;
+
+	/**
+	 * Creates the registry and binds it to the extension point.
+	 */
+	public ContentAssistantLookAndFeelRegistry() {
+		Platform.getExtensionRegistry().addRegistryChangeListener(event -> outOfSync = true, EXTENSION_POINT_ID);
+	}
+
+	/**
+	 * Get the contributed {@link IContentAssistantLookAndFeel}s that are relevant
+	 * to hook on content assistant according to document content types.
+	 *
+	 * @param contentTypes the content types of the document we're editing.
+	 * @return the list of {@link IContentAssistantLookAndFeel} contributed for at
+	 *         least one of the content types.
+	 */
+	public List<IContentAssistantLookAndFeel> getContentAssistantLookAndFeel(Set<IContentType> contentTypes) {
+		if (this.outOfSync) {
+			sync();
+		}
+		// we want to return extensions for least specialized content types first, with
+		// null being less specialized than any specific content type, and the default
+		// being the least specialized of all.
+		ContentTypeSpecializationComparator<IContentAssistantLookAndFeel> mostSpecialFirst = new ContentTypeSpecializationComparator<>();
+		List<IContentAssistantLookAndFeel> contributions = this.extensions.values().stream()
+				.filter(ext -> ext.targetContentType == null || contentTypes.contains(ext.targetContentType))
+				.sorted((left, right) -> {
+					if (left == null && right == null) {
+						return 0;
+					}
+					if (left == null) {
+						return -1;
+					}
+					if (right == null) {
+						return 1;
+					}
+					return -mostSpecialFirst.compare(left, right);
+				}).map(GenericContentTypeRelatedExtension<IContentAssistantLookAndFeel>::createDelegate)
+				.collect(Collectors.toList());
+		contributions.add(0, IContentAssistantLookAndFeel.DEFAULT);
+		return contributions;
+	}
+
+	private void sync() {
+		Set<IConfigurationElement> toRemoveExtensions = new HashSet<>(this.extensions.keySet());
+		for (IConfigurationElement extension : Platform.getExtensionRegistry()
+				.getConfigurationElementsFor(EXTENSION_POINT_ID)) {
+			toRemoveExtensions.remove(extension);
+			if (!this.extensions.containsKey(extension)) {
+				try {
+					this.extensions.put(extension,
+							new GenericContentTypeRelatedExtension<IContentAssistantLookAndFeel>(extension));
+				} catch (Exception ex) {
+					GenericEditorPlugin.getDefault().getLog()
+							.log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));
+				}
+			}
+		}
+		for (IConfigurationElement toRemove : toRemoveExtensions) {
+			this.extensions.remove(toRemove);
+		}
+		this.outOfSync = false;
+	}
+}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ExtensionBasedTextViewerConfiguration.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ExtensionBasedTextViewerConfiguration.java
@@ -187,6 +187,12 @@ public final class ExtensionBasedTextViewerConfiguration extends TextSourceViewe
 		Set<IContentType> types = getContentTypes(sourceViewer.getDocument());
 		contentAssistant = new GenericEditorContentAssistant(contentAssistProcessorTracker,
 				registry.getContentAssistProcessors(sourceViewer, editor, types), types);
+
+		ContentAssistantLookAndFeelRegistry lookAndFeelRegistry = GenericEditorPlugin.getDefault()
+				.getContentAssistantLookAndFeelRegistry();
+		lookAndFeelRegistry.getContentAssistantLookAndFeel(types)
+				.forEach(lookAndFeel -> lookAndFeel.applyTo(contentAssistant));
+
 		if (this.document != null) {
 			associateTokenContentTypes(this.document);
 		}
@@ -275,7 +281,7 @@ public final class ExtensionBasedTextViewerConfiguration extends TextSourceViewe
 		}
 		// add default reconciler:
 		reconcilers.add(new DefaultFoldingReconciler());
-		
+
 		reconcilingStrategies.addAll(foldingReconcilingStrategies);
 
 		if (!reconcilingStrategies.isEmpty()) {

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/GenericEditorContentAssistant.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/GenericEditorContentAssistant.java
@@ -26,7 +26,6 @@ import org.eclipse.jface.text.IInformationControl;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.ContentAssistant;
 import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
-import org.eclipse.jface.text.contentassist.IContentAssistant;
 import org.eclipse.swt.widgets.Shell;
 
 /**
@@ -42,7 +41,7 @@ import org.eclipse.swt.widgets.Shell;
  * @author christoph
  *
  */
-public class GenericEditorContentAssistant extends ContentAssistant {
+public class GenericEditorContentAssistant extends ContentAssistant implements IContentAssistantLookAndFeelProperties {
 	private static final DefaultContentAssistProcessor DEFAULT_CONTENT_ASSIST_PROCESSOR = new DefaultContentAssistProcessor();
 	private ContentTypeRelatedExtensionTracker<IContentAssistProcessor> contentAssistProcessorTracker;
 	private Set<IContentType> types;
@@ -69,12 +68,6 @@ public class GenericEditorContentAssistant extends ContentAssistant {
 		this.processors = Objects.requireNonNullElseGet(processors, () -> Collections.emptyList());
 		this.types = types;
 
-		setContextInformationPopupOrientation(IContentAssistant.CONTEXT_INFO_BELOW);
-		setProposalPopupOrientation(IContentAssistant.PROPOSAL_REMOVE);
-		setAutoActivationDelay(10);
-		enableColoredLabels(true);
-		enableAutoActivation(true);
-		enableAutoActivateCompletionOnType(true);
 		setInformationControlCreator(new AbstractReusableInformationControlCreator() {
 			@Override
 			protected IInformationControl doCreateInformationControl(Shell parent) {

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/GenericEditorPlugin.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/GenericEditorPlugin.java
@@ -45,6 +45,7 @@ public class GenericEditorPlugin extends AbstractUIPlugin {
 
 	private TextHoverRegistry textHoversRegistry;
 	private ContentAssistProcessorRegistry contentAssistProcessorsRegistry;
+	private ContentAssistantLookAndFeelRegistry contentAssistantLookAndFeelRegistry;
 	private QuickAssistProcessorRegistry quickAssistProcessorRegistry;
 	private ReconcilerRegistry reconcilierRegistry;
 	private PresentationReconcilerRegistry presentationReconcilierRegistry;
@@ -105,6 +106,19 @@ public class GenericEditorPlugin extends AbstractUIPlugin {
 			this.contentAssistProcessorsRegistry = new ContentAssistProcessorRegistry();
 		}
 		return this.contentAssistProcessorsRegistry;
+	}
+
+	/**
+	 * @return the registry allowing to access contributed
+	 *         {@link ContentAssistantLookAndFeel}s.
+	 * 
+	 * @since 1.3
+	 */
+	public synchronized ContentAssistantLookAndFeelRegistry getContentAssistantLookAndFeelRegistry() {
+		if (this.contentAssistantLookAndFeelRegistry == null) {
+			this.contentAssistantLookAndFeelRegistry = new ContentAssistantLookAndFeelRegistry();
+		}
+		return contentAssistantLookAndFeelRegistry;
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/IContentAssistantLookAndFeel.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/IContentAssistantLookAndFeel.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Avaloq Group AG (http://www.avaloq.com).
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Andrew Lamb (Avaloq Group AG) - initial implementation
+ *******************************************************************************/
+package org.eclipse.ui.internal.genericeditor;
+
+import org.eclipse.jface.text.contentassist.IContentAssistant;
+
+/**
+ * Interface to be implemented by contributions that want to set the look and
+ * feel of a generic editor content assistant.
+ * 
+ * @since 1.3
+ */
+public interface IContentAssistantLookAndFeel {
+	/**
+	 * Apply this look and feel to the given content assistant.
+	 * 
+	 * @param assistant the content assistant to set the look and feel properties
+	 *                  of.
+	 */
+	void applyTo(IContentAssistantLookAndFeelProperties assistant);
+
+	static final IContentAssistantLookAndFeel DEFAULT = assistant -> {
+		assistant.setContextInformationPopupOrientation(IContentAssistant.CONTEXT_INFO_BELOW);
+		assistant.setProposalPopupOrientation(IContentAssistant.PROPOSAL_REMOVE);
+		assistant.setAutoActivationDelay(10);
+		assistant.enableColoredLabels(true);
+		assistant.enableAutoActivation(true);
+		assistant.enableAutoActivateCompletionOnType(true);
+	};
+}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/IContentAssistantLookAndFeelProperties.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/IContentAssistantLookAndFeelProperties.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Avaloq Group AG (http://www.avaloq.com).
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Andrew Lamb (Avaloq Group AG) - initial implementation
+ *******************************************************************************/
+package org.eclipse.ui.internal.genericeditor;
+
+import org.eclipse.jface.text.contentassist.ICompletionProposalExtension;
+import org.eclipse.jface.text.contentassist.ICompletionProposalExtension6;
+import org.eclipse.jface.text.contentassist.IContentAssistant;
+
+/**
+ * Interface for setting the look and feel properties of a content assistant.
+ * 
+ * @since 1.3
+ */
+public interface IContentAssistantLookAndFeelProperties {
+	/**
+	 * Enables the content assistant's auto activation mode.
+	 *
+	 * @param enabled indicates whether auto activation is enabled or not
+	 */
+	void enableAutoActivation(boolean enabled);
+
+	/**
+	 * Enables the content assistant's auto insertion mode. If enabled, the content
+	 * assistant inserts a proposal automatically if it is the only proposal. In the
+	 * case of ambiguities, the user must make the choice.
+	 *
+	 * @param enabled indicates whether auto insertion is enabled or not
+	 */
+	void enableAutoInsert(boolean enabled);
+
+	/**
+	 * Sets the delay after which the content assistant is automatically invoked if
+	 * the cursor is behind an auto activation character.
+	 *
+	 * @param delay the auto activation delay (as of 3.6 a negative argument will be
+	 *              set to 0)
+	 */
+	void setAutoActivationDelay(int delay);
+
+	/**
+	 * Sets the proposal pop-ups' orientation. The following values may be used:
+	 * <ul>
+	 * <li>{@link IContentAssistant#PROPOSAL_OVERLAY PROPOSAL_OVERLAY}
+	 * <p>
+	 * proposal popup windows should overlay each other</li>
+	 * <li>{@link IContentAssistant#PROPOSAL_REMOVE PROPOSAL_REMOVE}
+	 * <p>
+	 * any currently shown proposal popup should be closed</li>
+	 * <li>{@link IContentAssistant#PROPOSAL_STACKED PROPOSAL_STACKED}
+	 * <p>
+	 * proposal popup windows should be vertical stacked, with no overlap, beneath
+	 * the line containing the current cursor location</li>
+	 * </ul>
+	 *
+	 * @param orientation the popup's orientation
+	 */
+	void setProposalPopupOrientation(int orientation);
+
+	/**
+	 * Sets the context information popup's orientation. The following values may be
+	 * used:
+	 * <ul>
+	 * <li>{@link IContentAssistant#CONTEXT_INFO_ABOVE CONTEXT_INFO_ABOVE}
+	 * <p>
+	 * context information popup should always appear above the line containing the
+	 * current cursor location</li>
+	 * <li>{@link IContentAssistant#CONTEXT_INFO_BELOW CONTEXT_INFO_BELOW}
+	 * <p>
+	 * context information popup should always appear below the line containing the
+	 * current cursor location</li>
+	 * </ul>
+	 *
+	 * @param orientation the popup's orientation
+	 */
+	void setContextInformationPopupOrientation(int orientation);
+
+	/**
+	 * Enables displaying an empty completion proposal pop-up. The default is not to
+	 * show an empty list.
+	 *
+	 * @param showEmpty <code>true</code> to show empty lists
+	 */
+	void setShowEmptyList(boolean showEmpty);
+
+	/**
+	 * Enables displaying a status line below the proposal popup. The default is not
+	 * to show the status line. The contents of the status line may be set via
+	 * {@link #setStatusMessage(String)}.
+	 *
+	 * @param show <code>true</code> to show a message line, <code>false</code> to
+	 *             not show one.
+	 */
+	void setStatusLineVisible(boolean show);
+
+	/**
+	 * Enables the support for colored labels in the proposal popup.
+	 * <p>
+	 * Completion proposals can implement {@link ICompletionProposalExtension6} to
+	 * provide colored proposal labels.
+	 * </p>
+	 *
+	 * @param isEnabled if <code>true</code> the support for colored labels is
+	 *                  enabled in the proposal popup
+	 */
+	void enableColoredLabels(boolean isEnabled);
+
+	/**
+	 * Set whether completion trigger chars are enabled. If set to false, completion
+	 * proposal trigger chars are ignored and only Enter key can be used to select a
+	 * proposal.
+	 *
+	 * @param enable whether current content assistant should consider completion
+	 *               trigger chars.
+	 * @see ICompletionProposalExtension#getTriggerCharacters()
+	 */
+	void enableCompletionProposalTriggerChars(boolean enable);
+
+	/**
+	 * Sets whether this completion list is shown on each valid character which is
+	 * either a letter or digit. This only applies to asynchronous content
+	 * assistants.
+	 *
+	 * @param enable whether or not to enable this feature
+	 */
+	void enableAutoActivateCompletionOnType(boolean enable);
+}

--- a/examples/org.eclipse.ui.genericeditor.examples/plugin.xml
+++ b/examples/org.eclipse.ui.genericeditor.examples/plugin.xml
@@ -34,6 +34,13 @@
       </contentAssistProcessor>
    </extension>
    <extension
+         point="org.eclipse.ui.genericeditor.contentAssistantLookAndFeel">
+      <contentAssistantLookAndFeel
+            class="org.eclipse.ui.genericeditor.examples.dotproject.ContentAssistantLookAndFeel"
+            contentType="org.eclipse.ui.genericeditor.examples.dotproject">
+      </contentAssistantLookAndFeel>
+   </extension>
+   <extension
          point="org.eclipse.ui.genericeditor.hoverProviders">
       <hoverProvider
             class="org.eclipse.ui.genericeditor.examples.dotproject.NatureLabelHoverProvider"

--- a/examples/org.eclipse.ui.genericeditor.examples/src/org/eclipse/ui/genericeditor/examples/dotproject/ContentAssistantLookAndFeel.java
+++ b/examples/org.eclipse.ui.genericeditor.examples/src/org/eclipse/ui/genericeditor/examples/dotproject/ContentAssistantLookAndFeel.java
@@ -1,0 +1,16 @@
+package org.eclipse.ui.genericeditor.examples.dotproject;
+
+import org.eclipse.ui.internal.genericeditor.IContentAssistantLookAndFeel;
+import org.eclipse.ui.internal.genericeditor.IContentAssistantLookAndFeelProperties;
+
+@SuppressWarnings("restriction")
+public class ContentAssistantLookAndFeel implements IContentAssistantLookAndFeel {
+
+	@Override
+	public void applyTo(IContentAssistantLookAndFeelProperties assistant) {
+		assistant.enableAutoActivation(true);
+		assistant.enableAutoActivateCompletionOnType(true);
+		assistant.setAutoActivationDelay(10);
+	}
+
+}


### PR DESCRIPTION
Adds an extension point so that the look and feel of the generic editor content assistant can be configured by extension contribution.