### PR TITLE
Fix spurious content-assist popup on MacOS

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/ContentAssistant.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/ContentAssistant.java
@@ -340,7 +340,7 @@ public class ContentAssistant implements IContentAssistant, IContentAssistantExt
 			if (e.character == 0 && (e.keyCode & SWT.KEYCODE_BIT) == 0)
 				return;
 
-			if (e.character != 0 && (e.stateMask == SWT.ALT))
+			if (e.character != 0 && (e.stateMask == SWT.ALT || ((e.stateMask & SWT.COMMAND) != 0)))
 				return;
 
 			TriggerType triggerType= getAutoActivationTriggerType(e.character);


### PR DESCRIPTION
Ported https://github.com/eclipse-platform/eclipse.platform.text/pull/150 from old repository

Original summary:
I think this was introduced by https://github.com/eclipse-platform/eclipse.platform.text/commit/78fc9f6f6566323c691f1fee1eb14de2f27e7d34

Have observed with LSP4e-based editors in Eclipse 2022-12, but presumably would affect everything that uses the jface text editor and has a content assistant installed.

To reproduce (on MacOS):
1. E.g. open a Rust file (with Eclipse Corrosion plugin installed) or a javascript file using Wild Web Developer
2. Position the cursor on some whitespace on a non comment line
3. Having made sure the file is already saved, press cmd-S to 'save' again.

The content assistant popup will be shown. This also seems to occur if you press cmd-? where ? is any letter not bound to a command, or bound to a command that doesn't succeed and mark the event as consumed. E.g. cmd-C with no text highlighted will also provoke the popup.

I guess this isn't an issue on Windows/Linux because ctrl is used as the primary modifier key, and that gets encoded as part of the character code point and gets filtered out by `Character.isLetter(c) || Character.isDigit(c)` on L1242.
