### PR TITLE
Set the container to the wizard in the WizardSelectionPage

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/WizardSelectionPage.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/WizardSelectionPage.java
@@ -115,6 +115,8 @@ public abstract class WizardSelectionPage extends WizardPage {
 		}
 
 		if (!isCreated) {
+			// Allow the wizard to know its surrounding container
+			wizard.setContainer(getContainer());
 			// Allow the wizard to create its pages
 			wizard.addPages();
 		}


### PR DESCRIPTION
If using a WizardSelectionPage the created (sub) wizard currently don't has any way to know about its surrounding container.

This sets the container in case wizard was not created before.