### PR TITLE
Touch org.eclipse.ui.tests to adopt to the recent ecj changes

### DIFF
--- a/tests/org.eclipse.ui.tests/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ui.tests/forceQualifierUpdate.txt
@@ -9,4 +9,4 @@ Bug 572789 - Comparator errors in I20210412-1800 after moving to compiler from 4
 Unanticipated comparator errors in I2022-0523-320
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
-
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1488


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1498

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1488