### PR TITLE
Fix LineAnnotationManagerTest + random failing PositionTrackerTest #882

### DIFF
--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/LineBasedFileSearch.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/LineBasedFileSearch.java
@@ -36,6 +36,7 @@ import org.eclipse.search.core.text.TextSearchRequestor;
 import org.eclipse.search.internal.ui.SearchPlugin;
 import org.eclipse.search.internal.ui.text.FileMatch;
 import org.eclipse.search.internal.ui.text.FileSearchQuery;
+import org.eclipse.search.internal.ui.text.LineElement;
 import org.eclipse.search.ui.text.AbstractTextSearchResult;
 import org.eclipse.search.ui.text.FileTextSearchScope;
 
@@ -72,7 +73,8 @@ public class LineBasedFileSearch extends FileSearchQuery  {
 				int startLine= doc.getLineOfOffset(matchRequestor.getMatchOffset());
 				int endLine= doc.getLineOfOffset(matchRequestor.getMatchOffset() + matchRequestor.getMatchLength());
 				synchronized(fLock) {
-					fResult.addMatch(new FileMatch(file, startLine, endLine - startLine + 1, null));
+					LineElement element= new LineElement(matchRequestor.getFile(), startLine, 0, "");
+					fResult.addMatch(new FileMatch(file, startLine, endLine - startLine + 1, element));
 				}
 			} catch (BadLocationException e) {
 				throw new CoreException(new Status(IStatus.ERROR, SearchPlugin.getID(), IStatus.ERROR, "bad location", e));
@@ -80,7 +82,7 @@ public class LineBasedFileSearch extends FileSearchQuery  {
 			return true;
 		}
 
-		private IDocument getDocument(IFile file) throws CoreException {
+		private synchronized IDocument getDocument(IFile file) throws CoreException {
 			if (file.equals(fLastFile)) {
 				return fLastDocument;
 			}

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/PositionTrackerTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/PositionTrackerTest.java
@@ -137,7 +137,7 @@ public class PositionTrackerTest {
 
 			for (int i= 0; i < originalStarts.length; i++) {
 				Position currentPosition= InternalSearchUI.getInstance().getPositionTracker().getCurrentPosition(matches[i]);
-				assertNotNull(currentPosition);
+				assertNotNull("null position for match: " + matches[i], currentPosition);
 				assertEquals(originalStarts[i] + "Test".length(), currentPosition.getOffset());
 
 			}


### PR DESCRIPTION
The LineAnnotationManagerTest is broken. Its LineBaseFileSearch throws exceptions leading to no search results being provided to the test to validate, which in turn results in a succeeding test. This also leads to subsequently executed search (or tests relying on them) to fail. Because of the current configuration of the AllFileSearchTests test suite, the PositionTrackerTest as the subsequent one randomly fails.

This change brings the LineAnnotationManagerTest into a state that (1) does not produce (silent) exceptions, (2) actually operates on search results and (3) successfully validates their representation in the annotation model.
To this end, it does the following:
- Make the LineBaseFileSearch thread safe, as it is used concurrently
- Provide a dummy LineElement for the search results, as the currently passed null element leads to an exception
- Make the LineAnnotationManagerTest validate on line positions rather than text positions, since that is what the annotation model actually contains
- Improve assertion messages in order to ease analyzing eventual further / upcoming test failures

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/882