### PR TITLE
CCE on selecting "Show remaining..." in JUnit view

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewer.java
@@ -1154,19 +1154,18 @@ public class TreeViewer extends AbstractTreeViewer {
 				createTreeItem(parent, element, -1);
 			}
 
-			// If we've expanded but still have not reached the limit
-			// select new expandable node, so user can click through
-			// to the end
+			// reset the selection. client's selection listener should not be triggered.
+			// there was only one selection on Expandable Node.
+			Item[] curSel = tree.getSelection();
+			if (curSel.length == 1) {
+				tree.deselect((TreeItem) curSel[0]);
+			}
+
+			// Scroll to the last element, so user can see what's expanded
+			// end continue expanding if needed
 			Object lastElement = getLastElement(parent);
-			if (lastElement instanceof ExpandableNode node) {
-				setSelection(new StructuredSelection(node), true);
-			} else {
-				// reset the selection. client's selection listener should not be triggered.
-				// there was only one selection on Expandable Node.
-				Item[] curSel = tree.getSelection();
-				if (curSel.length == 1) {
-					tree.deselect((TreeItem) curSel[0]);
-				}
+			if (lastElement instanceof ExpandableNode) {
+				reveal(lastElement);
 			}
 		} finally {
 			tree.setRedraw(true);


### PR DESCRIPTION
CCE happens because we always select expandable node on click and because the JUnit related selection listener code queries the selection from the widget instead of using selection from selection event while reacting on selection change. This is unusual, but allowed.

However, setting selection in first place is actually not needed, the only reason to do so was to reveal last element after expanding, so that user can simply click few times if needed. Revealing shown items however can be done without selection, so we don't run in such corner cases here.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1360