### PR TITLE
Make TableColumnViewerLabelProvider class public

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.32.0.qualifier
+Bundle-Version: 3.33.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TableColumnViewerLabelProvider.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TableColumnViewerLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2015 IBM Corporation and others.
+ * Copyright (c) 2006, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -20,13 +20,13 @@ package org.eclipse.jface.viewers;
  * TableColumnViewerLabelProvider is the mapping from the table based providers
  * to the ViewerLabelProvider.
  *
- * @since 3.3
+ * @since 3.33
  * @see ITableLabelProvider
  * @see ITableColorProvider
  * @see ITableFontProvider
  *
  */
-class TableColumnViewerLabelProvider extends WrappedViewerLabelProvider {
+public class TableColumnViewerLabelProvider extends WrappedViewerLabelProvider {
 
 	private ITableLabelProvider tableLabelProvider;
 


### PR DESCRIPTION
The class remained package-private, even after the experimental marker was removed with 8fb6198fecaf93552ac7007e9104360adfdca565, seemingly due to an oversight.

This is reinforced by the fact that the TreeColumnViewerLabelProvider, which directly extends the TableColumnViewerLabelProvider is public.

This leads to weird situations where one has to use the TreeColumnViewerLabelProvider for both TreeViewers and TableViewers, even though its name would only suggest one is compatible...

Resolves #1335