### PR TITLE
Key listener for +,* and -> added. Pop up menu to expand all remaining elements added.

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/messages.properties
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/messages.properties
@@ -85,11 +85,11 @@ PreferencesDialog.okButtonLabel = Apply and Close
 ##############################################################
 PreferenceStore.changeError=Error notifying a preference change listener. Check the log for details.
 FontRegistry.changeError=Error notifying a font registry change listener. Check the log for details.
-		
+
 ##############################################################
 # Abort Page Flipping Dialog
 ##############################################################
-AbortPageFlippingDialog.title=Could Not Accept Changes 
+AbortPageFlippingDialog.title=Could Not Accept Changes
 AbortPageFlippingDialog.message=The currently displayed page contains invalid values.
 
 ##############################################################
@@ -113,7 +113,7 @@ TextViewer.invalidRangeArg=Invalid range argument
 TextViewer.invalidVisibleRegionArg=Invalid visible region argument
 
 #############################################################
-# org.eclipse.jface.action 
+# org.eclipse.jface.action
 #############################################################
 Cancel_Current_Operation = Cancel Current Operation
 Set_SubTask = {0}: {1}
@@ -197,21 +197,21 @@ SafeRunnable.errorMessage = An error has occurred. See error log for more detail
 ColorSelector.Name=Color Selector
 
 #############################################################
-# org.eclipse.jface.viewers.deferred 
+# org.eclipse.jface.viewers.deferred
 #############################################################
 Sorting = sorting
 
 
 #############################################################
-# org.eclipse.jface.util 
+# org.eclipse.jface.util
 #############################################################
-LocalSelectionTransfer.errorMessage=Received wrong transfer data. 
+LocalSelectionTransfer.errorMessage=Received wrong transfer data.
 
 #############################################################
 # org.eclipse.jface.fieldAssist
 #############################################################
 FieldDecorationRegistry.errorMessage=Error in field content
-FieldDecorationRegistry.contentAssistMessage=Content Assist Available 
+FieldDecorationRegistry.contentAssistMessage=Content Assist Available
 FieldDecorationRegistry.requiredFieldMessage=Required Field
 FieldDecorationRegistry.errorQuickFixMessage=Error in field content. Quick Fix Available.
 
@@ -234,3 +234,4 @@ ConfigureColumnsDialog_down = Dow&n
 # org.eclipse.jface.viewers.internal.ExpandableNode
 ExpandableNode.defaultLabel = Show next {0} items from remaining {1}
 ExpandableNode.showRemaining = Show remaining {0} item{1}
+ExpandableNode.showAllRemaining = Show All Remaining Items

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
@@ -1530,7 +1530,7 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 	protected void handleDoubleSelect(SelectionEvent event) {
 		// expand ExpandableNode for default selection.
 		if (event.item != null && event.item.getData() instanceof ExpandableNode node) {
-			handleExpandableNodeClicked(event.item);
+			handleExpandableNodeClicked(event.item, false);
 			// do not notify client listeners for this item.
 			return;
 		}

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnViewer.java
@@ -31,6 +31,9 @@ import org.eclipse.jface.util.Policy;
 import org.eclipse.jface.viewers.internal.ExpandableNode;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.DisposeEvent;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.events.MenuEvent;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.MouseListener;
@@ -38,6 +41,7 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Item;
+import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Widget;
 
 /**
@@ -121,6 +125,15 @@ public abstract class ColumnViewer extends StructuredViewer {
 			};
 			control.addMouseListener(mouseListener);
 		}
+		control.addKeyListener(new KeyAdapter() {
+			@Override
+			public void keyPressed(KeyEvent e) {
+				if ((getControl() == null) || getControl().isDisposed()) {
+					return;
+				}
+				handleKeySelection(e);
+			}
+		});
 	}
 
 	/**
@@ -653,7 +666,9 @@ public abstract class ColumnViewer extends StructuredViewer {
 
 		if (cell != null) {
 			if (cell.getElement() instanceof ExpandableNode) {
-				handleExpandableNodeClicked(cell.getItem());
+				if (e.button == SWT.KeyDown) {
+					handleExpandableNodeClicked(cell.getItem(), false);
+				}
 			} else {
 				triggerEditorActivationEvent(new ColumnViewerEditorActivationEvent(cell, e));
 			}
@@ -887,7 +902,7 @@ public abstract class ColumnViewer extends StructuredViewer {
 	 *
 	 * @param cell selected on click
 	 */
-	void handleExpandableNodeClicked(Widget cell) {
+	void handleExpandableNodeClicked(Widget cell, boolean expandAll) {
 		// default implementation does nothing. Actual viewers can decide how to
 		// populate remaining elements.
 	}
@@ -1031,7 +1046,7 @@ public abstract class ColumnViewer extends StructuredViewer {
 	@Override
 	protected void handleDoubleSelect(SelectionEvent event) {
 		if (event.item != null && event.item.getData() instanceof ExpandableNode) {
-			handleExpandableNodeClicked(event.item);
+			handleExpandableNodeClicked(event.item, false);
 			// we do not want client listeners to be notified for this item.
 			return;
 		}
@@ -1092,5 +1107,21 @@ public abstract class ColumnViewer extends StructuredViewer {
 		}
 		// by default return given selection.
 		return selection;
+	}
+	/**
+	 * Handle keyboard key selection.
+	 * @param e Key event
+	 */
+	void handleKeySelection(KeyEvent e) {
+	}
+
+	/**
+	 * Handle pop up menu selection.
+	 *
+	 * @param e
+	 * @param popupMenu
+	 *
+	 */
+	void handleMenuSelection(MenuEvent e, Menu popupMenu) {
 	}
 }

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewer.java
@@ -24,15 +24,20 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.util.Policy;
 import org.eclipse.jface.viewers.internal.ExpandableNode;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.events.MenuEvent;
 import org.eclipse.swt.events.TreeEvent;
 import org.eclipse.swt.events.TreeListener;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Item;
+import org.eclipse.swt.widgets.Menu;
+import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.swt.widgets.Widget;
@@ -1133,7 +1138,7 @@ public class TreeViewer extends AbstractTreeViewer {
 	}
 
 	@Override
-	void handleExpandableNodeClicked(Widget w) {
+	void handleExpandableNodeClicked(Widget w, boolean expandAll) {
 		if (!(w instanceof Item item)) {
 			return;
 		}
@@ -1144,10 +1149,11 @@ public class TreeViewer extends AbstractTreeViewer {
 		}
 
 		Object[] sortedChildren = expNode.getRemainingElements();
-		Object[] children = applyItemsLimit(data, sortedChildren);
-		if (children.length == 0) {
+		if (sortedChildren.length == 0) {
 			return;
 		}
+
+		Object[] children = expandAll ? sortedChildren : applyItemsLimit(data, sortedChildren);
 
 		boolean oldBusy = isBusy();
 		Tree tree = getTree();
@@ -1203,5 +1209,40 @@ public class TreeViewer extends AbstractTreeViewer {
 			return null;
 		}
 		return items[length - 1].getData();
+	}
+
+	@Override
+	void handleKeySelection(KeyEvent e) {
+		if (e.keyCode == SWT.KEYPAD_MULTIPLY || e.keyCode == SWT.KEYPAD_ADD || e.keyCode == SWT.ARROW_RIGHT) {
+			if (e.widget instanceof Tree table) {
+				TreeItem[] selection = tree.getSelection();
+				if (selection.length != 1) {
+					return;
+				}
+				handleExpandableNodeClicked(selection[0], false);
+			}
+		}
+	}
+
+	@Override
+	void handleMenuSelection(MenuEvent e, Menu popupMenu) {
+		if (tree.getSelection().length != 1) {
+			return;
+		}
+		TreeItem selectedItem = tree.getSelection()[0];
+		if (!selectedItem.isDisposed() && selectedItem.getData() instanceof ExpandableNode) {
+			MenuItem[] items = popupMenu.getItems();
+			for (int i = 0; i < items.length; i++) {
+				items[i].dispose();
+			}
+			MenuItem newItem = new MenuItem(popupMenu, SWT.NONE);
+			newItem.setText(JFaceResources.getString("ExpandableNode.showAllRemaining")); //$NON-NLS-1$
+			newItem.addListener(SWT.Selection, (selEvent) -> {
+				if (!selectedItem.isDisposed() && selectedItem.getData() instanceof ExpandableNode) {
+					handleExpandableNodeClicked(selectedItem, true);
+				}
+			});
+		}
+
 	}
 }

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ViewerColumn.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ViewerColumn.java
@@ -19,9 +19,14 @@
 package org.eclipse.jface.viewers;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.jface.dialogs.PopupDialog;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.util.Policy;
 import org.eclipse.jface.viewers.internal.ExpandableNode;
+import org.eclipse.swt.events.MenuAdapter;
+import org.eclipse.swt.events.MenuEvent;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Widget;
 
 /**
@@ -145,14 +150,29 @@ public abstract class ViewerColumn {
 		}
 		labelProvider.update(cell);
 
-		// check if client has updated the label for this element. Otherwise use default
-		// label provided
+		// special handling for ExpandableNode
 		if (cell.getElement() instanceof ExpandableNode expNode) {
+			// set italic font
 			cell.setFont(JFaceResources.getFontRegistry().getItalic(JFaceResources.DEFAULT_FONT));
-			String text = cell.getText();
-			if (text.isEmpty() || text.equals(expNode.toString())) {
-				cell.setText(expNode.getLabel());
-			}
+
+			// set image to expandable node
+			Image image = JFaceResources.getImage(PopupDialog.POPUP_IMG_MENU);
+			cell.setImage(image);
+
+			// add pop up menu
+			Menu existingMenu = cell.getControl().getMenu();
+			final Menu popupMenu = existingMenu == null ? new Menu(cell.getControl()) : existingMenu;
+			cell.getControl().setMenu(popupMenu);
+
+			popupMenu.addMenuListener(new MenuAdapter() {
+				@Override
+				public void menuShown(MenuEvent e) {
+					getViewer().handleMenuSelection(e, popupMenu);
+				}
+			});
+
+			// set default text
+			cell.setText(expNode.getLabel());
 		}
 	}
 


### PR DESCRIPTION
Key listeners handle +,* and -> keys. This works with existing swt control listeners.
Pop up menu is visible only for ExpandableNode and it removes any menu entries for this node.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1015 https://github.com/eclipse-platform/eclipse.platform.ui/issues/1025