### PR TITLE
change isExpandableNode API signature to accept Item as parameter.

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnViewer.java
@@ -1048,10 +1048,12 @@ public abstract class ColumnViewer extends StructuredViewer {
 	 *
 	 * @param element model object representing a special "expandable" node
 	 * @return return if it is an instance of ExpandableNode
-	 * @since 3.31
+	 * @since 3.32
 	 */
-	public final boolean isExpandableNode(Object element) {
-		return element instanceof ExpandableNode;
-
+	public final boolean isExpandableNode(Item element) {
+		if (element == null) {
+			return false;
+		}
+		return element.getData() instanceof ExpandableNode;
 	}
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerWithLimitTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerWithLimitTest.java
@@ -88,7 +88,8 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 			processEvents();
 			TableItem[] items = table.getItems();
 			Object last = items[items.length - 1].getData();
-			assertFalse("Last item shouln't be expandable: " + last, tableViewer.isExpandableNode(last));
+			assertFalse("Last item shouln't be expandable: " + last,
+					tableViewer.isExpandableNode(items[items.length - 1]));
 		}
 
 		DataModel element = new DataModel(Integer.valueOf(rootModel.size() + 1));
@@ -134,7 +135,8 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 				assertLimitedItems(items);
 			} else {
 				Object last = items[items.length - 1].getData();
-				assertFalse("Last item shouln't be expandable: " + last, tableViewer.isExpandableNode(last));
+				assertFalse("Last item shouln't be expandable: " + last,
+						tableViewer.isExpandableNode(items[items.length - 1]));
 			}
 		}
 
@@ -150,7 +152,7 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertEquals("There are more/less items rendered than viewer limit", VIEWER_LIMIT * 2 + 1, itemsBefore.length);
 		Item item = itemsBefore[itemsBefore.length - 1];
 		Object data = item.getData();
-		assertTrue("Last node must be an Expandable Node", tableViewer.isExpandableNode(data));
+		assertTrue("Last node must be an Expandable Node", tableViewer.isExpandableNode(item));
 
 		String expected = calculateExpandableLabel(data);
 		assertEquals("Expandable node has an incorrect text", expected, item.getText());
@@ -188,7 +190,7 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 	private void clickUntilAllExpandableNodes(Table table) {
 		TableItem lastItem = table.getItems()[table.getItems().length - 1];
 		processEvents();
-		while (tableViewer.isExpandableNode(lastItem.getData())) {
+		while (tableViewer.isExpandableNode(lastItem)) {
 			clickTableItem(table, lastItem);
 			processEvents();
 			lastItem = table.getItems()[table.getItems().length - 1];
@@ -221,7 +223,8 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		ISelection selection = tableViewer.getSelection();
 		assertTrue("Selection must not be empty", selection instanceof IStructuredSelection);
 		Object selEle = ((IStructuredSelection) selection).getFirstElement();
-		assertTrue("Selection must be ExpandableNode", tableViewer.isExpandableNode(selEle));
+		assertTrue("Selection must be ExpandableNode",
+				tableViewer.isExpandableNode(tableViewer.getTable().getSelection()[0]));
 
 		// select an element which is visible
 		toSelect = rootModel.get(VIEWER_LIMIT / 2);
@@ -261,7 +264,7 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertEquals("There are more/less items rendered than viewer limit", VIEWER_LIMIT + 1, itemsBefore.length);
 		TableItem tableItem = itemsBefore[itemsBefore.length - 1];
 		Object data = tableItem.getData();
-		assertTrue("Last node must be an Expandable Node", tableViewer.isExpandableNode(data));
+		assertTrue("Last node must be an Expandable Node", tableViewer.isExpandableNode(tableItem));
 
 		String expectedLabel = calculateExpandableLabel(data);
 		assertEquals("Expandable node has an incorrect text", expectedLabel, tableItem.getText());

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitTest.java
@@ -49,7 +49,8 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		IStructuredSelection selection = treeViewer.getStructuredSelection();
 		assertFalse("Selection must not be empty", selection.isEmpty());
 		Object firstElement = selection.getFirstElement();
-		assertTrue("Selection must be expandable node: " + firstElement, treeViewer.isExpandableNode(firstElement));
+		assertTrue("Selection must be expandable node: " + firstElement,
+				treeViewer.isExpandableNode(treeViewer.getTree().getSelection()[0]));
 	}
 
 	private void assertSetSelection(DataModel firstEle) {
@@ -118,16 +119,14 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 	private TreeItem[] assertLimitedItems(TreeItem treeItem) {
 		TreeItem[] items = treeItem.getItems();
 		assertEquals("There should be only limited items", VIEWER_LIMIT + 1, items.length);
-		Object data = items[VIEWER_LIMIT].getData();
-		assertTrue("last item must be expandable node", treeViewer.isExpandableNode(data));
+		assertTrue("last item must be expandable node", treeViewer.isExpandableNode(items[VIEWER_LIMIT]));
 		return items;
 	}
 
 	private TreeItem[] assertLimitedItems() {
 		TreeItem[] rootLevelItems = treeViewer.getTree().getItems();
 		assertEquals("There should be only limited items", VIEWER_LIMIT + 1, rootLevelItems.length);
-		Object data = rootLevelItems[VIEWER_LIMIT].getData();
-		assertTrue("last item must be expandable node", treeViewer.isExpandableNode(data));
+		assertTrue("last item must be expandable node", treeViewer.isExpandableNode(rootLevelItems[VIEWER_LIMIT]));
 		return rootLevelItems;
 	}
 


### PR DESCRIPTION
We need to let client know that there is an ExpandableNode special item displayed. Instead of using model element we will try to use Item.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1044