### PR TITLE
Fix tests in org.eclipse.ui.tests.rcp

### DIFF
--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchAdvisorTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchAdvisorTest.java
@@ -33,7 +33,6 @@ import org.eclipse.ui.application.WorkbenchAdvisor;
 import org.eclipse.ui.tests.rcp.util.WorkbenchAdvisorObserver;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class WorkbenchAdvisorTest {
@@ -296,10 +295,6 @@ public class WorkbenchAdvisorTest {
 		assertEquals(PlatformUI.RETURN_OK, code);
 	}
 
-//  testShellClose() is commented out because it was failing with the shells having already been disposed.
-//      It's unclear what this was really trying to test anyway.
-
-	@Ignore
 	@Test
 	public void testShellClose() {
 		WorkbenchAdvisorObserver wa = new WorkbenchAdvisorObserver() {
@@ -310,7 +305,7 @@ public class WorkbenchAdvisorTest {
 
 				Shell[] shells = disp.getShells();
 				for (Shell shell : shells) {
-					if (shell != null) {
+					if (shell != null && !shell.isDisposed()) {
 						shell.close();
 					}
 				}
@@ -325,6 +320,7 @@ public class WorkbenchAdvisorTest {
 		wa.assertNextOperation(WorkbenchAdvisorObserver.PRE_STARTUP);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.PRE_WINDOW_OPEN);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.FILL_ACTION_BARS);
+		wa.assertNextOperation(WorkbenchAdvisorObserver.POST_WINDOW_RESTORE);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.POST_WINDOW_OPEN);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.POST_STARTUP);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.PRE_WINDOW_SHELL_CLOSE);

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchAdvisorTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchAdvisorTest.java
@@ -166,6 +166,7 @@ public class WorkbenchAdvisorTest {
 		wa.assertNextOperation(WorkbenchAdvisorObserver.PRE_STARTUP);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.PRE_WINDOW_OPEN);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.FILL_ACTION_BARS);
+		wa.assertNextOperation(WorkbenchAdvisorObserver.POST_WINDOW_RESTORE);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.POST_WINDOW_OPEN);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.POST_STARTUP);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.PRE_SHUTDOWN);
@@ -213,7 +214,7 @@ public class WorkbenchAdvisorTest {
 		wa2.assertNextOperation(WorkbenchAdvisorObserver.PRE_STARTUP);
 		wa2.assertNextOperation(WorkbenchAdvisorObserver.PRE_WINDOW_OPEN);
 		wa2.assertNextOperation(WorkbenchAdvisorObserver.FILL_ACTION_BARS);
-		// wa2.assertNextOperation(WorkbenchAdvisorObserver.POST_WINDOW_RESTORE);
+		wa2.assertNextOperation(WorkbenchAdvisorObserver.POST_WINDOW_RESTORE);
 		wa2.assertNextOperation(WorkbenchAdvisorObserver.POST_WINDOW_OPEN);
 		wa2.assertNextOperation(WorkbenchAdvisorObserver.POST_STARTUP);
 		wa2.assertNextOperation(WorkbenchAdvisorObserver.PRE_SHUTDOWN);
@@ -244,6 +245,7 @@ public class WorkbenchAdvisorTest {
 		wa.assertNextOperation(WorkbenchAdvisorObserver.PRE_STARTUP);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.PRE_WINDOW_OPEN);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.FILL_ACTION_BARS);
+		wa.assertNextOperation(WorkbenchAdvisorObserver.POST_WINDOW_RESTORE);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.POST_WINDOW_OPEN);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.POST_STARTUP);
 		wa.assertNextOperation(WorkbenchAdvisorObserver.PRE_SHUTDOWN);

--- a/tests/org.eclipse.ui.tests.rcp/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.rcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.tests.rcp; singleton:=true
-Bundle-Version: 3.6.100.qualifier
+Bundle-Version: 3.6.200.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,


### PR DESCRIPTION
* Fixes active tests in `org.eclispe.ui.tests.rcp`. Failures have not been detected as the tests are not executed during any CI builds.
* Reenables the test case `WorkbenchAdvisorTest.testShellClose`

This is a preparation for a subsequent PR enabling the execution of those tests in Tycho builds, as tested in #1145.