### PR TITLE
AccumulatingProgressMonitor: log warning like StatusLineManager

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/operation/AccumulatingProgressMonitor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/operation/AccumulatingProgressMonitor.java
@@ -19,7 +19,9 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.ProgressMonitorWrapper;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.util.Policy;
 import org.eclipse.swt.widgets.Display;
 
 /**
@@ -55,6 +57,8 @@ import org.eclipse.swt.widgets.Display;
 	private Collector collector;
 
 	private String currentTask = ""; //$NON-NLS-1$
+
+	private volatile Exception taskStarted;
 
 	private class Collector implements Runnable {
 		private String taskName;
@@ -140,6 +144,15 @@ import org.eclipse.swt.widgets.Display;
 
 	@Override
 	public void beginTask(final String name, final int totalWork) {
+		if (taskStarted != null) {
+			Exception e = new IllegalStateException(
+					"beginTask should only be called once per instance. At least call done() before further invocations", //$NON-NLS-1$
+					taskStarted);
+			Policy.getLog().log(Status.warning(e.getLocalizedMessage(), e));
+			done(); // workaround client error
+		}
+		taskStarted = new IllegalStateException(
+				"beginTask(" + name + ", " + totalWork + ") was called here previously"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		synchronized (this) {
 			collector = null;
 		}
@@ -177,6 +190,13 @@ import org.eclipse.swt.widgets.Display;
 
 	@Override
 	public void done() {
+		if (taskStarted == null) {
+			// ignore call to done() if beginTask() was not called!
+			// Otherwise an otherwise already started delegate would be finished
+			// see https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/61
+			return;
+		}
+		taskStarted = null;
 		synchronized (this) {
 			collector = null;
 		}


### PR DESCRIPTION
to get meaningfull stacktrace - as AccumulatingProgressMonitor uses asyncExec which does not reveal the caller of the method.