### PR TITLE
Unconfigure GenericTextEditorMergeViewer before document change

### DIFF
--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/compare/GenericEditorMergeViewer.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/compare/GenericEditorMergeViewer.java
@@ -52,7 +52,7 @@ public class GenericEditorMergeViewer extends TextMergeViewer {
 
 			@Override
 			public void inputDocumentAboutToBeChanged(IDocument oldInput, IDocument newInput) {
-				// Nothing to do
+				res.unconfigure();
 			}
 		});
 		return res;


### PR DESCRIPTION
This exception is throw-ed after document change, as I see ISourceViewer.unconfigure is never called

```
java.lang.IllegalStateException
	at org.eclipse.jface.text.TextViewer.setHyperlinkPresenter(TextViewer.java:5639)
	at org.eclipse.jface.text.source.SourceViewer.configure(SourceViewer.java:537)
	at org.eclipse.ui.internal.genericeditor.compare.GenericEditorMergeViewer.configureTextViewer(GenericEditorMergeViewer.java:68)
	at org.eclipse.ui.internal.genericeditor.compare.GenericEditorMergeViewer$1.inputDocumentChanged(GenericEditorMergeViewer.java:50)
	at org.eclipse.jface.text.TextViewer.fireInputDocumentChanged(TextViewer.java:2849)
	at org.eclipse.jface.text.TextViewer.setDocument(TextViewer.java:2890)
	at org.eclipse.jface.text.source.SourceViewer.setDocument(SourceViewer.java:682)
	at org.eclipse.jface.text.source.SourceViewer.setDocument(SourceViewer.java:622)
	at org.eclipse.compare.contentmergeviewer.TextMergeViewer$ContributorInfo.updateViewerDocument(TextMergeViewer.java:807)
	at org.eclipse.compare.contentmergeviewer.TextMergeViewer$ContributorInfo.internalSetDocument(TextMergeViewer.java:762)
	at org.eclipse.compare.contentmergeviewer.TextMergeViewer$ContributorInfo.setDocument(TextMergeViewer.java:679)
	at org.eclipse.compare.contentmergeviewer.TextMergeViewer.updateContent(TextMergeViewer.java:3051)
	at org.eclipse.compare.contentmergeviewer.ContentMergeViewer.internalRefresh(ContentMergeViewer.java:793)
	at org.eclipse.compare.contentmergeviewer.ContentMergeViewer.inputChanged(ContentMergeViewer.java:701)
	at org.eclipse.jface.viewers.ContentViewer.setInput(ContentViewer.java:282)
	at org.eclipse.compare.CompareViewerSwitchingPane.setViewer(CompareViewerSwitchingPane.java:133)
	at org.eclipse.compare.CompareViewerSwitchingPane.setInput(CompareViewerSwitchingPane.java:265)
	at org.eclipse.ltk.internal.ui.refactoring.TextEditChangePreviewViewer.setInput(TextEditChangePreviewViewer.java:249)
	at org.eclipse.ltk.internal.ui.refactoring.TextEditChangePreviewViewer.setInput(TextEditChangePreviewViewer.java:215)
	at org.eclipse.ltk.internal.ui.refactoring.AbstractChangeNode.feedInput(AbstractChangeNode.java:108)
	at org.eclipse.ltk.internal.ui.refactoring.PreviewWizardPage.showPreview(PreviewWizardPage.java:634)
	at org.eclipse.ltk.internal.ui.refactoring.PreviewWizardPage.lambda$0(PreviewWizardPage.java:605)
	at org.eclipse.jface.viewers.Viewer$1.run(Viewer.java:159)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.jface.util.SafeRunnable.run(SafeRunnable.java:174)
	at org.eclipse.jface.viewers.Viewer.fireSelectionChanged(Viewer.java:156)
	at org.eclipse.jface.viewers.StructuredViewer.updateSelection(StructuredViewer.java:2143)
	at org.eclipse.jface.viewers.StructuredViewer.handleSelect(StructuredViewer.java:1181)
	at org.eclipse.jface.viewers.CheckboxTreeViewer.handleSelect(CheckboxTreeViewer.java:299)
	at org.eclipse.jface.viewers.StructuredViewer$4.widgetSelected(StructuredViewer.java:1210)
	at org.eclipse.jface.util.OpenStrategy.fireSelectionEvent(OpenStrategy.java:263)
	at org.eclipse.jface.util.OpenStrategy$1.handleEvent(OpenStrategy.java:421)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4646)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1524)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1547)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1532)
	at org.eclipse.swt.widgets.Widget.notifyListeners(Widget.java:1325)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:4413)
	at org.eclipse.swt.widgets.Display.applicationNextEventMatchingMask(Display.java:5559)
	at org.eclipse.swt.widgets.Display.applicationProc(Display.java:5965)
	at org.eclipse.swt.internal.cocoa.OS.objc_msgSendSuper(Native Method)
	at org.eclipse.swt.widgets.Widget.callSuper(Widget.java:236)
	at org.eclipse.swt.widgets.Widget.mouseDownSuper(Widget.java:1147)
	at org.eclipse.swt.widgets.Tree.mouseDownSuper(Tree.java:2191)
	at org.eclipse.swt.widgets.Widget.mouseDown(Widget.java:1139)
	at org.eclipse.swt.widgets.Control.mouseDown(Control.java:2642)
	at org.eclipse.swt.widgets.Tree.mouseDown(Tree.java:2158)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:6320)
	at org.eclipse.swt.internal.cocoa.OS.objc_msgSendSuper(Native Method)
	at org.eclipse.swt.widgets.Widget.callSuper(Widget.java:236)
	at org.eclipse.swt.widgets.Widget.windowSendEvent(Widget.java:2264)
	at org.eclipse.swt.widgets.Shell.windowSendEvent(Shell.java:2511)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:6444)
	at org.eclipse.swt.internal.cocoa.OS.objc_msgSendSuper(Native Method)
	at org.eclipse.swt.widgets.Display.applicationSendEvent(Display.java:5692)
	at org.eclipse.swt.widgets.Display.applicationProc(Display.java:5831)
	at org.eclipse.swt.internal.cocoa.OS.objc_msgSend(Native Method)
	at org.eclipse.swt.internal.cocoa.NSApplication.sendEvent(NSApplication.java:117)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3986)
	at org.eclipse.jface.window.Window.runEventLoop(Window.java:823)
	at org.eclipse.jface.window.Window.open(Window.java:799)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation.lambda$0(RefactoringWizardOpenOperation.java:190)
	at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:67)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation.run(RefactoringWizardOpenOperation.java:209)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation.run(RefactoringWizardOpenOperation.java:126)
	at org.eclipse.ltk.internal.ui.refactoring.actions.RenameResourceHandler.performRename(RenameResourceHandler.java:106)
	at org.eclipse.ltk.internal.ui.refactoring.actions.RenameResourceHandler.execute(RenameResourceHandler.java:58)
	at org.eclipse.ui.internal.handlers.HandlerProxy.execute(HandlerProxy.java:283)
	at org.eclipse.ui.internal.handlers.E4HandlerProxy.execute(E4HandlerProxy.java:97)
	at jdk.internal.reflect.GeneratedMethodAccessor64.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.eclipse.e4.core.internal.di.MethodRequestor.execute(MethodRequestor.java:58)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invokeUsingClass(InjectorImpl.java:300)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invoke(InjectorImpl.java:234)
	at org.eclipse.e4.core.contexts.ContextInjectionFactory.invoke(ContextInjectionFactory.java:173)
	at org.eclipse.e4.core.commands.internal.HandlerServiceHandler.execute(HandlerServiceHandler.java:156)
	at org.eclipse.core.commands.Command.executeWithChecks(Command.java:488)
	at org.eclipse.core.commands.ParameterizedCommand.executeWithChecks(ParameterizedCommand.java:485)
	at org.eclipse.e4.core.commands.internal.HandlerServiceImpl.executeHandler(HandlerServiceImpl.java:213)
	at org.eclipse.ui.internal.handlers.LegacyHandlerService.executeCommandInContext(LegacyHandlerService.java:440)
	at org.eclipse.ui.internal.ide.actions.LTKLauncher.runCommand(LTKLauncher.java:140)
	at org.eclipse.ui.internal.ide.actions.LTKLauncher.openRenameWizard(LTKLauncher.java:99)
	at org.eclipse.ui.actions.RenameResourceAction.run(RenameResourceAction.java:464)
	at org.eclipse.ui.actions.BaseSelectionListenerAction.runWithEvent(BaseSelectionListenerAction.java:171)
	at org.eclipse.jface.commands.ActionHandler.execute(ActionHandler.java:121)
	at org.eclipse.ui.internal.handlers.E4HandlerProxy.execute(E4HandlerProxy.java:97)
	at jdk.internal.reflect.GeneratedMethodAccessor64.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.eclipse.e4.core.internal.di.MethodRequestor.execute(MethodRequestor.java:58)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invokeUsingClass(InjectorImpl.java:300)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invoke(InjectorImpl.java:234)
	at org.eclipse.e4.core.contexts.ContextInjectionFactory.invoke(ContextInjectionFactory.java:173)
	at org.eclipse.e4.core.commands.internal.HandlerServiceHandler.execute(HandlerServiceHandler.java:156)
	at org.eclipse.core.commands.Command.executeWithChecks(Command.java:488)
	at org.eclipse.core.commands.ParameterizedCommand.executeWithChecks(ParameterizedCommand.java:485)
	at org.eclipse.e4.core.commands.internal.HandlerServiceImpl.executeHandler(HandlerServiceImpl.java:213)
	at org.eclipse.e4.ui.bindings.keys.KeyBindingDispatcher.executeCommand(KeyBindingDispatcher.java:308)
	at org.eclipse.e4.ui.bindings.keys.KeyBindingDispatcher.press(KeyBindingDispatcher.java:580)
	at org.eclipse.e4.ui.bindings.keys.KeyBindingDispatcher.processKeyEvent(KeyBindingDispatcher.java:655)
	at org.eclipse.e4.ui.bindings.keys.KeyBindingDispatcher.filterKeySequenceBindings(KeyBindingDispatcher.java:439)
	at org.eclipse.e4.ui.bindings.keys.KeyBindingDispatcher$KeyDownFilter.handleEvent(KeyBindingDispatcher.java:96)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
	at org.eclipse.swt.widgets.Display.filterEvent(Display.java:1217)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4641)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1524)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1547)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1532)
	at org.eclipse.swt.widgets.Widget.sendKeyEvent(Widget.java:1561)
	at org.eclipse.swt.widgets.Widget.sendKeyEvent(Widget.java:1557)
	at org.eclipse.swt.widgets.Tree.sendKeyEvent(Tree.java:2753)
	at org.eclipse.swt.widgets.Control.keyDown(Control.java:2470)
	at org.eclipse.swt.widgets.Composite.keyDown(Composite.java:620)
	at org.eclipse.swt.widgets.Tree.keyDown(Tree.java:2114)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:6324)
	at org.eclipse.swt.internal.cocoa.OS.objc_msgSendSuper(Native Method)
	at org.eclipse.swt.widgets.Widget.callSuper(Widget.java:236)
	at org.eclipse.swt.widgets.Widget.windowSendEvent(Widget.java:2264)
	at org.eclipse.swt.widgets.Shell.windowSendEvent(Shell.java:2511)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:6444)
	at org.eclipse.swt.internal.cocoa.OS.objc_msgSendSuper(Native Method)
	at org.eclipse.swt.widgets.Display.applicationSendEvent(Display.java:5692)
	at org.eclipse.swt.widgets.Display.applicationProc(Display.java:5831)
	at org.eclipse.swt.internal.cocoa.OS.objc_msgSend(Native Method)
	at org.eclipse.swt.internal.cocoa.NSApplication.sendEvent(NSApplication.java:117)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3986)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1155)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:342)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1046)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:155)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:645)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:342)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:552)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:171)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:152)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:203)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:136)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:402)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:651)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:588)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1459)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1432)
```