### PR TITLE
NLS missing messages in Generic Editor messages

### DIFF
--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/messages.properties
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/messages.properties
@@ -15,3 +15,6 @@ DefaultWordHighlightStrategy_OccurrencesOf=Occurrence of ''{0}''
 
 TextViewer_open_hyperlink_error_title=Open Hyperlink
 TextViewer_open_hyperlink_error_message=The operation is not applicable to the current selection. Select a hyperlink target.
+
+GotoMatchingBracket_error_noMatchingBracket=No matching bracket found
+GotoMatchingBracket_error_bracketOutsideSelectedElement=Matching bracket is outside the selected element


### PR DESCRIPTION
GotoMatchingBracket_error_noMatchingBracket in:
org.eclipse.ui.internal.genericeditor.messages
and GotoMatchingBracket_error_bracketOutsideSelectedElement are missing.

First one can be seen if you open the source tab of the target editor.