### PR TITLE
Touch bundles affected by changed compiler generation for switch

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.ui.css.core/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Bug 521195 - Migrate to Batik 1.9.0
 Bug 532094 - Update releng with new hamcrest and apache batik
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686

--- a/bundles/org.eclipse.e4.ui.css.swt/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.ui.css.swt/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Bug 416898 - Some Platform UI bundles need to be touched to get API descriptions
 Bug 514690 - Build failure on I20170403-2000 and I20170404-0245
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686

--- a/bundles/org.eclipse.text/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.text/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 466364: Cannot run unit-tests anymore because classes from org.eclipse.jface
 Pick up new signing certificate
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686

--- a/bundles/org.eclipse.ui.workbench.texteditor/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.workbench.texteditor/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 509931: Comparator errors in M20170104-0545
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686

--- a/bundles/org.eclipse.ui.workbench/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.workbench/forceQualifierUpdate.txt
@@ -13,3 +13,4 @@ Bug 568058 - Comparator errors in I20201020-1800
 Bug 572789 - Comparator errors in I20210412-1800 after moving to compiler from 4.20 M1
 Bug 578351 - Lambda generation order is unstable in ecj 
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686