### PR TITLE
Migrate JFace Viewer tests to JUnit 4

### DIFF
--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/ColorAndFontLabelProviderTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/ColorAndFontLabelProviderTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.jface.tests.labelProviders;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import org.eclipse.jface.viewers.IColorProvider;
@@ -28,6 +29,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
+import org.junit.Test;
 
 /**
  * ColorAndFontProviderTest is a test of a color and font provider but not an
@@ -64,15 +66,6 @@ public class ColorAndFontLabelProviderTest extends CompositeLabelProviderTest {
 
 	}
 
-	/**
-	 * Create a new instance of the receiver.
-	 *
-	 * @param name
-	 */
-	public ColorAndFontLabelProviderTest(String name) {
-		super(name);
-	}
-
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
 		initializeColors(parent);
@@ -86,6 +79,7 @@ public class ColorAndFontLabelProviderTest extends CompositeLabelProviderTest {
 	/**
 	 * Test that all of the colours and fonts from the label provider are applied.
 	 */
+	@Test
 	public void testColorsAndFonts() {
 		Table table = (Table) fViewer.getControl();
 		TableItem item = table.getItem(0);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/ColorAndFontViewerLabelProviderTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/ColorAndFontViewerLabelProviderTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.jface.tests.labelProviders;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import org.eclipse.jface.viewers.IColorProvider;
@@ -30,6 +31,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
+import org.junit.Test;
 
 /**
  * ColorAndFontProviderTest is a test of a color and font provider that is an
@@ -72,15 +74,6 @@ public class ColorAndFontViewerLabelProviderTest extends CompositeLabelProviderT
 
 	}
 
-	/**
-	 * Create a new instance of the receiver.
-	 *
-	 * @param name
-	 */
-	public ColorAndFontViewerLabelProviderTest(String name) {
-		super(name);
-	}
-
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
 		initializeColors(parent);
@@ -94,6 +87,7 @@ public class ColorAndFontViewerLabelProviderTest extends CompositeLabelProviderT
 	/**
 	 * Test that all of the colours and fonts from the label provider are applied.
 	 */
+	@Test
 	public void testColorsAndFonts() {
 		Table table = (Table) fViewer.getControl();
 		TableItem item = table.getItem(0);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/CompositeLabelProviderTableTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/CompositeLabelProviderTableTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jface.tests.labelProviders;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.jface.viewers.IColorProvider;
 import org.eclipse.jface.viewers.IFontProvider;
 import org.eclipse.jface.viewers.IViewerLabelProvider;
@@ -26,6 +28,7 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
+import org.junit.Test;
 
 /**
  * CompositeLabelProviderTableTest tests a table that is a
@@ -59,15 +62,6 @@ public class CompositeLabelProviderTableTest extends CompositeLabelProviderTest 
 		}
 	}
 
-	/**
-	 * Create a new instance of the recevier.
-	 *
-	 * @param name
-	 */
-	public CompositeLabelProviderTableTest(String name) {
-		super(name);
-	}
-
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
 
@@ -82,6 +76,7 @@ public class CompositeLabelProviderTableTest extends CompositeLabelProviderTest 
 	/**
 	 * Test that all of the colours and fonts from the label provider are applied.
 	 */
+	@Test
 	public void testColorsAndFonts() {
 		Table table = (Table) fViewer.getControl();
 		TableItem item = table.getItem(0);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/CompositeLabelProviderTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/CompositeLabelProviderTest.java
@@ -58,15 +58,6 @@ public abstract class CompositeLabelProviderTest extends ViewerTestCase {
 	Font font;
 
 	/**
-	 * Create a new instance of the receiver.
-	 *
-	 * @param name
-	 */
-	public CompositeLabelProviderTest(String name) {
-		super(name);
-	}
-
-	/**
 	 * Initialize the colors used by the receiver.
 	 *
 	 * @param parent

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/DecoratingLabelProviderTreePathTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/DecoratingLabelProviderTreePathTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jface.tests.labelProviders;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.jface.viewers.IColorProvider;
 import org.eclipse.jface.viewers.IFontProvider;
 import org.eclipse.jface.viewers.ITreePathLabelProvider;
@@ -27,6 +29,7 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
+import org.junit.Test;
 
 /**
  * DecoratingLabelProviderTreePathTest is the tree path version of the
@@ -60,16 +63,6 @@ public class DecoratingLabelProviderTreePathTest extends CompositeLabelProviderT
 		}
 	}
 
-	/**
-	 * Create a new instance of the receiver.
-	 *
-	 * @param name
-	 */
-	public DecoratingLabelProviderTreePathTest(String name) {
-		super(name);
-
-	}
-
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
 
@@ -88,6 +81,7 @@ public class DecoratingLabelProviderTreePathTest extends CompositeLabelProviderT
 	/**
 	 * Test that all of the colours and fonts from the label provider are applied.
 	 */
+	@Test
 	public void testColorsAndFonts() {
 		Tree tree = (Tree) fViewer.getControl();
 		TreeItem item = tree.getItem(0);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/DecoratingLabelProviderTreeTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/DecoratingLabelProviderTreeTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jface.tests.labelProviders;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.jface.viewers.DecoratingLabelProvider;
 import org.eclipse.jface.viewers.IColorProvider;
 import org.eclipse.jface.viewers.IFontProvider;
@@ -25,6 +27,7 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
+import org.junit.Test;
 
 /**
  * @since 3.3
@@ -53,13 +56,6 @@ public class DecoratingLabelProviderTreeTest extends CompositeLabelProviderTest 
 		}
 	}
 
-	/**
-	 * @param name
-	 */
-	public DecoratingLabelProviderTreeTest(String name) {
-		super(name);
-	}
-
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
 
@@ -74,6 +70,7 @@ public class DecoratingLabelProviderTreeTest extends CompositeLabelProviderTest 
 	/**
 	 * Test that all of the colours and fonts from the label provider are applied.
 	 */
+	@Test
 	public void testColorsAndFonts() {
 		Tree tree = (Tree) fViewer.getControl();
 		TreeItem item = tree.getItem(0);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/DecoratingStyledCellLabelProviderTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/DecoratingStyledCellLabelProviderTest.java
@@ -14,6 +14,14 @@
 
 package org.eclipse.jface.tests.labelProviders;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.core.runtime.AssertionFailedException;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.tests.viewers.ViewerTestCase;
@@ -45,6 +53,8 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Most of the setup has been taken from
@@ -132,12 +142,14 @@ public class DecoratingStyledCellLabelProviderTest extends ViewerTestCase {
 	protected String changeMe = "OLD";
 	private static int COLUMN_COUNT = 3;
 
-	public DecoratingStyledCellLabelProviderTest(String name) {
-		super(name);
+	@Before
+	@Override
+	public void setUp() {
 		entries = new CountryEntry[3];
 		entries[0] = new AustriaEntry();
 		entries[1] = new GermanyEntry();
 		entries[2] = new EnglandEntry();
+		super.setUp();
 	}
 
 	@Override
@@ -223,10 +235,12 @@ public class DecoratingStyledCellLabelProviderTest extends ViewerTestCase {
 	}
 
 	// the tests
+	@Test
 	public void testGetDecorationContext() {
 		assertNotNull(getDecoratingStyledLabelProvider().getDecorationContext());
 	}
 
+	@Test
 	public void testSetDecorationContext() {
 		try {
 			getDecoratingStyledLabelProvider().setDecorationContext(null);
@@ -236,6 +250,7 @@ public class DecoratingStyledCellLabelProviderTest extends ViewerTestCase {
 		}
 	}
 
+	@Test
 	public void testUpdate() {
 		Table table = ((TableViewer) fViewer).getTable();
 		String before = table.getItem(0).toString();
@@ -244,6 +259,7 @@ public class DecoratingStyledCellLabelProviderTest extends ViewerTestCase {
 		assertNotSame(before, table.getItem(0).toString());
 	}
 
+	@Test
 	public void testGetForeground() {
 		// TODO: Incomplete test
 		// fViewer.getControl().getShell().setFocus();
@@ -263,6 +279,7 @@ public class DecoratingStyledCellLabelProviderTest extends ViewerTestCase {
 		// ti));
 	}
 
+	@Test
 	public void testGetBackground() {
 		// TODO: Incomplete test
 
@@ -275,6 +292,7 @@ public class DecoratingStyledCellLabelProviderTest extends ViewerTestCase {
 		// getDecoratingStyledLabelProvider().getBackground(ti));
 	}
 
+	@Test
 	public void testGetFont() {
 		// TODO: Incomplete test
 
@@ -284,6 +302,7 @@ public class DecoratingStyledCellLabelProviderTest extends ViewerTestCase {
 		// assertEquals(f, getDecoratingStyledLabelProvider().getFont(ti));
 	}
 
+	@Test
 	public void testGetImage() {
 		Table table = ((TableViewer) fViewer).getTable();
 
@@ -291,6 +310,7 @@ public class DecoratingStyledCellLabelProviderTest extends ViewerTestCase {
 
 	}
 
+	@Test
 	public void testGetLabelDecorator() {
 		assertNotNull(getDecoratingStyledLabelProvider().getLabelDecorator());
 
@@ -298,6 +318,7 @@ public class DecoratingStyledCellLabelProviderTest extends ViewerTestCase {
 		assertNull(getDecoratingStyledLabelProvider().getLabelDecorator());
 	}
 
+	@Test
 	public void testSetLabelDecorator() {
 		ILabelDecorator labelDecorator = getDecorator();
 		getDecoratingStyledLabelProvider().setLabelDecorator(labelDecorator);
@@ -305,6 +326,7 @@ public class DecoratingStyledCellLabelProviderTest extends ViewerTestCase {
 
 	}
 
+	@Test
 	public void testAddListener() {
 		String old = changeMe; // String will change because the listener will
 		// be listening for it
@@ -314,6 +336,7 @@ public class DecoratingStyledCellLabelProviderTest extends ViewerTestCase {
 		assertNotSame(old, changeMe);
 	}
 
+	@Test
 	public void testRemoveListener() {
 		String old = changeMe = "OLD";
 		ILabelProviderListener listener = getListener();
@@ -323,11 +346,13 @@ public class DecoratingStyledCellLabelProviderTest extends ViewerTestCase {
 		assertEquals(old, changeMe);
 	}
 
+	@Test
 	public void testIsLabelProperty() {
 		boolean check = getDecoratingStyledLabelProvider().isLabelProperty("element", "property");
 		assertTrue(check);
 	}
 
+	@Test
 	public void testDispose() {
 		fShell.dispose();
 		assertFalse(fViewer.getLabelProvider() instanceof DecoratingStyledCellLabelProvider);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/AbstractTreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/AbstractTreeViewerTest.java
@@ -13,6 +13,12 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,14 +28,12 @@ import org.eclipse.swt.widgets.Item;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.Widget;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
+import org.junit.After;
+import org.junit.Test;
 
 public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 
 	AbstractTreeViewer fTreeViewer;
-
-	public AbstractTreeViewerTest(String name) {
-		super(name);
-	}
 
 	protected void assertEqualsArray(String s, Object[] a1, Object[] a2) {
 		int s1 = a1.length;
@@ -50,6 +54,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 
 	protected abstract int getItemCount(TestElement element); // was IElement
 
+	@Test
 	public void testBulkExpand() {
 		// navigate
 		TestElement first = fRootElement.getFirstChild();
@@ -77,6 +82,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 		assertEqualsArray("old and new expand state are the same", list1, list2);
 	}
 
+	@Test
 	public void testDeleteChildExpanded() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement first2 = first.getFirstChild();
@@ -87,12 +93,14 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 		assertNull("first child is not visible", fViewer.testFindItem(first2));
 	}
 
+	@Test
 	public void testDeleteChildren() {
 		TestElement first = fRootElement.getFirstChild();
 		first.deleteChildren();
 		assertEquals("no children", 0, getItemCount(first));
 	}
 
+	@Test
 	public void testDeleteChildrenExpanded() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement first2 = first.getFirstChild();
@@ -103,6 +111,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 		assertEquals("no children", 0, getItemCount(first));
 	}
 
+	@Test
 	public void testExpand() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement first2 = first.getFirstChild();
@@ -111,6 +120,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 		assertNotNull("first child is visible", fViewer.testFindItem(first2));
 	}
 
+	@Test
 	public void testExpandElement() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement first2 = first.getFirstChild();
@@ -120,6 +130,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 		assertNotNull("first2 is visible", fViewer.testFindItem(first2));
 	}
 
+	@Test
 	public void testExpandElementAgain() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement first2 = first.getFirstChild();
@@ -136,6 +147,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 		assertNotNull("first3 is visible", fViewer.testFindItem(first3));
 	}
 
+	@Test
 	public void testExpandToLevel() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement first2 = first.getFirstChild();
@@ -151,6 +163,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 		assertNotNull("first3 is visible", fViewer.testFindItem(first3));
 	}
 
+	@Test
 	public void testFilterExpanded() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement first2 = first.getFirstChild();
@@ -160,12 +173,14 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 		assertEquals("filtered count", 5, getItemCount());
 	}
 
+	@Test
 	public void testInsertChildReveal() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement newElement = first.addChild(TestModelChange.INSERT | TestModelChange.REVEAL);
 		assertNotNull("new sibling is visible", fViewer.testFindItem(newElement));
 	}
 
+	@Test
 	public void testInsertChildRevealSelect() {
 		TestElement last = fRootElement.getLastChild();
 		TestElement newElement = last
@@ -174,6 +189,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 		assertSelectionEquals("new element is selected", newElement);
 	}
 
+	@Test
 	public void testInsertChildRevealSelectExpanded() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement newElement = first
@@ -189,6 +205,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 	 * added dummy node even though parent item was expanded - in updateChildren, it
 	 * wasn't handling a dummy node
 	 */
+	@Test
 	public void testRefreshWithAddedChildren() {
 		TestElement parent = fRootElement.addChild(TestModelChange.INSERT);
 		TestElement child = parent.addChild(TestModelChange.INSERT);
@@ -216,6 +233,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 	 * refreshed rather than using add for new A
 	 * AbstractTreeViewer.updateChildren(...) was not properly handling it
 	 */
+	@Test
 	public void testRefreshWithDuplicateChild() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement newElement = (TestElement) first.clone();
@@ -229,6 +247,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 	 * expanded, B is not - A gets deleted - B gets expanded because it reused A's
 	 * item
 	 */
+	@Test
 	public void testRefreshWithReusedItems() {
 		// TestElement a= fRootElement.getFirstChild();
 		// TestElement aa= a.getChildAt(0);
@@ -243,6 +262,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 		// assertFalse(expandedAfter.contains(ab));
 	}
 
+	@Test
 	public void testRenameChildElement() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement first2 = first.getFirstChild();
@@ -261,6 +281,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 	 * causing IDE to crash Problem was: - node A has child A - setExpanded with A
 	 * in the list caused an infinite recursion
 	 */
+	@Test
 	public void testSetExpandedWithCycle() {
 		TestElement first = fRootElement.getFirstChild();
 		first.addChild(first, new TestModelChange(TestModelChange.INSERT, first, first));
@@ -272,6 +293,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 	 * Test for Bug 41710 - assertion that an object may not be added to a given
 	 * TreeItem more than once.
 	 */
+	@Test
 	public void testSetDuplicateChild() {
 		// Widget root = fViewer.testFindItem(fRootElement);
 		// assertNotNull(root);
@@ -290,6 +312,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 	 * not backwards for an equal element, if the comparator returned 0. The example
 	 * below is a case where the previous implementation would fail.
 	 */
+	@Test
 	public void testChildIsNotDuplicatedWhenCompareEquals() {
 		fTreeViewer.setComparator(new TestLabelComparator());
 		fRootElement.deleteChildren();
@@ -310,6 +333,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 		assertEquals("Same element added to parent twice.", 3, tree.getItems().length);
 	}
 
+	@Test
 	public void testContains() {
 		// some random element.
 		assertFalse("element must not be available on the viewer", fTreeViewer.contains(fRootElement, ""));
@@ -330,6 +354,7 @@ public abstract class AbstractTreeViewerTest extends StructuredItemViewerTest {
 				fTreeViewer.contains(fRootElement.getFirstChild(), fRootElement.getFirstChild().getFirstChild()));
 	}
 
+	@After
 	@Override
 	public void tearDown() {
 		super.tearDown();

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/BaseLimitBasedViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/BaseLimitBasedViewerTest.java
@@ -29,10 +29,6 @@ public class BaseLimitBasedViewerTest extends ViewerTestCase {
 	protected static final int VIEWER_LIMIT = 4;
 	protected static final int DEFAULT_ELEMENTS_COUNT = 40;
 
-	public BaseLimitBasedViewerTest(String name) {
-		super(name);
-	}
-
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
 		return null;

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug138608Test.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug138608Test.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.StructuredViewer;
@@ -22,6 +24,8 @@ import org.eclipse.jface.viewers.TreeNode;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.swt.widgets.Composite;
+import org.junit.After;
+import org.junit.Test;
 
 /**
  * Description of the bug: Initially tree is populated by way shown below and is
@@ -46,13 +50,6 @@ import org.eclipse.swt.widgets.Composite;
 public class Bug138608Test extends ViewerTestCase {
 
 	private TreeContentProvider contentProvider;
-
-	/**
-	 * @param name
-	 */
-	public Bug138608Test(String name) {
-		super(name);
-	}
 
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
@@ -83,6 +80,7 @@ public class Bug138608Test extends ViewerTestCase {
 		return (TreeViewer) fViewer;
 	}
 
+	@Test
 	public void testBug138608() {
 		processEvents();
 		// Add 'd' as child of 'b' in data model first
@@ -104,6 +102,7 @@ public class Bug138608Test extends ViewerTestCase {
 
 	}
 
+	@After
 	@Override
 	public void tearDown() {
 		contentProvider = null;

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug180504TableViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug180504TableViewerTest.java
@@ -24,20 +24,13 @@ import org.eclipse.jface.viewers.TextCellEditor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.TableColumn;
+import org.junit.Test;
 
 /**
  * @since 3.3
  *
  */
 public class Bug180504TableViewerTest extends ViewerTestCase {
-
-	/**
-	 * @param name
-	 */
-	public Bug180504TableViewerTest(String name) {
-		super(name);
-		// TODO Auto-generated constructor stub
-	}
 
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
@@ -88,11 +81,13 @@ public class Bug180504TableViewerTest extends ViewerTestCase {
 		return (TableViewer) fViewer;
 	}
 
+	@Test
 	public void testBug180504ApplyEditor() {
 		getTableViewer().editElement(getTableViewer().getElementAt(0), 0);
 		getTableViewer().applyEditorValue();
 	}
 
+	@Test
 	public void testBug180504CancleEditor() {
 		getTableViewer().editElement(getTableViewer().getElementAt(0), 0);
 		getTableViewer().cancelEditing();

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug180504TreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug180504TreeViewerTest.java
@@ -27,6 +27,7 @@ import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.TreeColumn;
+import org.junit.Test;
 
 /**
  * @since 3.3
@@ -56,13 +57,6 @@ public class Bug180504TreeViewerTest extends ViewerTestCase {
 
 			return rv;
 		}
-	}
-	/**
-	 * @param name
-	 */
-	public Bug180504TreeViewerTest(String name) {
-		super(name);
-		// TODO Auto-generated constructor stub
 	}
 
 	@Override
@@ -160,11 +154,13 @@ public class Bug180504TreeViewerTest extends ViewerTestCase {
 		return (TreeViewer) fViewer;
 	}
 
+	@Test
 	public void testBug201002() {
 		getTreeViewer().editElement(((MyModel)getTreeViewer().getInput()).child.get(90).child.get(10), 0);
 		getTreeViewer().applyEditorValue();
 	}
 
+	@Test
 	public void testBug180504CancleEditor() {
 		getTreeViewer().editElement(((MyModel)getTreeViewer().getInput()).child.get(90).child.get(10), 0);
 		getTreeViewer().cancelEditing();

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug200337TableViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug200337TableViewerTest.java
@@ -23,20 +23,13 @@ import org.eclipse.jface.viewers.TextCellEditor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.TableColumn;
+import org.junit.Test;
 
 /**
  * @since 3.3
  *
  */
 public class Bug200337TableViewerTest extends ViewerTestCase {
-
-	/**
-	 * @param name
-	 */
-	public Bug200337TableViewerTest(String name) {
-		super(name);
-		// TODO Auto-generated constructor stub
-	}
 
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
@@ -86,6 +79,7 @@ public class Bug200337TableViewerTest extends ViewerTestCase {
 		return (TableViewer) fViewer;
 	}
 
+	@Test
 	public void testBug200337() {
 		getTableViewer().editElement(getTableViewer().getElementAt(0), 0);
 		getTableViewer().editElement(getTableViewer().getElementAt(90), 0);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug200558Test.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug200558Test.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.ICellModifier;
 import org.eclipse.jface.viewers.ITreeContentProvider;
@@ -25,20 +27,13 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.TreeColumn;
+import org.junit.Test;
 
 /**
  * @since 3.3
  *
  */
 public class Bug200558Test extends ViewerTestCase {
-
-	/**
-	 * @param name
-	 */
-	public Bug200558Test(String name) {
-		super(name);
-		// TODO Auto-generated constructor stub
-	}
 
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
@@ -117,6 +112,7 @@ public class Bug200558Test extends ViewerTestCase {
 		return (TreeViewer) fViewer;
 	}
 
+	@Test
 	public void testBug200558() {
 		getTreeViewer().editElement(getTreeViewer().getTree().getItem(0).getData(), 0);
 		assertEquals("Test", ((Text)getTreeViewer().getCellEditors()[0].getControl()).getText());

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug201002TableViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug201002TableViewerTest.java
@@ -27,19 +27,13 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
+import org.junit.Test;
 
 /**
  * @since 3.3
  *
  */
 public class Bug201002TableViewerTest extends ViewerTestCase {
-
-	/**
-	 * @param name
-	 */
-	public Bug201002TableViewerTest(String name) {
-		super(name);
-	}
 
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
@@ -89,6 +83,7 @@ public class Bug201002TableViewerTest extends ViewerTestCase {
 		return (TableViewer) fViewer;
 	}
 
+	@Test
 	public void testBug201002() {
 		getTableViewer().getTable().setTopIndex(0);
 		waitForTopIndexUpdate(true);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug201002TreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug201002TreeViewerTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 
 import org.eclipse.jface.viewers.CellEditor;
@@ -26,6 +28,7 @@ import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.TreeColumn;
+import org.junit.Test;
 
 /**
  * @since 3.3
@@ -55,13 +58,6 @@ public class Bug201002TreeViewerTest extends ViewerTestCase {
 
 			return rv;
 		}
-	}
-	/**
-	 * @param name
-	 */
-	public Bug201002TreeViewerTest(String name) {
-		super(name);
-		// TODO Auto-generated constructor stub
 	}
 
 	@Override
@@ -158,6 +154,7 @@ public class Bug201002TreeViewerTest extends ViewerTestCase {
 		return (TreeViewer) fViewer;
 	}
 
+	@Test
 	public void testBug201002() {
 		getTreeViewer().getTree().setTopItem(
 				getTreeViewer().getTree().getItem(0));
@@ -169,10 +166,7 @@ public class Bug201002TreeViewerTest extends ViewerTestCase {
 
 		}
 
-		assertEquals(true,
-				getTreeViewer().getTree().getTopItem() != getTreeViewer()
-						.getTree().getItem(0));
+		assertTrue(getTreeViewer().getTree().getTopItem() != getTreeViewer().getTree().getItem(0));
 	}
-
 
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug205700TreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug205700TreeViewerTest.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,10 +26,11 @@ import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Shell;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
-public class Bug205700TreeViewerTest extends TestCase {
+public class Bug205700TreeViewerTest {
 
 	private Shell shell;
 
@@ -41,8 +44,8 @@ public class Bug205700TreeViewerTest extends TestCase {
 
 	private final TreeNode child10 = new TreeNode("Child10");
 
-	@Override
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		shell = new Shell();
 
 		viewer = new TreeViewer(shell, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL);
@@ -55,11 +58,12 @@ public class Bug205700TreeViewerTest extends TestCase {
 		shell.open();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		shell.close();
 	}
 
+	@Test
 	public void testAddWithoutSorter() throws Exception {
 		assertItemNames(new String[] { "Child1", "Child5", "Child10" });
 
@@ -94,6 +98,7 @@ public class Bug205700TreeViewerTest extends TestCase {
 		assertEquals("at " + index, name, viewer.getTree().getItem(index).getText());
 	}
 
+	@Test
 	public void testAddWithSorter() throws Exception {
 		assertItemNames(new String[] { "Child1", "Child5", "Child10" });
 		viewer.setComparator(new ViewerComparator());
@@ -113,6 +118,7 @@ public class Bug205700TreeViewerTest extends TestCase {
 				"Child8", "Child9" });
 	}
 
+	@Test
 	public void testAddEquallySortedElements() throws Exception {
 		assertItemNames(new String[] { "Child1", "Child5", "Child10" });
 		viewer.setComparator(new ViewerComparator());

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug242231Test.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug242231Test.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.ComboBoxCellEditor;
@@ -22,6 +24,7 @@ import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
+import org.junit.Test;
 
 /**
  * This testcase for Bug 242231 checks that applyEditorValue(), which has been
@@ -31,13 +34,6 @@ import org.eclipse.swt.widgets.Composite;
  * @since 3.5
  */
 public class Bug242231Test extends ViewerTestCase {
-
-	/**
-	 * @param name
-	 */
-	public Bug242231Test(String name) {
-		super(name);
-	}
 
 	protected static final String[] COMBO_ITEMS = new String[] { "default value", "some value", "value changed" };
 	private TableViewer tableViewer;
@@ -82,6 +78,7 @@ public class Bug242231Test extends ViewerTestCase {
 		};
 	}
 
+	@Test
 	public void testBug242231() {
 		// get a test element from the model and set the label to a known value
 		TestElement testElement = fRootElement.getChildAt(0);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug256889TableViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug256889TableViewerTest.java
@@ -24,6 +24,8 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
+import org.junit.Before;
+import org.junit.Test;
 
 public class Bug256889TableViewerTest extends ViewerTestCase {
 
@@ -36,14 +38,6 @@ public class Bug256889TableViewerTest extends ViewerTestCase {
 	private List<String> model = new ArrayList<>();
 	private Table table;
 	private TableViewer tableViewer;
-
-	/**
-	 * @param name
-	 */
-	public Bug256889TableViewerTest(String name) {
-		super(name);
-		initModel();
-	}
 
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
@@ -117,7 +111,8 @@ public class Bug256889TableViewerTest extends ViewerTestCase {
 		fShell.setSize(300, 1000);
 	}
 
-	private void initModel() {
+	@Before
+	public void initModel() {
 		this.rowcounter = 0;
 		getModel().clear();
 		addElementsToModel();
@@ -153,6 +148,7 @@ public class Bug256889TableViewerTest extends ViewerTestCase {
 		return this.model;
 	}
 
+	@Test
 	public void testBug256889() {
 		table.selectAll();
 		tableViewer.getStructuredSelection();

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug287765Test.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug287765Test.java
@@ -27,14 +27,15 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Shell;
-
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * @since 3.4
  *
  */
-public class Bug287765Test extends TestCase {
+public class Bug287765Test {
 	private TreeViewer treeViewer;
 	private Node root;
 
@@ -127,10 +128,8 @@ public class Bug287765Test extends TestCase {
 		}
 	}
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-
+	@Before
+	public void setUp() throws Exception {
 		final Shell shell = new Shell();
 		shell.setLayout(new GridLayout());
 		shell.setSize(new Point(500, 200));
@@ -158,17 +157,17 @@ public class Bug287765Test extends TestCase {
 		shell.open();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		treeViewer.getControl().getShell().dispose();
 		treeViewer = null;
 		root = null;
-		super.tearDown();
 	}
 
 	/**
 	 * Test to make the bug occur
 	 */
+	@Test
 	public void testException() {
 		// Expand all the nodes
 		treeViewer.expandAll();

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug553483ViewerDropAdapterTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/Bug553483ViewerDropAdapterTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.jface.util.LocalSelectionTransfer;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ITreeContentProvider;
@@ -31,13 +34,14 @@ import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
-
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  *
  */
-public class Bug553483ViewerDropAdapterTest extends TestCase {
+public class Bug553483ViewerDropAdapterTest {
 
 	private Display display;
 	private Shell shell;
@@ -47,7 +51,7 @@ public class Bug553483ViewerDropAdapterTest extends TestCase {
 	private Point tgtPos2;
 	private int numberOfDrops;
 
-	@Override
+	@Before
 	public void setUp() throws Exception {
 		display = new Display();
 		shell = new Shell(display);
@@ -106,13 +110,14 @@ public class Bug553483ViewerDropAdapterTest extends TestCase {
 		}
 	}
 
-	@Override
+	@After
 	public void tearDown() throws Exception {
 		assertTrue(shell.isDisposed());
 
 		display.dispose();
 	}
 
+	@Test
 	public void testBug553483() {
 		boolean copyWasPosted = false;
 		boolean moveWasPosted = false;

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/CComboViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/CComboViewerTest.java
@@ -18,14 +18,12 @@ import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.widgets.Composite;
+import org.junit.Ignore;
 
 /**
  * @since 3.0
  */
 public class CComboViewerTest extends StructuredViewerTest {
-	public CComboViewerTest(String name) {
-		super(name);
-	}
 
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
@@ -48,14 +46,8 @@ public class CComboViewerTest extends StructuredViewerTest {
 		return list.getItem(at);
 	}
 
-	public static void main(String args[]) {
-		junit.textui.TestRunner.run(CComboViewerTest.class);
-	}
-
-	/**
-	 * TODO: Determine if this test is applicable to ComboViewer
-	 */
 	@Override
+	@Ignore("TODO: Determine if this test is applicable to ComboViewer")
 	public void testInsertChild() {
 
 	}

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/CheckboxTableViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/CheckboxTableViewerTest.java
@@ -13,6 +13,12 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,6 +38,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
+import org.junit.Test;
 
 public class CheckboxTableViewerTest extends TableViewerTest {
 	public static class CheckboxTableTestLabelProvider extends TestLabelProvider implements ITableLabelProvider {
@@ -61,9 +68,6 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 	}
 
 	public static class DeprecatedConstructor extends CheckboxTableViewerTest {
-		public DeprecatedConstructor(String name) {
-			super(name);
-		}
 
 		@Override
 		protected StructuredViewer createViewer(Composite parent) {
@@ -94,6 +98,7 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 			return viewer;
 		}
 
+		@Test
 		@Override
 		public void testViewerColumn() {
 			assertNull(getViewerColumn((TableViewer) fViewer, -1));
@@ -107,9 +112,6 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 	}
 
 	public static class FactoryMethod extends CheckboxTableViewerTest {
-		public FactoryMethod(String name) {
-			super(name);
-		}
 
 		@Override
 		protected StructuredViewer createViewer(Composite parent) {
@@ -139,10 +141,6 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 			viewer.setLabelProvider(new TableTestLabelProvider());
 			return viewer;
 		}
-	}
-
-	public CheckboxTableViewerTest(String name) {
-		super(name);
 	}
 
 	@Override
@@ -173,10 +171,7 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 		return viewer;
 	}
 
-	public static void main(String args[]) {
-		junit.textui.TestRunner.run(CheckboxTableViewerTest.class);
-	}
-
+	@Test
 	public void testCheckAllElements() {
 		CheckboxTableViewer ctv = (CheckboxTableViewer) fViewer;
 		ctv.setAllChecked(true);
@@ -187,6 +182,7 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 		assertTrue(!ctv.getChecked(fRootElement.getLastChild()));
 	}
 
+	@Test
 	public void testGrayAllElements() {
 		CheckboxTableViewer ctv = (CheckboxTableViewer) fViewer;
 		ctv.setAllGrayed(true);
@@ -197,6 +193,7 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 		assertTrue(!ctv.getGrayed(fRootElement.getLastChild()));
 	}
 
+	@Test
 	public void testGrayed() {
 		CheckboxTableViewer ctv = (CheckboxTableViewer) fViewer;
 		TestElement element = fRootElement.getFirstChild();
@@ -215,6 +212,7 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 		ctv.setAllGrayed(false);
 	}
 
+	@Test
 	public void testGrayedElements() {
 		CheckboxTableViewer ctv = (CheckboxTableViewer) fViewer;
 		TestElement first = fRootElement.getFirstChild();
@@ -238,12 +236,14 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 		ctv.setAllGrayed(false);
 	}
 
+	@Test
 	public void testWithoutCheckProvider() {
 		// Check that without a provider, no exceptions are thrown
 		CheckboxTableViewer ctv = (CheckboxTableViewer) fViewer;
 		ctv.refresh();
 	}
 
+	@Test
 	public void testCheckProviderInvoked() {
 		// Check that a refresh successfully causes the provider's
 		// setChecked and setGrayed methods to be invoked.
@@ -261,18 +261,22 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 		assertTrue("isGrayed should be invoked on a refresh", (!provider.isGrayedInvokedOn.isEmpty()));
 	}
 
+	@Test
 	public void testCheckedFalseGrayedFalse() {
 		testSpecificState(false, false);
 	}
 
+	@Test
 	public void testCheckedFalseGrayedTrue() {
 		testSpecificState(false, true);
 	}
 
+	@Test
 	public void testCheckedTrueGrayedFalse() {
 		testSpecificState(true, false);
 	}
 
+	@Test
 	public void testCheckedTrueGrayedTrue() {
 		testSpecificState(true, true);
 	}
@@ -298,6 +302,7 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 		assertEquals(item.getGrayed(), isGrayed);
 	}
 
+	@Test
 	public void testSetCheckProviderRefreshesItems() {
 		CheckboxTableViewer ctv = (CheckboxTableViewer) fViewer;
 
@@ -319,6 +324,7 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 		ctv.refresh();
 	}
 
+	@Test
 	public void testCheckProviderWithSorter() {
 		CheckboxTableViewer ctv = (CheckboxTableViewer) fViewer;
 
@@ -332,6 +338,7 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 		checkAllStates("Testing checkbox state with a sorter", ctv, 0);
 	}
 
+	@Test
 	public void testCheckProviderWithFilter() {
 		CheckboxTableViewer ctv = (CheckboxTableViewer) fViewer;
 
@@ -358,6 +365,7 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 		}
 	}
 
+	@Test
 	public void testCheckProviderUpdate() {
 		CheckboxTableViewer ctv = (CheckboxTableViewer) fViewer;
 
@@ -415,6 +423,7 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 				item.getGrayed());
 	}
 
+	@Test
 	public void testGetCheckedElements() {
 		CheckboxTableViewer ctv = (CheckboxTableViewer) fViewer;
 
@@ -436,6 +445,7 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 		assertTrue("getCheckedElements should not include any unchecked elements", checked.isEmpty());
 	}
 
+	@Test
 	public void testSetCheckedElements() {
 		CheckboxTableViewer ctv = (CheckboxTableViewer) fViewer;
 
@@ -460,6 +470,7 @@ public class CheckboxTableViewerTest extends TableViewerTest {
 		}
 	}
 
+	@Test
 	public void testSetGrayedElements() {
 		CheckboxTableViewer ctv = (CheckboxTableViewer) fViewer;
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/CheckboxTreeViewerMissingTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/CheckboxTreeViewerMissingTest.java
@@ -19,6 +19,8 @@ package org.eclipse.jface.tests.viewers;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.IBaseLabelProvider;
 import org.eclipse.swt.graphics.Image;
+import org.junit.After;
+import org.junit.Test;
 
 public class CheckboxTreeViewerMissingTest extends CheckboxTreeViewerTest {
 	private static Image testImage;
@@ -40,15 +42,12 @@ public class CheckboxTreeViewerMissingTest extends CheckboxTreeViewerTest {
 
 	}
 
-	public CheckboxTreeViewerMissingTest(String name) {
-		super(name);
-	}
-
 	@Override
 	public IBaseLabelProvider getTestLabelProvider() {
 		return new CheckboxMissingTableTestLabelProvider();
 	}
 
+	@After
 	@Override
 	public void tearDown() {
 		super.tearDown();
@@ -58,6 +57,7 @@ public class CheckboxTreeViewerMissingTest extends CheckboxTreeViewerTest {
 		}
 	}
 
+	@Test
 	@Override
 	public void testLabelProvider() {
 		super.testLabelProvider();

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/CheckboxTreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/CheckboxTreeViewerTest.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -27,6 +31,7 @@ import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.TreeItem;
+import org.junit.Test;
 
 public class CheckboxTreeViewerTest extends TreeViewerTest {
 	public static class CheckboxTableTestLabelProvider extends TestLabelProvider implements ITableLabelProvider {
@@ -55,10 +60,6 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 		}
 	}
 
-	public CheckboxTreeViewerTest(String name) {
-		super(name);
-	}
-
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
 		fTreeViewer = new CheckboxTreeViewer(parent);
@@ -66,10 +67,7 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 		return fTreeViewer;
 	}
 
-	public static void main(String args[]) {
-		junit.textui.TestRunner.run(CheckboxTreeViewerTest.class);
-	}
-
+	@Test
 	public void testCheckSubtree() {
 		CheckboxTreeViewer ctv = (CheckboxTreeViewer) fViewer;
 		TestElement first = fRootElement.getFirstChild();
@@ -87,6 +85,7 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 		assertTrue(!ctv.getChecked(firstfirstfirst));
 	}
 
+	@Test
 	public void testGrayed() {
 		CheckboxTreeViewer ctv = (CheckboxTreeViewer) fViewer;
 		TestElement element = fRootElement.getFirstChild();
@@ -103,6 +102,7 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 		assertTrue(!ctv.getGrayed(element));
 	}
 
+	@Test
 	public void testParentGrayed() {
 		CheckboxTreeViewer ctv = (CheckboxTreeViewer) fViewer;
 		TestElement first = fRootElement.getFirstChild();
@@ -123,6 +123,7 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 		ctv.setParentsGrayed(firstfirstfirst, false);
 	}
 
+	@Test
 	public void testWithoutCheckProvider() {
 		// Check that without a provider, no exceptions are thrown
 		CheckboxTreeViewer ctv = (CheckboxTreeViewer) fViewer;
@@ -130,6 +131,7 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 		ctv.refresh();
 	}
 
+	@Test
 	public void testCheckProviderInvoked() {
 		// Check that a refresh successfully causes the provider's
 		// setChecked and setGrayed methods to be invoked.
@@ -148,6 +150,7 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 
 	}
 
+	@Test
 	public void testCheckProviderLazilyInvoked() {
 		// Check that a refresh successfully causes the provider's
 		// setChecked and setGrayed methods to be invoked.
@@ -179,18 +182,22 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 		}
 	}
 
+	@Test
 	public void testCheckedFalseGrayedFalse() {
 		testSpecificState(false, false);
 	}
 
+	@Test
 	public void testCheckedFalseGrayedTrue() {
 		testSpecificState(false, true);
 	}
 
+	@Test
 	public void testCheckedTrueGrayedFalse() {
 		testSpecificState(true, false);
 	}
 
+	@Test
 	public void testCheckedTrueGrayedTrue() {
 		testSpecificState(true, true);
 	}
@@ -216,6 +223,7 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 		assertEquals(item.getGrayed(), isGrayed);
 	}
 
+	@Test
 	public void testSetCheckProviderRefreshesItems() {
 		CheckboxTreeViewer ctv = (CheckboxTreeViewer) fViewer;
 
@@ -239,6 +247,7 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 		ctv.refresh();
 	}
 
+	@Test
 	public void testCheckProviderWithSorter() {
 		CheckboxTreeViewer ctv = (CheckboxTreeViewer) fViewer;
 
@@ -253,6 +262,7 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 		checkAllStates("Testing checkbox state with a sorter", ctv, 0);
 	}
 
+	@Test
 	public void testCheckProviderWithFilter() {
 		CheckboxTreeViewer ctv = (CheckboxTreeViewer) fViewer;
 
@@ -280,6 +290,7 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 		}
 	}
 
+	@Test
 	public void testSetNewCheckProvider() {
 		CheckboxTreeViewer ctv = (CheckboxTreeViewer) fViewer;
 
@@ -351,6 +362,7 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 				item.getGrayed());
 	}
 
+	@Test
 	public void testGetCheckedElements() {
 		CheckboxTreeViewer ctv = (CheckboxTreeViewer) fViewer;
 
@@ -372,6 +384,7 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 		assertTrue("getCheckedElements should not include any unchecked elements", checked.isEmpty());
 	}
 
+	@Test
 	public void testSetCheckedElements() {
 		CheckboxTreeViewer ctv = (CheckboxTreeViewer) fViewer;
 
@@ -396,6 +409,7 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 		}
 	}
 
+	@Test
 	public void testSetGrayedElements() {
 		CheckboxTreeViewer ctv = (CheckboxTreeViewer) fViewer;
 
@@ -419,6 +433,7 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 		}
 	}
 
+	@Test
 	@SuppressWarnings("deprecation")
 	public void testSetAllChecked() {
 		CheckboxTreeViewer ctv = (CheckboxTreeViewer) fViewer;
@@ -439,6 +454,7 @@ public class CheckboxTreeViewerTest extends TreeViewerTest {
 		}
 	}
 
+	@Test
 	public void testSetGrayChecked() {
 		CheckboxTreeViewer ctv = (CheckboxTreeViewer) fViewer;
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/ComboViewerComparerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/ComboViewerComparerTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import org.eclipse.jface.util.ILogger;
 import org.eclipse.jface.util.ISafeRunnableRunner;
 import org.eclipse.jface.util.Policy;
@@ -27,10 +30,11 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
-public class ComboViewerComparerTest extends TestCase {
+public class ComboViewerComparerTest {
 
 	private Shell shell;
 
@@ -53,6 +57,7 @@ public class ComboViewerComparerTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testSetSelection() {
 		viewer.setContentProvider(ArrayContentProvider.getInstance());
 		viewer.setComparer(new IElementComparer() {
@@ -80,8 +85,8 @@ public class ComboViewerComparerTest extends TestCase {
 		assertEquals(aElement.getName(), selectedElement.getName());
 	}
 
-	@Override
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		oldLogger = Policy.getLog();
 		oldRunner = SafeRunnable.getRunner();
 		Policy.setLog(status -> fail(status.getMessage()));
@@ -103,8 +108,8 @@ public class ComboViewerComparerTest extends TestCase {
 		shell.open();
 	}
 
-	@Override
-	protected void tearDown() {
+	@After
+	public void tearDown() {
 		Policy.setLog(oldLogger);
 		SafeRunnable.setRunner(oldRunner);
 		processEvents();

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/ComboViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/ComboViewerTest.java
@@ -17,14 +17,12 @@ import org.eclipse.jface.viewers.ComboViewer;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
+import org.junit.Ignore;
 
 /**
  * @since 3.0
  */
 public class ComboViewerTest extends StructuredViewerTest {
-	public ComboViewerTest(String name) {
-		super(name);
-	}
 
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
@@ -46,13 +44,7 @@ public class ComboViewerTest extends StructuredViewerTest {
 		return list.getItem(at);
 	}
 
-	public static void main(String args[]) {
-		junit.textui.TestRunner.run(ComboViewerTest.class);
-	}
-
-	/**
-	 * TODO: Determine if this test is applicable to ComboViewer
-	 */
+	@Ignore("TODO: Determine if this test is applicable to ComboViewer")
 	@Override
 	public void testInsertChild() {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/LazySortedCollectionTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/LazySortedCollectionTest.java
@@ -14,31 +14,22 @@
 package org.eclipse.jface.tests.viewers;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.TreeSet;
 
 import org.eclipse.jface.viewers.deferred.LazySortedCollection;
+import org.junit.After;
 import org.junit.Assert;
-
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * @since 3.1
  */
-public class LazySortedCollectionTest extends TestCase {
-
-	public static void main(String[] args) {
-		junit.textui.TestRunner.run(LazySortedCollectionTest.class);
-	}
-
-	public static Test suite() {
-		return new TestSuite(LazySortedCollectionTest.class);
-	}
-
+public class LazySortedCollectionTest {
 	private TestComparator comparator;
 	private TestComparator comparisonComparator;
 
@@ -72,10 +63,8 @@ public class LazySortedCollectionTest extends TestCase {
 		}
 	}
 
-	@Override
-	protected void setUp() throws Exception {
-		System.out.println("--- " + getName());
-
+	@Before
+	public void setUp() throws Exception {
 		comparator = new TestComparator();
 		collection = new LazySortedCollection(comparator);
 		// Ensure a predictable tree structure
@@ -85,17 +74,13 @@ public class LazySortedCollectionTest extends TestCase {
 		comparisonCollection = new TreeSet<>(comparisonComparator);
 
 		addAll(elements);
-
-		super.setUp();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		System.out.println("Comparisons required by lazy collection: " + comparator.comparisons);
 		System.out.println("Comparisons required by reference implementation: " + comparisonComparator.comparisons);
 		System.out.println("");
-
-		super.tearDown();
 	}
 
 	/**
@@ -217,6 +202,7 @@ public class LazySortedCollectionTest extends TestCase {
 		return result;
 	}
 
+	@Test
 	public void testComparisonCount() {
 		assertEquals("additions should not require any comparisons", 0, comparator.comparisons);
 
@@ -232,6 +218,7 @@ public class LazySortedCollectionTest extends TestCase {
 	 *
 	 * @since 3.1
 	 */
+	@Test
 	public void testSortAll() {
 		// Test that sorting the entire array works
 		queryRange(0, elements.length, true);
@@ -249,6 +236,7 @@ public class LazySortedCollectionTest extends TestCase {
 	/**
 	 * Tests LazySortedCollection.removeNode(int) when removing a leaf node
 	 */
+	@Test
 	public void testRemoveLeafNode() {
 		forceFullSort();
 		remove(se[9]);
@@ -259,6 +247,7 @@ public class LazySortedCollectionTest extends TestCase {
 	 * Tests LazySortedCollection.removeNode(int) when removing a node with no left
 	 * child
 	 */
+	@Test
 	public void testRemoveNodeWithNoLeftChild() {
 		forceFullSort();
 		remove(se[23]);
@@ -271,6 +260,7 @@ public class LazySortedCollectionTest extends TestCase {
 	 *
 	 * @since 3.1
 	 */
+	@Test
 	public void testRemoveNodeWithNoRightChild() {
 		forceFullSort();
 		remove(se[13]);
@@ -282,6 +272,7 @@ public class LazySortedCollectionTest extends TestCase {
 	 *
 	 * @since 3.1
 	 */
+	@Test
 	public void testRemoveRootNode() {
 		forceFullSort();
 		remove(se[19]);
@@ -295,6 +286,7 @@ public class LazySortedCollectionTest extends TestCase {
 	 *
 	 * @since 3.1
 	 */
+	@Test
 	public void testRemoveWhereSwappedNodeIsntLeaf() {
 		forceFullSort();
 		remove(se[14]);
@@ -308,6 +300,7 @@ public class LazySortedCollectionTest extends TestCase {
 	 *
 	 * @since 3.1
 	 */
+	@Test
 	public void testRemoveWithUnsortedSwap() {
 		// Ensure that we've sorted nodes 13 and 14
 		queryRange(14, 1, true);
@@ -340,6 +333,7 @@ public class LazySortedCollectionTest extends TestCase {
 	 *
 	 * @since 3.1
 	 */
+	@Test
 	public void testRemoveFromUnsorted() {
 		remove(se[10]);
 		assertContentsValid();
@@ -350,6 +344,7 @@ public class LazySortedCollectionTest extends TestCase {
 	 *
 	 * @since 3.1
 	 */
+	@Test
 	public void testRemoveRootFromUnsorted() {
 		remove(se[19]);
 		assertContentsValid();
@@ -360,6 +355,7 @@ public class LazySortedCollectionTest extends TestCase {
 	 *
 	 * @since 3.1
 	 */
+	@Test
 	public void testRemoveUnknown() {
 		remove("some unknown element");
 		assertContentsValid();
@@ -374,6 +370,7 @@ public class LazySortedCollectionTest extends TestCase {
 	 *
 	 * @since 3.1
 	 */
+	@Test
 	public void testRemovePreviouslySwappedNode() {
 		queryRange(0, elements.length, true);
 		remove(se[14]);
@@ -389,6 +386,7 @@ public class LazySortedCollectionTest extends TestCase {
 	 *
 	 * @since 3.1
 	 */
+	@Test
 	public void testRemoveFullRange() {
 		removeRange(0, se.length);
 		assertContentsValid();
@@ -399,6 +397,7 @@ public class LazySortedCollectionTest extends TestCase {
 	 *
 	 * @since 3.1
 	 */
+	@Test
 	public void testRemoveFromStart() {
 		removeRange(0, se.length / 2);
 		assertContentsValid();
@@ -409,6 +408,7 @@ public class LazySortedCollectionTest extends TestCase {
 	 *
 	 * @since 3.1
 	 */
+	@Test
 	public void testRemoveFromEnd() {
 		int start = se.length / 2;
 		removeRange(start, se.length - start);
@@ -421,6 +421,7 @@ public class LazySortedCollectionTest extends TestCase {
 	 *
 	 * @since 3.1
 	 */
+	@Test
 	public void testRemoveIncludingRoot() {
 		removeRange(14, 6);
 		assertContentsValid();
@@ -432,6 +433,7 @@ public class LazySortedCollectionTest extends TestCase {
 	 * Tests moving an entire right subtree, and a left subtree including the tree
 	 * itself
 	 */
+	@Test
 	public void testRemoveRightSubtree() {
 		removeRange(9, 5);
 		assertContentsValid();
@@ -440,6 +442,7 @@ public class LazySortedCollectionTest extends TestCase {
 	/**
 	 * Test boundary conditions: Tests moving an entire left subtree
 	 */
+	@Test
 	public void testRemoveLeftSubtree() {
 		removeRange(3, 4);
 		assertContentsValid();
@@ -449,16 +452,19 @@ public class LazySortedCollectionTest extends TestCase {
 	 * Test boundary conditions: Tests moving an entire left subtree including the
 	 * tree itself
 	 */
+	@Test
 	public void testRemoveRightIncludingRoot() {
 		removeRange(3, 5);
 		assertContentsValid();
 	}
 
+	@Test
 	public void testClear() {
 		clear();
 		assertContentsValid();
 	}
 
+	@Test
 	public void testClearSorted() {
 		forceFullSort();
 		clear();

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/ListViewerComparatorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/ListViewerComparatorTest.java
@@ -14,24 +14,20 @@
 
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.jface.viewers.ListViewer;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.jface.viewers.ViewerSorter;
 import org.eclipse.swt.widgets.Composite;
+import org.junit.Test;
 
 /**
  * @since 3.2
  *
  */
 public class ListViewerComparatorTest extends ViewerComparatorTest {
-
-	/**
-	 * @param name
-	 */
-	public ListViewerComparatorTest(String name) {
-		super(name);
-	}
 
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
@@ -41,12 +37,14 @@ public class ListViewerComparatorTest extends ViewerComparatorTest {
 		return viewer;
 	}
 
+	@Test
 	@SuppressWarnings("deprecation")
 	public void testViewerSorter() {
 		fViewer.setSorter(new ViewerSorter());
 		assertSortedResult(TEAM1_SORTED);
 	}
 
+	@Test
 	@SuppressWarnings("deprecation")
 	public void testViewerSorterInsertElement() {
 		fViewer.setSorter(new ViewerSorter());
@@ -54,11 +52,13 @@ public class ListViewerComparatorTest extends ViewerComparatorTest {
 		assertSortedResult(TEAM1_SORTED_WITH_INSERT);
 	}
 
+	@Test
 	public void testViewerComparator() {
 		fViewer.setComparator(new ViewerComparator());
 		assertSortedResult(TEAM1_SORTED);
 	}
 
+	@Test
 	public void testViewerComparatorInsertElement() {
 		fViewer.setComparator(new ViewerComparator());
 		team1.addMember("Duong");
@@ -80,13 +80,6 @@ public class ListViewerComparatorTest extends ViewerComparatorTest {
 
 	protected ListViewer getListViewer() {
 		return (ListViewer) fViewer;
-	}
-
-	/**
-	 * @param args
-	 */
-	public static void main(String[] args) {
-		junit.textui.TestRunner.run(ListViewerComparatorTest.class);
 	}
 
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/ListViewerRefreshTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/ListViewerRefreshTest.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import java.util.ArrayList;
@@ -30,10 +31,11 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
-public class ListViewerRefreshTest extends TestCase {
+public class ListViewerRefreshTest {
 	/**
 	 * Used for viewing the UI. Set to 0 if not wanting to see the UI.
 	 */
@@ -47,8 +49,8 @@ public class ListViewerRefreshTest extends TestCase {
 
 	private ArrayList<String> input = null;
 
-	@Override
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		shell = new Shell();
 		shell.setSize(400, 200);
 		shell.setLayout(new FillLayout());
@@ -66,8 +68,8 @@ public class ListViewerRefreshTest extends TestCase {
 		shell.open();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		shell.dispose();
 		shell = null;
 	}
@@ -78,6 +80,7 @@ public class ListViewerRefreshTest extends TestCase {
 	 *
 	 * @throws Exception
 	 */
+	@Test
 	public void testNoSelectionRefresh() throws Exception {
 		shell.setText("Lost Scrolled Position Test"); //$NON-NLS-1$
 		readAndDispatch();
@@ -98,6 +101,7 @@ public class ListViewerRefreshTest extends TestCase {
 	 *
 	 * @throws Exception
 	 */
+	@Test
 	public void testSelectionRefresh() throws Exception {
 		shell.setText("Preserved Scrolled Position Test"); //$NON-NLS-1$
 		readAndDispatch();

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/ListViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/ListViewerTest.java
@@ -17,7 +17,11 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assume.assumeFalse;
 
 import org.eclipse.jface.util.Util;
 import org.eclipse.jface.viewers.ListViewer;
@@ -29,12 +33,9 @@ import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.List;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
+import org.junit.Test;
 
 public class ListViewerTest extends StructuredViewerTest {
-
-	public ListViewerTest(String name) {
-		super(name);
-	}
 
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
@@ -56,10 +57,7 @@ public class ListViewerTest extends StructuredViewerTest {
 		return list.getItem(at);
 	}
 
-	public static void main(String args[]) {
-		junit.textui.TestRunner.run(ListViewerTest.class);
-	}
-
+	@Test
 	public void testInsert() {
 		ListViewer v = ((ListViewer)fViewer);
 		TestElement element = new TestElement(fModel, fRootElement);
@@ -84,12 +82,10 @@ public class ListViewerTest extends StructuredViewerTest {
 		v.remove(element1);
 	}
 
+	@Test
 	public void testRevealBug69076() {
-		// TODO remove the Mac OS check when SWT has fixed the bug in List.java
-		// see bug 116105
-		if (Util.isLinux()) {
-			return;
-		}
+		assumeFalse("See bug 116105", Util.isLinux());
+
 		fViewer = null;
 		if (fShell != null) {
 			fShell.dispose();
@@ -123,6 +119,7 @@ public class ListViewerTest extends StructuredViewerTest {
 	 *
 	 * @throws Exception
 	 */
+	@Test
 	public void testRefreshBug141435() throws Exception {
 		fViewer = null;
 		if (fShell != null) {
@@ -163,6 +160,7 @@ public class ListViewerTest extends StructuredViewerTest {
 		}
 	}
 
+	@Test
 	public void testSelectionRevealBug177619() throws Exception {
 		TestElement model = TestElement.createModel(1, 100);
 		fViewer.setInput(model);
@@ -174,6 +172,7 @@ public class ListViewerTest extends StructuredViewerTest {
 		});
 	}
 
+	@Test
 	public void testSelectionNoRevealBug177619() throws Exception {
 		TestElement model = TestElement.createModel(1, 100);
 		fViewer.setInput(model);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/MultipleEqualElementsTreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/MultipleEqualElementsTreeViewerTest.java
@@ -13,6 +13,11 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -24,6 +29,7 @@ import org.eclipse.jface.viewers.TreeSelection;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.swt.widgets.Widget;
+import org.junit.Test;
 
 /**
  * Tests TreeViewer's support for multiple equal elements ().
@@ -61,10 +67,6 @@ public class MultipleEqualElementsTreeViewerTest extends TreeViewerTest {
 	private TreePath treePath_1_2;
 
 	private TreePath treePath_2;
-
-	public MultipleEqualElementsTreeViewerTest(String name) {
-		super(name);
-	}
 
 	public TreeViewer getTreeViewer() {
 		return (TreeViewer) fViewer;
@@ -106,6 +108,7 @@ public class MultipleEqualElementsTreeViewerTest extends TreeViewerTest {
 		fModel = fRootElement.getModel();
 	}
 
+	@Test
 	public void testElementMap() {
 		getTreeViewer().expandToLevel(element_1, AbstractTreeViewer.ALL_LEVELS);
 		getTreeViewer().expandToLevel(element_2, AbstractTreeViewer.ALL_LEVELS);
@@ -115,6 +118,7 @@ public class MultipleEqualElementsTreeViewerTest extends TreeViewerTest {
 		assertEquals(4, getTreeViewer().testFindItems(element_2_1_2).length);
 	}
 
+	@Test
 	public void testSelection() {
 		getTreeViewer().expandToLevel(element_1, AbstractTreeViewer.ALL_LEVELS);
 		getTreeViewer().expandToLevel(element_2, AbstractTreeViewer.ALL_LEVELS);
@@ -141,6 +145,7 @@ public class MultipleEqualElementsTreeViewerTest extends TreeViewerTest {
 		assertMatchingPath(treePath_2_21_212, getTreeViewer().getTree().getSelection()[0]);
 	}
 
+	@Test
 	public void testExpansion() {
 		getTreeViewer().expandToLevel(treePath_1_21_212, 1);
 		assertEqualsArray("element expansion", new Object[] { element_1, element_2_1 },
@@ -163,6 +168,7 @@ public class MultipleEqualElementsTreeViewerTest extends TreeViewerTest {
 		assertNull(item);
 	}
 
+	@Test
 	public void testUpdate() {
 		// materialize
 		getTreeViewer().setExpandedTreePaths(new TreePath[] { treePath_1_2_21, treePath_2_21 });
@@ -178,6 +184,7 @@ public class MultipleEqualElementsTreeViewerTest extends TreeViewerTest {
 		}
 	}
 
+	@Test
 	public void testAddWithoutMaterialize() {
 		TestElement newElement = element_2.addChild(TestModelChange.INSERT);
 		getTreeViewer().setExpandedTreePaths(new TreePath[] { treePath_1_2_21, treePath_2_21 });
@@ -185,6 +192,7 @@ public class MultipleEqualElementsTreeViewerTest extends TreeViewerTest {
 		assertEquals(2, items.length);
 	}
 
+	@Test
 	public void testAddAfterMaterialize() {
 		// materialize before adding
 		getTreeViewer().setExpandedTreePaths(new TreePath[] { treePath_1_2_21, treePath_2_21 });
@@ -194,6 +202,7 @@ public class MultipleEqualElementsTreeViewerTest extends TreeViewerTest {
 		assertEquals(2, items.length);
 	}
 
+	@Test
 	public void testRemoveWithParentAfterMaterialize() {
 		// materialize
 		getTreeViewer().expandToLevel(element_1, AbstractTreeViewer.ALL_LEVELS);
@@ -205,6 +214,7 @@ public class MultipleEqualElementsTreeViewerTest extends TreeViewerTest {
 		assertEquals(2, getTreeViewer().testFindItems(element_2_1_2).length);
 	}
 
+	@Test
 	public void testRemoveWithParentBeforeMaterialize() {
 		element_2.basicDeleteChild(element_2_1);
 		getTreeViewer().remove(element_2, new Object[] { element_2_1 });

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/SimpleTableViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/SimpleTableViewerTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.jface.viewers.ILabelProviderListener;
@@ -28,6 +30,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.ui.tests.harness.util.Mocks;
+import org.junit.Test;
 
 /**
  * @since 3.2
@@ -37,13 +40,6 @@ public class SimpleTableViewerTest extends ViewerTestCase {
 
 	private TableViewer tableViewer;
 
-	/**
-	 * @param name
-	 */
-	public SimpleTableViewerTest(String name) {
-		super(name);
-	}
-
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
 		tableViewer = new TableViewer(parent);
@@ -51,6 +47,7 @@ public class SimpleTableViewerTest extends ViewerTestCase {
 		return tableViewer;
 	}
 
+	@Test
 	public void testNullLabel() {
 		tableViewer.setLabelProvider(new ITableLabelProvider() {
 
@@ -83,6 +80,7 @@ public class SimpleTableViewerTest extends ViewerTestCase {
 		});
 	}
 
+	@Test
 	public void testLabelProviderListeners() {
 		Table table = tableViewer.getTable();
 		new TableColumn(table, SWT.NONE);
@@ -112,6 +110,7 @@ public class SimpleTableViewerTest extends ViewerTestCase {
 		Mocks.verify(mockLabelProvider);
 	}
 
+	@Test
 	public void testLabelProviderListenersWithColumn() {
 		Table table = tableViewer.getTable();
 		new TableColumn(table, SWT.NONE);
@@ -139,6 +138,7 @@ public class SimpleTableViewerTest extends ViewerTestCase {
 		assertEquals(0, listenerCounter[0]);
 	}
 
+	@Test
 	public void testColumnLabelProviderListeners() {
 		Table table = tableViewer.getTable();
 		new TableColumn(table, SWT.NONE);
@@ -166,6 +166,7 @@ public class SimpleTableViewerTest extends ViewerTestCase {
 		assertEquals(1, disposeCounter[0]);
 	}
 
+	@Test
 	public void testCellLabelProviderDispose() {
 		final int[] disposeCounter = { 0 };
 		tableViewer.setLabelProvider(new ColumnLabelProvider() {

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/SimpleTreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/SimpleTreeViewerTest.java
@@ -15,6 +15,9 @@
 
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import org.eclipse.jface.viewers.ILabelProviderListener;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.ITableLabelProvider;
@@ -31,6 +34,7 @@ import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
+import org.junit.Test;
 
 /**
  * @since 3.2
@@ -40,13 +44,6 @@ public class SimpleTreeViewerTest extends ViewerTestCase {
 
 	private TreeViewer treeViewer;
 
-	/**
-	 * @param name
-	 */
-	public SimpleTreeViewerTest(String name) {
-		super(name);
-	}
-
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
 		treeViewer = new TreeViewer(parent);
@@ -54,12 +51,14 @@ public class SimpleTreeViewerTest extends ViewerTestCase {
 		return treeViewer;
 	}
 
+	@Test
 	@SuppressWarnings("deprecation")
 	public void testSetTreePathViewerSorterOnNullInput() {
 		treeViewer.setInput(null);
 		treeViewer.setSorter(new TreePathViewerSorter());
 	}
 
+	@Test
 	public void testNullLabel() {
 		treeViewer.setLabelProvider(new ITableLabelProvider() {
 
@@ -104,6 +103,7 @@ public class SimpleTreeViewerTest extends ViewerTestCase {
 		}
 	}
 
+	@Test
 	public void testBug184441() {
 		MyViewerSorter sorter = new MyViewerSorter();
 		treeViewer.setComparator(sorter);
@@ -118,6 +118,7 @@ public class SimpleTreeViewerTest extends ViewerTestCase {
 		treeViewer.removeSelectionChangedListener(listener);
 	}
 
+	@Test
 	public void testBug184712() {
 		class TableAndTreeLabelProvider extends LabelProvider implements ITableLabelProvider {
 			@Override
@@ -139,6 +140,7 @@ public class SimpleTreeViewerTest extends ViewerTestCase {
 		assertEquals("right", treeViewer.getTree().getItem(0).getText());
 	}
 
+	@Test
 	public void test327004() {
 		treeViewer.setInput(null);
 		treeViewer.setContentProvider(new TreeNodeContentProvider());

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/SimpleVirtualLazyTreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/SimpleVirtualLazyTreeViewerTest.java
@@ -15,6 +15,10 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+
 import org.eclipse.jface.viewers.ILazyTreeContentProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.StructuredViewer;
@@ -28,6 +32,8 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Tests TreeViewer's VIRTUAL support with a lazy content provider.
@@ -90,10 +96,6 @@ public class SimpleVirtualLazyTreeViewerTest extends ViewerTestCase {
 		}
 	}
 
-	public SimpleVirtualLazyTreeViewerTest(String name) {
-		super(name);
-	}
-
 	public TreeViewer getTreeViewer() {
 		return (TreeViewer) fViewer;
 	}
@@ -109,6 +111,7 @@ public class SimpleVirtualLazyTreeViewerTest extends ViewerTestCase {
 	 */
 	protected boolean setDataCalled = false;
 
+	@Before
 	@Override
 	public void setUp() {
 		super.setUp();
@@ -130,11 +133,10 @@ public class SimpleVirtualLazyTreeViewerTest extends ViewerTestCase {
 		return treeViewer;
 	}
 
+	@Test
 	public void testCreation() {
-		if (disableTestsBug347491) {
-			System.out.println(getName() + " disabled due to Bug 347491");
-			return;
-		}
+		assumeFalse("disabled due to Bug 347491", disableTestsBug347491);
+		
 		assertTrue("SWT.SetData not received", setDataCalled);
 		processEvents();
 		assertTrue("tree should have items", getTreeViewer().getTree().getItemCount() > 0);
@@ -144,6 +146,7 @@ public class SimpleVirtualLazyTreeViewerTest extends ViewerTestCase {
 		assertEquals("R-0", getTreeViewer().getTree().getItem(0).getText());
 	}
 
+	@Test
 	public void testExpand() {
 		processEvents();
 		Tree tree = getTreeViewer().getTree();
@@ -176,25 +179,25 @@ public class SimpleVirtualLazyTreeViewerTest extends ViewerTestCase {
 		}
 	}
 
+	@Test
 	@SuppressWarnings("deprecation")
 	public void testSetSorterOnNullInput() {
 		fViewer.setInput(null);
 		fViewer.setSorter(new ViewerSorter());
 	}
 
+	@Test
 	public void testSetComparatorOnNullInput() {
 		fViewer.setInput(null);
 		fViewer.setComparator(new ViewerComparator());
 	}
 
 	/* test TreeViewer.remove(parent, index) */
+	@Test
 	public void testRemoveAt() {
+		assumeFalse("disabled due to Bug 347491", disableTestsBug347491);
 		assertTrue("expected less than " + (NUM_ROOTS / 2) + " but got " + updateElementCallCount,
 				updateElementCallCount < NUM_ROOTS / 2);
-		if (disableTestsBug347491) {
-			System.out.println(getName() + " disabled due to Bug 347491");
-			return;
-		}
 		assertTrue("SWT.SetData not received", setDataCalled);
 		TreeViewer treeViewer = (TreeViewer) fViewer;
 		// correct what the content provider is answering with

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/StructuredItemViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/StructuredItemViewerTest.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.jface.viewers.AbstractTreeViewer;
 import org.eclipse.jface.viewers.ICheckable;
+import org.junit.Test;
 
 public abstract class StructuredItemViewerTest extends StructuredViewerTest {
 
-	public StructuredItemViewerTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testCheckElement() {
 
 		if (fViewer instanceof ICheckable ctv) {

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/StructuredSelectionTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/StructuredSelectionTest.java
@@ -14,16 +14,19 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.jface.viewers.IElementComparer;
 import org.eclipse.jface.viewers.StructuredSelection;
+import org.junit.Test;
 
-import junit.framework.TestCase;
-
-public class StructuredSelectionTest extends TestCase {
+public class StructuredSelectionTest {
 
 	static final IElementComparer JAVA_LANG_OBJECT_COMPARER = new IElementComparer() {
 		@Override
@@ -51,14 +54,7 @@ public class StructuredSelectionTest extends TestCase {
 		}
 	};
 
-	public StructuredSelectionTest(String name) {
-		super(name);
-	}
-
-	public static void main(String args[]) {
-		junit.textui.TestRunner.run(StructuredSelectionTest.class);
-	}
-
+	@Test
 	public void testEquals() {
 		String element = "A selection";
 		StructuredSelection sel1 = new StructuredSelection(element);
@@ -67,6 +63,7 @@ public class StructuredSelectionTest extends TestCase {
 		EqualsHashCodeContractTestHelper.testExpectedEqualsObjects(sel1, sel2);
 	}
 
+	@Test
 	public void testEquals2() {
 		String element1 = "A selection";
 		String element2 = "A selection";
@@ -79,6 +76,7 @@ public class StructuredSelectionTest extends TestCase {
 		EqualsHashCodeContractTestHelper.testExpectedNotEqualsObjects(sel1, sel3);
 	}
 
+	@Test
 	public void testEquals3() { // two empty selections
 		StructuredSelection empty1 = new StructuredSelection();
 		StructuredSelection empty2 = new StructuredSelection();
@@ -86,6 +84,7 @@ public class StructuredSelectionTest extends TestCase {
 		EqualsHashCodeContractTestHelper.testExpectedEqualsObjects(empty1, empty2);
 	}
 
+	@Test
 	public void testEquals4() { // empty selection with non-empty selection
 		StructuredSelection sel = new StructuredSelection("A selection");
 		StructuredSelection empty = new StructuredSelection();
@@ -93,6 +92,7 @@ public class StructuredSelectionTest extends TestCase {
 		EqualsHashCodeContractTestHelper.testExpectedNotEqualsObjects(sel, empty);
 	}
 
+	@Test
 	public void testEquals5() { // equality is order-dependent
 		List<String> l1 = new ArrayList<>();
 		l1.add("element 1");
@@ -108,6 +108,7 @@ public class StructuredSelectionTest extends TestCase {
 		EqualsHashCodeContractTestHelper.testExpectedNotEqualsObjects(sel1, sel2);
 	}
 
+	@Test
 	public void testEquals6() { // different selections
 		List<String> l1 = new ArrayList<>();
 		l1.add("element 1");
@@ -127,6 +128,7 @@ public class StructuredSelectionTest extends TestCase {
 	/**
 	 * Empty selections via different constructors. Regression test for bug 40245.
 	 */
+	@Test
 	public void testEquals7() {
 		StructuredSelection empty1 = new StructuredSelection();
 		StructuredSelection empty2 = new StructuredSelection(new Object[0]);
@@ -134,6 +136,7 @@ public class StructuredSelectionTest extends TestCase {
 		EqualsHashCodeContractTestHelper.testExpectedEqualsObjects(empty1, empty2);
 	}
 
+	@Test
 	public void testEqualsWithComparer1() {
 		doTestEqualsWithComparer1(JAVA_LANG_OBJECT_COMPARER);
 		doTestEqualsWithComparer1(IDENTITY_COMPARER);
@@ -146,6 +149,7 @@ public class StructuredSelectionTest extends TestCase {
 		EqualsHashCodeContractTestHelper.testExpectedEqualsObjects(sel1, sel2);
 	}
 
+	@Test
 	public void testEqualsWithComparer2() {
 		doTestEqualsWithComparer2(JAVA_LANG_OBJECT_COMPARER);
 		doTestEqualsWithComparer2(IDENTITY_COMPARER);
@@ -158,6 +162,7 @@ public class StructuredSelectionTest extends TestCase {
 		EqualsHashCodeContractTestHelper.testExpectedEqualsObjects(sel1, sel2);
 	}
 
+	@Test
 	public void testEqualsWithComparer3() {
 		doTestEqualsWithComparer3(JAVA_LANG_OBJECT_COMPARER);
 		doTestEqualsWithComparer3(IDENTITY_COMPARER);
@@ -170,6 +175,7 @@ public class StructuredSelectionTest extends TestCase {
 		EqualsHashCodeContractTestHelper.testExpectedNotEqualsObjects(sel1, sel2);
 	}
 
+	@Test
 	public void testEqualsWithComparer4() {
 		doTestEqualsWithComparer4(JAVA_LANG_OBJECT_COMPARER);
 		doTestEqualsWithComparer4(IDENTITY_COMPARER);
@@ -182,6 +188,7 @@ public class StructuredSelectionTest extends TestCase {
 		EqualsHashCodeContractTestHelper.testExpectedNotEqualsObjects(sel1, sel2);
 	}
 
+	@Test
 	public void testEqualsWithComparer5() {
 		doTestEqualsWithComparer5(JAVA_LANG_OBJECT_COMPARER);
 		doTestEqualsWithComparer5(IDENTITY_COMPARER);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/StructuredViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/StructuredViewerTest.java
@@ -16,6 +16,11 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.IBaseLabelProvider;
 import org.eclipse.jface.viewers.IBasicPropertyConstants;
@@ -30,6 +35,7 @@ import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
+import org.junit.Test;
 
 public abstract class StructuredViewerTest extends ViewerTestCase {
 	public static class TestLabelFilter extends ViewerFilter {
@@ -105,10 +111,6 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		}
 	}
 
-	public StructuredViewerTest(String name) {
-		super(name);
-	}
-
 	protected void bulkChange(TestModelChange eventToFire) {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement newElement = first.getContainer().basicAddChild();
@@ -140,6 +142,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 				+ TestLabelProvider.fgSuffix;
 	}
 
+	@Test
 	public void testClearSelection() {
 		TestElement first = fRootElement.getFirstChild();
 		StructuredSelection selection = new StructuredSelection(first);
@@ -149,6 +152,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		assertTrue(result.isEmpty());
 	}
 
+	@Test
 	public void testDeleteChild() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement first2 = first.getFirstChild();
@@ -156,6 +160,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		assertNull("first child is not visible", fViewer.testFindItem(first2));
 	}
 
+	@Test
 	public void testDeleteInput() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement firstfirst = first.getFirstChild();
@@ -166,6 +171,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 				.testFindItem(firstfirst));
 	}
 
+	@Test
 	public void testDeleteSibling() {
 		TestElement first = fRootElement.getFirstChild();
 		assertNotNull("first child is visible", fViewer.testFindItem(first));
@@ -177,6 +183,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 	 * Tests to ensure that the viewer is properly diposed.  Includes:
 	 *     removal of filters
 	 */
+	@Test
 	public void testDispose() {
 		assertEquals(0, fViewer.getFilters().length);
 		fViewer.addFilter(new ViewerFilter() {
@@ -191,6 +198,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		assertEquals(0, fViewer.getFilters().length);
 	}
 
+	@Test
 	public void testFilter() {
 		ViewerFilter filter = new TestLabelFilter();
 		fViewer.addFilter(filter);
@@ -200,10 +208,10 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 
 	}
 
+	@Test
 	public void testSetFilters() {
 		ViewerFilter filter = new TestLabelFilter();
 		fViewer.setFilters(filter, new TestLabelFilter2());
-//    	System.err.println("Item: " + getItemCount() );
 		assertEquals("2 filters count", 1, getItemCount());
 
 		fViewer.setFilters(filter);
@@ -213,6 +221,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		assertEquals("unfiltered count", 10, getItemCount());
 	}
 
+	@Test
 	public void testSetAndGetData() {
 
 		//get with no data
@@ -313,6 +322,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		assertEquals("get after remove", null, fViewer.getData("epsilon"));
 	}
 
+	@Test
 	public void testInsertChild() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement newElement = first.addChild(TestModelChange.INSERT);
@@ -320,6 +330,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 				.testFindItem(newElement));
 	}
 
+	@Test
 	public void testInsertSibling() {
 		TestElement newElement = fRootElement.addChild(TestModelChange.INSERT);
 		processEvents();
@@ -334,6 +345,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 				.testFindItem(newElement));
 	}
 
+	@Test
 	public void testInsertSiblingReveal() {
 		TestElement newElement = fRootElement.addChild(TestModelChange.INSERT
 				| TestModelChange.REVEAL);
@@ -341,6 +353,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 				.testFindItem(newElement));
 	}
 
+	@Test
 	public void testInsertSiblings() {
 		TestElement[] newElements = fRootElement
 				.addChildren(TestModelChange.INSERT);
@@ -358,6 +371,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		}
 	}
 
+	@Test
 	public void testInsertSiblingSelectExpanded() {
 		TestElement newElement = fRootElement.addChild(TestModelChange.INSERT
 				| TestModelChange.REVEAL | TestModelChange.SELECT);
@@ -374,6 +388,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		assertSelectionEquals("new element is selected", newElement);
 	}
 
+	@Test
 	public void testInsertSiblingWithFilterFiltered() {
 		fViewer.addFilter(new TestLabelFilter());
 		TestElement newElement = new TestElement(fModel, fRootElement);
@@ -386,6 +401,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		assertEquals(5, getItemCount());
 	}
 
+	@Test
 	public void testInsertSiblingWithFilterNotFiltered() {
 		fViewer.addFilter(new TestLabelFilter());
 		TestElement newElement = new TestElement(fModel, fRootElement);
@@ -398,6 +414,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		assertEquals(6, getItemCount());
 	}
 
+	@Test
 	public void testInsertSiblingWithSorter() {
 		fViewer.setComparator(new TestLabelComparator());
 		TestElement newElement = new TestElement(fModel, fRootElement);
@@ -410,6 +427,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		assertSelectionEquals("new element is selected", newElement);
 	}
 
+	@Test
 	public void testLabelProvider() {
 		fViewer.setLabelProvider(getTestLabelProvider());
 		TestElement first = fRootElement.getFirstChild();
@@ -424,6 +442,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		return new TestLabelProvider();
 	}
 
+	@Test
 	public void testLabelProviderStateChange() {
 		TestLabelProvider provider = new TestLabelProvider();
 		fViewer.setLabelProvider(provider);
@@ -433,6 +452,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		assertEquals("rendered label", newLabel, getItemText(0));
 	}
 
+	@Test
 	public void testRename() {
 		TestElement first = fRootElement.getFirstChild();
 		String newLabel = first.getLabel() + " changed";
@@ -441,6 +461,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 				getItemText(0));
 	}
 
+	@Test
 	public void testRenameWithFilter() {
 		fViewer.addFilter(new TestLabelFilter());
 		TestElement first = fRootElement.getFirstChild();
@@ -453,6 +474,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 				.testFindItem(first));
 	}
 
+	@Test
 	public void testRenameWithLabelProvider() {
 		if (fViewer instanceof TableViewer) {
 			return;
@@ -464,6 +486,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		assertEquals("rendered label", newLabel, getItemText(0));
 	}
 
+	@Test
 	public void testRenameWithSorter() {
 		fViewer.setComparator(new TestLabelComparator());
 		TestElement first = fRootElement.getFirstChild();
@@ -472,6 +495,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		assertEquals("sorted first", newElementLabel, getItemText(0));
 	}
 
+	@Test
 	public void testSetInput() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement firstfirst = first.getFirstChild();
@@ -490,6 +514,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 				.testFindItem(firstfirst));
 	}
 
+	@Test
 	public void testSetSelection() {
 		TestElement first = fRootElement.getFirstChild();
 		StructuredSelection selection = new StructuredSelection(first);
@@ -499,11 +524,13 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		assertEquals(first, result.getFirstElement());
 	}
 
+	@Test
 	public void testSomeChildrenChanged() {
 		bulkChange(new TestModelChange(TestModelChange.STRUCTURE_CHANGE,
 				fRootElement));
 	}
 
+	@Test
 	public void testSorter() {
 		TestElement first = fRootElement.getFirstChild();
 		TestElement last = fRootElement.getLastChild();
@@ -522,6 +549,7 @@ public abstract class StructuredViewerTest extends ViewerTestCase {
 		assertEquals("unsorted", lastLabel, getItemText(size - 1));
 	}
 
+	@Test
 	public void testWorldChanged() {
 		bulkChange(new TestModelChange(TestModelChange.STRUCTURE_CHANGE, null));
 	}

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/StyledStringBuilderTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/StyledStringBuilderTest.java
@@ -13,17 +13,16 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.jface.viewers.StyledString;
 import org.eclipse.jface.viewers.StyledString.Styler;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.graphics.TextStyle;
+import org.junit.Test;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
-public class StyledStringBuilderTest extends TestCase {
+public class StyledStringBuilderTest {
 
 	public static class TestStyler extends Styler {
 
@@ -42,14 +41,7 @@ public class StyledStringBuilderTest extends TestCase {
 	public static final TestStyler STYLER1 = new TestStyler(SWT.BORDER_DOT);
 	public static final TestStyler STYLER2 = new TestStyler(SWT.BORDER_DASH);
 
-	public static Test allTests() {
-		return new TestSuite(StyledStringBuilderTest.class);
-	}
-
-	public static Test suite() {
-		return allTests();
-	}
-
+	@Test
 	public void testEmpty() {
 		StyledString styledString = new StyledString();
 
@@ -60,6 +52,7 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(styledString.getStyleRanges().length, 0);
 	}
 
+	@Test
 	public void testAppendString1() {
 		StyledString styledString = new StyledString();
 
@@ -72,9 +65,10 @@ public class StyledStringBuilderTest extends TestCase {
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
 
-		assertEquals(styleRanges[0], STYLER1, 0, str.length());
+		assertRangeEquals(styleRanges[0], STYLER1, 0, str.length());
 	}
 
+	@Test
 	public void testAppendString2() {
 		StyledString styledString = new StyledString();
 
@@ -89,9 +83,10 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, str1.length(), str2.length());
+		assertRangeEquals(styleRanges[0], STYLER1, str1.length(), str2.length());
 	}
 
+	@Test
 	public void testAppendString3() {
 		StyledString styledString = new StyledString();
 
@@ -106,9 +101,10 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, 0, str1.length());
+		assertRangeEquals(styleRanges[0], STYLER1, 0, str1.length());
 	}
 
+	@Test
 	public void testAppendString4() {
 		StyledString styledString = new StyledString();
 
@@ -124,9 +120,10 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, str1.length(), str2.length() * 2);
+		assertRangeEquals(styleRanges[0], STYLER1, str1.length(), str2.length() * 2);
 	}
 
+	@Test
 	public void testAppendString5() {
 		StyledString styledString = new StyledString();
 
@@ -143,10 +140,11 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(2, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, str1.length(), str2.length());
-		assertEquals(styleRanges[1], STYLER2, str1.length() + str2.length(), str3.length());
+		assertRangeEquals(styleRanges[0], STYLER1, str1.length(), str2.length());
+		assertRangeEquals(styleRanges[1], STYLER2, str1.length() + str2.length(), str3.length());
 	}
 
+	@Test
 	public void testAppendString6() {
 		StyledString styledString = new StyledString();
 
@@ -163,10 +161,11 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(2, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, 0, str1.length());
-		assertEquals(styleRanges[1], STYLER2, str1.length() + str2.length(), str3.length());
+		assertRangeEquals(styleRanges[0], STYLER1, 0, str1.length());
+		assertRangeEquals(styleRanges[1], STYLER2, str1.length() + str2.length(), str3.length());
 	}
 
+	@Test
 	public void testAppendString7() {
 		StyledString styledString = new StyledString();
 
@@ -183,9 +182,10 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, 0, res.length());
+		assertRangeEquals(styleRanges[0], STYLER1, 0, res.length());
 	}
 
+	@Test
 	public void testAppendChar1() {
 		StyledString styledString = new StyledString();
 
@@ -199,11 +199,12 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(3, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, 0, 1);
-		assertEquals(styleRanges[1], STYLER2, 1, 1);
-		assertEquals(styleRanges[2], STYLER1, 2, 1);
+		assertRangeEquals(styleRanges[0], STYLER1, 0, 1);
+		assertRangeEquals(styleRanges[1], STYLER2, 1, 1);
+		assertRangeEquals(styleRanges[2], STYLER1, 2, 1);
 	}
 
+	@Test
 	public void testAppendChar2() {
 		StyledString styledString = new StyledString();
 
@@ -217,10 +218,11 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(2, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, 0, 1);
-		assertEquals(styleRanges[1], STYLER2, 2, 1);
+		assertRangeEquals(styleRanges[0], STYLER1, 0, 1);
+		assertRangeEquals(styleRanges[1], STYLER2, 2, 1);
 	}
 
+	@Test
 	public void testAppendStyledString1() {
 		StyledString other = new StyledString();
 
@@ -240,10 +242,11 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(2, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, str1.length(), str2.length());
-		assertEquals(styleRanges[1], STYLER2, str1.length() + str2.length(), str3.length());
+		assertRangeEquals(styleRanges[0], STYLER1, str1.length(), str2.length());
+		assertRangeEquals(styleRanges[1], STYLER2, str1.length() + str2.length(), str3.length());
 	}
 
+	@Test
 	public void testAppendStyledString2() {
 		StyledString other = new StyledString();
 
@@ -263,10 +266,11 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(2, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, 0, str1.length() + str2.length());
-		assertEquals(styleRanges[1], STYLER2, str1.length() + str2.length(), str3.length());
+		assertRangeEquals(styleRanges[0], STYLER1, 0, str1.length() + str2.length());
+		assertRangeEquals(styleRanges[1], STYLER2, str1.length() + str2.length(), str3.length());
 	}
 
+	@Test
 	public void testAppendStyledString3() {
 
 		StyledString other = new StyledString();
@@ -287,10 +291,11 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(2, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, 0, str1.length());
-		assertEquals(styleRanges[1], STYLER2, str1.length() + str2.length(), str3.length());
+		assertRangeEquals(styleRanges[0], STYLER1, 0, str1.length());
+		assertRangeEquals(styleRanges[1], STYLER2, str1.length() + str2.length(), str3.length());
 	}
 
+	@Test
 	public void testAppendStyledString4() {
 
 		StyledString other = new StyledString();
@@ -311,10 +316,11 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(2, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, 0, str1.length());
-		assertEquals(styleRanges[1], STYLER2, str1.length(), str2.length());
+		assertRangeEquals(styleRanges[0], STYLER1, 0, str1.length());
+		assertRangeEquals(styleRanges[1], STYLER2, str1.length(), str2.length());
 	}
 
+	@Test
 	public void testAppendStyledString5() {
 		StyledString other = new StyledString();
 
@@ -334,9 +340,10 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, str1.length() + str2.length(), str3.length());
+		assertRangeEquals(styleRanges[0], STYLER1, str1.length() + str2.length(), str3.length());
 	}
 
+	@Test
 	public void testSetStyle1() {
 		String str1 = "One";
 		String str2 = "Two";
@@ -353,9 +360,10 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, 0, str1.length());
+		assertRangeEquals(styleRanges[0], STYLER1, 0, str1.length());
 	}
 
+	@Test
 	public void testSetStyle2() {
 
 		String str1 = "One";
@@ -373,9 +381,10 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, str1.length(), str2.length());
+		assertRangeEquals(styleRanges[0], STYLER1, str1.length(), str2.length());
 	}
 
+	@Test
 	public void testSetStyle3() {
 
 		String str1 = "One";
@@ -393,9 +402,10 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, str1.length(), res.length() - str1.length());
+		assertRangeEquals(styleRanges[0], STYLER1, str1.length(), res.length() - str1.length());
 	}
 
+	@Test
 	public void testSetStyle4() {
 
 		String str1 = "One";
@@ -413,9 +423,10 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, 0, res.length());
+		assertRangeEquals(styleRanges[0], STYLER1, 0, res.length());
 	}
 
+	@Test
 	public void testSetStyle5() {
 
 		String str1 = "One";
@@ -435,6 +446,7 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(0, styleRanges.length);
 	}
 
+	@Test
 	public void testSetStyle6() {
 
 		String str1 = "One";
@@ -451,10 +463,11 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(2, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER1, 0, str1.length());
-		assertEquals(styleRanges[1], STYLER2, str1.length(), str2.length());
+		assertRangeEquals(styleRanges[0], STYLER1, 0, str1.length());
+		assertRangeEquals(styleRanges[1], STYLER2, str1.length(), str2.length());
 	}
 
+	@Test
 	public void testSetStyleInsert() {
 
 		String str1 = "One";
@@ -474,11 +487,12 @@ public class StyledStringBuilderTest extends TestCase {
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(3, styleRanges.length);
 
-		assertEquals(styleRanges[0], STYLER1, str1.length(), 1);
-		assertEquals(styleRanges[1], STYLER2, str1.length() + 1, str2.length());
-		assertEquals(styleRanges[2], STYLER1, str1.length() + str2.length() + 1, str3.length() - 1);
+		assertRangeEquals(styleRanges[0], STYLER1, str1.length(), 1);
+		assertRangeEquals(styleRanges[1], STYLER2, str1.length() + 1, str2.length());
+		assertRangeEquals(styleRanges[2], STYLER1, str1.length() + str2.length() + 1, str3.length() - 1);
 	}
 
+	@Test
 	public void testSetStyleInsert2() {
 
 		String str1 = "one";
@@ -497,9 +511,10 @@ public class StyledStringBuilderTest extends TestCase {
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
 
-		assertEquals(styleRanges[0], STYLER1, 0, str1.length() + 1);
+		assertRangeEquals(styleRanges[0], STYLER1, 0, str1.length() + 1);
 	}
 
+	@Test
 	public void testSetStyle7() {
 
 		String str1 = "One";
@@ -516,10 +531,11 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(2, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER2, 0, str1.length());
-		assertEquals(styleRanges[1], STYLER1, str1.length(), str2.length());
+		assertRangeEquals(styleRanges[0], STYLER2, 0, str1.length());
+		assertRangeEquals(styleRanges[1], STYLER1, str1.length(), str2.length());
 	}
 
+	@Test
 	public void testSetStyle8() {
 
 		String str1 = "One";
@@ -537,9 +553,10 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(res, styledString.getString());
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
-		assertEquals(styleRanges[0], STYLER2, 0, res.length());
+		assertRangeEquals(styleRanges[0], STYLER2, 0, res.length());
 	}
 
+	@Test
 	public void testSetStyle9() {
 
 		String str1 = "One";
@@ -559,6 +576,7 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(0, styleRanges.length);
 	}
 
+	@Test
 	public void testSetStyle10() {
 
 		String str1 = "One";
@@ -577,10 +595,11 @@ public class StyledStringBuilderTest extends TestCase {
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(2, styleRanges.length);
 
-		assertEquals(styleRanges[0], STYLER1, 0, 1);
-		assertEquals(styleRanges[1], STYLER2, res.length() - 1, 1);
+		assertRangeEquals(styleRanges[0], STYLER1, 0, 1);
+		assertRangeEquals(styleRanges[1], STYLER2, res.length() - 1, 1);
 	}
 
+	@Test
 	public void testSetStyle11() {
 
 		String str1 = "One";
@@ -599,9 +618,10 @@ public class StyledStringBuilderTest extends TestCase {
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
 
-		assertEquals(styleRanges[0], STYLER1, 0, res.length());
+		assertRangeEquals(styleRanges[0], STYLER1, 0, res.length());
 	}
 
+	@Test
 	public void testSetStyle12() {
 
 		String str1 = "One";
@@ -620,9 +640,10 @@ public class StyledStringBuilderTest extends TestCase {
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
 
-		assertEquals(styleRanges[0], STYLER2, 0, res.length());
+		assertRangeEquals(styleRanges[0], STYLER2, 0, res.length());
 	}
 
+	@Test
 	public void testSetStyle13() {
 
 		String str1 = "One";
@@ -641,10 +662,11 @@ public class StyledStringBuilderTest extends TestCase {
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(2, styleRanges.length);
 
-		assertEquals(styleRanges[0], STYLER1, 0, res.length() - 1);
-		assertEquals(styleRanges[1], STYLER2, res.length() - 1, 1);
+		assertRangeEquals(styleRanges[0], STYLER1, 0, res.length() - 1);
+		assertRangeEquals(styleRanges[1], STYLER2, res.length() - 1, 1);
 	}
 
+	@Test
 	public void testSetStyle14() {
 
 		String str1 = "One";
@@ -663,10 +685,11 @@ public class StyledStringBuilderTest extends TestCase {
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(2, styleRanges.length);
 
-		assertEquals(styleRanges[0], STYLER1, 0, 1);
-		assertEquals(styleRanges[1], STYLER2, 1, res.length() - 1);
+		assertRangeEquals(styleRanges[0], STYLER1, 0, 1);
+		assertRangeEquals(styleRanges[1], STYLER2, 1, res.length() - 1);
 	}
 
+	@Test
 	public void testSetStyle15() {
 
 		String str1 = "One";
@@ -685,10 +708,11 @@ public class StyledStringBuilderTest extends TestCase {
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(2, styleRanges.length);
 
-		assertEquals(styleRanges[0], STYLER1, 0, 1);
-		assertEquals(styleRanges[1], STYLER2, str1.length(), str2.length());
+		assertRangeEquals(styleRanges[0], STYLER1, 0, 1);
+		assertRangeEquals(styleRanges[1], STYLER2, str1.length(), str2.length());
 	}
 
+	@Test
 	public void testSetStyle16() {
 
 		String res = "H2O";
@@ -705,9 +729,10 @@ public class StyledStringBuilderTest extends TestCase {
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
 
-		assertEquals(styleRanges[0], STYLER1, 0, res.length());
+		assertRangeEquals(styleRanges[0], STYLER1, 0, res.length());
 	}
 
+	@Test
 	public void testSetStyle17() {
 
 		String res = "H2O";
@@ -725,6 +750,7 @@ public class StyledStringBuilderTest extends TestCase {
 		assertEquals(0, styleRanges.length);
 	}
 
+	@Test
 	public void testSetStyle18() {
 		String res = "H2OH2O";
 
@@ -743,9 +769,10 @@ public class StyledStringBuilderTest extends TestCase {
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
 
-		assertEquals(styleRanges[0], STYLER1, 1, res.length() - 1);
+		assertRangeEquals(styleRanges[0], STYLER1, 1, res.length() - 1);
 	}
 
+	@Test
 	public void testSetStyle19() {
 		String res = "O2O2O2O2O2O2";
 
@@ -764,9 +791,10 @@ public class StyledStringBuilderTest extends TestCase {
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
 
-		assertEquals(styleRanges[0], STYLER1, 1, res.length() - 2);
+		assertRangeEquals(styleRanges[0], STYLER1, 1, res.length() - 2);
 	}
 
+	@Test
 	public void testSetStyle20() {
 		String res = "O2O2O2O2O2O2";
 
@@ -785,10 +813,11 @@ public class StyledStringBuilderTest extends TestCase {
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(2, styleRanges.length);
 
-		assertEquals(styleRanges[0], STYLER1, 2, 1);
-		assertEquals(styleRanges[1], STYLER2, 9, 1);
+		assertRangeEquals(styleRanges[0], STYLER1, 2, 1);
+		assertRangeEquals(styleRanges[1], STYLER2, 9, 1);
 	}
 
+	@Test
 	public void testSetStyle21() {
 		String res = "O2O2O2O2O2O2";
 
@@ -808,10 +837,11 @@ public class StyledStringBuilderTest extends TestCase {
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(2, styleRanges.length);
 
-		assertEquals(styleRanges[0], STYLER1, 2, 1);
-		assertEquals(styleRanges[1], STYLER2, 9, 1);
+		assertRangeEquals(styleRanges[0], STYLER1, 2, 1);
+		assertRangeEquals(styleRanges[1], STYLER2, 9, 1);
 	}
 
+	@Test
 	public void testCombination1() {
 		String str1 = "One";
 		String str2 = "Two";
@@ -831,10 +861,10 @@ public class StyledStringBuilderTest extends TestCase {
 		StyleRange[] styleRanges = styledString.getStyleRanges();
 		assertEquals(1, styleRanges.length);
 
-		assertEquals(styleRanges[0], STYLER1, str1.length(), str2.length() + str1.length());
+		assertRangeEquals(styleRanges[0], STYLER1, str1.length(), str2.length() + str1.length());
 	}
 
-	private static void assertEquals(StyleRange range, TestStyler style, int offset, int length) {
+	private static void assertRangeEquals(StyleRange range, TestStyler style, int offset, int length) {
 		assertEquals(offset, range.start);
 		assertEquals(length, range.length);
 		assertEquals(style.borderStyle, range.borderStyle);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableColorProviderTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableColorProviderTest.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.jface.tests.viewers.TableViewerTest.TableTestLabelProvider;
 import org.eclipse.jface.viewers.ColumnLayoutData;
 import org.eclipse.jface.viewers.ColumnWeightData;
@@ -31,6 +33,8 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * The TableColorProviderTest is a test suite designed to test
@@ -42,17 +46,9 @@ public class TableColorProviderTest extends StructuredViewerTest {
 	Color green = null;
 
 	/**
-	 * Create a new instance of the receiver
-	 *
-	 * @param name
-	 */
-	public TableColorProviderTest(String name) {
-		super(name);
-	}
-
-	/**
 	 * Test with a standard color provider.
 	 */
+	@Test
 	public void testColorProviderForeground() {
 		TableViewer viewer = (TableViewer) fViewer;
 		ColorViewLabelProvider provider = new ColorViewLabelProvider();
@@ -72,6 +68,7 @@ public class TableColorProviderTest extends StructuredViewerTest {
 	/**
 	 * Test that the backgrounds are being set.
 	 */
+	@Test
 	public void testColorProviderBackground() {
 		TableViewer viewer = (TableViewer) fViewer;
 		ColorViewLabelProvider provider = new ColorViewLabelProvider();
@@ -91,6 +88,7 @@ public class TableColorProviderTest extends StructuredViewerTest {
 	 * Test that the foregrounds are being set.
 	 *
 	 */
+	@Test
 	public void testTableItemsColorProviderForeground() {
 		TableViewer viewer = (TableViewer) fViewer;
 		TableColorViewLabelProvider provider = new TableColorViewLabelProvider();
@@ -110,6 +108,7 @@ public class TableColorProviderTest extends StructuredViewerTest {
 	 * Test the table item colours.
 	 *
 	 */
+	@Test
 	public void testTableItemsColorProviderBackground() {
 		TableViewer viewer = (TableViewer) fViewer;
 		TableColorViewLabelProvider provider = new TableColorViewLabelProvider();
@@ -125,20 +124,12 @@ public class TableColorProviderTest extends StructuredViewerTest {
 
 	}
 
+	@Before
 	@Override
 	public void setUp() {
 		super.setUp();
 		red = new Color(Display.getCurrent(), 255, 0, 0);
 		green = new Color(Display.getCurrent(), 0, 255, 0);
-	}
-
-	/**
-	 * Run as a stand alone test
-	 *
-	 * @param args
-	 */
-	public static void main(String[] args) {
-		junit.textui.TestRunner.run(TableColorProviderTest.class);
 	}
 
 	@Override

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableFontProviderTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableFontProviderTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.tests.viewers.TableViewerTest.TableTestLabelProvider;
 import org.eclipse.jface.viewers.ColumnLayoutData;
@@ -31,6 +33,8 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * The TableFontProviderTest is a test suite designed to test
@@ -42,17 +46,9 @@ public class TableFontProviderTest extends StructuredViewerTest {
 	Font font2;
 
 	/**
-	 * Create a new instance of the receiver
-	 *
-	 * @param name
-	 */
-	public TableFontProviderTest(String name) {
-		super(name);
-	}
-
-	/**
 	 * Test the general font provider.
 	 */
+	@Test
 	public void testFontProvider() {
 		TableViewer viewer = (TableViewer) fViewer;
 
@@ -73,6 +69,7 @@ public class TableFontProviderTest extends StructuredViewerTest {
 	 * Test that the fonts are being set.
 	 *
 	 */
+	@Test
 	public void testTableItemsFontProvider() {
 		TableViewer viewer = (TableViewer) fViewer;
 
@@ -89,21 +86,13 @@ public class TableFontProviderTest extends StructuredViewerTest {
 
 	}
 
+	@Before
 	@Override
 	public void setUp() {
 		super.setUp();
 		font1 = JFaceResources.getFont(JFaceResources.BANNER_FONT);
 		font2 = JFaceResources.getFont(JFaceResources.HEADER_FONT);
 
-	}
-
-	/**
-	 * Run as a stand alone test
-	 *
-	 * @param args
-	 */
-	public static void main(String[] args) {
-		junit.textui.TestRunner.run(TableFontProviderTest.class);
 	}
 
 	@Override

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerComparatorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerComparatorTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.jface.viewers.ColumnLayoutData;
 import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.jface.viewers.StructuredViewer;
@@ -25,19 +27,13 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
+import org.junit.Test;
 
 /**
  * @since 3.2
  *
  */
 public class TableViewerComparatorTest extends ViewerComparatorTest {
-
-	/**
-	 * @param name
-	 */
-	public TableViewerComparatorTest(String name) {
-		super(name);
-	}
 
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
@@ -66,12 +62,14 @@ public class TableViewerComparatorTest extends ViewerComparatorTest {
 		return viewer;
 	}
 
+	@Test
 	@SuppressWarnings("deprecation")
 	public void testViewerSorter() {
 		fViewer.setSorter(new ViewerSorter());
 		assertSortedResult(TEAM1_SORTED);
 	}
 
+	@Test
 	@SuppressWarnings("deprecation")
 	public void testViewerSorterInsertElement() {
 		fViewer.setSorter(new ViewerSorter());
@@ -79,11 +77,13 @@ public class TableViewerComparatorTest extends ViewerComparatorTest {
 		assertSortedResult(TEAM1_SORTED_WITH_INSERT);
 	}
 
+	@Test
 	public void testViewerComparator() {
 		fViewer.setComparator(new ViewerComparator());
 		assertSortedResult(TEAM1_SORTED);
 	}
 
+	@Test
 	public void testViewerComparatorInsertElement() {
 		fViewer.setComparator(new ViewerComparator());
 		team1.addMember("Duong");
@@ -105,13 +105,6 @@ public class TableViewerComparatorTest extends ViewerComparatorTest {
 
 	protected TableViewer getTableViewer() {
 		return (TableViewer) fViewer;
-	}
-
-	/**
-	 * @param args
-	 */
-	public static void main(String[] args) {
-		junit.textui.TestRunner.run(TableViewerComparatorTest.class);
 	}
 
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerTest.java
@@ -13,6 +13,12 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.lang.reflect.Method;
 
 import org.eclipse.jface.viewers.ColumnLayoutData;
@@ -29,6 +35,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
+import org.junit.Test;
 
 public class TableViewerTest extends StructuredItemViewerTest {
 	public static class TableTestLabelProvider extends TestLabelProvider implements ITableLabelProvider {
@@ -54,10 +61,6 @@ public class TableViewerTest extends StructuredItemViewerTest {
 		public Image getColumnImage(Object element, int columnIndex) {
 			return null;
 		}
-	}
-
-	public TableViewerTest(String name) {
-		super(name);
 	}
 
 	/**
@@ -101,6 +104,7 @@ public class TableViewerTest extends StructuredItemViewerTest {
 		}
 	}
 
+	@Test
 	public void testViewerColumn() {
 		assertNull(getViewerColumn((TableViewer) fViewer, -1));
 		assertNotNull(getViewerColumn((TableViewer) fViewer, 0));
@@ -141,10 +145,7 @@ public class TableViewerTest extends StructuredItemViewerTest {
 		return table.getItem(at).getText();
 	}
 
-	public static void main(String args[]) {
-		junit.textui.TestRunner.run(TableViewerTest.class);
-	}
-
+	@Test
 	@Override
 	public void testLabelProvider() {
 
@@ -163,6 +164,7 @@ public class TableViewerTest extends StructuredItemViewerTest {
 		// LabelProvider changes
 	}
 
+	@Test
 	@Override
 	public void testLabelProviderStateChange() {
 		TableViewer tableviewer = (TableViewer) fViewer;
@@ -182,6 +184,7 @@ public class TableViewerTest extends StructuredItemViewerTest {
 		fViewer.refresh();
 	}
 
+	@Test
 	public void testRemove() {
 		TableViewer tableviewer = (TableViewer) fViewer;
 		TestElement first = fRootElement.getFirstChild();
@@ -191,6 +194,7 @@ public class TableViewerTest extends StructuredItemViewerTest {
 
 	}
 
+	@Test
 	public void testContains() {
 		TableViewer tViewer = (TableViewer) fViewer;
 		// some random element.

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerWithLimitCompatibilityTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerWithLimitCompatibilityTest.java
@@ -20,10 +20,6 @@ import org.eclipse.swt.widgets.Composite;
 
 public class TableViewerWithLimitCompatibilityTest extends TableViewerTest {
 
-	public TableViewerWithLimitCompatibilityTest(String name) {
-		super(name);
-	}
-
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
 		ColumnViewer viewer = (ColumnViewer) super.createViewer(parent);
@@ -31,7 +27,4 @@ public class TableViewerWithLimitCompatibilityTest extends TableViewerTest {
 		return viewer;
 	}
 
-	public static void main(String args[]) {
-		junit.textui.TestRunner.run(TableViewerWithLimitCompatibilityTest.class);
-	}
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerWithLimitTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableViewerWithLimitTest.java
@@ -14,6 +14,10 @@
 
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,21 +38,20 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Item;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
+import org.junit.Test;
 
 public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 
-	public TableViewerWithLimitTest(String name) {
-		super(name);
-	}
-
 	TestTableViewer tableViewer;
 
+	@Test
 	public void testLimitedItemsCreatedWithExpansionNode() {
 		Table table = tableViewer.getTable();
 		TableItem[] items = table.getItems();
 		assertLimitedItems(items);
 	}
 
+	@Test
 	public void testAddElement() {
 		processEvents();
 		Table table = tableViewer.getTable();
@@ -98,6 +101,7 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertLimitedItems(table.getItems());
 	}
 
+	@Test
 	public void testRemoveElement() {
 		processEvents();
 		Table table = tableViewer.getTable();
@@ -140,6 +144,7 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 
 	}
 
+	@Test
 	public void testClickExpandableNode() {
 		Table table = tableViewer.getTable();
 		assertLimitedItems(table.getItems());
@@ -165,6 +170,7 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 				itemsAfterExp[itemsAfterExp.length - 1].getData().getClass(), DataModel.class);
 	}
 
+	@Test
 	public void testApplyFilter() {
 		Table table = tableViewer.getTable();
 		clickUntilAllExpandableNodes(table);
@@ -196,6 +202,7 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		processEvents();
 	}
 
+	@Test
 	public void testResetComparator() {
 		Table table = tableViewer.getTable();
 		// add an element at the end of the model. comparator will add it to right
@@ -213,6 +220,7 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertEquals("wrong item is found at given location", Integer.valueOf(4), data.id);
 	}
 
+	@Test
 	public void testSelection() {
 		// select an element which is not visible
 		DataModel toSelect = rootModel.get(rootModel.size() - VIEWER_LIMIT);
@@ -239,6 +247,7 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertTrue("Selection must not be empty", selection.isEmpty());
 	}
 
+	@Test
 	public void testRefresh() {
 		Table table = tableViewer.getTable();
 		assertLimitedItems(table.getItems());
@@ -286,6 +295,7 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		return expectedLabel;
 	}
 
+	@Test
 	public void testSetInput() {
 		List<DataModel> rootModel = new ArrayList<>();
 		DataModel rootLevel = new DataModel(Integer.valueOf(100));
@@ -298,6 +308,7 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertLimitedItems(tableViewer.getTable().getItems());
 	}
 
+	@Test
 	public void testBoundaryConditions() {
 		List<DataModel> dummy = new ArrayList<>();
 		dummy.add(new DataModel(Integer.valueOf(100)));
@@ -336,6 +347,7 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 
 	}
 
+	@Test
 	public void testContains() {
 		// some random element.
 		assertFalse("element must not be available on the viewer", tableViewer.contains(""));
@@ -370,10 +382,6 @@ public class TableViewerWithLimitTest extends BaseLimitBasedViewerTest {
 	protected void setInput() {
 		rootModel = createModel(DEFAULT_ELEMENTS_COUNT);
 		fViewer.setInput(rootModel);
-	}
-
-	public static void main(String args[]) {
-		junit.textui.TestRunner.run(TableViewerWithLimitTest.class);
 	}
 
 	private static void clickTableItem(Control viewerControl, TableItem item) {

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeSelectionTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeSelectionTest.java
@@ -15,6 +15,9 @@
 
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -23,23 +26,20 @@ import org.eclipse.jface.viewers.IElementComparer;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TreePath;
 import org.eclipse.jface.viewers.TreeSelection;
-
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * @since 3.2
  *
  */
-public class TreeSelectionTest extends TestCase {
+public class TreeSelectionTest {
 
-	public TreeSelectionTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testNewWithEmptyTreePath() {
 		assertNotNull(new TreeSelection(new TreePath(new Object[0])));
 	}
 
+	@Test
 	public void testBug1384558() {
 		Object one = new Object();
 		Object two = new Object();
@@ -58,31 +58,37 @@ public class TreeSelectionTest extends TestCase {
 		EqualsHashCodeContractTestHelper.testExpectedNotEqualsObjects(treeSelection1, treeSelection2);
 	}
 
+	@Test
 	public void testEquals1() {
 		EqualsHashCodeContractTestHelper.testExpectedEqualsObjects(new TreeSelection(), new TreeSelection());
 	}
 
+	@Test
 	public void testEquals2() {
 		EqualsHashCodeContractTestHelper.testExpectedEqualsObjects(new TreeSelection((TreePath) null),
 				new TreeSelection((TreePath) null));
 	}
 
+	@Test
 	public void testEquals3() {
 		EqualsHashCodeContractTestHelper.testExpectedEqualsObjects(new TreeSelection((TreePath[]) null),
 				new TreeSelection((TreePath[]) null));
 	}
 
+	@Test
 	public void testEquals4() {
 		EqualsHashCodeContractTestHelper.testExpectedEqualsObjects(new TreeSelection(new TreePath[0]),
 				new TreeSelection(new TreePath[0]));
 	}
 
+	@Test
 	public void testEquals5() {
 		Object one = new Object();
 		EqualsHashCodeContractTestHelper.testExpectedEqualsObjects(new TreeSelection(newTreePath(one)),
 				new TreeSelection(newTreePath(one)));
 	}
 
+	@Test
 	public void testEquals6() {
 		Object one = new Object();
 		Object two = new Object();
@@ -90,6 +96,7 @@ public class TreeSelectionTest extends TestCase {
 				new TreeSelection(newTreePath(two)));
 	}
 
+	@Test
 	public void testEquals7() {
 		Object one = new Object();
 		Object two = new Object();
@@ -98,6 +105,7 @@ public class TreeSelectionTest extends TestCase {
 				new TreeSelection(newTreePath(one, two, three)));
 	}
 
+	@Test
 	public void testEquals8() {
 		Object one = new Object();
 		Object two = new Object();
@@ -105,6 +113,7 @@ public class TreeSelectionTest extends TestCase {
 				new TreeSelection(newTreePath(two, one)));
 	}
 
+	@Test
 	public void testEquals9() {
 		Object one = new Object();
 		Object two = new Object();
@@ -115,6 +124,7 @@ public class TreeSelectionTest extends TestCase {
 				new TreeSelection(newTreePaths(newTreePath(one, two), newTreePath(three, four))));
 	}
 
+	@Test
 	public void testEquals10() {
 		Object one = new Object();
 		Object two = new Object();
@@ -125,25 +135,30 @@ public class TreeSelectionTest extends TestCase {
 				new TreeSelection(newTreePaths(newTreePath(three, four), newTreePath(one, two))));
 	}
 
+	@Test
 	public void testEquals11() {
 		EqualsHashCodeContractTestHelper.testExpectedEqualsObjects(new TreeSelection(), new StructuredSelection());
 	}
 
+	@Test
 	public void testEquals12() {
 		EqualsHashCodeContractTestHelper.testExpectedEqualsObjects(new TreeSelection((TreePath) null),
 				new StructuredSelection());
 	}
 
+	@Test
 	public void testEquals13() {
 		EqualsHashCodeContractTestHelper.testExpectedEqualsObjects(new TreeSelection(newTreePath("element")),
 				new StructuredSelection("element"));
 	}
 
+	@Test
 	public void testEquals14() {
 		EqualsHashCodeContractTestHelper.testExpectedNotEqualsObjects(new TreeSelection(newTreePath("element 1")),
 				new StructuredSelection("element 2"));
 	}
 
+	@Test
 	public void testEquals15() {
 		EqualsHashCodeContractTestHelper.testExpectedEqualsObjects(
 				new TreeSelection(newTreePath("element 1", "element 2")),
@@ -153,6 +168,7 @@ public class TreeSelectionTest extends TestCase {
 				new StructuredSelection(new Object[] { "element 2", }));
 	}
 
+	@Test
 	public void testEquals16() {
 		EqualsHashCodeContractTestHelper.testExpectedEqualsObjects(
 				new TreeSelection(
@@ -160,6 +176,7 @@ public class TreeSelectionTest extends TestCase {
 				new StructuredSelection(Arrays.asList("element 2", "element 4")));
 	}
 
+	@Test
 	public void testEquals17() {
 		EqualsHashCodeContractTestHelper.testExpectedNotEqualsObjects(
 				new TreeSelection(
@@ -167,6 +184,7 @@ public class TreeSelectionTest extends TestCase {
 				new StructuredSelection(Arrays.asList("element 4", "element 2")));
 	}
 
+	@Test
 	public void testEquals18() {
 		doTestEquals18(StructuredSelectionTest.JAVA_LANG_OBJECT_COMPARER);
 		doTestEquals18(StructuredSelectionTest.IDENTITY_COMPARER);
@@ -177,6 +195,7 @@ public class TreeSelectionTest extends TestCase {
 				new StructuredSelection(new ArrayList<>(), comparer));
 	}
 
+	@Test
 	public void testEquals19() {
 		doTestEquals19(StructuredSelectionTest.JAVA_LANG_OBJECT_COMPARER);
 		doTestEquals19(StructuredSelectionTest.IDENTITY_COMPARER);
@@ -188,6 +207,7 @@ public class TreeSelectionTest extends TestCase {
 				new StructuredSelection(Arrays.asList("element 2"), comparer));
 	}
 
+	@Test
 	public void testEquals20() {
 		doTestEquals20(StructuredSelectionTest.JAVA_LANG_OBJECT_COMPARER);
 		doTestEquals20(StructuredSelectionTest.IDENTITY_COMPARER);
@@ -199,6 +219,7 @@ public class TreeSelectionTest extends TestCase {
 				new StructuredSelection(Arrays.asList("element 2", "element 4"), comparer));
 	}
 
+	@Test
 	public void testEquals21() {
 		doTestEquals21(StructuredSelectionTest.JAVA_LANG_OBJECT_COMPARER);
 		doTestEquals21(StructuredSelectionTest.IDENTITY_COMPARER);
@@ -210,6 +231,7 @@ public class TreeSelectionTest extends TestCase {
 				new StructuredSelection(Arrays.asList("element 2"), comparer));
 	}
 
+	@Test
 	public void testEquals22() {
 		doTestEquals22(StructuredSelectionTest.JAVA_LANG_OBJECT_COMPARER);
 		doTestEquals22(StructuredSelectionTest.IDENTITY_COMPARER);
@@ -221,6 +243,7 @@ public class TreeSelectionTest extends TestCase {
 				new StructuredSelection(new ArrayList<>(), comparer));
 	}
 
+	@Test
 	public void testEquals23() {
 		doTestEquals23(StructuredSelectionTest.JAVA_LANG_OBJECT_COMPARER);
 		doTestEquals23(StructuredSelectionTest.IDENTITY_COMPARER);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerColumnTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerColumnTest.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import java.lang.reflect.Method;
 
 import org.eclipse.jface.viewers.ColumnViewer;
@@ -26,6 +30,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
 import org.eclipse.swt.widgets.TreeItem;
+import org.junit.Test;
 
 public class TreeViewerColumnTest extends AbstractTreeViewerTest {
 
@@ -53,10 +58,6 @@ public class TreeViewerColumnTest extends AbstractTreeViewerTest {
 		public Image getColumnImage(Object element, int columnIndex) {
 			return null;
 		}
-	}
-
-	public TreeViewerColumnTest(String name) {
-		super(name);
 	}
 
 	@Override
@@ -100,10 +101,6 @@ public class TreeViewerColumnTest extends AbstractTreeViewerTest {
 		return ((Tree) fViewer.getControl()).getItems()[at].getText();
 	}
 
-	public static void main(String args[]) {
-		junit.textui.TestRunner.run(TreeViewerColumnTest.class);
-	}
-
 	private static ViewerColumn getViewerColumn(ColumnViewer viewer, int index) {
 		Method method;
 		try {
@@ -115,6 +112,7 @@ public class TreeViewerColumnTest extends AbstractTreeViewerTest {
 		}
 	}
 
+	@Test
 	public void testViewerColumn() {
 		assertNull(getViewerColumn((TreeViewer) fViewer, -1));
 		assertNotNull(getViewerColumn((TreeViewer) fViewer, 0));
@@ -122,6 +120,7 @@ public class TreeViewerColumnTest extends AbstractTreeViewerTest {
 		assertNull(getViewerColumn((TreeViewer) fViewer, 2));
 	}
 
+	@Test
 	@Override
 	public void testLabelProvider() {
 		TreeViewer viewer = (TreeViewer) fViewer;
@@ -139,6 +138,7 @@ public class TreeViewerColumnTest extends AbstractTreeViewerTest {
 		fViewer.refresh();
 	}
 
+	@Test
 	@Override
 	public void testLabelProviderStateChange() {
 		TreeViewer viewer = (TreeViewer) fViewer;

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerComparatorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerComparatorTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,6 +29,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
+import org.junit.Test;
 
 /**
  * @since 3.2
@@ -93,10 +96,7 @@ public class TreeViewerComparatorTest extends ViewerComparatorTest {
 		}
 	}
 
-	public TreeViewerComparatorTest(String name) {
-		super(name);
-	}
-
+	@Test
 	@SuppressWarnings("deprecation")
 	public void testViewerSorter() {
 		fViewer.setSorter(new ViewerSorter());
@@ -105,6 +105,7 @@ public class TreeViewerComparatorTest extends ViewerComparatorTest {
 		assertSortedResult(expected);
 	}
 
+	@Test
 	@SuppressWarnings("deprecation")
 	public void testViewerSorterInsertElement() {
 		fViewer.setSorter(new ViewerSorter());
@@ -114,6 +115,7 @@ public class TreeViewerComparatorTest extends ViewerComparatorTest {
 		assertSortedResult(expected);
 	}
 
+	@Test
 	public void testViewerComparator() {
 		fViewer.setComparator(new ViewerComparator());
 		getTreeViewer().expandAll();
@@ -121,6 +123,7 @@ public class TreeViewerComparatorTest extends ViewerComparatorTest {
 		assertSortedResult(expected);
 	}
 
+	@Test
 	public void testViewerComparatorInsertElement() {
 		fViewer.setComparator(new ViewerComparator());
 		getTreeViewer().expandAll();
@@ -179,13 +182,6 @@ public class TreeViewerComparatorTest extends ViewerComparatorTest {
 		input.add(team2);
 		input.add(team3);
 		fViewer.setInput(input);
-	}
-
-	/**
-	 * @param args
-	 */
-	public static void main(String[] args) {
-		junit.textui.TestRunner.run(TreeViewerComparatorTest.class);
 	}
 
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerTest.java
@@ -21,10 +21,6 @@ import org.eclipse.swt.widgets.TreeItem;
 
 public class TreeViewerTest extends AbstractTreeViewerTest {
 
-	public TreeViewerTest(String name) {
-		super(name);
-	}
-
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
 		fTreeViewer = new TreeViewer(parent);
@@ -54,7 +50,4 @@ public class TreeViewerTest extends AbstractTreeViewerTest {
 		return tree.getItems()[at].getText();
 	}
 
-	public static void main(String args[]) {
-		junit.textui.TestRunner.run(TreeViewerTest.class);
-	}
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitCompatibilityTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitCompatibilityTest.java
@@ -20,10 +20,6 @@ import org.eclipse.swt.widgets.Composite;
 
 public class TreeViewerWithLimitCompatibilityTest extends TreeViewerTest {
 
-	public TreeViewerWithLimitCompatibilityTest(String name) {
-		super(name);
-	}
-
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
 		ColumnViewer viewer = (ColumnViewer) super.createViewer(parent);
@@ -31,10 +27,6 @@ public class TreeViewerWithLimitCompatibilityTest extends TreeViewerTest {
 		// this should not break any existing tests.
 		viewer.setDisplayIncrementally(Integer.MAX_VALUE);
 		return viewer;
-	}
-
-	public static void main(String args[]) {
-		junit.textui.TestRunner.run(TreeViewerWithLimitCompatibilityTest.class);
 	}
 
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitTest.java
@@ -14,6 +14,11 @@
 
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,15 +31,13 @@ import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.internal.ExpandableNode;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.TreeItem;
+import org.junit.Test;
 
 public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 
 	private TestTreeViewer treeViewer;
 
-	public TreeViewerWithLimitTest(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testSetSelection() {
 		DataModel firstEle = rootModel.get(0);
 		assertSetSelection(firstEle);
@@ -60,6 +63,7 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertEquals("incorrect element is selected", firstEle, selection.getFirstElement());
 	}
 
+	@Test
 	public void testReveal() throws Exception {
 		DataModel firstEle = rootModel.get(0);
 		DataModel toReveal = firstEle.children.get(2).children.get(2);
@@ -84,6 +88,7 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertTrue("item to select must be inside expandable node", found);
 	}
 
+	@Test
 	public void testCollapseAll() {
 		treeViewer.expandAll();
 		processEvents();
@@ -99,9 +104,11 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		}
 	}
 
+	@Test
 	public void testCollapseToLevel() {
 	}
 
+	@Test
 	public void testExpandAll() {
 		treeViewer.expandAll();
 		processEvents();
@@ -131,6 +138,7 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		return rootLevelItems;
 	}
 
+	@Test
 	public void testExpandToLevelInt() {
 		treeViewer.expandToLevel(2, true);
 		processEvents();
@@ -149,6 +157,7 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertNull("Dummy tree item data must be null", items[0].getData());
 	}
 
+	@Test
 	public void testExpandToLevelObjectInt() {
 		DataModel firstEle = rootModel.get(0);
 		treeViewer.expandToLevel(firstEle, 3, true);
@@ -165,6 +174,7 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		}
 	}
 
+	@Test
 	public void testRemoveItemsAtParent() {
 		treeViewer.expandAll();
 		processEvents();
@@ -179,6 +189,7 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertEquals("element contains unexpected data", thirdOfFirst, visItem.getData());
 	}
 
+	@Test
 	public void testRemoveItem() {
 		processEvents();
 		treeViewer.expandAll();
@@ -193,6 +204,7 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertEquals("element contains unexpected data", firstEle, firstItem.getData());
 	}
 
+	@Test
 	public void testSetAutoExpandLevel() {
 		treeViewer.setInput(new DataModel(Integer.valueOf(100)));
 		treeViewer.setAutoExpandLevel(2);
@@ -207,6 +219,7 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		}
 	}
 
+	@Test
 	public void testInsert() {
 		TreeItem thirdItem = treeViewer.getTree().getItem(2);
 		assertEquals("unexpected element found at position 2", rootModel.get(2), thirdItem.getData());
@@ -218,6 +231,7 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertEquals("unexpected element found at position 2", newElement, thirdItem.getData());
 	}
 
+	@Test
 	public void testRefresh() {
 		DataModel firstEle = rootModel.remove(0);
 		TreeItem firstItem = treeViewer.getTree().getItem(0);
@@ -229,6 +243,7 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertEquals("element contains unexpected data", firstEle, firstItem.getData());
 	}
 
+	@Test
 	public void testSetFilters() {
 		DataModel firstEle = rootModel.get(0);
 		TreeItem firstItem = treeViewer.getTree().getItem(0);
@@ -240,6 +255,7 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertEquals("element contains unexpected data", firstEle, firstItem.getData());
 	}
 
+	@Test
 	public void testSetInput() {
 		List<DataModel> rootModel = new ArrayList<>();
 		DataModel rootLevel = new DataModel(Integer.valueOf(100));
@@ -252,6 +268,7 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertLimitedItems();
 	}
 
+	@Test
 	public void testContains() {
 		// some random element.
 		assertFalse("element must not be available on the viewer", treeViewer.contains(fRootElement, ""));
@@ -285,10 +302,6 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 	protected void setInput() {
 		rootModel = createModel(DEFAULT_ELEMENTS_COUNT);
 		treeViewer.setInput(rootModel);
-	}
-
-	public static void main(String args[]) {
-		junit.textui.TestRunner.run(TreeViewerWithLimitTest.class);
 	}
 
 	private static class TestTreeContentProvider implements ITreeContentProvider {

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/ViewerComparatorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/ViewerComparatorTest.java
@@ -228,8 +228,4 @@ public abstract class ViewerComparatorTest extends ViewerTestCase {
 
 	}
 
-	public ViewerComparatorTest(String name) {
-		super(name);
-	}
-
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/ViewerTestCase.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/ViewerTestCase.java
@@ -14,6 +14,9 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.util.ILogger;
 import org.eclipse.jface.util.ISafeRunnableRunner;
@@ -28,10 +31,10 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
+import org.junit.After;
+import org.junit.Before;
 
-import junit.framework.TestCase;
-
-public abstract class ViewerTestCase extends TestCase {
+public abstract class ViewerTestCase {
 
 	Display fDisplay;
 	protected Shell fShell;
@@ -44,8 +47,8 @@ public abstract class ViewerTestCase extends TestCase {
 	private ILogger oldLogger;
 	private ISafeRunnableRunner oldRunner;
 
-	public ViewerTestCase(String name) {
-		super(name);
+	@Before
+	public void initializeOsDependentStates() {
 		disableTestsBug347491 = Util.isCocoa();
 		eventLoopAdjustmentBug531048 = Util.isGtk();
 	}
@@ -109,7 +112,7 @@ public abstract class ViewerTestCase extends TestCase {
 		}
 	}
 
-	@Override
+	@Before
 	public void setUp() {
 		oldLogger = Policy.getLog();
 		oldRunner = SafeRunnable.getRunner();
@@ -143,7 +146,7 @@ public abstract class ViewerTestCase extends TestCase {
 		}
 	}
 
-	@Override
+	@After
 	public void tearDown() {
 		Policy.setLog(oldLogger);
 		SafeRunnable.setRunner(oldRunner);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualLazyTableViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualLazyTableViewerTest.java
@@ -14,6 +14,12 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,6 +27,9 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.swt.widgets.Table;
+import org.junit.After;
+import org.junit.Ignore;
+import org.junit.Test;
 
 /**
  * The VirtualLazyTableViewerTest is a test of table viewers with lazy
@@ -31,15 +40,6 @@ public class VirtualLazyTableViewerTest extends VirtualTableViewerTest {
 	private List<Integer> updatedElements;
 	// by default, no failure is triggered when updateElement is called
 	int updatedElementFailureTriggerIndex = -1;
-
-	/**
-	 * Create a new instance of the receiver/
-	 *
-	 * @param name
-	 */
-	public VirtualLazyTableViewerTest(String name) {
-		super(name);
-	}
 
 	@Override
 	protected TestModelContentProvider getContentProvider() {
@@ -59,6 +59,7 @@ public class VirtualLazyTableViewerTest extends VirtualTableViewerTest {
 		fModel = fRootElement.getModel();
 	}
 
+	@After
 	@Override
 	public void tearDown() {
 		super.tearDown();
@@ -76,6 +77,7 @@ public class VirtualLazyTableViewerTest extends VirtualTableViewerTest {
 	/**
 	 * Test selecting all elements.
 	 */
+	@Test
 	public void testSetIndexedSelection() {
 		TestElement[] children = fRootElement.getChildren();
 		int selectionSize = children.length / 2;
@@ -102,6 +104,7 @@ public class VirtualLazyTableViewerTest extends VirtualTableViewerTest {
 
 	}
 
+	@Test
 	public void testSetInputDoesNotMaterializeEverything() {
 		fViewer.setInput(null);
 		updatedElements.clear();
@@ -120,6 +123,7 @@ public class VirtualLazyTableViewerTest extends VirtualTableViewerTest {
 		assertEquals(materializedSize, updatedElements.size());
 	}
 
+	@Test
 	public void testBug160153() {
 		int childCount = fRootElement.getChildCount();
 		TestElement lastChild = fRootElement.getChildAt(childCount - 1);
@@ -131,45 +135,33 @@ public class VirtualLazyTableViewerTest extends VirtualTableViewerTest {
 		assertNull("last Child should no longer be in the map", fViewer.testFindItem(lastChild));
 	}
 
+	@Ignore("This test is no use here as it is based on the assumption that all items are created.")
 	@Override
 	public void testSorter() {
-		// This test is no use here as it is
-		// based on the assumption that all items
-		// are created.
 	}
 
+	@Ignore("This test is no use here as it is based on the assumption that all items are created.")
 	@Override
 	public void testRenameWithSorter() {
-		// This test is no use here as it is
-		// based on the assumption that all items
-		// are created.
 	}
 
+	@Ignore("This test is no use here as it is based on the assumption that all items are created.")
 	@Override
 	public void testSetFilters() {
-		// This test is no use here as it is
-		// based on the assumption that all items
-		// are created.
 	}
 
+	@Ignore("This test is no use here as it is based on the assumption that all items are created.")
 	@Override
 	public void testFilter() {
-		// This test is no use here as it is
-		// based on the assumption that all items
-		// are created.
 	}
 
+	@Ignore("This test is no use here as it is based on the assumption that all items are created.")
 	@Override
 	public void testRenameWithFilter() {
-		// This test is no use here as it is
-		// based on the assumption that all items
-		// are created.
 	}
 
+	@Ignore("This test is no use here as it is based on the assumption that all items are created.")
 	@Override
 	public void testContains() {
-		// This test is no use here as it is
-		// based on the assumption that all items
-		// are created.
 	}
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualLazyTreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualLazyTreeViewerTest.java
@@ -15,19 +15,26 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Tree;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 
 public class VirtualLazyTreeViewerTest extends TreeViewerTest {
 
-	protected int setDataCalls = 0;
+	@Rule
+	public TestName testName = new TestName();
 
-	public VirtualLazyTreeViewerTest(String name) {
-		super(name);
-	}
+	protected int setDataCalls = 0;
 
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
@@ -50,179 +57,185 @@ public class VirtualLazyTreeViewerTest extends TreeViewerTest {
 		super.setInput();
 	}
 
-	@Override
-	public void tearDown() {
-		super.tearDown();
-//    	System.out.println("calls: " + setDataCalls);
-	}
-
+	@Test
 	public void testLeafIsExpandable() {
 		TestElement leafElement = fRootElement.getChildAt(2).getChildAt(3).getChildAt(2);
 		assertEquals(0, leafElement.getChildCount());
 		assertFalse(fTreeViewer.isExpandable(leafElement));
 	}
 
+	@Test
 	public void testRootIsExpandable() {
 		TestElement rootElement = fRootElement.getChildAt(2);
 		assertTrue(rootElement.getChildCount() > 0);
 		assertTrue(fTreeViewer.isExpandable(rootElement));
 	}
 
+	@Test
 	public void testNodeIsExpandable() {
 		TestElement nodeElement = fRootElement.getChildAt(2).getChildAt(3);
 		assertTrue(nodeElement.getChildCount() > 0);
 		assertTrue(fTreeViewer.isExpandable(nodeElement));
 	}
 
+	@Ignore("Test leads to infinite loop. Duplicate children are a bad idea in virtual trees.")
 	@Override
 	public void testRefreshWithDuplicateChild() {
-		// Test leads to infinite loop. Duplicate children are a bad idea in virtual trees.
 	}
 
+	@Ignore("Test leads to infinite loop. Cycles are a bad idea in virtual trees.")
 	@Override
 	public void testSetExpandedWithCycle() {
-		// Test leads to infinite loop. Cycles are a bad idea in virtual trees.
 	}
 
+	@Ignore("no need to test since virtual trees do not support filtering")
 	@Override
 	public void testFilterExpanded() {
-		// no need to test since virtual trees do not support filtering
 	}
 
+	@Ignore("no need to test since virtual trees do not support filtering")
 	@Override
 	public void testFilter() {
-		// no need to test since virtual trees do not support filtering
 	}
 
+	@Ignore("no need to test since virtual trees do not support filtering")
 	@Override
 	public void testSetFilters() {
-		// no need to test since virtual trees do not support filtering
 	}
 
+	@Ignore("no need to test since virtual trees do not support filtering")
 	@Override
 	public void testInsertSiblingWithFilterFiltered() {
-		// no need to test since virtual trees do not support filtering
 	}
 
+	@Ignore("no need to test since virtual trees do not support filtering")
 	@Override
 	public void testInsertSiblingWithFilterNotFiltered() {
-		// no need to test since virtual trees do not support filtering
 	}
 
+	@Ignore("no need to test since virtual trees do not support sorting")
 	@Override
 	public void testInsertSiblingWithSorter() {
 		// no need to test since virtual trees do not support sorting
 	}
 
+	@Ignore("no need to test since virtual trees do not support filtering")
 	@Override
 	public void testRenameWithFilter() {
-		// no need to test since virtual trees do not support filtering
 	}
 
+	@Ignore("no need to test since virtual trees do not support sorting")
 	@Override
 	public void testRenameWithSorter() {
-		// no need to test since virtual trees do not support sorting
 	}
 
+	@Ignore("no need to test since virtual trees do not support sorting")
 	@Override
 	public void testSorter() {
-		// no need to test since virtual trees do not support sorting
 	}
 
+	@Ignore("test is not relevant for lazy tree viewer")
 	@Override
 	public void testChildIsNotDuplicatedWhenCompareEquals() {
-		// test is not relevant for lazy tree viewer
 	}
 
 	// Temporary overrides for bug 347491:
+	@Test
 	@Override
 	public void testRefreshWithAddedChildren() {
 		if (disableTestsBug347491) {
 			return;
 		}
 		if (setDataCalls == 0) {
-			System.err.println("SWT.SetData is not received. Cancelled test " + getName());
+			System.err.println("SWT.SetData is not received. Cancelled test " + testName.getMethodName());
 			return;
 		}
 		super.testRefreshWithAddedChildren();
 	}
 
+	@Test
 	@Override
 	public void testDeleteSibling() {
 		if (disableTestsBug347491) {
 			return;
 		}
 		if (setDataCalls == 0) {
-			System.err.println("SWT.SetData is not received. Cancelled test " + getName());
+			System.err.println("SWT.SetData is not received. Cancelled test " + testName.getMethodName());
 			return;
 		}
 		super.testDeleteSibling();
 	}
 
+	@Test
 	@Override
 	public void testExpandToLevel() {
 		if (setDataCalls == 0) {
-			System.err.println("SWT.SetData is not received. Cancelled test " + getName());
+			System.err.println("SWT.SetData is not received. Cancelled test " + testName.getMethodName());
 			return;
 		}
 		super.testExpandToLevel();
 	}
 
+	@Test
 	@Override
 	public void testInsertSibling() {
 		if (disableTestsBug347491) {
 			return;
 		}
 		if (setDataCalls == 0) {
-			System.err.println("SWT.SetData is not received. Cancelled test " + getName());
+			System.err.println("SWT.SetData is not received. Cancelled test " + testName.getMethodName());
 			return;
 		}
 		super.testInsertSibling();
 	}
 
+	@Test
 	@Override
 	public void testInsertSiblings() {
 		if (disableTestsBug347491) {
 			return;
 		}
 		if (setDataCalls == 0) {
-			System.err.println("SWT.SetData is not received. Cancelled test " + getName());
+			System.err.println("SWT.SetData is not received. Cancelled test " + testName.getMethodName());
 			return;
 		}
 		super.testInsertSiblings();
 	}
 
+	@Test
 	@Override
 	public void testSetInput() {
 		if (disableTestsBug347491) {
 			return;
 		}
 		if (setDataCalls == 0) {
-			System.err.println("SWT.SetData is not received. Cancelled test " + getName());
+			System.err.println("SWT.SetData is not received. Cancelled test " + testName.getMethodName());
 			return;
 		}
 		super.testSetInput();
 	}
 
+	@Test
 	@Override
 	public void testSomeChildrenChanged() {
 		if (disableTestsBug347491) {
 			return;
 		}
 		if (setDataCalls == 0) {
-			System.err.println("SWT.SetData is not received. Cancelled test " + getName());
+			System.err.println("SWT.SetData is not received. Cancelled test " + testName.getMethodName());
 			return;
 		}
 		super.testSomeChildrenChanged();
 	}
 
+	@Test
 	@Override
 	public void testWorldChanged() {
 		if (disableTestsBug347491) {
 			return;
 		}
 		if (setDataCalls == 0) {
-			System.err.println("SWT.SetData is not received. Cancelled test " + getName());
+			System.err.println("SWT.SetData is not received. Cancelled test " + testName.getMethodName());
 			return;
 		}
 		super.testWorldChanged();

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualTableViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualTableViewerTest.java
@@ -15,6 +15,11 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -27,11 +32,19 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 
 /**
  * The TableViewerTest is a test of the SWT#VIRTUAL support in TableViewers,
  */
 public class VirtualTableViewerTest extends TableViewerTest {
+
+	@Rule
+	public TestName testName = new TestName();
 
 	Set<TableItem> visibleItems = new HashSet<>();
 
@@ -46,15 +59,7 @@ public class VirtualTableViewerTest extends TableViewerTest {
 	 */
 	protected boolean setDataCalled = false;
 
-	/**
-	 * Create a new instance of the receiver.
-	 *
-	 * @param name
-	 */
-	public VirtualTableViewerTest(String name) {
-		super(name);
-	}
-
+	@Before
 	@Override
 	public void setUp() {
 		super.setUp();
@@ -92,7 +97,7 @@ public class VirtualTableViewerTest extends TableViewerTest {
 		if (setDataCalled) {
 			return true;
 		}
-		System.err.println("SWT.SetData is not received. Cancelled test " + getName());
+		System.err.println("SWT.SetData is not received. Cancelled test " + testName.getMethodName());
 		return false;
 	}
 
@@ -105,6 +110,7 @@ public class VirtualTableViewerTest extends TableViewerTest {
 		return visibleItems.toArray(new TableItem[visibleItems.size()]);
 	}
 
+	@Test
 	public void testElementsCreated() {
 
 		TableItem[] items = getVisibleItems();
@@ -120,6 +126,7 @@ public class VirtualTableViewerTest extends TableViewerTest {
 		return getVisibleItems().length;
 	}
 
+	@Test
 	@Override
 	public void testFilter() {
 		ViewerFilter filter = new TestLabelFilter();
@@ -138,6 +145,7 @@ public class VirtualTableViewerTest extends TableViewerTest {
 		assertEquals("unfiltered count", 10, getItemCount());
 	}
 
+	@Test
 	@Override
 	public void testSetFilters() {
 		ViewerFilter filter = new TestLabelFilter();
@@ -163,52 +171,41 @@ public class VirtualTableViewerTest extends TableViewerTest {
 		assertEquals("unfiltered count", 10, getItemCount());
 	}
 
+	@Ignore("This test is no use here as it is based on the assumption that all items are created.")
 	@Override
 	public void testInsertSibling() {
-		// This test is no use here as it is
-		// based on the assumption that all items
-		// are created.
 	}
 
+	@Ignore("This test is no use here as it is based on the assumption that all items are created.")
 	@Override
 	public void testInsertSiblingReveal() {
-		// This test is no use here as it is
-		// based on the assumption that all items
-		// are created.
 	}
 
+	@Ignore("This test is no use here as it is based on the assumption that all items are created.")
 	@Override
 	public void testInsertSiblings() {
-		// This test is no use here as it is
-		// based on the assumption that all items
-		// are created.
 	}
 
+	@Ignore("This test is no use here as it is based on the assumption that all items are created.")
 	@Override
 	public void testInsertSiblingWithFilterFiltered() {
-		// This test is no use here as it is
-		// based on the assumption that all items
-		// are created.
 	}
 
+	@Ignore("This test is no use here as it is based on the assumption that all items are created.")
 	@Override
 	public void testInsertSiblingWithFilterNotFiltered() {
-		// This test is no use here as it is
-		// based on the assumption that all items
-		// are created.
 	}
 
+	@Ignore("This test is no use here as it is based on the assumption that all items are created.")
 	@Override
 	public void testInsertSiblingWithSorter() {
-		// This test is no use here as it is
-		// based on the assumption that all items
-		// are created.
 	}
 
+	@Test
 	@Override
 	public void testRenameWithFilter() {
 		if (!setDataCalled) {
-			System.err.println("SWT.SetData is not received. Cancelled test " + getName());
+			System.err.println("SWT.SetData is not received. Cancelled test " + testName.getMethodName());
 			return;
 		}
 		fViewer.addFilter(new TestLabelFilter());
@@ -225,12 +222,12 @@ public class VirtualTableViewerTest extends TableViewerTest {
 		assertNotNull("changed sibling is not visible", fViewer.testFindItem(first));
 	}
 
+	@Ignore("This test us based on findItem assuming all items are created so it is not valid.")
 	@Override
 	public void testSetInput() {
-		// This test us based on findItem assuming all items
-		// are created so it is not valid.
 	}
 
+	@Test
 	@Override
 	public void testRenameWithSorter() {
 		// Call update to make sure the viewer is in a correct state
@@ -264,27 +261,22 @@ public class VirtualTableViewerTest extends TableViewerTest {
 		assertEquals("unsorted", firstLabel, getItemText(0));
 	}
 
+	@Ignore("This test is no use here as it is based on the assumption that all items are created.")
 	@Override
 	public void testInsertSiblingSelectExpanded() {
-		// This test is no use here as it is
-		// based on the assumption that all items
-		// are created.
 	}
 
+	@Ignore("This test is no use here as it is based on the assumption that all items are created.")
 	@Override
 	public void testSomeChildrenChanged() {
-		// This test is no use here as it is
-		// based on the assumption that all items
-		// are created.
 	}
 
+	@Ignore("This test is no use here as it is based on the assumption that all items are created.")
 	@Override
 	public void testWorldChanged() {
-		// This test is no use here as it is
-		// based on the assumption that all items
-		// are created.
 	}
 
+	@Test
 	@Override
 	public void testDeleteSibling() {
 		// Force creation of the item first
@@ -292,6 +284,7 @@ public class VirtualTableViewerTest extends TableViewerTest {
 		super.testDeleteSibling();
 	}
 
+	@Test
 	@Override
 	public void testSetSelection() {
 		// Force creation of the item first
@@ -302,6 +295,7 @@ public class VirtualTableViewerTest extends TableViewerTest {
 	/**
 	 * Test selecting all elements.
 	 */
+	@Test
 	public void testSetAllSelection() {
 		TestElement[] children = fRootElement.getChildren();
 		StructuredSelection selection = new StructuredSelection(children);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualTreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualTreeViewerTest.java
@@ -25,10 +25,6 @@ import org.eclipse.swt.widgets.Tree;
  */
 public class VirtualTreeViewerTest extends TreeViewerTest {
 
-	public VirtualTreeViewerTest(String name) {
-		super(name);
-	}
-
 	@Override
 	protected StructuredViewer createViewer(Composite parent) {
 		Tree tree = new Tree(parent, SWT.VIRTUAL);


### PR DESCRIPTION
* Migrates the tests in `org.eclipse.jface.tests.viewer` to JUnit 4
* Replaces some test method precondition checks with assume calls
* Replaces test name access with `TestName` rule