### PR TITLE
Use PDEProject.getManifest(project) instead of hard coded location

### DIFF
--- a/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/dialogs/FilteredContributionDialog.java
+++ b/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/dialogs/FilteredContributionDialog.java
@@ -1034,8 +1034,7 @@ public abstract class FilteredContributionDialog extends SaveDialogBoundsSetting
 	}
 
 	static String getBundle(IProject project) {
-		final IFile f = project.getFile("/META-INF/MANIFEST.MF"); //$NON-NLS-1$
-
+		final IFile f = PDEProject.getManifest(project);
 		if (f != null && f.exists()) {
 			try (final InputStream s = f.getContents();
 					BufferedReader r = new BufferedReader(new InputStreamReader(s));) {


### PR DESCRIPTION
Currently a hardcoded location is used but PDE can configure the location of the manifest.

This replace the hardcoded string by the appropriate method from PDE to determine the real location

Fix https://github.com/eclipse-platform/eclipse.platform.ui/issues/1236

FYI as discussed at [EclipseCon23](https://www.eclipsecon.org/2023) @merks @juergen-albert @stbischof