### PR TITLE
Workaround for changed IStatusLineManager.getProgressMonitor() API

### DIFF
--- a/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/BrowserViewer.java
+++ b/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/BrowserViewer.java
@@ -399,6 +399,8 @@ public class BrowserViewer extends Composite {
 		});
 
 		browser.addProgressListener(new ProgressListener() {
+			private IProgressMonitor monitor;
+
 			@Override
 			public void changed(ProgressEvent event) {
 					//System.out.println("progress: " + event.current + ", " + event.total); //$NON-NLS-1$ //$NON-NLS-2$
@@ -409,16 +411,21 @@ public class BrowserViewer extends Composite {
 
 				int percentProgress = event.current * 100 / event.total;
 				if (container != null) {
-					IProgressMonitor monitor = container.getActionBars()
-							.getStatusLineManager().getProgressMonitor();
 					if (done) {
-						monitor.done();
+						if (monitor != null) {
+							monitor.done();
+						}
 						progressWorked = 0;
+						monitor = null;
 					} else if (progressWorked == 0) {
+						IStatusLineManager statusLineManager = container.getActionBars().getStatusLineManager();
+						monitor = statusLineManager.getProgressMonitor();
 						monitor.beginTask("", event.total); //$NON-NLS-1$
 						progressWorked = percentProgress;
 					} else {
-						monitor.worked(event.current - progressWorked);
+						if (monitor != null) {
+							monitor.worked(event.current - progressWorked);
+						}
 						progressWorked = event.current;
 					}
 				}
@@ -439,9 +446,7 @@ public class BrowserViewer extends Composite {
 
 			@Override
 			public void completed(ProgressEvent event) {
-				if (container != null) {
-					IProgressMonitor monitor = container.getActionBars()
-							.getStatusLineManager().getProgressMonitor();
+				if (container != null && monitor != null) {
 					monitor.done();
 				}
 				if (showToolbar) {


### PR DESCRIPTION
The change in 7fe83e4b8b7d62b0b8b31971389599afaf0a27ca broke method contract from `IStatusLineManager.getProgressMonitor()`. It was originally stating "returns monitor", not it says "creates new monitor".

So the browser listener is not able now to use
`IStatusLineManager.getProgressMonitor()` directly and has to keep a local monitor instance.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1398