### PR TITLE
[eclipse-platform/eclipse.platform#226] Import more than one project

### DIFF
--- a/bundles/org.eclipse.ui.navigator.resources/plugin.xml
+++ b/bundles/org.eclipse.ui.navigator.resources/plugin.xml
@@ -259,9 +259,17 @@
       			id="org.eclipse.ui.navigator.resources.FoldersAsProjectsActionProvider"
 				class="org.eclipse.ui.internal.navigator.resources.actions.FoldersAsProjectsActionProvider">
 			<enablement>
-				<or>
-					<adapt type="org.eclipse.core.resources.IFolder" />
-				</or>
+      <with
+            variable="selection">
+         <and>
+            <iterate
+                  ifEmpty="false">
+               <adapt
+                     type="org.eclipse.core.resources.IFolder">
+               </adapt>
+            </iterate>
+         </and>
+      </with>
 			</enablement>
 		</actionProvider>
       <actionProvider

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/OpenFolderAsProjectAction.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/OpenFolderAsProjectAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2015 Red Hat Inc.
+ * Copyright (c) 2014, 2015, 2023 Red Hat Inc. and others
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,15 +10,21 @@
  *
  * Contributors:
  *     Mickael Istria (Red Hat Inc.) - initial API and implementation
+ *     Nikifor Fedorov (ArSysOp) - Import more than one project at once (eclipse.platform#226)
  ******************************************************************************/
-
 package org.eclipse.ui.internal.navigator.resources.actions;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.operations.OperationHistoryFactory;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -26,9 +32,14 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.IJobFunction;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
+import org.eclipse.core.runtime.jobs.JobGroup;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.osgi.util.NLS;
@@ -46,24 +57,90 @@ import org.eclipse.ui.navigator.CommonViewer;
  */
 public class OpenFolderAsProjectAction extends Action {
 
-	private final IFolder folder;
+	private final Collection<IFolder> folders;
 	private final CommonViewer viewer;
 
 	/**
 	 * @param folder
 	 * @param viewer
 	 */
-	public OpenFolderAsProjectAction(IFolder folder, CommonViewer viewer) {
-		super(WorkbenchNavigatorMessages.OpenProjectAction_OpenExistingProject);
-		this.folder = folder;
+	public OpenFolderAsProjectAction(Collection<IFolder> folder, CommonViewer viewer) {
+		super(folder.size() > 1 //
+				? WorkbenchNavigatorMessages.OpenProjectAction_OpenExistingProjects //
+				: WorkbenchNavigatorMessages.OpenProjectAction_OpenExistingProject);
+		this.folders = folder;
 		this.viewer = viewer;
 		setDescription(WorkbenchNavigatorMessages.OpenProjectAction_OpenExistingProject_desc);
-		setImageDescriptor(PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(SharedImages.IMG_OBJ_PROJECT));
+		setImageDescriptor(
+				PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(SharedImages.IMG_OBJ_PROJECT));
+	}
+
+	/**
+	 * @param folder
+	 * @param viewer
+	 */
+	public OpenFolderAsProjectAction(IFolder folder, CommonViewer viewer) {
+		this(Collections.singleton(folder), viewer);
 	}
 
 	@Override
 	public void run() {
-		Job job = Job.create(NLS.bind(WorkbenchNavigatorMessages.OpenProjectAction_opening, folder.getName()), monitor -> {
+		List<IProject> imported = new LinkedList<IProject>();
+		JobGroup group = new JobGroup(WorkbenchNavigatorMessages.OpenProjectAction_multiple, 0, folders.size());
+		Job.getJobManager().addJobChangeListener(new GroupFinishedListener(group,
+				() -> reflectChanges(imported, folders.stream().map(IFolder::getParent).distinct().toList())));
+		for (IFolder folder : folders) {
+			Job job = Job.create(NLS.bind(WorkbenchNavigatorMessages.OpenProjectAction_opening, folder.getName()),
+					new ActualImport(folder, imported::add));
+			job.setPriority(Job.INTERACTIVE);
+			job.setJobGroup(group);
+			job.schedule();
+		}
+	}
+
+	private void reflectChanges(List<IProject> imported, List<IContainer> refreshed) {
+		viewer.getTree().getDisplay().asyncExec(() -> {
+			refreshed.forEach(viewer::refresh);
+			viewer.setSelection(new StructuredSelection(imported));
+		});
+	}
+
+	private static final class GroupFinishedListener extends JobChangeAdapter {
+
+		private final JobGroup target;
+		private final Runnable finalize;
+
+		public GroupFinishedListener(JobGroup target, Runnable finalize) {
+			this.target = target;
+			this.finalize = finalize;
+		}
+
+		@Override
+		public void done(IJobChangeEvent event) {
+			if (!target.equals(event.getJob().getJobGroup())) {
+				return;
+			}
+			if (event.getJobGroupResult() == null) {
+				return;
+			}
+			Job.getJobManager().removeJobChangeListener(this);
+			finalize.run();
+		}
+
+	}
+
+	private static final class ActualImport implements IJobFunction {
+
+		private final IFolder folder;
+		private final Consumer<IProject> reflect;
+
+		private ActualImport(IFolder folder, Consumer<IProject> reflect) {
+			this.folder = folder;
+			this.reflect = reflect;
+		}
+
+		@Override
+		public IStatus run(IProgressMonitor monitor) {
 			IProject parentProject = folder.getProject();
 			Set<IWorkingSet> parentWorkingSets = new HashSet<>();
 			IWorkingSetManager workingSetManager = PlatformUI.getWorkbench().getWorkingSetManager();
@@ -85,10 +162,7 @@ public class OpenFolderAsProjectAction extends Action {
 					IProject newProject = (IProject) operation.getAffectedObjects()[0];
 					workingSetManager.addToWorkingSets(newProject,
 							parentWorkingSets.toArray(new IWorkingSet[parentWorkingSets.size()]));
-					viewer.getTree().getDisplay().asyncExec(() -> {
-						viewer.refresh(folder.getParent());
-						viewer.setSelection(new StructuredSelection(newProject));
-					});
+					reflect.accept(newProject);
 					return Status.OK_STATUS;
 				}
 				return status;
@@ -97,8 +171,7 @@ public class OpenFolderAsProjectAction extends Action {
 			} catch (CoreException ex) {
 				return ex.getStatus();
 			}
-		});
-		job.setPriority(Job.INTERACTIVE);
-		job.schedule();
+		}
+
 	}
 }

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/SelectProjectForFolderAction.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/SelectProjectForFolderAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2015 Red Hat Inc.
+ * Copyright (c) 2014, 2015, 2023 Red Hat Inc. and others
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,9 +10,13 @@
  *
  * Contributors:
  *     Mickael Istria (Red Hat Inc.) - initial API and implementation
+ *     Nikifor Fedorov (ArSysOp) - Import more than one project at once (eclipse.platform#226)
  ******************************************************************************/
 
 package org.eclipse.ui.internal.navigator.resources.actions;
+
+import java.util.Collection;
+import java.util.Collections;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.action.Action;
@@ -29,23 +33,31 @@ import org.eclipse.ui.navigator.CommonViewer;
  */
 public class SelectProjectForFolderAction extends Action {
 
-	private IProject project;
-	private CommonViewer viewer;
+	private final Collection<IProject> project;
+	private final CommonViewer viewer;
 
 	/**
 	 * @param project
 	 * @param viewer
 	 */
-	public SelectProjectForFolderAction(IProject project, CommonViewer viewer) {
-		super(NLS.bind(WorkbenchNavigatorMessages.SelectProjectForFolderAction_SelectProject, project.getName()));
+	public SelectProjectForFolderAction(Collection<IProject> project, CommonViewer viewer) {
+		super(WorkbenchNavigatorMessages.SelectProjectForFolderAction_SelectProjects);
 		this.project = project;
 		this.viewer = viewer;
 		setImageDescriptor(PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(SharedImages.IMG_OBJ_PROJECT));
 	}
 
+	public SelectProjectForFolderAction(IProject project, CommonViewer viewer) {
+		super(NLS.bind(WorkbenchNavigatorMessages.SelectProjectForFolderAction_SelectProject, project.getName()));
+		this.project = Collections.singleton(project);
+		this.viewer = viewer;
+		setImageDescriptor(
+				PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(SharedImages.IMG_OBJ_PROJECT));
+	}
+
 	@Override
 	public void run() {
-		viewer.setSelection(new StructuredSelection( new Object[] { this.project } ));
+		viewer.setSelection(new StructuredSelection(project));
 	}
 
 }

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/plugin/WorkbenchNavigatorMessages.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/plugin/WorkbenchNavigatorMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2016 IBM Corporation and others.
+ * Copyright (c) 2003, 2016, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * Contributors:
  * IBM Corporation - initial API and implementation
  * Mickael Istria (Red Hat Inc.) - [266030] Allow "others" working set
+ * Nikifor Fedorov (ArSysOp) - Import more than one project at once (eclipse.platform#226)
  *******************************************************************************/
 package org.eclipse.ui.internal.navigator.resources.plugin;
 
@@ -70,10 +71,13 @@ public class WorkbenchNavigatorMessages extends NLS {
 	public static String ProjectExplorerPart_workingSetModel;
 
 	public static String OpenProjectAction_OpenExistingProject;
+	public static String OpenProjectAction_OpenExistingProjects;
 	public static String OpenProjectAction_OpenExistingProject_desc;
 	public static String OpenProjectAction_opening;
+	public static String OpenProjectAction_multiple;
 
 	public static String SelectProjectForFolderAction_SelectProject;
+	public static String SelectProjectForFolderAction_SelectProjects;
 
 	public static String NestedProjectLabelProvider_nestedProjectLabel;
 

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/plugin/messages.properties
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/plugin/messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2005, 2014 IBM Corporation and others.
+# Copyright (c) 2005, 2014, 2023 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
 #     IBM Corporation - initial API and implementation
 #     Mickael Istria (Red Hat Inc.) - 427774
 #                                   - [266030] Allow "others" working set
+#     Nikifor Fedorov (ArSysOp) - Import more than one project at once (eclipse.platform#226)
 ###############################################################################
 #String externalization, key=value
 #Tue Aug 15 11:29:14 EDT 2006
@@ -45,9 +46,12 @@ ProjectExplorerPart_workspace=Workspace
 ProjectExplorerPart_workingSetModel=Working Sets
 ResourceMgmtActionProvider_logTitle=Exception in {0}. run: {1}
 OpenProjectAction_OpenExistingProject=Impor&t as Project
+OpenProjectAction_OpenExistingProjects=Impor&t as Projects
 OpenProjectAction_OpenExistingProject_desc=Imports this existing Project into Workspace
 OpenProjectAction_opening=Opening ''{0}'' as project...
+OpenProjectAction_multiple=Opening multiple folders as projects...
 SelectProjectForFolderAction_SelectProject=&Go to project ''{0}''
+SelectProjectForFolderAction_SelectProjects=&Go to corresponding projects
 NestedProjectLabelProvider_nestedProjectLabel={0} (in {1})
 workingSet_others=Other Projects
 ShowInActionProvider_showInAction_label=Sho&w In

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/NavigatorTestSuite.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/NavigatorTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corporation and others.
+ * Copyright (c) 2005, 2018, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,12 +14,14 @@
  *     Thibault Le Ouay <thibaultleouay@gmail.com> - Bug 457870
  *     C. Sean Young <csyoung@google.com> - Bug 436645
  *     Dawid Pakuła <zulus@w3des.net> - Bug 536785
+ *     Nikifor Fedorov (ArSysOp) - Import more than one project at once (eclipse.platform#226)
  *
  *******************************************************************************/
 package org.eclipse.ui.tests.navigator;
 
 import org.eclipse.ui.tests.navigator.cdt.CdtTest;
 import org.eclipse.ui.tests.navigator.jst.JstPipelineTest;
+import org.eclipse.ui.tests.navigator.resources.FoldersAsProjectsContributionTest;
 import org.eclipse.ui.tests.navigator.resources.NestedResourcesTests;
 import org.eclipse.ui.tests.navigator.resources.PathComparatorTest;
 import org.junit.runner.RunWith;
@@ -33,7 +35,7 @@ import org.junit.runners.Suite.SuiteClasses;
 		LabelProviderTest.class, SorterTest.class, ViewerTest.class, CdtTest.class, M12Tests.class,
 		FirstClassM1Tests.class, LinkHelperTest.class, ShowInTest.class, ResourceTransferTest.class,
 		EvaluationCacheTest.class,
-		NestedResourcesTests.class, PathComparatorTest.class
+		NestedResourcesTests.class, PathComparatorTest.class, FoldersAsProjectsContributionTest.class
 		// DnDTest.class, // DnDTest.testSetDragOperation() fails
 		// PerformanceTest.class // Does not pass on all platforms see bug 264449
 })

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/FoldersAsProjectsContributionTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/FoldersAsProjectsContributionTest.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2023 ArSysOp
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Nikifor Fedorov (ArSysOp) - Initial API and implementation
+ ******************************************************************************/
+package org.eclipse.ui.tests.navigator.resources;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jface.action.GroupMarker;
+import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.action.MenuManager;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.ui.actions.ActionContext;
+import org.eclipse.ui.internal.navigator.resources.actions.FoldersAsProjectsActionProvider;
+import org.eclipse.ui.navigator.ICommonMenuConstants;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public final class FoldersAsProjectsContributionTest {
+
+	private final IMenuManager manager = new MenuManager();
+	private final ProjectsStructure workspace = new ProjectsStructure.Imported();
+
+	@Before
+	public void prepare() throws CoreException {
+		manager.add(new GroupMarker(ICommonMenuConstants.GROUP_OPEN));
+		manager.add(new GroupMarker(ICommonMenuConstants.GROUP_PORT));
+		workspace.create("outer", "inner1", "inner2");
+	}
+
+	@Test
+	public void notAFolder() {
+		String notAFolder = "Some string";
+		provider(new StructuredSelection(notAFolder)).fillContextMenu(manager);
+		assertFalse(contributionAdded(manager));
+	}
+
+	@Test
+	public void noDescription() {
+		IFolder justAFolder = ResourcesPlugin.getWorkspace().getRoot().getFolder(new Path("some/folder"));
+		provider(new StructuredSelection(justAFolder)).fillContextMenu(manager);
+		assertFalse(contributionAdded(manager));
+	}
+
+	@Test
+	public void alreadyAdded() throws CoreException {
+		provider(new StructuredSelection(projectTree())).fillContextMenu(manager);
+		assertTrue(contributionAdded(manager));
+	}
+
+	@Test
+	public void notYetImported() throws CoreException {
+		workspace.deleteLeavingContents("inner1");
+		workspace.deleteLeavingContents("inner2");
+		provider(new StructuredSelection(projectTree())).fillContextMenu(manager);
+		assertTrue(contributionAdded(manager));
+	}
+
+	@Test
+	public void ambiguity() throws CoreException {
+		workspace.deleteLeavingContents("inner1");
+		provider(new StructuredSelection(projectTree())).fillContextMenu(manager);
+		assertFalse(contributionAdded(manager));
+	}
+
+	@After
+	public void clean() throws CoreException {
+		manager.removeAll();
+		workspace.clear();
+	}
+
+	private FoldersAsProjectsActionProvider provider(StructuredSelection selection) {
+		FoldersAsProjectsActionProvider provider = new FoldersAsProjectsActionProvider();
+		provider.setContext(new ActionContext(selection));
+		return provider;
+	}
+
+	private boolean contributionAdded(IMenuManager manager) {
+		return manager.getItems().length > 2;
+	}
+
+	private List<IFolder> projectTree() throws CoreException {
+		return Arrays.asList( //
+				ResourcesPlugin.getWorkspace().getRoot().getProject("outer").getFolder("inner1"), //
+				ResourcesPlugin.getWorkspace().getRoot().getProject("outer").getFolder("inner2"));
+	}
+
+}

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/ProjectsStructure.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/ProjectsStructure.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2023 ArSysOp
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Nikifor Fedorov (ArSysOp) - Initial API and implementation
+ ******************************************************************************/
+package org.eclipse.ui.tests.navigator.resources;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+abstract class ProjectsStructure {
+
+	abstract void create(String first, String second, String third) throws CoreException;
+
+	final void clear() throws CoreException {
+		for (IProject project : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {
+			project.delete(true, true, new NullProgressMonitor());
+		}
+	}
+
+	protected final IProject createInner(String name, IProject parent) throws CoreException {
+		IProjectDescription description = ResourcesPlugin.getWorkspace().newProjectDescription(name);
+		description.setLocation(parent.getLocation().append(name));
+		return createAndOpen(description);
+	}
+
+	protected final IProject createAndOpen(IProjectDescription description) throws CoreException {
+		IProject handle = ResourcesPlugin.getWorkspace().getRoot().getProject(description.getName());
+		handle.create(description, new NullProgressMonitor());
+		handle.open(new NullProgressMonitor());
+		return handle;
+	}
+
+	protected final void deleteLeavingContents(String name) throws CoreException {
+		ResourcesPlugin.getWorkspace().getRoot().getProject(name).delete(false, true, new NullProgressMonitor());
+	}
+
+	static final class Imported extends ProjectsStructure {
+
+		@Override
+		void create(String first, String second, String third) throws CoreException {
+			IProject base = createAndOpen(ResourcesPlugin.getWorkspace().newProjectDescription(first));
+			createInner(second, base);
+			createInner(third, base);
+		}
+
+	}
+
+	static final class NotImported extends ProjectsStructure {
+
+		@Override
+		void create(String first, String second, String third) throws CoreException {
+			new Imported().create(first, second, third);
+			deleteLeavingContents(second);
+			deleteLeavingContents(third);
+		}
+
+	}
+
+}


### PR DESCRIPTION
Project Explorer allows to import folder as project with the context menu action. The problem here is that if you have lots of folders to import, you are forced to import them one-by-one. This PR proposes a change which makes this menu entry available and usable on multiple folder selection. Entry will still be unavailable, if any of the selected items is not a folder with project description file in it. Corresponding test checking item availability was also added.

Fixes eclipse-platform/eclipse.platform#226