### PR TITLE
Add empty tree functionality to CheckedTreeSelectionDialog

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/CheckedTreeSelectionDialog.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/CheckedTreeSelectionDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -229,6 +229,16 @@ public class CheckedTreeSelectionDialog extends SelectionStatusDialog {
 	}
 
 	/**
+	 * Returns whether an empty tree is allowed
+	 *
+	 * @return true if empty tree is ok, false otherwise
+	 * @since 3.131
+	 */
+	protected boolean isEmptyTreeAllowed() {
+		return false;
+	}
+
+	/**
 	 * Validate the receiver and update the status with the result.
 	 *
 	 */
@@ -238,6 +248,11 @@ public class CheckedTreeSelectionDialog extends SelectionStatusDialog {
 				fCurrStatus = fValidator.validate(fViewer.getCheckedElements());
 				updateStatus(fCurrStatus);
 			} else if (!fCurrStatus.isOK()) {
+				fCurrStatus = new Status(IStatus.OK, PlatformUI.PLUGIN_ID, IStatus.OK, "", //$NON-NLS-1$
+						null);
+			}
+		} else if (isEmptyTreeAllowed()) {
+			if (!fCurrStatus.isOK()) {
 				fCurrStatus = new Status(IStatus.OK, PlatformUI.PLUGIN_ID, IStatus.OK, "", //$NON-NLS-1$
 						null);
 			}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/CheckedTreeSelectionDialog.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/CheckedTreeSelectionDialog.java
@@ -102,7 +102,7 @@ public class CheckedTreeSelectionDialog extends SelectionStatusDialog {
 	 * @param parent             The shell to parent from.
 	 * @param labelProvider      the label provider to render the entries
 	 * @param contentProvider    the content provider to evaluate the tree structure
-	 * @param isEmptyTreeAllowed true if an empty tree can be input, false otherwise
+	 * @param allowEmptyTree <code>true</code> if an empty tree can be input, <code>false</code> if an empty tree must be treated as an error
 	 * @since 3.131
 	 */
 	public CheckedTreeSelectionDialog(Shell parent, ILabelProvider labelProvider, ITreeContentProvider contentProvider,

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/CheckedTreeSelectionDialog.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/CheckedTreeSelectionDialog.java
@@ -82,6 +82,8 @@ public class CheckedTreeSelectionDialog extends SelectionStatusDialog {
 
 	private int fStyle = SWT.BORDER;
 
+	private boolean fIsEmptyTreeAllowed;
+
 	/**
 	 * Constructs an instance of <code>ElementTreeSelectionDialog</code>.
 	 *
@@ -92,6 +94,21 @@ public class CheckedTreeSelectionDialog extends SelectionStatusDialog {
 	public CheckedTreeSelectionDialog(Shell parent, ILabelProvider labelProvider,
 			ITreeContentProvider contentProvider) {
 		this(parent, labelProvider, contentProvider, SWT.BORDER);
+	}
+
+	/**
+	 * Constructs an instance of <code>ElementTreeSelectionDialog</code>.
+	 *
+	 * @param parent             The shell to parent from.
+	 * @param labelProvider      the label provider to render the entries
+	 * @param contentProvider    the content provider to evaluate the tree structure
+	 * @param isEmptyTreeAllowed true if an empty tree can be input, false otherwise
+	 * @since 3.131
+	 */
+	public CheckedTreeSelectionDialog(Shell parent, ILabelProvider labelProvider, ITreeContentProvider contentProvider,
+			boolean isEmptyTreeAllowed) {
+		this(parent, labelProvider, contentProvider, SWT.BORDER);
+		fIsEmptyTreeAllowed = isEmptyTreeAllowed;
 	}
 
 	/**
@@ -235,7 +252,7 @@ public class CheckedTreeSelectionDialog extends SelectionStatusDialog {
 	 * @since 3.131
 	 */
 	protected boolean isEmptyTreeAllowed() {
-		return false;
+		return fIsEmptyTreeAllowed;
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/CheckedTreeSelectionDialog.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/CheckedTreeSelectionDialog.java
@@ -106,9 +106,8 @@ public class CheckedTreeSelectionDialog extends SelectionStatusDialog {
 	 * @since 3.131
 	 */
 	public CheckedTreeSelectionDialog(Shell parent, ILabelProvider labelProvider, ITreeContentProvider contentProvider,
-			boolean isEmptyTreeAllowed) {
-		this(parent, labelProvider, contentProvider, SWT.BORDER);
-		fIsEmptyTreeAllowed = isEmptyTreeAllowed;
+			boolean allowEmptyTree) {
+		this(parent, labelProvider, contentProvider, SWT.BORDER, allowEmptyTree);
 	}
 
 	/**
@@ -122,6 +121,23 @@ public class CheckedTreeSelectionDialog extends SelectionStatusDialog {
 	 */
 	public CheckedTreeSelectionDialog(Shell parent, ILabelProvider labelProvider, ITreeContentProvider contentProvider,
 			int style) {
+		this(parent, labelProvider, contentProvider, style, false);
+	}
+
+	/**
+	 * Constructs an instance of <code>ElementTreeSelectionDialog</code>.
+	 *
+	 * @param parent          The shell to parent from.
+	 * @param labelProvider   the label provider to render the entries
+	 * @param contentProvider the content provider to evaluate the tree structure
+	 * @param style           the style of the tree
+	 * @param allowEmptyTree  <code>true</code> if an empty tree can be input,
+	 *                        <code>false</code> if an empty tree must be treated as
+	 *                        an error
+	 * @since 3.131
+	 */
+	public CheckedTreeSelectionDialog(Shell parent, ILabelProvider labelProvider, ITreeContentProvider contentProvider,
+			int style, boolean allowEmptyTree) {
 		super(parent);
 		fLabelProvider = labelProvider;
 		fContentProvider = contentProvider;
@@ -130,6 +146,7 @@ public class CheckedTreeSelectionDialog extends SelectionStatusDialog {
 		fContainerMode = false;
 		fExpandedElements = null;
 		fStyle = style;
+		fAllowEmptyTree = allowEmptyTree;
 	}
 
 	/**
@@ -246,16 +263,6 @@ public class CheckedTreeSelectionDialog extends SelectionStatusDialog {
 	}
 
 	/**
-	 * Returns whether an empty tree is allowed
-	 *
-	 * @return true if empty tree is ok, false otherwise
-	 * @since 3.131
-	 */
-	protected boolean isEmptyTreeAllowed() {
-		return fIsEmptyTreeAllowed;
-	}
-
-	/**
 	 * Validate the receiver and update the status with the result.
 	 *
 	 */
@@ -268,7 +275,7 @@ public class CheckedTreeSelectionDialog extends SelectionStatusDialog {
 				fCurrStatus = new Status(IStatus.OK, PlatformUI.PLUGIN_ID, IStatus.OK, "", //$NON-NLS-1$
 						null);
 			}
-		} else if (isEmptyTreeAllowed()) {
+		} else if (fAllowEmptyTree) {
 			if (!fCurrStatus.isOK()) {
 				fCurrStatus = new Status(IStatus.OK, PlatformUI.PLUGIN_ID, IStatus.OK, "", //$NON-NLS-1$
 						null);

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/CheckedTreeSelectionDialog.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/CheckedTreeSelectionDialog.java
@@ -82,7 +82,7 @@ public class CheckedTreeSelectionDialog extends SelectionStatusDialog {
 
 	private int fStyle = SWT.BORDER;
 
-	private boolean fIsEmptyTreeAllowed;
+	private final boolean fAllowEmptyTree;
 
 	/**
 	 * Constructs an instance of <code>ElementTreeSelectionDialog</code>.


### PR DESCRIPTION
- add new isEmptyTreeAllowed() protected method to CheckedTreeSelectionDialog to allow sub-classes to permit empty trees
- fixes: #1215