### PR TITLE
Fix italic left over by the Show node.

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TableViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TableViewer.java
@@ -478,15 +478,13 @@ public class TableViewer extends AbstractTableViewer {
 			Object[] nextChildren = applyItemsLimit(data, sortedChildren);
 
 			if (nextChildren.length > 0) {
-				// update the expandable node with first item.
-				doUpdateItem(item, nextChildren[0], true);
-				// create remaining elements
-				if (nextChildren.length > 1) {
-					// current index is updated so start creating from next index.
-					int index = doIndexOf(item) + 1;
-					for (int i = 1; i < nextChildren.length; i++) {
-						createItem(nextChildren[i], index++);
-					}
+				disassociate(item);
+				int index = doIndexOf(item);
+				// will also call item.dispose()
+				doRemove(new int[] { index });
+
+				for (int i = 0; i < nextChildren.length; i++) {
+					createItem(nextChildren[i], index++);
 				}
 				// If we've expanded but still have not reached the limit
 				// select new expandable node, so user can click through

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewer.java
@@ -1159,15 +1159,13 @@ public class TreeViewer extends AbstractTreeViewer {
 				parent = getControl();
 			}
 
-			// update widget
-			updateItem(item, children[0]);
-			updatePlus(item, children[0]);
+			// destroy widget
+			disassociate(item);
+			item.dispose();
 
-			if (children.length > 1) {
-				// create children on parent
-				for (int i = 1; i < children.length; i++) {
-					createTreeItem(parent, children[i], -1);
-				}
+			// create children on parent
+			for (Object element : children) {
+				createTreeItem(parent, element, -1);
 			}
 
 			// If we've expanded but still have not reached the limit


### PR DESCRIPTION
As we set italic font to Show item updating the item with new element left behind it's font.
Now destroy the Show item and create items from it's position onwards. (No impact on performance - previous performance data matches with the fix)

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1032