### PR TITLE
 Add color setting for form header messages

### DIFF
--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/FormHeading.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/FormHeading.java
@@ -18,11 +18,13 @@ import java.util.Hashtable;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.ListenerList;
+import org.eclipse.e4.ui.css.swt.dom.WidgetElement;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.IToolBarManager;
 import org.eclipse.jface.action.ToolBarManager;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IMessageProvider;
+import org.eclipse.jface.resource.ColorRegistry;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CLabel;
@@ -387,7 +389,6 @@ public class FormHeading extends Canvas {
 		private IMessage[] messages;
 		private Hyperlink messageHyperlink;
 		private ListenerList<IHyperlinkListener> listeners;
-		private Color fg;
 		private int fontHeight = -1;
 		private int fontBaselineHeight = -1;
 
@@ -571,24 +572,29 @@ public class FormHeading extends Canvas {
 		}
 
 		public void setForeground(Color fg) {
-			this.fg = fg;
 			updateForeground();
 		}
 
 		private void updateForeground() {
 			Color theFg;
+			String cssClassName = null;
+			ColorRegistry colorRegistry = JFaceResources.getColorRegistry();
 
 			switch (messageType) {
 			case IMessageProvider.ERROR:
-				theFg = getDisplay().getSystemColor(SWT.COLOR_RED);
+				theFg = colorRegistry.get("org.eclipse.ui.workbench.FORM_HEADING_ERROR_COLOR"); //$NON-NLS-1$
+				cssClassName = "MPartFormHeaderCLabelError"; //$NON-NLS-1$
 				break;
 			case IMessageProvider.WARNING:
-				theFg = getDisplay().getSystemColor(SWT.COLOR_DARK_YELLOW);
+				theFg = colorRegistry.get("org.eclipse.ui.workbench.FORM_HEADING_WARNING_COLOR"); //$NON-NLS-1$
+				cssClassName = "MPartFormHeaderCLabelWarning"; //$NON-NLS-1$
 				break;
 			default:
-				theFg = fg;
+				theFg = colorRegistry.get("org.eclipse.ui.workbench.FORM_HEADING_INFO_COLOR"); //$NON-NLS-1$
+				cssClassName = "MPartFormHeaderCLabelInfo"; //$NON-NLS-1$
 			}
 			getMessageControl().setForeground(theFg);
+			WidgetElement.setCSSClass(getMessageControl(), cssClassName);
 		}
 	}
 

--- a/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.themes;singleton:=true
-Bundle-Version: 1.2.2200.qualifier
+Bundle-Version: 1.2.2300.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.e4.ui.css.swt.theme

--- a/bundles/org.eclipse.ui.themes/css/dark/e4-dark_partstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/dark/e4-dark_partstyle.css
@@ -108,8 +108,18 @@
 }
 .MPart FormHeading > CLabel {
     background-color: #505f70;
-    color: #E98787;
 }
+
+.MPartFormHeaderCLabelError {
+	color:'#org-eclipse-ui-workbench-FORM_HEADING_ERROR_COLOR';
+}
+.MPartFormHeaderCLabelWarning {
+	color:'#org-eclipse-ui-workbench-FORM_HEADING_WARNING_COLOR';
+}
+.MPartFormHeaderCLabelInfo {
+	color:'#org-eclipse-ui-workbench-FORM_HEADING_INFO_COLOR';
+}
+
 /* ------------------------------------------------------------- */
 
 #org-eclipse-jdt-ui-SourceView StyledText,

--- a/bundles/org.eclipse.ui.themes/css/dark/e4-dark_preferencestyle.css
+++ b/bundles/org.eclipse.ui.themes/css/dark/e4-dark_preferencestyle.css
@@ -62,6 +62,9 @@ IEclipsePreferences#org-eclipse-ui-workbench:org-eclipse-ui-themes { /* pseudo a
 		'org.eclipse.ui.workbench.INFORMATION_FOREGROUND=238,238,238'
 		'org.eclipse.ui.workbench.HOVER_BACKGROUND=52,57,61'
 		'org.eclipse.ui.workbench.HOVER_FOREGROUND=238,238,238'
+		'org.eclipse.ui.workbench.FORM_HEADING_ERROR_COLOR=255,110,110'
+		'org.eclipse.ui.workbench.FORM_HEADING_WARNING_COLOR=255,200,0'
+		'org.eclipse.ui.workbench.FORM_HEADING_INFO_COLOR=170,170,170'
 		'ERROR_COLOR=247,68,117'
 		'HYPERLINK_COLOR=111,197,238'
 		'INCOMING_COLOR=31,179,235'
@@ -73,4 +76,3 @@ IEclipsePreferences#org-eclipse-ui-workbench:org-eclipse-ui-themes { /* pseudo a
 		'org.eclipse.jface.REVISION_NEWEST_COLOR=75,44,3'
 		'org.eclipse.jface.REVISION_OLDEST_COLOR=154,113,61'
 }
-

--- a/bundles/org.eclipse.ui/plugin.properties
+++ b/bundles/org.eclipse.ui/plugin.properties
@@ -343,6 +343,12 @@ Color.hoverForegroundDeprecatedDesc=Hover foreground Color is deprecated. Use or
 
 Color.errorText=Error text color
 Color.errorTextDesc=Color used to show error messages.
+Color.formHeadingErrorMessage=Form heading error
+Color.formHeadingErrorMessageDesc=Color used to show error messages.
+Color.formHeadingWarningMessage=Form heading warning
+Color.formHeadingWarningMessageDesc=Color used to show warning messages.
+Color.formHeadingInfoMessage=Form heading info
+Color.formHeadingInfoMessageDesc=Color used to show info messages.
 Color.hyperlinkText=Hyperlink text color
 Color.hyperlinkTextDesc=Color used to show links.
 Color.activeHyperlinkText=Active hyperlink text color

--- a/bundles/org.eclipse.ui/plugin.xml
+++ b/bundles/org.eclipse.ui/plugin.xml
@@ -1627,6 +1627,36 @@
          </description>
       </colorDefinition>
       <colorDefinition
+            label="%Color.formHeadingErrorMessage"
+            value="COLOR_RED"
+            categoryId="org.eclipse.ui.workbenchMisc"
+            id="org.eclipse.ui.workbench.FORM_HEADING_ERROR_COLOR"
+            isEditable="false">
+         <description>
+            %Color.formHeadingErrorMessageDesc
+         </description>
+      </colorDefinition>
+      <colorDefinition
+            label="%Color.formHeadingWarningMessage"
+            value="COLOR_DARK_YELLOW"
+            categoryId="org.eclipse.ui.workbenchMisc"
+            id="org.eclipse.ui.workbench.FORM_HEADING_WARNING_COLOR"
+            isEditable="false">
+         <description>
+            %Color.formHeadingWarningMessageDesc
+         </description>
+      </colorDefinition>
+      <colorDefinition
+            label="%Color.formHeadingInfoMessage"
+            value="COLOR_BLACK"
+            categoryId="org.eclipse.ui.workbenchMisc"
+            id="org.eclipse.ui.workbench.FORM_HEADING_INFO_COLOR"
+            isEditable="false">
+         <description>
+            %Color.formHeadingInfoMessageDesc
+         </description>
+      </colorDefinition>
+      <colorDefinition
             categoryId="org.eclipse.ui.workbenchMisc"
             id="HYPERLINK_COLOR"
             value="COLOR_LINK_FOREGROUND"


### PR DESCRIPTION
Hard coding the color of the CLabel in the FormHeader will set the same color for all message types. To keep the correct color for the message, new colors are introduced in the settings. The CSS engine uses the colors to style the messages in the different themes.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/938