### PR TITLE
Restarting workspace should take into account changes to eclipse.ini

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchMessages.java
@@ -91,7 +91,6 @@ public class WorkbenchMessages extends NLS {
 	public static String SaveAll_toolTip;
 	public static String Workbench_revert;
 	public static String Workbench_revertToolTip;
-	public static String Workbench_missingPropertyMessage;
 	public static String Workbench_move;
 
 	public static String Workbench_moveToolTip;

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
@@ -57,7 +57,6 @@ SaveAll_text = Sav&e All
 SaveAll_toolTip = Save All
 Workbench_revert = Rever&t
 Workbench_revertToolTip = Revert
-Workbench_missingPropertyMessage=Unable to relaunch the platform with the current workspace because the ''{0}'' property has not been set.
 Workbench_move = Mo&ve...
 Workbench_moveToolTip = Move
 Workbench_rename = Rena&me...
@@ -693,8 +692,8 @@ Startup_Loading_Workbench=Loading Workbench
 Workbench_problemsSavingMsg=Could not save workbench layout.
 Workbench_problemsRestoring=Problems occurred restoring workbench.
 Workbench_problemsSaving=Problems occurred saving workbench.
-Workbench_problemsRestartErrorTitle = Missing System Property
-Workbench_problemsRestartErrorMessage = Unable to relaunch the workbench because the {0} property has not been set.
+Workbench_problemsRestartErrorTitle = Restart with different workspace
+Workbench_problemsRestartErrorMessage = Restarting with different workspace does not work in development mode.
 
 PageLayout_missingRefPart=Referenced part does not exist yet: {0}.
 


### PR DESCRIPTION
Background:
===========
There are 3 return codes supported by Eclipse
- 0  - Normal exit
- 23 - Restart the eclipse with previous launcher arguments
- 24 - Restart the eclipse with the arguments provided by Eclipse application itself

The above mentioned problem is not with the exit code 23. The reason is that the eclipse launcher restarts itself in this case, hence eclipse.ini is also reloaded. However eclipse launcher does not restart itself in case of code 24 and parses the arguments provided by Eclipse application in shared memory and simply relaunches java, which means that eclipse.ini will not be reloaded.

For restarts, eclipse should be using code 23 but we had to switch to code 24 to fix following issue.
[[WorkbenchLauncher] Restart asks for the workspace to run](https://bugs.eclipse.org/bugs/show_bug.cgi?id=264072)
And then the fix of following built up on it.
[[Workspace chooser] "Older Workspace Version" dialog: "Cancel" button shouldn't close Eclipse but go back to workspace chooser](https://bugs.eclipse.org/bugs/show_bug.cgi?id=538830)

Fix:
====
For code 24, the arguments in shared memory are for launcher, so instead of launcher just parsing the args and relaunching java, it should restart the launcher with appropriate arguments. With relaunching the launcher, eclipse.ini will be reloaded like its done for code 23.

Eclipse launcher is updated to relaunch for code 24 as well. Moreover, there are 3 new launcher arguments introduced, 2 are internal to launcher and one is external to launcher and can be set by eclipse application as a relaunch argument.

- `--launcher.oldUserArgsStart` and `--launcher.oldUserArgsEnd`: The user arguments passed to eclipse launcher for first start are tracked between these arguments during relaunches. E.g., if eclipse was started as `eclipse A B C` where A B C are some arguments to launcher and for relaunch, Eclipse application mentioned `X Y Z` arguments then relaunch command will be `eclipse --launcher.oldUserArgsStart A B C --launcher.oldUserArgsEnd A B C X Y Z`. Moreover, launcher relaunch will ignore all arguments between and including `--launcher.oldUserArgsStart` and `--launcher.oldUserArgsEnd`.
- `--launcher.skipOldUserArgs`: If eclipse application wants to relaunch with provided arguments only and ignore the older user args then it can mention this argument. So for the case where eclipse was started as `eclipse A B C` and Eclipse application mentioned `X Y Z` as relaunch arguments along with `--launcher.skipOldUserArgs` then relaunch command will be
`eclipse --launcher.oldUserArgsStart A B C --launcher.oldUserArgsEnd X Y Z` where launcher relaunch will ignore all arguments between and including `--launcher.oldUserArgsStart` and `--launcher.oldUserArgsEnd`.

For restarts, Eclipse application just mentions the `-data` argument now as relaunch arguments instead of mentioning complete java args. However, user can still mention more arguments for relaunch and Eclipse restart will respect them as well and append the `-data` argument at the end of user arguments.

See also https://github.com/eclipse-equinox/equinox/pull/401
Fixes https://github.com/eclipse-equinox/p2/issues/166