### PR TITLE
Issue #934: NPE during refresh()

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredViewer.java
@@ -1415,13 +1415,16 @@ public abstract class StructuredViewer extends ContentViewer implements IPostSel
 	@Override
 	public void refresh() {
 		Control control = getControl();
-		control.setRedraw(false);
+		if (control != null) {
+			control.setRedraw(false);
+		}
 		try {
 			refresh(getRoot());
 		} finally {
-			control.setRedraw(true);
+			if (control != null) {
+				control.setRedraw(true);
+			}
 		}
-
 	}
 
 	/**


### PR DESCRIPTION
The root cause for the raised issue is in fact a mocked Viewer, which returns a null control, but it seems best to be fail-safe for similarly bad behaving viewer implementations.

fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/934

The real bad guy in this issue is https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/81bc54533b79f02000b74fe81a1ecfc17e8a7ff8/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/search/TreeContentProviderTest.java#L133, but I agree that we should make it fail-safe here.