### PR TITLE
Avoid redraw animation on StructuredViewer

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredViewer.java
@@ -1414,7 +1414,14 @@ public abstract class StructuredViewer extends ContentViewer implements IPostSel
 
 	@Override
 	public void refresh() {
-		refresh(getRoot());
+		Control control = getControl();
+		control.setRedraw(false);
+		try {
+			refresh(getRoot());
+		} finally {
+			control.setRedraw(true);
+		}
+
 	}
 
 	/**


### PR DESCRIPTION
When the a table contains a big amount of markers, selecting another resolution leads to the typical "animated removal" of all contained items on Windows, which fully blocks the UI thread due to redrawing after each item removed.

This animation is internal behavior of the viewers and seems something which does note help the user due to screen artifacts which are created and slows down the update process.

See also https://github.com/eclipse-platform/eclipse.platform.ui/pull/909