### PR TITLE
Correct output and source specifications in build.properties

### DIFF
--- a/bundles/org.eclipse.core.databinding.beans/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding.beans/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.databinding.beans
-Bundle-Version: 1.10.100.qualifier
+Bundle-Version: 1.10.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.databinding.beans,

--- a/bundles/org.eclipse.core.databinding.beans/build.properties
+++ b/bundles/org.eclipse.core.databinding.beans/build.properties
@@ -17,3 +17,4 @@ bin.includes = .,\
                about.html
 src.includes = about.html
 source.. = src/
+output.. = bin/

--- a/bundles/org.eclipse.core.filebuffers/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.filebuffers/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.filebuffers; singleton:=true
-Bundle-Version: 3.8.200.qualifier
+Bundle-Version: 3.8.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.core.filebuffers/build.properties
+++ b/bundles/org.eclipse.core.filebuffers/build.properties
@@ -21,3 +21,4 @@ src.includes = about.html,\
                schema/
 
 source.. = src/
+output.. = bin/

--- a/bundles/org.eclipse.e4.ui.css.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.css.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.css.swt;singleton:=true
-Bundle-Version: 0.15.200.qualifier
+Bundle-Version: 0.15.300.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.css.swt/build.properties
+++ b/bundles/org.eclipse.e4.ui.css.swt/build.properties
@@ -12,6 +12,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 source.. = src/
+output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\

--- a/bundles/org.eclipse.jface.databinding/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.databinding
-Bundle-Version: 1.15.100.qualifier
+Bundle-Version: 1.15.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface.databinding.dialog,

--- a/bundles/org.eclipse.jface.databinding/build.properties
+++ b/bundles/org.eclipse.jface.databinding/build.properties
@@ -17,3 +17,4 @@ bin.includes = .,\
                about.html
 src.includes = about.html
 source.. = src/
+output.. = bin/

--- a/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.text
-Bundle-Version: 3.24.200.qualifier
+Bundle-Version: 3.24.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.jface.text/build.properties
+++ b/bundles/org.eclipse.jface.text/build.properties
@@ -21,3 +21,5 @@ src.includes = about.html
 
 source.. = src/,\
            projection/
+
+output.. = bin/

--- a/bundles/org.eclipse.jface/build.properties
+++ b/bundles/org.eclipse.jface/build.properties
@@ -19,6 +19,7 @@ bin.includes = plugin.properties,\
                .options
 src.includes = about.html
 source.. = src/
+output.. = bin/
 additional.bundles = org.eclipse.pde.api.tools.annotations
 
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless

--- a/bundles/org.eclipse.search.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.search.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search.core;singleton:=true
-Bundle-Version: 3.16.0.qualifier
+Bundle-Version: 3.16.100.qualifier
 Bundle-Activator: org.eclipse.search.internal.core.SearchCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.search.core/build.properties
+++ b/bundles/org.eclipse.search.core/build.properties
@@ -19,3 +19,4 @@ bin.includes = plugin.xml,\
 src.includes = about.html,\
                schema/
 source.. = search/
+output.. = bin/

--- a/bundles/org.eclipse.search/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search; singleton:=true
-Bundle-Version: 3.16.0.qualifier
+Bundle-Version: 3.16.100.qualifier
 Bundle-Activator: org.eclipse.search.internal.ui.SearchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.search/build.properties
+++ b/bundles/org.eclipse.search/build.properties
@@ -24,3 +24,4 @@ src.includes = about.html,\
                schema/
 source.. = search/,\
            new search/
+output.. = bin/

--- a/bundles/org.eclipse.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.text
-Bundle-Version: 3.13.100.qualifier
+Bundle-Version: 3.13.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.text/build.properties
+++ b/bundles/org.eclipse.text/build.properties
@@ -20,3 +20,5 @@ src.includes = about.html
 
 source.. = src/,\
            projection/
+
+output.. = bin/

--- a/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.editors; singleton:=true
-Bundle-Version: 3.17.100.qualifier
+Bundle-Version: 3.17.200.qualifier
 Bundle-Activator: org.eclipse.ui.internal.editors.text.EditorsPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.editors/build.properties
+++ b/bundles/org.eclipse.ui.editors/build.properties
@@ -22,3 +22,5 @@ src.includes = about.html,\
                schema/
 
 source.. = src/
+
+output.. = bin/

--- a/bundles/org.eclipse.ui.forms/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.forms/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.ui.forms;singleton:=true
-Bundle-Version: 3.13.100.qualifier
+Bundle-Version: 3.13.200.qualifier
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.forms,

--- a/bundles/org.eclipse.ui.forms/build.properties
+++ b/bundles/org.eclipse.ui.forms/build.properties
@@ -19,4 +19,5 @@ bin.includes = plugin.properties,\
                plugin.xml,\
                .options
 source.. = src/
+output.. = bin/
 src.includes = about.html

--- a/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide; singleton:=true
-Bundle-Version: 3.22.0.qualifier
+Bundle-Version: 3.22.100.qualifier
 Bundle-Activator: org.eclipse.ui.internal.ide.IDEWorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/bundles/org.eclipse.ui.ide/build.properties
+++ b/bundles/org.eclipse.ui.ide/build.properties
@@ -25,5 +25,6 @@ src.includes = about.html,\
                schema/
 source.. = extensions/,\
            src/
+output.. = bin/
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 pom.model.property.code.ignoredWarnings = -warn:-deprecation,raw,unchecked

--- a/bundles/org.eclipse.ui.themes/.classpath
+++ b/bundles/org.eclipse.ui.themes/.classpath
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/bundles/org.eclipse.ui.themes/.project
+++ b/bundles/org.eclipse.ui.themes/.project
@@ -16,11 +16,6 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.pde.api.tools.apiAnalysisBuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
 			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
@@ -29,7 +24,6 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
-		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
 	</natures>
 	<filteredResources>
 		<filter>

--- a/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.themes;singleton:=true
-Bundle-Version: 1.2.2300.qualifier
+Bundle-Version: 1.2.2400.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.e4.ui.css.swt.theme

--- a/bundles/org.eclipse.ui.themes/build.properties
+++ b/bundles/org.eclipse.ui.themes/build.properties
@@ -11,8 +11,6 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-source.. = src/
-output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\

--- a/bundles/org.eclipse.ui.views/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.views; singleton:=true
-Bundle-Version: 3.12.100.qualifier
+Bundle-Version: 3.12.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.internal.views.contentoutline;x-internal:=true,

--- a/bundles/org.eclipse.ui.views/build.properties
+++ b/bundles/org.eclipse.ui.views/build.properties
@@ -19,3 +19,4 @@ bin.includes = icons/,\
                META-INF/
 src.includes = about.html
 source.. = src/
+output.. = bin/

--- a/bundles/org.eclipse.ui.win32/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.win32/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.ui.win32
-Bundle-Version: 3.5.100.qualifier
+Bundle-Version: 3.5.200.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.ui.ide;bundle-version="[3.2.0,4.0.0)"
 Require-Bundle: org.eclipse.core.resources;resolution:=optional

--- a/bundles/org.eclipse.ui.win32/build.properties
+++ b/bundles/org.eclipse.ui.win32/build.properties
@@ -11,8 +11,9 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-source..=src/
-src.includes=about.html
+source.. = src/
+output.. = bin/
+src.includes = about.html
 bin.includes = .,\
                META-INF/,\
                fragment-win32.properties,\

--- a/bundles/org.eclipse.ui.workbench.texteditor/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench.texteditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench.texteditor; singleton:=true
-Bundle-Version: 3.17.200.qualifier
+Bundle-Version: 3.17.300.qualifier
 Bundle-Activator: org.eclipse.ui.internal.texteditor.TextEditorPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.workbench.texteditor/build.properties
+++ b/bundles/org.eclipse.ui.workbench.texteditor/build.properties
@@ -22,3 +22,5 @@ src.includes = about.html,\
                schema/
 
 source.. = src/
+
+output.. = bin/

--- a/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui; singleton:=true
-Bundle-Version: 3.205.0.qualifier
+Bundle-Version: 3.205.100.qualifier
 Bundle-Activator: org.eclipse.ui.internal.UIPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/bundles/org.eclipse.ui/build.properties
+++ b/bundles/org.eclipse.ui/build.properties
@@ -21,3 +21,4 @@ bin.includes = icons/,\
 src.includes = about.html,\
                schema/
 source.. = src/
+output.. = bin/

--- a/examples/org.eclipse.e4.ui.examples.job/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.e4.ui.examples.job/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: e4 Progress Examples Plug-in
 Bundle-SymbolicName: org.eclipse.e4.ui.examples.job;singleton:=true
-Bundle-Version: 0.4.0.qualifier
+Bundle-Version: 0.4.100.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.e4.ui.examples.jobs,
  org.eclipse.e4.ui.examples.jobs.views

--- a/examples/org.eclipse.e4.ui.examples.job/build.properties
+++ b/examples/org.eclipse.e4.ui.examples.job/build.properties
@@ -1,6 +1,8 @@
 source.. = src/
+output.. = bin/
 bin.includes = plugin.xml,\
                icons/,\
                META-INF/,\
                job_factory_view.e4xmi,\
-               progress_view.e4xmi
+               progress_view.e4xmi,\
+               .

--- a/examples/org.eclipse.jface.examples.databinding/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.jface.examples.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.examples.databinding
-Bundle-Version: 1.4.200.qualifier
+Bundle-Version: 1.4.300.qualifier
 Eclipse-BundleShape: dir
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/examples/org.eclipse.jface.examples.databinding/build.properties
+++ b/examples/org.eclipse.jface.examples.databinding/build.properties
@@ -17,4 +17,5 @@ bin.includes = .,\
                about.html
 src.includes = about.html
 source.. = src/
+output.. = bin/
 javacWarnings..=-raw,unchecked

--- a/examples/org.eclipse.ui.examples.fieldassist/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.fieldassist/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.examples.fieldassist; singleton:=true
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Bundle-Activator: org.eclipse.ui.examples.fieldassist.FieldAssistPlugin
 Bundle-Localization: plugin
 Bundle-Vendor: %Bundle-Vendor

--- a/examples/org.eclipse.ui.examples.fieldassist/build.properties
+++ b/examples/org.eclipse.ui.examples.fieldassist/build.properties
@@ -13,6 +13,8 @@
 ###############################################################################
 source.. = Eclipse UI Examples Field Assist/
 
+output.. = bin/
+
 bin.includes = doc-html/,\
                icons/,\
                about.html,\

--- a/examples/org.eclipse.ui.examples.javaeditor/.classpath
+++ b/examples/org.eclipse.ui.examples.javaeditor/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" output="javaEditorBin" path="Eclipse Java Editor Example"/>
-	<classpathentry kind="src" output="templateEditorBin" path="Template Editor Example"/>
+	<classpathentry kind="src" path="Eclipse Java Editor Example"/>
+	<classpathentry kind="src" path="Template Editor Example"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/examples/org.eclipse.ui.examples.javaeditor/.gitignore
+++ b/examples/org.eclipse.ui.examples.javaeditor/.gitignore
@@ -1,2 +1,3 @@
 /javaEditorBin/
 /templateEditorBin/
+bin/

--- a/examples/org.eclipse.ui.examples.javaeditor/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.javaeditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.examples.javaeditor; singleton:=true
-Bundle-Version: 3.4.200.qualifier
+Bundle-Version: 3.4.300.qualifier
 Bundle-Activator: org.eclipse.ui.examples.javaeditor.JavaEditorExamplePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/examples/org.eclipse.ui.examples.job/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.job/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.examples.job;singleton:=true
-Bundle-Version: 3.3.0
+Bundle-Version: 3.3.100
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.examples.jobs,

--- a/examples/org.eclipse.ui.examples.job/build.properties
+++ b/examples/org.eclipse.ui.examples.job/build.properties
@@ -12,6 +12,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 source.. = src/
+output.. = bin/
 bin.includes = plugin.xml,\
                icons/,\
                .,\

--- a/examples/org.eclipse.ui.examples.markerHelp/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.markerHelp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.examples.markerHelp;singleton:=true
-Bundle-Version: 3.2.0
+Bundle-Version: 3.2.100
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.ide;bundle-version="3.15.0"

--- a/examples/org.eclipse.ui.examples.markerHelp/build.properties
+++ b/examples/org.eclipse.ui.examples.markerHelp/build.properties
@@ -12,6 +12,7 @@
 #     Tim Neumann <tim.neumann@advantest.com> - initial API and implementation
 ###############################################################################
 source.. = src/
+output.. = bin/
 bin.includes = plugin.xml,\
                .,\
                META-INF/

--- a/examples/org.eclipse.ui.examples.propertysheet/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.propertysheet/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.examples.propertysheet; singleton:=true
-Bundle-Version: 3.5.200.qualifier
+Bundle-Version: 3.5.300.qualifier
 Bundle-Activator: org.eclipse.ui.examples.propertysheet.PropertySheetPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/examples/org.eclipse.ui.examples.propertysheet/build.properties
+++ b/examples/org.eclipse.ui.examples.propertysheet/build.properties
@@ -12,7 +12,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 source.. = Eclipse UI Examples PropertySheet/
-
+output.. = bin/
 bin.includes = doc-html/,\
                icons/,\
                about.html,\

--- a/examples/org.eclipse.ui.examples.readmetool/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.readmetool/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.examples.readmetool; singleton:=true
-Bundle-Version: 3.7.200.qualifier
+Bundle-Version: 3.7.300.qualifier
 Bundle-Activator: org.eclipse.ui.examples.readmetool.ReadmePlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/examples/org.eclipse.ui.examples.readmetool/build.properties
+++ b/examples/org.eclipse.ui.examples.readmetool/build.properties
@@ -12,7 +12,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 source.. = Eclipse UI Examples Readme Tool/
-
+output.. = bin/
 bin.includes = doc/,\
                doc-html/,\
                icons/,\

--- a/examples/org.eclipse.ui.examples.undo/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.undo/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.examples.undo; singleton:=true
-Bundle-Version: 3.5.200.qualifier
+Bundle-Version: 3.5.300.qualifier
 Bundle-Activator: org.eclipse.ui.examples.undo.UndoPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,

--- a/examples/org.eclipse.ui.examples.undo/build.properties
+++ b/examples/org.eclipse.ui.examples.undo/build.properties
@@ -12,7 +12,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 source.. = Eclipse UI Examples Undo/
-
+output.. = bin/
 bin.includes = doc-html/,\
                icons/,\
                about.html,\

--- a/examples/org.eclipse.ui.forms.examples/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.forms.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.forms.examples; singleton:=true
-Bundle-Version: 3.4.0.qualifier
+Bundle-Version: 3.4.100.qualifier
 Bundle-Activator: org.eclipse.ui.forms.examples.internal.ExamplesPlugin
 Bundle-Vendor: Eclipse.org
 Bundle-Localization: plugin

--- a/examples/org.eclipse.ui.forms.examples/build.properties
+++ b/examples/org.eclipse.ui.forms.examples/build.properties
@@ -12,6 +12,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 source.. = src/
+output.. = bin/
 bin.includes = plugin.xml,\
                .,\
                icons/,\

--- a/tests/org.eclipse.core.filebuffers.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.core.filebuffers.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.core.filebuffers.tests;singleton:=true
-Bundle-Version: 3.13.200.qualifier
+Bundle-Version: 3.13.300.qualifier
 Bundle-Activator: org.eclipse.core.filebuffers.tests.FileBuffersTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/tests/org.eclipse.core.filebuffers.tests/build.properties
+++ b/tests/org.eclipse.core.filebuffers.tests/build.properties
@@ -24,6 +24,8 @@ src.includes = about.html
 
 source.. = src/
 
+output.. = bin/
+
 # Maven/Tycho pom model adjustments
 pom.model.property.code.ignoredWarnings = ${tests.ignoredWarnings}
 pom.model.property.testClass = org.eclipse.core.filebuffers.tests.FileBuffersTestSuite

--- a/tests/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jface.text.tests
-Bundle-Version: 3.13.300.qualifier
+Bundle-Version: 3.13.400.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/tests/org.eclipse.jface.text.tests/build.properties
+++ b/tests/org.eclipse.jface.text.tests/build.properties
@@ -22,6 +22,8 @@ src.includes = about.html
 
 source.. = src/
 
+output.. = bin/
+
 # Maven/Tycho pom model adjustments
 pom.model.property.code.ignoredWarnings = ${tests.ignoredWarnings}
 pom.model.property.testClass = org.eclipse.jface.text.tests.JFaceTextTestSuite

--- a/tests/org.eclipse.ltk.core.refactoring.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.ltk.core.refactoring.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ltk.core.refactoring.tests; singleton:=true
-Bundle-Version: 3.10.200.qualifier
+Bundle-Version: 3.10.300.qualifier
 Bundle-Activator: org.eclipse.ltk.core.refactoring.tests.RefactoringCoreTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/tests/org.eclipse.ltk.core.refactoring.tests/build.properties
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/build.properties
@@ -19,4 +19,5 @@ bin.includes = plugin.xml,\
                META-INF/
 src.includes = about.html
 source.. = src/
+output.. = bin/
 pom.model.property.testClass=org.eclipse.ltk.core.refactoring.tests.AllTests

--- a/tests/org.eclipse.ltk.ui.refactoring.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ltk.ui.refactoring.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.ltk.ui.refactoring.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ltk.ui.refactoring.tests;singleton:=true
-Bundle-Version: 3.11.200.qualifier
+Bundle-Version: 3.11.300.qualifier
 Bundle-Activator: org.eclipse.ltk.ui.refactoring.tests.RefactoringUITestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/tests/org.eclipse.ltk.ui.refactoring.tests/build.properties
+++ b/tests/org.eclipse.ltk.ui.refactoring.tests/build.properties
@@ -19,4 +19,5 @@ bin.includes = test.xml,\
                plugin.xml
 src.includes = about.html
 source.. = src/
+output.. = bin/
 pom.model.property.testClass=org.eclipse.ltk.ui.refactoring.tests.AllTests

--- a/tests/org.eclipse.search.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.search.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search.tests;singleton:=true
-Bundle-Version: 3.11.300.qualifier
+Bundle-Version: 3.11.400.qualifier
 Bundle-Activator: org.eclipse.search.tests.SearchTestPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/tests/org.eclipse.search.tests/build.properties
+++ b/tests/org.eclipse.search.tests/build.properties
@@ -14,6 +14,7 @@
 ###############################################################################
 src.includes = about.html
 source.. = src/
+output.. = bin/
 bin.includes = plugin.properties,\
                .,\
                testresources/,\

--- a/tests/org.eclipse.text.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.text.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.text.tests
-Bundle-Version: 3.14.200.qualifier
+Bundle-Version: 3.14.300.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/tests/org.eclipse.text.tests/build.properties
+++ b/tests/org.eclipse.text.tests/build.properties
@@ -22,6 +22,8 @@ src.includes = about.html
 source.. = projection/,\
            src/
 
+output.. = bin/
+
 # Maven/Tycho pom model adjustments
 pom.model.property.code.ignoredWarnings = ${tests.ignoredWarnings}
 pom.model.property.testClass = org.eclipse.text.tests.EclipseTextTestSuite

--- a/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.editors.tests;singleton:=true
-Bundle-Version: 3.13.200.qualifier
+Bundle-Version: 3.13.300.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.editors.tests

--- a/tests/org.eclipse.ui.editors.tests/build.properties
+++ b/tests/org.eclipse.ui.editors.tests/build.properties
@@ -23,6 +23,8 @@ src.includes = about.html
 
 source.. = src/
 
+output.. = bin/
+
 # Maven/Tycho pom model adjustments
 pom.model.property.code.ignoredWarnings = ${tests.ignoredWarnings}
 pom.model.property.testClass = org.eclipse.ui.editors.tests.EditorsTestSuite

--- a/tests/org.eclipse.ui.genericeditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.genericeditor.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.genericeditor.tests;singleton:=true
-Bundle-Version: 1.3.300.qualifier
+Bundle-Version: 1.3.400.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.genericeditor.tests,

--- a/tests/org.eclipse.ui.genericeditor.tests/build.properties
+++ b/tests/org.eclipse.ui.genericeditor.tests/build.properties
@@ -24,6 +24,8 @@ src.includes = about.html
 
 source.. = src/
 
+output.. = bin/
+
 # Maven/Tycho pom model adjustments
 pom.model.property.code.ignoredWarnings = ${tests.ignoredWarnings}
 pom.model.property.testClass = org.eclipse.ui.genericeditor.tests.GenericEditorTestSuite

--- a/tests/org.eclipse.ui.ide.application.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.ide.application.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse UI IDE Application Tests
 Bundle-SymbolicName: org.eclipse.ui.ide.application.tests; singleton:=true
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.4.100.qualifier
 Eclipse-BundleShape: dir
 Bundle-Vendor: Eclipse.org
 Fragment-Host: org.eclipse.ui.ide.application

--- a/tests/org.eclipse.ui.ide.application.tests/build.properties
+++ b/tests/org.eclipse.ui.ide.application.tests/build.properties
@@ -12,7 +12,7 @@
 #     Manumitting Technologies Inc - initial API and implementation
 ###############################################################################
 source.. = src/
-
+output.. = bin/
 bin.includes = .,\
                META-INF/
 src.includes = about.html

--- a/tests/org.eclipse.ui.tests.navigator/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.navigator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundlename
 Bundle-SymbolicName: org.eclipse.ui.tests.navigator;singleton:=true
-Bundle-Version: 3.7.300.qualifier
+Bundle-Version: 3.7.400.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/tests/org.eclipse.ui.tests.navigator/build.properties
+++ b/tests/org.eclipse.ui.tests.navigator/build.properties
@@ -17,7 +17,7 @@ source.. = src/
 javacWarnings..=-deadCode
 
 src.includes = about.html
-output.uinavtests.jar = bin/
+output.. = bin/
 bin.includes = testdata/,\
                META-INF/,\
                about.html,\

--- a/tests/org.eclipse.ui.tests.performance/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.performance/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Performance Plug-in
 Bundle-SymbolicName: org.eclipse.ui.tests.performance;singleton:=true
-Bundle-Version: 1.6.200.qualifier
+Bundle-Version: 1.6.300.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.core.tests.harness,

--- a/tests/org.eclipse.ui.tests.performance/build.properties
+++ b/tests/org.eclipse.ui.tests.performance/build.properties
@@ -13,6 +13,7 @@
 #     Lars Vogel <Lars.Vogel@vogella.com> - Bug 474544
 ###############################################################################
 source.. = src/
+output.. = bin/
 bin.includes = plugin.xml,\
                test.xml,\
                META-INF/,\

--- a/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse UI Tests
 Bundle-SymbolicName: org.eclipse.ui.tests; singleton:=true
-Bundle-Version: 3.15.1400.qualifier
+Bundle-Version: 3.15.1500.qualifier
 Eclipse-BundleShape: dir
 Bundle-Activator: org.eclipse.ui.tests.TestPlugin
 Bundle-Vendor: Eclipse.org

--- a/tests/org.eclipse.ui.tests/build.properties
+++ b/tests/org.eclipse.ui.tests/build.properties
@@ -13,7 +13,7 @@
 #     Lars Vogel <Lars.Vogel@vogella.com> - Bug 474544
 ###############################################################################
 source.. = Eclipse UI Tests/
-
+output.. = bin/
 bin.includes = icons/,\
                doc/,\
                data/,\

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.workbench.texteditor.tests
-Bundle-Version: 3.14.200.qualifier
+Bundle-Version: 3.14.300.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/build.properties
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/build.properties
@@ -22,6 +22,8 @@ src.includes = about.html
 
 source.. = src/
 
+output.. = bin/
+
 # Maven/Tycho pom model adjustments
 pom.model.property.code.ignoredWarnings = ${tests.ignoredWarnings}
 pom.model.property.testClass = org.eclipse.ui.workbench.texteditor.tests.WorkbenchTextEditorTestSuite


### PR DESCRIPTION
* Add missing output entries
* Remove source entries in org.eclipse.ui.themes, which has no source folders
* Fix classpath with unseparated bin folders and adapt .gitignore in org.eclipse.ui.examples.javaeditor
* Add missing inclusion of generated classes in binary output for org.eclipse.e4.ui.examples.job