### PR TITLE
Code Mining: Redraw of end-of-line annotation is skipped #1070

### DIFF
--- a/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.text
-Bundle-Version: 3.24.100.qualifier
+Bundle-Version: 3.24.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationDrawingStrategy.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationDrawingStrategy.java
@@ -211,20 +211,24 @@ class InlinedAnnotationDrawingStrategy implements IDrawingStrategy {
 	}
 
 	private static void drawAfterLine(LineContentAnnotation annotation, GC gc, StyledText textWidget, int widgetOffset, int length, Color color) {
-		if (gc == null) {
+		if (isDeleted(annotation)) {
 			return;
 		}
-		if (textWidget.getCharCount() == 0) {
-			annotation.draw(gc, textWidget, widgetOffset, length, color, 0, 0);
+		if (gc != null) {
+			if (textWidget.getCharCount() == 0) {
+				annotation.draw(gc, textWidget, widgetOffset, length, color, 0, 0);
+			} else {
+				int line= textWidget.getLineAtOffset(widgetOffset);
+				int lineEndOffset= (line == textWidget.getLineCount() - 1) ? //
+						textWidget.getCharCount() - 1 : //
+						textWidget.getOffsetAtLine(line + 1) - 1;
+				Rectangle bounds= textWidget.getTextBounds(lineEndOffset, lineEndOffset);
+				int lineEndX= bounds.x + bounds.width + gc.stringExtent("   ").x; //$NON-NLS-1$
+				annotation.setLocation(lineEndX, textWidget.getLinePixel(line) + textWidget.getLineVerticalIndent(line));
+				annotation.draw(gc, textWidget, widgetOffset, length, color, lineEndX, textWidget.getLinePixel(line) + textWidget.getLineVerticalIndent(line));
+			}
 		} else {
-			int line= textWidget.getLineAtOffset(widgetOffset);
-			int lineEndOffset= (line == textWidget.getLineCount() - 1) ? //
-					textWidget.getCharCount() - 1 : //
-					textWidget.getOffsetAtLine(line + 1) - 1;
-			Rectangle bounds= textWidget.getTextBounds(lineEndOffset, lineEndOffset);
-			int lineEndX= bounds.x + bounds.width + gc.stringExtent("   ").x; //$NON-NLS-1$
-			annotation.setLocation(lineEndX, textWidget.getLinePixel(line) + textWidget.getLineVerticalIndent(line));
-			annotation.draw(gc, textWidget, widgetOffset, length, color, lineEndX, textWidget.getLinePixel(line) + textWidget.getLineVerticalIndent(line));
+			textWidget.redrawRange(widgetOffset, length, true);
 		}
 	}
 


### PR DESCRIPTION
The redraw of end-of-line annotations was not handled previously, since the graphics context is null in that case. This change handles such redraws by requesting a redraw of the range from the text widget.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1070