### PR TITLE
Suppress warnings for fields hiding other fields

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/WBWRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/WBWRenderer.java
@@ -121,6 +121,7 @@ public class WBWRenderer extends SWTPartRenderer {
 	@Inject
 	Logger logger;
 
+	@SuppressWarnings("hiding")
 	@Inject
 	private IEclipseContext context;
 
@@ -129,6 +130,7 @@ public class WBWRenderer extends SWTPartRenderer {
 
 	private ThemeDefinitionChangedHandler themeDefinitionChanged;
 
+	@SuppressWarnings("hiding")
 	@Inject
 	private EModelService modelService;
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeSelection.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/TreeSelection.java
@@ -45,6 +45,7 @@ public class TreeSelection extends StructuredSelection implements ITreeSelection
 	 * The canonical empty selection. This selection should be used instead of
 	 * <code>null</code>.
 	 */
+	@SuppressWarnings("hiding")
 	public static final TreeSelection EMPTY = new TreeSelection();
 
 	private static final TreePath[] EMPTY_TREE_PATHS= new TreePath[0];

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CloseUnrelatedProjectsAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CloseUnrelatedProjectsAction.java
@@ -57,6 +57,7 @@ public class CloseUnrelatedProjectsAction extends CloseResourceAction {
 	/**
 	 * The id of this action.
 	 */
+	@SuppressWarnings("hiding")
 	public static final String ID = PlatformUI.PLUGIN_ID + ".CloseUnrelatedProjectsAction"; //$NON-NLS-1$
 
 	private List<IResource> projectsToClose = new ArrayList<>();

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/MoveProjectAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/MoveProjectAction.java
@@ -48,6 +48,7 @@ public class MoveProjectAction extends CopyProjectAction {
 	/**
 	 * The id of this action.
 	 */
+	@SuppressWarnings("hiding")
 	public static final String ID = PlatformUI.PLUGIN_ID + ".MoveProjectAction";//$NON-NLS-1$
 
 	/**

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/MoveResourceAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/MoveResourceAction.java
@@ -38,6 +38,7 @@ public class MoveResourceAction extends CopyResourceAction {
 	/**
 	 * The id of this action.
 	 */
+	@SuppressWarnings("hiding")
 	public static final String ID = PlatformUI.PLUGIN_ID
 			+ ".MoveResourceAction"; //$NON-NLS-1$
 

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/OpenFileAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/OpenFileAction.java
@@ -42,6 +42,7 @@ public class OpenFileAction extends OpenSystemEditorAction {
 	/**
 	 * The id of this action.
 	 */
+	@SuppressWarnings("hiding")
 	public static final String ID = PlatformUI.PLUGIN_ID + ".OpenFileAction";//$NON-NLS-1$
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/PerspectiveWithMultiViewPlaceholdersInFolder.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/PerspectiveWithMultiViewPlaceholdersInFolder.java
@@ -25,6 +25,7 @@ import org.eclipse.ui.IPageLayout;
  */
 public class PerspectiveWithMultiViewPlaceholdersInFolder extends PerspectiveWithMultiViewPlaceholdersInPlaceholderFolder {
 
+	@SuppressWarnings("hiding")
 	public static String PERSP_ID = "org.eclipse.ui.tests.PerspectiveWithMultiViewPlaceholdersInFolder"; //$NON-NLS-1$
 
 	public PerspectiveWithMultiViewPlaceholdersInFolder() {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/SaveableMockViewPart.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/SaveableMockViewPart.java
@@ -38,6 +38,7 @@ import org.eclipse.ui.internal.DefaultSaveable;
 public class SaveableMockViewPart extends MockViewPart implements
 		ISaveablePart, ISaveablesSource {
 
+	@SuppressWarnings("hiding")
 	public static String ID = "org.eclipse.ui.tests.api.SaveableMockViewPart";
 
 	private boolean isDirty = false;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/UserSaveableMockViewPart.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/UserSaveableMockViewPart.java
@@ -25,6 +25,7 @@ import org.eclipse.ui.ISaveablePart2;
 public class UserSaveableMockViewPart extends MockViewPart implements
 		ISaveablePart2 {
 
+	@SuppressWarnings("hiding")
 	public static String ID = "org.eclipse.ui.tests.api.UserSaveableMockViewPart";
 
 	private boolean isDirty = false;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/UserSaveableSharedViewPart.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/UserSaveableSharedViewPart.java
@@ -27,6 +27,7 @@ public class UserSaveableSharedViewPart extends MockViewPart implements
 	/**
 	 * The shared ID.
 	 */
+	@SuppressWarnings("hiding")
 	public static String ID = "org.eclipse.ui.tests.api.UserSaveableSharedViewPart";
 
 	public static class SharedModel {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/decorators/TestResourceDecoratorContributor.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/decorators/TestResourceDecoratorContributor.java
@@ -16,7 +16,9 @@ package org.eclipse.ui.tests.decorators;
 import org.eclipse.core.resources.IResource;
 
 public class TestResourceDecoratorContributor extends TestAdaptableDecoratorContributor {
+	@SuppressWarnings("hiding")
 	public static final String SUFFIX = "IResource.1";
+	@SuppressWarnings("hiding")
 	public static final String ID = "org.eclipse.ui.tests.decorators.resourceDescorator";
 	public TestResourceDecoratorContributor() {
 		setExpectedElementType(IResource.class);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/decorators/TestResourceMappingDecoratorContributor.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/decorators/TestResourceMappingDecoratorContributor.java
@@ -17,7 +17,9 @@ import org.eclipse.core.resources.mapping.ResourceMapping;
 
 public class TestResourceMappingDecoratorContributor extends
 		TestAdaptableDecoratorContributor {
+	@SuppressWarnings("hiding")
 	public static final String SUFFIX = "ResourceMapping.1";
+	@SuppressWarnings("hiding")
 	public static final String ID = "org.eclipse.ui.tests.decorators.resourceMappingDescorator";
 	public TestResourceMappingDecoratorContributor() {
 		setExpectedElementType(ResourceMapping.class);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/decorators/TestUnadaptableDecoratorContributor.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/decorators/TestUnadaptableDecoratorContributor.java
@@ -17,7 +17,9 @@ package org.eclipse.ui.tests.decorators;
  * Decorator used to test an unadaptaed contribution
  */
 public class TestUnadaptableDecoratorContributor extends TestAdaptableDecoratorContributor {
+	@SuppressWarnings("hiding")
 	public static final String SUFFIX = "ICommon.2";
+	@SuppressWarnings("hiding")
 	public static final String ID = "org.eclipse.ui.tests.decorators.generalAdaptabilityOff";
 	public TestUnadaptableDecoratorContributor() {
 		setSuffix(SUFFIX);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/TestNewPropertySheetHandler.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/TestNewPropertySheetHandler.java
@@ -26,6 +26,7 @@ import org.eclipse.ui.views.properties.PropertyShowInContext;
  */
 public class TestNewPropertySheetHandler extends NewPropertySheetHandler {
 
+	@SuppressWarnings("hiding")
 	public static final String ID = NewPropertySheetHandler.ID + "Test";
 
 	@Override


### PR DESCRIPTION
There are several fields that hide fields of superclasses because of having the same name and produce according warnings. In some cases this is intended or necessary, so the warnings should be suppressed. These cases comprise:
* Class-specific IDs and default objects (like EMPTY)
* Fields hiding superclass fields that should not be accessed

This change adds the according suppressions.