### PR TITLE
SoftLimit on viewers: hide ExpandableNode

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTableViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTableViewer.java
@@ -964,31 +964,7 @@ public abstract class AbstractTableViewer extends ColumnViewer {
 				if (count < indices.length) {
 					System.arraycopy(indices, 0, indices = new int[count], 0, count);
 				}
-
-				// item to select may be hidden inside expandable node.
-				if (getItemsLimit() > 0 && indices.length < list.size()
-						&& getLastElement() instanceof ExpandableNode expNode) {
-
-					// extract only non found items already.
-					List<Object> notFoundItems = new ArrayList<Object>(list);
-					for (int index : indices) {
-						notFoundItems.remove(doGetItem(index).getData());
-					}
-
-					Object[] remEles = expNode.getRemainingElements();
-					OuterLoop : for (Object searchItem : notFoundItems) {
-						for (Object remEle : remEles) {
-							if (equals(remEle, searchItem)) {
-								int[] placeHolder = new int[indices.length + 1];
-								System.arraycopy(indices, 0, placeHolder, 0, indices.length);
-								placeHolder[placeHolder.length - 1] = items.length - 1;
-								indices = placeHolder;
-								break OuterLoop;
-							}
-						}
-					}
-				}
-
+				// invisible items (part of expandable node, or filtered) are ignored
 				doSelect(indices);
 			}
 		}

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
@@ -24,7 +24,6 @@ package org.eclipse.jface.viewers;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -2644,40 +2643,7 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 				}
 			}
 		}
-
-		// there can be some items inside expandable node and not populated yet. In this
-		// case try to find the item to select inside all the visible expandable nodes.
-		if (newSelection.size() < v.size() && getItemsLimit() > 0) {
-			// make out still not found items
-			List<Object> notFound = new ArrayList<>();
-			for (Object toSelect : v) {
-				boolean bFound = false;
-				for (Item found : newSelection) {
-					if (equals(toSelect, found.getData())) {
-						bFound = true;
-						break;
-					}
-				}
-				if (!bFound) {
-					notFound.add(toSelect);
-				}
-			}
-
-			// find out all visible expandable nodes
-			Collection<ExpandableNode> expandItems = getExpandableNodes();
-
-			// search for still missing items inside expandable nodes
-			for (Object nFound : notFound) {
-				for (ExpandableNode expNode : expandItems) {
-					if (findElementInExpandableNode(expNode, nFound)) {
-						Widget w = findItem(expNode);
-						if (w instanceof Item item) {
-							newSelection.add(item);
-						}
-					}
-				}
-			}
-		}
+		// invisible items (part of expandable node, or filtered) are ignored
 
 		setSelection(newSelection);
 
@@ -2692,16 +2658,6 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 				showItem(newSelection.get(i));
 			}
 		}
-	}
-
-	private boolean findElementInExpandableNode(ExpandableNode expNode, Object toFind) {
-		Object[] remEles = getFilteredChildren(expNode);
-		for (Object element : remEles) {
-			if (equals(element, toFind)) {
-				return true;
-			}
-		}
-		return false;
 	}
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnViewer.java
@@ -1063,13 +1063,14 @@ public abstract class ColumnViewer extends StructuredViewer {
 	 * it will remain the same. Please do not use this API without consulting with
 	 * the API development team.
 	 * </p>
+	 * This code must run in the UI Thread.
 	 *
-	 * @param element model object representing a special "expandable" node
-	 * @return return if it is an instance of ExpandableNode
+	 * @param item widget item
+	 * @return return if the item is the expansion placeholder
 	 * @since 3.31
 	 */
-	public final boolean isExpandableNode(Object element) {
-		return element instanceof ExpandableNode;
+	public static final boolean isExpandableNode(Item item) {
+		return item.getData() instanceof ExpandableNode;
 
 	}
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerWithLimitTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerWithLimitTest.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.viewers.ColumnViewer;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredContentProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -87,8 +88,8 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 			tableViewer.add(element);
 			processEvents();
 			TableItem[] items = table.getItems();
-			Object last = items[items.length - 1].getData();
-			assertFalse("Last item shouln't be expandable: " + last, tableViewer.isExpandableNode(last));
+			TableItem last = items[items.length - 1];
+			assertFalse("Last item shouln't be expandable: " + last, ColumnViewer.isExpandableNode(last));
 		}
 
 		DataModel element = new DataModel(Integer.valueOf(rootModel.size() + 1));
@@ -133,8 +134,8 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 			if (rootModel.size() > VIEWER_LIMIT + 1) {
 				assertLimitedItems(items);
 			} else {
-				Object last = items[items.length - 1].getData();
-				assertFalse("Last item shouln't be expandable: " + last, tableViewer.isExpandableNode(last));
+				TableItem last = items[items.length - 1];
+				assertFalse("Last item shouln't be expandable: " + last, ColumnViewer.isExpandableNode(last));
 			}
 		}
 
@@ -149,10 +150,9 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		Item[] itemsBefore = table.getItems();
 		assertEquals("There are more/less items rendered than viewer limit", VIEWER_LIMIT * 2 + 1, itemsBefore.length);
 		Item item = itemsBefore[itemsBefore.length - 1];
-		Object data = item.getData();
-		assertTrue("Last node must be an Expandable Node", tableViewer.isExpandableNode(data));
+		assertTrue("Last node must be an Expandable Node", ColumnViewer.isExpandableNode(item));
 
-		String expected = calculateExpandableLabel(data);
+		String expected = calculateExpandableLabel(item.getData());
 		assertEquals("Expandable node has an incorrect text", expected, item.getText());
 
 		// click until all expandable nodes are expanded.
@@ -188,7 +188,7 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 	private void clickUntilAllExpandableNodes(Table table) {
 		TableItem lastItem = table.getItems()[table.getItems().length - 1];
 		processEvents();
-		while (tableViewer.isExpandableNode(lastItem.getData())) {
+		while (ColumnViewer.isExpandableNode(lastItem)) {
 			clickTableItem(table, lastItem);
 			processEvents();
 			lastItem = table.getItems()[table.getItems().length - 1];
@@ -219,9 +219,7 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		tableViewer.setSelection(new StructuredSelection(toSelect));
 		processEvents();
 		ISelection selection = tableViewer.getSelection();
-		assertTrue("Selection must not be empty", selection instanceof IStructuredSelection);
-		Object selEle = ((IStructuredSelection) selection).getFirstElement();
-		assertTrue("Selection must be ExpandableNode", tableViewer.isExpandableNode(selEle));
+		assertTrue("Selecting unvisible item must select none", selection.isEmpty());
 
 		// select an element which is visible
 		toSelect = rootModel.get(VIEWER_LIMIT / 2);
@@ -229,7 +227,7 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		processEvents();
 		selection = tableViewer.getSelection();
 		assertTrue("Selection must not be empty", selection instanceof IStructuredSelection);
-		selEle = ((IStructuredSelection) selection).getFirstElement();
+		Object selEle = ((IStructuredSelection) selection).getFirstElement();
 		assertEquals("selection must be desired element which is visible", toSelect, selEle);
 
 		// select something not present in model.
@@ -260,10 +258,9 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 	private void assertLimitedItems(TableItem[] itemsBefore) {
 		assertEquals("There are more/less items rendered than viewer limit", VIEWER_LIMIT + 1, itemsBefore.length);
 		TableItem tableItem = itemsBefore[itemsBefore.length - 1];
-		Object data = tableItem.getData();
-		assertTrue("Last node must be an Expandable Node", tableViewer.isExpandableNode(data));
+		assertTrue("Last node must be an Expandable Node", ColumnViewer.isExpandableNode(tableItem));
 
-		String expectedLabel = calculateExpandableLabel(data);
+		String expectedLabel = calculateExpandableLabel(tableItem.getData());
 		assertEquals("Expandable node has an incorrect text", expectedLabel, tableItem.getText());
 	}
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitTest.java
@@ -17,13 +17,13 @@ package org.eclipse.jface.tests.viewers;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.jface.viewers.ColumnViewer;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jface.viewers.TreeViewer;
-import org.eclipse.jface.viewers.internal.ExpandableNode;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.TreeItem;
 
@@ -40,16 +40,14 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertSetSelection(firstEle);
 
 		DataModel invisible = rootModel.get(rootModel.size() - VIEWER_LIMIT);
-		assertSetSelectionExpNode(invisible);
+		assertSelectInvisibleNodeSelectsNone(invisible);
 	}
 
-	private void assertSetSelectionExpNode(DataModel invisible) {
+	private void assertSelectInvisibleNodeSelectsNone(DataModel invisible) {
 		treeViewer.setSelection(new StructuredSelection(invisible), true);
 		processEvents();
 		IStructuredSelection selection = treeViewer.getStructuredSelection();
-		assertFalse("Selection must not be empty", selection.isEmpty());
-		Object firstElement = selection.getFirstElement();
-		assertTrue("Selection must be expandable node: " + firstElement, treeViewer.isExpandableNode(firstElement));
+		assertTrue(selection.isEmpty());
 	}
 
 	private void assertSetSelection(DataModel firstEle) {
@@ -71,17 +69,7 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		// now try to reveal non expanded item. it should not reveal anything because in
 		// case of limit based tree we don't create an item if it hidden.
 		DataModel inVisible = firstEle.children.get(2).children.get(VIEWER_LIMIT + 2);
-		assertSetSelectionExpNode(inVisible);
-		ExpandableNode selected = (ExpandableNode) treeViewer.getStructuredSelection().getFirstElement();
-		Object[] remaining = selected.getRemainingElements();
-		boolean found = false;
-		for (Object object : remaining) {
-			if (object == inVisible) {
-				found = true;
-				break;
-			}
-		}
-		assertTrue("item to select must be inside expandable node", found);
+		assertSelectInvisibleNodeSelectsNone(inVisible);
 	}
 
 	public void testCollapseAll() {
@@ -115,19 +103,17 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		}
 	}
 
-	private TreeItem[] assertLimitedItems(TreeItem treeItem) {
+	private static TreeItem[] assertLimitedItems(TreeItem treeItem) {
 		TreeItem[] items = treeItem.getItems();
 		assertEquals("There should be only limited items", VIEWER_LIMIT + 1, items.length);
-		Object data = items[VIEWER_LIMIT].getData();
-		assertTrue("last item must be expandable node", treeViewer.isExpandableNode(data));
+		assertTrue("last item must be expandable node", ColumnViewer.isExpandableNode(items[VIEWER_LIMIT]));
 		return items;
 	}
 
 	private TreeItem[] assertLimitedItems() {
 		TreeItem[] rootLevelItems = treeViewer.getTree().getItems();
 		assertEquals("There should be only limited items", VIEWER_LIMIT + 1, rootLevelItems.length);
-		Object data = rootLevelItems[VIEWER_LIMIT].getData();
-		assertTrue("last item must be expandable node", treeViewer.isExpandableNode(data));
+		assertTrue("last item must be expandable node", ColumnViewer.isExpandableNode(rootLevelItems[VIEWER_LIMIT]));
 		return rootLevelItems;
 	}
 


### PR DESCRIPTION
* Make that selection never contains ExpandableNode, since it's not part of model
* Selecting a not-yet-expanded node does nothing, similarly to how filtered elements are not selectable
* Make that only the TreeItem is accepted to check whether it's the expansion placeholder or not, to clarify it's not a model element we're chasing here.