### PR TITLE
Remove obsolete comment

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/operation/ModalContext.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/operation/ModalContext.java
@@ -387,9 +387,6 @@ public class ModalContext {
 						} else if (throwable instanceof InterruptedException e) {
 							throw e;
 						} else if (throwable instanceof OperationCanceledException) {
-							// See 1GAN3L5: ITPUI:WIN2000 - ModalContext
-							// converts OperationCancelException into
-							// InvocationTargetException
 							InterruptedException interruptedException = new InterruptedException(throwable.getMessage());
 							interruptedException.initCause(throwable);
 							throw interruptedException;


### PR DESCRIPTION
The comment is outdated and misleading as it refers to a different kind of exception than is actually created.

Follow-up to #1259.