### PR TITLE
Fix random failing PositionTrackerTest #882

### DIFF
--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/PositionTrackerTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/PositionTrackerTest.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.search.tests.filesearch;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeFalse;
@@ -137,8 +141,8 @@ public class PositionTrackerTest {
 
 			for (int i= 0; i < originalStarts.length; i++) {
 				Position currentPosition= InternalSearchUI.getInstance().getPositionTracker().getCurrentPosition(matches[i]);
-				assertNotNull(currentPosition);
-				assertEquals(originalStarts[i] + "Test".length(), currentPosition.getOffset());
+				assertThat(String.format("No position for match '%s' in file '%s'", matches[i], file), currentPosition, not(is(nullValue())));
+				assertEquals(originalStarts[i] + "Test".length(),currentPosition.getOffset());
 
 			}
 		} finally {


### PR DESCRIPTION
The test cases in `PositionTrackerTest` are randomly failing because the text editor part initializes a `DocumentLineDiffer` that concurrently modifies the document, thus affecting the matches that are validated via ssertions in these tests.
    
This change disables some properties that result in the `DocumentLineDiffer` not being instantiated during the test execution. It also reenables one of the test cases for MacOS, which should be fixed by this change.
In addition, the change improves the failing assertion, which is a null check that currently gives no context information. This change improves the error message in case the assertion fails.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/882