### PR TITLE
Fix and enable MediaRulesTest:testMediaRule

### DIFF
--- a/tests/org.eclipse.e4.ui.tests.css.core/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests.css.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.e4.ui.tests.css.core
-Bundle-Version: 1.302.700.qualifier
+Bundle-Version: 1.302.800.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.swt,
  org.eclipse.e4.ui.css.core,

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/MediaRulesTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/MediaRulesTest.java
@@ -15,12 +15,12 @@
 package org.eclipse.e4.ui.tests.css.core.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.e4.ui.tests.css.core.util.ParserTestUtil;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.w3c.dom.css.CSSRuleList;
 import org.w3c.dom.css.CSSStyleSheet;
 
 /**
@@ -29,18 +29,16 @@ import org.w3c.dom.css.CSSStyleSheet;
 public class MediaRulesTest {
 
 	@Test
-	@Disabled("//THIS TEST KNOWN TO FAIL Dec 16/08")
 	void testMediaRule() throws Exception {
 		String css = """
-			@media screen, print {
-			BODY { line-height: 1.2 }
-			}
-			Label { background-color: #FF0000 }""";
+				@media screen, print {
+				BODY { line-height: 1.2 }
+				}
+				Label { background-color: #FF0000 }""";
 		CSSStyleSheet styleSheet = ParserTestUtil.parseCss(css);
 		assertNotNull(styleSheet);
-		CSSRuleList rules = styleSheet.getCssRules();
-
-
-		assertEquals(1, rules.getLength());
+		assertEquals(2, styleSheet.getCssRules().getLength());
+		assertFalse(styleSheet.getCssRules().item(0).getCssText().contains("line-height"));
+		assertTrue(styleSheet.getCssRules().item(1).getCssText().contains("background-color"));
 	}
 }


### PR DESCRIPTION
Enabled some disabled tests which aren't in broken state anymore and fixed other disabled tests.
https://github.com/eclipse-platform/eclipse.platform/issues/525

In the MediaRulesTest class, we test for if a CSS rule with @media tag is considered on parsing. Ideally we want the rule to be ignored.
Suppose we have a CSS string like:
@media screen, print {
					BODY { background-color: red }
					}
 In the previous version of the test (which was disabled), it was expected that the rule "BODY { background-color: red }" under @media tag would be completely ignored. But now the behaviour has changed. It seems like the rules under @media are loaded indeed on parsing but the attributes are ignored, i.e. it looks like "BODY {  }".

However, this behaviour doesn't have any side effect since a rule with no attributes neither change anything nor resets anything.