### PR TITLE
Increase build duration timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
 	options {
-		timeout(time: 60, unit: 'MINUTES')
+		timeout(time: 80, unit: 'MINUTES')
 		buildDiscarder(logRotator(numToKeepStr:'5'))
 		disableConcurrentBuilds(abortPrevious: true)
 	}


### PR DESCRIPTION
As more and more tests are running as part of this build, we need to increase the timeout.