### PR TITLE
Reenable checks and reduce unnecessary sleep time in CompletionTest #907

### DIFF
--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/CompletionTest.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/CompletionTest.java
@@ -231,11 +231,10 @@ public class CompletionTest extends AbstratGenericEditorTest {
 		testCompletion();
 		emulatePressLeftArrowKey();
 		final Set<Shell> beforeShells = Arrays.stream(editor.getSite().getShell().getDisplay().getShells()).filter(Shell::isVisible).collect(Collectors.toSet());
-		DisplayHelper.sleep(editor.getSite().getShell().getDisplay(), LongRunningBarContentAssistProcessor.DELAY + 500); // adding delay is a workaround for bug521484, use only 100ms without the bug
+		DisplayHelper.sleep(editor.getSite().getShell().getDisplay(), 200);
 		this.completionShell= findNewShell(beforeShells, editor.getSite().getShell().getDisplay(), true);
 		final Table completionProposalList = findCompletionSelectionControl(this.completionShell);
-		assertEquals("Missing proposals from a Processor", 2, completionProposalList.getItemCount()); // replace with line below when #5214894 is done
-		// checkCompletionContent(completionProposalList); // use this instead of assert above when #521484 is done
+		checkCompletionContent(completionProposalList);
 	}
 
 	private void emulatePressLeftArrowKey() {


### PR DESCRIPTION
Some checks in `CompletionTest.testMoveCaretBackUsesAllProcessors_bug522255` had been disabled and a high sleep time had been introduced because of bug 521484. Since the bug has been fixed some time ago, this is now unnecessary. This change reduces the sleep time and reenables the original check.

Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/907