### PR TITLE
Notification Popup Builder API for shell

### DIFF
--- a/bundles/org.eclipse.jface.notifications/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.notifications/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.jface.notifications
-Bundle-Version: 0.6.100.qualifier
+Bundle-Version: 0.7.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.jface.notifications,
  org.eclipse.jface.notifications.internal;x-internal:=true

--- a/bundles/org.eclipse.jface.notifications/src/org/eclipse/jface/notifications/NotificationPopup.java
+++ b/bundles/org.eclipse.jface.notifications/src/org/eclipse/jface/notifications/NotificationPopup.java
@@ -24,6 +24,7 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
 
 /**
  * NotificationPopup is a default implementation of
@@ -64,9 +65,15 @@ public class NotificationPopup extends AbstractNotificationPopup {
 		private Boolean fadeIn;
 		private boolean hasCloseButton;
 		private Image titleImage;
+		private Shell shell;
 
 		private Builder(Display display) {
 			this.display = display;
+		}
+
+		private Builder shell(Shell shell) {
+			this.shell = shell;
+			return this;
 		}
 
 		/**
@@ -183,6 +190,21 @@ public class NotificationPopup extends AbstractNotificationPopup {
 		return new Builder(display);
 	}
 
+	/**
+	 * Creates a new builder instance using a shell.
+	 * <p>
+	 * The shell is set as parent shell in the notification popup.
+	 * </p>
+	 *
+	 * @see AbstractNotificationPopup#setParentShell(Shell)
+	 * @param shell the shell to use
+	 * @return the builder instance
+	 * @since 0.7
+	 */
+	public static Builder forShell(Shell shell) {
+		return new Builder(shell.getDisplay()).shell(shell);
+	}
+
 	private Function<Composite, ? extends Control> contentCreator;
 	private Function<Composite, Control> titleCreator;
 	private boolean hasCloseButton;
@@ -200,6 +222,10 @@ public class NotificationPopup extends AbstractNotificationPopup {
 		}
 		if (builder.fadeIn != null) {
 			setFadingEnabled(builder.fadeIn);
+		}
+
+		if (builder.shell != null) {
+			setParentShell(builder.shell);
 		}
 	}
 

--- a/tests/org.eclipse.jface.tests.notifications/src/org/eclipse/jface/tests/notifications/NotificationPopupTest.java
+++ b/tests/org.eclipse.jface.tests.notifications/src/org/eclipse/jface/tests/notifications/NotificationPopupTest.java
@@ -27,6 +27,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.notifications.NotificationPopup;
 import org.eclipse.jface.notifications.NotificationPopup.Builder;
 import org.eclipse.jface.notifications.internal.CommonImages;
+import org.eclipse.jface.widgets.WidgetFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
@@ -47,6 +48,7 @@ public class NotificationPopupTest {
 
 	private Display display;
 	private Builder builder;
+	private Shell shell;
 
 	@Before
 	public void setUp() {
@@ -56,6 +58,10 @@ public class NotificationPopupTest {
 
 	@After
 	public void tearDown() {
+		if (shell != null) {
+			shell.close();
+			shell.dispose();
+		}
 		if (!Platform.isRunning()) {
 			if (this.display != null) {
 				this.display.syncExec(() -> this.display.dispose());
@@ -87,8 +93,7 @@ public class NotificationPopupTest {
 	@Test
 	public void createsWithTextContent() {
 		Text[] text = new Text[1];
-		NotificationPopup notication =
-		this.builder.title("Hello World", false).content(parent -> {
+		NotificationPopup notication = this.builder.title("Hello World", false).content(parent -> {
 			text[0] = new Text(parent, SWT.NONE);
 			text[0].setText("My custom Text");
 			return text[0];
@@ -114,6 +119,20 @@ public class NotificationPopupTest {
 		List<Control> controls = getNotificationPopupControls(notication);
 		notication.close();
 		assertThat(controls, hasItem(is(text[0])));
+	}
+
+	@Test
+	public void createsForShell() {
+		shell = WidgetFactory.shell(SWT.NONE).create(display);
+		this.builder = NotificationPopup.forShell(shell);
+
+		NotificationPopup notication = this.builder.text("This is a test").title("Hello World", false).delay(1).build();
+		notication.open();
+		List<Control> controls = getNotificationPopupControls(notication);
+
+		assertThat(controls, hasItem(aLabelWith("Hello World")));
+		assertThat(controls, hasItem(aLabelWith("This is a test")));
+		notication.close();
 	}
 
 	private List<Control> getNotificationPopupControls(NotificationPopup notication) {


### PR DESCRIPTION
Allow setting the shell in the builder API for Notification Popups.

Issue: https://github.com/eclipse-platform/eclipse.platform.ui/issues/1226