### PR TITLE
Fix several warnings due to name clashes

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/codemining/annotation/AnnotationCodeMiningProvider.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/codemining/annotation/AnnotationCodeMiningProvider.java
@@ -155,8 +155,8 @@ public class AnnotationCodeMiningProvider extends AbstractCodeMiningProvider
 	private @Nullable IAnnotationAccessExtension annotationAccess= null;
 
 	@Override
-	public CompletableFuture<List<? extends ICodeMining>> provideCodeMinings(ITextViewer viewer, IProgressMonitor monitor) {
-		if (!(viewer instanceof ISourceViewerExtension5)) {
+	public CompletableFuture<List<? extends ICodeMining>> provideCodeMinings(ITextViewer textViewer, IProgressMonitor monitor) {
+		if (!(textViewer instanceof ISourceViewerExtension5)) {
 			throw new IllegalArgumentException("Cannot attach to TextViewer without code mining support"); //$NON-NLS-1$
 		}
 
@@ -164,13 +164,13 @@ public class AnnotationCodeMiningProvider extends AbstractCodeMiningProvider
 			return CompletableFuture.completedFuture(Collections.emptyList());
 		}
 
-		this.viewer= viewer;
+		this.viewer= textViewer;
 
-		final IAnnotationAccess annotationAccess= getAdapter(IAnnotationAccess.class);
-		if (!(annotationAccess instanceof IAnnotationAccessExtension)) {
+		if (getAdapter(IAnnotationAccess.class) instanceof IAnnotationAccessExtension annotationAccessExtension) {
+			this.annotationAccess= annotationAccessExtension;
+		} else {
 			throw new IllegalStateException("annotationAccess must implement IAnnotationAccessExtension"); //$NON-NLS-1$
 		}
-		this.annotationAccess= (IAnnotationAccessExtension) annotationAccess;
 
 		return provideCodeMiningsInternal(monitor);
 	}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ExtensionBasedTextViewerConfiguration.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ExtensionBasedTextViewerConfiguration.java
@@ -94,7 +94,7 @@ public final class ExtensionBasedTextViewerConfiguration extends TextSourceViewe
 	private ITextEditor editor;
 	private Set<IContentType> resolvedContentTypes;
 	private Set<IContentType> fallbackContentTypes = Set.of();
-	private IDocument document;
+	private IDocument watchedDocument;
 
 	private GenericEditorContentAssistant contentAssistant;
 
@@ -187,8 +187,8 @@ public final class ExtensionBasedTextViewerConfiguration extends TextSourceViewe
 		Set<IContentType> types = getContentTypes(sourceViewer.getDocument());
 		contentAssistant = new GenericEditorContentAssistant(contentAssistProcessorTracker,
 				registry.getContentAssistProcessors(sourceViewer, editor, types), types, fPreferenceStore);
-		if (this.document != null) {
-			associateTokenContentTypes(this.document);
+		if (this.watchedDocument != null) {
+			associateTokenContentTypes(this.watchedDocument);
 		}
 		watchDocument(sourceViewer.getDocument());
 		return contentAssistant;
@@ -205,16 +205,16 @@ public final class ExtensionBasedTextViewerConfiguration extends TextSourceViewe
 		return super.getPresentationReconciler(sourceViewer);
 	}
 
-	void watchDocument(IDocument documentParam) {
-		if (document == documentParam) {
+	void watchDocument(IDocument document) {
+		if (this.watchedDocument == document) {
 			return;
 		}
-		if (document != null) {
-			document.removeDocumentPartitioningListener(this);
+		if (this.watchedDocument != null) {
+			this.watchedDocument.removeDocumentPartitioningListener(this);
 		}
 		if (document != null) {
-			document = documentParam;
-			associateTokenContentTypes(documentParam);
+			this.watchedDocument = document;
+			associateTokenContentTypes(document);
 			document.addDocumentPartitioningListener(this);
 		}
 	}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/markers/MarkerInformationControl.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/markers/MarkerInformationControl.java
@@ -65,11 +65,11 @@ public class MarkerInformationControl extends AbstractInformationControl impleme
 	}
 
 	@Override
-	protected void createContent(Composite parent) {
-		parent.setLayout(new RowLayout(SWT.VERTICAL));
-		parent.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
-		parent.setBackgroundMode(SWT.INHERIT_DEFAULT);
-		this.parent = parent;
+	protected void createContent(Composite parentComposite) {
+		parentComposite.setLayout(new RowLayout(SWT.VERTICAL));
+		parentComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
+		parentComposite.setBackgroundMode(SWT.INHERIT_DEFAULT);
+		this.parent = parentComposite;
 	}
 
 	private static Image getImage(IMarker marker) {

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CopyFilesAndFoldersOperation.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CopyFilesAndFoldersOperation.java
@@ -886,8 +886,8 @@ public class CopyFilesAndFoldersOperation {
 		if (fork) {
 			WorkspaceModifyOperation op = new WorkspaceModifyOperation() {
 				@Override
-				public void execute(IProgressMonitor monitor) {
-					copyFileStores(stores, destinationPath, monitor);
+				public void execute(IProgressMonitor operationMonitor) {
+					copyFileStores(stores, destinationPath, operationMonitor);
 				}
 			};
 			try {

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/RenameResourceAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/RenameResourceAction.java
@@ -549,8 +549,8 @@ public class RenameResourceAction extends WorkspaceAction {
 						displayError(status.getMessage());
 					} else if (!LTKLauncher.renameResource(newName, new StructuredSelection(inlinedResource))) {
 						// LTK Launcher couldn't rename the resource
-						IPath newPath = inlinedResource.getFullPath().removeLastSegments(1).append(newName);
-						runWithNewPath(newPath, inlinedResource);
+						IPath path = inlinedResource.getFullPath().removeLastSegments(1).append(newName);
+						runWithNewPath(path, inlinedResource);
 					}
 				}
 				inlinedResource = null;

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/WorkspaceAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/WorkspaceAction.java
@@ -138,7 +138,7 @@ public abstract class WorkspaceAction extends SelectionListenerAction {
 	 * instance can be executed multiple times concurrently. This method must
 	 * not access or modify any mutable state on action class.
 	 *
-	 * @param monitor
+	 * @param mon
 	 *            a progress monitor
 	 * @return The result of the execution
 	 */

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/ContainerGenerator.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/ContainerGenerator.java
@@ -56,7 +56,7 @@ import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
 public class ContainerGenerator {
 	private IPath containerFullPath;
 
-	private IContainer container;
+	private IContainer generatedContainer;
 
 	/**
 	 * Creates a generator for the container resource (folder or project) at the
@@ -148,22 +148,22 @@ public class ContainerGenerator {
 		IDEWorkbenchPlugin.getPluginWorkspace().run(monitor1 -> {
 			SubMonitor subMonitor = SubMonitor.convert(monitor1,
 					IDEWorkbenchMessages.ContainerGenerator_progressMessage, containerFullPath.segmentCount());
-			if (container != null) {
+			if (generatedContainer != null) {
 				return;
 			}
 
 			// Does the container exist already?
 			IWorkspaceRoot root = getWorkspaceRoot();
-			container = (IContainer) root.findMember(containerFullPath);
-			if (container != null) {
+			generatedContainer = (IContainer) root.findMember(containerFullPath);
+			if (generatedContainer != null) {
 				return;
 			}
 
 			// Create the container for the given path
-			container = root;
+			generatedContainer = root;
 			for (int i = 0; i < containerFullPath.segmentCount(); i++) {
 				String currentSegment = containerFullPath.segment(i);
-				IResource resource = container.findMember(currentSegment);
+				IResource resource = generatedContainer.findMember(currentSegment);
 				if (resource != null) {
 					if (resource.getType() == IResource.FILE) {
 						String msg = NLS.bind(IDEWorkbenchMessages.ContainerGenerator_pathOccupied,
@@ -171,18 +171,18 @@ public class ContainerGenerator {
 						throw new CoreException(
 								new Status(IStatus.ERROR, IDEWorkbenchPlugin.IDE_WORKBENCH, 1, msg, null));
 					}
-					container = (IContainer) resource;
+					generatedContainer = (IContainer) resource;
 					subMonitor.worked(1);
 				} else if (i == 0) {
 					IProject projectHandle = createProjectHandle(root, currentSegment);
-					container = createProject(projectHandle, subMonitor.split(1));
+					generatedContainer = createProject(projectHandle, subMonitor.split(1));
 				} else {
-					IFolder folderHandle = createFolderHandle(container, currentSegment);
-					container = createFolder(folderHandle, subMonitor.split(1));
+					IFolder folderHandle = createFolderHandle(generatedContainer, currentSegment);
+					generatedContainer = createFolder(folderHandle, subMonitor.split(1));
 				}
 			}
 		}, null, IResource.NONE, monitor);
-		return container;
+		return generatedContainer;
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/FilteredResourcesSelectionDialog.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/FilteredResourcesSelectionDialog.java
@@ -1036,26 +1036,26 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 					if (filenamePattern.isEmpty()) // relative patterns don't need a file name
 						filenamePattern = "**"; //$NON-NLS-1$
 
-					String containerPattern = stringPattern.substring(isMatchPrefix(stringPattern) ? 1 : 0, sep);
+					String newContainerPattern = stringPattern.substring(isMatchPrefix(stringPattern) ? 1 : 0, sep);
 
 					if (searchContainer != null) {
 						relativeContainerPattern = new SearchPattern(
 								SearchPattern.RULE_EXACT_MATCH | SearchPattern.RULE_PATTERN_MATCH);
 						relativeContainerPattern
-								.setPattern(searchContainer.getFullPath().append(containerPattern).toString());
+								.setPattern(searchContainer.getFullPath().append(newContainerPattern).toString());
 					}
 
-					if (!containerPattern.startsWith(Character.toString('*'))) {
+					if (!newContainerPattern.startsWith(Character.toString('*'))) {
 						// bug 552418 - make the search always "root less", so that users don't need to
 						// type the initial "*/"
-						if (!containerPattern.startsWith(Character.toString(IPath.SEPARATOR))) {
-							containerPattern = IPath.SEPARATOR + containerPattern;
+						if (!newContainerPattern.startsWith(Character.toString(IPath.SEPARATOR))) {
+							newContainerPattern = IPath.SEPARATOR + newContainerPattern;
 						}
-						containerPattern = '*' + containerPattern;
+						newContainerPattern = '*' + newContainerPattern;
 					}
 					this.containerPattern = new SearchPattern(SearchPattern.RULE_EXACT_MATCH
 							| SearchPattern.RULE_PREFIX_MATCH | SearchPattern.RULE_PATTERN_MATCH);
-					this.containerPattern.setPattern(containerPattern);
+					this.containerPattern.setPattern(newContainerPattern);
 				}
 				if (isMatchPrefix(stringPattern)) {
 					filenamePattern = '>' + filenamePattern;

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/ResourceListSelectionDialog.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/ResourceListSelectionDialog.java
@@ -411,30 +411,29 @@ public class ResourceListSelectionDialog extends SelectionDialog {
 	 */
 	@Override
 	protected Control createDialogArea(Composite parent) {
-
-		Composite dialogArea = (Composite) super.createDialogArea(parent);
-		Label l = new Label(dialogArea, SWT.NONE);
+		Composite dialogAreaComposite = (Composite) super.createDialogArea(parent);
+		Label l = new Label(dialogAreaComposite, SWT.NONE);
 		l.setText(IDEWorkbenchMessages.ResourceSelectionDialog_label);
 		GridData data = new GridData(GridData.FILL_HORIZONTAL);
 		l.setLayoutData(data);
 
-		pattern = new Text(dialogArea, SWT.SINGLE | SWT.BORDER);
+		pattern = new Text(dialogAreaComposite, SWT.SINGLE | SWT.BORDER);
 		pattern.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		l = new Label(dialogArea, SWT.NONE);
+		l = new Label(dialogAreaComposite, SWT.NONE);
 		l.setText(IDEWorkbenchMessages.ResourceSelectionDialog_matching);
 		data = new GridData(GridData.FILL_HORIZONTAL);
 		l.setLayoutData(data);
-		resourceNames = new Table(dialogArea, SWT.SINGLE | SWT.BORDER | SWT.V_SCROLL);
+		resourceNames = new Table(dialogAreaComposite, SWT.SINGLE | SWT.BORDER | SWT.V_SCROLL);
 		data = new GridData(GridData.FILL_BOTH);
 		data.heightHint = 12 * resourceNames.getItemHeight();
 		resourceNames.setLayoutData(data);
 
-		l = new Label(dialogArea, SWT.NONE);
+		l = new Label(dialogAreaComposite, SWT.NONE);
 		l.setText(IDEWorkbenchMessages.ResourceSelectionDialog_folders);
 		data = new GridData(GridData.FILL_HORIZONTAL);
 		l.setLayoutData(data);
 
-		folderNames = new Table(dialogArea, SWT.SINGLE | SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
+		folderNames = new Table(dialogAreaComposite, SWT.SINGLE | SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
 		data = new GridData(GridData.FILL_BOTH);
 		data.widthHint = 300;
 		data.heightHint = 4 * folderNames.getItemHeight();
@@ -477,7 +476,7 @@ public class ResourceListSelectionDialog extends SelectionDialog {
 		});
 
 		if (getAllowUserToToggleDerived()) {
-			showDerivedButton = new Button(dialogArea, SWT.CHECK);
+			showDerivedButton = new Button(dialogAreaComposite, SWT.CHECK);
 			showDerivedButton.setText(IDEWorkbenchMessages.ResourceSelectionDialog_showDerived);
 			showDerivedButton.addSelectionListener(new SelectionAdapter() {
 				@Override
@@ -489,8 +488,8 @@ public class ResourceListSelectionDialog extends SelectionDialog {
 			showDerivedButton.setSelection(getShowDerived());
 		}
 
-		applyDialogFont(dialogArea);
-		return dialogArea;
+		applyDialogFont(dialogAreaComposite);
+		return dialogAreaComposite;
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/SaveAsDialog.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/SaveAsDialog.java
@@ -297,9 +297,9 @@ public class SaveAsDialog extends TitleAreaDialog {
 			}
 		}
 
-		IStatus result = workspace.validateName(resourceName, IResource.FILE);
-		if (!result.isOK()) {
-			setErrorMessage(result.getMessage());
+		IStatus resultStatus = workspace.validateName(resourceName, IResource.FILE);
+		if (!resultStatus.isOK()) {
+			setErrorMessage(resultStatus.getMessage());
 			return false;
 		}
 

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/WizardExportResourcesPage.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/WizardExportResourcesPage.java
@@ -282,9 +282,9 @@ public abstract class WizardExportResourcesPage extends WizardDataTransferPage {
 
 		showLinkedResources = getShowLinkedResources();
 		this.resourceGroup = new ResourceTreeAndListGroup(parent, input,
-				getResourceProvider(IResource.FOLDER | IResource.PROJECT, showLinkedResources),
+				getResourceProvider(IResource.FOLDER | IResource.PROJECT),
 				WorkbenchLabelProvider.getDecoratingWorkbenchLabelProvider(),
-				getResourceProvider(IResource.FILE, showLinkedResources),
+				getResourceProvider(IResource.FILE),
 				WorkbenchLabelProvider.getDecoratingWorkbenchLabelProvider(), SWT.NONE,
 				DialogUtil.inRegularFontMode(parent));
 
@@ -386,7 +386,7 @@ public abstract class WizardExportResourcesPage extends WizardDataTransferPage {
 	 * Returns a content provider for <code>IResource</code>s that returns only
 	 * children of the given resource type.
 	 */
-	private ITreeContentProvider getResourceProvider(int resourceType, boolean showLinkedResources) {
+	private ITreeContentProvider getResourceProvider(int resourceType) {
 		return new ResourceProvider(resourceType, showLinkedResources);
 	}
 
@@ -408,10 +408,10 @@ public abstract class WizardExportResourcesPage extends WizardDataTransferPage {
 	 */
 	protected void updateContentProviders(boolean showLinked) {
 		showLinkedResources = showLinked;
-		resourceGroup.setTreeProviders(getResourceProvider(IResource.FOLDER | IResource.PROJECT, showLinkedResources),
+		resourceGroup.setTreeProviders(getResourceProvider(IResource.FOLDER | IResource.PROJECT),
 				WorkbenchLabelProvider.getDecoratingWorkbenchLabelProvider());
 
-		resourceGroup.setListProviders(getResourceProvider(IResource.FILE, showLinkedResources),
+		resourceGroup.setListProviders(getResourceProvider(IResource.FILE),
 				WorkbenchLabelProvider.getDecoratingWorkbenchLabelProvider());
 	}
 

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/model/WorkbenchContentProvider.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/model/WorkbenchContentProvider.java
@@ -67,10 +67,10 @@ public class WorkbenchContentProvider extends BaseWorkbenchContentProvider
 	}
 
 	@Override
-	public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
-		super.inputChanged(viewer, oldInput, newInput);
+	public void inputChanged(Viewer newViewer, Object oldInput, Object newInput) {
+		super.inputChanged(newViewer, oldInput, newInput);
 
-		this.viewer = viewer;
+		this.viewer = newViewer;
 		IWorkspace oldWorkspace = null;
 		IWorkspace newWorkspace = null;
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/ide/dialogs/PathVariableSelectionDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/ide/dialogs/PathVariableSelectionDialog.java
@@ -139,10 +139,10 @@ public final class PathVariableSelectionDialog extends SelectionDialog {
 	@Override
 	protected Control createDialogArea(Composite parent) {
 		// create composite
-		Composite dialogArea = (Composite) super.createDialogArea(parent);
+		Composite dialogAreaComposite = (Composite) super.createDialogArea(parent);
 
-		pathVariablesGroup.createContents(dialogArea);
-		return dialogArea;
+		pathVariablesGroup.createContents(dialogAreaComposite);
+		return dialogAreaComposite;
 	}
 
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/ide/undo/AbstractMarkersOperation.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/ide/undo/AbstractMarkersOperation.java
@@ -209,21 +209,21 @@ abstract class AbstractMarkersOperation extends AbstractWorkspaceOperation {
 	 */
 
 	private void updateTargetResources() {
-		IResource[] resources = null;
+		IResource[] newResources = null;
 		if (markers == null) {
 			if (markerDescriptions != null) {
-				resources = new IResource[markerDescriptions.length];
+				newResources = new IResource[markerDescriptions.length];
 				for (int i = 0; i < markerDescriptions.length; i++) {
-					resources[i] = markerDescriptions[i].getResource();
+					newResources[i] = markerDescriptions[i].getResource();
 				}
 			}
 		} else {
-			resources = new IResource[markers.length];
+			newResources = new IResource[markers.length];
 			for (int i = 0; i < markers.length; i++) {
-				resources[i] = markers[i].getResource();
+				newResources[i] = markers[i].getResource();
 			}
 		}
-		setTargetResources(resources);
+		setTargetResources(newResources);
 	}
 
 	/*

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/ide/undo/ResourceDescription.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/ide/undo/ResourceDescription.java
@@ -60,7 +60,7 @@ public abstract class ResourceDescription {
 			}
 
 			@Override
-			public void createExistentResourceFromHandle(IResource resource, IProgressMonitor monitor)
+			public void createExistentResourceFromHandle(IResource unusedResource, IProgressMonitor monitor)
 					throws CoreException {
 				delegate.createExistentResourceFromHandle(monitor);
 			}
@@ -71,7 +71,8 @@ public abstract class ResourceDescription {
 			}
 
 			@Override
-			public void recordStateFromHistory(IResource resource, IProgressMonitor monitor) throws CoreException {
+			public void recordStateFromHistory(IResource unusedResource, IProgressMonitor monitor)
+					throws CoreException {
 				delegate.recordStateFromHistory(monitor);
 			}
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/ide/undo/WorkspaceUndoUtil.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/ide/undo/WorkspaceUndoUtil.java
@@ -163,7 +163,7 @@ public class WorkspaceUndoUtil {
 	 *
 	 * @param resourcesToDelete
 	 *            an array of resources to be deleted
-	 * @param monitor
+	 * @param mon
 	 *            the progress monitor to use to show the operation's progress
 	 * @param uiInfo
 	 *            the IAdaptable (or <code>null</code>) provided by the

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchErrorHandler.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchErrorHandler.java
@@ -207,16 +207,16 @@ public class IDEWorkbenchErrorHandler extends WorkbenchErrorHandler {
 					IDialogConstants.SHOW_DETAILS_LABEL };
 		}
 
-		FatalErrorDialog dialog = new FatalErrorDialog(parent, title, null, // accept
+		FatalErrorDialog errorDialog = new FatalErrorDialog(parent, title, null, // accept
 				// the
 				// default
 				// window
 				// icon
 				message, detail, MessageDialog.QUESTION, labels, defaultIndex);
 		if (detail != null) {
-			dialog.setDetailButton(2);
+			errorDialog.setDetailButton(2);
 		}
-		return dialog;
+		return errorDialog;
 	}
 
 	/**
@@ -268,13 +268,13 @@ public class IDEWorkbenchErrorHandler extends WorkbenchErrorHandler {
 		/**
 		 * Updates the dialog message
 		 *
-		 * @param message
+		 * @param newMessage
 		 *            new message
 		 */
-		public void updateMessage(String message) {
-			this.message = message;
+		public void updateMessage(String newMessage) {
+			this.message = newMessage;
 			if (messageLabel != null && !messageLabel.isDisposed()) {
-				this.messageLabel.setText(message);
+				this.messageLabel.setText(newMessage);
 				this.messageLabel.update();
 			}
 		}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/LineDelimiterEditor.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/LineDelimiterEditor.java
@@ -207,7 +207,7 @@ public class LineDelimiterEditor {
 	 *            the project for which the line editor will be modified
 	 * @return the preferences
 	 */
-	private Preferences getPreferences(IProject project) {
+	private static Preferences getPreferences(IProject project) {
 		if (project != null) {
 			return Platform.getPreferencesService().getRootNode().node(ProjectScope.SCOPE).node(project.getName());
 		}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/WorkbenchActionBuilder.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/WorkbenchActionBuilder.java
@@ -83,7 +83,7 @@ import org.eclipse.ui.menus.CommandContributionItemParameter;
  */
 public class WorkbenchActionBuilder extends ActionBarAdvisor {
 
-	private final IWorkbenchWindow window;
+	private final IWorkbenchWindow workbenchWindow;
 
 	// generic actions
 	private IWorkbenchAction closeAction;
@@ -238,14 +238,14 @@ public class WorkbenchActionBuilder extends ActionBarAdvisor {
 	 */
 	public WorkbenchActionBuilder(IActionBarConfigurer configurer) {
 		super(configurer);
-		window = configurer.getWindowConfigurer().getWindow();
+		workbenchWindow = configurer.getWindowConfigurer().getWindow();
 	}
 
 	/**
 	 * Returns the window to which this action builder is contributing.
 	 */
 	private IWorkbenchWindow getWindow() {
-		return window;
+		return workbenchWindow;
 	}
 
 	/**
@@ -293,7 +293,7 @@ public class WorkbenchActionBuilder extends ActionBarAdvisor {
 					return;
 				}
 				// update the "toggled" state based on the current editor
-				ICommandService commandService = window.getService(ICommandService.class);
+				ICommandService commandService = workbenchWindow.getService(ICommandService.class);
 				commandService.refreshElements(IWorkbenchCommandConstants.WINDOW_PIN_EDITOR, null);
 			}
 
@@ -318,11 +318,11 @@ public class WorkbenchActionBuilder extends ActionBarAdvisor {
 		propPrefListener = event -> {
 			if (event.getProperty().equals(
 					IPreferenceConstants.REUSE_EDITORS_BOOLEAN)) {
-				if (window.getShell() != null
-						&& !window.getShell().isDisposed()) {
+				if (workbenchWindow.getShell() != null
+						&& !workbenchWindow.getShell().isDisposed()) {
 					// this property change notification could be from a non-ui thread
-					window.getShell().getDisplay().asyncExec(() -> {
-						if (window.getShell() != null && !window.getShell().isDisposed()) {
+					workbenchWindow.getShell().getDisplay().asyncExec(() -> {
+						if (workbenchWindow.getShell() != null && !workbenchWindow.getShell().isDisposed()) {
 							updatePinActionToolbar();
 						}
 					});
@@ -721,7 +721,7 @@ public class WorkbenchActionBuilder extends ActionBarAdvisor {
 	 */
 	private void addWorkingSetBuildActions(MenuManager menu) {
 		buildWorkingSetMenu = new MenuManager(IDEWorkbenchMessages.Workbench_buildSet);
-		IContributionItem workingSetBuilds = new BuildSetMenu(window,
+		IContributionItem workingSetBuilds = new BuildSetMenu(workbenchWindow,
 				getActionBarConfigurer());
 		buildWorkingSetMenu.add(workingSetBuilds);
 		menu.add(buildWorkingSetMenu);
@@ -825,11 +825,11 @@ public class WorkbenchActionBuilder extends ActionBarAdvisor {
 
 		getActionBarConfigurer().getStatusLineManager().remove(statusLineItem);
 		if (pageListener != null) {
-			window.removePageListener(pageListener);
+			workbenchWindow.removePageListener(pageListener);
 			pageListener = null;
 		}
 		if (partListener != null) {
-			window.getPartService().removePartListener(partListener);
+			workbenchWindow.getPartService().removePartListener(partListener);
 			partListener = null;
 		}
 		if (prefListener != null) {
@@ -1356,8 +1356,8 @@ public class WorkbenchActionBuilder extends ActionBarAdvisor {
 			}
 
 			private void updateCommandEnablement(String commandId) {
-				IHandlerService handlerService = window.getService(IHandlerService.class);
-				ICommandService commandService = window.getService(ICommandService.class);
+				IHandlerService handlerService = workbenchWindow.getService(IHandlerService.class);
+				ICommandService commandService = workbenchWindow.getService(ICommandService.class);
 				if (handlerService != null && commandService != null) {
 					Command buildAllCmd = commandService.getCommand(commandId);
 					buildAllCmd.setEnabled(handlerService.getCurrentState());
@@ -1370,7 +1370,7 @@ public class WorkbenchActionBuilder extends ActionBarAdvisor {
 		else {
 			// Dispatch the update to be run later in the UI thread.
 			// This helps to reduce flicker if autobuild is being temporarily disabled programmatically.
-			Shell shell = window.getShell();
+			Shell shell = workbenchWindow.getShell();
 			if (shell != null && !shell.isDisposed()) {
 				shell.getDisplay().asyncExec(update);
 			}
@@ -1408,16 +1408,16 @@ public class WorkbenchActionBuilder extends ActionBarAdvisor {
 		toolBarManager.markDirty();
 		toolBarManager.update(false);
 		toolBarItem.update(ICoolBarManager.SIZE);
-		window.getShell().getDisplay().asyncExec(() -> {
-			if (window.getShell() != null && !window.getShell().isDisposed()) {
-				ICommandService commandService = window.getService(ICommandService.class);
+		workbenchWindow.getShell().getDisplay().asyncExec(() -> {
+			if (workbenchWindow.getShell() != null && !workbenchWindow.getShell().isDisposed()) {
+				ICommandService commandService = workbenchWindow.getService(ICommandService.class);
 				commandService.refreshElements(IWorkbenchCommandConstants.WINDOW_PIN_EDITOR, null);
 			}
 		});
 	}
 
 	private IContributionItem getPinEditorItem() {
-		return ContributionItemFactory.PIN_EDITOR.create(window);
+		return ContributionItemFactory.PIN_EDITOR.create(workbenchWindow);
 	}
 
 	private IContributionItem getUndoItem() {

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/actions/OpenLocalFileAction.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/actions/OpenLocalFileAction.java
@@ -41,7 +41,7 @@ import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
  */
 public class OpenLocalFileAction extends Action implements IWorkbenchWindowActionDelegate {
 
-	private IWorkbenchWindow window;
+	private IWorkbenchWindow workbenchWindow;
 	private String filterPath;
 
 	/**
@@ -53,13 +53,13 @@ public class OpenLocalFileAction extends Action implements IWorkbenchWindowActio
 
 	@Override
 	public void dispose() {
-		window =  null;
+		workbenchWindow =  null;
 		filterPath =  null;
 	}
 
 	@Override
 	public void init(IWorkbenchWindow window) {
-		this.window =  window;
+		this.workbenchWindow =  window;
 		filterPath =  System.getProperty("user.home"); //$NON-NLS-1$
 	}
 
@@ -74,7 +74,7 @@ public class OpenLocalFileAction extends Action implements IWorkbenchWindowActio
 
 	@Override
 	public void run() {
-		FileDialog dialog =  new FileDialog(window.getShell(), SWT.OPEN | SWT.MULTI | SWT.SHEET);
+		FileDialog dialog =  new FileDialog(workbenchWindow.getShell(), SWT.OPEN | SWT.MULTI | SWT.SHEET);
 		dialog.setText(IDEWorkbenchMessages.OpenLocalFileAction_title);
 		dialog.setFilterPath(filterPath);
 		dialog.open();
@@ -90,13 +90,13 @@ public class OpenLocalFileAction extends Action implements IWorkbenchWindowActio
 				fileStore =  fileStore.getChild(name);
 				IFileInfo fetchInfo = fileStore.fetchInfo();
 				if (!fetchInfo.isDirectory() && fetchInfo.exists()) {
-					IWorkbenchPage page =  window.getActivePage();
+					IWorkbenchPage page =  workbenchWindow.getActivePage();
 					try {
 						IDE.openEditorOnFileStore(page, fileStore);
 					} catch (PartInitException e) {
 						String msg =  NLS.bind(IDEWorkbenchMessages.OpenLocalFileAction_message_errorOnOpen, fileStore.getName());
 						IDEWorkbenchPlugin.log(msg,e.getStatus());
-						MessageDialog.open(MessageDialog.ERROR,window.getShell(), IDEWorkbenchMessages.OpenLocalFileAction_title, msg, SWT.SHEET);
+						MessageDialog.open(MessageDialog.ERROR,workbenchWindow.getShell(), IDEWorkbenchMessages.OpenLocalFileAction_title, msg, SWT.SHEET);
 					}
 				} else {
 					if (++numberOfFilesNotFound > 1)
@@ -108,7 +108,7 @@ public class OpenLocalFileAction extends Action implements IWorkbenchWindowActio
 			if (numberOfFilesNotFound > 0) {
 				String msgFmt =  numberOfFilesNotFound == 1 ? IDEWorkbenchMessages.OpenLocalFileAction_message_fileNotFound : IDEWorkbenchMessages.OpenLocalFileAction_message_filesNotFound;
 				String msg =  NLS.bind(msgFmt, notFound.toString());
-				MessageDialog.open(MessageDialog.ERROR, window.getShell(), IDEWorkbenchMessages.OpenLocalFileAction_title, msg, SWT.SHEET);
+				MessageDialog.open(MessageDialog.ERROR, workbenchWindow.getShell(), IDEWorkbenchMessages.OpenLocalFileAction_title, msg, SWT.SHEET);
 			}
 		}
 	}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/BuildOrderPreferencePage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/BuildOrderPreferencePage.java
@@ -516,8 +516,8 @@ public class BuildOrderPreferencePage extends PreferencePage implements
 	 * See IWorkbenchPreferencePage. This class does nothing with he Workbench.
 	 */
 	@Override
-	public void init(IWorkbench workbench) {
-		this.workbench = workbench;
+	public void init(IWorkbench currentWorkbench) {
+		this.workbench = currentWorkbench;
 		setPreferenceStore(PrefUtil.getInternalPreferenceStore());
 	}
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/PathVariableEditDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/PathVariableEditDialog.java
@@ -79,10 +79,10 @@ public class PathVariableEditDialog extends SelectionDialog {
 	@Override
 	protected Control createDialogArea(Composite parent) {
 		// create composite
-		Composite dialogArea = (Composite) super.createDialogArea(parent);
+		Composite dialogAreaComposite = (Composite) super.createDialogArea(parent);
 
-		pathVariablesGroup.createContents(dialogArea);
-		return dialogArea;
+		pathVariablesGroup.createContents(dialogAreaComposite);
+		return dialogAreaComposite;
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ProjectReferencePage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ProjectReferencePage.java
@@ -16,6 +16,7 @@ package org.eclipse.ui.internal.ide.dialogs;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -109,7 +110,7 @@ public class ProjectReferencePage extends PropertyPage {
 	 * @param project the project to provide content for
 	 * @return the content provider that shows the project content
 	 */
-	protected IStructuredContentProvider getContentProvider(
+	protected static IStructuredContentProvider getContentProvider(
 			final IProject project) {
 		return new WorkbenchContentProvider() {
 			@Override
@@ -120,7 +121,7 @@ public class ProjectReferencePage extends PropertyPage {
 
 				// Collect all the projects in the workspace except the given project
 				IProject[] projects = ((IWorkspace) o).getRoot().getProjects();
-				ArrayList<IProject> referenced = new ArrayList<>(projects.length);
+				List<IProject> referenced = new ArrayList<>(projects.length);
 				boolean found = false;
 				for (IProject currentProject : projects) {
 					if (!found && currentProject.equals(project)) {
@@ -132,10 +133,10 @@ public class ProjectReferencePage extends PropertyPage {
 
 				// Add any referenced that do not exist in the workspace currently
 				try {
-					projects = project.getDescription().getReferencedProjects();
-					for (IProject project : projects) {
-						if (!referenced.contains(project)) {
-							referenced.add(project);
+					IProject[] referencedProjects = project.getDescription().getReferencedProjects();
+					for (IProject referencedProject : referencedProjects) {
+						if (!referenced.contains(referencedProject)) {
+							referenced.add(referencedProject);
 						}
 					}
 				} catch (CoreException e) {

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ResourceFilterEditDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ResourceFilterEditDialog.java
@@ -76,9 +76,9 @@ public class ResourceFilterEditDialog extends SelectionDialog {
 
 	@Override
 	protected Control createDialogArea(Composite parent) {
-		Composite dialogArea = (Composite) super.createDialogArea(parent);
-		resourceFilterGroup.createContents(dialogArea);
-		return dialogArea;
+		Composite dialogAreaComposite = (Composite) super.createDialogArea(parent);
+		resourceFilterGroup.createContents(dialogAreaComposite);
+		return dialogAreaComposite;
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ResourceFilterGroup.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ResourceFilterGroup.java
@@ -1715,17 +1715,14 @@ class FilterCopy extends UIResourceFilterDescription {
 		if (children == null) {
 			if (getChildrenLimit() > 0) {
 				children = new LinkedList<>();
-				Object arguments = getArguments();
-				if (arguments instanceof IResourceFilterDescription[]) {
-					IResourceFilterDescription[] filters = (IResourceFilterDescription[]) arguments;
+				if (getArguments() instanceof IResourceFilterDescription[] filters) {
 					for (IResourceFilterDescription filter : filters) {
 						FilterCopy child = new FilterCopy(UIResourceFilterDescription.wrap(filter));
 						child.parent = this;
 						children.add(child);
 					}
 				}
-				if (arguments instanceof FilterCopy[]) {
-					FilterCopy[] filters = (FilterCopy[]) arguments;
+				if (getArguments() instanceof FilterCopy[] filters) {
 					if (filters != null)
 						for (FilterCopy filter : filters) {
 							FilterCopy child = filter;
@@ -1821,7 +1818,7 @@ class FilterEditDialog extends TrayDialog {
 		@Override
 		public Object getID() {return "dummy";} //$NON-NLS-1$
 		@Override
-		public void create(Composite argumentComposite, Font font) {}
+		public void create(Composite composite, Font font) {}
 		@Override
 		public void dispose() {}
 		@Override
@@ -1829,7 +1826,7 @@ class FilterEditDialog extends TrayDialog {
 		@Override
 		public String validate() {return null;}
 		@Override
-		public StyledString formatStyledText(FilterCopy filter,
+		public StyledString formatStyledText(FilterCopy filterCopy,
 				Styler fPlainStyler, Styler fBoldStyler) {return null;}
 	};
 
@@ -2290,7 +2287,7 @@ interface ICustomFilterArgumentUI {
 	/**
 	 * @return the formatted StyledText
 	 */
-	StyledString formatStyledText(FilterCopy filter, Styler fPlainStyler,
+	StyledString formatStyledText(FilterCopy filterCopy, Styler fPlainStyler,
 			Styler fBoldStyler);
 
 	/**
@@ -2996,13 +2993,13 @@ class MultiMatcherCustomFilterArgumentUI implements ICustomFilterArgumentUI {
 	}
 
 	@Override
-	public StyledString formatStyledText(FilterCopy filter,
+	public StyledString formatStyledText(FilterCopy filterCopy,
 			Styler fPlainStyler, Styler fBoldStyler) {
-		return new StyledString(formatMultiMatcherArgument(filter), fPlainStyler);
+		return new StyledString(formatMultiMatcherArgument(filterCopy), fPlainStyler);
 	}
 
-	private String formatMultiMatcherArgument(FilterCopy filter) {
-		String argumentString = (String) filter.getArguments();
+	private String formatMultiMatcherArgument(FilterCopy filterCopy) {
+		String argumentString = (String) filterCopy.getArguments();
 		FileInfoAttributesMatcher.Argument argument = FileInfoAttributesMatcher.decodeArguments(argumentString);
 
 		StringBuilder builder = new StringBuilder();
@@ -3163,9 +3160,10 @@ class DefaultCustomFilterArgumentUI implements ICustomFilterArgumentUI {
 	}
 
 	@Override
-	public StyledString formatStyledText(FilterCopy filter,
+	public StyledString formatStyledText(FilterCopy filterCopy,
 			Styler fPlainStyler, Styler fBoldStyler) {
-		return new StyledString(filter.getArguments() != null ? filter.getArguments().toString() :
+		return new StyledString(
+				filterCopy.getArguments() != null ? filterCopy.getArguments().toString() :
 			"", fPlainStyler); //$NON-NLS-1$
 	}
 }

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ResourceWorkingSetPage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ResourceWorkingSetPage.java
@@ -493,8 +493,8 @@ public class ResourceWorkingSetPage extends WizardPage implements IWorkingSetPag
 		}
 		firstCheck = false;
 		if (errorMessage == null && (workingSet == null || newText.equals(workingSet.getName()) == false)) {
-			for (IWorkingSet workingSet : PlatformUI.getWorkbench().getWorkingSetManager().getWorkingSets()) {
-				if (newText.equals(workingSet.getName())) {
+			for (IWorkingSet set : PlatformUI.getWorkbench().getWorkingSetManager().getWorkingSets()) {
+				if (newText.equals(set.getName())) {
 					errorMessage = IDEWorkbenchMessages.ResourceWorkingSetPage_warning_workingSetExists;
 				}
 			}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/SortFieldContribution.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/SortFieldContribution.java
@@ -120,14 +120,14 @@ public class SortFieldContribution extends MarkersContribution {
 			 *
 			 * @return Listener
 			 */
-			private Listener getMenuItemListener(final MarkerField field,
+			private Listener getMenuItemListener(final MarkerField markerField,
 					final ExtendedMarkersView view) {
 				return event -> {
 
 					MenuItem item = (MenuItem) event.widget;
 
 					if (item.getSelection() && view != null)
-						view.setPrimarySortField(field);
+						view.setPrimarySortField(markerField);
 				};
 			}
 		};

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ViewerSettingsAndStatusDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ViewerSettingsAndStatusDialog.java
@@ -67,26 +67,26 @@ public abstract class ViewerSettingsAndStatusDialog extends ViewSettingsDialog {
 	@Override
 	protected Control createDialogArea(Composite parent) {
 
-		Composite dialogArea = (Composite) super.createDialogArea(parent);
+		Composite dialogAreaComposite = (Composite) super.createDialogArea(parent);
 
-		dialogArea.setLayout(new GridLayout(1, true));
+		dialogAreaComposite.setLayout(new GridLayout(1, true));
 
-		initializeDialogUnits(dialogArea);
+		initializeDialogUnits(dialogAreaComposite);
 
-		createMessageArea(dialogArea).setLayoutData(
+		createMessageArea(dialogAreaComposite).setLayoutData(
 				new GridData(SWT.FILL, SWT.NONE, true, false));
 
-		createDialogContentArea(dialogArea).setLayoutData(
+		createDialogContentArea(dialogAreaComposite).setLayoutData(
 				new GridData(SWT.FILL, SWT.FILL, true, true));
 
-		applyDialogFont(dialogArea);
+		applyDialogFont(dialogAreaComposite);
 
 		initializeDialog();
 
-		return dialogArea;
+		return dialogAreaComposite;
 	}
 
-	protected abstract Control createDialogContentArea(Composite dialogArea);
+	protected abstract Control createDialogContentArea(Composite dialogAreaComposite);
 
 	protected void initializeDialog() {
 		handleStatusUdpate(IStatus.INFO, getDefaultMessage());

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportRootWizardPage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportRootWizardPage.java
@@ -555,8 +555,7 @@ public class SmartImportRootWizardPage extends WizardPage {
 		tree.setContentProvider(new ITreeContentProvider() {
 			@Override
 			public Object[] getElements(Object inputElement) {
-				Map<File, ?> potentialProjects = (Map<File, ?>) inputElement;
-				return potentialProjects.keySet().toArray(new File[potentialProjects.size()]);
+				return ((Map<File, ?>) inputElement).keySet().toArray(File[]::new);
 			}
 
 			@Override

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/TarInputStream.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/TarInputStream.java
@@ -285,13 +285,13 @@ public class TarInputStream extends FilterInputStream
 			// We get a file called ././@LongLink which just contains
 			// the real pathname.
 			byte[] longNameData = new byte[(int) entry.getSize()];
-			int bytesread = 0;
-			while (bytesread < longNameData.length) {
-				int cur = read(longNameData, bytesread, longNameData.length - bytesread);
+			int readBytesOfEntry = 0;
+			while (readBytesOfEntry < longNameData.length) {
+				int cur = read(longNameData, readBytesOfEntry, longNameData.length - readBytesOfEntry);
 				if (cur < 0) {
 					throw new IOException("early end of stream"); //$NON-NLS-1$
 				}
-				bytesread += cur;
+				readBytesOfEntry += cur;
 			}
 
 			int pos = 0;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/WizardFileSystemResourceImportPage1.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/WizardFileSystemResourceImportPage1.java
@@ -325,17 +325,17 @@ public class WizardFileSystemResourceImportPage1 extends WizardResourceImportPag
 	}
 
 	private Composite createAdvancedSection(Composite parent) {
-		Composite linkedResourceComposite= new Composite(parent, SWT.NONE);
-		linkedResourceComposite.setFont(parent.getFont());
-		linkedResourceComposite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+		Composite compositeForSection= new Composite(parent, SWT.NONE);
+		compositeForSection.setFont(parent.getFont());
+		compositeForSection.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		GridLayout layout= new GridLayout();
 		layout.marginHeight= 0;
 		layout.marginWidth= 0;
-		linkedResourceComposite.setLayout(layout);
+		compositeForSection.setLayout(layout);
 
 
 		// create linked resource check
-		createLinksInWorkspaceButton= new Button(linkedResourceComposite, SWT.CHECK);
+		createLinksInWorkspaceButton= new Button(compositeForSection, SWT.CHECK);
 		createLinksInWorkspaceButton.setFont(parent.getFont());
 		createLinksInWorkspaceButton.setText(DataTransferMessages.FileImport_createLinksInWorkspace);
 		createLinksInWorkspaceButton.setSelection(false);
@@ -347,12 +347,12 @@ public class WizardFileSystemResourceImportPage1 extends WizardResourceImportPag
 			}
 		});
 
-		Button tmp= new Button(linkedResourceComposite, SWT.CHECK);
+		Button tmp= new Button(compositeForSection, SWT.CHECK);
 		int indent = tmp.computeSize(SWT.DEFAULT, SWT.DEFAULT).x;
 		tmp.dispose();
 
 		// create virtual folders check
-		createVirtualFoldersButton= new Button(linkedResourceComposite, SWT.CHECK);
+		createVirtualFoldersButton= new Button(compositeForSection, SWT.CHECK);
 		createVirtualFoldersButton.setFont(parent.getFont());
 		createVirtualFoldersButton.setText(DataTransferMessages.FileImport_createVirtualFolders);
 		createVirtualFoldersButton.setToolTipText(DataTransferMessages.FileImport_createVirtualFoldersTooltip);
@@ -369,7 +369,7 @@ public class WizardFileSystemResourceImportPage1 extends WizardResourceImportPag
 		gridData.horizontalIndent = indent;
 		createVirtualFoldersButton.setLayoutData(gridData);
 
-		Composite relativeGroup= new Composite(linkedResourceComposite, 0);
+		Composite relativeGroup= new Composite(compositeForSection, 0);
 		gridData = new GridData(SWT.FILL, SWT.FILL, true, true);
 		gridData.horizontalIndent = indent;
 		relativeGroup.setFont(parent.getFont());
@@ -411,7 +411,7 @@ public class WizardFileSystemResourceImportPage1 extends WizardResourceImportPag
 		updateWidgetEnablements();
 		relativePathVariableGroup.setSelection(true);
 
-		return linkedResourceComposite;
+		return compositeForSection;
 
 	}
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/internal/TableComparator.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/views/markers/internal/TableComparator.java
@@ -231,7 +231,7 @@ public class TableComparator extends ViewerComparator implements Comparator {
 		return fields;
 	}
 
-	private boolean verifyPriorities(int[] priorities) {
+	private static boolean verifyPriorities(int[] priorities) {
 		int length = priorities.length;
 		boolean[] included = new boolean[length];
 		Arrays.fill(included, false);
@@ -248,7 +248,7 @@ public class TableComparator extends ViewerComparator implements Comparator {
 		return true;
 	}
 
-	private boolean verifyDirections(int[] directions) {
+	private static boolean verifyDirections(int[] directions) {
 		for (int direction : directions) {
 			if (direction != ASCENDING && direction != DESCENDING) {
 				return false;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/datatransfer/ExternalProjectImportWizard.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/datatransfer/ExternalProjectImportWizard.java
@@ -97,11 +97,11 @@ public class ExternalProjectImportWizard extends Wizard implements
 	}
 
 	@Override
-	public void init(IWorkbench workbench, IStructuredSelection currentSelection) {
+	public void init(IWorkbench workbench, IStructuredSelection selection) {
 		setWindowTitle(DataTransferMessages.DataTransfer_importTitle);
 		setDefaultPageImageDescriptor(
 				IDEWorkbenchPlugin.getIDEImageDescriptor("wizban/importproj_wiz.png")); //$NON-NLS-1$
-		this.currentSelection = currentSelection;
+		this.currentSelection = selection;
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/datatransfer/FileSystemImportWizard.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/datatransfer/FileSystemImportWizard.java
@@ -86,8 +86,8 @@ public class FileSystemImportWizard extends Wizard implements IImportWizard {
 
 
 	@Override
-	public void init(IWorkbench workbench, IStructuredSelection currentSelection) {
-		this.workbench = workbench;
+	public void init(IWorkbench currentWorkbench, IStructuredSelection currentSelection) {
+		this.workbench = currentWorkbench;
 		this.selection = currentSelection;
 
 		List<IResource> selectedResources = IDE.computeSelectedResources(currentSelection);

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/datatransfer/PopulateRootOperation.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/datatransfer/PopulateRootOperation.java
@@ -64,15 +64,15 @@ public class PopulateRootOperation extends SelectFilesOperation {
 	 */
 	protected FileSystemElement createElement(FileSystemElement parent,
 			Object fileSystemObject, int depth) throws InterruptedException {
-		ModalContext.checkCanceled(monitor);
+		ModalContext.checkCanceled(currentMonitor);
 		boolean isContainer = provider.isFolder(fileSystemObject);
 		String elementLabel = parent == null ? provider
 				.getFullPath(fileSystemObject) : provider
 				.getLabel(fileSystemObject);
 
-		MinimizedFileSystemElement result = new MinimizedFileSystemElement(
+		MinimizedFileSystemElement createdElement = new MinimizedFileSystemElement(
 				elementLabel, parent, isContainer);
-		result.setFileSystemObject(fileSystemObject);
+		createdElement.setFileSystemObject(fileSystemObject);
 
 		if (isContainer) {
 			if (depth > 0) {
@@ -82,13 +82,13 @@ public class PopulateRootOperation extends SelectFilesOperation {
 				}
 				Iterator childrenEnum = children.iterator();
 				while (childrenEnum.hasNext()) {
-					createElement(result, childrenEnum.next(), depth - 1);
+					createElement(createdElement, childrenEnum.next(), depth - 1);
 				}
-				result.setPopulated();
+				createdElement.setPopulated();
 			}
 
 		}
 
-		return result;
+		return createdElement;
 	}
 }

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/datatransfer/SelectFilesOperation.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/datatransfer/SelectFilesOperation.java
@@ -33,7 +33,7 @@ import org.eclipse.ui.internal.wizards.datatransfer.DataTransferMessages;
  *	(the Cancel button) if the operation drags on for too long
  */
 public class SelectFilesOperation implements IRunnableWithProgress {
-	IProgressMonitor monitor;
+	IProgressMonitor currentMonitor;
 
 	Object root;
 
@@ -63,7 +63,7 @@ public class SelectFilesOperation implements IRunnableWithProgress {
 	 */
 	protected FileSystemElement createElement(FileSystemElement parent,
 			Object fileSystemObject) throws InterruptedException {
-		ModalContext.checkCanceled(monitor);
+		ModalContext.checkCanceled(currentMonitor);
 		boolean isContainer = provider.isFolder(fileSystemObject);
 		String elementLabel = parent == null ? provider
 				.getFullPath(fileSystemObject) : provider
@@ -73,9 +73,9 @@ public class SelectFilesOperation implements IRunnableWithProgress {
 			return null;
 		}
 
-		FileSystemElement result = new FileSystemElement(elementLabel, parent,
+		FileSystemElement createdElement = new FileSystemElement(elementLabel, parent,
 				isContainer);
-		result.setFileSystemObject(fileSystemObject);
+		createdElement.setFileSystemObject(fileSystemObject);
 
 		if (isContainer) {
 			boolean haveChildOrFile = false;
@@ -85,18 +85,18 @@ public class SelectFilesOperation implements IRunnableWithProgress {
 			}
 			Iterator childrenEnum = children.iterator();
 			while (childrenEnum.hasNext()) {
-				if (createElement(result, childrenEnum.next()) != null) {
+				if (createElement(createdElement, childrenEnum.next()) != null) {
 					haveChildOrFile = true;
 				}
 			}
 
 			if (!haveChildOrFile && parent != null) {
-				parent.removeFolder(result);
-				result = null;
+				parent.removeFolder(createdElement);
+				createdElement = null;
 			}
 		}
 
-		return result;
+		return createdElement;
 	}
 
 	/**
@@ -146,7 +146,7 @@ public class SelectFilesOperation implements IRunnableWithProgress {
 	@Override
 	public void run(IProgressMonitor monitor) throws InterruptedException {
 		try {
-			this.monitor = monitor;
+			this.currentMonitor = monitor;
 			monitor.beginTask(DataTransferMessages.DataTransfer_scanningMatching, IProgressMonitor.UNKNOWN);
 			result = createElement(null, root);
 			if (result == null) {

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/datatransfer/ZipFileImportWizard.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/datatransfer/ZipFileImportWizard.java
@@ -100,8 +100,8 @@ public class ZipFileImportWizard extends Wizard implements IImportWizard {
 	}
 
 	@Override
-	public void init(IWorkbench workbench, IStructuredSelection currentSelection) {
-		this.workbench = workbench;
+	public void init(IWorkbench currentWorkbench, IStructuredSelection currentSelection) {
+		this.workbench = currentWorkbench;
 		this.selection = currentSelection;
 		List<IResource> selectedResources = IDE.computeSelectedResources(currentSelection);
 		if (!selectedResources.isEmpty()) {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/multiselection/AbstractMultiSelectionHandler.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/texteditor/multiselection/AbstractMultiSelectionHandler.java
@@ -78,8 +78,8 @@ abstract class AbstractMultiSelectionHandler extends AbstractHandler {
 	public abstract void execute() throws ExecutionException;
 
 	@Override
-	public Object execute(ExecutionEvent event) throws ExecutionException {
-		if (initFrom(event)) {
+	public Object execute(ExecutionEvent executionEvent) throws ExecutionException {
+		if (initFrom(executionEvent)) {
 			execute();
 		}
 		return null;
@@ -341,8 +341,8 @@ abstract class AbstractMultiSelectionHandler extends AbstractHandler {
 		return document.getLineOffset(lineNo) + document.getLineInformation(lineNo).getLength();
 	}
 
-	private boolean initFrom(ExecutionEvent event) {
-		this.event = event;
+	private boolean initFrom(ExecutionEvent executionEvent) {
+		this.event = executionEvent;
 		initTextEditor();
 		if (textEditor == null)
 			return false;

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/activities/ExtensionActivityRegistry.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/activities/ExtensionActivityRegistry.java
@@ -41,17 +41,17 @@ final class ExtensionActivityRegistry extends AbstractActivityRegistry {
 	 */
 	private static final String PREFIX = "UIActivities."; //$NON-NLS-1$
 
-	private List<ActivityRequirementBindingDefinition> activityRequirementBindingDefinitions;
+	private List<ActivityRequirementBindingDefinition> extensionActivityRequirementBindingDefinitions;
 
-	private List<ActivityDefinition> activityDefinitions;
+	private List<ActivityDefinition> extensionActivityDefinitions;
 
-	private List<ActivityPatternBindingDefinition> activityPatternBindingDefinitions;
+	private List<ActivityPatternBindingDefinition> extensionActivityPatternBindingDefinitions;
 
-	private List<CategoryActivityBindingDefinition> categoryActivityBindingDefinitions;
+	private List<CategoryActivityBindingDefinition> extensionCategoryActivityBindingDefinitions;
 
-	private List<CategoryDefinition> categoryDefinitions;
+	private List<CategoryDefinition> extensionCategoryDefinitions;
 
-	private List<String> defaultEnabledActivities;
+	private List<String> extensionDefaultEnabledActivities;
 
 	private IExtensionRegistry extensionRegistry;
 
@@ -96,9 +96,9 @@ final class ExtensionActivityRegistry extends AbstractActivityRegistry {
 	 *         not found.
 	 */
 	private ActivityDefinition getActivityDefinitionById(String id) {
-		int size = activityDefinitions.size();
+		int size = extensionActivityDefinitions.size();
 		for (int i = 0; i < size; i++) {
-			ActivityDefinition activityDef = activityDefinitions.get(i);
+			ActivityDefinition activityDef = extensionActivityDefinitions.get(i);
 			if (activityDef.getId().equals(id)) {
 				return activityDef;
 			}
@@ -107,40 +107,40 @@ final class ExtensionActivityRegistry extends AbstractActivityRegistry {
 	}
 
 	private void load() {
-		if (activityRequirementBindingDefinitions == null) {
-			activityRequirementBindingDefinitions = new ArrayList<>();
+		if (extensionActivityRequirementBindingDefinitions == null) {
+			extensionActivityRequirementBindingDefinitions = new ArrayList<>();
 		} else {
-			activityRequirementBindingDefinitions.clear();
+			extensionActivityRequirementBindingDefinitions.clear();
 		}
 
-		if (activityDefinitions == null) {
-			activityDefinitions = new ArrayList<>();
+		if (extensionActivityDefinitions == null) {
+			extensionActivityDefinitions = new ArrayList<>();
 		} else {
-			activityDefinitions.clear();
+			extensionActivityDefinitions.clear();
 		}
 
-		if (activityPatternBindingDefinitions == null) {
-			activityPatternBindingDefinitions = new ArrayList<>();
+		if (extensionActivityPatternBindingDefinitions == null) {
+			extensionActivityPatternBindingDefinitions = new ArrayList<>();
 		} else {
-			activityPatternBindingDefinitions.clear();
+			extensionActivityPatternBindingDefinitions.clear();
 		}
 
-		if (categoryActivityBindingDefinitions == null) {
-			categoryActivityBindingDefinitions = new ArrayList<>();
+		if (extensionCategoryActivityBindingDefinitions == null) {
+			extensionCategoryActivityBindingDefinitions = new ArrayList<>();
 		} else {
-			categoryActivityBindingDefinitions.clear();
+			extensionCategoryActivityBindingDefinitions.clear();
 		}
 
-		if (categoryDefinitions == null) {
-			categoryDefinitions = new ArrayList<>();
+		if (extensionCategoryDefinitions == null) {
+			extensionCategoryDefinitions = new ArrayList<>();
 		} else {
-			categoryDefinitions.clear();
+			extensionCategoryDefinitions.clear();
 		}
 
-		if (defaultEnabledActivities == null) {
-			defaultEnabledActivities = new ArrayList<>();
+		if (extensionDefaultEnabledActivities == null) {
+			extensionDefaultEnabledActivities = new ArrayList<>();
 		} else {
-			defaultEnabledActivities.clear();
+			extensionDefaultEnabledActivities.clear();
 		}
 
 		IConfigurationElement[] configurationElements = extensionRegistry
@@ -175,26 +175,26 @@ final class ExtensionActivityRegistry extends AbstractActivityRegistry {
 
 		// merge enablement overrides from plugin_customization.ini
 		IPreferenceStore store = WorkbenchPlugin.getDefault().getPreferenceStore();
-		for (ActivityDefinition activityDef : activityDefinitions) {
+		for (ActivityDefinition activityDef : extensionActivityDefinitions) {
 			String id = activityDef.getId();
 			String preferenceKey = createPreferenceKey(id);
 			if ("".equals(store.getDefaultString(preferenceKey))) //$NON-NLS-1$
 				continue;
 			if (store.getDefaultBoolean(preferenceKey)) {
-				if (!defaultEnabledActivities.contains(id) && activityDef.getEnabledWhen() == null)
-					defaultEnabledActivities.add(id);
+				if (!extensionDefaultEnabledActivities.contains(id) && activityDef.getEnabledWhen() == null)
+					extensionDefaultEnabledActivities.add(id);
 			} else {
-				defaultEnabledActivities.remove(id);
+				extensionDefaultEnabledActivities.remove(id);
 			}
 		}
 
 		// Removal of all defaultEnabledActivites which target to expression
 		// controlled activities.
-		for (int i = 0; i < defaultEnabledActivities.size();) {
-			String id = defaultEnabledActivities.get(i);
+		for (int i = 0; i < extensionDefaultEnabledActivities.size();) {
+			String id = extensionDefaultEnabledActivities.get(i);
 			ActivityDefinition activityDef = getActivityDefinitionById(id);
 			if (activityDef != null && activityDef.getEnabledWhen() != null) {
-				defaultEnabledActivities.remove(i);
+				extensionDefaultEnabledActivities.remove(i);
 				StatusManager.getManager().handle(new Status(IStatus.WARNING, PlatformUI.PLUGIN_ID,
 						"Default enabled activity declarations will be ignored (id: " + id + ")")); //$NON-NLS-1$ //$NON-NLS-2$
 			} else {
@@ -203,7 +203,7 @@ final class ExtensionActivityRegistry extends AbstractActivityRegistry {
 		}
 
 		// remove all requirement bindings that reference expression-bound activities
-		for (Iterator<ActivityRequirementBindingDefinition> i = activityRequirementBindingDefinitions.iterator(); i
+		for (Iterator<ActivityRequirementBindingDefinition> i = extensionActivityRequirementBindingDefinitions.iterator(); i
 				.hasNext();) {
 			ActivityRequirementBindingDefinition bindingDef = i.next();
 			ActivityDefinition activityDef = getActivityDefinitionById(bindingDef.getRequiredActivityId());
@@ -224,36 +224,36 @@ final class ExtensionActivityRegistry extends AbstractActivityRegistry {
 
 		boolean activityRegistryChanged = false;
 
-		if (!activityRequirementBindingDefinitions.equals(super.activityRequirementBindingDefinitions)) {
-			super.activityRequirementBindingDefinitions = Collections
-					.unmodifiableList(new ArrayList<>(activityRequirementBindingDefinitions));
+		if (!extensionActivityRequirementBindingDefinitions.equals(super.activityRequirementBindingDefinitions)) {
+			activityRequirementBindingDefinitions = Collections
+					.unmodifiableList(new ArrayList<>(extensionActivityRequirementBindingDefinitions));
 			activityRegistryChanged = true;
 		}
 
-		if (!activityDefinitions.equals(super.activityDefinitions)) {
-			super.activityDefinitions = Collections.unmodifiableList(new ArrayList<>(activityDefinitions));
+		if (!extensionActivityDefinitions.equals(super.activityDefinitions)) {
+			activityDefinitions = Collections.unmodifiableList(new ArrayList<>(extensionActivityDefinitions));
 			activityRegistryChanged = true;
 		}
 
-		if (!activityPatternBindingDefinitions.equals(super.activityPatternBindingDefinitions)) {
-			super.activityPatternBindingDefinitions = Collections
-					.unmodifiableList(new ArrayList<>(activityPatternBindingDefinitions));
+		if (!extensionActivityPatternBindingDefinitions.equals(super.activityPatternBindingDefinitions)) {
+			activityPatternBindingDefinitions = Collections
+					.unmodifiableList(new ArrayList<>(extensionActivityPatternBindingDefinitions));
 			activityRegistryChanged = true;
 		}
 
-		if (!categoryActivityBindingDefinitions.equals(super.categoryActivityBindingDefinitions)) {
-			super.categoryActivityBindingDefinitions = Collections
-					.unmodifiableList(new ArrayList<>(categoryActivityBindingDefinitions));
+		if (!extensionCategoryActivityBindingDefinitions.equals(super.categoryActivityBindingDefinitions)) {
+			categoryActivityBindingDefinitions = Collections
+					.unmodifiableList(new ArrayList<>(extensionCategoryActivityBindingDefinitions));
 			activityRegistryChanged = true;
 		}
 
-		if (!categoryDefinitions.equals(super.categoryDefinitions)) {
-			super.categoryDefinitions = Collections.unmodifiableList(new ArrayList<>(categoryDefinitions));
+		if (!extensionCategoryDefinitions.equals(super.categoryDefinitions)) {
+			categoryDefinitions = Collections.unmodifiableList(new ArrayList<>(extensionCategoryDefinitions));
 			activityRegistryChanged = true;
 		}
 
-		if (!defaultEnabledActivities.equals(super.defaultEnabledActivities)) {
-			super.defaultEnabledActivities = Collections.unmodifiableList(new ArrayList<>(defaultEnabledActivities));
+		if (!extensionDefaultEnabledActivities.equals(super.defaultEnabledActivities)) {
+			defaultEnabledActivities = Collections.unmodifiableList(new ArrayList<>(extensionDefaultEnabledActivities));
 			activityRegistryChanged = true;
 		}
 
@@ -277,7 +277,7 @@ final class ExtensionActivityRegistry extends AbstractActivityRegistry {
 				.readDefaultEnablement(new ConfigurationElementMemento(configurationElement));
 
 		if (enabledActivity != null) {
-			defaultEnabledActivities.add(enabledActivity);
+			extensionDefaultEnabledActivities.add(enabledActivity);
 		}
 
 	}
@@ -288,7 +288,7 @@ final class ExtensionActivityRegistry extends AbstractActivityRegistry {
 						getNamespace(configurationElement));
 
 		if (activityRequirementBindingDefinition != null) {
-			activityRequirementBindingDefinitions.add(activityRequirementBindingDefinition);
+			extensionActivityRequirementBindingDefinitions.add(activityRequirementBindingDefinition);
 		}
 	}
 
@@ -312,7 +312,7 @@ final class ExtensionActivityRegistry extends AbstractActivityRegistry {
 					}
 				}
 			}
-			activityDefinitions.add(activityDefinition);
+			extensionActivityDefinitions.add(activityDefinition);
 		}
 	}
 
@@ -322,7 +322,7 @@ final class ExtensionActivityRegistry extends AbstractActivityRegistry {
 						getNamespace(configurationElement));
 
 		if (activityPatternBindingDefinition != null) {
-			activityPatternBindingDefinitions.add(activityPatternBindingDefinition);
+			extensionActivityPatternBindingDefinitions.add(activityPatternBindingDefinition);
 		}
 	}
 
@@ -332,7 +332,7 @@ final class ExtensionActivityRegistry extends AbstractActivityRegistry {
 						getNamespace(configurationElement));
 
 		if (categoryActivityBindingDefinition != null) {
-			categoryActivityBindingDefinitions.add(categoryActivityBindingDefinition);
+			extensionCategoryActivityBindingDefinitions.add(categoryActivityBindingDefinition);
 		}
 	}
 
@@ -341,7 +341,7 @@ final class ExtensionActivityRegistry extends AbstractActivityRegistry {
 				new ConfigurationElementMemento(configurationElement), getNamespace(configurationElement));
 
 		if (categoryDefinition != null) {
-			categoryDefinitions.add(categoryDefinition);
+			extensionCategoryDefinitions.add(categoryDefinition);
 		}
 	}
 }

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/providers/EditorElement.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/providers/EditorElement.java
@@ -30,8 +30,6 @@ public class EditorElement extends QuickAccessElement {
 
 	private static final String DIRTY_MARK = "*"; //$NON-NLS-1$
 
-	private static final String separator = " - "; //$NON-NLS-1$
-
 	private IEditorReference editorReference;
 	private boolean dirty;
 

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/providers/PreferenceElement.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/providers/PreferenceElement.java
@@ -29,8 +29,6 @@ import org.eclipse.ui.quickaccess.QuickAccessElement;
  */
 public class PreferenceElement extends QuickAccessElement {
 
-	private static final String separator = " - "; //$NON-NLS-1$
-
 	private IPreferenceNode preferenceNode;
 
 	private String prefix;

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/statushandlers/InternalDialog.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/statushandlers/InternalDialog.java
@@ -87,7 +87,7 @@ public class InternalDialog extends TrayDialog {
 	/**
 	 * This composite holds all components of the dialog.
 	 */
-	private Composite dialogArea;
+	private Composite dialogAreaComposite;
 	/**
 	 * This composite is initially scrolled to the 0 x 0 size. When more than one
 	 * status arrives, listArea is resized and a list is created on it to present
@@ -204,8 +204,8 @@ public class InternalDialog extends TrayDialog {
 	protected Control createDialogArea(Composite parent) {
 		createTitleArea(parent);
 		createListArea(parent);
-		dialogArea = parent;
-		Dialog.applyDialogFont(dialogArea);
+		dialogAreaComposite = parent;
+		Dialog.applyDialogFont(dialogAreaComposite);
 		return parent;
 	}
 
@@ -324,7 +324,7 @@ public class InternalDialog extends TrayDialog {
 	 * Method which should be invoked when new errors become available for display.
 	 */
 	void refresh() {
-		if (dialogArea == null || dialogArea.isDisposed()) {
+		if (dialogAreaComposite == null || dialogAreaComposite.isDisposed()) {
 			return;
 		}
 		updateTitleArea();
@@ -341,7 +341,7 @@ public class InternalDialog extends TrayDialog {
 	}
 
 	void refreshDialogSize() {
-		if (dialogArea == null || dialogArea.isDisposed()) {
+		if (dialogAreaComposite == null || dialogAreaComposite.isDisposed()) {
 			return;
 		}
 		Point newSize = getShell().computeSize(SWT.DEFAULT, SWT.DEFAULT);
@@ -357,16 +357,16 @@ public class InternalDialog extends TrayDialog {
 	 * has been disposed will have no effect.
 	 */
 	private void showDetailsArea() {
-		if (dialogArea != null && !dialogArea.isDisposed()) {
+		if (dialogAreaComposite != null && !dialogAreaComposite.isDisposed()) {
 			if (detailsManager.isOpen()) {
 				detailsManager.close();
-				detailsManager.createDetailsArea(dialogArea, getCurrentStatusAdapter());
+				detailsManager.createDetailsArea(dialogAreaComposite, getCurrentStatusAdapter());
 				dialogState.put(IStatusDialogConstants.DETAILS_OPENED, Boolean.TRUE);
 			} else {
 				toggleDetailsArea();
 				dialogState.put(IStatusDialogConstants.DETAILS_OPENED, Boolean.TRUE);
 			}
-			dialogArea.layout();
+			dialogAreaComposite.layout();
 		}
 	}
 
@@ -382,7 +382,7 @@ public class InternalDialog extends TrayDialog {
 			getButton(IDialogConstants.DETAILS_ID).setText(IDialogConstants.SHOW_DETAILS_LABEL);
 			opened = false;
 		} else {
-			detailsManager.createDetailsArea(dialogArea, getCurrentStatusAdapter());
+			detailsManager.createDetailsArea(dialogAreaComposite, getCurrentStatusAdapter());
 			getButton(IDialogConstants.DETAILS_ID).setText(IDialogConstants.HIDE_DETAILS_LABEL);
 			opened = true;
 		}
@@ -411,7 +411,7 @@ public class InternalDialog extends TrayDialog {
 		if ((opened && diffY > 0) || (!opened && diffY < 0)) {
 			getShell().setSize(new Point(windowSize.x, windowSize.y + (diffY)));
 		}
-		dialogArea.layout();
+		dialogAreaComposite.layout();
 		return opened;
 	}
 

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/contentassist/BarContentAssistProcessor.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/contentassist/BarContentAssistProcessor.java
@@ -73,31 +73,31 @@ public class BarContentAssistProcessor implements IContentAssistProcessorExtensi
 
 	protected static class ContextInformationValidator implements IContextInformationValidator {
 
-		protected BarContextInformation info;
+		protected BarContextInformation contextInfo;
 
-		protected ITextViewer viewer;
+		protected ITextViewer textViewer;
 
-		protected int offset;
+		protected int textOffset;
 
 		@Override
 		public void install(IContextInformation info, ITextViewer viewer, int offset) {
 			if (info instanceof BarContextInformation) {
-				this.info= (BarContextInformation) info;
+				this.contextInfo= (BarContextInformation) info;
 			}
-			this.viewer= viewer;
-			this.offset= offset;
+			this.textViewer= viewer;
+			this.textOffset= offset;
 		}
 
 		@Override
 		public boolean isContextInformationValid(int offset) {
-			if (this.info == null) {
+			if (this.contextInfo == null) {
 				return false;
 			}
 			try {
-				IDocument document= viewer.getDocument();
-				IRegion line= document.getLineInformationOfOffset(this.offset);
+				IDocument document= textViewer.getDocument();
+				IRegion line= document.getLineInformationOfOffset(this.textOffset);
 				int end= line.getOffset() + line.getLength();
-				return (offset >= this.offset && offset < end);
+				return (offset >= this.textOffset && offset < end);
 			} catch (BadLocationException e) {
 				return false;
 			}

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/contentassist/ContextInformationPresenterTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/contentassist/ContextInformationPresenterTest.java
@@ -48,12 +48,12 @@ public class ContextInformationPresenterTest extends AbstractContentAssistTest {
 		 */
 		@Override
 		public boolean updatePresentation(int offset, TextPresentation presentation) {
-			if (info == null) { // Ignore unknown information
+			if (contextInfo == null) { // Ignore unknown information
 				return false;
 			}
 
-			int begin= info.getContextInformationPosition();
-			int end= begin + info.getContextDisplayString().length();
+			int begin= contextInfo.getContextInformationPosition();
+			int end= begin + contextInfo.getContextDisplayString().length();
 			boolean style= (offset >= begin && offset <= end);
 			if (style == isStyled) {
 				return false;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/BadElementFactory.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/BadElementFactory.java
@@ -29,13 +29,14 @@ public class BadElementFactory implements IElementFactory {
 	/**
 	 * Set to cause the factory to fail.
 	 */
-	public static boolean fail = false;
+	public static boolean shouldFailOnCreateElement = false;
 
 
 	/**
-	 * Set to true when {@link #createElement(IMemento)} is called while fail is true.
+	 * Set to true when {@link #createElement(IMemento)} is called while
+	 * shouldFailOnCreateElement fail is true.
 	 */
-	public static boolean failAttempted = false;
+	public static boolean elementCreationAttemptedWhileShouldFail = false;
 
 	public static class BadElementInstance implements IAdaptable,
 			IPersistableElement {
@@ -43,13 +44,14 @@ public class BadElementFactory implements IElementFactory {
 		/**
 		 * Set to cause save to fail.
 		 */
-		public static boolean fail = false;
+		public static boolean shouldSaveFail = false;
 
 
 		/**
-		 * Set to true when {@link #saveState(IMemento)} is called while fail is true.
+		 * Set to true when {@link #saveState(IMemento)} is called while shouldSaveFail
+		 * is true.
 		 */
-		public static boolean failAttempted = false;
+		public static boolean saveAttemptedWhileShouldFail = false;
 
 
 		@SuppressWarnings("unchecked")
@@ -68,8 +70,8 @@ public class BadElementFactory implements IElementFactory {
 
 		@Override
 		public void saveState(IMemento memento) {
-			if (fail) {
-				failAttempted = true;
+			if (shouldSaveFail) {
+				saveAttemptedWhileShouldFail = true;
 				throw new RuntimeException();
 			}
 
@@ -79,8 +81,8 @@ public class BadElementFactory implements IElementFactory {
 
 	@Override
 	public IAdaptable createElement(IMemento memento) {
-		if (fail) {
-			failAttempted = true;
+		if (shouldFailOnCreateElement) {
+			elementCreationAttemptedWhileShouldFail = true;
 			throw new RuntimeException();
 		}
 		return new BadElementInstance();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IActionDelegateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IActionDelegateTest.java
@@ -77,7 +77,7 @@ public abstract class IActionDelegateTest extends UITestCase {
 	 * Returns the last mock action delegate which was created.
 	 */
 	protected MockActionDelegate getDelegate() throws Throwable {
-		MockActionDelegate delegate = MockActionDelegate.lastDelegate;
+		MockActionDelegate delegate = MockActionDelegate.lastMockActionDelegate;
 		assertNotNull(delegate);
 		return delegate;
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchWindowActionDelegateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchWindowActionDelegateTest.java
@@ -66,7 +66,7 @@ public class IWorkbenchWindowActionDelegateTest extends IActionDelegateTest {
 	 */
 	@Override
 	protected MockActionDelegate getDelegate() throws Throwable {
-		MockActionDelegate delegate = MockWorkbenchWindowActionDelegate.lastDelegate;
+		MockActionDelegate delegate = MockWorkbenchWindowActionDelegate.lastMockWorkbenchWindowActionDelegate;
 		assertNotNull(delegate);
 		return delegate;
 	}
@@ -99,7 +99,7 @@ public class IWorkbenchWindowActionDelegateTest extends IActionDelegateTest {
 	public void XXXtestDisposeWorkbenchWindowActionDelegateBug81422() {
 		String id = MockWorkbenchWindowActionDelegate.SET_ID;
 		fPage.showActionSet(id);
-		MockWorkbenchWindowActionDelegate mockWWinActionDelegate = MockWorkbenchWindowActionDelegate.lastDelegate;
+		MockWorkbenchWindowActionDelegate mockWWinActionDelegate = MockWorkbenchWindowActionDelegate.lastMockWorkbenchWindowActionDelegate;
 		// hide (from the compiler) the fact that the interfaces are implemented
 		Object mockAsObject = mockWWinActionDelegate;
 		// asserts that the mock object actually implements both interfaces mentioned in the PR

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetTest.java
@@ -303,12 +303,12 @@ public class IWorkingSetTest extends UITestCase {
 				.setElements(new IAdaptable[] { new BadElementFactory.BadElementInstance() });
 		IMemento m = XMLMemento.createWriteRoot("ws");
 		fWorkingSet.saveState(m);
-		BadElementFactory.fail = true;
+		BadElementFactory.shouldFailOnCreateElement = true;
 		IWorkingSet copy = new WorkingSet(fWorkingSet.getName(), fWorkingSet.getId(), m) {};
 		try {
-			assertFalse(BadElementFactory.failAttempted);
+			assertFalse(BadElementFactory.elementCreationAttemptedWhileShouldFail);
 			IAdaptable [] elements = copy.getElements();
-			assertTrue(BadElementFactory.failAttempted);
+			assertTrue(BadElementFactory.elementCreationAttemptedWhileShouldFail);
 			assertEquals("Element array should be empty", 0, elements.length);
 		}
 		catch (RuntimeException e) {
@@ -325,11 +325,11 @@ public class IWorkingSetTest extends UITestCase {
 		fWorkingSet
 				.setElements(new IAdaptable[] { new BadElementFactory.BadElementInstance() });
 		IMemento m = XMLMemento.createWriteRoot("ws");
-		BadElementFactory.BadElementInstance.fail = true;
-		assertFalse(BadElementFactory.BadElementInstance.failAttempted);
+		BadElementFactory.BadElementInstance.shouldSaveFail = true;
+		assertFalse(BadElementFactory.BadElementInstance.saveAttemptedWhileShouldFail);
 		try {
 			fWorkingSet.saveState(m);
-			assertTrue(BadElementFactory.BadElementInstance.failAttempted);
+			assertTrue(BadElementFactory.BadElementInstance.saveAttemptedWhileShouldFail);
 		} catch (RuntimeException e) {
 			fail("Error saving elements for broken persistable", e);
 		}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/MockActionDelegate.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/MockActionDelegate.java
@@ -25,11 +25,11 @@ public class MockActionDelegate implements IWorkbenchWindowActionDelegate {
 
 	public static final String ACTION_SET_ID = "org.eclipse.ui.tests.api.MockActionSet";
 
-	public static MockActionDelegate lastDelegate;
+	public static MockActionDelegate lastMockActionDelegate;
 
 	public MockActionDelegate() {
 		callHistory = new CallHistory(this);
-		lastDelegate = this;
+		lastMockActionDelegate = this;
 	}
 
 	/*

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/MockWorkbenchWindowActionDelegate.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/MockWorkbenchWindowActionDelegate.java
@@ -20,7 +20,7 @@ import org.eclipse.ui.IWorkbenchWindow;
 
 public class MockWorkbenchWindowActionDelegate extends MockActionDelegate
 		implements IActionDelegate2 {
-	public static MockWorkbenchWindowActionDelegate lastDelegate;
+	public static MockWorkbenchWindowActionDelegate lastMockWorkbenchWindowActionDelegate;
 
 	public static String SET_ID = "org.eclipse.ui.tests.api.MockActionSet";
 
@@ -31,7 +31,7 @@ public class MockWorkbenchWindowActionDelegate extends MockActionDelegate
 	 */
 	public MockWorkbenchWindowActionDelegate() {
 		super();
-		lastDelegate = this;
+		lastMockWorkbenchWindowActionDelegate = this;
 	}
 
 	@Override


### PR DESCRIPTION
Resolves warnings of kind "hiding field" by either
* removing the variable if it is unnecessary or a duplicate, or
* renaming the hiding or the hidden variable, or
* making the method static in case a parameter is hiding a field.

Together with #1431, #1432, this should resolve all warnings of type "hiding field" in this repository. To avoid faulty name replacements, all name changes have been performed via warnings-free refactorings,