### PR TITLE
Assign all test projects to "Test" working set via Oomph setup

### DIFF
--- a/releng/org.eclipse.ui.releng/platformUi.setup
+++ b/releng/org.eclipse.ui.releng/platformUi.setup
@@ -102,7 +102,7 @@
             project="org.eclipse.ui"/>
         <operand
             xsi:type="predicates:NamePredicate"
-            pattern=".*\.tests.*|org\.eclipse\.ui\.dynamicCode"/>
+            pattern=".*\.test.*|.*\.tests.*|org\.eclipse\.ui\.dynamicCode"/>
       </predicate>
     </workingSet>
     <workingSet


### PR DESCRIPTION
The Oomph setup does currently not assign all test projects to the "Platform UI Tests" working set. Assignment happens via a regex that does only assign projects containing "tests" in their name, but not those containing only "test". They will be assigned to the "Platform UI" project set instead.

This change adapts the Oomph setup to also assign the test projects identified by "test" in their name to the test projects working set.