### PR TITLE
Fix warnings in org.eclipse.ui.genericeditor.tests

### DIFF
--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/CompletionTest.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/CompletionTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.genericeditor.tests;
 
+import static org.eclipse.ui.genericeditor.tests.contributions.BarContentAssistProcessor.BAR_CONTENT_ASSIST_PROPOSAL;
+import static org.eclipse.ui.genericeditor.tests.contributions.LongRunningBarContentAssistProcessor.LONG_RUNNING_BAR_CONTENT_ASSIST_PROPOSAL;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -65,7 +67,6 @@ import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.jface.text.contentassist.IContextInformationValidator;
 import org.eclipse.jface.text.tests.util.DisplayHelper;
 
-import org.eclipse.ui.genericeditor.tests.contributions.BarContentAssistProcessor;
 import org.eclipse.ui.genericeditor.tests.contributions.EnabledPropertyTester;
 import org.eclipse.ui.genericeditor.tests.contributions.LongRunningBarContentAssistProcessor;
 
@@ -184,7 +185,7 @@ public class CompletionTest extends AbstratGenericEditorTest {
 		final TableItem initialProposalItem = completionProposalList.getItem(1);
 		final String initialProposalString = ((ICompletionProposal)initialProposalItem.getData()).getDisplayString();
 		assertThat("Unexpected initial proposal item", 
-				BarContentAssistProcessor.PROPOSAL, endsWith(initialProposalString));
+				BAR_CONTENT_ASSIST_PROPOSAL, endsWith(initialProposalString));
 		completionProposalList.setSelection(initialProposalItem);
 		// asynchronous
 		waitForProposalRelatedCondition("Proposal list did not show two items after finishing computing", completionProposalList, 
@@ -193,9 +194,9 @@ public class CompletionTest extends AbstratGenericEditorTest {
 		final TableItem firstCompletionProposalItem = completionProposalList.getItem(0);
 		final TableItem secondCompletionProposalItem = completionProposalList.getItem(1);
 		String firstCompletionProposalText = ((ICompletionProposal)firstCompletionProposalItem.getData()).getDisplayString();
-		String secondCOmpletionProposalText =  ((ICompletionProposal)secondCompletionProposalItem.getData()).getDisplayString();
-		assertThat("Unexpected first proposal item", BarContentAssistProcessor.PROPOSAL, endsWith(firstCompletionProposalText));
-		assertThat("Unexpected second proposal item", LongRunningBarContentAssistProcessor.PROPOSAL, endsWith(secondCOmpletionProposalText));
+		String secondCompletionProposalText =  ((ICompletionProposal)secondCompletionProposalItem.getData()).getDisplayString();
+		assertThat("Unexpected first proposal item", BAR_CONTENT_ASSIST_PROPOSAL, endsWith(firstCompletionProposalText));
+		assertThat("Unexpected second proposal item", LONG_RUNNING_BAR_CONTENT_ASSIST_PROPOSAL, endsWith(secondCompletionProposalText));
 		String selectedProposalString = ((ICompletionProposal)completionProposalList.getSelection()[0].getData()).getDisplayString();
 		assertEquals("Addition of completion proposal should keep selection", initialProposalString, selectedProposalString);
 	}

--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/ContextInfoTest.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/ContextInfoTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.genericeditor.tests;
 
+import static org.eclipse.ui.genericeditor.tests.contributions.BarContentAssistProcessor.BAR_CONTENT_ASSIST_PROPOSAL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -33,7 +34,6 @@ import org.eclipse.text.tests.Accessor;
 import org.eclipse.jface.text.contentassist.ContentAssistant;
 import org.eclipse.jface.text.source.SourceViewer;
 
-import org.eclipse.ui.genericeditor.tests.contributions.BarContentAssistProcessor;
 import org.eclipse.ui.tests.harness.util.UITestCase;
 
 import org.eclipse.ui.texteditor.ITextEditorActionConstants;
@@ -49,7 +49,7 @@ public class ContextInfoTest extends AbstratGenericEditorTest {
 	@Test
 	public void testContextInfo() throws Exception {
 		cleanFileAndEditor();
-		createAndOpenFile("foobar.txt", BarContentAssistProcessor.PROPOSAL);
+		createAndOpenFile("foobar.txt", BAR_CONTENT_ASSIST_PROPOSAL);
 
 		final Set<Shell> beforeShells = Arrays.stream(editor.getSite().getShell().getDisplay().getShells()).filter(Shell::isVisible).collect(Collectors.toSet());
 		TextOperationAction action = (TextOperationAction) editor.getAction(ITextEditorActionConstants.CONTENT_ASSIST_CONTEXT_INFORMATION);
@@ -74,7 +74,7 @@ public class ContextInfoTest extends AbstratGenericEditorTest {
 	@Test
 	public void testContextInfo_hide_Bug512251() throws Exception {
 		cleanFileAndEditor();
-		createAndOpenFile("foobar.txt", BarContentAssistProcessor.PROPOSAL);
+		createAndOpenFile("foobar.txt", BAR_CONTENT_ASSIST_PROPOSAL);
 
 		final Set<Shell> beforeShells = Arrays.stream(editor.getSite().getShell().getDisplay().getShells()).filter(Shell::isVisible).collect(Collectors.toSet());
 		TextOperationAction action = (TextOperationAction) editor.getAction(ITextEditorActionConstants.CONTENT_ASSIST_CONTEXT_INFORMATION);

--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/contributions/BarContentAssistProcessor.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/contributions/BarContentAssistProcessor.java
@@ -29,11 +29,11 @@ import org.eclipse.jface.text.contentassist.IContextInformationValidator;
 
 public class BarContentAssistProcessor implements IContentAssistProcessor {
 
-	public static final String PROPOSAL = "bars are good for a beer.";
+	public static final String BAR_CONTENT_ASSIST_PROPOSAL = "bars are good for a beer.";
 	private final String completeString;
 
 	public BarContentAssistProcessor() {
-		this(PROPOSAL);
+		this(BAR_CONTENT_ASSIST_PROPOSAL);
 	}
 
 	public BarContentAssistProcessor(String completeString) {
@@ -96,20 +96,22 @@ public class BarContentAssistProcessor implements IContentAssistProcessor {
 	@Override
 	public IContextInformationValidator getContextInformationValidator() {
 		return new IContextInformationValidator() {
-			ITextViewer viewer;
-			int offset;
+			private ITextViewer viewer;
+			private int offset;
+			
 			@Override
-			public void install(IContextInformation info, ITextViewer viewer, int offset) {
-				this.viewer= viewer;
-				this.offset= offset;
+			public void install(IContextInformation info, ITextViewer infoViewer, int documentOffset) {
+				this.viewer= infoViewer;
+				this.offset= documentOffset;
 			}
+			
 			@Override
-			public boolean isContextInformationValid(int offset) {
+			public boolean isContextInformationValid(int offsetToTest) {
 				try {
 					IDocument document= viewer.getDocument();
 					IRegion line= document.getLineInformationOfOffset(this.offset);
 					int end= line.getOffset() + line.getLength();
-					return (offset >= this.offset && offset < end);
+					return (offsetToTest >= this.offset && offsetToTest < end);
 				} catch (BadLocationException e) {
 					return false;
 				}

--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/contributions/LongRunningBarContentAssistProcessor.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/contributions/LongRunningBarContentAssistProcessor.java
@@ -18,11 +18,11 @@ import org.eclipse.jface.text.contentassist.ICompletionProposal;
 
 public class LongRunningBarContentAssistProcessor extends BarContentAssistProcessor {
 
-	public static final String PROPOSAL = "bars are also good for soft drink cocktails.";
+	public static final String LONG_RUNNING_BAR_CONTENT_ASSIST_PROPOSAL = "bars are also good for soft drink cocktails.";
 	public static final int DELAY = 2000;
 
 	public LongRunningBarContentAssistProcessor() {
-		super(PROPOSAL);
+		super(LONG_RUNNING_BAR_CONTENT_ASSIST_PROPOSAL);
 	}
 
 	@Override


### PR DESCRIPTION
Minor non-functional changes to tests in `org.eclipse.ui.genericeditor.tests` to fix existing warnings.