### PR TITLE
fix StatusLine progress

### DIFF
--- a/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.editors; singleton:=true
-Bundle-Version: 3.17.0.qualifier
+Bundle-Version: 3.17.100.qualifier
 Bundle-Activator: org.eclipse.ui.internal.editors.text.EditorsPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName


### PR DESCRIPTION
Reusing a IProgressManager requires to finally call
progressMonitor.done() before using it again.

see
https://bugs.eclipse.org/bugs/show_bug.cgi?id=485748
and
https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/773