### PR TITLE
File Search should offer to search in all opened editors

### DIFF
--- a/bundles/org.eclipse.search/new search/org/eclipse/search/ui/ISearchPageContainer.java
+++ b/bundles/org.eclipse.search/new search/org/eclipse/search/ui/ISearchPageContainer.java
@@ -62,6 +62,13 @@ public interface ISearchPageContainer {
 	public static final int SELECTED_PROJECTS_SCOPE= 3;
 
 	/**
+	 * Current Project scope (value <code>4</code>).
+	 *
+	 * @since 3.16
+	 */
+	public static final int OPENED_EDITORS_SCOPE = 4;
+
+	/**
 	 * Returns the selection with which this container was opened.
 	 *
 	 * @return the selection passed to this container when it was opened
@@ -85,8 +92,9 @@ public interface ISearchPageContainer {
 	 public void setPerformActionEnabled(boolean state);
 
 	/**
-	 * Returns search container's selected scope.
-	 * The scope is WORKSPACE_SCOPE, SELECTED_PROJECTS_SCOPE, SELECTION_SCOPE or WORKING_SET_SCOPE.
+	 * Returns search container's selected scope. The scope is WORKSPACE_SCOPE,
+	 * SELECTED_PROJECTS_SCOPE, SELECTION_SCOPE, OPENED_EDITORS_SCOPE or
+	 * WORKING_SET_SCOPE.
 	 *
 	 * @return the selected scope
 	 * @since 2.0
@@ -94,9 +102,12 @@ public interface ISearchPageContainer {
 	public int getSelectedScope();
 
 	/**
-	 * Sets the selected scope of this search page container.
-	 * The scope is WORKSPACE_SCOPE, SELECTED_PROJECTS_SCOPE, SELECTION_SCOPE or WORKING_SET_SCOPE.
-	 * @param scope the newly selected scope
+	 * Sets the selected scope of this search page container. The scope is
+	 * WORKSPACE_SCOPE, SELECTED_PROJECTS_SCOPE, SELECTION_SCOPE,
+	 * OPENED_EDITORS_SCOPE or WORKING_SET_SCOPE.
+	 * 
+	 * @param scope
+	 *            the newly selected scope
 	 *
 	 * @since 2.0
 	 */

--- a/bundles/org.eclipse.search/plugin.xml
+++ b/bundles/org.eclipse.search/plugin.xml
@@ -293,6 +293,7 @@
 			extensions="*:1"
 			showScopeSection="true"		
 			canSearchEnclosingProjects="true"
+			canSearchOpenedEditors="true"
 			class="org.eclipse.search.internal.ui.text.TextSearchPage">
 		</page>
 	</extension>

--- a/bundles/org.eclipse.search/schema/searchPages.exsd
+++ b/bundles/org.eclipse.search/schema/searchPages.exsd
@@ -174,6 +174,14 @@ If the attribute &quot;showScopeSection&quot; is missing or set to &quot;false&q
                </documentation>
             </annotation>
          </attribute>
+         <attribute name="canSearchOpenedEditors" type="boolean">
+            <annotation>
+               <documentation>
+                  If this attribute is missing or set to &quot;false&quot;, the &quot;Opened Editors&quot; search scope is not shown in the search dialog&apos;s scope part.
+If the attribute &quot;showScopeSection&quot; is missing or set to &quot;false&quot;, this attribute will be ignored.
+               </documentation>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchDialog.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchDialog.java
@@ -771,7 +771,8 @@ public class SearchDialog extends ExtendedDialogWindow implements ISearchPageCon
 			c.setLayout(new GridLayout());
 
 			int index= fDescriptors.indexOf(descriptor);
-			fScopeParts[index]= new ScopePart(this, descriptor.canSearchInProjects());
+			fScopeParts[index] = new ScopePart(this, descriptor.canSearchInProjects(),
+					descriptor.canSearchInOpenedEditors());
 			Control part= fScopeParts[index].createPart(c);
 			applyDialogFont(part);
 			part.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, true, false));

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.java
@@ -191,6 +191,8 @@ public final class SearchMessages extends NLS {
 	public static String ScopePart_workingSetText_accessible_label;
 	public static String ScopePart_workingSetScope_text;
 	public static String ScopePart_workspaceScope_text;
+	public static String ScopePart_openedEditorsScope_text;
+	public static String ScopePart_openedEditorsScope_tooltip_text;
 	public static String ScopePart_workingSetConcatenation;
 	public static String CopyToClipboardAction_label;
 	public static String CopyToClipboardAction_tooltip;

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.properties
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.properties
@@ -202,6 +202,8 @@ ScopePart_workingSetChooseButton_text= C&hoose...
 ScopePart_workingSetText_accessible_label=Working set name
 ScopePart_workingSetScope_text=Wor&king set:
 ScopePart_workspaceScope_text= &Workspace
+ScopePart_openedEditorsScope_text=Files opened in &editors
+ScopePart_openedEditorsScope_tooltip_text=Only workspace files (in projects) are supported
 
 # Concatenate two working set names e.g. "Source, Lib"
 ScopePart_workingSetConcatenation= {0}, {1}

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchPageDescriptor.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchPageDescriptor.java
@@ -64,6 +64,7 @@ class SearchPageDescriptor implements IPluginContribution, Comparable<SearchPage
 	private final static String EXTENSIONS_ATTRIBUTE= "extensions"; //$NON-NLS-1$
 	private final static String SHOW_SCOPE_SECTION_ATTRIBUTE= "showScopeSection"; //$NON-NLS-1$
 	private final static String CAN_SEARCH_ENCLOSING_PROJECTS= "canSearchEnclosingProjects"; //$NON-NLS-1$
+	private final static String CAN_SEARCH_OPENED_EDITORS = "canSearchOpenedEditors"; //$NON-NLS-1$
 	private final static String ENABLED_ATTRIBUTE= "enabled"; //$NON-NLS-1$
 	private final static String SEARCH_VIEW_HELP_CONTEXT_ID_ATTRIBUTE= "searchViewHelpContextId"; //$NON-NLS-1$
 
@@ -184,6 +185,19 @@ class SearchPageDescriptor implements IPluginContribution, Comparable<SearchPage
 	 */
 	public boolean canSearchInProjects() {
 		return Boolean.parseBoolean(fElement.getAttribute(CAN_SEARCH_ENCLOSING_PROJECTS));
+	}
+
+	/**
+	 * Returns <code>true</code> if the page can handle searches in opened
+	 * editors. The value should be ignored if <code>showScopeSection()</code>
+	 * returns <code>false</code>.
+	 *
+	 * This attribute is optional and defaults to <code>false</code>.
+	 * 
+	 * @return Returns if the page can handle searches in opened editors
+	 */
+	public boolean canSearchInOpenedEditors() {
+		return Boolean.parseBoolean(fElement.getAttribute(CAN_SEARCH_OPENED_EDITORS));
 	}
 
 	/**

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/text/TextSearchPage.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/text/TextSearchPage.java
@@ -323,6 +323,8 @@ public class TextSearchPage extends DialogPage implements ISearchPage, IReplaceP
 				return getSelectedResourcesScope();
 			case ISearchPageContainer.SELECTED_PROJECTS_SCOPE:
 				return getEnclosingProjectScope();
+			case ISearchPageContainer.OPENED_EDITORS_SCOPE:
+				return getOpenedEditorstScope();
 			case ISearchPageContainer.WORKING_SET_SCOPE:
 				IWorkingSet[] workingSets= getContainer().getSelectedWorkingSets();
 				return FileTextSearchScope.newSearchScope(workingSets, getExtensions(), fSearchDerived);
@@ -352,6 +354,10 @@ public class TextSearchPage extends DialogPage implements ISearchPage, IReplaceP
 		return FileTextSearchScope.newSearchScope(res, getExtensions(), fSearchDerived);
 	}
 
+	private FileTextSearchScope getOpenedEditorstScope() {
+		IResource[] arr = ScopePart.selectedResourcesFromEditors().toArray(new IResource[0]);
+		return FileTextSearchScope.newSearchScope(arr, getExtensions(), fSearchDerived);
+	}
 
 	private SearchPatternData findInPrevious(String pattern) {
 		for (SearchPatternData element : fPreviousSearchPatterns) {


### PR DESCRIPTION
Adds "Opened editors" scope to the "Text" search.

![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/964108/eee131f7-ab98-41c8-9c16-4edf332f78e0)

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1116