### PR TITLE
Improve org.eclipse.ui.menus extension point documentation

### DIFF
--- a/bundles/org.eclipse.ui/schema/menus.exsd
+++ b/bundles/org.eclipse.ui/schema/menus.exsd
@@ -527,12 +527,14 @@ This should be the starting point for &lt;i&gt;all&lt;/i&gt; contributions into 
                   A &lt;code&gt;URI&lt;/code&gt; specification that defines the insertion point at which the contained additions will be added.
 
 The format for the URI is comprised of three basic parts:
-
-Scheme: One of &quot;menu&quot;, &quot;popup&quot; or &quot;toolbar. Indicates the type of the manager used to handle the contributions
-Id: This is either the id of an existing menu, a view id or the id of the editor &apos;type&apos;
-Query: The query format is &amp;lt;placement&amp;gt;=&amp;lt;id&amp;gt; where:
- &amp;lt;placement&amp;gt; is either &quot;before&quot;, &quot;after&quot;, or &quot;endof&quot; and
- &amp;lt;id&amp;gt; is the id of an existing menu item.  The placement modifier is executed when this contribution is processed.  Following contributions may change the final shape of the menu when they are processed.
+&lt;ul&gt;
+   &lt;li&gt;Scheme: One of &quot;menu&quot;, &quot;popup&quot; or &quot;toolbar&quot;. Indicates the type of the manager used to handle the contributions&lt;/li&gt;
+   &lt;li&gt;Id: This is either the id of an existing menu, a view id or the id of the editor &apos;type&apos;&lt;/li&gt;
+   &lt;li&gt;Query: The query format is &amp;lt;placement&amp;gt;=&amp;lt;id&amp;gt; where &amp;lt;placement&amp;gt; is either &quot;before&quot;, &quot;after&quot;, or &quot;endof&quot; and &amp;lt;id&amp;gt; is the id of an existing menu item.&lt;/li&gt;
+ &lt;/ul&gt;
+ &lt;p&gt;
+The placement modifier is executed when this contribution is processed. Following contributions may change the final shape of the menu when they are processed.
+&lt;/p&gt;
                </documentation>
             </annotation>
          </attribute>
@@ -919,22 +921,6 @@ If defined then it can be  used as a reference in the Query part of the location
 
    <annotation>
       <appInfo>
-         <meta.section type="apiInfo"/>
-      </appInfo>
-      <documentation>
-         &lt;p&gt;
-It is preferred that menu contributions be added in the &lt;code&gt;plugin.xml&lt;/code&gt;.  Plugins can
-programmatically add their own menu contributions using &lt;code&gt;org.eclipse.ui.menus.IMenuService&lt;/code&gt; and &lt;code&gt;org.eclipse.ui.menus.AbstractContributionFactory&lt;/code&gt;, but should be sure to remove them if the plugin is unloaded.  The &lt;code&gt;IMenuService&lt;/code&gt; can be retrieved through any of the &lt;code&gt;IServiceLocators&lt;/code&gt;, the workbench, the workbench window, or the part site.
-&lt;/p&gt;
-&lt;p&gt;
-See &lt;a href=&quot;org_eclipse_ui_commands.html&quot;&gt;org.eclipse.ui.commands&lt;/a&gt; to define a command and &lt;a href=&quot;org_eclipse_ui_handlers.html&quot;&gt;org.eclipse.ui.handlers&lt;/a&gt; to define an implementation for the command.
-&lt;/p&gt;
-&lt;p&gt;To register a context menu, use the &lt;code&gt;IWorkbenchPartSite.registerContextMenu&lt;/code&gt; methods.&lt;/p&gt;
-      </documentation>
-   </annotation>
-
-   <annotation>
-      <appInfo>
          <meta.section type="since"/>
       </appInfo>
       <documentation>
@@ -969,6 +955,22 @@ A basic extension looks like this.
 &lt;p&gt;
 This is the simplest example; adding a command contribution after an existing menu&apos;s additions group.
 &lt;/p&gt;
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiInfo"/>
+      </appInfo>
+      <documentation>
+         &lt;p&gt;
+It is preferred that menu contributions be added in the &lt;code&gt;plugin.xml&lt;/code&gt;.  Plugins can
+programmatically add their own menu contributions using &lt;code&gt;org.eclipse.ui.menus.IMenuService&lt;/code&gt; and &lt;code&gt;org.eclipse.ui.menus.AbstractContributionFactory&lt;/code&gt;, but should be sure to remove them if the plugin is unloaded.  The &lt;code&gt;IMenuService&lt;/code&gt; can be retrieved through any of the &lt;code&gt;IServiceLocators&lt;/code&gt;, the workbench, the workbench window, or the part site.
+&lt;/p&gt;
+&lt;p&gt;
+See &lt;a href=&quot;org_eclipse_ui_commands.html&quot;&gt;org.eclipse.ui.commands&lt;/a&gt; to define a command and &lt;a href=&quot;org_eclipse_ui_handlers.html&quot;&gt;org.eclipse.ui.handlers&lt;/a&gt; to define an implementation for the command.
+&lt;/p&gt;
+&lt;p&gt;To register a context menu, use the &lt;code&gt;IWorkbenchPartSite.registerContextMenu&lt;/code&gt; methods.&lt;/p&gt;
       </documentation>
    </annotation>
 


### PR DESCRIPTION
Fixes a typo and improves formatting in `locationURI` documentation for `menuContribution` elements.