### PR TITLE
Limit the visibility of "Find References" to the active Generic Editor

### DIFF
--- a/bundles/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.ui.genericeditor;singleton:=true
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ui.workbench.texteditor;bundle-version="3.10.0",

--- a/bundles/org.eclipse.ui.genericeditor/plugin.xml
+++ b/bundles/org.eclipse.ui.genericeditor/plugin.xml
@@ -112,6 +112,11 @@
          <command
                commandId="org.eclipse.ui.genericeditor.findReferences"
                style="push">
+            <visibleWhen>
+               <reference
+                     definitionId="org.eclipse.ui.genericeditor.GenericEditor.active">
+               </reference>
+            </visibleWhen>
          </command>
       </menuContribution>
       <menuContribution


### PR DESCRIPTION
The visibility of this menu item must be restricted because other editors like the Xtext Editor come with their own "Find References" action.

Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=564610
Also referenced in https://gitlab.eclipse.org/eclipse-wg/ide-wg/ide-wg-dev-funded-efforts/ide-wg-dev-funded-program-planning-council-top-issues/-/issues/30

With this change the _Xtext Editor_ only shows its own _Find References_ action. I have also tested (with Typescript files) that this menu item is still visible and functional in the _Generic Editor_.