### PR TITLE
SoftLimit: improve Preferences page text/tooltip/keywords

### DIFF
--- a/bundles/org.eclipse.ui.ide/plugin.properties
+++ b/bundles/org.eclipse.ui.ide/plugin.properties
@@ -231,6 +231,7 @@ PreferenceKeywords.Editing = editing
 PreferenceKeywords.Appearance = appearance
 PreferenceKeywords.ColorLabels = color label
 PreferenceKeywords.General = click background heap
+PreferenceKeywords.ViewLimit = view limit maximum elements items
 PreferenceKeywords.Themes = themes
 PreferenceKeywords.AppearancePage = presentation MRU dark light tabs
 PreferenceKeywords.Tabs = tab

--- a/bundles/org.eclipse.ui.ide/plugin.xml
+++ b/bundles/org.eclipse.ui.ide/plugin.xml
@@ -456,6 +456,9 @@
             id="org.eclipse.ui.ide.general"
             label="%PreferenceKeywords.General"/>
       <keyword
+            id="org.eclipse.ui.ide.viewlimit"
+            label="%PreferenceKeywords.ViewLimit"/>
+      <keyword
             id="org.eclipse.ui.ide.themes"
             label="%PreferenceKeywords.Themes"/>
       <keyword
@@ -564,6 +567,7 @@
             class="org.eclipse.ui.internal.ide.dialogs.IDEWorkbenchPreferencePage"
             id="org.eclipse.ui.preferencePages.Workbench">
          <keywordReference id="org.eclipse.ui.ide.general"/>
+         <keywordReference id="org.eclipse.ui.ide.viewlimit"/>
       </page>
       <page
             name="%PreferencePages.Globalization"

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchMessages.java
@@ -731,6 +731,7 @@ public class WorkbenchMessages extends NLS {
 	public static String WorkbenchPreference_workbenchSaveInterval;
 	public static String WorkbenchPreference_workbenchSaveIntervalError;
 	public static String WorkbenchPreference_largeViewLimit;
+	public static String WorkbenchPreference_largeViewLimitTooltip;
 	public static String WorkbenchPreference_largeViewLimitError;
 	public static String WorkbenchEditorsAction_label;
 	public static String WorkbookEditorsAction_label;

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/WorkbenchPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/WorkbenchPreferencePage.java
@@ -37,6 +37,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferenceConstants;
 import org.eclipse.ui.IWorkbenchPreferencePage;
@@ -158,7 +159,24 @@ public class WorkbenchPreferencePage extends PreferencePage implements IWorkbenc
 		groupComposite.setLayoutData(gd);
 
 		largeViewLimit = new IntegerFieldEditor(IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT,
-				WorkbenchMessages.WorkbenchPreference_largeViewLimit, groupComposite);
+				WorkbenchMessages.WorkbenchPreference_largeViewLimit, groupComposite) {
+
+			@Override
+			protected Text createTextWidget(Composite parent) {
+				Text w = super.createTextWidget(parent);
+				w.setToolTipText(WorkbenchMessages.WorkbenchPreference_largeViewLimitTooltip);
+				return w;
+			}
+
+			@Override
+			public Label getLabelControl(Composite parent) {
+				Label label = super.getLabelControl(parent);
+				if (label != null) {
+					label.setToolTipText(WorkbenchMessages.WorkbenchPreference_largeViewLimitTooltip);
+				}
+				return label;
+			}
+		};
 
 		largeViewLimit.setPreferenceStore(getPreferenceStore());
 		largeViewLimit.setPage(this);

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
@@ -711,7 +711,10 @@ WorkbenchPreference_workbenchSaveIntervalError=The workbench save interval shoul
 WorkbenchEditorsAction_label=S&witch to Editor...
 WorkbookEditorsAction_label=&Quick Switch Editor
 
-WorkbenchPreference_largeViewLimit=Default increment for displaying elements in UI:
+WorkbenchPreference_largeViewLimit=Initial maximum number of elements shown in views:
+WorkbenchPreference_largeViewLimitTooltip=Use 0 for no limit. \
+If the number of elements exceeds given limit, user interaction is required to show more elements. \
+This limit is a hint: not all views support this limit or may use different one.
 WorkbenchPreference_largeViewLimitError=The limit should be an integer between 0 and {0}.
 
 WorkbenchEditorsDialog_title=Switch to Editor


### PR DESCRIPTION
- Text: `Initial maximum number of elements shown in views:`
- Tooltip: `Use 0 for no limit. If the number of elements exceeds given limit, user interaction is required to show more elements. This limit is a hint: not all views support support this limit or may use different one.`
- Keywords: `view limit maximum elements items`

![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/964108/beba5e67-eadd-49b3-bd59-7d59f346f0c6)


Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1026