### PR TITLE
Allow duplicate folder names in SmartImport wizard #1294

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportRootWizardPage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportRootWizardPage.java
@@ -31,8 +31,10 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -712,8 +714,14 @@ public class SmartImportRootWizardPage extends WizardPage {
 	}
 
 	protected boolean isExistingProjectName(File element) {
-		String name = element.getName();
-		return !name.isEmpty() && ResourcesPlugin.getWorkspace().getRoot().getProject(name).exists();
+		try {
+			String name = SmartImportJob.getOptionalProjectDescription(element).map(IProjectDescription::getName)
+					.orElse(""); //$NON-NLS-1$
+			return !name.isEmpty() && ResourcesPlugin.getWorkspace().getRoot().getProject(name).exists();
+		} catch (CoreException e) {
+			StatusManager.getManager().handle(e.getStatus(), StatusManager.LOG | StatusManager.SHOW);
+			return false;
+		}
 	}
 
 	protected void validatePage() {


### PR DESCRIPTION
Only block if new project's description's name is set and already taken. Otherwise the smart import will come up with a new project name prepending the parent folder name followed by "_" (recursively).

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1294