### PR TITLE
Perform proper cleanup after working set wizard tests #275

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIEditWorkingSetWizardAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIEditWorkingSetWizardAuto.java
@@ -41,66 +41,64 @@ import org.junit.runners.JUnit4;
  * wizard page texts.
  */
 @RunWith(JUnit4.class)
-public class UIEditWorkingSetWizardAuto extends UIWorkingSetWizardsAuto {
-	IWorkingSetPage fDefaultEditPage;
+public class UIEditWorkingSetWizardAuto extends UIWorkingSetWizardsAuto<WorkingSetEditWizard> {
 
 	public UIEditWorkingSetWizardAuto() {
 		super(UIEditWorkingSetWizardAuto.class.getSimpleName());
 	}
 
 	@Override
-	protected void doSetUp() throws Exception {
-		WorkingSetRegistry registry = WorkbenchPlugin.getDefault()
-				.getWorkingSetRegistry();
-		fDefaultEditPage = registry.getDefaultWorkingSetPage();
-		fWizard = new WorkingSetEditWizard(fDefaultEditPage);
-		super.doSetUp();
+	protected WorkingSetEditWizard createWizardToTest() {
+		return new WorkingSetEditWizard(getDefaultEditPage());
+	}
+
+	private IWorkingSetPage getDefaultEditPage() {
+		WorkingSetRegistry registry = WorkbenchPlugin.getDefault().getWorkingSetRegistry();
+		return registry.getDefaultWorkingSetPage();
 	}
 
 	@Test
 	public void testEditPage() throws Throwable {
-		IWizardPage page = fWizardDialog.getCurrentPage();
+		IWizardPage page = getWizardDialog().getCurrentPage();
 		assertTrue(page instanceof IWorkingSetPage);
 
 		/*
 		 * Verify that correct working set edit page is displayed
 		 */
-		assertSame(page.getClass(), fDefaultEditPage.getClass());
+		assertSame(page.getClass(), getDefaultEditPage().getClass());
 		/*
 		 * Test initial page state
 		 */
 		assertFalse(page.canFlipToNextPage());
-		assertFalse(fWizard.canFinish());
+		assertFalse(getWizard().canFinish());
 		assertNull(page.getErrorMessage());
 		/*
 		 * Test page state with preset page input
 		 */
-		IWorkingSetManager workingSetManager = fWorkbench
-				.getWorkingSetManager();
-		IWorkingSet workingSet = workingSetManager.createWorkingSet(
-				WORKING_SET_NAME_1, new IAdaptable[] { p1, f2 });
-		((WorkingSetEditWizard) fWizard).setSelection(workingSet);
+		IWorkingSetManager workingSetManager = fWorkbench.getWorkingSetManager();
+		IWorkingSet workingSet = workingSetManager.createWorkingSet(WORKING_SET_NAME_1,
+				new IAdaptable[] { getProject1(), getFileInProject2() });
+		getWizard().setSelection(workingSet);
 
 		List<Widget> widgets = getWidgets((Composite) page.getControl(), Text.class);
 		Text text = (Text) widgets.get(0);
 		assertEquals(WORKING_SET_NAME_1, text.getText());
 		assertFalse(page.canFlipToNextPage());
-		assertTrue(fWizard.canFinish());
+		assertTrue(getWizard().canFinish());
 		assertNull(page.getErrorMessage());
 		widgets = getWidgets((Composite) page.getControl(), Tree.class);
 		Tree tree = (Tree) widgets.get(0);
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
-		assertEquals(workspace.getRoot().getProjects().length, tree
-				.getItemCount());
+		assertEquals(workspace.getRoot().getProjects().length, tree.getItemCount());
 		setTextWidgetText(WORKING_SET_NAME_2, page);
-		assertTrue(fWizard.canFinish());
+		assertTrue(getWizard().canFinish());
 
 		/*
 		 * Test page state with partial page input
 		 */
 		setTextWidgetText("", page);
 		assertFalse(page.canFlipToNextPage());
-		assertFalse(fWizard.canFinish());
+		assertFalse(getWizard().canFinish());
 		assertNotNull(page.getErrorMessage());
 
 		/*
@@ -109,17 +107,16 @@ public class UIEditWorkingSetWizardAuto extends UIWorkingSetWizardsAuto {
 		setTextWidgetText(WORKING_SET_NAME_2, page);
 		checkTreeItems();
 		assertFalse(page.canFlipToNextPage());
-		assertTrue(fWizard.canFinish());
+		assertTrue(getWizard().canFinish());
 		assertNull(page.getErrorMessage());
 
-		fWizard.performFinish();
-		workingSet = ((WorkingSetEditWizard) fWizard).getSelection();
+		getWizard().performFinish();
+		workingSet = getWizard().getSelection();
 		IAdaptable[] workingSetItems = workingSet.getElements();
 		assertEquals(WORKING_SET_NAME_2, workingSet.getName());
-		assertTrue(ArrayUtil.contains(workingSetItems, p1));
-		assertTrue(ArrayUtil.contains(workingSetItems, p2));
+		assertTrue(ArrayUtil.contains(workingSetItems, getProject1()));
+		assertTrue(ArrayUtil.contains(workingSetItems, getProject2()));
 
-		DialogCheck.assertDialogTexts(fWizardDialog);
+		DialogCheck.assertDialogTexts(getWizardDialog());
 	}
 }
-

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UINewWorkingSetWizardAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UINewWorkingSetWizardAuto.java
@@ -25,6 +25,7 @@ import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.Widget;
 import org.eclipse.ui.IWorkingSet;
+import org.eclipse.ui.dialogs.IWorkingSetNewWizard;
 import org.eclipse.ui.dialogs.IWorkingSetPage;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.dialogs.WorkingSetNewWizard;
@@ -43,21 +44,20 @@ import org.junit.runners.JUnit4;
  * and wizard page texts.
  */
 @RunWith(JUnit4.class)
-public class UINewWorkingSetWizardAuto extends UIWorkingSetWizardsAuto {
+public class UINewWorkingSetWizardAuto extends UIWorkingSetWizardsAuto<IWorkingSetNewWizard> {
 
 	public UINewWorkingSetWizardAuto() {
 		super(UINewWorkingSetWizardAuto.class.getSimpleName());
 	}
 
 	@Override
-	protected void doSetUp() throws Exception {
-		fWizard = getWorkbench().getWorkingSetManager().createWorkingSetNewWizard(null);
-		super.doSetUp();
+	protected IWorkingSetNewWizard createWizardToTest() {
+		return getWorkbench().getWorkingSetManager().createWorkingSetNewWizard(null);
 	}
 
 	@Test
 	public void testTypePage() throws Throwable {
-		IWizardPage page = fWizardDialog.getCurrentPage();
+		IWizardPage page = getWizardDialog().getCurrentPage();
 		WorkingSetDescriptor[] descriptors = getEditableWorkingSetDescriptors();
 
 		// the first page must be the type selection page iff there is more than one working set type
@@ -76,19 +76,19 @@ public class UINewWorkingSetWizardAuto extends UIWorkingSetWizardsAuto {
 			 */
 			assertEquals(descriptors.length, table.getItemCount());
 			assertFalse(typePage.canFlipToNextPage());
-			assertFalse(fWizard.canFinish());
+			assertFalse(getWizard().canFinish());
 			/*
 			 * Test page state with page complete input
 			 */
 			table.setSelection(descriptors.length - 1);
 			table.notifyListeners(SWT.Selection, new Event());
 			assertTrue(typePage.canFlipToNextPage());
-			assertFalse(fWizard.canFinish());
+			assertFalse(getWizard().canFinish());
 
 			/*
 			 * Check page texts
 			 */
-			DialogCheck.assertDialogTexts(fWizardDialog);
+			DialogCheck.assertDialogTexts(getWizardDialog());
 		}
 	}
 
@@ -96,7 +96,7 @@ public class UINewWorkingSetWizardAuto extends UIWorkingSetWizardsAuto {
 	public void testEditPage() throws Throwable {
 		WorkingSetRegistry registry = WorkbenchPlugin.getDefault()
 				.getWorkingSetRegistry();
-		IWizardPage page = fWizardDialog.getCurrentPage();
+		IWizardPage page = getWizardDialog().getCurrentPage();
 		IWizardPage defaultEditPage = registry.getDefaultWorkingSetPage();
 		String defaultEditPageClassName = defaultEditPage.getClass().getName();
 		WorkingSetDescriptor[] descriptors = getEditableWorkingSetDescriptors();
@@ -131,9 +131,9 @@ public class UINewWorkingSetWizardAuto extends UIWorkingSetWizardsAuto {
 				}
 			}
 			assertTrue(found);
-			fWizardDialog.showPage(fWizard.getNextPage(page));
+			getWizardDialog().showPage(getWizard().getNextPage(page));
 		}
-		page = fWizardDialog.getCurrentPage();
+		page = getWizardDialog().getCurrentPage();
 		assertTrue(page instanceof IWorkingSetPage);
 
 		/*
@@ -144,7 +144,7 @@ public class UINewWorkingSetWizardAuto extends UIWorkingSetWizardsAuto {
 		 * Test initial page state
 		 */
 		assertFalse(page.canFlipToNextPage());
-		assertFalse(fWizard.canFinish());
+		assertFalse(getWizard().canFinish());
 		assertNull(page.getErrorMessage());
 		assertNull(page.getMessage());
 
@@ -153,7 +153,7 @@ public class UINewWorkingSetWizardAuto extends UIWorkingSetWizardsAuto {
 		 */
 		setTextWidgetText(WORKING_SET_NAME_1, page);
 		assertFalse(page.canFlipToNextPage());
-		assertTrue(fWizard.canFinish());  // allow for empty sets
+		assertTrue(getWizard().canFinish());  // allow for empty sets
 		assertNull(page.getErrorMessage());
 		assertNotNull(page.getMessage());
 
@@ -162,25 +162,25 @@ public class UINewWorkingSetWizardAuto extends UIWorkingSetWizardsAuto {
 		 */
 		checkTreeItems();
 		assertFalse(page.canFlipToNextPage());
-		assertTrue(fWizard.canFinish());
+		assertTrue(getWizard().canFinish());
 		assertNull(page.getErrorMessage());
 		assertNull(page.getMessage());
 
-		fWizard.performFinish();
-		IWorkingSet workingSet = ((WorkingSetNewWizard) fWizard).getSelection();
+		getWizard().performFinish();
+		IWorkingSet workingSet = ((WorkingSetNewWizard) getWizard()).getSelection();
 		IAdaptable[] workingSetItems = workingSet.getElements();
 		assertEquals(WORKING_SET_NAME_1, workingSet.getName());
 
 		List<Widget> widgets = getWidgets((Composite) page.getControl(), Tree.class);
 		Tree tree = (Tree) widgets.get(0);
 		assertEquals(workingSetItems.length, tree.getItemCount());
-		assertTrue(ArrayUtil.contains(workingSetItems, p1));
-		assertTrue(ArrayUtil.contains(workingSetItems, p2));
+		assertTrue(ArrayUtil.contains(workingSetItems, getProject1()));
+		assertTrue(ArrayUtil.contains(workingSetItems, getProject2()));
 
 		/*
 		 * Check page texts
 		 */
-		DialogCheck.assertDialogTexts(fWizardDialog);
+		DialogCheck.assertDialogTexts(getWizardDialog());
 	}
 }
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIWorkingSetWizardsAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIWorkingSetWizardsAuto.java
@@ -47,62 +47,102 @@ import org.eclipse.ui.tests.harness.util.UITestCase;
 /**
  * Abstract test class for the working set wizard tests.
  */
-public abstract class UIWorkingSetWizardsAuto extends UITestCase {
-	protected static final int SIZING_WIZARD_WIDTH = 470;
-
-	protected static final int SIZING_WIZARD_HEIGHT = 550;
-
-	protected static final int SIZING_WIZARD_WIDTH_2 = 500;
-
-	protected static final int SIZING_WIZARD_HEIGHT_2 = 500;
-
+public abstract class UIWorkingSetWizardsAuto<W extends IWizard> extends UITestCase {
 	protected static final String WORKING_SET_NAME_1 = "ws1";
 
 	protected static final String WORKING_SET_NAME_2 = "ws2";
 
-	protected WizardDialog fWizardDialog;
+	private static final int SIZING_WIZARD_WIDTH_2 = 500;
 
-	protected IWizard fWizard;
+	private static final int SIZING_WIZARD_HEIGHT_2 = 500;
 
-	protected IProject p1;
+	private WizardDialog wizardDialog;
 
-	protected IProject p2;
+	private W wizardToTest;
 
-	protected IFile f1;
+	private IProject project1;
 
-	protected IFile f2;
+	private IProject project2;
+
+	private IFile fileInProject2;
 
 	public UIWorkingSetWizardsAuto(String name) {
 		super(name);
 	}
 
-	protected void checkTreeItems() {
-		List<Widget> widgets = getWidgets((Composite) fWizardDialog.getCurrentPage()
-				.getControl(), Tree.class);
-		Tree tree = (Tree) widgets.get(0);
-		TreeItem[] treeItems = tree.getItems();
-		for (TreeItem treeItem : treeItems) {
-			treeItem.setChecked(true);
-			Event event = new Event();
-			event.detail = SWT.CHECK;
-			event.item = treeItem;
-			tree.notifyListeners(SWT.Selection, event);
+	protected WizardDialog getWizardDialog() {
+		return wizardDialog;
+	}
+
+	protected W getWizard() {
+		return wizardToTest;
+	}
+
+	protected IProject getProject1() {
+		return project1;
+	}
+
+	protected IProject getProject2() {
+		return project2;
+	}
+
+	protected IFile getFileInProject2() {
+		return fileInProject2;
+	}
+
+	@Override
+	protected void doSetUp() throws Exception {
+		super.doSetUp();
+		wizardToTest = createWizardToTest();
+		wizardDialog = createWizardDialog();
+		initializeTestResources();
+	}
+
+	protected abstract W createWizardToTest();
+
+	private WizardDialog createWizardDialog() {
+		Shell parentShell = DialogCheck.getShell();
+		WizardDialog wizardDialog = new WizardDialog(parentShell, getWizard());
+		wizardDialog.create();
+		Shell dialogShell = wizardDialog.getShell();
+		dialogShell.setSize(Math.max(SIZING_WIZARD_WIDTH_2, dialogShell.getSize().x), SIZING_WIZARD_HEIGHT_2);
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(dialogShell, IWorkbenchHelpContextIds.WORKING_SET_NEW_WIZARD);
+		return wizardDialog;
+	}
+
+	private void initializeTestResources() throws CoreException {
+		project1 = FileUtil.createProject("TP1");
+		project2 = FileUtil.createProject("TP2");
+		FileUtil.createFile("f1.txt", project1);
+		fileInProject2 = FileUtil.createFile("f2.txt", project2);
+	}
+
+	@Override
+	protected void doTearDown() throws Exception {
+		removeAllWorkingSets();
+		cleanupWorkspace();
+		disposeWizardAndDialog();
+		super.doTearDown();
+	}
+
+	private void removeAllWorkingSets() {
+		IWorkingSetManager workingSetManager = fWorkbench.getWorkingSetManager();
+		IWorkingSet[] workingSets = workingSetManager.getWorkingSets();
+		for (IWorkingSet workingSet : workingSets) {
+			workingSetManager.removeWorkingSet(workingSet);
 		}
 	}
 
-	private void deleteResources() throws CoreException {
-		ResourcesPlugin.getWorkspace().run(__ -> {
-			deleteProject(p1);
-			deleteProject(p2);
-		}, null);
-	}
-
-	private void deleteProject(IProject project) {
+	private void cleanupWorkspace() {
 		try {
-			FileUtil.deleteProject(project);
+			ResourcesPlugin.getWorkspace().getRoot().delete(true, null);
 		} catch (CoreException e) {
 			TestPlugin.getDefault().getLog().log(e.getStatus());
 			throw createAssertionError(e);
+		} finally {
+			project1 = null;
+			project2 = null;
+			fileInProject2 = null;
 		}
 	}
 
@@ -137,8 +177,23 @@ public abstract class UIWorkingSetWizardsAuto extends UITestCase {
 		return mostSevere;
 	}
 
-	private Shell getShell() {
-		return DialogCheck.getShell();
+	private void disposeWizardAndDialog() {
+		wizardDialog = null;
+		wizardToTest.dispose();
+		wizardToTest = null;
+	}
+
+	protected void checkTreeItems() {
+		List<Widget> widgets = getWidgets((Composite) getWizardDialog().getCurrentPage().getControl(), Tree.class);
+		Tree tree = (Tree) widgets.get(0);
+		TreeItem[] treeItems = tree.getItems();
+		for (TreeItem treeItem : treeItems) {
+			treeItem.setChecked(true);
+			Event event = new Event();
+			event.detail = SWT.CHECK;
+			event.item = treeItem;
+			tree.notifyListeners(SWT.Selection, event);
+		}
 	}
 
 	protected List<Widget> getWidgets(Composite composite, Class<?> clazz) {
@@ -156,49 +211,11 @@ public abstract class UIWorkingSetWizardsAuto extends UITestCase {
 		return selectedChildren;
 	}
 
-	/**
-	 * <code>fWizard</code> must be initialized by subclasses prior to
-	 * calling this.
-	 */
-	@Override
-	protected void doSetUp() throws Exception {
-		super.doSetUp();
-
-		fWizardDialog = new WizardDialog(getShell(), fWizard);
-		fWizardDialog.create();
-		Shell dialogShell = fWizardDialog.getShell();
-		dialogShell.setSize(Math.max(SIZING_WIZARD_WIDTH_2, dialogShell
-				.getSize().x), SIZING_WIZARD_HEIGHT_2);
-		PlatformUI.getWorkbench().getHelpSystem().setHelp(fWizardDialog.getShell(),
-				IWorkbenchHelpContextIds.WORKING_SET_NEW_WIZARD);
-
-		IWorkingSetManager workingSetManager = fWorkbench
-				.getWorkingSetManager();
-		IWorkingSet[] workingSets = workingSetManager.getWorkingSets();
-		for (IWorkingSet workingSet : workingSets) {
-			workingSetManager.removeWorkingSet(workingSet);
-		}
-		setupResources();
-	}
-
-	private void setupResources() throws CoreException {
-		p1 = FileUtil.createProject("TP1");
-		p2 = FileUtil.createProject("TP2");
-		f1 = FileUtil.createFile("f1.txt", p1);
-		f2 = FileUtil.createFile("f2.txt", p2);
-	}
-
 	protected void setTextWidgetText(String text, IWizardPage page) {
 		List<Widget> widgets = getWidgets((Composite) page.getControl(), Text.class);
 		Text textWidget = (Text) widgets.get(0);
 		textWidget.setText(text);
 		textWidget.notifyListeners(SWT.Modify, new Event());
-	}
-
-	@Override
-	protected void doTearDown() throws Exception {
-		deleteResources();
-		super.doTearDown();
 	}
 
 	protected WorkingSetDescriptor[] getEditableWorkingSetDescriptors() {


### PR DESCRIPTION
The tests for working set wizards change the workspace's working sets without resetting them afterwards. Instead, they cleanup working sets during test setup. In addition, workspace resources are cleaned up selectively after test execution instead of cleaning up the workspace resources into total.

This change addresses this a follows:
- Cleans up working set changes after test execution
- Improves resource cleanup by deleting all workspace resources
- Refactors test implementations by improving encapsulation in test classes to avoid unwanted/undetected side effects that may be related to random failures of `UIEditWorkingSetWizardAuto.testEditPage`

Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/275