### PR TITLE
Add Basic Support for Named Command Handlers

### DIFF
--- a/bundles/org.eclipse.core.commands/.settings/.api_filters
+++ b/bundles/org.eclipse.core.commands/.settings/.api_filters
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.core.commands" version="2">
+    <resource path="src/org/eclipse/core/commands/IHandler.java" type="org.eclipse.core.commands.IHandler">
+        <filter comment="Add Basic Support for Named Command Handlers #1317" id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.core.commands.IHandler"/>
+                <message_argument value="getHandlerLabel()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.core.commands/src/org/eclipse/core/commands/IHandler.java
+++ b/bundles/org.eclipse.core.commands/src/org/eclipse/core/commands/IHandler.java
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Niklas Kellner  - Named Handler API
  *******************************************************************************/
 package org.eclipse.core.commands;
 
@@ -90,4 +91,18 @@ public interface IHandler {
 	 *            performed.
 	 */
 	void removeHandlerListener(IHandlerListener handlerListener);
+
+	/**
+	 * Return the label for this handler. The handler can implement this method to
+	 * provide a more dynamic label according to the actual action that is
+	 * performed. When returning null, callers may instead use the invoking command
+	 * label or a generic label.
+	 *
+	 * @return name of the Handler, can be null
+	 *
+	 * @since 3.11
+	 */
+	default String getHandlerLabel() {
+		return null;
+	}
 }

--- a/bundles/org.eclipse.e4.core.commands/src/org/eclipse/e4/core/commands/internal/HandlerServiceHandler.java
+++ b/bundles/org.eclipse.e4.core.commands/src/org/eclipse/e4/core/commands/internal/HandlerServiceHandler.java
@@ -44,7 +44,7 @@ public class HandlerServiceHandler extends AbstractHandlerWithState {
 
 	protected final String commandId;
 	// Remove state from currentStateHandler when it goes out of scope
-	private WeakReference<IObjectWithState> currentStateHandler = new WeakReference<IObjectWithState>(null);
+	protected WeakReference<IObjectWithState> currentStateHandler = new WeakReference<IObjectWithState>(null);
 
 	public HandlerServiceHandler(String commandId) {
 		this.commandId = commandId;
@@ -265,6 +265,8 @@ public class HandlerServiceHandler extends AbstractHandlerWithState {
 				typed.addState(id, getState(id));
 			}
 		}
+
+		fireHandlerChanged(new HandlerEvent(this, false, false));
 	}
 
 }

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/commands/ActionHandler.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/commands/ActionHandler.java
@@ -14,12 +14,15 @@
  *******************************************************************************/
 package org.eclipse.jface.commands;
 
+import java.util.Optional;
+
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.HandlerEvent;
 import org.eclipse.core.commands.IHandlerListener;
 import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.action.LegacyActionTools;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.swt.widgets.Event;
 
@@ -167,5 +170,10 @@ public final class ActionHandler extends AbstractHandler {
 		buffer.append(')');
 
 		return buffer.toString();
+	}
+
+	@Override
+	public String getHandlerLabel() {
+		return Optional.of(action).map(IAction::getText).map(LegacyActionTools::removeAcceleratorText).orElse(null);
 	}
 }

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchHandlerServiceHandler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchHandlerServiceHandler.java
@@ -15,6 +15,8 @@
 package org.eclipse.ui.internal;
 
 import java.util.Map;
+import org.eclipse.core.commands.IHandler;
+import org.eclipse.core.commands.IObjectWithState;
 import org.eclipse.e4.core.commands.internal.HandlerServiceHandler;
 import org.eclipse.e4.core.commands.internal.HandlerServiceImpl;
 import org.eclipse.e4.core.contexts.IEclipseContext;
@@ -42,4 +44,15 @@ public class WorkbenchHandlerServiceHandler extends HandlerServiceHandler implem
 		}
 	}
 
+	@Override
+	public String getHandlerLabel() {
+
+		IObjectWithState handler = currentStateHandler.get();
+
+		if (handler instanceof IHandler namedHandler) {
+			return namedHandler.getHandlerLabel();
+		}
+
+		return null;
+	}
 }

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/E4HandlerProxy.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/E4HandlerProxy.java
@@ -226,4 +226,9 @@ public class E4HandlerProxy implements IHandler2, IHandlerListener, IElementUpda
 		}
 	}
 
+	@Override
+	public String getHandlerLabel() {
+		return handler.getHandlerLabel();
+	}
+
 }

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/menus/CommandContributionItem.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/menus/CommandContributionItem.java
@@ -15,6 +15,8 @@
 package org.eclipse.ui.menus;
 
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.CommandEvent;
 import org.eclipse.core.commands.ExecutionException;
@@ -494,6 +496,9 @@ public class CommandContributionItem extends ContributionItem {
 		MenuItem item = (MenuItem) widget;
 
 		String text = label;
+
+		text = legacyActionLabelSupport(text);
+
 		if (text == null) {
 			if (command != null) {
 				try {
@@ -535,11 +540,20 @@ public class CommandContributionItem extends ContributionItem {
 		}
 	}
 
+	private String legacyActionLabelSupport(String text) {
+		return Optional.of(command).map(ParameterizedCommand::getCommand).map(Command::getHandler)
+				.map(IHandler::getHandlerLabel).filter(Objects::nonNull)
+				.orElse(text);
+	}
+
 	private void updateToolItem() {
 		ToolItem item = (ToolItem) widget;
 
 		String text = label;
-		String tooltip = label;
+
+		text = legacyActionLabelSupport(text);
+
+		String tooltip = text;
 
 		if (text == null) {
 			if (command != null) {
@@ -579,6 +593,8 @@ public class CommandContributionItem extends ContributionItem {
 		Button item = (Button) widget;
 
 		String text = label;
+		text = legacyActionLabelSupport(text);
+
 		if (text == null) {
 			if (command != null) {
 				try {


### PR DESCRIPTION
Fixes Regression: https://github.com/eclipse-platform/eclipse.platform.ui/issues/1314

With this a basic support for named handlers is introduced, currently this is for compatibility between ActionHandlers and E4.