### PR TITLE
TreeViewer: auto expansion for elements with single children

### DIFF
--- a/bundles/org.eclipse.jface/.settings/.api_filters
+++ b/bundles/org.eclipse.jface/.settings/.api_filters
@@ -1,52 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.jface" version="2">
-    <resource path="META-INF/MANIFEST.MF">
-        <filter id="926941240">
-            <message_arguments>
-                <message_argument value="3.32.0"/>
-                <message_argument value="3.31.0"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="src/org/eclipse/jface/viewers/AbstractTreeViewer.java" type="org.eclipse.jface.viewers.AbstractTreeViewer">
         <filter id="336658481">
             <message_arguments>
                 <message_argument value="org.eclipse.jface.viewers.AbstractTreeViewer"/>
                 <message_argument value="NO_EXPAND"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="src/org/eclipse/jface/viewers/IStructuredSelection.java" type="org.eclipse.jface.viewers.IStructuredSelection">
-        <filter id="404000815">
-            <message_arguments>
-                <message_argument value="org.eclipse.jface.viewers.IStructuredSelection"/>
-                <message_argument value="stream()"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="src/org/eclipse/jface/viewers/ViewerCell.java" type="org.eclipse.jface.viewers.ViewerCell">
-        <filter comment="constants should be final" id="388100214">
-            <message_arguments>
-                <message_argument value="org.eclipse.jface.viewers.ViewerCell"/>
-                <message_argument value="ABOVE"/>
-            </message_arguments>
-        </filter>
-        <filter comment="constants should be final" id="388100214">
-            <message_arguments>
-                <message_argument value="org.eclipse.jface.viewers.ViewerCell"/>
-                <message_argument value="BELOW"/>
-            </message_arguments>
-        </filter>
-        <filter comment="constants should be final" id="388100214">
-            <message_arguments>
-                <message_argument value="org.eclipse.jface.viewers.ViewerCell"/>
-                <message_argument value="LEFT"/>
-            </message_arguments>
-        </filter>
-        <filter comment="constants should be final" id="388100214">
-            <message_arguments>
-                <message_argument value="org.eclipse.jface.viewers.ViewerCell"/>
-                <message_argument value="RIGHT"/>
             </message_arguments>
         </filter>
     </resource>

--- a/bundles/org.eclipse.jface/.settings/.api_filters
+++ b/bundles/org.eclipse.jface/.settings/.api_filters
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.jface" version="2">
+    <resource path="META-INF/MANIFEST.MF">
+        <filter id="926941240">
+            <message_arguments>
+                <message_argument value="3.32.0"/>
+                <message_argument value="3.31.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/jface/viewers/AbstractTreeViewer.java" type="org.eclipse.jface.viewers.AbstractTreeViewer">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.viewers.AbstractTreeViewer"/>
+                <message_argument value="NO_EXPAND"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/jface/viewers/IStructuredSelection.java" type="org.eclipse.jface.viewers.IStructuredSelection">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.viewers.IStructuredSelection"/>
+                <message_argument value="stream()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/jface/viewers/ViewerCell.java" type="org.eclipse.jface.viewers.ViewerCell">
+        <filter comment="constants should be final" id="388100214">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.viewers.ViewerCell"/>
+                <message_argument value="ABOVE"/>
+            </message_arguments>
+        </filter>
+        <filter comment="constants should be final" id="388100214">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.viewers.ViewerCell"/>
+                <message_argument value="BELOW"/>
+            </message_arguments>
+        </filter>
+        <filter comment="constants should be final" id="388100214">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.viewers.ViewerCell"/>
+                <message_argument value="LEFT"/>
+            </message_arguments>
+        </filter>
+        <filter comment="constants should be final" id="388100214">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.viewers.ViewerCell"/>
+                <message_argument value="RIGHT"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
@@ -2504,11 +2504,9 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 	 * default. Turning this behavior on should be done cautiously on trees with
 	 * lazy-loaded child-nodes.
 	 * <p>
-	 * <p>
 	 * Using {@code ALL_LEVELS} as argument will recursively expand as many levels
 	 * as possible until a widget at the according level has more than a single
 	 * child.
-	 * </p>
 	 *
 	 * @param level {@code NO_EXPAND} for disabled, {@code ALL_LEVELS} for infinite
 	 *              expansion or any positive integer value to set a level to which

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
@@ -93,7 +93,7 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 	 * Constant indicating that no level of the tree should be expanded or collapsed
 	 *
 	 * @see #setAutoExpandOnSingleChildLevels(int)
-	 * @since 3.33
+	 * @since 3.34
 	 */
 	public static final int NO_EXPAND = 0;
 
@@ -1238,7 +1238,7 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 	 * @return {@code NO_EXPAND} for disabled, {@code ALL_LEVELS} for infinite
 	 *         expansion or any integer value for a specific number of levels to
 	 *         expand.
-	 * @since 3.33
+	 * @since 3.34
 	 */
 	public int getAutoExpandOnSingleChildLevels() {
 		return autoExpandOnSingleChildLevels;
@@ -2515,7 +2515,7 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 	 *              expansion is recursively applied for the given number of levels
 	 *              if the widget at each of the according levels only has a single
 	 *              child.
-	 * @since 3.33
+	 * @since 3.34
 	 */
 	public void setAutoExpandOnSingleChildLevels(int level) {
 		autoExpandOnSingleChildLevels = level;
@@ -2695,7 +2695,7 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 	 *
 	 * @param elementOrTreePath the widget to expand
 	 * @param expanded          the new expanded state of {@code elementOrTreePath}
-	 * @since 3.33
+	 * @since 3.34
 	 */
 	public void setExpandedStateWithAutoExpandOnSingleChild(Object elementOrTreePath, boolean expanded) {
 		Assert.isNotNull(elementOrTreePath);

--- a/tests/org.eclipse.jface.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.jface.tests
-Bundle-Version: 1.4.400.qualifier
+Bundle-Version: 1.4.500.qualifier
 Automatic-Module-Name: org.eclipse.jface.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.12.0",

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/AbstractTreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/AbstractTreeViewerTest.java
@@ -164,6 +164,143 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 	}
 
 	@Test
+	public void testAutoExpandOnSingleChild() {
+		TestElement modelRoot = TestElement.createModel(5, 1);
+		TestElement trivialPathRoot = modelRoot.getFirstChild();
+		fViewer.setInput(modelRoot);
+
+		fTreeViewer.setAutoExpandOnSingleChildLevels(2);
+		fTreeViewer.setExpandedStateWithAutoExpandOnSingleChild(trivialPathRoot, true);
+
+		assertTrue("The expanded widget child is not expanded", fTreeViewer.getExpandedState(trivialPathRoot));
+		assertTrue("The first child of the trivial path was not auto-expanded",
+				fTreeViewer.getExpandedState(trivialPathRoot.getFirstChild()));
+		assertFalse("Trivial path is expanded further than specified depth ",
+				fTreeViewer.getExpandedState(trivialPathRoot.getFirstChild().getFirstChild()));
+	}
+
+	@Test
+	public void testAutoExpandOnSingleChildDeeperDownPath() {
+		TestElement modelRoot = TestElement.createModel(6, 1);
+		TestElement trivialPathRoot = modelRoot.getFirstChild();
+		fViewer.setInput(modelRoot);
+
+		fTreeViewer.setExpandedState(modelRoot, true); // https://github.com/eclipse-platform/eclipse.platform.ui/pull/1072#discussion_r1431558570
+		fTreeViewer.setExpandedState(trivialPathRoot, true); // https://github.com/eclipse-platform/eclipse.platform.ui/pull/1072#discussion_r1431558570
+		fTreeViewer.setAutoExpandOnSingleChildLevels(2);
+		fTreeViewer.setExpandedStateWithAutoExpandOnSingleChild(trivialPathRoot.getFirstChild(), true);
+
+		assertTrue("The first child of the trivial path was not auto-expanded",
+				fTreeViewer.getExpandedState(trivialPathRoot.getFirstChild()));
+		assertTrue("The second child of the trivial path was not auto-expanded",
+				fTreeViewer.getExpandedState(trivialPathRoot.getFirstChild().getFirstChild()));
+		assertFalse("Trivial path is expanded further than specified depth ",
+				fTreeViewer.getExpandedState(trivialPathRoot.getFirstChild().getFirstChild().getFirstChild()));
+	}
+
+	@Test
+	public void testAutoExpandOnSingleChildFromRoot() {
+		TestElement modelRoot = TestElement.createModel(5, 5);
+		TestElement trivialPathRoot = modelRoot;
+		fViewer.setInput(modelRoot);
+
+		fTreeViewer.setAutoExpandOnSingleChildLevels(2);
+		fTreeViewer.setExpandedStateWithAutoExpandOnSingleChild(trivialPathRoot, true);
+
+		assertFalse("The first child of the trivial path was auto-expanded",
+				fTreeViewer.getExpandedState(trivialPathRoot.getFirstChild()));
+	}
+
+	@Test
+	public void testAutoExpandOnSingleChildFromRootWithSensibleTrivialPath() {
+		TestElement modelRoot = TestElement.createModel(5, 1);
+		TestElement trivialPathRoot = modelRoot;
+		fViewer.setInput(modelRoot);
+
+		fTreeViewer.setAutoExpandOnSingleChildLevels(2);
+		fTreeViewer.setExpandedStateWithAutoExpandOnSingleChild(trivialPathRoot, true);
+
+		assertTrue("The first child of the trivial path was auto-expanded",
+				fTreeViewer.getExpandedState(trivialPathRoot.getFirstChild()));
+	}
+
+	@Test
+	public void testAutoExpandOnSingleChildSmallerThanAutoExpandDepth() {
+		TestElement modelRoot = TestElement.createModel(2, 1);
+		TestElement trivialPathRoot = modelRoot.getFirstChild();
+		fViewer.setInput(modelRoot);
+
+		fTreeViewer.setAutoExpandOnSingleChildLevels(10);
+		fTreeViewer.setExpandedStateWithAutoExpandOnSingleChild(trivialPathRoot, true);
+
+		assertTrue("The expanded widget child is not expanded", fTreeViewer.getExpandedState(trivialPathRoot));
+		assertFalse("The first child of the trivial path was auto-expanded although it contains zero children",
+				fTreeViewer.getExpandedState(trivialPathRoot.getFirstChild()));
+	}
+
+	@Test
+	public void testSetAutoExpandOnSingleChildLevels() {
+		fTreeViewer.setAutoExpandOnSingleChildLevels(AbstractTreeViewer.NO_EXPAND);
+		assertEquals("Setting an auto-expansion level of NO_EXPAND works",
+				fTreeViewer.getAutoExpandOnSingleChildLevels(), AbstractTreeViewer.NO_EXPAND);
+
+		fTreeViewer.setAutoExpandOnSingleChildLevels(4);
+		assertEquals("Setting a non-trivial auto-expansion level works", fTreeViewer.getAutoExpandOnSingleChildLevels(),
+				4);
+
+		fTreeViewer.setAutoExpandOnSingleChildLevels(AbstractTreeViewer.NO_EXPAND);
+		assertEquals("Setting an auto-expansion level of NO_EXPAND works",
+				fTreeViewer.getAutoExpandOnSingleChildLevels(), AbstractTreeViewer.NO_EXPAND);
+	}
+
+	@Test
+	public void testAutoExpandOnSingleChildManualDisable() {
+		// We need our own model since some default models do not generate trivial
+		// paths
+		TestElement modelRoot = TestElement.createModel(5, 1);
+		TestElement trivialPathRoot = modelRoot.getFirstChild();
+		fViewer.setInput(modelRoot);
+
+		fTreeViewer.setAutoExpandOnSingleChildLevels(AbstractTreeViewer.NO_EXPAND);
+		fTreeViewer.setExpandedStateWithAutoExpandOnSingleChild(trivialPathRoot, true);
+
+		assertTrue("The expanded widget child is not expanded", fTreeViewer.getExpandedState(trivialPathRoot));
+		assertFalse("The first child of the trivial path was auto-expanded",
+				fTreeViewer.getExpandedState(trivialPathRoot.getFirstChild()));
+	}
+
+	public void testAutoExpandOnSingleChildManualEnableAndThenDisable() {
+		TestElement modelRoot = TestElement.createModel(5, 1);
+		TestElement trivialPathRoot = modelRoot.getFirstChild();
+		fViewer.setInput(modelRoot);
+
+		fTreeViewer.setAutoExpandOnSingleChildLevels(2);
+		fTreeViewer.setAutoExpandOnSingleChildLevels(AbstractTreeViewer.NO_EXPAND);
+		fTreeViewer.setExpandedStateWithAutoExpandOnSingleChild(trivialPathRoot, true);
+
+		assertTrue("The expanded widget child is not expanded", fTreeViewer.getExpandedState(trivialPathRoot));
+		assertFalse("The first child of the trivial path was auto-expanded",
+				fTreeViewer.getExpandedState(trivialPathRoot.getFirstChild()));
+	}
+
+	@Test
+	public void testAutoExpandOnSingleChildInfiniteExpand() {
+		TestElement modelRoot = TestElement.createModel(5, 1);
+		TestElement trivialPathRoot = modelRoot.getFirstChild();
+		fViewer.setInput(modelRoot);
+
+		fTreeViewer.setAutoExpandOnSingleChildLevels(AbstractTreeViewer.ALL_LEVELS);
+		fTreeViewer.setExpandedStateWithAutoExpandOnSingleChild(trivialPathRoot, true);
+
+		assertTrue("The expanded widget child is not expanded", fTreeViewer.getExpandedState(trivialPathRoot));
+		TestElement child = trivialPathRoot.getFirstChild();
+		for (int depth = 1; child != null; depth++) {
+			assertTrue("The " + depth + ". child of the trivial path was not auto-expanded",
+					fTreeViewer.getExpandedState(trivialPathRoot.getFirstChild()));
+			child = child.getFirstChild();
+		}
+	}
+
 	public void testFilterExpanded() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement first2 = first.getFirstChild();

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerTest.java
@@ -63,9 +63,12 @@ public class TreeViewerTest extends AbstractTreeViewerTest {
 		fViewer.setInput(modelRoot);
 
 		fTreeViewer.setAutoExpandOnSingleChildLevels(2);
+		Tree tree = (Tree) fTreeViewer.getControl();
+		TreeItem itemToExpand = ((Tree) fViewer.getControl()).getItem(0);
+
 		Event event = new Event();
-		event.item = ((Tree) fViewer.getControl()).getItem(0);
-		((TreeItem) event.item).getParent().notifyListeners(SWT.Expand, event);
+		event.item = itemToExpand;
+		tree.notifyListeners(SWT.Expand, event);
 
 		assertTrue("The expanded widget child is not expanded", fTreeViewer.getExpandedState(trivialPathRoot));
 		assertTrue("The first child of the trivial path was not auto-expanded",

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerTest.java
@@ -13,11 +13,17 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
+import org.junit.Test;
 
 public class TreeViewerTest extends AbstractTreeViewerTest {
 
@@ -48,6 +54,24 @@ public class TreeViewerTest extends AbstractTreeViewerTest {
 	protected String getItemText(int at) {
 		Tree tree = (Tree) fTreeViewer.getControl();
 		return tree.getItems()[at].getText();
+	}
+
+	@Test
+	public void testAutoExpandOnSingleChildThroughEvent() {
+		TestElement modelRoot = TestElement.createModel(5, 1);
+		TestElement trivialPathRoot = modelRoot.getFirstChild();
+		fViewer.setInput(modelRoot);
+
+		fTreeViewer.setAutoExpandOnSingleChildLevels(2);
+		Event event = new Event();
+		event.item = ((Tree) fViewer.getControl()).getItem(0);
+		((TreeItem) event.item).getParent().notifyListeners(SWT.Expand, event);
+
+		assertTrue("The expanded widget child is not expanded", fTreeViewer.getExpandedState(trivialPathRoot));
+		assertTrue("The first child of the trivial path was not auto-expanded",
+				fTreeViewer.getExpandedState(trivialPathRoot.getFirstChild()));
+		assertFalse("Trivial path is expanded further than specified depth ",
+				fTreeViewer.getExpandedState(trivialPathRoot.getFirstChild().getFirstChild()));
 	}
 
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualLazyTreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualLazyTreeViewerTest.java
@@ -242,6 +242,7 @@ public class VirtualLazyTreeViewerTest extends TreeViewerTest {
 		super.testWorldChanged();
 	}
 
+	@Test
 	@Override
 	public void testContains() {
 		if (disableTestsBug347491) {
@@ -253,4 +254,18 @@ public class VirtualLazyTreeViewerTest extends TreeViewerTest {
 		}
 		super.testContains();
 	}
+
+	@Test
+	@Override
+	public void testAutoExpandOnSingleChildThroughEvent() {
+		if (disableTestsBug347491) {
+			return;
+		}
+		if (setDataCalls == 0) {
+			System.err.println("SWT.SetData is not received. Cancelled test " + testName.getMethodName());
+			return;
+		}
+		super.testAutoExpandOnSingleChildThroughEvent();
+	}
+
 }


### PR DESCRIPTION
As implementation of #1063, This PR addresses the need to automatically expand paths which consist of chained singular nodes, eg:

```
com.wittmaxi.plugin
 └─src
    └─org.foo.com
       └─Bar.java
```
It introduces two new API-Methods into TreeViewer:

-setAutoExpandTrivialPathsLevel
-getAutoExpandTrivialPathsLevel

The PR also uses the new features in the Project Explorer, thus resolving #1063 