### PR TITLE
Touch bundles affected by the changed ecj version

### DIFF
--- a/bundles/org.eclipse.core.commands/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.core.commands/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 546976 - Gerrit Jenkins jobs report comparator warnings which are not reported by official builds
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.core.databinding.beans/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.core.databinding.beans/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.core.databinding.observable/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.core.databinding.observable/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 509973 - Comparator errors in I20170105-0320
 Bug 511251 - Comparator errors in I20170127-2200
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.core.databinding.property/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.core.databinding.property/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 https://bugs.eclipse.org/bugs/show_bug.cgi?id=492238#c12
 Bug 509973 - Comparator errors in I20170105-0320
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.core.databinding/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.core.databinding/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 546976 - Gerrit Jenkins jobs report comparator warnings which are not reported by official builds
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.e4.core.commands/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.core.commands/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.e4.emf.xpath/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.emf.xpath/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.e4.ui.bindings/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.ui.bindings/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.e4.ui.css.core/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.ui.css.core/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 521195 - Migrate to Batik 1.9.0
 Bug 532094 - Update releng with new hamcrest and apache batik
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.e4.ui.css.swt.theme/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.e4.ui.css.swt/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.ui.css.swt/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 416898 - Some Platform UI bundles need to be touched to get API descriptions back
 Bug 514690 - Build failure on I20170403-2000 and I20170404-0245
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.e4.ui.dialogs/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.ui.dialogs/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.e4.ui.model.workbench/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.ui.model.workbench/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 509973 - Comparator errors in I20170105-0320
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.e4.ui.progress/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.ui.progress/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 566668 - Comparator errors in I20200904-0210
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 429184 - [Metadata] comparator errors in most recent I-builds
 Bug 509973 - Comparator errors in I20170105-0320
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.e4.ui.workbench.swt/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/forceQualifierUpdate.txt
@@ -5,3 +5,4 @@ Bug 416898 - Some Platform UI bundles need to be touched to get API descriptions
 Bug 429184 - [Metadata] comparator errors in most recent I-builds
 Bug 521182 - [compiler] method reference on null object should throw NPE at runtime (JLS compliance)
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.e4.ui.workbench/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.ui.workbench/forceQualifierUpdate.txt
@@ -5,3 +5,4 @@ Bug 509973 - Comparator errors in I20170105-0320
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.e4.ui.workbench3/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.ui.workbench3/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.jface.databinding/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.jface.databinding/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 509973 - Comparator errors in I20170105-0320
 Bug 521182 - [compiler] method reference on null object should throw NPE at runtime (JLS compliance)
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.jface.text/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.jface.text/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 511251 - Comparator errors in I20170127-2200
 Bug 521182 - [compiler] method reference on null object should throw NPE at runtime (JLS compliance)
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.ltk.ui.refactoring/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ltk.ui.refactoring/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update, add the bug here
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.search/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.search/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 572789 - Comparator errors in I20210412-1800 after moving to compiler from 4.20 M1
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.text.quicksearch/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.text.quicksearch/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.text/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.text/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 466364: Cannot run unit-tests anymore because classes from org.eclipse.jface.text cannot be loaded because of "signer information does not match signer information of other classes in the same package"
 Pick up new signing certificate
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.ui.editors/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.editors/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 509931: Comparator errors in M20170104-0545
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.ui.forms/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.forms/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Bug 416898 - Some Platform UI bundles need to be touched to get API descriptions
 Bug 510796 - Comparator errors in I20170120-2000
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.ui.genericeditor/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.genericeditor/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.ui.ide.application/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.ide.application/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.ui.navigator.resources/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.navigator.resources/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 530021 - Unsigned bundles in platform UI in I20170119-0110
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.ui.navigator/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.navigator/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 572789 - Comparator errors in I20210412-1800 after moving to compiler from 4.20 M1
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.ui.views.log/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.views.log/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.ui.views/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.views/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Pick up new signing certificate
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.ui.workbench.texteditor/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.workbench.texteditor/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 509931: Comparator errors in M20170104-0545
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.urischeme/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.urischeme/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/examples/org.eclipse.jface.examples.databinding/forceQualifierUpdate.txt
+++ b/examples/org.eclipse.jface.examples.databinding/forceQualifierUpdate.txt
@@ -6,3 +6,4 @@ Build issues on 2020-05-27
 Bug 575106 - Comparator error in 20210729-0050
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/examples/org.eclipse.ui.examples.contributions/forceQualifierUpdate.txt
+++ b/examples/org.eclipse.ui.examples.contributions/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/examples/org.eclipse.ui.examples.readmetool/forceQualifierUpdate.txt
+++ b/examples/org.eclipse.ui.examples.readmetool/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.core.filebuffers.tests/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.core.filebuffers.tests/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.e4.ui.tests.css.core/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.e4.ui.tests.css.core/forceQualifierUpdate.txt
@@ -5,3 +5,4 @@ Bug 532094 - Update releng with new hamcrest and apache batik
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.e4.ui.tests.css.swt/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 435488 - java.lang.NoSuchMethodError: org.eclipse.e4.ui.css.swt.helpers.EclipsePreferencesHelper.getOverriddenPropertyNames
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.jface.tests.databinding.conformance/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.jface.tests.databinding.conformance/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.jface.tests.databinding/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.jface.tests.databinding/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 511251 - Comparator errors in I20170127-2200
 Bug 521182 - [compiler] method reference on null object should throw NPE at runtime (JLS compliance)
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.jface.text.tests/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.jface.text.tests/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Pick up new signing certificate
 Bug 572789 - Comparator errors in I20210412-1800 after moving to compiler from 4.20 M1
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.ltk.core.refactoring.tests/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update, add the bug here
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.ltk.ui.refactoring.tests/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ltk.ui.refactoring.tests/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update, add the bug here
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.search.tests/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.search.tests/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.tests.urischeme/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.tests.urischeme/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1245
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.text.quicksearch.tests/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.text.quicksearch.tests/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.text.tests/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.text.tests/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.ui.editors.tests/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ui.editors.tests/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.ui.genericeditor.tests/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ui.genericeditor.tests/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.ui.tests.forms/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ui.tests.forms/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.ui.tests.harness/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ui.tests.harness/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.ui.tests.navigator/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ui.tests.navigator/forceQualifierUpdate.txt
@@ -7,3 +7,4 @@ Bug 472126 - Unusual comparator error in I-build and M-build
 Bug 479158 - ui.tests.navigator shows up in comparator "errors"
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.ui.tests.performance/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ui.tests.performance/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Bug 485690 - comparator errors in UI performance test bundle
 Bug 511251 - Comparator errors in I20170127-2200
 Bug 553836 - [Tests] Remove UITestCase dependency on TestCase
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.ui.tests.pluginchecks/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ui.tests.pluginchecks/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 485690 - comparator errors in UI performance test bundle
 Bug 511251 - Comparator errors in I20170127-2200
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.ui.tests.rcp/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ui.tests.rcp/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.ui.tests.views.properties.tabbed/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ui.tests.views.properties.tabbed/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.ui.tests/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ui.tests/forceQualifierUpdate.txt
@@ -10,3 +10,4 @@ Unanticipated comparator errors in I2022-0523-320
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1488
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tools/bundles/org.eclipse.e4.tools.emf.editor3x/forceQualifierUpdate.txt
+++ b/tools/bundles/org.eclipse.e4.tools.emf.editor3x/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403237 - o.e.e4.tools cannot be build with "mvn clean install"
 Bug 463856 - Trouble doing an I-build of org.eclipse.e4.core.tools.feature
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tools/bundles/org.eclipse.e4.tools.emf.ui/forceQualifierUpdate.txt
+++ b/tools/bundles/org.eclipse.e4.tools.emf.ui/forceQualifierUpdate.txt
@@ -7,3 +7,4 @@ Bug 562167 - Comparator errors in I20200415-0620
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tools/bundles/org.eclipse.e4.tools.services/forceQualifierUpdate.txt
+++ b/tools/bundles/org.eclipse.e4.tools.services/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Bug 463856 - Trouble doing an I-build of org.eclipse.e4.core.tools.feature
 Bug 509973 - Comparator errors in I20170105-0320
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/tools/bundles/org.eclipse.e4.tools/forceQualifierUpdate.txt
+++ b/tools/bundles/org.eclipse.e4.tools/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403237 - o.e.e4.tools cannot be build with "mvn clean install"
 Bug 463856 - Trouble doing an I-build of org.eclipse.e4.core.tools.feature
 Bug 567095 - Comparator errors in I20200917-1800
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1394 
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659