### PR TITLE
Set RAT expression to null when deactivating context

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/contexts/ContextService.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/contexts/ContextService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2015 IBM Corporation and others.
+ * Copyright (c) 2005, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -180,6 +180,9 @@ public final class ContextService implements IContextService {
 			final UpdateExpression rat = activationToRat.remove(activation);
 			if (rat != null) {
 				rat.updating = false;
+				// The updating status has been set to false, so the expression is no longer
+				// useful. Set it to null to avoid potential memory leak.
+				rat.expression = null;
 				if (rat.cached != null && rat.cached != EvaluationResult.FALSE) {
 					contextService.deactivateContext(activation.getContextId());
 				}


### PR DESCRIPTION
If UpdateExpression updating is set to false, the expression will be no longer evaluated. So it can be set to null.
This avoids potential memory leaks as for example on Sirius [1] discussed here [2].

[1] https://github.com/eclipse-sirius/sirius-desktop/issues/178
[2] https://github.com/eclipse-platform/eclipse.platform/discussions/889