### PR TITLE
Store workbench preference dialog setting using suffix ".dialogBounds"

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/WorkbenchPreferenceDialog.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/WorkbenchPreferenceDialog.java
@@ -149,7 +149,8 @@ public class WorkbenchPreferenceDialog extends FilteredPreferenceDialog {
 	protected IDialogSettings getDialogBoundsSettings() {
 		Bundle bundle = WorkbenchPlugin.getDefault().getBundle();
 		IDialogSettings settings = PlatformUI.getDialogSettingsProvider(bundle).getDialogSettings();
-		return DialogSettings.getOrCreateSection(settings, getClass().getSimpleName());
+		String name = getClass().getSimpleName() + ".dialogBounds"; //$NON-NLS-1$
+		return DialogSettings.getOrCreateSection(settings, name);
 	}
 
 }


### PR DESCRIPTION
Like in https://github.com/eclipse-platform/eclipse.platform.ui/pull/1282.

Follow-up of
https://github.com/eclipse-platform/eclipse.platform.ui/pull/964