### PR TITLE
[memory] optimize e4 ClassUtils.getPackageName()

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/utils/ClassUtils.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/utils/ClassUtils.java
@@ -35,11 +35,7 @@ public class ClassUtils {
 	 * Return the package name of Class <code>c</code>.
 	 */
 	public static String getPackageName(Class<?> c) {
-		String name = c.getName();
-		int index = name.lastIndexOf('.');
-		if (index > 0) {
-			return name.substring(0, index);
-		}
-		return null;
+		Package p = c.getPackage();
+		return p == null ? null : p.getName();
 	}
 }


### PR DESCRIPTION
to return always the same String Instance
Saves all duplicate Strings in
org.eclipse.e4.ui.css.swt.dom.WidgetElement.namespaceURI

it's only 1 MB.. but why not...
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/51790620/897083b0-0366-44c9-8064-0c86699e0f48)
