### PR TITLE
Fix warnings in I-build

### DIFF
--- a/bundles/org.eclipse.search.core/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
+++ b/bundles/org.eclipse.search.core/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
@@ -240,22 +240,22 @@ public class TextSearchVisitor {
 					}
 				}
 			} catch (UnsupportedCharsetException e) {
-				String[] args= { getCharSetName(file), file.getFullPath().makeRelative().toString()};
+				Object[] args= { getCharSetName(file), file.getFullPath().makeRelative().toString()};
 				String message = MessageFormat.format(SearchCoreMessages.TextSearchVisitor_unsupportedcharset, args);
 				return new Status(IStatus.ERROR, SearchCorePlugin.PLUGIN_ID, IStatus.ERROR, message, e);
 			} catch (IllegalCharsetNameException e) {
-				String[] args= { getCharSetName(file), file.getFullPath().makeRelative().toString()};
+				Object[] args= { getCharSetName(file), file.getFullPath().makeRelative().toString()};
 				String message = MessageFormat.format(SearchCoreMessages.TextSearchVisitor_illegalcharset, args);
 				return new Status(IStatus.ERROR, SearchCorePlugin.PLUGIN_ID, IStatus.ERROR, message, e);
 			} catch (IOException e) {
-				String[] args= { getExceptionMessage(e), file.getFullPath().makeRelative().toString()};
+				Object[] args= { getExceptionMessage(e), file.getFullPath().makeRelative().toString()};
 				String message = MessageFormat.format(SearchCoreMessages.TextSearchVisitor_error, args);
 				return new Status(IStatus.ERROR, SearchCorePlugin.PLUGIN_ID, IStatus.ERROR, message, e);
 			} catch (CoreException e) {
 				if (fIsLightweightAutoRefresh && IResourceStatus.RESOURCE_NOT_FOUND == e.getStatus().getCode()) {
 					return monitor.isCanceled() ? Status.CANCEL_STATUS : Status.OK_STATUS;
 				}
-				String[] args= { getExceptionMessage(e), file.getFullPath().makeRelative().toString() };
+				Object[] args= { getExceptionMessage(e), file.getFullPath().makeRelative().toString() };
 				String message = MessageFormat.format(SearchCoreMessages.TextSearchVisitor_error, args);
 				return new Status(IStatus.ERROR, SearchCorePlugin.PLUGIN_ID, IStatus.ERROR, message, e);
 			} catch (StackOverflowError e) {


### PR DESCRIPTION
```
Type String[] of the last argument to method format(String, Object...)
doesn't exactly match the vararg parameter type. Cast to Object[] to
confirm the non-varargs invocation, or pass individual arguments of type
Object for a varargs invocation.
```
as can be seen at
https://download.eclipse.org/eclipse/downloads/drops4/I20230917-1800/compilelogs/plugins/org.eclipse.search.core_3.16.0.v20230913-0751/@dot.html#OTHER_WARNINGS