### PR TITLE
Add a shorthand E4 aware way of setting the help context

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/PlatformUI.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/PlatformUI.java
@@ -20,8 +20,10 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.internal.workbench.swt.DialogSettingsProviderService;
 import org.eclipse.e4.ui.model.application.MApplication;
+import org.eclipse.e4.ui.services.help.EHelpService;
 import org.eclipse.jface.dialogs.IDialogSettingsProvider;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.application.WorkbenchAdvisor;
 import org.eclipse.ui.internal.Workbench;
@@ -307,5 +309,26 @@ public final class PlatformUI {
 		}
 		bundleContext.ungetService(reference);
 		return Optional.ofNullable(service.getApplication());
+	}
+
+	/**
+	 * Sets the given help id on the given control in a way that works both for
+	 * E3/E4 applications
+	 *
+	 * @param control       the control on which to register the id
+	 * @param helpContextId the id to use when F1 help is invoked
+	 * @since 3.131
+	 */
+	public static void setHelp(Composite control, String helpContextId) {
+		if (control == null || helpContextId == null) {
+			return;
+		}
+		Workbench workbench = Workbench.getInstance();
+		if (workbench == null) {
+			getApplication().map(MApplication::getContext).map(ctx -> ctx.get(EHelpService.class))
+					.ifPresent(helpService -> helpService.setHelp(control, helpContextId));
+		} else {
+			PlatformUI.getWorkbench().getHelpSystem().setHelp(control, helpContextId);
+		}
 	}
 }

--- a/bundles/org.eclipse.ui.workbench/META-INF/rewrite/platformui_sethelp.yml
+++ b/bundles/org.eclipse.ui.workbench/META-INF/rewrite/platformui_sethelp.yml
@@ -1,0 +1,9 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.eclipse.ui.PlatformUISetHelp
+displayName: Replace calls of PlatformUI.getWorkbench().getHelpSystem() with PlatformUI.getWorkbench().getHelpSystem().setHelp(...) with e4 safe PlatformUI.setHelp(...) variant
+recipeList:
+  - org.openrewrite.java.SimplifyMethodChain:
+      methodPatternChain: ['org.eclipse.ui.PlatformUI getWorkbench()', 'org.eclipse.ui.IWorkbench getHelpSystem()', 'org.eclipse.ui.help.IWorkbenchHelpSystem setHelp(..)']
+      newMethodName: setHelp
+      matchOverrides: false


### PR DESCRIPTION
A usual problem when running code inside an E4 RCP is that many dialogs access the PlatformUI#getWorkbench() to set the help context, this then fails. Beside that, the call chain is quite cumbersome as well as one usually has to call PlatformUI.getWorkbench().getHelpSystem().setHelp( ..).

This adds a new method PlatformUI#setHelp that is much shorter to call and allows detection if running with a workbench or E4 context.

Beside that, it also includes a open rewrite recipe for easy refactoring of existing code base.