### PR TITLE
Enable viewer limits by default

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchPreferenceInitializer.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchPreferenceInitializer.java
@@ -126,8 +126,8 @@ public class WorkbenchPreferenceInitializer extends AbstractPreferenceInitialize
 
 		node.putInt(IWorkbenchPreferenceConstants.DISPOSE_CLOSED_BROWSER_HOVER_TIMEOUT, -1);
 
-		// Disable viewer limit configuration until more testing and stabilization.
-		node.putInt(IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT, 0);
+		// Don't show more than 1000 child elements per parent by default
+		node.putInt(IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT, 1000);
 
 		node.put(IWorkbenchPreferenceConstants.RESOURCE_RENAME_MODE,
 				IWorkbenchPreferenceConstants.RESOURCE_RENAME_MODE_INLINE);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ViewerItemsLimitTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ViewerItemsLimitTest.java
@@ -89,9 +89,8 @@ public class ViewerItemsLimitTest extends UITestCase {
 		super.doSetUp();
 		cleanUp();
 		preferenceStore = WorkbenchPlugin.getDefault().getPreferenceStore();
-		// TODO: preference is set to zero, enable once preference is restored
-//		int viewLimit = preferenceStore.getInt(IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT);
-//		assertEquals("Default viewer limit must be " + DEFAULT_VIEW_LIMIT, DEFAULT_VIEW_LIMIT, viewLimit);
+		int viewLimit = preferenceStore.getInt(IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT);
+		assertEquals("Default viewer limit must be " + DEFAULT_VIEW_LIMIT, DEFAULT_VIEW_LIMIT, viewLimit);
 		window = getActiveWindow();
 		activePage = window.getActivePage();
 		defaultPerspective = activePage.getPerspective();


### PR DESCRIPTION
Set default workbench preference for the view limit to 1000, which is what we believe the most practical value on most platforms to avoid UI freezes in large viewers.

Note: this limit can also be disabled in products by specifying `org.eclipse.ui.workbench/largeViewLimit=0` in the plugin_customization.ini file.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1425