### PR TITLE
Expandable node is shown at wrong place, sorting broken after expand

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeViewer.java
@@ -1151,9 +1151,8 @@ public class TreeViewer extends AbstractTreeViewer {
 			item.dispose();
 
 			// create children on parent
-			// For performance insert every item at index 0 (in reverse order):
-			for (int i = children.length - 1; i >= 0; i--) {
-				createTreeItem(parent, children[i], 0);
+			for (Object element : children) {
+				createTreeItem(parent, element, -1);
 			}
 
 			// reset the selection. client's selection listener should not be triggered.


### PR DESCRIPTION
If items limit is enabled, clicking on expandable element adds all elements **before** the node, so the sort order is totally wrong and "expandable node" appears "in the middle" of the siblings.

However, "hidden and now expanded" elements (if exists) should always be appended **to the end** of the shown children.

This is a regression from 5930a51b59272ef620b4b7ab09e39d356912baa1 / https://github.com/eclipse-platform/eclipse.platform.ui/pull/1331.

The problem with the patch above is that it inserts all previously hidden elements at the zero index in the tree, but the tree **has already some children**, so instead of adding new elements below existing, the patch prepends them.

Since https://github.com/eclipse-platform/eclipse.platform.ui/pull/1331 consists of only two changes (changed tree item creation order on expand and updated javadoc), this is revert the former one.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1417