### PR TITLE
Recommend OSGi EventHandler for APP_STARTUP_COMPLETE over IStartup

### DIFF
--- a/bundles/org.eclipse.ui.monitoring/.project
+++ b/bundles/org.eclipse.ui.monitoring/.project
@@ -30,6 +30,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>

--- a/bundles/org.eclipse.ui.monitoring/.settings/org.eclipse.pde.ds.annotations.prefs
+++ b/bundles/org.eclipse.ui.monitoring/.settings/org.eclipse.pde.ds.annotations.prefs
@@ -1,0 +1,7 @@
+dsVersion=V1_4
+eclipse.preferences.version=1
+enabled=true
+generateBundleActivationPolicyLazy=true
+path=OSGI-INF
+validationErrorLevel=error
+validationErrorLevel.missingImplicitUnbindMethod=error

--- a/bundles/org.eclipse.ui.monitoring/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.monitoring/META-INF/MANIFEST.MF
@@ -12,5 +12,9 @@ Export-Package: org.eclipse.ui.internal.monitoring;x-internal:=true,
  org.eclipse.ui.monitoring;x-internal:=true
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.jface;bundle-version="[3.10.0,4.0.0)",
- org.eclipse.ui;bundle-version="[3.106.0,4.0.0)"
+ org.eclipse.ui;bundle-version="[3.106.0,4.0.0)",
+ org.eclipse.e4.ui.workbench;bundle-version="[1.15.300,2.0.0)"
+Service-Component: OSGI-INF/org.eclipse.ui.internal.monitoring.MonitoringStartup.xml
 Automatic-Module-Name: org.eclipse.ui.monitoring
+Import-Package: org.osgi.service.event;version="[1.4.0,2.0.0)",
+ org.osgi.service.event.propertytypes;version="[1.4.0,2.0.0)"

--- a/bundles/org.eclipse.ui.monitoring/build.properties
+++ b/bundles/org.eclipse.ui.monitoring/build.properties
@@ -17,6 +17,7 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.properties,\
+               OSGI-INF/,\
                plugin.xml,\
                about.html,\
                .options

--- a/bundles/org.eclipse.ui.monitoring/plugin.xml
+++ b/bundles/org.eclipse.ui.monitoring/plugin.xml
@@ -20,9 +20,6 @@
       name="%UiFreezeEventLogger.name"
       schema="schema/org.eclipse.ui.monitoring.logger.exsd"/>
 
-   <extension point="org.eclipse.ui.startup">
-      <startup class="org.eclipse.ui.internal.monitoring.MonitoringStartup"/>
-   </extension>
    <extension
          point="org.eclipse.core.runtime.preferences">
       <initializer

--- a/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/MonitoringStartup.java
+++ b/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/MonitoringStartup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2014, 2019 Google Inc and others.
+ * Copyright (C) 2014, 2023 Google Inc and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,21 +17,27 @@
 package org.eclipse.ui.internal.monitoring;
 
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.e4.ui.workbench.UIEvents;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.IStartup;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.monitoring.preferences.MonitoringPreferenceListener;
 import org.eclipse.ui.monitoring.PreferenceConstants;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+import org.osgi.service.event.propertytypes.EventTopics;
 
 /**
  * Starts the event loop monitoring thread. Initializes preferences from {@link IPreferenceStore}.
  */
-public class MonitoringStartup implements IStartup {
+@Component(service = EventHandler.class)
+@EventTopics(UIEvents.UILifeCycle.APP_STARTUP_COMPLETE)
+public class MonitoringStartup implements EventHandler {
 	private EventLoopMonitorThread monitoringThread;
 
 	@Override
-	public void earlyStartup() {
+	public void handleEvent(Event event) {
 		if (monitoringThread != null) {
 			return;
 		}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IStartup.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IStartup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,6 +17,53 @@ package org.eclipse.ui;
  * Plug-ins that register a startup extension will be activated after the
  * Workbench initializes and have an opportunity to run code that can't be
  * implemented using the normal contribution mechanisms.
+ * <p>
+ * Users can disable the execution of specific extensions in their workspace's
+ * preferences via<br>
+ * {@code  General -> Startup and Shutdown -> Plug-ins activated on startup}.
+ * </p>
+ * <p>
+ * Instead of implementing this interface and registering the implementation as
+ * Eclipse-Extension, handlers that want to be notified upon application
+ * start-up can be registered declaratively as OSGi
+ * {@link org.osgi.service.event.EventHandler} service for the
+ * {@link org.eclipse.e4.ui.workbench.UIEvents.UILifeCycle#APP_STARTUP_COMPLETE}
+ * event.<br>
+ * Such an event-handler is always executed and cannot be disabled via a
+ * preferences.
+ * <p>
+ * For example a class
+ *
+ * <pre>
+ * public class MyStartupHandler implements IStartup {
+ * 	&#64;Override
+ * 	public void earlyStartup() {
+ * 		// do handling...
+ * 	}
+ * }
+ * </pre>
+ *
+ * can be rewritten to
+ *
+ * <pre>
+ * &#64;Component(service = EventHandler.class)
+ * &#64;EventTopics(UIEvents.UILifeCycle.APP_STARTUP_COMPLETE)
+ * public class MyStartupHandler implements EventHandler {
+ * 	&#64;Override
+ * 	public void handleEvent(Event event) {
+ * 		// do handling...
+ * 	}
+ * }
+ * </pre>
+ *
+ * Processing of OSGi declarative services annotations has to be enabled for the
+ * containing Plug-in and it has to import the package
+ * {@code org.osgi.service.event} and
+ * {@code org.osgi.service.event.propertytypes} as well as a dependency to
+ * {@code org.eclipse.e4.ui.workbench}. At the same time the registration of the
+ * handler as Eclipse Extension for the {@code org.eclipse.ui.startup}
+ * extension-point can be removed.
+ * </p>
  *
  * @since 2.0
  */


### PR DESCRIPTION
And migrate `MonitoringStartup` accordingly.

This also uses the `org.osgi.service.event.propertytypes.EventTopics` `ComponentPropertyType` for which PDE has very recently got support for via https://github.com/eclipse-pde/eclipse.pde/pull/923.

Instead of just recommending the OSGi EventHandler over IStartup, we could also deprecate `IStartup` and the associcate extension-point in favor of this approach? I can then migrate the only remaining usage in the SDK in P2.