### PR TITLE
Fix wrong version bump on org.eclipse.e4.ui.workbench3

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench3/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench3/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench3;singleton:=true
-Bundle-Version: 0.17.400.qualifier
+Bundle-Version: 0.17.300.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
This fixes API error saying unnecessary version bump. The bundle was not published yet via IBuild, so we can revert.

Regression from
https://github.com/eclipse-platform/eclipse.platform.ui/pull/1347