### PR TITLE
Pack the original OperationCanceledException in ModalContext::run

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/operation/ModalContext.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/operation/ModalContext.java
@@ -382,15 +382,17 @@ public class ModalContext {
 							// other thread).
 							new InvocationTargetException(null).printStackTrace();
 						}
-						if (throwable instanceof InvocationTargetException) {
-							throw (InvocationTargetException) throwable;
-						} else if (throwable instanceof InterruptedException) {
-							throw (InterruptedException) throwable;
+						if (throwable instanceof InvocationTargetException e) {
+							throw e;
+						} else if (throwable instanceof InterruptedException e) {
+							throw e;
 						} else if (throwable instanceof OperationCanceledException) {
 							// See 1GAN3L5: ITPUI:WIN2000 - ModalContext
 							// converts OperationCancelException into
 							// InvocationTargetException
-							throw new InterruptedException(throwable.getMessage());
+							InterruptedException interruptedException = new InterruptedException(throwable.getMessage());
+							interruptedException.initCause(throwable);
+							throw interruptedException;
 						} else {
 							throw new InvocationTargetException(throwable);
 						}


### PR DESCRIPTION
Provide the original `OperationCanceledException` when throwing an `InterruptedException` in `ModalContext::run`. This makes it easier to determine the cause of the `InterruptedException` from outside the method (i.e. in the `catch`-clauses)

This is the same that's already being done in [other places in the code](https://github.com/eclipse-platform/eclipse.platform.ui/commit/d8c2f8631708c3420e9d5b2581d2dbcd66153dbf).