### PR TITLE
Fix Javadoc view not starting

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/html/HTMLPrinter.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/html/HTMLPrinter.java
@@ -63,6 +63,11 @@ public class HTMLPrinter {
 	}
 
 	private static org.eclipse.text.html.RGB fromRGB(RGB val) {
+		// Preserve	null RGB as HTMLBuilder contains the default colors and sets them accordingly
+		// in case of null parameter passed
+		if (val == null) {
+			return null;
+		}
 		return new org.eclipse.text.html.RGB(val.red, val.green, val.blue);
 	}
 	private static void cacheColors(Display display) {

--- a/bundles/org.eclipse.text/src/org/eclipse/text/html/HTMLBuilder.java
+++ b/bundles/org.eclipse.text/src/org/eclipse/text/html/HTMLBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -53,10 +53,10 @@ public class HTMLBuilder {
 	}
 	
 	public void setColors(RGB bg, RGB fg, RGB link, RGB alink) {
-		this.bgColor = bg;
-		this.fgColor = fg;
-		this.linkColor = link;
-		this.alinkColor = alink;
+		this.bgColor = bg != null ? bg : DEFAULT_BG_COLOR_RGB;
+		this.fgColor = fg != null ? fg : DEFAULT_FG_COLOR_RGB;
+		this.linkColor = link != null ? link : DEFAULT_LINK_COLOR_RGB;
+		this.alinkColor = alink != null ? alink : DEFAULT_ACTIVE_LINK_COLOR_RGB;
 	}
 
 	private static String replace(String text, char c, String s) {


### PR DESCRIPTION
Null values passed are preserved and sent to HTMLBuilder which sets them to default colors if needed.