### PR TITLE
Do not inform client listeners for ExpandableNode selection & fix getRawChildren.

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
@@ -25,6 +25,7 @@ package org.eclipse.jface.viewers;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -1431,9 +1432,6 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 					return super.getRawChildren(parent);
 				}
 				IContentProvider cp = getContentProvider();
-				if (getItemsLimit() > 0 && parent instanceof ExpandableNode expNode) {
-					return expNode.getRemainingElements();
-				}
 				if (cp instanceof ITreePathContentProvider) {
 					ITreePathContentProvider tpcp = (ITreePathContentProvider) cp;
 					if (path == null) {
@@ -2686,7 +2684,7 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 	}
 
 	private boolean findElementInExpandableNode(ExpandableNode expNode, Object toFind) {
-		Object[] remEles = getFilteredChildren(expNode);
+		Object[] remEles = expNode.getRemainingElements();
 		for (Object element : remEles) {
 			if (equals(element, toFind)) {
 				return true;
@@ -3399,6 +3397,33 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 			return node.contains(element);
 		}
 		return false;
+	}
+
+	@Override
+	ISelection getUpdatedSelection(ISelection selection) {
+		if (getItemsLimit() <= 0) {
+			return selection;
+		}
+		if (!(selection instanceof TreeSelection treeSel)) {
+			return super.getUpdatedSelection(selection);
+		}
+		List<TreePath> pathsList = new ArrayList<>(Arrays.asList(treeSel.getPaths()));
+		Iterator<TreePath> itr = pathsList.iterator();
+		boolean foundExpNode = false;
+		while (itr.hasNext()) {
+			if (itr.next().getLastSegment() instanceof ExpandableNode) {
+				itr.remove();
+				foundExpNode = true;
+			}
+		}
+		if (foundExpNode) {
+			TreePath[] treePaths = new TreePath[pathsList.size()];
+			pathsList.toArray(treePaths);
+			selection = new TreeSelection(treePaths, treeSel.getElementComparer());
+			return selection;
+		}
+
+		return selection;
 	}
 
 }

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnViewer.java
@@ -17,7 +17,10 @@
 
 package org.eclipse.jface.viewers;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.runtime.Assert;
@@ -701,9 +704,6 @@ public abstract class ColumnViewer extends StructuredViewer {
 		boolean oldBusy = isBusy();
 		setBusy(true);
 		try {
-			if (parent instanceof ExpandableNode expNode) {
-				return expNode.getRemainingElements();
-			}
 			return super.getRawChildren(parent);
 		} finally {
 			setBusy(oldBusy);
@@ -1053,5 +1053,44 @@ public abstract class ColumnViewer extends StructuredViewer {
 	public final boolean isExpandableNode(Object element) {
 		return element instanceof ExpandableNode;
 
+	}
+
+	@Override
+	protected void updateSelection(ISelection selection) {
+		super.updateSelection(getUpdatedSelection(selection));
+	}
+
+	@Override
+	protected void firePostSelectionChanged(SelectionChangedEvent event) {
+		ISelection givenSel = event.getSelection();
+		ISelection updatedSel = getUpdatedSelection(givenSel);
+		if (givenSel != updatedSel) {
+			event = new SelectionChangedEvent(event.getSelectionProvider(), updatedSel);
+		}
+		super.firePostSelectionChanged(event);
+	}
+
+	@SuppressWarnings("unchecked")
+	ISelection getUpdatedSelection(ISelection selection) {
+		if (getItemsLimit() <= 0) {
+			return selection;
+		}
+
+		if (selection instanceof StructuredSelection structSel) {
+			List<Object> list = new ArrayList<>(structSel.toList());
+			Iterator<?> itr = list.iterator();
+			boolean found = false;
+			while (itr.hasNext()) {
+				if (itr.next() instanceof ExpandableNode) {
+					itr.remove();
+					found = true;
+				}
+			}
+			if (found) {
+				return new StructuredSelection(list);
+			}
+		}
+		// by default return given selection.
+		return selection;
 	}
 }

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredViewer.java
@@ -33,7 +33,6 @@ import org.eclipse.jface.internal.InternalPolicy;
 import org.eclipse.jface.util.OpenStrategy;
 import org.eclipse.jface.util.Policy;
 import org.eclipse.jface.util.SafeRunnable;
-import org.eclipse.jface.viewers.internal.ExpandableNode;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.DragSource;
 import org.eclipse.swt.dnd.DragSourceListener;
@@ -815,11 +814,6 @@ public abstract class StructuredViewer extends ContentViewer implements IPostSel
 	 * @see #addPostSelectionChangedListener(ISelectionChangedListener)
 	 */
 	protected void firePostSelectionChanged(final SelectionChangedEvent event) {
-		// do not inform client listeners on ExpandableNode selection
-		if (event.getSelection() instanceof StructuredSelection sel
-				&& sel.getFirstElement() instanceof ExpandableNode) {
-			return;
-		}
 		for (ISelectionChangedListener l : postSelectionChangedListeners) {
 			SafeRunnable.run(new SafeRunnable() {
 				@Override

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewer.java
@@ -1139,11 +1139,12 @@ public class TreeViewer extends AbstractTreeViewer {
 		}
 
 		Object data = item.getData();
-		if (data == null) {
+		if (!(data instanceof ExpandableNode expNode)) {
 			return;
 		}
 
-		Object[] children = getSortedChildren(data);
+		Object[] sortedChildren = expNode.getRemainingElements();
+		Object[] children = applyItemsLimit(data, sortedChildren);
 		if (children.length == 0) {
 			return;
 		}

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/Viewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/Viewer.java
@@ -17,7 +17,6 @@ package org.eclipse.jface.viewers;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.jface.util.SafeRunnable;
-import org.eclipse.jface.viewers.internal.ExpandableNode;
 import org.eclipse.swt.events.HelpEvent;
 import org.eclipse.swt.events.HelpListener;
 import org.eclipse.swt.widgets.Control;
@@ -145,13 +144,6 @@ public abstract class Viewer implements IInputSelectionProvider {
 	 * @see ISelectionChangedListener#selectionChanged
 	 */
 	protected void fireSelectionChanged(final SelectionChangedEvent event) {
-
-		// do not inform client listeners on ExpandableNode selection
-		if (event.getSelection() instanceof StructuredSelection sel
-				&& sel.getFirstElement() instanceof ExpandableNode) {
-			return;
-		}
-
 		for (ISelectionChangedListener l : selectionChangedListeners) {
 			SafeRunnable.run(new SafeRunnable() {
 				@Override


### PR DESCRIPTION
Selection is updated before informing clients by removing ExpandableNode.
getRawChildren(Object element) no more consider ExpandableNode.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1096