### PR TITLE
Remove unnecessary 'Bundle-ClassPath: .' MANIFEST.MF entries

### DIFF
--- a/bundles/org.eclipse.core.commands/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.commands/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.commands
 Bundle-Version: 3.11.100.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.commands,

--- a/bundles/org.eclipse.core.databinding.beans/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding.beans/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.databinding.beans
 Bundle-Version: 1.10.100.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.databinding.beans,

--- a/bundles/org.eclipse.core.databinding.observable/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding.observable/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.databinding.observable
 Bundle-Version: 1.13.100.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.databinding.observable,

--- a/bundles/org.eclipse.core.databinding.property/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding.property/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.databinding.property
 Bundle-Version: 1.10.100.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.databinding.property,

--- a/bundles/org.eclipse.core.databinding/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.databinding
 Bundle-Version: 1.13.100.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.databinding,

--- a/bundles/org.eclipse.e4.ui.model.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.model.workbench/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.ui.model.workbench;singleton:=true
 Bundle-Version: 2.4.100.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/org.eclipse.jface.databinding/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.databinding/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.databinding
 Bundle-Version: 1.15.100.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface.databinding.dialog,

--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
 Bundle-Version: 3.30.100.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,

--- a/bundles/org.eclipse.ui.ide.application/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide.application/META-INF/MANIFEST.MF
@@ -5,7 +5,6 @@ Bundle-SymbolicName: org.eclipse.ui.ide.application;singleton:=true
 Bundle-Version: 1.5.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
-Bundle-ClassPath: .
 Require-Bundle: org.eclipse.ui.ide;bundle-version="[3.16.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.15.0,4.0.0)",

--- a/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide; singleton:=true
 Bundle-Version: 3.21.100.qualifier
-Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.internal.ide.IDEWorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/bundles/org.eclipse.ui.monitoring/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.monitoring/META-INF/MANIFEST.MF
@@ -1,6 +1,5 @@
 Manifest-Version: 1.0
 Bundle-ActivationPolicy: lazy
-Bundle-ClassPath: .
 Bundle-Localization: plugin
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name

--- a/bundles/org.eclipse.ui.views/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.views; singleton:=true
 Bundle-Version: 3.12.100.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.internal.views.contentoutline;x-internal:=true,

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
 Bundle-Version: 3.129.100.qualifier
-Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
@@ -2,8 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui; singleton:=true
-Bundle-Version: 3.203.100.qualifier
-Bundle-ClassPath: .
+Bundle-Version: 3.203.200.qualifier
 Bundle-Activator: org.eclipse.ui.internal.UIPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/examples/org.eclipse.jface.examples.databinding/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.jface.examples.databinding/META-INF/MANIFEST.MF
@@ -4,7 +4,6 @@ Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.examples.databinding
 Bundle-Version: 1.4.100.qualifier
 Eclipse-BundleShape: dir
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.jface,

--- a/examples/org.eclipse.ui.examples.job/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.job/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.examples.job;singleton:=true
 Bundle-Version: 3.3.0
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.examples.jobs,

--- a/examples/org.eclipse.ui.examples.markerHelp/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.markerHelp/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.examples.markerHelp;singleton:=true
 Bundle-Version: 3.2.0
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.ide;bundle-version="3.15.0"

--- a/examples/org.eclipse.ui.examples.readmetool/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.readmetool/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.examples.readmetool; singleton:=true
 Bundle-Version: 3.7.100.qualifier
-Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.examples.readmetool.ReadmePlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/examples/org.eclipse.ui.forms.examples/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.forms.examples/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.forms.examples; singleton:=true
 Bundle-Version: 3.4.0.qualifier
-Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.forms.examples.internal.ExamplesPlugin
 Bundle-Vendor: Eclipse.org
 Bundle-Localization: plugin

--- a/tests/org.eclipse.e4.emf.xpath.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.emf.xpath.test/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.emf.xpath.test;singleton:=true
 Bundle-Version: 0.4.0.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.ui.tests;singleton:=true
 Bundle-Version: 0.15.200.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.emf.ecore.xmi;bundle-version="2.4.0",

--- a/tests/org.eclipse.jface.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.jface.tests
 Bundle-Version: 1.4.200.qualifier
-Bundle-ClassPath: .
 Automatic-Module-Name: org.eclipse.jface.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.12.0",

--- a/tools/bundles/org.eclipse.e4.tools.emf.ui/META-INF/MANIFEST.MF
+++ b/tools/bundles/org.eclipse.e4.tools.emf.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.tools.emf.ui;singleton:=true
 Bundle-Version: 4.8.100.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tools/bundles/org.eclipse.e4.tools.persistence/META-INF/MANIFEST.MF
+++ b/tools/bundles/org.eclipse.e4.tools.persistence/META-INF/MANIFEST.MF
@@ -5,7 +5,6 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.e4.tools.persistence;singleton:=true
 Automatic-Module-Name: org.eclipse.e4.tools.persistence
 Bundle-Version: 1.1.100.qualifier
-Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.20.0,4.0.0)",


### PR DESCRIPTION
The default value of 'Bundle-ClassPath' is the dot which is used when the header is not specified. Therefore there is no need to specify it with that value.