### PR TITLE
Fix javadoc

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IStartup.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IStartup.java
@@ -31,7 +31,7 @@ package org.eclipse.ui;
  * event.<br>
  * Such an event-handler is always executed and cannot be disabled via a
  * preferences.
- * <p>
+ * </p>
  * For example a class
  *
  * <pre>
@@ -56,6 +56,7 @@ package org.eclipse.ui;
  * }
  * </pre>
  *
+ * <p>
  * Processing of OSGi declarative services annotations has to be enabled for the
  * containing Plug-in and it has to import the package
  * {@code org.osgi.service.event} and


### PR DESCRIPTION
As per https://www.w3.org/TR/html401/struct/text.html#edef-P p tag can not contain other nested block-level elements (like pre used here).

Error is visible at
https://download.eclipse.org/eclipse/downloads/drops4/I20231213-1800/compilelogs/platform.doc.isv.javadoc.txt and has been broken by change in
https://github.com/eclipse-platform/eclipse.platform.ui/pull/1362/