### PR TITLE
Add an array based implementation of (IIndexable)LazyContentProvider

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.30.100.qualifier
+Bundle-Version: 3.31.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/LazyArrayContentProvider.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/LazyArrayContentProvider.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jface.viewers;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ *
+ * Like {@link ArrayContentProvider} but for JFace tables using SWT.VIRTUAL.
+ * Because of the way virtual tables work, sorting and filtering must be
+ * performed on the model objects itself, the provider offers the follwoing
+ * methods to do this:
+ * <ul>
+ * <li>{@link #filter(Predicate)}</li>
+ * <li>{@link #sort(Comparator)}</li>
+ * <li>{@link #filterAndSort(Predicate, Comparator)}</li>
+ * </ul>
+ *
+ * @since 3.31
+ *
+ */
+public class LazyArrayContentProvider implements IIndexableLazyContentProvider {
+
+	private static final Object[] EMPTY_ARRAY = new Object[0];
+	private Object[] objects = EMPTY_ARRAY;
+	private Object[] filteredObjects;
+	private TableViewer tableViewer;
+	private boolean parallel;
+
+	/**
+	 * Create an instance of the {@link LazyArrayContentProvider} wich do not use
+	 * parallel filtering and sort
+	 */
+	public LazyArrayContentProvider() {
+		this(false);
+	}
+
+	/**
+	 * Creates an instance of the {@link LazyArrayContentProvider} with the given
+	 * parallel flag for sorting/filtering.
+	 *
+	 * @param parallel if <code>true</code> performs sorting and filtering in
+	 *                 parallel, if <code>false</code> using only the current
+	 *                 thread.
+	 */
+	public LazyArrayContentProvider(boolean parallel) {
+		this.parallel = parallel;
+	}
+
+	@Override
+	public void updateElement(int index) {
+		if (tableViewer != null) {
+			Object element = getCurrentObjects()[index];
+			tableViewer.replace(element, index);
+		}
+	}
+
+	private Object[] getCurrentObjects() {
+		if (filteredObjects != null) {
+			return filteredObjects;
+		}
+		return objects;
+	}
+
+	@Override
+	public int findElement(Object element) {
+		Object[] currentObjects = getCurrentObjects();
+		for (int i = 0; i < currentObjects.length; i++) {
+			Object object = currentObjects[i];
+			if (element == object) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	@Override
+	public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+		filteredObjects = null;
+		if (viewer instanceof TableViewer tableViewer) {
+			this.tableViewer = tableViewer;
+			if (newInput instanceof Collection<?> collection) {
+				objects = collection.toArray();
+			} else if (newInput instanceof Object[] objectArray) {
+				objects = objectArray;
+			} else {
+				objects = EMPTY_ARRAY;
+			}
+			tableViewer.setItemCount(objects.length);
+		} else {
+			this.tableViewer = null;
+			this.objects = EMPTY_ARRAY;
+		}
+	}
+
+	/**
+	 * Sort the current contents of the table
+	 *
+	 * @param <T>
+	 * @param comparator the comparator for comapring objects
+	 */
+	public <T> void sort(Comparator<T> comparator) {
+		filterAndSort(null, comparator);
+	}
+
+	/**
+	 * Filter the current contents of the table
+	 *
+	 * @param <T>
+	 * @param predicate the predicate for filtering
+	 */
+	public <T> void filter(Predicate<T> predicate) {
+		filterAndSort(predicate, null);
+	}
+
+	/**
+	 * Filter and sort the data with the given predicate and comparator.
+	 *
+	 * @param <T>
+	 * @param predicate  the predicate for filtering, might be <code>null</code> if
+	 *                   no filtering is desired.
+	 * @param comparator the comparator for comapring objects, might be
+	 *                   <code>null</code> if the original ordering should be
+	 *                   retained.
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public <T> void filterAndSort(Predicate<T> predicate, Comparator<T> comparator) {
+		if (predicate == null && comparator == null) {
+			return;
+		}
+		Stream<?> stream = Arrays.stream(getCurrentObjects());
+		if (parallel) {
+			stream = stream.parallel();
+		}
+		if (predicate != null) {
+			stream = stream.filter((Predicate) predicate);
+		}
+		if (comparator != null) {
+			stream = stream.sorted((Comparator) comparator);
+		}
+		filteredObjects = stream.toArray();
+		if (tableViewer != null) {
+			tableViewer.setItemCount(filteredObjects.length);
+			tableViewer.refresh();
+		}
+	}
+
+	/**
+	 * resets any filtering or sorting of the data
+	 */
+	public void reset() {
+		filteredObjects = null;
+		if (tableViewer != null) {
+			tableViewer.setItemCount(objects.length);
+		}
+	}
+
+}

--- a/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet068TableViewerLazy.java
+++ b/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet068TableViewerLazy.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2006 - 2016 Tom Schindl and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Tom Schindl <tom.schindl@bestsolution.at> - initial API and implementation
+ *     Lars Vogel <Lars.Vogel@gmail.com> - Bug 414565, 487940
+ *******************************************************************************/
+
+package org.eclipse.jface.snippets.viewers;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.LazyArrayContentProvider;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableColumn;
+
+/**
+ * A simple example to demonstrate the usage of {@link LazyArrayContentProvider}
+ */
+public class Snippet068TableViewerLazy {
+
+	private static final int LARGE_NUMBER_OF_ITEMS = 1_000_000;
+
+	private final class LabelProviderExtension extends LabelProvider {
+
+		AtomicLong counter = new AtomicLong();
+
+		@Override
+		public String getText(Object element) {
+			counter.incrementAndGet();
+			return super.getText(element);
+		}
+	}
+
+	public static class MyModel {
+		public int counter;
+
+		public MyModel(int counter) {
+			this.counter = counter;
+		}
+
+		@Override
+		public String toString() {
+			return "Item " + this.counter;
+		}
+	}
+
+	public Snippet068TableViewerLazy(Shell shell) {
+		final TableViewer v = new TableViewer(shell,
+				SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER | SWT.VIRTUAL);
+		LabelProviderExtension ext = new LabelProviderExtension();
+		v.setLabelProvider(ext);
+		v.setContentProvider(new LazyArrayContentProvider());
+		v.getTable().setLinesVisible(true);
+		v.setUseHashlookup(true);
+		createColumn(v.getTable(), "Values");
+		System.out.println("Create Model with " + LARGE_NUMBER_OF_ITEMS + " items...");
+		MyModel[] model = createModel();
+		System.out.println("Set Input ...");
+		v.setInput(model);
+		System.out.println("We are done here...");
+		Thread thread = new Thread(new Runnable() {
+
+			@Override
+			public void run() {
+				try {
+					long last = 0;
+					while (true) {
+						TimeUnit.SECONDS.sleep(1);
+						long current = ext.counter.get();
+						if (current != last) {
+							last = current;
+							System.out.println("Total render requests: " + current);
+						}
+					}
+				} catch (InterruptedException e) {
+					return;
+				}
+
+			}
+		});
+		thread.setDaemon(true);
+		thread.start();
+	}
+
+	public void createColumn(Table tb, String text) {
+		TableColumn column = new TableColumn(tb, SWT.NONE);
+		column.setWidth(100);
+		column.setText(text);
+		tb.setHeaderVisible(true);
+	}
+
+	private MyModel[] createModel() {
+		MyModel[] elements = new MyModel[LARGE_NUMBER_OF_ITEMS];
+
+		for (int i = 0; i < elements.length; i++) {
+			elements[i] = new MyModel(i);
+		}
+
+		return elements;
+	}
+
+	public static void main(String[] args) {
+		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setLayout(new FillLayout());
+		new Snippet068TableViewerLazy(shell);
+		shell.open();
+
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch())
+				display.sleep();
+		}
+
+		display.dispose();
+
+	}
+
+}


### PR DESCRIPTION
Currently JFace leaves users a bit alone when it comes to virtual tables as beside the API there is only little helper classes or implementations for basic usage.

This adds a new LazyArrayContentProvider that is like the existing ArrayContentProvider but for lazy tables including methods that support sorting and filtering.