### PR TITLE
Remove cancel dialog during Eclipse shutdown

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
@@ -37,9 +37,6 @@ public class IDEWorkbenchMessages extends NLS {
 	// package: org.eclipse.ui.ide
 
 	public static String IDEWorkbenchAdvisor_noPerspective;
-	public static String IDEWorkbenchAdvisor_cancelHistoryPruning;
-	public static String IDEWorkbenchAdvisor_preHistoryCompaction;
-	public static String IDEWorkbenchAdvisor_postHistoryCompaction;
 
 	public static String IDE_noFileEditorSelectedUserCanceled;
 	public static String IDE_noFileEditorFound;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
@@ -41,9 +41,6 @@
 # package: org.eclipse.ui.ide
 
 IDEWorkbenchAdvisor_noPerspective=No perspectives are open. To open a perspective, press this button:
-IDEWorkbenchAdvisor_cancelHistoryPruning=Cancel to skip compacting local history.
-IDEWorkbenchAdvisor_preHistoryCompaction=Saving workbench state.
-IDEWorkbenchAdvisor_postHistoryCompaction=Disconnecting from workspace.
 
 IDE_noFileEditorSelectedUserCanceled = No editor selected, operation canceled by user.
 IDE_noFileEditorFound = No editor found to edit the file resource.


### PR DESCRIPTION
Removes the dialog during Eclipse shutdown which only flashes up in my Eclipse SDK build without any option to read it or interact with it.

The currently dialog behavior is also highly inconsistent or non-functional.

The cancel dialog during Eclipse shutdown, does not allow to cancel the shutdown, it allow affects the history pruning in the hard-code assumption that pruning happens in  (Math.abs(total - 4.0)).

Fixes #1269