### PR TITLE
Remove conflict marker from project root POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-<<<<<<< HEAD
   Copyright (c) 2012, 2016 Eclipse Foundation and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0


### PR DESCRIPTION
A small cosmetic change. 😄 There doesn't seem to be any other occurrences of stray `<<<<<<<` markers in the repository.