### PR TITLE
Fix "javax.inject cannot be resolved to a type"

### DIFF
--- a/releng/org.eclipse.ui.releng/platformUiTools.p2f
+++ b/releng/org.eclipse.ui.releng/platformUiTools.p2f
@@ -52,6 +52,11 @@
         <repository location='https://download.eclipse.org/tools/orbit/downloads/latest-I'/>
       </repositories>
     </iu>
+    <iu id='javax.annotation' name='javax.annotation' version='1.3.5'>
+      <repositories size='1'>
+        <repository location='https://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532/repository'/>
+      </repositories>
+    </iu>
     <iu id='assertj-core' name='assertj-core' version='3.21.0'>
       <repositories size='1'>
         <repository location='https://download.eclipse.org/eclipse/updates/I-builds'/>


### PR DESCRIPTION
Install javax.annotation 1.3.5 from Orbit to avoid compilation errors in many platform projects.