### PR TITLE
Properly assign values to fields in ResourceInfoPage

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ResourceInfoPage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ResourceInfoPage.java
@@ -317,7 +317,7 @@ public class ResourceInfoPage extends PropertyPage {
 			gd = new GridData();
 			locationTitle.setLayoutData(gd);
 
-			Text locationValue = new Text(basicInfoComposite, SWT.WRAP
+			locationValue = new Text(basicInfoComposite, SWT.WRAP
 					| SWT.READ_ONLY);
 			final String locationStr = TextProcessor.process(IDEResourceInfoUtils
 					.getLocationText(resource));
@@ -375,7 +375,7 @@ public class ResourceInfoPage extends PropertyPage {
 			Label sizeTitle = new Label(basicInfoComposite, SWT.LEFT);
 			sizeTitle.setText(SIZE_TITLE);
 
-			Text sizeValue = new Text(basicInfoComposite, SWT.LEFT
+			sizeValue = new Text(basicInfoComposite, SWT.LEFT
 					| SWT.READ_ONLY);
 			sizeValue.setText(IDEResourceInfoUtils.getSizeString(resource));
 			gd = new GridData();


### PR DESCRIPTION
The creation logic of the ResourceInfoPage creates two text input fields that are not assigned to the according fields of the class but stored as equally named local variables. This produces warnings and is obviously unintended as no value is assigned to the fields. So currently all logic defined for the case that the fields are non-null is never executed.