### PR TITLE
Do not let runtime exceptions disturb the update flow of menus

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/MenuManagerRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/MenuManagerRenderer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2020 IBM Corporation and others.
+ * Copyright (c) 2009, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -22,6 +22,7 @@
  *     Daniel Kruegler <daniel.kruegler@gmail.com> - Bug 473779
  *     Simon Scholz <simon.scholz@vogella.com> - Bug 506306
  *     Axel Richard <axel.richard@oebo.fr> - Bug 354538
+ *     Christoph Läubrich - issue #1435
  *******************************************************************************/
 package org.eclipse.e4.ui.workbench.renderers.swt;
 
@@ -37,6 +38,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.e4.core.commands.ExpressionContext;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IContextFunction;
@@ -1170,7 +1172,16 @@ public class MenuManagerRenderer extends SWTPartRenderer {
 							mgrToUpdate.clear();
 						}
 						for (IContributionManager mgr1 : toUpdate) {
-							mgr1.update(false);
+							try {
+								mgr1.update(false);
+							} catch (RuntimeException e) {
+								String message = String.format(
+										"ContributionManager '%s' threw an exception while performing update!", mgr1); //$NON-NLS-1$
+								ILog.get().error(message, e);
+								synchronized (mgrToUpdate) {
+									mgrToUpdate.add(mgr1);
+								}
+							}
 						}
 					});
 				}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/menus/DynamicMenuContributionItem.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/menus/DynamicMenuContributionItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2015 IBM Corporation and others.
+ * Copyright (c) 2008, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,11 +10,13 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Christoph Läubrich - handle runtime exceptions produced by dynamic contribution
  ******************************************************************************/
 
 package org.eclipse.ui.internal.menus;
 
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.jface.action.ContributionItem;
 import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.jface.action.IContributionManager;
@@ -62,7 +64,11 @@ public class DynamicMenuContributionItem extends ContributionItem {
 	@Override
 	public boolean isDynamic() {
 		if (loadedDynamicContribution != null) {
-			return loadedDynamicContribution.isDynamic();
+			try {
+				return loadedDynamicContribution.isDynamic();
+			} catch (RuntimeException e) {
+				reportErrorForContribution(loadedDynamicContribution, e);
+			}
 		}
 		return true;
 	}
@@ -70,7 +76,11 @@ public class DynamicMenuContributionItem extends ContributionItem {
 	@Override
 	public boolean isDirty() {
 		if (loadedDynamicContribution != null) {
-			return loadedDynamicContribution.isDirty();
+			try {
+				return loadedDynamicContribution.isDirty();
+			} catch (RuntimeException e) {
+				reportErrorForContribution(loadedDynamicContribution, e);
+			}
 		}
 		return super.isDirty();
 	}
@@ -78,7 +88,11 @@ public class DynamicMenuContributionItem extends ContributionItem {
 	@Override
 	public boolean isEnabled() {
 		if (loadedDynamicContribution != null) {
-			return loadedDynamicContribution.isEnabled();
+			try {
+				return loadedDynamicContribution.isEnabled();
+			} catch (RuntimeException e) {
+				reportErrorForContribution(loadedDynamicContribution, e);
+			}
 		}
 		return super.isEnabled();
 	}
@@ -86,7 +100,11 @@ public class DynamicMenuContributionItem extends ContributionItem {
 	@Override
 	public boolean isGroupMarker() {
 		if (loadedDynamicContribution != null) {
-			return loadedDynamicContribution.isGroupMarker();
+			try {
+				return loadedDynamicContribution.isGroupMarker();
+			} catch (RuntimeException e) {
+				reportErrorForContribution(loadedDynamicContribution, e);
+			}
 		}
 		return super.isGroupMarker();
 	}
@@ -94,7 +112,11 @@ public class DynamicMenuContributionItem extends ContributionItem {
 	@Override
 	public boolean isSeparator() {
 		if (loadedDynamicContribution != null) {
-			return loadedDynamicContribution.isSeparator();
+			try {
+				return loadedDynamicContribution.isSeparator();
+			} catch (RuntimeException e) {
+				reportErrorForContribution(loadedDynamicContribution, e);
+			}
 		}
 		return super.isSeparator();
 	}
@@ -102,7 +124,11 @@ public class DynamicMenuContributionItem extends ContributionItem {
 	@Override
 	public boolean isVisible() {
 		if (loadedDynamicContribution != null) {
-			return loadedDynamicContribution.isVisible();
+			try {
+				return loadedDynamicContribution.isVisible();
+			} catch (RuntimeException e) {
+				reportErrorForContribution(loadedDynamicContribution, e);
+			}
 		}
 		return super.isVisible();
 	}
@@ -110,7 +136,11 @@ public class DynamicMenuContributionItem extends ContributionItem {
 	@Override
 	public void saveWidgetState() {
 		if (loadedDynamicContribution != null) {
-			loadedDynamicContribution.saveWidgetState();
+			try {
+				loadedDynamicContribution.saveWidgetState();
+			} catch (RuntimeException e) {
+				reportErrorForContribution(loadedDynamicContribution, e);
+			}
 		}
 		super.saveWidgetState();
 	}
@@ -118,7 +148,11 @@ public class DynamicMenuContributionItem extends ContributionItem {
 	@Override
 	public void setVisible(boolean visible) {
 		if (loadedDynamicContribution != null) {
-			loadedDynamicContribution.setVisible(visible);
+			try {
+				loadedDynamicContribution.setVisible(visible);
+			} catch (RuntimeException e) {
+				reportErrorForContribution(loadedDynamicContribution, e);
+			}
 		}
 		super.setVisible(visible);
 	}
@@ -126,29 +160,49 @@ public class DynamicMenuContributionItem extends ContributionItem {
 	@Override
 	public void fill(Composite parent) {
 		IContributionItem contributionItem = getContributionItem();
-		if (contributionItem != null)
-			contributionItem.fill(parent);
+		if (contributionItem != null) {
+			try {
+				contributionItem.fill(parent);
+			} catch (RuntimeException e) {
+				reportErrorForContribution(contributionItem, e);
+			}
+		}
 	}
 
 	@Override
 	public void fill(CoolBar parent, int index) {
 		IContributionItem contributionItem = getContributionItem();
-		if (contributionItem != null)
-			contributionItem.fill(parent, index);
+		if (contributionItem != null){
+			try {
+				contributionItem.fill(parent, index);
+			} catch (RuntimeException e) {
+				reportErrorForContribution(contributionItem, e);
+			}
+		}
 	}
 
 	@Override
 	public void fill(Menu menu, int index) {
 		IContributionItem contributionItem = getContributionItem();
-		if (contributionItem != null)
-			contributionItem.fill(menu, index);
+		if (contributionItem != null) {
+			try {
+				contributionItem.fill(menu, index);
+			} catch (RuntimeException e) {
+				reportErrorForContribution(contributionItem, e);
+			}
+		}
 	}
 
 	@Override
 	public void fill(ToolBar parent, int index) {
 		IContributionItem contributionItem = getContributionItem();
-		if (contributionItem != null)
-			contributionItem.fill(parent, index);
+		if (contributionItem != null) {
+			try {
+				contributionItem.fill(parent, index);
+			} catch (RuntimeException e) {
+				reportErrorForContribution(contributionItem, e);
+			}
+		}
 	}
 
 	private IContributionItem getContributionItem() {
@@ -177,7 +231,11 @@ public class DynamicMenuContributionItem extends ContributionItem {
 	@Override
 	public void dispose() {
 		if (loadedDynamicContribution != null) {
-			loadedDynamicContribution.dispose();
+			try {
+				loadedDynamicContribution.dispose();
+			} catch (RuntimeException e) {
+				reportErrorForContribution(loadedDynamicContribution, e);
+			}
 			loadedDynamicContribution = null;
 		}
 		super.dispose();
@@ -186,14 +244,22 @@ public class DynamicMenuContributionItem extends ContributionItem {
 	@Override
 	public void update() {
 		if (loadedDynamicContribution != null) {
-			loadedDynamicContribution.update();
+			try {
+				loadedDynamicContribution.update();
+			} catch (RuntimeException e) {
+				reportErrorForContribution(loadedDynamicContribution, e);
+			}
 		}
 	}
 
 	@Override
 	public void update(String id) {
 		if (loadedDynamicContribution != null) {
-			loadedDynamicContribution.update(id);
+			try {
+				loadedDynamicContribution.update(id);
+			} catch (RuntimeException e) {
+				reportErrorForContribution(loadedDynamicContribution, e);
+			}
 		}
 	}
 
@@ -201,8 +267,18 @@ public class DynamicMenuContributionItem extends ContributionItem {
 	public void setParent(IContributionManager parent) {
 		super.setParent(parent);
 		if (loadedDynamicContribution != null) {
-			loadedDynamicContribution.setParent(parent);
+			try {
+				loadedDynamicContribution.setParent(parent);
+			} catch (RuntimeException e) {
+				reportErrorForContribution(loadedDynamicContribution, e);
+			}
 		}
+	}
+
+	private static void reportErrorForContribution(IContributionItem contributionItem, RuntimeException e) {
+		String message = String.format("Dynamic menu contribution '%s' threw an unexpected exception", //$NON-NLS-1$
+				contributionItem);
+		ILog.get().error(message, e);
 	}
 
 }


### PR DESCRIPTION
Currently it can happen that a single contribution throws a runtime exception that supress the processing of further contribution updates.

This mitigates this in two ways:

1. if one manger fails to update others are still considered for update and the failing one is rescheduled for the next cycle
2. DynamicMenuContributionItem is enhanced to catch runtime exceptions and handles them as if the creation of the contributing item itself has failed.

Fix https://github.com/eclipse-platform/eclipse.platform.ui/issues/1435