### PR TITLE
Do not try to create children for Show node in search view.

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
@@ -2596,6 +2596,7 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 		Assert.isNotNull(elementOrTreePath);
 		if (checkBusy())
 			return;
+
 		Widget item = internalExpand(elementOrTreePath, false);
 		if (item instanceof Item) {
 			if (expanded) {

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewer.java
@@ -1203,4 +1203,18 @@ public class TreeViewer extends AbstractTreeViewer {
 		}
 		return items[length - 1].getData();
 	}
+
+	@Override
+	public void setExpandedState(Object elementOrTreePath, boolean expanded) {
+		// Special behavior for ExpandableNode. Expand the it if it's widget is found
+		// otherwise do not expand it.
+		if (isExpandableNode(elementOrTreePath)) {
+			Widget expItem = findItem(elementOrTreePath);
+			if (expItem != null) {
+				handleExpandableNodeClicked(expItem);
+			}
+			return;
+		}
+		super.setExpandedState(elementOrTreePath, expanded);
+	}
 }

--- a/bundles/org.eclipse.search/new search/org/eclipse/search/ui/text/AbstractTextSearchViewPage.java
+++ b/bundles/org.eclipse.search/new search/org/eclipse/search/ui/text/AbstractTextSearchViewPage.java
@@ -51,6 +51,7 @@ import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.util.OpenStrategy;
+import org.eclipse.jface.viewers.ColumnViewer;
 import org.eclipse.jface.viewers.DecoratingLabelProvider;
 import org.eclipse.jface.viewers.IBaseLabelProvider;
 import org.eclipse.jface.viewers.IOpenListener;
@@ -84,6 +85,7 @@ import org.eclipse.ui.part.IPageSite;
 import org.eclipse.ui.part.Page;
 import org.eclipse.ui.part.PageBook;
 import org.eclipse.ui.progress.UIJob;
+import org.eclipse.ui.views.WorkbenchViewerSetup;
 
 import org.eclipse.ui.texteditor.IUpdate;
 
@@ -731,7 +733,7 @@ public abstract class AbstractTextSearchViewPage extends Page implements ISearch
 			fCollapseAllAction.setViewer(viewer);
 			fExpandAllAction.setViewer(viewer);
 		}
-
+		WorkbenchViewerSetup.setupViewer((ColumnViewer) fViewer);
 		fCopyToClipboardAction.setViewer(fViewer);
 		fSelectAllAction.setViewer(fViewer);
 

--- a/bundles/org.eclipse.search/new search/org/eclipse/search2/internal/ui/basic/views/TreeViewerNavigator.java
+++ b/bundles/org.eclipse.search/new search/org/eclipse/search2/internal/ui/basic/views/TreeViewerNavigator.java
@@ -108,6 +108,11 @@ public class TreeViewerNavigator implements INavigate {
 			return child;
 		TreeItem nextSibling= getNextSibling(currentItem, true);
 		if (nextSibling != null) {
+			// expand the node first and fetch the sibling again.
+			if (fViewer.isExpandableNode(nextSibling.getData())) {
+				fViewer.setExpandedState(nextSibling.getData(), true);
+				nextSibling = getNextSibling(currentItem, true);
+			}
 			if (hasMatches(nextSibling))
 				return nextSibling;
 			return getFirstChildWithMatches(nextSibling);
@@ -116,6 +121,11 @@ public class TreeViewerNavigator implements INavigate {
 		while (parent != null) {
 			nextSibling= getNextSibling(parent, true);
 			if (nextSibling != null) {
+				// expand the node first and fetch the sibling again.
+				if (fViewer.isExpandableNode(nextSibling.getData())) {
+					fViewer.setExpandedState(nextSibling.getData(), true);
+					nextSibling = getNextSibling(parent, true);
+				}
 				if (hasMatches(nextSibling))
 					return nextSibling;
 				return getFirstChildWithMatches(nextSibling);


### PR DESCRIPTION
Navigate feature of SearchView tries to create children for element for Show node.
We should not support expanded state for ExpandableNode.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1024