### PR TITLE
Disable CSS styling of text editors

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AbstractTextEditor.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AbstractTextEditor.java
@@ -3398,6 +3398,14 @@ public abstract class AbstractTextEditor extends EditorPart implements ITextEdit
 		// Disable orientation switching until we fully support it.
 		styledText.addListener(SWT.OrientationChange, event -> event.doit = false);
 
+		if (getPreferenceStore() != null) {
+			// We're managing our appearance from our preferences. Disable CSS styling.
+			// The CSS engine does set the editor preferences on theme switches, so we
+			// will pick up changes.
+			styledText.setData("org.eclipse.e4.ui.css.disabled", Boolean.TRUE); //$NON-NLS-1$
+		}
+
+		
 		if (getHelpContextId() != null)
 			PlatformUI.getWorkbench().getHelpSystem().setHelp(styledText, getHelpContextId());
 


### PR DESCRIPTION
Migrated the Gerrit from Bug 559321, done by Thomas Wolf.

AbstractTextEditor and subclasses manage their appearance via the editor preferences. If CSS styling is enabled, CSS will override the preferences. So disable CSS styling, and use only the preferences. The CSS engine does set these preferences on theme switches, so the appearance does follow the theme, but now also obeys any preference changes the users makes.

(Note that preference changes get lost on theme switches. But that is unrelated; it appears to be bug 544714.)