### PR TITLE
Migrate several JFace tests to JUnit 4

### DIFF
--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/InputDialogTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/InputDialogTest.java
@@ -13,23 +13,23 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.dialogs;
 
-import junit.framework.TestCase;
-
 import org.eclipse.jface.dialogs.InputDialog;
+import org.junit.After;
+import org.junit.Test;
 
-public class InputDialogTest extends TestCase {
+public class InputDialogTest {
 
 	private InputDialog dialog;
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		if (dialog != null) {
 			dialog.close();
 			dialog = null;
 		}
-		super.tearDown();
 	}
 
+	@Test
 	public void testSetErrorMessageEarly() {
 		dialog = new InputDialog(null, "TEST", "value", "test", null);
 		dialog.setBlockOnOpen(false);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/ProgressIndicatorStyleTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/ProgressIndicatorStyleTest.java
@@ -14,14 +14,15 @@
 
 package org.eclipse.jface.tests.dialogs;
 
+import static org.junit.Assert.assertEquals;
+
 import java.lang.reflect.Field;
 
 import org.eclipse.jface.dialogs.ProgressIndicator;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.ProgressBar;
 import org.eclipse.swt.widgets.Shell;
-
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Test case to assert proper styles have been set for ProgressIndicator.
@@ -29,20 +30,16 @@ import junit.framework.TestCase;
  * @since 3.4
  *
  */
-public class ProgressIndicatorStyleTest extends TestCase {
+public class ProgressIndicatorStyleTest {
 
 	protected ProgressIndicator progress;
 	protected ProgressBar deter, indeter;
 	protected int style;
 
-	public ProgressIndicatorStyleTest(String name) {
-		super(name);
-
-	}
-
 	/**
 	 * Test the indicator styles.
 	 */
+	@Test
 	public void testProgressIndicator() {
 		style = SWT.SMOOTH;
 		verifyIndicator();

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/ProgressMonitorDialogTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/ProgressMonitorDialogTest.java
@@ -16,15 +16,13 @@ package org.eclipse.jface.tests.dialogs;
 
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.swt.widgets.Display;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+public class ProgressMonitorDialogTest {
 
-public class ProgressMonitorDialogTest extends TestCase {
-
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-
+	@Before
+	public void setUp() throws Exception {
 		// ensure we've initialized a display for this thread
 		Display.getDefault();
 	}
@@ -42,18 +40,22 @@ public class ProgressMonitorDialogTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRunTrueTrue() throws Exception {
 		testRun(true, true);
 	}
 
+	@Test
 	public void testRunTrueFalse() throws Exception {
 		testRun(true, false);
 	}
 
+	@Test
 	public void testRunFalseTrue() throws Exception {
 		testRun(false, true);
 	}
 
+	@Test
 	public void testRunFalseFalse() throws Exception {
 		testRun(false, false);
 	}

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/SafeRunnableErrorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/SafeRunnableErrorTest.java
@@ -13,10 +13,11 @@
  ******************************************************************************/
 package org.eclipse.jface.tests.dialogs;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.core.runtime.ISafeRunnable;
 import org.eclipse.jface.util.SafeRunnable;
-
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * NOTE - these tests are not really very good, in order to really test this you
@@ -26,7 +27,7 @@ import junit.framework.TestCase;
  * @since 3.4
  *
  */
-public class SafeRunnableErrorTest extends TestCase {
+public class SafeRunnableErrorTest {
 
 	int count;
 
@@ -43,6 +44,7 @@ public class SafeRunnableErrorTest extends TestCase {
 		});
 	}
 
+	@Test
 	public void testSafeRunnableHandler() {
 		// Just make sure that nothing bad happens when we throw here
 		SafeRunnable.run(new SafeRunnable() {
@@ -53,12 +55,14 @@ public class SafeRunnableErrorTest extends TestCase {
 		});
 	}
 
+	@Test
 	public void testSafeRunnableHandlerOtherThread() throws Exception {
 		Thread t = runner();
 		t.run();
 		t.join();
 	}
 
+	@Test
 	public void testSafeRunnableHandlerMulti() {
 		ISafeRunnable runnable = new SafeRunnable() {
 			@Override

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/StatusDialogTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/StatusDialogTest.java
@@ -13,6 +13,8 @@
  ******************************************************************************/
 package org.eclipse.jface.tests.dialogs;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.StatusDialog;
@@ -20,15 +22,17 @@ import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
-public class StatusDialogTest extends TestCase {
+public class StatusDialogTest {
 
 	private static final String PLUGIN_ID = "org.eclipse.ui.tests";
 
 	private Shell shell;
 
+	@Test
 	public void testEscapeAmpesandInStatusLabelBug395426() {
 		TestableStatusDialog dialog = new TestableStatusDialog(shell);
 		dialog.open();
@@ -37,13 +41,13 @@ public class StatusDialogTest extends TestCase {
 		assertEquals("&&", statusLabel.getText());
 	}
 
-	@Override
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		shell = new Shell();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		shell.dispose();
 	}
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/TitleAreaDialogTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/TitleAreaDialogTest.java
@@ -18,26 +18,26 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ResourceLocator;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Shell;
+import org.junit.After;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
-public class TitleAreaDialogTest extends TestCase {
+public class TitleAreaDialogTest {
 
 	static ImageDescriptor descriptor = ResourceLocator
 			.imageDescriptorFromBundle("org.eclipse.jface.tests", "icons/anything.gif").orElse(null);
 
 	private TitleAreaDialog dialog;
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		if (dialog != null) {
 			dialog.close();
 			dialog = null;
 		}
-		super.tearDown();
 	}
 
 	// Test setting the title image before creating the dialog.
+	@Test
 	public void testSetTitleImageEarly() {
 		dialog = new TitleAreaDialog(null);
 		dialog.setBlockOnOpen(false);
@@ -49,6 +49,7 @@ public class TitleAreaDialogTest extends TestCase {
 		dialog.open();
 	}
 
+	@Test
 	public void testSetTitleImageNull() {
 		dialog = new TitleAreaDialog(null);
 		dialog.setBlockOnOpen(false);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/DecorationOverlayIconTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/DecorationOverlayIconTest.java
@@ -13,7 +13,11 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.images;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -23,13 +27,12 @@ import org.eclipse.jface.viewers.DecorationOverlayIcon;
 import org.eclipse.jface.viewers.IDecoration;
 import org.eclipse.swt.graphics.Image;
 import org.junit.Before;
-
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * @since 3.13
  */
-public class DecorationOverlayIconTest extends TestCase {
+public class DecorationOverlayIconTest {
 
 	private ImageDescriptor baseDescriptor1;
 	private Image baseImage1;
@@ -38,7 +41,6 @@ public class DecorationOverlayIconTest extends TestCase {
 	private ImageDescriptor overlayDescriptor1;
 	private ImageDescriptor overlayDescriptor2;
 
-	@Override
 	@Before
 	public void setUp() {
 		ImageRegistry imageRegistry = JFaceResources.getImageRegistry();
@@ -56,6 +58,7 @@ public class DecorationOverlayIconTest extends TestCase {
 		assertNotNull(overlayDescriptor2);
 	}
 
+	@Test
 	public void testEqualsAndHashCode() {
 		// same base and overlay
 		DecorationOverlayIcon icon1 = new DecorationOverlayIcon(baseImage1,
@@ -135,6 +138,7 @@ public class DecorationOverlayIconTest extends TestCase {
 
 	}
 
+	@Test
 	public void testEqualsAndHashCode2() {
 		// what is true about the underlying image descriptors should be true about
 		// the DecorationOverlayIcon too.

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/DeferredImageDescriptorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/DeferredImageDescriptorTest.java
@@ -15,19 +15,23 @@
 
 package org.eclipse.jface.tests.images;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import java.net.URL;
 
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.ImageData;
-
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Test loading ImageDescriptors from a URL calculated on demand.
  */
-public class DeferredImageDescriptorTest extends TestCase {
+public class DeferredImageDescriptorTest {
 
+	@Test
 	public void testDeferredLoading() {
 		ImageData empty = ImageDescriptor.getMissingImageDescriptor().getImageData(100);
 		assertEquals(empty, ImageDescriptor.createFromURLSupplier(true, () -> null).getImageData(100));
@@ -40,12 +44,14 @@ public class DeferredImageDescriptorTest extends TestCase {
 				.getImageData(100));
 	}
 
+	@Test
 	public void testCreateImage() {
 		assertNotNull(ImageDescriptor
 				.createFromURLSupplier(true, () -> DeferredImageDescriptorTest.class.getResource("anything.gif"))
 				.createImage());
 	}
 
+	@Test
 	public void testAdaptToURL() {
 		ImageDescriptor descriptor = ImageDescriptor.createFromURLSupplier(false,
 				() -> DeferredImageDescriptorTest.class.getResource("anything.gif"));

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/FileImageDescriptorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/FileImageDescriptorTest.java
@@ -19,7 +19,12 @@
 
 package org.eclipse.jface.tests.images;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.URL;
@@ -33,10 +38,9 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageFileNameProvider;
+import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
-
-import junit.framework.TestCase;
 
 /**
  * Test loading a directory full of images.
@@ -44,22 +48,14 @@ import junit.framework.TestCase;
  * @since 3.4
  *
  */
-public class FileImageDescriptorTest extends TestCase {
+public class FileImageDescriptorTest {
 
 	protected static final String IMAGES_DIRECTORY = "/icons/imagetests";
 
 	/**
-	 * Create a new instance of the receiver.
-	 *
-	 * @param name
-	 */
-	public FileImageDescriptorTest(String name) {
-		super(name);
-	}
-
-	/**
 	 * Test loading the image descriptors.
 	 */
+	@Test
 	public void testFileImageDescriptorWorkbench() {
 
 		Class<?> missing = null;
@@ -103,6 +99,7 @@ public class FileImageDescriptorTest extends TestCase {
 	/**
 	 * Test the file image descriptor.
 	 */
+	@Test
 	public void testFileImageDescriptorLocal() {
 
 		ImageDescriptor descriptor = ImageDescriptor.createFromFile(FileImageDescriptorTest.class, "anything.gif");
@@ -116,6 +113,7 @@ public class FileImageDescriptorTest extends TestCase {
 	/**
 	 * Test for a missing file image descriptor.
 	 */
+	@Test
 	public void testFileImageDescriptorMissing() {
 
 		ImageDescriptor descriptor = ImageDescriptor.createFromFile(FileImageDescriptorTest.class, "missing.gif");
@@ -127,6 +125,7 @@ public class FileImageDescriptorTest extends TestCase {
 	/**
 	 * Test for a missing file image descriptor.
 	 */
+	@Test
 	public void testFileImageDescriptorMissingWithDefault() {
 
 		ImageDescriptor descriptor = ImageDescriptor.createFromFile(FileImageDescriptorTest.class, "missing.gif");
@@ -139,6 +138,7 @@ public class FileImageDescriptorTest extends TestCase {
 	 * Test that individually created images of a given descriptor are not equal
 	 * (See issue #682).
 	 */
+	@Test
 	public void testDifferentImagesPerFileImageDescriptor() {
 		ImageDescriptor descriptor = ImageDescriptor.createFromFile(FileImageDescriptorTest.class, "anything.gif");
 		Image image1 = descriptor.createImage();
@@ -150,6 +150,7 @@ public class FileImageDescriptorTest extends TestCase {
 		image2.dispose();
 	}
 
+	@Test
 	public void testGetxName() {
 		ImageDescriptor descriptor = ImageDescriptor.createFromFile(FileImageDescriptorTest.class,
 				"/icons/imagetests/zoomIn.png");
@@ -160,6 +161,7 @@ public class FileImageDescriptorTest extends TestCase {
 		assertEquals(imageData.width * 2, imageDataZoomed.width);
 	}
 
+	@Test
 	public void testGetxPath() {
 		ImageDescriptor descriptor = ImageDescriptor.createFromFile(FileImageDescriptorTest.class,
 				"/icons/imagetests/16x16/zoomIn.png");
@@ -170,6 +172,7 @@ public class FileImageDescriptorTest extends TestCase {
 		assertEquals(imageData.width * 2, imageDataZoomed.width);
 	}
 
+	@Test
 	public void testGetxPathRectangular() {
 		ImageDescriptor descriptor = ImageDescriptor.createFromFile(FileImageDescriptorTest.class,
 				"/icons/imagetests/rectangular-57x16.png");
@@ -181,6 +184,7 @@ public class FileImageDescriptorTest extends TestCase {
 		assertEquals(imageData.height * 2, imageDataZoomed.height);
 	}
 
+	@Test
 	public void testGetxPath150() {
 		ImageDescriptor descriptor = ImageDescriptor.createFromFile(FileImageDescriptorTest.class,
 				"/icons/imagetests/rectangular-57x16.png");
@@ -192,6 +196,7 @@ public class FileImageDescriptorTest extends TestCase {
 		assertEquals(Math.round(imageData.height * 1.5), imageDataZoomed.height);
 	}
 
+	@Test
 	public void testImageFileNameProviderGetxPath() {
 		ImageDescriptor descriptor = ImageDescriptor.createFromFile(FileImageDescriptorTest.class,
 				"/icons/imagetests/rectangular-57x16.png");
@@ -215,6 +220,7 @@ public class FileImageDescriptorTest extends TestCase {
 		assertNull("FileImageDescriptor's ImageFileNameProvider does return a 250% path", imagePath250);
 	}
 
+	@Test
 	public void testImageFileNameProviderGetxName() {
 		ImageDescriptor descriptor = ImageDescriptor.createFromFile(FileImageDescriptorTest.class,
 				"/icons/imagetests/zoomIn.png");
@@ -230,6 +236,7 @@ public class FileImageDescriptorTest extends TestCase {
 		assertNull("FileImageDescriptor's ImageFileNameProvider does return a @1.5x path", imagePath150);
 	}
 
+	@Test
 	public void testAdaptToURL() {
 		ImageDescriptor descriptor = ImageDescriptor.createFromFile(FileImageDescriptorTest.class,
 				"/icons/imagetests/rectangular-57x16.png");

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/ImageRegistryTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/ImageRegistryTest.java
@@ -14,6 +14,9 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.images;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IconAndMessageDialog;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -21,21 +24,14 @@ import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.graphics.Image;
-
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * @since 3.0
  */
-public class ImageRegistryTest extends TestCase {
-	public ImageRegistryTest(String name) {
-		super(name);
-	}
+public class ImageRegistryTest {
 
-	public static void main(String args[]) {
-		junit.textui.TestRunner.run(ImageRegistryTest.class);
-	}
-
+	@Test
 	public void testGetNull() {
 		ImageRegistry reg = JFaceResources.getImageRegistry();
 
@@ -43,6 +39,7 @@ public class ImageRegistryTest extends TestCase {
 		assertNull("Registry should handle null", result);
 	}
 
+	@Test
 	public void testGetString() {
 
 		// note, we must touch the class to ensure the static initialer runs
@@ -70,6 +67,7 @@ public class ImageRegistryTest extends TestCase {
 	 * Note that they can be <code>null</code> from SWT.
 	 *
 	 */
+	@Test
 	public void testGetIconMessageDialogImages() {
 
 		IconAndMessageDialog iconDialog = new MessageDialog(null, "testGetDialogIcons", null, "Message", Window.CANCEL,

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/LazyResourceManagerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/LazyResourceManagerTest.java
@@ -14,6 +14,11 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.images;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -27,11 +32,10 @@ import org.eclipse.jface.resource.LazyResourceManager;
 import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.graphics.Image;
-
-import junit.framework.TestCase;
+import org.junit.Test;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
-public class LazyResourceManagerTest extends TestCase {
+public class LazyResourceManagerTest {
 	private static class CachableTestDescriptor extends DeviceResourceDescriptor<Object> {
 		CachableTestDescriptor() {
 			super(true);
@@ -115,10 +119,7 @@ public class LazyResourceManagerTest extends TestCase {
 
 	}
 
-	public LazyResourceManagerTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testDefaultImage() {
 		// note, we must touch the class to ensure the static initialer runs
 		// so the image registry is up to date
@@ -148,6 +149,7 @@ public class LazyResourceManagerTest extends TestCase {
 
 	}
 
+	@Test
 	public void testUncachable() {
 		TestResourceManager tst = new TestResourceManager();
 		LazyResourceManager mgr = new LazyResourceManager(2, tst);
@@ -201,6 +203,7 @@ public class LazyResourceManagerTest extends TestCase {
 	/**
 	 * Creates multiple resources for 2 Descriptors. Only 1 of them can be cached
 	 **/
+	@Test
 	public void testLazyResourceManagerRefCounting() {
 		TestResourceManager tst = new TestResourceManager();
 		LazyResourceManager mgr = new LazyResourceManager(1, tst);
@@ -238,6 +241,7 @@ public class LazyResourceManagerTest extends TestCase {
 	}
 
 	/** Creates resources for 3 Descriptors. Only 2 of them can be cached **/
+	@Test
 	public void testLazyResourceManager() {
 		TestResourceManager tst = new TestResourceManager();
 		LazyResourceManager mgr = new LazyResourceManager(2, tst);
@@ -302,6 +306,7 @@ public class LazyResourceManagerTest extends TestCase {
 	 * Creates resources for 3 Descriptors. Only the 2 last recently used should be
 	 * cached
 	 **/
+	@Test
 	public void testLazyResourceManagerLRU() {
 		TestResourceManager tst = new TestResourceManager();
 		LazyResourceManager mgr = new LazyResourceManager(2, tst);
@@ -361,6 +366,7 @@ public class LazyResourceManagerTest extends TestCase {
 		assertCached(expected2, mgr, tst, descriptor2); // 2 still cached, because recently used
 	}
 
+	@Test
 	public void testNullDescriptor() {
 		TestResourceManager tst = new TestResourceManager();
 		LazyResourceManager mgr = new LazyResourceManager(2, tst);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/ResourceManagerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/ResourceManagerTest.java
@@ -14,6 +14,11 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.images;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Objects;
 
 import org.eclipse.jface.resource.ColorDescriptor;
@@ -32,14 +37,15 @@ import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
+import org.junit.After;
 import org.junit.Assert;
-
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * @since 3.1
  */
-public class ResourceManagerTest extends TestCase {
+public class ResourceManagerTest {
 
 	private DeviceResourceDescriptor<?>[] descriptors;
 	private Image testImage;
@@ -90,9 +96,8 @@ public class ResourceManagerTest extends TestCase {
 		}
 	}
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		TestDescriptor.refCount = 0;
 		Display display = Display.getCurrent();
 		globalResourceManager = new DeviceResourceManager(display);
@@ -140,9 +145,8 @@ public class ResourceManagerTest extends TestCase {
 		numDupes = 12;
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		globalResourceManager.dispose();
 		Assert.assertEquals("Detected leaks", 0, TestDescriptor.refCount);
 		testImage.dispose();
@@ -162,6 +166,7 @@ public class ResourceManagerTest extends TestCase {
 	 *
 	 * @throws Exception
 	 */
+	@Test
 	public void testDescriptorAllocations() throws Exception {
 		Display display = Display.getCurrent();
 
@@ -191,6 +196,7 @@ public class ResourceManagerTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testDeviceManagerAllocations() throws Exception {
 
 		// Allocate resources directly using the descriptors.
@@ -233,6 +239,7 @@ public class ResourceManagerTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testLocalManagerAllocations() throws Exception {
 		// These arrays are indices into the descriptors array. For example, {0,1,7}
 		// is a quick shorthand to indicate we should allocate resources 0, 1, and 7.
@@ -279,6 +286,7 @@ public class ResourceManagerTest extends TestCase {
 
 	}
 
+	@Test
 	public void testImageDataResourceAllocations() throws Exception {
 		// These arrays are indices into the descriptors array. For example, {0,1,7}
 		// is a quick shorthand to indicate we should allocate resources 0, 1, and 7.
@@ -293,6 +301,7 @@ public class ResourceManagerTest extends TestCase {
 	/*
 	 * See https://bugs.eclipse.org/bugs/show_bug.cgi?id=135088
 	 */
+	@Test
 	public void testResourceManagerFind() throws Exception {
 		DeviceResourceDescriptor<?> descriptor = descriptors[0];
 		Object resource = globalResourceManager.find(descriptor);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/UrlImageDescriptorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/UrlImageDescriptorTest.java
@@ -15,7 +15,11 @@
  ******************************************************************************/
 package org.eclipse.jface.tests.images;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 
 import java.net.URL;
 
@@ -25,15 +29,15 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageFileNameProvider;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
-public class UrlImageDescriptorTest extends TestCase {
+public class UrlImageDescriptorTest {
 
 	/**
 	 * Test that individually created images of a given descriptor are not equal
 	 * (See issue #682).
 	 */
+	@Test
 	public void testDifferentImagesPerUrlImageDescriptor() {
 		ImageDescriptor descriptor = ImageDescriptor
 				.createFromURL(FileImageDescriptorTest.class.getResource("/icons/imagetests/anything.gif"));
@@ -46,6 +50,7 @@ public class UrlImageDescriptorTest extends TestCase {
 		image2.dispose();
 	}
 
+	@Test
 	public void testGetxName() {
 		ImageDescriptor descriptor = ImageDescriptor
 				.createFromURL(FileImageDescriptorTest.class.getResource("/icons/imagetests/zoomIn.png"));
@@ -56,6 +61,7 @@ public class UrlImageDescriptorTest extends TestCase {
 		assertEquals(imageData.width * 2, imageDataZoomed.width);
 	}
 
+	@Test
 	public void testGetxPath() {
 		ImageDescriptor descriptor = ImageDescriptor
 				.createFromURL(FileImageDescriptorTest.class.getResource("/icons/imagetests/16x16/zoomIn.png"));
@@ -66,6 +72,7 @@ public class UrlImageDescriptorTest extends TestCase {
 		assertEquals(imageData.width * 2, imageDataZoomed.width);
 	}
 
+	@Test
 	public void testImageFileNameProviderGetxPath() {
 		ImageDescriptor descriptor = ImageDescriptor
 				.createFromURL(FileImageDescriptorTest.class.getResource("/icons/imagetests/rectangular-57x16.png"));
@@ -90,6 +97,7 @@ public class UrlImageDescriptorTest extends TestCase {
 		assertNull("URLImageDescriptor's ImageFileNameProvider does return a 250% path", imagePath250);
 	}
 
+	@Test
 	public void testImageFileNameProviderGetxName() {
 		ImageDescriptor descriptor = ImageDescriptor
 				.createFromURL(FileImageDescriptorTest.class.getResource("/icons/imagetests/zoomIn.png"));
@@ -106,6 +114,7 @@ public class UrlImageDescriptorTest extends TestCase {
 		assertNull("URLImageDescriptor's ImageFileNameProvider does return a @1.5x path", imagePath150);
 	}
 
+	@Test
 	public void testAdaptToURL() {
 		ImageDescriptor descriptor = ImageDescriptor
 				.createFromURL(FileImageDescriptorTest.class.getResource("/icons/imagetests/rectangular-57x16.png"));

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/ColumnLabelProviderLambdaTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/ColumnLabelProviderLambdaTest.java
@@ -1,5 +1,7 @@
 package org.eclipse.jface.tests.labelProviders;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.tests.viewers.StructuredViewerTest.TestLabelProvider;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
@@ -8,11 +10,11 @@ import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Shell;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+public class ColumnLabelProviderLambdaTest {
 
-public class ColumnLabelProviderLambdaTest extends TestCase {
-
+	@Test
 	public void testCreateTextProvider() {
 		Shell shell = LabelProviderLambdaTest.initializeShell();
 		TableViewer viewer = (TableViewer) LabelProviderLambdaTest.initializeViewer(shell);
@@ -25,6 +27,7 @@ public class ColumnLabelProviderLambdaTest extends TestCase {
 		assertEquals("same label text", Integer.valueOf(0).toString(), firstElementText);
 	}
 
+	@Test
 	public void testCreateImageProvider() {
 		Shell shell = LabelProviderLambdaTest.initializeShell();
 		TableViewer viewer = (TableViewer) LabelProviderLambdaTest.initializeViewer(shell);
@@ -37,13 +40,14 @@ public class ColumnLabelProviderLambdaTest extends TestCase {
 		assertEquals("same image", fgImage, provider.getImage(model[0]));
 	}
 
+	@Test
 	public void testCreateTextImageProvider() {
 		Shell shell = LabelProviderLambdaTest.initializeShell();
 		TableViewer viewer = (TableViewer) LabelProviderLambdaTest.initializeViewer(shell);
 		Image fgImage = ImageDescriptor.createFromFile(TestLabelProvider.class, "images/java.gif").createImage();
 		TableViewerColumn columnViewer = new TableViewerColumn(viewer, SWT.NONE, 0);
-		columnViewer.setLabelProvider(ColumnLabelProvider
-				.createTextImageProvider(Object::toString, inputElement -> fgImage));
+		columnViewer.setLabelProvider(
+				ColumnLabelProvider.createTextImageProvider(Object::toString, inputElement -> fgImage));
 		shell.open();
 		Integer[] model = (Integer[]) columnViewer.getViewer().getInput();
 		ColumnLabelProvider provider = (ColumnLabelProvider) columnViewer.getViewer().getLabelProvider(0);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/IDecorationContextTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/IDecorationContextTest.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.jface.tests.labelProviders;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import org.eclipse.core.runtime.AssertionFailedException;
 import org.eclipse.jface.viewers.DecoratingStyledCellLabelProvider;
 import org.eclipse.jface.viewers.DecorationContext;
@@ -23,8 +26,7 @@ import org.eclipse.jface.viewers.ILabelDecorator;
 import org.eclipse.jface.viewers.ILabelProviderListener;
 import org.eclipse.jface.viewers.StyledString;
 import org.eclipse.swt.graphics.Image;
-
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Most of the setup has been taken from
@@ -33,7 +35,7 @@ import junit.framework.TestCase;
  * @since 3.4
  *
  */
-public class IDecorationContextTest extends TestCase {
+public class IDecorationContextTest {
 
 	private static IDecorationContext getDecorationContext() {
 		return new IDecorationContext() {
@@ -128,10 +130,7 @@ public class IDecorationContextTest extends TestCase {
 						getDecorationContext());
 	}
 
-	public IDecorationContextTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testDefaultContextIsUsed() {
 		// Create a DecoratingStyledCellLabelProvider with a null
 		// decorationContext
@@ -140,6 +139,7 @@ public class IDecorationContextTest extends TestCase {
 
 	}
 
+	@Test
 	public void testSetDecorationContextNull() {
 		DecoratingStyledCellLabelProvider label = getDecoratingStyledCellLabelProvider(false);
 		try {

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/LabelProviderLambdaTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/LabelProviderLambdaTest.java
@@ -1,5 +1,7 @@
 package org.eclipse.jface.tests.labelProviders;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.tests.viewers.StructuredViewerTest.TestLabelProvider;
 import org.eclipse.jface.viewers.ArrayContentProvider;
@@ -11,10 +13,9 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
-public class LabelProviderLambdaTest extends TestCase {
+public class LabelProviderLambdaTest {
 
 	protected static Shell initializeShell() {
 		Display display = Display.getDefault();
@@ -39,6 +40,7 @@ public class LabelProviderLambdaTest extends TestCase {
 		return model;
 	}
 
+	@Test
 	public void testCreateTextProvider() {
 		Shell shell = initializeShell();
 		StructuredViewer viewer = initializeViewer(shell);
@@ -49,12 +51,12 @@ public class LabelProviderLambdaTest extends TestCase {
 		assertEquals("rendered label", Integer.valueOf(0).toString(), firstElementText);
 	}
 
+	@Test
 	public void testCreateTextImageProvider() {
 		Shell shell = initializeShell();
 		StructuredViewer viewer = initializeViewer(shell);
 		Image fgImage = ImageDescriptor.createFromFile(TestLabelProvider.class, "images/java.gif").createImage();
-		viewer.setLabelProvider(LabelProvider.createTextImageProvider(Object::toString,
-				inputElement -> fgImage));
+		viewer.setLabelProvider(LabelProvider.createTextImageProvider(Object::toString, inputElement -> fgImage));
 		shell.open();
 		Table table = (Table) viewer.getControl();
 		String firstElementText = table.getItem(0).getText();
@@ -64,6 +66,7 @@ public class LabelProviderLambdaTest extends TestCase {
 
 	}
 
+	@Test
 	public void testCreateImageProvider() {
 		Shell shell = initializeShell();
 		StructuredViewer viewer = initializeViewer(shell);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/layout/AbstractColumnLayoutTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/layout/AbstractColumnLayoutTest.java
@@ -15,6 +15,9 @@
 
 package org.eclipse.jface.tests.layout;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.jface.layout.TableColumnLayout;
 import org.eclipse.jface.viewers.ColumnPixelData;
 import org.eclipse.jface.viewers.ColumnWeightData;
@@ -25,19 +28,20 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
-
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * @since 3.4
  *
  */
-public final class AbstractColumnLayoutTest extends TestCase {
+public final class AbstractColumnLayoutTest {
 	Display display;
 	Shell shell;
 
-	@Override
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		display = Display.getCurrent();
 		if (display == null) {
 			display = new Display();
@@ -48,8 +52,8 @@ public final class AbstractColumnLayoutTest extends TestCase {
 
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		shell.dispose();
 	}
 
@@ -57,6 +61,7 @@ public final class AbstractColumnLayoutTest extends TestCase {
 	 * Ensures that the minimum size is not taken into account in a shell unless the
 	 * weighted size falls below the minimum.
 	 */
+	@Test
 	public void testIgnoreMinimumSize() {
 		Composite composite = new Composite(shell, SWT.NONE);
 		TableColumnLayout layout = new TableColumnLayout();
@@ -86,6 +91,7 @@ public final class AbstractColumnLayoutTest extends TestCase {
 	 * Ensures that width values based on weight are recalculated when a column
 	 * falls below minimums.
 	 */
+	@Test
 	public void testRecalculatePreferredSize() {
 		Composite composite = new Composite(shell, SWT.NONE);
 		TableColumnLayout layout = new TableColumnLayout();
@@ -116,6 +122,7 @@ public final class AbstractColumnLayoutTest extends TestCase {
 	 * Ensures that computeSize doesn't rely on the current size. That strategy can
 	 * lead to endless growth on {@link Shell#pack()}.
 	 */
+	@Test
 	public void testComputeSize() {
 		Composite composite = new Composite(shell, SWT.NONE);
 		TableColumnLayout layout = new TableColumnLayout();

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/layout/GeometryTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/layout/GeometryTest.java
@@ -14,17 +14,19 @@
 
 package org.eclipse.jface.tests.layout;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
 import org.eclipse.jface.util.Geometry;
 import org.eclipse.swt.graphics.Rectangle;
+import org.junit.Test;
 
 /**
  * @since 3.3
  *
  */
-public class GeometryTest extends TestCase {
+public class GeometryTest {
 
+	@Test
 	public void testNewGeometryMethods() {
 		// Test the new Geometry methods
 		Rectangle margins = Geometry.createDiffRectangle(0, 10, 40, 80);
@@ -35,8 +37,7 @@ public class GeometryTest extends TestCase {
 
 		assertEquals(expectedResult, expandedRectangle);
 
-		Rectangle difference = Geometry.subtract(expandedRectangle,
-				testRectangle);
+		Rectangle difference = Geometry.subtract(expandedRectangle, testRectangle);
 
 		assertEquals(margins, difference);
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/layout/GridDataFactoryTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/layout/GridDataFactoryTest.java
@@ -13,17 +13,18 @@
  ******************************************************************************/
 package org.eclipse.jface.tests.layout;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
-
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * @since 3.5
  */
-public class GridDataFactoryTest extends TestCase {
-
+public class GridDataFactoryTest {
+	@Test
 	public void testToStringWithAllOverrides() {
 		GridDataFactory factory = GridDataFactory.fillDefaults()
 				.grab(true, false)
@@ -38,6 +39,7 @@ public class GridDataFactoryTest extends TestCase {
 				factory.toString());
 	}
 
+	@Test
 	public void testToStringGrab() {
 		GridDataFactory factory = GridDataFactory.fillDefaults()
 				.grab(false, true);
@@ -47,6 +49,7 @@ public class GridDataFactoryTest extends TestCase {
 				factory.toString());
 	}
 
+	@Test
 	public void testToStringAlign() {
 		GridDataFactory factory = GridDataFactory.fillDefaults()
 				.align(SWT.FILL, SWT.BOTTOM);
@@ -56,6 +59,7 @@ public class GridDataFactoryTest extends TestCase {
 				factory.toString());
 	}
 
+	@Test
 	public void testToStringIndent() {
 		GridDataFactory factory = GridDataFactory.fillDefaults()
 				.indent(10, 39);
@@ -65,6 +69,7 @@ public class GridDataFactoryTest extends TestCase {
 				factory.toString());
 	}
 
+	@Test
 	public void testToStringSpan() {
 		GridDataFactory factory = GridDataFactory.fillDefaults()
 				.span(2, 3);
@@ -74,6 +79,7 @@ public class GridDataFactoryTest extends TestCase {
 				factory.toString());
 	}
 
+	@Test
 	public void testToStringMinSize() {
 		GridDataFactory factory = GridDataFactory.fillDefaults()
 				.minSize(30, 10);
@@ -83,6 +89,7 @@ public class GridDataFactoryTest extends TestCase {
 				factory.toString());
 	}
 
+	@Test
 	public void testToStringHint() {
 		GridDataFactory factory = GridDataFactory.fillDefaults()
 				.hint(SWT.DEFAULT, 310);
@@ -92,6 +99,7 @@ public class GridDataFactoryTest extends TestCase {
 				factory.toString());
 	}
 
+	@Test
 	public void testToNoOverrides() {
 		GridDataFactory factory = GridDataFactory.fillDefaults();
 
@@ -100,6 +108,7 @@ public class GridDataFactoryTest extends TestCase {
 				factory.toString());
 	}
 
+	@Test
 	public void testGridDataCreate() {
 		GridData actual = GridDataFactory.create(GridData.FILL_HORIZONTAL).create();
 		GridData expected = new GridData(GridData.FILL_HORIZONTAL);
@@ -107,4 +116,3 @@ public class GridDataFactoryTest extends TestCase {
 		assertEquals(expected.toString(), actual.toString());
 	}
 }
-

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/layout/GridLayoutFactoryTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/layout/GridLayoutFactoryTest.java
@@ -13,14 +13,16 @@
  ******************************************************************************/
 package org.eclipse.jface.tests.layout;
 
-import org.eclipse.jface.layout.GridLayoutFactory;
+import static org.junit.Assert.assertEquals;
 
-import junit.framework.TestCase;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.junit.Test;
 
 /**
  * @since 3.3
  */
-public class GridLayoutFactoryTest extends TestCase {
+public class GridLayoutFactoryTest {
+	@Test
 	public void testToStringAll() {
 		GridLayoutFactory factory = GridLayoutFactory.fillDefaults()
 			.numColumns(3)
@@ -34,6 +36,7 @@ public class GridLayoutFactoryTest extends TestCase {
 				factory.toString());
 	}
 
+	@Test
 	public void testToStringNumColumns() {
 		GridLayoutFactory factory = GridLayoutFactory.fillDefaults()
 			.numColumns(3);
@@ -43,6 +46,7 @@ public class GridLayoutFactoryTest extends TestCase {
 				factory.toString());
 	}
 
+	@Test
 	public void testToStringEqualWidth() {
 		GridLayoutFactory factory = GridLayoutFactory.fillDefaults()
 			.equalWidth(true);
@@ -52,6 +56,7 @@ public class GridLayoutFactoryTest extends TestCase {
 				factory.toString());
 	}
 
+	@Test
 	public void testToStringExtendedMargins() {
 		GridLayoutFactory factory = GridLayoutFactory.fillDefaults()
 			.extendedMargins(10, 20, 30, 40);
@@ -61,6 +66,7 @@ public class GridLayoutFactoryTest extends TestCase {
 				factory.toString());
 	}
 
+	@Test
 	public void testToStringMargins() {
 		GridLayoutFactory factory = GridLayoutFactory.fillDefaults()
 			.margins(30, 50);
@@ -70,6 +76,7 @@ public class GridLayoutFactoryTest extends TestCase {
 				factory.toString());
 	}
 
+	@Test
 	public void testToStringSpacing() {
 		GridLayoutFactory factory = GridLayoutFactory.fillDefaults()
 			.spacing(39, 59);
@@ -79,6 +86,7 @@ public class GridLayoutFactoryTest extends TestCase {
 				factory.toString());
 	}
 
+	@Test
 	public void testToStringNoOverrides() {
 		GridLayoutFactory factory = GridLayoutFactory.fillDefaults();
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/layout/TreeColumnLayoutTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/layout/TreeColumnLayoutTest.java
@@ -13,19 +13,23 @@
  ******************************************************************************/
 package org.eclipse.jface.tests.layout;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.fail;
 
 import org.eclipse.jface.layout.TreeColumnLayout;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class TreeColumnLayoutTest extends TestCase {
+public class TreeColumnLayoutTest {
 
 	private Display display;
 	private Shell parent;
 
+	@Test
 	public void testBug395890LayoutAfterExpandEventWithDisposedTree() throws Exception {
 		Tree tree = new Tree(parent, SWT.NONE);
 		TreeColumnLayout layout = new TreeColumnLayout();
@@ -40,8 +44,8 @@ public class TreeColumnLayoutTest extends TestCase {
 		}
 	}
 
-	@Override
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		display = Display.getCurrent();
 		if (display == null) {
 			display = new Display();
@@ -49,8 +53,8 @@ public class TreeColumnLayoutTest extends TestCase {
 		parent = new Shell(display, SWT.NONE);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		parent.dispose();
 	}
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/preferences/BooleanFieldEditorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/preferences/BooleanFieldEditorTest.java
@@ -16,6 +16,10 @@
 
 package org.eclipse.jface.tests.preferences;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.lang.reflect.Field;
 
 import org.eclipse.jface.preference.BooleanFieldEditor;
@@ -28,10 +32,10 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
-public class BooleanFieldEditorTest extends TestCase {
+public class BooleanFieldEditorTest {
 
 	private Shell shell;
 	private BooleanFieldEditor bfEditorWithSameLabel;
@@ -40,16 +44,15 @@ public class BooleanFieldEditorTest extends TestCase {
 	private boolean otherThreadEventOccurred = false;
 	private final Object lock = new Object();
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-
+	@Before
+	public void setUp() throws Exception {
 		shell = new Shell();
 
 		bfEditorWithSameLabel = new BooleanFieldEditor("name", "label", shell);
 		bfEditorWithSeparateLabel = new BooleanFieldEditor("name2", "label", BooleanFieldEditor.SEPARATE_LABEL, shell);
 	}
 
+	@Test
 	public void testSetLabelText() {
 		bfEditorWithSameLabel.setLabelText("label text");
 		assertEquals("label text", bfEditorWithSameLabel.getLabelText());
@@ -58,6 +61,7 @@ public class BooleanFieldEditorTest extends TestCase {
 		assertEquals("label text", bfEditorWithSameLabel.getLabelText());
 	}
 
+	@Test
 	public void testLoad() {
 		PreferenceStore myPreferenceStore = new PreferenceStore();
 		bfEditorWithSameLabel.setPreferenceName("name");
@@ -74,6 +78,7 @@ public class BooleanFieldEditorTest extends TestCase {
 		assertTrue(bfEditorWithSameLabel.getBooleanValue());
 	}
 
+	@Test
 	public void testLoadDefault() {
 		bfEditorWithSameLabel.setPropertyChangeListener(event -> otherThreadEventOccurred());
 
@@ -95,6 +100,7 @@ public class BooleanFieldEditorTest extends TestCase {
 		assertTrue(otherThreadEventOccurred);
 	}
 
+	@Test
 	public void testGetBooleanValue() {
 		PreferenceStore myPreferenceStore = new PreferenceStore();
 		bfEditorWithSameLabel.setPreferenceName("name");
@@ -112,6 +118,7 @@ public class BooleanFieldEditorTest extends TestCase {
 		assertTrue(bfEditorWithSameLabel.getBooleanValue());
 	}
 
+	@Test
 	public void testStore() {
 		PreferenceStore myPreferenceStore = new PreferenceStore();
 		bfEditorWithSameLabel.setPreferenceName("name");
@@ -134,6 +141,7 @@ public class BooleanFieldEditorTest extends TestCase {
 		assertTrue(myPreferenceStore.getBoolean("name"));
 	}
 
+	@Test
 	public void testValueChanged() {
 		bfEditorWithSameLabel.setPropertyChangeListener(event -> otherThreadEventOccurred());
 
@@ -157,6 +165,7 @@ public class BooleanFieldEditorTest extends TestCase {
 		assertTrue(otherThreadEventOccurred);
 	}
 
+	@Test
 	public void testSetFocus() {
 		bfEditorWithSameLabel = new BooleanFieldEditor("name", "label", shell) {
 			@Override
@@ -180,6 +189,7 @@ public class BooleanFieldEditorTest extends TestCase {
 		assertTrue(otherThreadEventOccurred);
 	}
 
+	@Test
 	public void testSetEnabled() {
 		Button buttonWithSameLabel = getButton(bfEditorWithSameLabel);
 
@@ -208,6 +218,7 @@ public class BooleanFieldEditorTest extends TestCase {
 		assertTrue(separateLabel.isEnabled());
 	}
 
+	@Test
 	public void testAdjustForNumColumns() {
 		final BooleanFieldEditor[] editors = new BooleanFieldEditor[2];
 
@@ -278,11 +289,6 @@ public class BooleanFieldEditorTest extends TestCase {
 				}
 			}
 		}
-	}
-
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
 	}
 
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/preferences/IntegerFieldEditorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/preferences/IntegerFieldEditorTest.java
@@ -15,24 +15,24 @@
 
 package org.eclipse.jface.tests.preferences;
 
-
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import org.eclipse.jface.preference.IntegerFieldEditor;
 import org.eclipse.jface.preference.PreferenceStore;
 import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
+import org.junit.Before;
+import org.junit.Test;
 
-public class IntegerFieldEditorTest extends TestCase {
+public class IntegerFieldEditorTest {
 
 	private Shell shell;
 	private IntegerFieldEditor integerFieldEditor;
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-
+	@Before
+	public void setUp() throws Exception {
 		shell = new Shell();
 
 		integerFieldEditor = new IntegerFieldEditor("name", "label", shell);
@@ -40,6 +40,7 @@ public class IntegerFieldEditorTest extends TestCase {
 		integerFieldEditor.setValidateStrategy(StringFieldEditor.VALIDATE_ON_KEY_STROKE);
 	}
 
+	@Test
 	public void testLoad() {
 		PreferenceStore myPreferenceStore = new PreferenceStore();
 		integerFieldEditor.setPreferenceName("name");
@@ -55,6 +56,7 @@ public class IntegerFieldEditorTest extends TestCase {
 		assertEquals(integerFieldEditor.getIntValue(), 6);
 	}
 
+	@Test
 	public void testLoadDefault() {
 		PreferenceStore myPreferenceStore = new PreferenceStore();
 		integerFieldEditor.setPreferenceName("name");
@@ -66,6 +68,7 @@ public class IntegerFieldEditorTest extends TestCase {
 		assertEquals(integerFieldEditor.getIntValue(), 5);
 	}
 
+	@Test
 	public void testSetValueInWidget() {
 		PreferenceStore myPreferenceStore = new PreferenceStore();
 		integerFieldEditor.setPreferenceName("name");
@@ -80,6 +83,7 @@ public class IntegerFieldEditorTest extends TestCase {
 		assertEquals(integerFieldEditor.getIntValue(), 6);
 	}
 
+	@Test
 	public void testSetValueInEditor() {
 		PreferenceStore myPreferenceStore = new PreferenceStore();
 		integerFieldEditor.setPreferenceName("name");
@@ -95,6 +99,7 @@ public class IntegerFieldEditorTest extends TestCase {
 		assertEquals(integerFieldEditor.getIntValue(), 6);
 	}
 
+	@Test
 	public void testValidate() {
 		PreferenceStore myPreferenceStore = new PreferenceStore();
 		integerFieldEditor.setPreferenceName("name");
@@ -105,10 +110,4 @@ public class IntegerFieldEditorTest extends TestCase {
 		assertFalse(integerFieldEditor.isValid());
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
-
 }
-

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/preferences/StringFieldEditorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/preferences/StringFieldEditorTest.java
@@ -16,28 +16,30 @@
 
 package org.eclipse.jface.tests.preferences;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import org.eclipse.jface.preference.PreferenceStore;
 import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
-public class StringFieldEditorTest extends TestCase {
+public class StringFieldEditorTest {
 
 	private Shell shell;
 	private StringFieldEditor stringFieldEditor;
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-
+	@Before
+	public void setUp() throws Exception {
 		shell = new Shell();
 
 		stringFieldEditor = new StringFieldEditor("name", "label", shell);
 	}
 
+	@Test
 	public void testSetLabelText() {
 		stringFieldEditor.setLabelText("label text");
 		assertEquals("label text", stringFieldEditor.getLabelText());
@@ -46,6 +48,7 @@ public class StringFieldEditorTest extends TestCase {
 		assertEquals("label text", stringFieldEditor.getLabelText());
 	}
 
+	@Test
 	public void testLoad() {
 		PreferenceStore myPreferenceStore = new PreferenceStore();
 		stringFieldEditor.setPreferenceName("name");
@@ -61,6 +64,7 @@ public class StringFieldEditorTest extends TestCase {
 		assertEquals(stringFieldEditor.getStringValue(), "bar");
 	}
 
+	@Test
 	public void testLoadDefault() {
 		PreferenceStore myPreferenceStore = new PreferenceStore();
 		stringFieldEditor.setPreferenceName("name");
@@ -72,6 +76,7 @@ public class StringFieldEditorTest extends TestCase {
 		assertEquals(stringFieldEditor.getStringValue(), "foo");
 	}
 
+	@Test
 	public void testSetValueInWidget() {
 		PreferenceStore myPreferenceStore = new PreferenceStore();
 		stringFieldEditor.setPreferenceName("name");
@@ -86,6 +91,7 @@ public class StringFieldEditorTest extends TestCase {
 		assertEquals(stringFieldEditor.getStringValue(), "bar");
 	}
 
+	@Test
 	public void testSetValueInEditor() {
 		PreferenceStore myPreferenceStore = new PreferenceStore();
 		stringFieldEditor.setPreferenceName("name");
@@ -101,6 +107,7 @@ public class StringFieldEditorTest extends TestCase {
 		assertEquals(stringFieldEditor.getStringValue(), "bar");
 	}
 
+	@Test
 	public void testBug289599() {
 		PreferenceStore store = new PreferenceStore();
 		store.setDefault("foo", "bar");
@@ -124,10 +131,4 @@ public class StringFieldEditorTest extends TestCase {
 		assertEquals("bar", store.getString("foo"));
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
-
 }
-

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/window/ApplicationWindowTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/window/ApplicationWindowTest.java
@@ -17,21 +17,20 @@ package org.eclipse.jface.tests.window;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.window.ApplicationWindow;
 import org.eclipse.swt.widgets.Shell;
+import org.junit.After;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
-public class ApplicationWindowTest extends TestCase {
+public class ApplicationWindowTest {
 
 	private ApplicationWindow window;
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		if (window != null) {
 			// close the window
 			window.close();
 			window = null;
 		}
-		super.tearDown();
 	}
 
 	private void testBug334093(boolean fork, boolean cancelable) throws Exception {
@@ -64,6 +63,7 @@ public class ApplicationWindowTest extends TestCase {
 		});
 	}
 
+	@Test
 	public void testBug334093() throws Exception {
 		boolean[] options = new boolean[] { true, false };
 		for (boolean forkOption : options) {

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/wizards/ButtonAlignmentTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/wizards/ButtonAlignmentTest.java
@@ -15,39 +15,37 @@
 
 package org.eclipse.jface.tests.wizards;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-public class ButtonAlignmentTest extends TestCase {
+public class ButtonAlignmentTest {
 
 	private TheTestWizard wizard;
 	private TheTestWizardDialog dialog;
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-
+	@Before
+	public void setUp() throws Exception {
 		// ensure we've initialized a display for this thread
 		Display.getDefault();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		if (dialog != null && dialog.getShell() != null
 				&& !dialog.getShell().isDisposed()) {
 			dialog.close();
 		}
-		super.tearDown();
 	}
 
-	public ButtonAlignmentTest() {
-		super("ButtonAlignmentTest");
-	}
-
+	@Test
 	public void testButtonAlignment() {
 		wizard = new TheTestWizard();
 		dialog = new TheTestWizardDialog(null, wizard);
@@ -85,6 +83,7 @@ public class ButtonAlignmentTest extends TestCase {
 				"Cancel button's alignment is off", dialog.getCancelButton(), children[cancelIndex]); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testButtonAlignmentWithoutBackNextButtons() {
 		wizard = new TheTestWizard() {
 			@Override
@@ -116,6 +115,7 @@ public class ButtonAlignmentTest extends TestCase {
 				"Cancel button's alignment is off", dialog.getCancelButton(), children[cancelIndex]); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testBug270174() {
 		wizard = new TheTestWizard() {
 			@Override

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/wizards/WizardProgressMonitorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/wizards/WizardProgressMonitorTest.java
@@ -15,6 +15,9 @@
 
 package org.eclipse.jface.tests.wizards;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.wizard.IWizard;
 import org.eclipse.jface.wizard.ProgressMonitorPart;
@@ -23,29 +26,28 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Layout;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
-public class WizardProgressMonitorTest extends TestCase {
+public class WizardProgressMonitorTest {
 
 	private ProgressMonitoringWizardDialog dialog;
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		// initialize a display
 		Display.getDefault();
 		dialog = new ProgressMonitoringWizardDialog(new TheTestWizard());
 		dialog.setBlockOnOpen(false);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		if (dialog != null) {
 			dialog.close();
 		}
 		dialog = null;
-		super.tearDown();
 	}
 
 	/**
@@ -57,6 +59,7 @@ public class WizardProgressMonitorTest extends TestCase {
 	 *
 	 * @throws Exception
 	 */
+	@Test
 	public void testProgressLabelsClearedBug271530() throws Exception {
 		// make up some random task names
 		final String[] taskNames = { "Task A", "Task B" }; //$NON-NLS-1$ //$NON-NLS-2$
@@ -167,6 +170,7 @@ public class WizardProgressMonitorTest extends TestCase {
 	 *
 	 * @throws Exception
 	 */
+	@Test
 	public void testProgressMonitorWithoutStopButtonBug287887() throws Exception {
 		// make up some random task names
 		final String[] taskNames = { "Task A", "Task B" }; //$NON-NLS-1$ //$NON-NLS-2$

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/wizards/WizardTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/wizards/WizardTest.java
@@ -15,6 +15,11 @@
 
 package org.eclipse.jface.tests.wizards;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IPageChangedListener;
 import org.eclipse.jface.dialogs.IPageChangingListener;
@@ -23,10 +28,11 @@ import org.eclipse.jface.util.Policy;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
-public class WizardTest extends TestCase {
+public class WizardTest {
 	/**
 	 *
 	 */
@@ -45,12 +51,7 @@ public class WizardTest extends TestCase {
 	boolean pageChanged = false;
 	boolean pageChangingFired = false;
 
-
-	public WizardTest() {
-		super("NewWizardTest");
-	}
-
-
+	@Test
 	public void testEndingWithFinish() {
 		//test page count
 		assertEquals("Wizard has wrong number of pages", NUM_PAGES, wizard.getPageCount());
@@ -80,11 +81,12 @@ public class WizardTest extends TestCase {
 		//test getMessage()
 		assertSame("WizardPage error message should be null", null, wizard.page1.getErrorMessage());
 		wizard.page1.textInputField.setText(TheTestWizardPage.BAD_TEXT_FIELD_CONTENTS);
-		assertEquals("WizardPage error message set correctly", TheTestWizardPage.BAD_TEXT_FIELD_STATUS, wizard.page1.getErrorMessage());
+		assertEquals("WizardPage error message set correctly", TheTestWizardPage.BAD_TEXT_FIELD_STATUS,
+				wizard.page1.getErrorMessage());
 
 		//test page completion
 		wizard.page1.textInputField.setText(TheTestWizardPage.GOOD_TEXT_FIELD_CONTENTS);
-		assertEquals("Page should be completed", true, wizard.page1.canFlipToNextPage());
+		assertTrue("Page should be completed", wizard.page1.canFlipToNextPage());
 		//Setting good value should've cleared the error message
 		assertSame("WizardPage error message should be null", null, wizard.page1.getErrorMessage());
 
@@ -98,65 +100,67 @@ public class WizardTest extends TestCase {
 
 		//test canFinish()
 		wizard.page2.textInputField.setText(TheTestWizardPage.BAD_TEXT_FIELD_CONTENTS);
-		assertEquals("Wizard should not be able to finish", false, wizard.canFinish());
+		assertFalse("Wizard should not be able to finish", wizard.canFinish());
 		wizard.page2.textInputField.setText(TheTestWizardPage.GOOD_TEXT_FIELD_CONTENTS);
-		assertEquals("Wizard should be able to finish", true, wizard.canFinish());
+		assertTrue("Wizard should be able to finish", wizard.canFinish());
 
 		//test simulated Finish button hit
 		//TheTestWizard's performFinish() sets DID_FINISH to true
 		dialog.finishPressed();
-		assertEquals("Wizard didn't perform finish", true, DID_FINISH);
+		assertTrue("Wizard didn't perform finish", DID_FINISH);
 	}
 
+	@Test
 	public void testEndingWithCancel() {
 		assertSame("Wizard not on starting page", wizard.page1, dialog.getCurrentPage());
 
 		//TheTestWizard's performFinish() sets DID_FINISH to true, ensure it was not called
 		wizard.performCancel();
-		assertEquals("Wizard finished but should not have", false, DID_FINISH);
+		assertFalse("Wizard finished but should not have", DID_FINISH);
 
 		dialog.cancelPressed();
-		assertEquals("Wizard performed finished but should not have", false, DID_FINISH);
+		assertFalse("Wizard performed finished but should not have", DID_FINISH);
 	}
 
+	@Test
 	public void testPageChanging() {
 		//initially on first page
 		assertSame("Wizard started on wrong page", wizard.page1, dialog.getCurrentPage());
-		assertEquals("Back button should be disabled on first page", false, dialog.getBackButton().getEnabled());
-		assertEquals("Next button should be enabled on first page", true, dialog.getNextButton().getEnabled());
+		assertFalse("Back button should be disabled on first page", dialog.getBackButton().getEnabled());
+		assertTrue("Next button should be enabled on first page", dialog.getNextButton().getEnabled());
 
 		//move to middle page 2
 		dialog.nextPressed();
 		assertSame("Wizard.nextPressed() set wrong page", wizard.page2, dialog.getCurrentPage());
-		assertEquals("Back button should be enabled on middle page", true, dialog.getBackButton().getEnabled());
-		assertEquals("Next button should be enabled on middle page", true, dialog.getNextButton().getEnabled());
+		assertTrue("Back button should be enabled on middle page", dialog.getBackButton().getEnabled());
+		assertTrue("Next button should be enabled on middle page", dialog.getNextButton().getEnabled());
 
 		//test that can't complete by inserting bad value to be validated
 		wizard.page2.textInputField.setText(TheTestWizardPage.BAD_TEXT_FIELD_CONTENTS);
-		assertEquals("Finish should be disabled when bad field value", false, dialog.getFinishedButton().getEnabled());
-		assertEquals("Cancel should always be enabled", true, dialog.getCancelButton().getEnabled());
+		assertFalse("Finish should be disabled when bad field value", dialog.getFinishedButton().getEnabled());
+		assertTrue("Cancel should always be enabled", dialog.getCancelButton().getEnabled());
 
 		//test that can complete by inserting good value to be validated
 		wizard.page2.textInputField.setText(TheTestWizardPage.GOOD_TEXT_FIELD_CONTENTS);
-		assertEquals("Finish should be enabled when good field value", true, dialog.getFinishedButton().getEnabled());
+		assertTrue("Finish should be enabled when good field value", dialog.getFinishedButton().getEnabled());
 
 		//move to last page 3
 		dialog.nextPressed();
 		assertSame("Wizard.nextPressed() set wrong page", wizard.page3, dialog.getCurrentPage());
-		assertEquals("Back button should be enabled on last page", true, dialog.getBackButton().getEnabled());
-		assertEquals("Next button should be disenabled on last page", false, dialog.getNextButton().getEnabled());
+		assertTrue("Back button should be enabled on last page", dialog.getBackButton().getEnabled());
+		assertFalse("Next button should be disenabled on last page", dialog.getNextButton().getEnabled());
 
 		//move back to page 2
 		dialog.backPressed();
 		assertSame("Wizard.backPressed() set wrong page", wizard.page2, dialog.getCurrentPage());
-		assertEquals("Back button should be enabled on middle page", true, dialog.getBackButton().getEnabled());
-		assertEquals("Next button should be enabled on middle page", true, dialog.getNextButton().getEnabled());
+		assertTrue("Back button should be enabled on middle page", dialog.getBackButton().getEnabled());
+		assertTrue("Next button should be enabled on middle page", dialog.getNextButton().getEnabled());
 
 		//move back to page 1
 		dialog.backPressed();
 		assertSame("Wizard.backPressed() set wrong page", wizard.page1, dialog.getCurrentPage());
-		assertEquals("Back button should be disabled on first page", false, dialog.getBackButton().getEnabled());
-		assertEquals("Next button should be enabled on first page", true, dialog.getNextButton().getEnabled());
+		assertFalse("Back button should be disabled on first page", dialog.getBackButton().getEnabled());
+		assertTrue("Next button should be enabled on first page", dialog.getNextButton().getEnabled());
 
 		//move Next to page 2
 		dialog.buttonPressed(IDialogConstants.NEXT_ID);
@@ -166,6 +170,7 @@ public class WizardTest extends TestCase {
 		assertSame("Wizard.backPressed() set wrong page", wizard.page1, dialog.getCurrentPage());
 	}
 
+	@Test
 	public void testShowPage() {
 		//move to page 3
 		dialog.nextPressed();
@@ -179,9 +184,10 @@ public class WizardTest extends TestCase {
 
 		//TODO Next test fails due to bug #249369
 //		assertEquals("Back button should be disabled on first page", false, dialog.getBackButton().getEnabled());
-		assertEquals("Next button should be enabled on first page", true, dialog.getNextButton().getEnabled());
+		assertTrue("Next button should be enabled on first page", dialog.getNextButton().getEnabled());
 	}
 
+	@Test
 	public void testPageChangeListening() {
 		pageChanged = false;
 		pageChangingFired = false;
@@ -189,18 +195,18 @@ public class WizardTest extends TestCase {
 		IPageChangedListener changedListener = event -> pageChanged = true;
 
 		IPageChangingListener changingListener = event -> {
-			assertEquals("Page should not have changed yet", false, pageChanged);
+			assertFalse("Page should not have changed yet", pageChanged);
 			pageChangingFired = true;
 		};
 
 		//test that listener notifies us of page change
 		dialog.addPageChangedListener(changedListener);
 		dialog.addPageChangingListener(changingListener); //assert is in the listener
-		assertEquals("Page change notified unintentially", false, pageChanged);
+		assertFalse("Page change notified unintentially", pageChanged);
 		//change to page 2
 		dialog.nextPressed();
-		assertEquals("Wasn't notified of page change", true, pageChanged);
-		assertEquals("Wasn't notified of page changing", true, pageChangingFired);
+		assertTrue("Wasn't notified of page change", pageChanged);
+		assertTrue("Wasn't notified of page changing", pageChangingFired);
 
 		dialog.removePageChangingListener(changingListener); //if not removed, its assert will fail on next nextPressed()
 		//change to page 2
@@ -211,10 +217,10 @@ public class WizardTest extends TestCase {
 		dialog.removePageChangedListener(changedListener);
 		//change to page 3
 		dialog.nextPressed();
-		assertEquals("Page change notified unintentially", false, pageChanged);
+		assertFalse("Page change notified unintentially", pageChanged);
 	}
 
-
+	@Test
 	public void testWizardDispose() {
 		wizard.setThrowExceptionOnDispose(true);
 
@@ -233,6 +239,7 @@ public class WizardTest extends TestCase {
 		shell.dispose();
 	}
 
+	@Test
 	public void testWizardPageDispose() {
 		wizard.page2.setThrowExceptionOnDispose(true);
 		final boolean logged[] = new boolean[1];
@@ -251,11 +258,8 @@ public class WizardTest extends TestCase {
 
 	//----------------------------------------------------
 
-
-	@Override
-	protected void setUp() throws Exception {
-		// TODO Auto-generated method stub
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		DID_FINISH = false;
 		color1 = new RGB(255, 0, 0);
 		color2 = new RGB(0, 255, 0);
@@ -263,8 +267,8 @@ public class WizardTest extends TestCase {
 		createWizardDialog();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		if(dialog.getShell() != null && ! dialog.getShell().isDisposed()) {
 			dialog.close();
 		}


### PR DESCRIPTION
* Migrates several tests in `org.eclipse.jface.tests` to JUnit 4 (except the viewer tests. see #1222, and JFaceActionTests, see #1220)
* Fixes some warnings due to using `assertEquals` instead of `assertFalse`/`assertTrue`