### PR TITLE
Replace apitools javadoc tags with annotations

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/AbstractGroupMarker.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/AbstractGroupMarker.java
@@ -15,14 +15,15 @@
 package org.eclipse.jface.action;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 
 /**
  * Abstract superclass for group marker classes.
  * <p>
  * This class is not intended to be subclassed outside the framework.
  * </p>
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public abstract class AbstractGroupMarker extends ContributionItem {
 	/**
 	 * Constructor for use by subclasses.

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/ActionContributionItem.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/ActionContributionItem.java
@@ -31,6 +31,7 @@ import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.Policy;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.jface.util.Util;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Point;
@@ -51,8 +52,8 @@ import org.eclipse.swt.widgets.Widget;
  * <p>
  * This class may be instantiated; it is not intended to be subclassed.
  * </p>
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class ActionContributionItem extends ContributionItem {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/GroupMarker.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/GroupMarker.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jface.action;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+
 /**
  * A group marker is a special kind of contribution item denoting
  * the beginning of a group. These groups are used to structure
@@ -23,8 +25,8 @@ package org.eclipse.jface.action;
  * This class may be instantiated; it is not intended to be
  * subclassed outside the framework.
  * </p>
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class GroupMarker extends AbstractGroupMarker {
 	/**
 	 * Create a new group marker with the given name.

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/IAction.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/IAction.java
@@ -16,6 +16,7 @@ package org.eclipse.jface.action;
 import org.eclipse.core.commands.IHandlerAttributes;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.util.IPropertyChangeListener;
+import org.eclipse.pde.api.tools.annotations.NoImplement;
 import org.eclipse.swt.events.HelpListener;
 import org.eclipse.swt.widgets.Event;
 
@@ -42,8 +43,8 @@ import org.eclipse.swt.widgets.Event;
  * </p>
  *
  * @see Action
- * @noimplement This interface is not intended to be implemented by clients.
  */
+@NoImplement
 public interface IAction {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/IContributionItem.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/IContributionItem.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.jface.action;
 
+import org.eclipse.pde.api.tools.annotations.NoImplement;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.CoolBar;
 import org.eclipse.swt.widgets.Menu;
@@ -37,8 +38,8 @@ import org.eclipse.swt.widgets.ToolBar;
  * </p>
  *
  * @see IContributionManager
- * @noimplement This interface is not intended to be implemented by clients.
  */
+@NoImplement
 public interface IContributionItem {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/IContributionManagerOverrides.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/IContributionManagerOverrides.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jface.action;
 
+import org.eclipse.pde.api.tools.annotations.NoImplement;
+
 /**
  * This interface is used by instances of <code>IContributionItem</code>
  * to determine if the values for certain properties have been overriden
@@ -23,8 +25,8 @@ package org.eclipse.jface.action;
  * </p>
  *
  * @since 2.0
- * @noimplement This interface is not intended to be implemented by clients.
  */
+@NoImplement
 public interface IContributionManagerOverrides {
 	/**
 	 * Id for the enabled property. Value is <code>"enabled"</code>.

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/IMenuManager.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/IMenuManager.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jface.action;
 
+import org.eclipse.pde.api.tools.annotations.NoImplement;
+
 /**
  * The <code>IMenuManager</code> interface provides protocol for managing
  * contributions to a menu bar and its sub menus. An <code>IMenuManager</code>
@@ -26,9 +28,8 @@ package org.eclipse.jface.action;
  * This package provides a concrete menu manager implementation,
  * {@link MenuManager MenuManager}.
  * </p>
- *
- * @noimplement This interface is not intended to be implemented by clients.
  */
+@NoImplement
 public interface IMenuManager extends IContributionManager, IContributionItem {
 	/**
 	 * Adds a menu listener to this menu.

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/Separator.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/Separator.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jface.action;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
@@ -28,8 +29,8 @@ import org.eclipse.swt.widgets.ToolItem;
  * This class may be instantiated; it is not intended to be
  * subclassed outside the framework.
  * </p>
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class Separator extends AbstractGroupMarker {
 	/**
 	 * Creates a separator which does not start a new group.

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/SubContributionItem.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/SubContributionItem.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jface.action;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.CoolBar;
 import org.eclipse.swt.widgets.Menu;
@@ -25,8 +26,8 @@ import org.eclipse.swt.widgets.ToolBar;
  * <p>
  * This class is not intended to be subclassed.
  * </p>
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class SubContributionItem implements IContributionItem {
 	/**
 	 * The visibility of the item.

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/ToolBarContributionItem.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/ToolBarContributionItem.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.internal.provisional.action.IToolBarContributionItem;
 import org.eclipse.jface.util.Policy;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.SelectionEvent;
@@ -46,8 +47,8 @@ import org.eclipse.swt.widgets.ToolItem;
  * </p>
  *
  * @since 3.0
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class ToolBarContributionItem extends ContributionItem implements IToolBarContributionItem {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/DialogSettings.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/DialogSettings.java
@@ -39,6 +39,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.jface.internal.XmlProcessorFactoryJFace;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -70,9 +71,8 @@ import org.xml.sax.SAXException;
  * settings.save("c:\\temp\\test\\dialog.xml");
  * </code>
  * </pre>
- * @noextend This class is not intended to be subclassed by clients.
  */
-
+@NoExtend
 public class DialogSettings implements IDialogSettings {
 	// The name of the DialogSettings.
 	private String name;

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/IDialogLabelKeys.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/IDialogLabelKeys.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jface.dialogs;
 
+import org.eclipse.pde.api.tools.annotations.NoImplement;
+
 /**
  * IDialogLabelKeys contains publicly accessible keys to the common dialog
  * labels used throughout JFace.  <code>IDialogConstants</code> provides
@@ -24,10 +26,8 @@ package org.eclipse.jface.dialogs;
  *
  * @see IDialogConstants
  * @since 3.7
- *
- * @noimplement This interface is not intended to be implemented by clients.
-
  */
+@NoImplement
 public interface IDialogLabelKeys {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/fieldassist/ControlDecoration.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/fieldassist/ControlDecoration.java
@@ -16,6 +16,7 @@ package org.eclipse.jface.fieldassist;
 
 import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.jface.util.Util;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.events.DisposeListener;
@@ -75,9 +76,8 @@ import org.eclipse.swt.widgets.Widget;
  *
  * @see FieldDecoration
  * @see FieldDecorationRegistry
- *
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class ControlDecoration {
 	/**
 	 * Debug flag for tracing

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/internal/MenuManagerEventHelper.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/internal/MenuManagerEventHelper.java
@@ -16,12 +16,14 @@ package org.eclipse.jface.internal;
 
 import org.eclipse.jface.action.IMenuListener2;
 import org.eclipse.jface.action.MenuManager;
+import org.eclipse.pde.api.tools.annotations.NoInstantiate;
+import org.eclipse.pde.api.tools.annotations.NoReference;
 
 /**
  * @since 3.8.100
- * @noinstantiate This class is not intended to be instantiated by clients.
- * @noreference This class is not intended to be referenced by clients.
  */
+@NoInstantiate
+@NoReference
 public final class MenuManagerEventHelper {
 
 	private IMenuListener2 showHelper;

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/operation/ModalContext.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/operation/ModalContext.java
@@ -23,6 +23,8 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.ProgressMonitorWrapper;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.util.Policy;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+import org.eclipse.pde.api.tools.annotations.NoInstantiate;
 import org.eclipse.swt.widgets.Display;
 
 /**
@@ -35,9 +37,9 @@ import org.eclipse.swt.widgets.Display;
  * <p>
  * This class is not intended to be subclassed.
  * </p>
- * @noinstantiate This class is not intended to be instantiated by clients.
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoInstantiate
+@NoExtend
 public class ModalContext {
 	/**
 	 * Indicates whether ModalContext is in debug mode; <code>false</code> by

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/PreferenceConverter.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/PreferenceConverter.java
@@ -18,6 +18,7 @@ import java.util.StringTokenizer;
 
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.resource.StringConverter;
+import org.eclipse.pde.api.tools.annotations.NoInstantiate;
 import org.eclipse.swt.SWTException;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Point;
@@ -46,9 +47,8 @@ import org.eclipse.swt.widgets.Display;
  * </p>
  * Note: touching this class has the side effect of creating a display (static
  * initializer).
- *
- * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@NoInstantiate
 public class PreferenceConverter {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/PreferenceStore.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/PreferenceStore.java
@@ -30,6 +30,7 @@ import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.jface.util.SafeRunnable;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 
 /**
  * A concrete preference store implementation based on an internal
@@ -40,8 +41,8 @@ import org.eclipse.jface.util.SafeRunnable;
  * </p>
  *
  * @see IPreferenceStore
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class PreferenceStore extends EventManager implements
 		IPersistentPreferenceStore {
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ColorRegistry.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ColorRegistry.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
@@ -44,8 +45,8 @@ import org.eclipse.swt.widgets.Display;
  * </p>
  *
  * @since 3.0
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class ColorRegistry extends ResourceRegistry {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/CompositeImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/CompositeImageDescriptor.java
@@ -17,6 +17,7 @@ package org.eclipse.jface.resource;
 import java.util.Objects;
 import java.util.function.ToIntFunction;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageDataProvider;
@@ -48,8 +49,8 @@ public abstract class CompositeImageDescriptor extends ImageDescriptor {
 	 * @see #createCachedImageDataProvider(ImageDescriptor)
 	 *
 	 * @since 3.13
-	 * @noextend This class is not intended to be subclassed by clients.
 	 */
+	@NoExtend
 	protected abstract class CachedImageDataProvider implements ImageDataProvider {
 		/**
 		 * Returns the {@link ImageData#width} in points. This method must only

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FontRegistry.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/FontRegistry.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.util.Policy;
 import org.eclipse.jface.util.Util;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
 import org.eclipse.swt.graphics.Font;
@@ -58,8 +59,8 @@ import org.eclipse.swt.widgets.Display;
  * </p>
  *
  * Since 3.0 this class extends ResourceRegistry.
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class FontRegistry extends ResourceRegistry {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageRegistry.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageRegistry.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.graphics.Image;
@@ -44,8 +45,8 @@ import org.eclipse.swt.widgets.Display;
  * Unlike the FontRegistry, it is an error to replace images. As a result
  * there are no events that fire when values are changed in the registry
  * </p>
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class ImageRegistry {
 	/**
 	 * display used when getting images

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/JFaceResources.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/JFaceResources.java
@@ -30,6 +30,8 @@ import org.eclipse.jface.dialogs.PopupDialog;
 import org.eclipse.jface.dialogs.TitleAreaDialog;
 import org.eclipse.jface.preference.PreferenceDialog;
 import org.eclipse.jface.wizard.Wizard;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+import org.eclipse.pde.api.tools.annotations.NoInstantiate;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Control;
@@ -52,10 +54,9 @@ import org.osgi.framework.FrameworkUtil;
  * <li>an image registry</li>
  * <li>a resource bundle</li>
  * </ul>
- *
- * @noinstantiate This class is not intended to be instantiated by clients.
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoInstantiate
+@NoExtend
 public class JFaceResources {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ResourceLocator.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ResourceLocator.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.pde.api.tools.annotations.NoInstantiate;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
@@ -29,8 +30,8 @@ import org.osgi.framework.FrameworkUtil;
  * resources in bundles.
  *
  * @since 3.17
- * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@NoInstantiate
 public final class ResourceLocator {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/StringConverter.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/StringConverter.java
@@ -19,6 +19,8 @@ import java.util.NoSuchElementException;
 import java.util.StringTokenizer;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+import org.eclipse.pde.api.tools.annotations.NoInstantiate;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Point;
@@ -43,9 +45,9 @@ import org.eclipse.swt.graphics.Rectangle;
  * All methods declared on this class are static. This
  * class cannot be instantiated.
  * </p>
- * @noinstantiate This class is not intended to be instantiated by clients.
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoInstantiate
+@NoExtend
 public class StringConverter {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/util/StructuredTextSegmentListener.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/util/StructuredTextSegmentListener.java
@@ -21,6 +21,7 @@ import org.eclipse.equinox.bidi.advanced.IStructuredTextExpert;
 import org.eclipse.equinox.bidi.advanced.StructuredTextEnvironment;
 import org.eclipse.equinox.bidi.advanced.StructuredTextExpertFactory;
 import org.eclipse.equinox.bidi.custom.StructuredTextTypeHandler;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.events.SegmentEvent;
 import org.eclipse.swt.events.SegmentListener;
 
@@ -34,8 +35,8 @@ import org.eclipse.swt.events.SegmentListener;
  * </p>
  *
  * @since 3.9
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class StructuredTextSegmentListener implements SegmentListener {
 
 	private final IStructuredTextExpert expert;

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ArrayContentProvider.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ArrayContentProvider.java
@@ -17,6 +17,8 @@ package org.eclipse.jface.viewers;
 
 import java.util.Collection;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+
 /**
  * This implementation of <code>IStructuredContentProvider</code> handles
  * the case where the viewer input is an unchanging array or collection of elements.
@@ -25,8 +27,8 @@ import java.util.Collection;
  * </p>
  *
  * @since 2.1
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class ArrayContentProvider implements IStructuredContentProvider {
 
 	private static ArrayContentProvider instance;

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/CellEditor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/CellEditor.java
@@ -20,6 +20,7 @@ import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.jface.util.SafeRunnable;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.widgets.Composite;
@@ -95,9 +96,8 @@ public abstract class CellEditor {
 	/**
 	 * Struct-like layout data for cell editors, with reasonable defaults for
 	 * all fields.
-	 *
-	 * @noextend This class is not intended to be subclassed by clients.
 	 */
+	@NoExtend
 	public static class LayoutData {
 		/**
 		 * Horizontal alignment; <code>SWT.LEFT</code> by default.

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/CheckboxCellEditor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/CheckboxCellEditor.java
@@ -14,6 +14,7 @@
 package org.eclipse.jface.viewers;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -30,8 +31,8 @@ import org.eclipse.swt.widgets.Control;
  * of the check box is being toggled by the end users; the listener method
  * <code>applyEditorValue</code> is immediately called to signal the change.
  * </p>
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class CheckboxCellEditor extends CellEditor {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/CheckboxTableViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/CheckboxTableViewer.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.jface.util.SafeRunnable;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Composite;
@@ -40,8 +41,8 @@ import org.eclipse.swt.widgets.Widget;
  * with a domain-specific content provider, label provider, element filter (optional),
  * and element sorter (optional).
  * </p>
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class CheckboxTableViewer extends TableViewer implements ICheckable {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColorCellEditor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColorCellEditor.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jface.viewers;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontMetrics;
@@ -37,8 +38,8 @@ import org.eclipse.swt.widgets.Tree;
  * <p>
  * This class may be instantiated; it is not intended to be subclassed.
  * </p>
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class ColorCellEditor extends DialogCellEditor {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnLayoutData.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnLayoutData.java
@@ -13,14 +13,16 @@
  *******************************************************************************/
 package org.eclipse.jface.viewers;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+
 /**
  * An abstract column layout data describing the information needed
  * (by <code>TableLayout</code>) to properly lay out a table.
  * <p>
  * This class is not intended to be subclassed outside the framework.
  * </p>
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public abstract class ColumnLayoutData {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnPixelData.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnPixelData.java
@@ -14,6 +14,7 @@
 package org.eclipse.jface.viewers;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 
 /**
  * Describes the width of a table column in pixels, and
@@ -21,8 +22,8 @@ import org.eclipse.core.runtime.Assert;
  * <p>
  * This class may be instantiated; it is not intended to be subclassed.
  * </p>
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class ColumnPixelData extends ColumnLayoutData {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnViewerEditorDeactivationEvent.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnViewerEditorDeactivationEvent.java
@@ -18,12 +18,14 @@ package org.eclipse.jface.viewers;
 
 import java.util.EventObject;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+
 /**
  * This event is fired when an editor deactivated
  *
  * @since 3.3
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class ColumnViewerEditorDeactivationEvent extends EventObject {
 
 	private static final long serialVersionUID = 1L;

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnWeightData.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnWeightData.java
@@ -14,6 +14,7 @@
 package org.eclipse.jface.viewers;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 
 /**
  * Describes the width of a table column in terms of a weight,
@@ -21,8 +22,8 @@ import org.eclipse.core.runtime.Assert;
  * <p>
  * This class may be instantiated; it is not intended to be subclassed.
  * </p>
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class ColumnWeightData extends ColumnLayoutData {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ComboBoxCellEditor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ComboBoxCellEditor.java
@@ -19,6 +19,7 @@ import java.text.MessageFormat; // Not using ICU to support standalone JFace
 // scenario
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.events.FocusAdapter;
@@ -37,8 +38,8 @@ import org.eclipse.swt.widgets.Control;
  * <p>
  * This class may be instantiated; it is not intended to be subclassed.
  * </p>
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class ComboBoxCellEditor extends AbstractComboBoxCellEditor {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/IDecoration.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/IDecoration.java
@@ -14,6 +14,7 @@
 package org.eclipse.jface.viewers;
 
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.pde.api.tools.annotations.NoImplement;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 
@@ -22,8 +23,8 @@ import org.eclipse.swt.graphics.Font;
  *
  * This interface is not meant to be implemented and will be provided to
  * instances of <code>ILightweightLabelDecorator</code>.
- * @noimplement This interface is not intended to be implemented by clients.
  */
+@NoImplement
 public interface IDecoration {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ListViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ListViewer.java
@@ -20,6 +20,7 @@ package org.eclipse.jface.viewers;
 import java.util.List;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
@@ -38,8 +39,8 @@ import org.eclipse.swt.widgets.Control;
  * </p>
  *
  * @see TableViewer
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class ListViewer extends AbstractListViewer {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredSelection.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredSelection.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 
 /**
  * A concrete implementation of the <code>IStructuredSelection</code> interface,
@@ -29,8 +30,8 @@ import org.eclipse.jface.resource.JFaceResources;
  * <p>
  * This class is not intended to be subclassed.
  * </p>
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class StructuredSelection implements IStructuredSelection {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredViewerInternals.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredViewerInternals.java
@@ -14,6 +14,10 @@
 
 package org.eclipse.jface.viewers;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+import org.eclipse.pde.api.tools.annotations.NoImplement;
+import org.eclipse.pde.api.tools.annotations.NoInstantiate;
+import org.eclipse.pde.api.tools.annotations.NoReference;
 import org.eclipse.swt.widgets.Item;
 import org.eclipse.swt.widgets.Widget;
 
@@ -21,18 +25,18 @@ import org.eclipse.swt.widgets.Widget;
  * This class is not part of the public API of JFace. See bug 267722.
  *
  * @since 3.5
- * @noextend This class is not intended to be subclassed by clients.
- * @noinstantiate This class is not intended to be instantiated by clients.
  */
+@NoInstantiate
+@NoExtend
 public class StructuredViewerInternals {
 
 	/**
 	 * Nothing to see here.
 	 *
 	 * @since 3.5
-	 * @noextend This interface is not intended to be extended by clients.
-	 * @noimplement This interface is not intended to be implemented by clients.
 	 */
+	@NoExtend
+	@NoImplement
 	protected static interface AssociateListener {
 
 		/**
@@ -67,8 +71,8 @@ public class StructuredViewerInternals {
 	 *            the viewer
 	 * @param listener
 	 *            the {@link AssociateListener}
-	 * @noreference This method is not intended to be referenced by clients.
 	 */
+	@NoReference
 	protected static void setAssociateListener(StructuredViewer viewer,
 			AssociateListener listener) {
 		viewer.setAssociateListener(listener);
@@ -82,9 +86,8 @@ public class StructuredViewerInternals {
 	 * @param element
 	 *            the element
 	 * @return the Widgets corresponding to the element
-	 *
-	 * @noreference This method is not intended to be referenced by clients.
 	 */
+	@NoReference
 	protected static Widget[] getItems(StructuredViewer viewer, Object element) {
 		return viewer.findItems(element);
 	}

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TableViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TableViewer.java
@@ -21,6 +21,7 @@ package org.eclipse.jface.viewers;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.viewers.internal.ExpandableNode;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
@@ -65,8 +66,8 @@ import org.eclipse.swt.widgets.Widget;
  * @see SWT#VIRTUAL
  * @see #doFindItem(Object)
  * @see #internalRefresh(Object, boolean)
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class TableViewer extends AbstractTableViewer {
 	/**
 	 * This viewer's table control.

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewer.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.eclipse.jface.util.Policy;
 import org.eclipse.jface.viewers.internal.ExpandableNode;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.TreeEvent;
 import org.eclipse.swt.events.TreeListener;
@@ -65,8 +66,8 @@ import org.eclipse.swt.widgets.Widget;
  * Users setting up an editable tree with more than 1 column <b>have</b> to pass the
  * SWT.FULL_SELECTION style bit
  * </p>
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class TreeViewer extends AbstractTreeViewer {
 
 	private static final String VIRTUAL_DISPOSE_KEY = Policy.JFACE

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/deferred/IConcurrentModel.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/deferred/IConcurrentModel.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jface.viewers.deferred;
 
+import org.eclipse.pde.api.tools.annotations.NoImplement;
 
 /**
  * Interface for a set of unordered elements that can fire change notifications.
@@ -32,8 +33,8 @@ package org.eclipse.jface.viewers.deferred;
  * </p>
  *
  * @since 3.1
- * @noimplement This interface is not intended to be implemented by clients.
  */
+@NoImplement
 public interface IConcurrentModel {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/internal/ExpandableNode.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/internal/ExpandableNode.java
@@ -21,6 +21,7 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 
 /**
  * The expandable placeholder element to be used for viewer items that represent
@@ -34,9 +35,8 @@ import org.eclipse.jface.viewers.TableViewer;
  * The node consists of a parent element, list of all children of this parent
  * and the offset to which child elements are supposed to be created and shown
  * in the viewer.
- *
- * @noextend This class is not intended to be subclassed by clients.
  */
+@NoExtend
 public class ExpandableNode {
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/widgets/AbstractCompositeFactory.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/widgets/AbstractCompositeFactory.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jface.widgets;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Layout;
 
@@ -24,10 +25,9 @@ import org.eclipse.swt.widgets.Layout;
  * @param <F> factory
  * @param <C> control
  *
- * @noextend this class is not intended to be subclassed by clients.
- *
  * @since 3.18
  */
+@NoExtend
 public abstract class AbstractCompositeFactory<F extends AbstractCompositeFactory<?, ?>, C extends Composite>
 		extends AbstractControlFactory<F, C> {
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/widgets/AbstractControlFactory.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/widgets/AbstractControlFactory.java
@@ -16,6 +16,7 @@ package org.eclipse.jface.widgets;
 
 import java.util.function.Supplier;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Composite;
@@ -29,10 +30,9 @@ import org.eclipse.swt.widgets.Control;
  * @param <F> factory
  * @param <C> control
  *
- * @noextend this class is not intended to be subclassed by clients.
- *
  * @since 3.18
  */
+@NoExtend
 public abstract class AbstractControlFactory<F extends AbstractControlFactory<?, ?>, C extends Control>
 		extends AbstractWidgetFactory<F, C, Composite> {
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/widgets/AbstractItemFactory.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/widgets/AbstractItemFactory.java
@@ -13,6 +13,7 @@
 ******************************************************************************/
 package org.eclipse.jface.widgets;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Item;
 import org.eclipse.swt.widgets.Widget;
@@ -26,10 +27,9 @@ import org.eclipse.swt.widgets.Widget;
  * @param <I> item
  * @param <P> parent
  *
- * @noextend this class is not intended to be subclassed by clients.
- *
  * @since 3.18
  */
+@NoExtend
 public abstract class AbstractItemFactory<F extends AbstractItemFactory<?, ?, ?>, I extends Item, P extends Widget>
 		extends AbstractWidgetFactory<F, I, P> {
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/widgets/AbstractWidgetFactory.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/widgets/AbstractWidgetFactory.java
@@ -16,6 +16,7 @@ package org.eclipse.jface.widgets;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
 import org.eclipse.swt.widgets.Widget;
 
 /**
@@ -27,10 +28,9 @@ import org.eclipse.swt.widgets.Widget;
  * @param <W> widget
  * @param <P> parent
  *
- * @noextend this class is not intended to be subclassed by clients.
- *
  * @since 3.18
  */
+@NoExtend
 public abstract class AbstractWidgetFactory<F extends AbstractWidgetFactory<?, ?, ?>, W extends Widget, P extends Widget> {
 	private Class<F> factoryClass;
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/widgets/Property.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/widgets/Property.java
@@ -13,6 +13,8 @@
 ******************************************************************************/
 package org.eclipse.jface.widgets;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+import org.eclipse.pde.api.tools.annotations.NoImplement;
 import org.eclipse.swt.widgets.Widget;
 
 /**
@@ -28,11 +30,10 @@ import org.eclipse.swt.widgets.Widget;
  *
  * @param <T> the type of the widget the property is used for
  *
- * @noimplement this interface is not intended to be implemented by clients.
- * @noextend this class is not intended to be subclassed by clients.
- *
  * @since 3.18
  */
+@NoImplement
+@NoExtend
 @FunctionalInterface
 public interface Property<T extends Widget> {
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/widgets/WidgetSupplier.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/widgets/WidgetSupplier.java
@@ -13,6 +13,8 @@
 ******************************************************************************/
 package org.eclipse.jface.widgets;
 
+import org.eclipse.pde.api.tools.annotations.NoExtend;
+import org.eclipse.pde.api.tools.annotations.NoImplement;
 import org.eclipse.swt.widgets.Widget;
 
 /**
@@ -29,11 +31,10 @@ import org.eclipse.swt.widgets.Widget;
  * @param <W> the type of the widget to be created
  * @param <P> the type of the parent the widget should be created in
  *
- * @noimplement this interface is not intended to be implemented by clients.
- * @noextend this class is not intended to be subclassed by clients.
- *
  * @since 3.18
  */
+@NoImplement
+@NoExtend
 @FunctionalInterface
 public interface WidgetSupplier<W extends Widget, P extends Widget> {
 


### PR DESCRIPTION
Identified in
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1655 that so far annotations were missing in generated .api_description files.
Local build shown that everything is still picked up with annotations only, even the one that wasn't before (LazyResourceManager) and caused this issue.