### PR TITLE
[org.eclipse.ui.workbench.texteditor.tests]: Add @After methods to tear down the created Composites

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.workbench.texteditor.tests
-Bundle-Version: 3.14.100.qualifier
+Bundle-Version: 3.14.200.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/TextViewerDeleteLineTargetTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/TextViewerDeleteLineTargetTest.java
@@ -16,6 +16,7 @@ package org.eclipse.ui.workbench.texteditor.tests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,6 +39,7 @@ public class TextViewerDeleteLineTargetTest {
 
 	private Document document;
 
+	private Shell parentShell;
 	private TextViewerDeleteLineTarget underTest;
 
 	@Before
@@ -46,10 +48,19 @@ public class TextViewerDeleteLineTargetTest {
 				"\n" +
 				"third line\n");
 
-		TextViewer textViewer= new TextViewer(new Shell(), SWT.NONE);
+		parentShell= new Shell();
+		TextViewer textViewer= new TextViewer(parentShell, SWT.NONE);
 		textViewer.setDocument(document);
 
 		underTest= new TextViewerDeleteLineTarget(textViewer);
+	}
+
+	@After
+	public void tearDown() {
+		if (parentShell != null) {
+			parentShell.dispose();
+			parentShell= null;
+		}
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/minimap/MinimapWidgetTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/minimap/MinimapWidgetTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests.minimap;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,20 +47,30 @@ public class MinimapWidgetTest {
 
 	private ITextViewer editorViewer;
 
+	private Composite minimapParent;
+
 	private StyledText editorStyledText;
 
 	private StyledText minimapStyledText;
 
 	@Before
 	public void createMinimap() {
-		Composite parent= new Shell();
-		editorViewer= new TextViewer(parent, SWT.NONE);
-		MinimapWidget minimapWidget= new MinimapWidget(parent, editorViewer);
+		minimapParent= new Shell();
+		editorViewer= new TextViewer(minimapParent, SWT.NONE);
+		MinimapWidget minimapWidget= new MinimapWidget(minimapParent, editorViewer);
 		minimapWidget.install();
 
 		editorStyledText= editorViewer.getTextWidget();
 		minimapStyledText= (StyledText) minimapWidget.getControl();
 
+	}
+
+	@After
+	public void tearDownMinimap() {
+		if (minimapParent != null) {
+			minimapParent.dispose();
+			minimapParent= null;
+		}
 	}
 
 	@Test


### PR DESCRIPTION
This prevents a leak of OS-resources which cannot be reached by the JVM-GarbageCollector