### PR TITLE
Move to Jenkins pod that can use 8 GB memory instead of 4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 		disableConcurrentBuilds(abortPrevious: true)
 	}
 	agent {
-		label "centos-latest"
+		label "centos-8-8gb"
 	}
 	tools {
 		maven 'apache-maven-latest'


### PR DESCRIPTION
See related
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3896
- https://github.com/eclipse-cbi/cbi/wiki#resource-pack
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/1287