### PR TITLE
IllegalStateException: call to beginTask() missing

### DIFF
--- a/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/BrowserViewer.java
+++ b/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/BrowserViewer.java
@@ -448,6 +448,7 @@ public class BrowserViewer extends Composite {
 			public void completed(ProgressEvent event) {
 				if (container != null && monitor != null) {
 					monitor.done();
+					progressWorked = 0;
 				}
 				if (showToolbar) {
 					loading = false;
@@ -900,8 +901,10 @@ public class BrowserViewer extends Composite {
 	public void setContainer(IBrowserViewerContainer container) {
 		if (container==null && this.container!=null) {
 			IStatusLineManager manager = this.container.getActionBars().getStatusLineManager();
-			if (manager!=null)
+			if (manager != null) {
 				manager.getProgressMonitor().done();
+			}
+			progressWorked = 0;
 		}
 		this.container = container;
 	}


### PR DESCRIPTION
Continuation of
https://github.com/eclipse-platform/eclipse.platform.ui/pull/1402 that was supposed to fix a regression from
https://github.com/eclipse-platform/eclipse.platform.ui/pull/1077

Unfortunately the fix was not complete, and in some cases while navigating back and forth in the "internal browser" view following warning is still reported to the log:

```
java.lang.IllegalStateException: call to beginTask() missing
	at org.eclipse.jface.action.StatusLineManager$1.worked(StatusLineManager.java:221)
	at org.eclipse.ui.internal.browser.BrowserViewer$3.changed(BrowserViewer.java:427)
	at org.eclipse.swt.browser.WebKit.lambda$15(WebKit.java:2492)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:132)
```

This time it looks like monitor.beginTask() was called *after* monitor.done() call, so the patch tries to reset progressWorked counter to force changed() code create new monitor instance.

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/1398