### PR TITLE
WIP SHOWCASE [performance] Tree batch expand

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
@@ -46,6 +46,7 @@ import org.eclipse.swt.events.TreeListener;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Item;
+import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.swt.widgets.Widget;
 
@@ -362,9 +363,7 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 
 		// Optimize for the empty case
 		if (items.length == 0) {
-			for (Object element : elements) {
-				createTreeItem(widget, element, -1);
-			}
+			createItems(widget, elements);
 			return;
 		}
 
@@ -447,6 +446,13 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 				}
 			}
 		}
+	}
+
+	/**
+	 * @since 3.33
+	 */
+	protected void createItems(Widget widget, Object[] elements) {
+		// to be overriden!
 	}
 
 	/**
@@ -846,9 +852,7 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 				} else {
 					children = getSortedChildren(parentElement);
 				}
-				for (Object element : children) {
-					createTreeItem(widget, element, -1);
-				}
+				createItems(widget, children);
 			}
 		} finally {
 			setBusy(oldBusy);
@@ -856,16 +860,16 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 	}
 
 	/**
-	 * Creates a single item for the given parent and synchronizes it with the
-	 * given element.
+	 * Creates a single item for the given parent and synchronizes it with the given
+	 * element. The fastest way to insert many items is documented in
+	 * {@link TreeItem#TreeItem(Tree,int,int)}
 	 *
-	 * @param parent
-	 *            the parent widget
-	 * @param element
-	 *            the element
-	 * @param index
-	 *            if non-negative, indicates the position to insert the item
-	 *            into its parent
+	 * @param parent  the parent widget
+	 * @param element the element
+	 * @param index   if non-negative, indicates the position to insert the item
+	 *                into its parent
+	 * @see org.eclipse.swt.widgets.TreeItem#TreeItem(org.eclipse.swt.widgets.Tree,
+	 *      int, int)
 	 */
 	protected void createTreeItem(Widget parent, Object element, int index) {
 		Item item = newItem(parent, SWT.NULL, index);
@@ -1831,6 +1835,7 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 				return;
 			}
 			createChildren(widget, false);
+			// XXX for performance widget should be expanded after expanding children:
 			if (widget instanceof Item) {
 				setExpanded((Item) widget, true);
 			}
@@ -1844,6 +1849,7 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 					}
 				}
 			}
+			// XXX expanding here fails on linux
 		}
 	}
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewer.java
@@ -398,6 +398,31 @@ public class TreeViewer extends AbstractTreeViewer {
 	}
 
 	/**
+	 * @since 3.33
+	 */
+	@Override
+	final protected void createItems(Widget widget, Object[] elements) {
+		TreeItem parent = ((TreeItem) widget);
+		if (1 == 0) {
+			// old implementation
+			// For performance insert every item at index 0 (in reverse order):
+			for (int i = elements.length - 1; i >= 0; i--) {
+				createTreeItem(widget, elements[i], 0);
+			}
+		} else {
+			// batch implementation
+			parent.setItemCount(elements.length);
+			TreeItem[] items = parent.getItems();
+			for (int i = elements.length - 1; i >= 0; i--) {
+				Object element = elements[i];
+				TreeItem item = items[i];
+				updateItem(item, element);
+				updatePlus(item, element);
+			}
+		}
+	}
+
+	/**
 	 * For a TreeViewer with a tree with the VIRTUAL style bit set, replace the
 	 * given parent's child at index with the given element. If the given parent
 	 * is this viewer's input or an empty tree path, this will replace the root
@@ -1150,9 +1175,7 @@ public class TreeViewer extends AbstractTreeViewer {
 			item.dispose();
 
 			// create children on parent
-			for (Object element : children) {
-				createTreeItem(parent, element, -1);
-			}
+			createItems(parent, children);
 
 			// If we've expanded but still have not reached the limit
 			// select new expandable node, so user can click through


### PR DESCRIPTION
[win]:
OLD implementation:
3 ms to process 10000 items
5 ms to process 100000 items
The time to select scales as O(n^0,19) as the size of the model grows from 10000 to 100000
1068 ms to process 10000 items
10672 ms to process 100000 items
The time to reveal scales as O(n^1,00) as the size of the model grows from 10000 to 100000

NEW batch implementation:
3 ms to process 10000 items
20 ms to process 100000 items  <----- WORSE
The time to select scales as O(n^0,75) as the size of the model grows from 10000 to 100000
1053 ms to process 10000 items
10487 ms to process 100000 items
The time to reveal scales as O(n^1,00) as the size of the model grows from 10000 to 100000