### PR TITLE
SoftLimit: reduced limit is not applied

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/views/WorkbenchViewerSetup.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/views/WorkbenchViewerSetup.java
@@ -42,7 +42,13 @@ public class WorkbenchViewerSetup {
 			int itemsLimit = getItemsLimit();
 			registeredViewers.values().forEach(v -> {
 				v.setDisplayIncrementally(itemsLimit);
-				v.refresh();
+				Object input = v.getInput();
+				if (input != null) {
+					v.setInput(null);
+					v.setInput(input);
+				} else {
+					v.refresh();
+				}
 			});
 		}
 	};

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ViewerItemsLimitTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ViewerItemsLimitTest.java
@@ -322,6 +322,7 @@ public class ViewerItemsLimitTest extends UITestCase {
 		// change the viewer limit
 		setNewViewerLimit(VIEW_LIMIT_DOUBLE);
 		processBackgroundUpdates(100);
+		commonViewer.expandAll();
 		processEventsUntil(() -> getFirstItem(commonViewer).getItems().length > VIEW_LIMIT_DOUBLE, 30_000);
 
 		firstItem = getFirstItem(commonViewer);
@@ -340,7 +341,7 @@ public class ViewerItemsLimitTest extends UITestCase {
 
 		// job may take some time to create marker.
 		processBackgroundUpdates(100);
-
+		commonViewer.expandAll();
 		firstItem = getFirstItem(commonViewer);
 		assertEquals("all the items must be visible with limit more than input", numberOfMarkers,
 				firstItem.getItems().length);


### PR DESCRIPTION
In case viewer already shows more elements as new limit, just a refresh() doesn't do anything visible.

Let's reset the input (which would unmap all created elements).

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1013