### PR TITLE
SIOOBE in genericeditor.DefaultWordHighlightStrategy if editor contains collapsed sections

### DIFF
--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/DefaultWordHighlightStrategy.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/DefaultWordHighlightStrategy.java
@@ -124,6 +124,9 @@ public class DefaultWordHighlightStrategy implements IReconcilingStrategy, IReco
 	}
 
 	private static String findCurrentWord(String text, int offset) {
+		if (offset < 0 || offset >= text.length()) {
+			return null;
+		}
 		String wordStart = null;
 		String wordEnd = null;
 


### PR DESCRIPTION
Added trivial range check in `DefaultWordHighlightStrategy.findCurrentWord()`.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1394