### PR TITLE
Add "Advanced Text Editor" strategy to the list of possible strategies

### DIFF
--- a/bundles/org.eclipse.ui.genericeditor/plugin.properties
+++ b/bundles/org.eclipse.ui.genericeditor/plugin.properties
@@ -37,3 +37,5 @@ command.toggle.highlight.name = Toggle Highlight
 menu.source.label = Source
 gotoMatchingBracketCommand_name =  Go to Matching Bracket
 gotoMatchingBracketCommand_description = Moves the cursor to the matching bracket
+systemEditorOrGenericEditorStrategy=System Editor; if none: Advanced Text Editor
+genericEditorStrategy=Advanced Text Editor

--- a/bundles/org.eclipse.ui.genericeditor/plugin.xml
+++ b/bundles/org.eclipse.ui.genericeditor/plugin.xml
@@ -260,4 +260,19 @@
             contentType="org.eclipse.core.runtime.text">
       </reconciler>
    </extension>
+   <extension
+         point="org.eclipse.ui.ide.unassociatedEditorStrategy">
+      <strategy
+            class="org.eclipse.ui.internal.genericeditor.SystemEditorOrGenericTextEditorStrategy"
+            id="org.eclipse.ui.internal.genericeditor.systemEditorOrGenericEditor"
+            interactive="false"
+            label="%systemEditorOrGenericEditorStrategy">
+      </strategy>
+      <strategy
+            class="org.eclipse.ui.internal.genericeditor.GenericTextEditorStrategy"
+            id="org.eclipse.ui.internal.genericeditor.genericTextEditor"
+            interactive="false"
+            label="%genericEditorStrategy">
+      </strategy>
+   </extension>
 </plugin>

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/GenericTextEditorStrategy.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/GenericTextEditorStrategy.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Andrey Loskutov (loskutov@gmx.de) and others
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov (loskutov@gmx.de)
+ *******************************************************************************/
+package org.eclipse.ui.internal.genericeditor;
+
+import org.eclipse.ui.IEditorDescriptor;
+import org.eclipse.ui.IEditorRegistry;
+import org.eclipse.ui.ide.IUnassociatedEditorStrategy;
+
+/**
+ * Use generic text editor for unassociated text files.
+ * <p>
+ * This allows to see syntax highlighting in all editors opened on "not
+ * associated" file extensions, if there is a tm4e support for that syntax
+ * available - for example with python, css, html, xml files.
+ * </p>
+ */
+public final class GenericTextEditorStrategy implements IUnassociatedEditorStrategy {
+
+	@Override
+	public IEditorDescriptor getEditorDescriptor(String name, IEditorRegistry editorReg) {
+		// don't care about file name and always return generic editor id
+		// No files from "registered" editors will appear here
+		return editorReg.findEditor(ExtensionBasedTextEditor.GENERIC_EDITOR_ID);
+	}
+
+}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/SystemEditorOrGenericTextEditorStrategy.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/SystemEditorOrGenericTextEditorStrategy.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Andrey Loskutov (loskutov@gmx.de) and others
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov (loskutov@gmx.de)
+ *******************************************************************************/
+package org.eclipse.ui.internal.genericeditor;
+
+import org.eclipse.ui.IEditorDescriptor;
+import org.eclipse.ui.IEditorRegistry;
+import org.eclipse.ui.ide.IUnassociatedEditorStrategy;
+
+/**
+ * Strategy for unassociated file types:
+ * <ol>
+ * <li>The operating system is consulted to determine if an in-place component
+ * editor is available (e.g. OLE editor on Win32 platforms).</li>
+ * <li>The operating system is consulted to determine if an external editor is
+ * available.</li>
+ * <li>The workbench editor registry is consulted to determine if the generic
+ * text editor is available.</li>
+ * </ol>
+ */
+public final class SystemEditorOrGenericTextEditorStrategy implements IUnassociatedEditorStrategy {
+
+	@Override
+	public IEditorDescriptor getEditorDescriptor(String name, IEditorRegistry editorReg) {
+		IEditorDescriptor editorDesc = null;
+		// next check the OS for in-place editor (OLE on Win32)
+		if (editorReg.isSystemInPlaceEditorAvailable(name)) {
+			editorDesc = editorReg.findEditor(IEditorRegistry.SYSTEM_INPLACE_EDITOR_ID);
+		}
+
+		// next check with the OS for an external editor
+		if (editorDesc == null && editorReg.isSystemExternalEditorAvailable(name)) {
+			editorDesc = editorReg.findEditor(IEditorRegistry.SYSTEM_EXTERNAL_EDITOR_ID);
+		}
+
+		// next lookup the default text editor
+		if (editorDesc == null) {
+			editorDesc = editorReg.findEditor(ExtensionBasedTextEditor.GENERIC_EDITOR_ID);
+		}
+		return editorDesc;
+	}
+}


### PR DESCRIPTION
Extend the options provided in "Open unassociated files with:" selection box to "Advanced Text Editor" (and "System Editor, if none: Advanced Text Editor"), which offer more functionality as "Text" by default.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1380