### PR TITLE
Remove deprecated o.e.osgi.services bundle from o.e.e4.rcp feature

### DIFF
--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -179,10 +179,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.osgi.services"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.osgi.util"
          version="0.0.0"/>
 


### PR DESCRIPTION
The bundle o.e.osgi.services has been deprecated for removal as part of https://github.com/eclipse-equinox/equinox/issues/18