### PR TITLE
Fixed version of org.eclipse.e4.tools.jdt.templates

### DIFF
--- a/tools/bundles/org.eclipse.e4.tools.jdt.templates/META-INF/MANIFEST.MF
+++ b/tools/bundles/org.eclipse.e4.tools.jdt.templates/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.e4.tools.jdt.templates;singleton:=true
-Bundle-Version: 4.10.0.qualifier
+Bundle-Version: 4.10.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.jdt.ui;bundle-version="3.20.0",
  org.eclipse.ui.editors;bundle-version="3.6.0",


### PR DESCRIPTION
Only qualifier changed for
(org.eclipse.e4.tools.jdt.templates/4.10.0.v20230727-0604). Expected to have bigger x.y.z than what is available in baseline (4.10.0.v20230414-0427)

Regression from f243cf0a28785b89b7c50bf4e1cce48a917d89bd

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/981