### PR TITLE
Allow for asynchronous calculation of menus in ActionContributionItem

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/ActionContributionItem.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/ActionContributionItem.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.jface.action;
 
+import java.util.Arrays;
+
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.NotEnabledException;
 import org.eclipse.jface.action.ExternalActionManager.IBindingManagerCallback;
@@ -1168,7 +1170,22 @@ public class ActionContributionItem extends ContributionItem {
 		if (holdMenu == null) {
 			return;
 		}
+
+		// for backwards compatibility (in case the menu is NOT calculated asynchronously)
 		copyMenu(holdMenu, proxy);
+
+		// in case the menu is populated asynchronously by the menu creator, this listener will update it once it's complete
+		holdMenu.addListener(SWT.Show, evt -> {
+			// This one is (currently) being triggered from ContextuaLaunchAction
+			if (evt.data == null || evt.data != holdMenu)
+				return;
+
+			// remove all items in the proxy...
+			Arrays.stream(proxy.getItems()).forEach(Widget::dispose);
+
+			// ... and replace them with the new content
+			copyMenu(holdMenu, proxy);
+		});
 	}
 
 	/**


### PR DESCRIPTION
# What it does
Allow for asynchronous calculation of menus in `ActionContributionItem` by adding a listener that copies and shows the resulting menu once it's done. It is the responsibility of the `IMenuCreator` to fire the proper event (`SWT.Show` on the created menu) so that the listener reacts to it. A current usage of this mechanism can be found in https://github.com/eclipse-platform/eclipse.platform/pull/1005.

This PR doesn't have any effect if there are no changes in the `IMenuCreator` _i.e._ it preserves backwards compatibility.

# How to test
Apply both this PR and https://github.com/eclipse-platform/eclipse.platform/pull/1005 and test [the other one](https://github.com/eclipse-platform/eclipse.platform/pull/1005).