### PR TITLE
Null pointer thrown from addEditorOnboardingCommandId when keybinding without command exists

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/e4/compatibility/ModeledPageLayout.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/e4/compatibility/ModeledPageLayout.java
@@ -20,11 +20,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.commands.MBindingTable;
+import org.eclipse.e4.ui.model.application.commands.MCommand;
 import org.eclipse.e4.ui.model.application.commands.MKeyBinding;
 import org.eclipse.e4.ui.model.application.descriptor.basic.MPartDescriptor;
 import org.eclipse.e4.ui.model.application.ui.MElementContainer;
@@ -644,7 +646,9 @@ public class ModeledPageLayout implements IPageLayout {
 		if (numberOfOnboardingCommands >= 5)
 			return;
 
-		Predicate<MKeyBinding> commandWithEqualId = b -> b.getCommand().getElementId().equals(commandId);
+		Predicate<MKeyBinding> commandWithEqualId = b -> Optional.of(b).map(MKeyBinding::getCommand)
+				.map(MCommand::getElementId).filter(elementId -> elementId.equals(commandId)).isPresent();
+
 		Function<MKeyBinding, String> toCommandText = b -> {
 			try {
 				return b.getCommand().getCommandName() + EDITOR_ONBOARDING_COMMAND_SEPARATOR

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/ModeledPageLayoutTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/ModeledPageLayoutTest.java
@@ -124,6 +124,22 @@ public class ModeledPageLayoutTest {
 		assertThat(getNumberOfOnboardingCommands(perspective.getTags()), is(5));
 	}
 
+	@Test
+	public void addEditorOnboardingCommandWhenBrokenKeyBindingExsists() throws Exception {
+		MBindingTable bindingTable = MCommandsFactory.INSTANCE.createBindingTable();
+		MKeyBinding binding = createBinding("unknownCommand", "Unknown", "M1+1+5");
+		binding.setCommand(null);
+		bindingTable.getBindings().add(binding);
+		bindingTable.getBindings().add(createBinding("org.eclipse.ui.window.quickAccess", "Find Actions", "M1+3"));
+
+		application.getBindingTables().add(bindingTable);
+
+		pageLayout.addEditorOnboardingCommandId("org.eclipse.ui.window.quickAccess");
+
+		assertThat(perspective.getTags(), hasItem(ModeledPageLayout.EDITOR_ONBOARDING_COMMAND + "Find Actions$$$"
+				+ KeySequence.getInstance("M1+3").format()));
+	}
+
 	private int getNumberOfOnboardingCommands(List<String> commands) {
 		return commands.stream().filter(t -> t.startsWith(EDITOR_ONBOARDING_COMMAND)).mapToInt(i -> 1).sum();
 	}


### PR DESCRIPTION
fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1205