### PR TITLE
Hide ExpandableNode from client's label provider.

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ViewerColumn.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ViewerColumn.java
@@ -138,17 +138,16 @@ public abstract class ViewerColumn {
 			Assert.isTrue(false, "Column " + cell.getColumnIndex() + //$NON-NLS-1$
 			" has no label provider."); //$NON-NLS-1$
 		}
-		labelProvider.update(cell);
-
-		// check if client has updated the label for this element. Otherwise use default
-		// label provided
+		// Set font and label for ExpandableNode. Client label provider should not
+		// receive it.
 		if (cell.getElement() instanceof ExpandableNode expNode) {
 			cell.setFont(JFaceResources.getFontRegistry().getItalic(JFaceResources.DEFAULT_FONT));
-			String text = cell.getText();
-			if (text.isEmpty() || text.equals(expNode.toString())) {
-				cell.setText(expNode.getLabel());
-			}
+			cell.setText(expNode.getLabel());
+			return;
 		}
+
+		labelProvider.update(cell);
+
 	}
 
 	/**


### PR DESCRIPTION
Unsafe(No type check before accessing passed model element) client's label provider can lead to ClassCastException. So we can never pass ExpandableNode to client's label provider.

see https://github.com/eclipse-platform/eclipse.platform.ui/issues/1353