### PR TITLE
Add getter for the supplied error status of ErrorEditorPart

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/ErrorEditorPart.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/ErrorEditorPart.java
@@ -94,4 +94,12 @@ public class ErrorEditorPart extends EditorPart {
 		super.dispose();
 		parentControl = null;
 	}
+
+	/**
+	 * @return Returns the error status or <code>null</code> if part was created
+	 *         without an explicit error status.
+	 */
+	public IStatus getError() {
+		return error;
+	}
 }


### PR DESCRIPTION
Currently the ErrorEditorPart supplied status can only be seen by a user in the UI, this is a bit unfortunate if for example in an automated test and ErrorEditorPart is seen there is no way to find out what's going wrong and give good assertion messages.

This adds ErrorEditorPart#getError to allow such programmatic investigations if ErrorEditorPart is seen in the code.

An example can be seen here: 
- https://github.com/eclipse-pde/eclipse.pde/pull/819

[the unit test fails](https://github.com/eclipse-pde/eclipse.pde/runs/18054820323) because we get an error part but there is no way for the test to tell the user whats going wrong.