### PR TITLE
Fixes #912 - Avoid lower corners when drawing square tabs

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
@@ -400,8 +400,12 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 						|| Objects.equals(outerKeylineColor, parent.getBackground())
 						? 0
 						: 1);
-		points[index++] = margin;
-		points[index++] = bottomY;
+
+		if (active) {
+			points[index++] = margin;
+			points[index++] = bottomY;
+		}
+
 		points[index++] = startX;
 		points[index++] = bottomY;
 
@@ -418,15 +422,6 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 			points[index++] = parentSize.x - 1 - margin;
 			points[index++] = bottomY;
 		}
-
-		points[index++] = parentSize.x - 1 - margin;
-		points[index++] = parentSize.y - 1;
-
-		points[index++] = points[0];
-		points[index++] = parentSize.y - 1;
-
-		points[index++] = points[0];
-		points[index++] = points[1];
 
 		int[] tmpPoints = new int[index];
 		System.arraycopy(points, 0, tmpPoints, 0, index);


### PR DESCRIPTION
The last points in the polyline were visiting the lower right and lower left corners of the CTabFolder's client area before heading back to the starting point. These are now removed.

This makes "computeSquareTabOutline" behave the same way as "computeRoundTabOutline" does, which did not attempt to draw lines outside of the tab itself (also a horizontal leading/trailing line when in active mode).