### PR TITLE
Restore command state support #925

### DIFF
--- a/bundles/org.eclipse.core.commands/src/org/eclipse/core/commands/AbstractHandlerWithState.java
+++ b/bundles/org.eclipse.core.commands/src/org/eclipse/core/commands/AbstractHandlerWithState.java
@@ -68,9 +68,14 @@ public abstract class AbstractHandlerWithState extends AbstractHandler implement
 		if (states == null) {
 			states = new HashMap<>(3);
 		}
-		states.put(stateId, state);
+		State oldState = states.put(stateId, state);
 		state.addListener(this);
-		handleStateChange(state, null);
+		if (oldState != null) {
+			oldState.removeListener(this);
+			handleStateChange(state, oldState.getValue());
+		} else {
+			handleStateChange(state, null);
+		}
 	}
 
 	@Override
@@ -125,5 +130,13 @@ public abstract class AbstractHandlerWithState extends AbstractHandler implement
 				}
 			}
 		}
+	}
+
+	@Override
+	public void dispose() {
+		for (String id : getStateIds()) {
+			removeState(id);
+		}
+		super.dispose();
 	}
 }

--- a/bundles/org.eclipse.e4.core.commands/src/org/eclipse/e4/core/commands/internal/HandlerServiceHandler.java
+++ b/bundles/org.eclipse.e4.core.commands/src/org/eclipse/e4/core/commands/internal/HandlerServiceHandler.java
@@ -14,12 +14,14 @@
 
 package org.eclipse.e4.core.commands.internal;
 
-import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.AbstractHandlerWithState;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.HandlerEvent;
 import org.eclipse.core.commands.IHandler;
+import org.eclipse.core.commands.IObjectWithState;
 import org.eclipse.core.commands.NotHandledException;
+import org.eclipse.core.commands.State;
 import org.eclipse.core.expressions.IEvaluationContext;
 import org.eclipse.e4.core.commands.ExpressionContext;
 import org.eclipse.e4.core.commands.internal.HandlerServiceImpl.ExecutionContexts;
@@ -33,13 +35,15 @@ import org.eclipse.e4.core.di.annotations.Execute;
 /**
  * Provide an IHandler to delegate calls to.
  */
-public class HandlerServiceHandler extends AbstractHandler {
+public class HandlerServiceHandler extends AbstractHandlerWithState {
 
 	private static final String FAILED_TO_FIND_HANDLER_DURING_EXECUTION = "Failed to find handler during execution"; //$NON-NLS-1$
 	private static final String HANDLER_MISSING_EXECUTE_ANNOTATION = " handler is missing @Execute"; //$NON-NLS-1$
 	private static final Object missingExecute = new Object();
 
 	protected final String commandId;
+	// Remove state from currentStateHandler when it goes out of scope
+	private IObjectWithState currentStateHandler;
 
 	public HandlerServiceHandler(String commandId) {
 		this.commandId = commandId;
@@ -54,6 +58,7 @@ public class HandlerServiceHandler extends AbstractHandler {
 			return super.isEnabled();
 		}
 		Object handler = HandlerServiceImpl.lookUpHandler(executionContext, commandId);
+		switchHandler(handler);
 		if (handler == null) {
 			setBaseEnabled(false);
 			return super.isEnabled();
@@ -73,6 +78,7 @@ public class HandlerServiceHandler extends AbstractHandler {
 			return;
 		}
 		Object handler = HandlerServiceImpl.lookUpHandler(executionContext, commandId);
+		switchHandler(handler);
 		if (handler == null) {
 			return;
 		}
@@ -124,6 +130,7 @@ public class HandlerServiceHandler extends AbstractHandler {
 		ExecutionContexts contexts = HandlerServiceImpl.peek();
 		if (contexts != null) {
 			Object handler = HandlerServiceImpl.lookUpHandler(contexts.context, commandId);
+			switchHandler(handler);
 			if (handler instanceof IHandler) {
 				return ((IHandler) handler).isHandled();
 			}
@@ -142,6 +149,7 @@ public class HandlerServiceHandler extends AbstractHandler {
 		}
 
 		Object handler = HandlerServiceImpl.lookUpHandler(executionContext, commandId);
+		switchHandler(handler);
 		if (handler == null) {
 			return null;
 		}
@@ -188,4 +196,73 @@ public class HandlerServiceHandler extends AbstractHandler {
 	public String toString() {
 		return this.getClass().getSimpleName() + "(\"" + commandId + "\")"; //$NON-NLS-1$//$NON-NLS-2$
 	}
+
+	@Override
+	public void addState(String stateId, State state) {
+		super.addState(stateId, state);
+		IObjectWithState handler = lookUpHandlerWithState();
+		if (handler != null) {
+			handler.addState(stateId, state);
+		}
+	}
+
+	@Override
+	public void removeState(String stateId) {
+		IObjectWithState handler = lookUpHandlerWithState();
+		if (handler != null) {
+			handler.removeState(stateId);
+		}
+		super.removeState(stateId);
+	}
+
+	@Override
+	public void handleStateChange(State state, Object oldValue) {
+	}
+
+	@Override
+	public void dispose() {
+		switchHandler(null);
+		super.dispose();
+	}
+
+	private IObjectWithState lookUpHandlerWithState() {
+		ExecutionContexts contexts = HandlerServiceImpl.peek();
+		if (contexts == null) {
+			return null;
+		}
+		Object handler = HandlerServiceImpl.lookUpHandler(contexts.context, commandId);
+		switchHandler(handler);
+		if (!(handler instanceof IObjectWithState)) {
+			return null;
+		}
+		if (handler instanceof IHandler) {
+			if (!((IHandler) handler).isHandled()) {
+				return null;
+			}
+		}
+		return (IObjectWithState) handler;
+	}
+
+	private void switchHandler(Object handler) {
+		IObjectWithState typed;
+		if (handler instanceof IObjectWithState) {
+			typed = (IObjectWithState) handler;
+		} else {
+			typed = null;
+		}
+		IObjectWithState oldHandler = currentStateHandler;
+		if (oldHandler == typed) {
+			return;
+		}
+		currentStateHandler = typed;
+		for (String id : getStateIds()) {
+			if (oldHandler != null) {
+				oldHandler.removeState(id);
+			}
+			if (typed != null) {
+				typed.addState(id, getState(id));
+			}
+		}
+	}
+
 }

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/E4HandlerProxy.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/E4HandlerProxy.java
@@ -24,7 +24,9 @@ import org.eclipse.core.commands.HandlerEvent;
 import org.eclipse.core.commands.IHandler;
 import org.eclipse.core.commands.IHandler2;
 import org.eclipse.core.commands.IHandlerListener;
+import org.eclipse.core.commands.IObjectWithState;
 import org.eclipse.core.commands.NotHandledException;
+import org.eclipse.core.commands.State;
 import org.eclipse.core.expressions.IEvaluationContext;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -50,7 +52,7 @@ import org.eclipse.ui.menus.UIElement;
  * @since 3.5
  *
  */
-public class E4HandlerProxy implements IHandler2, IHandlerListener, IElementUpdater {
+public class E4HandlerProxy implements IHandler2, IHandlerListener, IElementUpdater, IObjectWithState {
 	public HandlerActivation activation;
 	private final Command command;
 	private final IHandler handler;
@@ -193,6 +195,36 @@ public class E4HandlerProxy implements IHandler2, IHandlerListener, IElementUpda
 		}
 		builder.append("]"); //$NON-NLS-1$
 		return builder.toString();
+	}
+
+	@Override
+	public void addState(String id, State state) {
+		if (handler instanceof IObjectWithState) {
+			((IObjectWithState) handler).addState(id, state);
+		}
+	}
+
+	@Override
+	public State getState(String stateId) {
+		if (handler instanceof IObjectWithState) {
+			return ((IObjectWithState) handler).getState(stateId);
+		}
+		return null;
+	}
+
+	@Override
+	public String[] getStateIds() {
+		if (handler instanceof IObjectWithState) {
+			return ((IObjectWithState) handler).getStateIds();
+		}
+		return new String[0];
+	}
+
+	@Override
+	public void removeState(String stateId) {
+		if (handler instanceof IObjectWithState) {
+			((IObjectWithState) handler).removeState(stateId);
+		}
 	}
 
 }

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/HandlerProxy.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/HandlerProxy.java
@@ -24,7 +24,7 @@ import org.eclipse.core.commands.HandlerEvent;
 import org.eclipse.core.commands.IHandler;
 import org.eclipse.core.commands.IHandler2;
 import org.eclipse.core.commands.IHandlerListener;
-import org.eclipse.core.commands.IStateListener;
+import org.eclipse.core.commands.IObjectWithState;
 import org.eclipse.core.commands.State;
 import org.eclipse.core.expressions.EvaluationResult;
 import org.eclipse.core.expressions.Expression;
@@ -341,6 +341,11 @@ public final class HandlerProxy extends AbstractHandlerWithState implements IEle
 				if (configurationElement != null) {
 					handler = (IHandler) configurationElement.createExecutableExtension(handlerAttributeName);
 					handler.addHandlerListener(getHandlerListener());
+					if (handler instanceof IObjectWithState) {
+						for (String id : getStateIds()) {
+							((IObjectWithState) handler).addState(id, getState(id));
+						}
+					}
 					setEnabled(evaluationService == null ? null : evaluationService.getCurrentState());
 					refreshElements();
 					return true;
@@ -453,9 +458,6 @@ public final class HandlerProxy extends AbstractHandlerWithState implements IEle
 			radioState = state;
 			refreshElements();
 		}
-		if (handler instanceof IStateListener) {
-			((IStateListener) handler).handleStateChange(state, oldValue);
-		}
 	}
 
 	/**
@@ -474,5 +476,21 @@ public final class HandlerProxy extends AbstractHandlerWithState implements IEle
 	 */
 	public IHandler getHandler() {
 		return handler;
+	}
+
+	@Override
+	public void addState(String stateId, State state) {
+		super.addState(stateId, state);
+		if (handler instanceof IObjectWithState) {
+			((IObjectWithState) handler).addState(stateId, state);
+		}
+	}
+
+	@Override
+	public void removeState(String stateId) {
+		if (handler instanceof IObjectWithState) {
+			((IObjectWithState) handler).removeState(stateId);
+		}
+		super.removeState(stateId);
 	}
 }

--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/HoverTest.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/HoverTest.java
@@ -127,7 +127,7 @@ public class HoverTest extends AbstratGenericEditorTest {
 			marker.setAttribute(MarkerResolutionGenerator.FIXME, true);
 			AbstractInformationControlManager manager= triggerCompletionAndRetrieveInformationControlManager();
 			Object hoverData= getHoverData(manager);
-			assertTrue(hoverData instanceof Map);
+			assertTrue(""+hoverData, hoverData instanceof Map);
 			assertTrue(((Map<?, ?>) hoverData).containsValue(Collections.singletonList(marker)));
 			assertTrue(((Map<?, ?>) hoverData).containsValue(AlrightyHoverProvider.LABEL));
 			assertFalse(((Map<?, ?>) hoverData).containsValue(HelloHoverProvider.LABEL));

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandsTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandsTestSuite.java
@@ -43,6 +43,7 @@ import org.junit.runners.Suite;
 	ActionDelegateProxyTest.class,
 	ToggleStateTest.class,
 	RadioStateTest.class,
+	WorkbenchStateTest.class,
 	E4CommandImageTest.class
 })
 public final class CommandsTestSuite {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/RadioStateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/RadioStateTest.java
@@ -14,19 +14,23 @@
 
 package org.eclipse.ui.tests.commands;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.Parameterization;
 import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.core.commands.State;
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.commands.IElementReference;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.handlers.RadioState;
 import org.eclipse.ui.menus.UIElement;
 import org.eclipse.ui.services.IServiceLocator;
-import org.eclipse.ui.tests.harness.util.UITestCase;
-import org.junit.Ignore;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -37,19 +41,15 @@ import org.junit.runners.JUnit4;
  *
  */
 @RunWith(JUnit4.class)
-@Ignore("broke during e4 transition and still need adjustments")
-public class RadioStateTest extends UITestCase {
+public class RadioStateTest {
+
+	private final IWorkbench fWorkbench = PlatformUI.getWorkbench();
 
 	private ICommandService commandService;
 	private IHandlerService handlerService;
 
-	public RadioStateTest(String testName) {
-		super(testName);
-	}
-
-	@Override
-	protected void doSetUp() throws Exception {
-		super.doSetUp();
+	@Before
+	public void doSetUp() throws Exception {
 		commandService = fWorkbench
 				.getService(ICommandService.class);
 		handlerService = fWorkbench

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/StateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/StateTest.java
@@ -14,6 +14,11 @@
 
 package org.eclipse.ui.tests.commands;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.core.commands.AbstractHandlerWithState;
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.ExecutionEvent;
@@ -23,13 +28,15 @@ import org.eclipse.core.commands.common.CommandException;
 import org.eclipse.jface.commands.PersistentState;
 import org.eclipse.jface.menus.TextState;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.handlers.IHandlerActivation;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.handlers.RegistryRadioState;
 import org.eclipse.ui.tests.TestPlugin;
-import org.eclipse.ui.tests.harness.util.UITestCase;
-import org.junit.Ignore;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -40,8 +47,7 @@ import org.junit.runners.JUnit4;
  * @since 3.2
  */
 @RunWith(JUnit4.class)
-@Ignore("functionality broken since e4 transition because org.eclipse.e4.core.commands.internal.HandlerServiceHandler does not implement org.eclipse.core.commands.IObjectWithState.")
-public class StateTest extends UITestCase {
+public class StateTest {
 
 	/**
 	 *
@@ -122,18 +128,10 @@ public class StateTest extends UITestCase {
 	 */
 	private IHandlerActivation handlerActivation;
 
-	/**
-	 * Constructor for <code>StateTest</code>.
-	 *
-	 * @param name
-	 *            The name of the test
-	 */
-	public StateTest(String name) {
-		super(name);
-	}
+	private final IWorkbench fWorkbench = PlatformUI.getWorkbench();
 
-	@Override
-	protected final void doSetUp() {
+	@Before
+	public final void doSetUp() {
 		// Reset the object state to the initial object.
 		final ICommandService commandService = fWorkbench
 				.getService(ICommandService.class);
@@ -146,10 +144,18 @@ public class StateTest extends UITestCase {
 		final IHandlerService handlerService = fWorkbench
 				.getService(IHandlerService.class);
 		handlerActivation = handlerService.activateHandler(COMMAND_ID, handler);
+		// side effect: force handler association in
+		// org.eclipse.e4.core.commands.internal.HandlerServiceHandler
+		// This is done by org.eclipse.ui.menus.CommandContributionItem.isEnabled() and
+		// org.eclipse.e4.ui.workbench.renderers.swt.ToolItemUpdater
+		// during normal operation
+		// See org.eclipse.ui.tests.commands.WorkbenchStateTest for an integration test
+		// that does not rely on explicit polling
+		assertTrue(command.isHandled());
 	}
 
-	@Override
-	protected final void doTearDown() {
+	@After
+	public final void doTearDown() {
 		// Unregister the object state handler.
 		final IHandlerService handlerService = fWorkbench
 				.getService(IHandlerService.class);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/ToggleStateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/ToggleStateTest.java
@@ -15,21 +15,26 @@
 
 package org.eclipse.ui.tests.commands;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.Parameterization;
 import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.core.commands.State;
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.commands.IElementReference;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.handlers.RegistryToggleState;
 import org.eclipse.ui.menus.UIElement;
 import org.eclipse.ui.services.IServiceLocator;
-import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.Before;
 import org.junit.FixMethodOrder;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -42,20 +47,14 @@ import org.junit.runners.MethodSorters;
  */
 @RunWith(JUnit4.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-@Ignore("broke during e4 transition and still need adjustments")
-public class ToggleStateTest extends UITestCase {
+public class ToggleStateTest {
 
+	private final IWorkbench fWorkbench = PlatformUI.getWorkbench();
 	private ICommandService commandService;
 	private IHandlerService handlerService;
 
-	public ToggleStateTest() {
-		super(ToggleStateTest.class.getName());
-	}
-
-
-	@Override
-	protected void doSetUp() throws Exception {
-		super.doSetUp();
+	@Before
+	public void doSetUp() throws Exception {
 		commandService = fWorkbench.getService(ICommandService.class);
 		handlerService = fWorkbench.getService(IHandlerService.class);
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/WorkbenchStateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/WorkbenchStateTest.java
@@ -1,0 +1,282 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Vasili Gulevich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.tests.commands;
+
+import static org.junit.Assert.assertSame;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
+
+import org.eclipse.core.commands.Command;
+import org.eclipse.core.commands.State;
+import org.eclipse.jface.action.ToolBarManager;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.ToolBar;
+import org.eclipse.swt.widgets.ToolItem;
+import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.commands.ICommandService;
+import org.eclipse.ui.contexts.IContextActivation;
+import org.eclipse.ui.contexts.IContextService;
+import org.eclipse.ui.handlers.RegistryToggleState;
+import org.eclipse.ui.menus.IMenuService;
+import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.eclipse.ui.tests.menus.HandlerWithStateMock;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @since 3.5
+ *
+ */
+public class WorkbenchStateTest {
+	/**
+	 * The object to which the command is set as a test.
+	 */
+	private static final Object OBJECT_CHANGED = "CHANGED";
+
+	/**
+	 * The object to which the command is set before the test starts.
+	 */
+	private static final Object OBJECT_INITIAL = "INITIAL";
+
+	/**
+	 * The identifier of the state storing a simple object.
+	 */
+	private static final String OBJECT_STATE_ID = "OBJECT";
+
+	private static final String VIEW_ID = "org.eclipse.ui.tests.api.MenuTestHarness";
+	private static final String CONTEXT_ID = "org.eclipse.ui.tests.issue925";
+
+	private final IWorkbench fWorkbench = PlatformUI.getWorkbench();
+	private final ICommandService commandService = fWorkbench.getService(ICommandService.class);
+	private final IContextService contextService = fWorkbench.getService(IContextService.class);
+
+	private IWorkbenchWindow testWindow;
+
+	private final Command command = commandService.getCommand("org.eclipse.ui.tests.commandWithState");
+
+	@Before
+	public final void before() {
+		testWindow = UITestCase.openTestWindow();
+		IViewPart view = testWindow.getActivePage().findView(VIEW_ID);
+		Assert.assertNull(view);
+		Assert.assertFalse(
+				((Collection<String>) contextService.getActiveContextIds()).contains("org.eclipse.ui.tests.issue925"));
+		command.getState(OBJECT_STATE_ID).setValue(OBJECT_INITIAL);
+		command.getState(RegistryToggleState.STATE_ID).setValue(false);
+		Assert.assertFalse(command.isEnabled());
+		Assert.assertFalse(command.isHandled());
+		Assert.assertNull(getHandlerState());
+	}
+
+	@After
+	public final void after() {
+		testWindow.close();
+	}
+
+	@Test
+	public final void commandListensHandler() {
+		// https://github.com/eclipse-platform/eclipse.platform.ui/issues/925
+		// This test forces handler reassociation by explicitly polling command
+		// accessors like isHandled()
+
+		IContextActivation contextActivation = contextService.activateContext(CONTEXT_ID);
+		try {
+			// side effect: handler reassociation
+			Assert.assertTrue("Command should be handled once context activates", command.isHandled());
+			assertSame("The initial state was not correct", OBJECT_INITIAL,
+					command.getState(OBJECT_STATE_ID).getValue());
+			assertSame("Handler state should match command state", command.getState(OBJECT_STATE_ID).getValue(),
+					getHandlerState());
+			HandlerWithStateMock.INSTANCE.getState(OBJECT_STATE_ID).setValue(OBJECT_CHANGED);
+			assertSame("Handler state should match command state", command.getState(OBJECT_STATE_ID).getValue(),
+					getHandlerState());
+		} finally {
+			contextService.deactivateContext(contextActivation);
+		}
+		// side effect: handler reassociation
+		Assert.assertFalse("Command should not be handled outside of context", command.isHandled());
+		Assert.assertNull("Handler should have states removed when context exits", getHandlerState());
+	}
+
+	@Test
+	public final void toolbarCheckStateIsUpdated() {
+		// https://github.com/eclipse-platform/eclipse.platform.ui/issues/925
+		// This test relies on toolbar context monitoring to perform command queries on
+		// context switch, command queries then reassociate handlers
+		// See org.eclipse.e4.ui.workbench.renderers.swt.ToolItemUpdater
+
+		final IMenuService menus = testWindow.getService(IMenuService.class);
+		// The toolbar has to be visible,for its updater to kick in, so we have to use
+		// an open window
+		ToolBar toolbar = new ToolBar(testWindow.getShell(), 0);
+		final ToolBarManager toolbarManager = new ToolBarManager(toolbar);
+		menus.populateContributionManager(toolbarManager, "toolbar:org.eclipse.ui.tests.commands.WorkbenchStateTest");
+		try {
+
+			BooleanSupplier isChecked = () -> itemByLabel(toolbar, "Command Wtih State").getSelection();
+
+			assertEventually("Item should be unchecked initially", not(isChecked));
+
+			IContextActivation contextActivation = contextService.activateContext(CONTEXT_ID);
+			try {
+				assertEventually("Handler is associated", () -> getHandlerState() != null);
+				assertEventually("Initial state of command is unchecked", not(isChecked));
+
+				HandlerWithStateMock.INSTANCE.getState(RegistryToggleState.STATE_ID).setValue(true);
+
+				assertEventually("Item should be checked on a request from handler", isChecked);
+
+				HandlerWithStateMock.INSTANCE.getState(RegistryToggleState.STATE_ID).setValue(false);
+
+				assertEventually("Item should be unchecked on a request from handler", not(isChecked));
+
+			} finally {
+				contextService.deactivateContext(contextActivation);
+			}
+		} finally {
+			menus.releaseContributions(toolbarManager);
+		}
+
+	}
+
+	@Test
+	public final void viewToolbarReassociatesCommandEventually() throws PartInitException {
+		// https://github.com/eclipse-platform/eclipse.platform.ui/issues/925
+		// This test relies on toolbar context monitoring to perform command queries on
+		// context switch, command queries then reassociate handlers
+		// The toolbar is automatically populated with test view, making this a full
+		// integration test
+
+		testWindow.getActivePage().showView(VIEW_ID);
+
+		Assert.assertNull("Handler should not be initialized with states, until context is activated",
+				getHandlerState());
+
+		IContextActivation contextActivation = contextService.activateContext(CONTEXT_ID);
+		try {
+			// View shows toolbar that should eventually poll the command causing
+			// state reassociation
+			// As toolbar updates are throttled, some wait might be necessary
+			assertEventually("Handler should be initialized when context is active",
+					() -> OBJECT_INITIAL == getHandlerState());
+
+			HandlerWithStateMock.INSTANCE.getState(OBJECT_STATE_ID).setValue(OBJECT_CHANGED);
+
+			assertSame("Command state should match handler state", OBJECT_CHANGED, getCommandState());
+
+		} finally {
+			contextService.deactivateContext(contextActivation);
+		}
+		assertEventually("Handler should have states removed when context exits", () -> getHandlerState() == null);
+	}
+
+	@Test
+	public final void toolbarReassociatesCommandEventually() {
+		// https://github.com/eclipse-platform/eclipse.platform.ui/issues/925
+		// Here we test states the are not related to selection or enablement, as those
+		// have special handling in workbench
+
+		final IMenuService menus = testWindow.getService(IMenuService.class);
+		final ToolBarManager toolbarManager = new ToolBarManager(new ToolBar(testWindow.getShell(), 0));
+		menus.populateContributionManager(toolbarManager, "toolbar:org.eclipse.ui.tests.commands.WorkbenchStateTest");
+		try {
+			Assert.assertNull("Handler should not be initialized with states, until context is activated",
+					getHandlerState());
+
+			IContextActivation contextActivation = contextService.activateContext(CONTEXT_ID);
+			try {
+				// View shows toolbar that should eventually poll the command causing
+				// state reassociation
+				// As toolbar updates are throttled, some wait might be necessary
+				assertEventually("Handler should be initialized when context is active",
+						() -> OBJECT_INITIAL == getHandlerState());
+
+				HandlerWithStateMock.INSTANCE.getState(OBJECT_STATE_ID).setValue(OBJECT_CHANGED);
+
+				assertSame("Command state should match handler state", OBJECT_CHANGED, getCommandState());
+
+			} finally {
+				contextService.deactivateContext(contextActivation);
+			}
+			assertEventually("Handler should have states removed when context exits", () -> getHandlerState() == null);
+		} finally {
+			menus.releaseContributions(toolbarManager);
+		}
+	}
+
+	private Object getHandlerState() {
+		if (HandlerWithStateMock.INSTANCE == null) {
+			return null;
+		}
+		State state = HandlerWithStateMock.INSTANCE.getState(OBJECT_STATE_ID);
+		if (state == null) {
+			return null;
+		}
+		return state.getValue();
+	}
+
+	private Object getCommandState() {
+		State state = command.getState(OBJECT_STATE_ID);
+		if (state == null) {
+			return null;
+		}
+		return state.getValue();
+	}
+
+	private static void assertEventually(String message, BooleanSupplier predicate) {
+		Display display = PlatformUI.getWorkbench().getDisplay();
+		// Run defered operations
+		for (int i = 0; i < 10; i++) {
+			if (display != null && !display.isDisposed()) {
+				while (!display.isDisposed() && display.readAndDispatch()) {
+				}
+				Thread.yield();
+			}
+		}
+
+		long stop = System.currentTimeMillis() + 1000;
+		while (System.currentTimeMillis() < stop && !display.isDisposed()) {
+			if (predicate.getAsBoolean()) {
+				return;
+			}
+			while (!display.isDisposed() && display.readAndDispatch()) {
+			}
+			Thread.yield();
+		}
+		Assert.fail(message);
+	}
+
+	private static BooleanSupplier not(BooleanSupplier isChecked) {
+		Objects.requireNonNull(isChecked);
+		return () -> !isChecked.getAsBoolean();
+	}
+
+	private ToolItem itemByLabel(ToolBar toolbar, String label) {
+		for (ToolItem item : toolbar.getItems()) {
+			if (label.equals(item.getText())) {
+				return item;
+			}
+		}
+		return null;
+	}
+
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/HandlerWithStateMock.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/HandlerWithStateMock.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Vasili Gulevich - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.ui.tests.menus;
+
+import org.eclipse.core.commands.AbstractHandlerWithState;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.State;
+
+public final class HandlerWithStateMock extends AbstractHandlerWithState {
+	public static HandlerWithStateMock INSTANCE;
+
+	public HandlerWithStateMock() {
+		INSTANCE = this;
+	}
+
+	@Override
+	public void handleStateChange(State state, Object oldValue) {
+
+	}
+
+	@Override
+	public Object execute(ExecutionEvent event) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void dispose() {
+		INSTANCE = null;
+		super.dispose();
+	}
+
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/session/HandlerStateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/session/HandlerStateTest.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.session;
 
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.State;
 import org.eclipse.jface.commands.PersistentState;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
+
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 /**
  * A test to verify the persistence of handler state between sessions.
@@ -63,6 +63,11 @@ public class HandlerStateTest extends TestCase {
 	 */
 	private static final String TRUE_STATE_ID = "TRUE";
 
+	private final IWorkbench workbench = PlatformUI.getWorkbench();
+	private final ICommandService service = workbench.getService(ICommandService.class);
+	private final Command command = service.getCommand(COMMAND_ID);
+
+
 	/**
 	 * Constructs a new instance of <code>HandlerStateTest</code>.
 	 *
@@ -78,10 +83,6 @@ public class HandlerStateTest extends TestCase {
 	 * is changed.
 	 */
 	public final void testInitialHandlerState() {
-		final IWorkbench workbench = PlatformUI.getWorkbench();
-		final ICommandService service = workbench
-				.getService(ICommandService.class);
-		final Command command = service.getCommand(COMMAND_ID);
 		State state;
 		boolean actual;
 
@@ -109,10 +110,6 @@ public class HandlerStateTest extends TestCase {
 	 * Verifies that the handler state is persisted between sessions.
 	 */
 	public final void testModifiedHandlerState() {
-		final IWorkbench workbench = PlatformUI.getWorkbench();
-		final ICommandService service = workbench
-				.getService(ICommandService.class);
-		final Command command = service.getCommand(COMMAND_ID);
 		State state;
 		boolean actual;
 

--- a/tests/org.eclipse.ui.tests/plugin.xml
+++ b/tests/org.eclipse.ui.tests/plugin.xml
@@ -2752,8 +2752,59 @@
          <state
                class="org.eclipse.jface.menus.TextState"
                id="TEXT"/>
+         <state
+               class="org.eclipse.ui.handlers.RegistryToggleState"
+               id="org.eclipse.ui.commands.toggleState">
+         </state>
       </command>
    </extension>
+   
+   <extension
+       point="org.eclipse.ui.handlers">
+    <handler
+          class="org.eclipse.ui.tests.menus.HandlerWithStateMock"
+          commandId="org.eclipse.ui.tests.commandWithState">
+       <activeWhen>
+          <with
+                variable="activeContexts">
+             <iterate
+                   ifEmpty="false"
+                   operator="or">
+                <equals
+                      value="org.eclipse.ui.tests.issue925">
+                </equals>
+             </iterate>
+          </with>
+       </activeWhen>
+    </handler>
+    </extension>
+    <extension
+           point="org.eclipse.ui.contexts">
+        <context
+              description="Enable a stateful command handler to reproduce issue #925"
+              id="org.eclipse.ui.tests.issue925"
+              name="issue925">
+        </context>
+    </extension>
+    <extension
+       point="org.eclipse.ui.menus">
+        <menuContribution
+              allPopups="false"
+              locationURI="toolbar:org.eclipse.ui.tests.api.MenuTestHarness">
+           <command
+                 commandId="org.eclipse.ui.tests.commandWithState"
+                 style="toggle">
+           </command>
+        </menuContribution>
+        <menuContribution
+              allPopups="false"
+              locationURI="toolbar:org.eclipse.ui.tests.commands.WorkbenchStateTest">
+           <command
+                 commandId="org.eclipse.ui.tests.commandWithState"
+                 style="toggle">
+           </command>
+        </menuContribution>
+    </extension>
    
    <!-- for bug 125792 -->
    <extension


### PR DESCRIPTION
Restore state support for command handlers as documented in [IObjectWithState](https://github.com/eclipse-platform/eclipse.platform.ui/blob/50553ea8426afdc390e14676abf8906c44d184a4/bundles/org.eclipse.core.commands/src/org/eclipse/core/commands/IObjectWithState.java#L29) Javadoc.
See previous work in [Bug 549802](https://bugs.eclipse.org/bugs/show_bug.cgi?id=549802)
Fixes #925

This PR assumes that `IObjectWithState` protocol is not deprecated. If it is feasible to deprecate it, do not merge this PR.

Command state support had been lost during migration to E4 as proxies failed to properly support `IObjectWithState` protocol or ignored it altogether.

- [HandlerProxy](https://github.com/eclipse-platform/eclipse.platform.ui/blob/50553ea8426afdc390e14676abf8906c44d184a4/bundles/org.eclipse.ui.workbench/Eclipse%20UI/org/eclipse/ui/internal/handlers/HandlerProxy.java#L63)
- [HandlerServiceHandler](https://github.com/eclipse-platform/eclipse.platform.ui/blob/50553ea8426afdc390e14676abf8906c44d184a4/bundles/org.eclipse.e4.core.commands/src/org/eclipse/e4/core/commands/internal/HandlerServiceHandler.java#L36)
- [E4HandlerProxy](https://github.com/eclipse-platform/eclipse.platform.ui/blob/50553ea8426afdc390e14676abf8906c44d184a4/bundles/org.eclipse.ui.workbench/Eclipse%20UI/org/eclipse/ui/internal/handlers/E4HandlerProxy.java#L53)

do now support the protocol. Following tests are modified to rely on command state polling and reenabled:

StateTest
ToggleStateTest
RadioStateTest

A new test WorkbenchStateTest demonstrates how state propagation works in workbench environment without explicit polling.

Main changes:
- internal APIs are extended to implement IObjectWIthState
- HandlerServiceHandler is now stateful