### PR TITLE
Improve message shown for expandable node

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/messages.properties
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/messages.properties
@@ -232,4 +232,5 @@ ConfigureColumnsDialog_up = &Up
 ConfigureColumnsDialog_down = Dow&n
 
 # org.eclipse.jface.viewers.internal.ExpandableNode
-ExpandableNode.defaultLabel = Show {0}...{1} ({2})
+ExpandableNode.defaultLabel = Show next {0} items from remaining {1}
+ExpandableNode.showRemaining = Show remaining {0} item{1}

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnViewer.java
@@ -872,7 +872,7 @@ public abstract class ColumnViewer extends StructuredViewer {
 		// limit the number of items to be created. sorted always gets the remaining
 		// elements to be created.
 		final int itemsLimit = getItemsLimit();
-		if (itemsLimit <= 0 || sorted.length <= itemsLimit) {
+		if (itemsLimit <= 0 || sorted.length <= itemsLimit || sorted.length == itemsLimit + 1) {
 			return sorted;
 		}
 
@@ -958,6 +958,12 @@ public abstract class ColumnViewer extends StructuredViewer {
 		// there can any number of elements in the model. but viewer was showing
 		// ExpandableNode. Then return the same length.
 		if (visibleChildren[visibleItemsLength - 1].getData() instanceof ExpandableNode) {
+			if (sortedAll.length == visibleItemsLength) {
+				// model returns now exact the visible number of elements (note, last visible is
+				// expandable node): just return all without expandable node
+				return sortedAll;
+			}
+
 			// Now we need exactly previously visible length.
 			Object[] subArray = new Object[visibleItemsLength];
 			System.arraycopy(sortedAll, 0, subArray, 0, visibleItemsLength - 1);

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/internal/ExpandableNode.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/internal/ExpandableNode.java
@@ -99,6 +99,13 @@ public class ExpandableNode {
 	}
 
 	/**
+	 * @return limit value
+	 */
+	public int getLimit() {
+		return limit;
+	}
+
+	/**
 	 * This method returns those children of the current node which are supposed to
 	 * be not created / shown yet in the viewer.
 	 *
@@ -157,15 +164,21 @@ public class ExpandableNode {
 	/**
 	 * {@return label shown for the node in the viewer}
 	 */
+	@SuppressWarnings("boxing")
 	public String getLabel() {
-		Integer start = Integer.valueOf(this.start + 1);
-		Integer length = Integer.valueOf(orginalArray.length + addedElements.size());
-		int next = this.start + this.limit;
-		if (next > orginalArray.length + addedElements.size()) {
-			next = orginalArray.length + addedElements.size();
+		int all = orginalArray.length + addedElements.size();
+		int remaining = all - start;
+		String label;
+		if (remaining > limit) {
+			if (remaining == limit + 1) {
+				String suffix = remaining == 1 ? "" : "s"; //$NON-NLS-1$ //$NON-NLS-2$
+				return JFaceResources.format("ExpandableNode.showRemaining", remaining, suffix); //$NON-NLS-1$ ;
+			}
+			label = JFaceResources.format("ExpandableNode.defaultLabel", limit, remaining); //$NON-NLS-1$
+		} else {
+			String suffix = remaining == 1 ? "" : "s"; //$NON-NLS-1$ //$NON-NLS-2$
+			label = JFaceResources.format("ExpandableNode.showRemaining", remaining, suffix); //$NON-NLS-1$
 		}
-		Integer nextBlock = Integer.valueOf(next);
-		String label = JFaceResources.format("ExpandableNode.defaultLabel", start, nextBlock, length); //$NON-NLS-1$
 		return label;
 	}
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/BaseLimitBasedViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/BaseLimitBasedViewerTest.java
@@ -27,6 +27,7 @@ public class BaseLimitBasedViewerTest extends ViewerTestCase {
 
 	List<DataModel> rootModel;
 	protected static final int VIEWER_LIMIT = 4;
+	protected static final int DEFAULT_ELEMENTS_COUNT = 40;
 
 	public BaseLimitBasedViewerTest(String name) {
 		super(name);
@@ -37,16 +38,16 @@ public class BaseLimitBasedViewerTest extends ViewerTestCase {
 		return null;
 	}
 
-	protected static List<DataModel> createModel() {
+	protected static List<DataModel> createModel(final int maxCount) {
 		List<DataModel> rootModel = new ArrayList<>();
-		for (int i = 0; i < 40; i++) {
+		for (int i = 0; i < maxCount; i++) {
 			if (i % 2 == 0) {
 				DataModel rootLevel = new DataModel(Integer.valueOf(i));
-				for (int j = 0; j < 40; j++) {
+				for (int j = 0; j < maxCount; j++) {
 					if (j % 2 == 0) {
 						DataModel level1 = new DataModel(Integer.valueOf(j));
 						level1.parent = rootLevel;
-						for (int k = 0; k < 40; k++) {
+						for (int k = 0; k < maxCount; k++) {
 							if (k % 2 == 0) {
 								DataModel level2 = new DataModel(Integer.valueOf(k));
 								level2.parent = level1;

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitTest.java
@@ -180,10 +180,14 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 	}
 
 	public void testRemoveItem() {
+		processEvents();
+		treeViewer.expandAll();
+		processEvents();
 		DataModel firstEle = rootModel.remove(0);
 		TreeItem firstItem = treeViewer.getTree().getItem(0);
 		assertEquals("element contains unexpected data", firstEle, firstItem.getData());
 		treeViewer.remove(firstEle);
+		processEvents();
 		firstEle = rootModel.get(0);
 		firstItem = treeViewer.getTree().getItem(0);
 		assertEquals("element contains unexpected data", firstEle, firstItem.getData());
@@ -243,7 +247,7 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		treeViewer.setInput(rootModel);
 		processEvents();
 		assertEquals("there must be only one item", 1, treeViewer.getTree().getItems().length);
-		treeViewer.setInput(createModel());
+		treeViewer.setInput(createModel(DEFAULT_ELEMENTS_COUNT));
 		processEvents();
 		assertLimitedItems();
 	}
@@ -279,7 +283,7 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 
 	@Override
 	protected void setInput() {
-		rootModel = createModel();
+		rootModel = createModel(DEFAULT_ELEMENTS_COUNT);
 		treeViewer.setInput(rootModel);
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ViewerItemsLimitTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ViewerItemsLimitTest.java
@@ -242,12 +242,23 @@ public class ViewerItemsLimitTest extends UITestCase {
 		if (nextBlock > realInputSize) {
 			nextBlock = realInputSize;
 		}
-		String expLabel = JFaceResources.format("ExpandableNode.defaultLabel", currentLimit + 1, nextBlock,
-				realInputSize);
-
-		assertEquals("Incorrect text for expand node", expLabel, lastItem.getText().trim());
+		String expLabel = calculateExpandableLabel(lastItem.getData(), realInputSize);
 		ExpandableNode node = (ExpandableNode) lastItem.getData();
 		assertEquals(expLabel, node.getLabel());
+	}
+
+	@SuppressWarnings("boxing")
+	private String calculateExpandableLabel(Object data, int realInputSize) {
+		ExpandableNode node = (ExpandableNode) data;
+		int remaining = realInputSize - node.getOffset();
+		String expectedLabel;
+		if (remaining > node.getLimit()) {
+			expectedLabel = JFaceResources.format("ExpandableNode.defaultLabel", node.getLimit(), remaining); //$NON-NLS-1$
+		} else {
+			String suffix = remaining == 1 ? "" : "s"; //$NON-NLS-1$
+			expectedLabel = JFaceResources.format("ExpandableNode.showRemaining", remaining, suffix); //$NON-NLS-1$
+		}
+		return expectedLabel;
 	}
 
 	private void setNewViewerLimit(int viewerLimit) {


### PR DESCRIPTION
- In case there are more then limit (X) items hidden, will show "Show next X items from remaining Y"
- In case there are less then limit (X) items hidden, will show Show remaining X item(s)
- If elements added not "one by one" to the viewer, avoids showing expandable node if only one element would be hidden

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1012 
Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1028

![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/964108/56b5d097-66b1-4b9c-81c2-e91cdb151f58)

![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/964108/6fbc69d7-7850-43a7-aabf-7e7218595c5f)

