### PR TITLE
Examples of valid use of monitors that log warnings now

### DIFF
--- a/examples/org.eclipse.ui.examples.job/src/org/eclipse/ui/examples/jobs/TestJob.java
+++ b/examples/org.eclipse.ui.examples.job/src/org/eclipse/ui/examples/jobs/TestJob.java
@@ -14,10 +14,14 @@
  *******************************************************************************/
 package org.eclipse.ui.examples.jobs;
 
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.resource.ResourceLocator;
@@ -99,6 +103,31 @@ public class TestJob extends Job {
 		}
 		try {
 			for (int i = 0; i < ticks; i++) {
+				// First case: just any resource operation
+				try {
+					ResourcesPlugin.getWorkspace().getRoot().refreshLocal(0, monitor);
+				} catch (CoreException e) {
+					e.printStackTrace();
+				}
+				// Second case: just call ResourcesPlugin.getWorkspace().run()
+				try {
+					ResourcesPlugin.getWorkspace().run(new IWorkspaceRunnable() {
+
+						@Override
+						public void run(IProgressMonitor innerMonitor) {
+							//
+						}
+					}, ResourcesPlugin.getWorkspace().getRoot(), IWorkspace.AVOID_UPDATE, monitor);
+				} catch (CoreException e) {
+					e.printStackTrace();
+				}
+				// Third case: just call a join...
+				try {
+					Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, monitor);
+				} catch (OperationCanceledException | InterruptedException e) {
+					e.printStackTrace();
+				}
+
 				if (monitor.isCanceled()) {
 					return Status.CANCEL_STATUS;
 				}

--- a/examples/org.eclipse.ui.examples.job/src/org/eclipse/ui/examples/jobs/views/JobsView.java
+++ b/examples/org.eclipse.ui.examples.job/src/org/eclipse/ui/examples/jobs/views/JobsView.java
@@ -25,6 +25,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -43,6 +44,7 @@ import org.eclipse.ui.actions.WorkspaceModifyOperation;
 import org.eclipse.ui.examples.jobs.TestJob;
 import org.eclipse.ui.examples.jobs.TestJobRule;
 import org.eclipse.ui.examples.jobs.UITestJob;
+import org.eclipse.ui.internal.IPreferenceConstants;
 import org.eclipse.ui.part.ViewPart;
 import org.eclipse.ui.progress.IProgressConstants;
 import org.eclipse.ui.progress.IProgressService;
@@ -79,6 +81,8 @@ public class JobsView extends ViewPart {
 	}
 
 	protected void createJobs() {
+		InstanceScope.INSTANCE.getNode("org.eclipse.ui.workbench").putBoolean(IPreferenceConstants.RUN_IN_BACKGROUND, //$NON-NLS-1$
+				false);
 		int jobCount = Integer.parseInt(quantityField.getText());
 		boolean ui = threadField.getSelection();
 		long duration = getDuration();


### PR DESCRIPTION
Import org.eclipse.ui.examples.job project, start Eclipse from debugger, open "Job Factory" view, toggle "user job" and click on "Create jobs" button. It will flood the error log with warnings.

![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/964108/74a4510a-5f56-4f84-9398-187bfdfc188e)

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/1158.