### PR TITLE
Fix handler leak #925

### DIFF
--- a/bundles/org.eclipse.core.commands/src/org/eclipse/core/commands/IObjectWithState.java
+++ b/bundles/org.eclipse.core.commands/src/org/eclipse/core/commands/IObjectWithState.java
@@ -31,12 +31,18 @@ public interface IObjectWithState {
 	/**
 	 * Adds state to this object.
 	 *
-	 * @param id
-	 *            The identifier indicating the type of state being added; must
-	 *            not be <code>null</code>.
-	 * @param state
-	 *            The new state to add to this object; must not be
-	 *            <code>null</code>.
+	 * Usually, consumers will call <code>removeState()</code> with a matching id in
+	 * the same lifecycle of IObjectWithState. However, this behavior is not
+	 * guaranteed. Implementors should not rely on <code>removeState()</code> for
+	 * resource disposal. The recommended practice is to free resources associated
+	 * with non-removed states in some kind of dispose() method.
+	 *
+	 * @see AbstractHandlerWithState
+	 *
+	 * @param id    The identifier indicating the type of state being added; must
+	 *              not be <code>null</code>.
+	 * @param state The new state to add to this object; must not be
+	 *              <code>null</code>.
 	 */
 	public void addState(String id, State state);
 

--- a/bundles/org.eclipse.e4.core.commands/src/org/eclipse/e4/core/commands/internal/HandlerServiceHandler.java
+++ b/bundles/org.eclipse.e4.core.commands/src/org/eclipse/e4/core/commands/internal/HandlerServiceHandler.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.e4.core.commands.internal;
 
+import java.lang.ref.WeakReference;
 import org.eclipse.core.commands.AbstractHandlerWithState;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
@@ -43,7 +44,7 @@ public class HandlerServiceHandler extends AbstractHandlerWithState {
 
 	protected final String commandId;
 	// Remove state from currentStateHandler when it goes out of scope
-	private IObjectWithState currentStateHandler;
+	private WeakReference<IObjectWithState> currentStateHandler = new WeakReference<IObjectWithState>(null);
 
 	public HandlerServiceHandler(String commandId) {
 		this.commandId = commandId;
@@ -250,11 +251,12 @@ public class HandlerServiceHandler extends AbstractHandlerWithState {
 		} else {
 			typed = null;
 		}
-		IObjectWithState oldHandler = currentStateHandler;
+
+		IObjectWithState oldHandler = currentStateHandler.get();
 		if (oldHandler == typed) {
 			return;
 		}
-		currentStateHandler = typed;
+		currentStateHandler = new WeakReference<>(typed);
 		for (String id : getStateIds()) {
 			if (oldHandler != null) {
 				oldHandler.removeState(id);


### PR DESCRIPTION
Fixes #925
Fixes a regression introduced in https://github.com/eclipse-platform/eclipse.platform.ui/pull/1253

Handlers can store references to external objects so cleaning them up when another handler is activated is not quick enough. WeakReference is enough to detect handler switch, so we use that.

The main problem with this fix is the loss of side-effects on cleanup of old instances of `IObjectWithState` as `removeState()` is never called for them.