### PR TITLE
[WiP] Activate RCP tests in Tycho build

### DIFF
--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchAdvisorTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchAdvisorTest.java
@@ -166,6 +166,7 @@ public class WorkbenchAdvisorTest {
 		wa.assertNextOperation(WorkbenchAdvisorObserver.PRE_STARTUP);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.PRE_WINDOW_OPEN);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.FILL_ACTION_BARS);
+		wa.assertNextOperation(WorkbenchAdvisorObserver.POST_WINDOW_RESTORE);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.POST_WINDOW_OPEN);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.POST_STARTUP);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.PRE_SHUTDOWN);
@@ -213,7 +214,7 @@ public class WorkbenchAdvisorTest {
 		wa2.assertNextOperation(WorkbenchAdvisorObserver.PRE_STARTUP);
 		wa2.assertNextOperation(WorkbenchAdvisorObserver.PRE_WINDOW_OPEN);
 		wa2.assertNextOperation(WorkbenchAdvisorObserver.FILL_ACTION_BARS);
-		// wa2.assertNextOperation(WorkbenchAdvisorObserver.POST_WINDOW_RESTORE);
+		wa2.assertNextOperation(WorkbenchAdvisorObserver.POST_WINDOW_RESTORE);
 		wa2.assertNextOperation(WorkbenchAdvisorObserver.POST_WINDOW_OPEN);
 		wa2.assertNextOperation(WorkbenchAdvisorObserver.POST_STARTUP);
 		wa2.assertNextOperation(WorkbenchAdvisorObserver.PRE_SHUTDOWN);
@@ -244,6 +245,7 @@ public class WorkbenchAdvisorTest {
 		wa.assertNextOperation(WorkbenchAdvisorObserver.PRE_STARTUP);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.PRE_WINDOW_OPEN);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.FILL_ACTION_BARS);
+		wa.assertNextOperation(WorkbenchAdvisorObserver.POST_WINDOW_RESTORE);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.POST_WINDOW_OPEN);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.POST_STARTUP);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.PRE_SHUTDOWN);

--- a/tests/org.eclipse.ui.tests.rcp/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.rcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.tests.rcp; singleton:=true
-Bundle-Version: 3.6.100.qualifier
+Bundle-Version: 3.6.200.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,

--- a/tests/org.eclipse.ui.tests.rcp/build.properties
+++ b/tests/org.eclipse.ui.tests.rcp/build.properties
@@ -26,5 +26,7 @@ output.. = bin/
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 # This plug-in's name does not comply with Tycho's naming convention for test-plugins -> packaging type has to be specified explicitly
 pom.model.packaging = eclipse-test-plugin
-# Test not yet ready for Surefire
-pom.model.property.skipTests = true
+pom.model.property.testClass = org.eclipse.ui.tests.rcp.RcpTestSuite
+# Tests have to run headless, with an application
+pom.model.property.tycho.surefire.useUIHarness = false
+pom.model.property.tycho.surefire.useUIThread = true


### PR DESCRIPTION
This PR aims at validating whether tests in `org.eclipse.ui.tests.rcp` can be enabled for Tycho build.

When executing the build locally, the tests run fine.

Relates to #1143.