### PR TITLE
Perform atomic test cleanup of multiple projects #275

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIWorkingSetWizardsAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIWorkingSetWizardsAuto.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.wizard.IWizard;
@@ -89,20 +90,20 @@ public abstract class UIWorkingSetWizardsAuto extends UITestCase {
 		}
 	}
 
-	private void deleteResources() {
-		try {
-			if (p1 != null) {
-				FileUtil.deleteProject(p1);
-			}
-			if (p2 != null) {
-				FileUtil.deleteProject(p2);
-			}
+	private void deleteResources() throws CoreException {
+		ResourcesPlugin.getWorkspace().run(__ -> {
+			deleteProject(p1);
+			deleteProject(p2);
+		}, null);
+	}
 
+	private void deleteProject(IProject project) {
+		try {
+			FileUtil.deleteProject(project);
 		} catch (CoreException e) {
 			TestPlugin.getDefault().getLog().log(e.getStatus());
 			throw createAssertionError(e);
 		}
-
 	}
 
 	private AssertionError createAssertionError(CoreException originalException) {


### PR DESCRIPTION
The `UIEditWorkingSetWizardAuto#testEditPage` randomly fails because the project deletion during test cleanup fails. The project file of the second project to be deleted is already locked.

To avoid that the deletion of the first project triggers some asynchronous tasks that interfere with the deletion of the second project, this change combines both deletions into an atomic workspace operation. In addition, the change separates the exception handling for both projects to see from the stack trace which of the deletions caused the exception.

Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/275