### PR TITLE
FoldingTest.testCustomFoldingReconciler randomly fails with NPE

### DIFF
--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/FoldingTest.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/FoldingTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import org.junit.Test;
 
@@ -83,6 +84,7 @@ public class FoldingTest extends AbstratGenericEditorTest {
 		DisplayHelper.waitForCondition(editor.getSite().getShell().getDisplay(), 5000, () -> {
 			Position[] actualPositions = getAnnotationsFromAnnotationModel().stream() //
 					.map(getProjectionAnnotationModel()::getPosition) //
+					.filter(Objects::nonNull)
 					.sorted(Comparator.comparingInt(Position::getOffset))
 					.toArray(Position[]::new);
 			return Arrays.deepEquals(actualPositions, expectedPositions);


### PR DESCRIPTION
`org.eclipse.jface.text.source.IAnnotationModel.getPosition(Annotation)` can return null but that was ignored in the test. Added null filter.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/947