### PR TITLE
Mark deprecated Dialog constants from 2005 for removal

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/Dialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/Dialog.java
@@ -69,7 +69,7 @@ public abstract class Dialog extends Window {
 	 * @deprecated use
 	 *             org.eclipse.swt.widgets.Display.getSystemImage(SWT.ICON_ERROR)
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2023-12")
 	public static final String DLG_IMG_ERROR = "dialog_error_image"; //$NON-NLS-1$
 
 	/**
@@ -78,7 +78,7 @@ public abstract class Dialog extends Window {
 	 * @deprecated use
 	 *             org.eclipse.swt.widgets.Display.getSystemImage(SWT.ICON_INFORMATION)
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2023-12")
 	public static final String DLG_IMG_INFO = "dialog_info_imageg"; //$NON-NLS-1$
 
 	/**
@@ -87,7 +87,7 @@ public abstract class Dialog extends Window {
 	 *
 	 * @deprecated org.eclipse.swt.widgets.Display.getSystemImage(SWT.ICON_QUESTION)
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2023-12")
 	public static final String DLG_IMG_QUESTION = "dialog_question_image"; //$NON-NLS-1$
 
 	/**


### PR DESCRIPTION
Marked as deprecated since 2005, should be marked for removal for the future.