### PR TITLE
Adds minimal readme to JFace databinding snippets

### DIFF
--- a/examples/org.eclipse.jface.examples.databinding/Readme.adoc
+++ b/examples/org.eclipse.jface.examples.databinding/Readme.adoc
@@ -1,0 +1,7 @@
+JFace Data Binding/Snippets
+
+Snippets show how common use cases can be implemented using the JFace Data Binding framework. 
+
+They are typically a single self-contained Java class with a main method.
+
+Most of the examples in the snippets folder provide a main method, you can run it as a Java Application to see what happens.


### PR DESCRIPTION
Re-using parts of https://wiki.eclipse.org/JFace_Data_Binding/Snippets

This is just a start, we may or at least should migrate the descriptions for the snippets also.