### PR TITLE
Add method for optionally returning the first element of a given type

### DIFF
--- a/bundles/org.eclipse.jface/.settings/.api_filters
+++ b/bundles/org.eclipse.jface/.settings/.api_filters
@@ -1,5 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.jface" version="2">
+    <resource path="META-INF/MANIFEST.MF">
+        <filter comment="I assume an new default method still new API in public interface" id="932184123">
+            <message_arguments>
+                <message_argument value="3.32.0"/>
+                <message_argument value="3.30.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/jface/viewers/IStructuredSelection.java" type="org.eclipse.jface.viewers.IStructuredSelection">
+        <filter comment="Usually user code does not implement selections and multiple inheritance is unlikley" id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.viewers.IStructuredSelection"/>
+                <message_argument value="getFirstElementOf(Class&lt;T&gt;)"/>
+            </message_arguments>
+        </filter>
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.viewers.IStructuredSelection"/>
+                <message_argument value="getSingleElementOf(Class&lt;T&gt;)"/>
+            </message_arguments>
+        </filter>
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.viewers.IStructuredSelection"/>
+                <message_argument value="stream()"/>
+            </message_arguments>
+        </filter>
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.viewers.IStructuredSelection"/>
+                <message_argument value="streamOf(Class&lt;T&gt;)"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/jface/viewers/ViewerCell.java" type="org.eclipse.jface.viewers.ViewerCell">
         <filter comment="constants should be final" id="388100214">
             <message_arguments>

--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.31.100.qualifier
+Bundle-Version: 3.32.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/AbstractSelectionDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/AbstractSelectionDialog.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -218,10 +217,8 @@ public abstract class AbstractSelectionDialog<T> extends TrayDialog {
 	 */
 	protected void setResult(ISelection selection, Class<T> target) {
 		List<T> selected = null;
-		if (selection instanceof IStructuredSelection && target != null) {
-			IStructuredSelection structured = (IStructuredSelection) selection;
-			selected = ((List<?>) structured.toList()).stream().filter(target::isInstance)
-					.map(target::cast).collect(Collectors.toList());
+		if (selection instanceof IStructuredSelection structured && target != null) {
+			selected = structured.streamOf(target).toList();
 		}
 		setResult(selected);
 	}

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/util/SafeRunnableDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/util/SafeRunnableDialog.java
@@ -16,6 +16,7 @@ package org.eclipse.jface.util;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Optional;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.dialogs.ErrorDialog;
@@ -23,7 +24,6 @@ import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.CellLabelProvider;
-import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerCell;
@@ -232,11 +232,8 @@ class SafeRunnableDialog extends ErrorDialog {
 	 * @return IStatus or <code>null</code>.
 	 */
 	private IStatus getSingleSelection() {
-		IStructuredSelection selection = statusListViewer.getStructuredSelection();
-		if (selection != null && selection.size() == 1) {
-			return (IStatus) selection.getFirstElement();
-		}
-		return null;
+		return Optional.ofNullable(statusListViewer.getStructuredSelection())
+				.flatMap(selection -> selection.getSingleElementOf(IStatus.class)).orElse(null);
 	}
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTableViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTableViewer.java
@@ -1500,7 +1500,7 @@ public abstract class AbstractTableViewer extends ColumnViewer {
 	 *
 	 * @param element model element
 	 * @return if given model element is contained in the viewer
-	 * @since 3.31
+	 * @since 3.32
 	 */
 	public boolean contains(Object element) {
 		if (findItem(element) != null) {

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredSelection.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredSelection.java
@@ -18,6 +18,9 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.resource.JFaceResources;
@@ -182,6 +185,18 @@ public class StructuredSelection implements IStructuredSelection {
 	}
 
 	@Override
+	public <T> Optional<T> getFirstElementOf(Class<T> type) {
+		if (elements != null) {
+			for (Object o : elements) {
+				if (type.isInstance(o)) {
+					return Optional.of(type.cast(o));
+				}
+			}
+		}
+		return Optional.empty();
+	}
+
+	@Override
 	public boolean isEmpty() {
 		return elements == null || elements.length == 0;
 	}
@@ -207,6 +222,14 @@ public class StructuredSelection implements IStructuredSelection {
 		return Arrays.asList(elements == null ? new Object[0] : elements);
 	}
 
+	@Override
+	public Stream<Object> stream() {
+		if (elements == null || elements.length == 0) {
+			return Stream.empty();
+		}
+		return Arrays.stream(elements);
+	}
+
 	/**
 	 * Internal method which returns a string representation of this
 	 * selection suitable for debug purposes only.
@@ -215,6 +238,7 @@ public class StructuredSelection implements IStructuredSelection {
 	 */
 	@Override
 	public String toString() {
-		return isEmpty() ? JFaceResources.getString("<empty_selection>") : toList().toString(); //$NON-NLS-1$
+		return isEmpty() ? JFaceResources.getString("<empty_selection>") //$NON-NLS-1$
+				: stream().map(String::valueOf).collect(Collectors.joining(", ", "[", "]")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 	}
 }


### PR DESCRIPTION
IStructuredSelection#getFirstElement is widely used but because selections are not generic returns a plain Object resulting in different boilerplate patterns across the code including optimistic casting, instance of and similar. In the case for an empty selection null is returned adding some risk for NPE if not used appropriate and even though there is an isEmpty() method Optionals usually offer a much more convenient way to handle the absence of a value.

This adds a new method to access the first element with an Optional describing the result and specify a desired type of element fixing both the risk of null-pointer-access, remove the boilerplate for additional cast/instanceof checks as well as allowing easy to understand chaining and default value handling.