### PR TITLE
Add stream support to IStructuredSelection

### DIFF
--- a/bundles/org.eclipse.jface/.settings/.api_filters
+++ b/bundles/org.eclipse.jface/.settings/.api_filters
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.jface" version="2">
+    <resource path="META-INF/MANIFEST.MF">
+        <filter id="926941240">
+            <message_arguments>
+                <message_argument value="3.32.0"/>
+                <message_argument value="3.31.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/jface/viewers/IStructuredSelection.java" type="org.eclipse.jface.viewers.IStructuredSelection">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.viewers.IStructuredSelection"/>
+                <message_argument value="stream()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/jface/viewers/ViewerCell.java" type="org.eclipse.jface.viewers.ViewerCell">
         <filter comment="constants should be final" id="388100214">
             <message_arguments>

--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.31.100.qualifier
+Bundle-Version: 3.32.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/AbstractSelectionDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/AbstractSelectionDialog.java
@@ -220,7 +220,7 @@ public abstract class AbstractSelectionDialog<T> extends TrayDialog {
 		List<T> selected = null;
 		if (selection instanceof IStructuredSelection && target != null) {
 			IStructuredSelection structured = (IStructuredSelection) selection;
-			selected = ((List<?>) structured.toList()).stream().filter(target::isInstance)
+			selected = structured.stream().filter(target::isInstance)
 					.map(target::cast).collect(Collectors.toList());
 		}
 		setResult(selected);

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/IStructuredSelection.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/IStructuredSelection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,11 +10,14 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Christoph Läubrich - add support for stream() method
  *******************************************************************************/
 package org.eclipse.jface.viewers;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * A selection containing elements.
@@ -57,4 +60,15 @@ public interface IStructuredSelection extends ISelection, Iterable {
 	 * @return the selected elements as a list
 	 */
 	public List toList();
+
+	/**
+	 * Returns the elements in this selection as a <code>Stream</code>.
+	 *
+	 * @return the selected elements as a stream
+	 * @since 3.32
+	 */
+	@SuppressWarnings("unchecked")
+	default Stream<Object> stream() {
+		return StreamSupport.stream(spliterator(), false);
+	}
 }

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredSelection.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredSelection.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.resource.JFaceResources;
@@ -207,6 +208,14 @@ public class StructuredSelection implements IStructuredSelection {
 		return Arrays.asList(elements == null ? new Object[0] : elements);
 	}
 
+	@Override
+	public Stream<Object> stream() {
+		if (isEmpty()) {
+			return Stream.empty();
+		}
+		return Arrays.stream(elements);
+	}
+
 	/**
 	 * Internal method which returns a string representation of this
 	 * selection suitable for debug purposes only.
@@ -215,6 +224,7 @@ public class StructuredSelection implements IStructuredSelection {
 	 */
 	@Override
 	public String toString() {
-		return isEmpty() ? JFaceResources.getString("<empty_selection>") : toList().toString(); //$NON-NLS-1$
+		return isEmpty() ? JFaceResources.getString("<empty_selection>") //$NON-NLS-1$
+				: Arrays.toString(elements);
 	}
 }


### PR DESCRIPTION
Streams offer much more flexibility as they can be filtered, mapped and finally collected to any useful representation of the data.

This adds a new `stream() `method to `IStructuredSelection` so consumers of selections can benefit from this without any additional casting or boilerplate code (example of code simplification included in this PR), implement it as a default method for backward compatibility of implementors and adjust the implementation to return a slightly more efficient variant.

This is a minimal change extracted from
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/1089

and hopefully less controversial to go in soon.