### PR TITLE
Enable maven profiler to see what adds to the build times

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,4 +5,9 @@
 		<artifactId>tycho-build</artifactId>
 		<version>4.0.4</version>
 	</extension>
+	<extension>
+		<groupId>fr.jcgay.maven</groupId>
+		<artifactId>maven-profiler</artifactId>
+		<version>3.2</version>
+	</extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,9 @@ pipeline {
 						-Dcompare-version-with-baselines.skip=false \
 						-Dproject.build.sourceEncoding=UTF-8 \
 						-Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS \
-						-DtrimStackTrace=false 
+						-DtrimStackTrace=false \
+						-Dprofile \
+						-DprofileFormat=CONSOLE
 					"""
 				}
 			}


### PR DESCRIPTION
This add the maven profiler and enables to output the results to the console.

This is not really meant to be merged, just to see what currently takes the most time when building a PR.