### PR TITLE
Support multiple IPresentationReconciler in generic editor

### DIFF
--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/CompositePresentationReconciler.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/CompositePresentationReconciler.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Christoph Läubrich - Initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.internal.genericeditor;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.presentation.IPresentationDamager;
+import org.eclipse.jface.text.presentation.IPresentationReconciler;
+import org.eclipse.jface.text.presentation.IPresentationRepairer;
+
+class CompositePresentationReconciler implements IPresentationReconciler {
+
+	private List<IPresentationReconciler> reconciliers;
+
+	public CompositePresentationReconciler(List<IPresentationReconciler> reconciliers) {
+		this.reconciliers = reconciliers;
+	}
+
+	@Override
+	public void uninstall() {
+		for (int i = reconciliers.size() - 1; i >= 0; i--) {
+			IPresentationReconciler reconciler = reconciliers.get(i);
+			reconciler.uninstall();
+		}
+
+	}
+
+	@Override
+	public void install(ITextViewer viewer) {
+		for (IPresentationReconciler reconciler : reconciliers) {
+			reconciler.install(viewer);
+		}
+	}
+
+	@Override
+	public IPresentationRepairer getRepairer(String contentType) {
+		return reconciliers.stream().map(reconciler -> reconciler.getRepairer(contentType)).filter(Objects::nonNull)
+				.findFirst().orElse(null);
+	}
+
+	@Override
+	public IPresentationDamager getDamager(String contentType) {
+		return reconciliers.stream().map(reconciler -> reconciler.getDamager(contentType)).filter(Objects::nonNull)
+				.findFirst().orElse(null);
+	}
+
+}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ExtensionBasedTextViewerConfiguration.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ExtensionBasedTextViewerConfiguration.java
@@ -199,10 +199,13 @@ public final class ExtensionBasedTextViewerConfiguration extends TextSourceViewe
 		PresentationReconcilerRegistry registry = GenericEditorPlugin.getDefault().getPresentationReconcilerRegistry();
 		List<IPresentationReconciler> reconciliers = registry.getPresentationReconcilers(sourceViewer, editor,
 				getContentTypes(sourceViewer.getDocument()));
-		if (!reconciliers.isEmpty()) {
+		if (reconciliers.isEmpty()) {
+			return super.getPresentationReconciler(sourceViewer);
+		}
+		if (reconciliers.size() == 1) {
 			return reconciliers.get(0);
 		}
-		return super.getPresentationReconciler(sourceViewer);
+		return new CompositePresentationReconciler(reconciliers);
 	}
 
 	void watchDocument(IDocument document) {


### PR DESCRIPTION
Currently only one `IPresentationReconciler` is supported and if there are multiple ones the first is chosen.

This adds support for multiple `IPresentationReconciler` being registered, if there is only one the instance is returned, otherwise a wrapper is created that delegates to the individual ones.

Fix https://github.com/eclipse-platform/eclipse.platform.ui/issues/1328