### PR TITLE
Touch the bundle to fix unstable build because of new hamcrest library

### DIFF
--- a/tests/org.eclipse.tests.urischeme/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.tests.urischeme/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1245


### PR DESCRIPTION
See https://download.eclipse.org/eclipse/downloads/drops4/I20230811-0350/

See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1245