### PR TITLE
Fix display used for ImageRegistry creation

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/plugin/AbstractUIPlugin.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/plugin/AbstractUIPlugin.java
@@ -158,14 +158,14 @@ public abstract class AbstractUIPlugin extends Plugin {
 	 * @see #getImageRegistry
 	 */
 	protected ImageRegistry createImageRegistry() {
-
-		// If we are in the UI Thread use that
-		if (Display.getCurrent() != null) {
-			return new ImageRegistry(Display.getCurrent());
-		}
-
+		// Use display of workbench if available
 		if (PlatformUI.isWorkbenchRunning()) {
 			return new ImageRegistry(PlatformUI.getWorkbench().getDisplay());
+		}
+
+		// Otherwise use display of the current thread if available
+		if (Display.getCurrent() != null) {
+			return new ImageRegistry(Display.getCurrent());
 		}
 
 		// Invalid thread access if it is not the UI Thread

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/ApiTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/ApiTestSuite.java
@@ -83,7 +83,7 @@ import org.junit.runners.Suite;
 	 SaveablesListTest.class,
 	 PerspectiveExtensionReaderTest.class,
 	 ModeledPageLayoutTest.class,
-
+	 WorkbenchPluginTest.class
 })
 public class ApiTestSuite {
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/WorkbenchPluginTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/WorkbenchPluginTest.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package org.eclipse.ui.tests.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeFalse;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.core.runtime.Platform.OS;
+import org.eclipse.core.tests.harness.TestBarrier2;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.ImageRegistry;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.junit.Test;
+
+public class WorkbenchPluginTest {
+	/**
+	 * The test is supposed to initialize the image registry of an AbstractUIPlugin
+	 * from another thread. To this end, we use a new plug-in instance to simulate
+	 * the behavior of any specialization of an AbstractUIPlugin (like
+	 * WorkbenchPluginTest) being first accessed from another thread.
+	 */
+	private final AbstractUIPlugin testPlugin = new AbstractUIPlugin() {
+	};
+
+	@Test
+	public void testGetImageRegistryFromAdditionalDisplay() {
+		assumeFalse("multiple displays are not allowed on Linux", OS.isLinux());
+		assumeFalse("multiple displays are not allowed on MaxOS", OS.isMac());
+
+		String dummyFilename = "test"; //$NON-NLS-1$
+		Display displayInOtherThread = initializeDisplayInOtherThread();
+		try {
+			displayInOtherThread.syncExec(() -> getFileIcon(dummyFilename));
+			final Image iconFromMainThread = getFileIcon(dummyFilename);
+			disposeDisplay(displayInOtherThread);
+			assertThat("icon retrieved in main thread has been disposed through other display",
+					iconFromMainThread.isDisposed(), is(false));
+		} finally {
+			disposeDisplay(displayInOtherThread);
+		}
+	}
+
+	private Image getFileIcon(String filename) {
+		ImageRegistry registry = testPlugin.getImageRegistry();
+		Image fileIcon = registry.get(filename);
+		if (fileIcon != null) {
+			return fileIcon;
+		}
+		ImageDescriptor imageDescriptor = PlatformUI.getWorkbench().getEditorRegistry().getImageDescriptor(filename);
+		if (imageDescriptor != null) {
+			registry.put(filename, imageDescriptor);
+		}
+		return registry.get(filename);
+	}
+
+	private Display initializeDisplayInOtherThread() {
+		AtomicReference<Display> displayReference = new AtomicReference<>();
+		TestBarrier2 displayCreationBarrier = new TestBarrier2();
+		new Thread(() -> {
+			Display display = new Display();
+			displayCreationBarrier.setStatus(TestBarrier2.STATUS_DONE);
+			displayReference.set(display);
+			while (!display.isDisposed()) {
+				if (!display.readAndDispatch()) {
+					display.sleep();
+				}
+			}
+		}, "async display creation").start();
+		displayCreationBarrier.waitForStatus(TestBarrier2.STATUS_DONE);
+		return displayReference.get();
+	}
+
+	private void disposeDisplay(Display display) {
+		if (!display.isDisposed()) {
+			display.syncExec(() -> display.dispose());
+		}
+	}
+
+}


### PR DESCRIPTION
The `AbstractUIPlugin`, which is implemented by several UI plugins, creates and provides an  ImageRegistry`. This registry is initialized with the display of the current thread, if the current thread has a display, and with the display of the workbench otherwise. In consequence, if the first access to the ImageRegistry happens from a thread with a (temporary) display that is disposed at some point in time, all images will (unexpectedly) be disposed as well.  This can currently only happen
on Windows, as Linux and MacOS do not allow multiple display.

This change adapts the `ImageRegistry` creation in the `AbstractUIPlugin` so that the display of the workbench is used, if available. The current thread's display is only used if no workbench is running. This results in the `ImageRegistry` being disposed with the workbench instead of any temporary display. On systems that have no support for multiple displays, the change will simply have no effect. It also adds a regression test for the unexpected behavior.