### PR TITLE
Implement Windows Defender Auto-fix

### DIFF
--- a/bundles/org.eclipse.ui.workbench/.settings/org.eclipse.pde.ds.annotations.prefs
+++ b/bundles/org.eclipse.ui.workbench/.settings/org.eclipse.pde.ds.annotations.prefs
@@ -1,4 +1,4 @@
-dsVersion=V1_3
+dsVersion=V1_4
 eclipse.preferences.version=1
 enabled=true
 generateBundleActivationPolicyLazy=true

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WindowsDefenderConfigurator.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WindowsDefenderConfigurator.java
@@ -1,0 +1,347 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2024 Hannes Wellmann and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Hannes Wellmann - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.ui.internal;
+
+import static org.eclipse.ui.internal.WorkbenchPlugin.PI_WORKBENCH;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.preferences.ConfigurationScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.IPreferencesService;
+import org.eclipse.core.runtime.preferences.IScopeContext;
+import org.eclipse.e4.ui.workbench.UIEvents;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.preference.PreferenceDialog;
+import org.eclipse.jface.widgets.ButtonFactory;
+import org.eclipse.jface.widgets.LinkFactory;
+import org.eclipse.jface.widgets.WidgetFactory;
+import org.eclipse.jface.window.Window;
+import org.eclipse.osgi.service.datalocation.Location;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.dialogs.PreferencesUtil;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+import org.osgi.service.event.propertytypes.EventTopics;
+import org.osgi.service.prefs.BackingStoreException;
+
+/**
+ * A start-up event handler that, if running on Windows, suggests the user to
+ * exclude the current installation directory from being scanned by the Windows
+ * Defender, if it is active on the computer.
+ */
+@Component(service = EventHandler.class)
+@EventTopics(UIEvents.UILifeCycle.APP_STARTUP_COMPLETE)
+public class WindowsDefenderConfigurator implements EventHandler {
+	private static final String WINDOWS_DEFENDER_EXCLUDED_INSTALLATION_PATH = "windows.defender.excluded.path"; //$NON-NLS-1$
+	public static final String PREFERENCE_SKIP = "windows.defender.check.skip"; //$NON-NLS-1$
+	public static final boolean PREFERENCE_SKIP_DEFAULT = false;
+
+	@Reference
+	private IPreferencesService preferences;
+
+	@Override
+	public void handleEvent(Event event) {
+		if (isRelevant()) {
+			Job job = Job.create(WorkbenchMessages.WindowsDefenderConfigurator_statusCheck, m -> {
+				SubMonitor monitor = SubMonitor.convert(m, 10);
+				if (preferences.getBoolean(PI_WORKBENCH, PREFERENCE_SKIP, PREFERENCE_SKIP_DEFAULT, null)) {
+					return;
+				}
+				Optional<Path> installLocation = getInstallationLocation();
+				if (installLocation.isPresent()) {
+					String checkedPath = getPreference(ConfigurationScope.INSTANCE)
+							.get(WINDOWS_DEFENDER_EXCLUDED_INSTALLATION_PATH, ""); //$NON-NLS-1$
+					if (!checkedPath.isBlank() && installLocation.get().equals(Path.of(checkedPath))) {
+						return; // This installation has already been checked at the current location
+					}
+				}
+				monitor.worked(1);
+				runExclusionCheck(monitor.split(9), installLocation);
+			});
+			job.setSystem(true);
+			job.schedule();
+		}
+	}
+
+	public static boolean isRelevant() {
+		return Platform.OS_WIN32.equals(Platform.getOS()) && !Platform.inDevelopmentMode();
+	}
+
+	/**
+	 * Opens the dialog to run the exclusion, regardless of any preference.
+	 *
+	 * @return {@code true} if this installation is now excluded, {@code false} if
+	 *         Windows Defender is inactive and null if the process was aborted.
+	 */
+	public static Boolean runCheckEnforced(IProgressMonitor m) throws CoreException {
+		Optional<Path> installLocation = getInstallationLocation();
+		return runExclusionCheck(m, installLocation);
+	}
+
+	private enum HandlingOption {
+		EXECUTE_EXCLUSION, IGNORE_THIS_INSTALLATION;
+	}
+
+	/**
+	 * Performs the exclusion of this installation from Windows defender.
+	 *
+	 * @return {@code true} if this installation is now excluded, {@code false} if
+	 *         Windows Defender is inactive and null if the process was aborted.
+	 */
+	private static Boolean runExclusionCheck(IProgressMonitor m, Optional<Path> installLocation) throws CoreException {
+		SubMonitor monitor = SubMonitor.convert(m, 3);
+		if (!isWindowsDefenderActive(monitor.split(1))) {
+			return Boolean.FALSE;
+		}
+
+		HandlingOption decision = askForDefenderHandlingDecision();
+		if (decision != null) {
+			switch (decision) {
+			case EXECUTE_EXCLUSION -> {
+				try {
+					WindowsDefenderConfigurator.excludeDirectoryFromScanning(monitor.split(2));
+					savePreference(ConfigurationScope.INSTANCE, WINDOWS_DEFENDER_EXCLUDED_INSTALLATION_PATH,
+							installLocation.map(Path::toString).orElse("")); //$NON-NLS-1$
+				} catch (IOException e) {
+					PlatformUI.getWorkbench().getDisplay()
+							.syncExec(() -> MessageDialog.openError(null, "Exclusion failed", //$NON-NLS-1$
+									bindProductName(WorkbenchMessages.WindowsDefenderConfigurator_exclusionFailed)));
+				}
+			}
+			case IGNORE_THIS_INSTALLATION -> savePreference(ConfigurationScope.INSTANCE, PREFERENCE_SKIP, "true"); //$NON-NLS-1$
+			}
+		}
+		return decision == HandlingOption.EXECUTE_EXCLUSION ? Boolean.TRUE : null;
+	}
+
+	private static HandlingOption askForDefenderHandlingDecision() {
+		String message = bindProductName(WorkbenchMessages.WindowsDefenderConfigurator_exclusionCheckMessage);
+
+		return PlatformUI.getWorkbench().getDisplay().syncCall(() -> {
+			HandlingOption[] choice = new HandlingOption[] { null };
+			MessageDialog dialog = new MessageDialog(Display.getCurrent().getActiveShell(),
+					WorkbenchMessages.WindowsDefenderConfigurator_statusCheck, null, message, MessageDialog.INFORMATION,
+					0, IDialogConstants.PROCEED_LABEL, IDialogConstants.CANCEL_LABEL) {
+
+				@Override
+				protected Control createCustomArea(Composite parent) {
+					ButtonFactory radioButtonFactory = WidgetFactory.button(SWT.RADIO | SWT.WRAP);
+
+					Button performExclusion = radioButtonFactory
+							.text(bindProductName(WorkbenchMessages.WindowsDefenderConfigurator_performExclusionChoice))
+							.onSelect(e -> {
+								choice[0] = HandlingOption.EXECUTE_EXCLUSION;
+								getButton(0).setEnabled(true);
+							}).create(parent);
+					Point size = performExclusion.computeSize(SWT.DEFAULT, SWT.DEFAULT);
+					GridDataFactory.swtDefaults().hint((int) (size.x * 0.6), (int) (size.y * 2.3)).indent(0, 5)
+							.applyTo(performExclusion);
+
+					Button keepScanning = radioButtonFactory
+							.text(bindProductName(
+									WorkbenchMessages.WindowsDefenderConfigurator_ignoreThisInstallationChoice))
+							.onSelect(e -> {
+								choice[0] = HandlingOption.IGNORE_THIS_INSTALLATION;
+								getButton(0).setEnabled(true);
+							}).create(parent);
+					GridDataFactory.swtDefaults().indent(0, 5).applyTo(keepScanning);
+
+					LinkFactory.newLink(SWT.WRAP)
+							.text(WorkbenchMessages.WindowsDefenderConfigurator_detailsAndOptionsLinkText)
+							.onSelect((e -> {
+								PreferenceDialog dialog = PreferencesUtil.createPreferenceDialogOn(null,
+										"org.eclipse.ui.preferencePages.Startup", null, null); //$NON-NLS-1$
+								dialog.setBlockOnOpen(false);
+								dialog.open();
+								this.setReturnCode(Window.CANCEL);
+								this.close();
+							})).create(parent);
+
+					return parent;
+				}
+
+				@Override
+				protected void createButtonsForButtonBar(Composite parent) {
+					super.createButtonsForButtonBar(parent);
+					getButton(0).setEnabled(false);
+					getButton(1).forceFocus(); // prevents auto-focusing one of the radio-buttons which selects them
+				}
+			};
+			int open = dialog.open();
+			return open == Window.OK ? choice[0] : null;
+		});
+	}
+
+	public static String bindProductName(String message) {
+		return NLS.bind(message, Platform.getProduct().getName());
+	}
+
+	public static IEclipsePreferences getPreference(IScopeContext instance) {
+		return instance.getNode(PI_WORKBENCH);
+	}
+
+	public static void savePreference(IScopeContext scope, String key, String value) throws CoreException {
+		IEclipsePreferences preferences = getPreference(scope);
+		preferences.put(key, value);
+		try {
+			preferences.flush();
+		} catch (BackingStoreException e) {
+			throw new CoreException(Status.error("Failed to safe preference " + preferences, e)); //$NON-NLS-1$
+		}
+	}
+
+	private static Optional<Path> getInstallationLocation() {
+		// For install location see:
+		// https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fmisc%2Fruntime-options.html&anchor=locations
+		try {
+			Location installLocation = Platform.getConfigurationLocation();
+			return Optional.of(Path.of(installLocation.getURL().toURI())); // assume location has a file-URL
+		} catch (URISyntaxException e) { // ignore
+		}
+		return Optional.empty();
+	}
+
+	private static List<Path> getExecutablePath() {
+		@SuppressWarnings("restriction")
+		String eclipseLauncher = System.getProperty(org.eclipse.osgi.internal.location.EquinoxLocations.PROP_LAUNCHER);
+		return List.of(Path.of(eclipseLauncher));
+	}
+
+	private static boolean isWindowsDefenderActive(IProgressMonitor monitor) throws CoreException {
+		// https://learn.microsoft.com/en-us/powershell/module/defender/get-mpcomputerstatus
+		List<String> command = List.of("powershell.exe", "-Command", "(Get-MpComputerStatus).AMRunningMode"); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
+		try {
+			List<String> lines = runProcess(command, monitor);
+			String onlyLine = lines.size() == 1 ? lines.get(0) : ""; //$NON-NLS-1$
+			return switch (onlyLine) {
+			// Known values as listed in
+			// https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/microsoft-defender-antivirus-windows#use-powershell-to-check-the-status-of-microsoft-defender-antivirus
+			case "SxS Passive Mode", "Passive mode" -> false; //$NON-NLS-1$ //$NON-NLS-2$
+			case "Normal", "EDR Block Mode" -> true; //$NON-NLS-1$//$NON-NLS-2$
+			default -> throw new IOException("Process terminated with unexpected result:\n" + String.join("\n", lines)); //$NON-NLS-1$//$NON-NLS-2$
+			};
+		} catch (IOException e) {
+			throw new CoreException(Status.error(WorkbenchMessages.WindowsDefenderConfigurator_statusCheckFailed, e));
+		}
+	}
+
+	public static String createAddExclusionsPowershellCommand(String extraSeparator) {
+		List<Path> paths = getExecutablePath();
+		// For detailed explanations about how to read existing exclusions and how to
+		// add new ones see:
+		// https://learn.microsoft.com/en-us/powershell/module/defender/add-mppreference
+		// https://learn.microsoft.com/en-us/powershell/module/defender/get-mppreference
+		//
+		// For .NET's stream API called LINQ see:
+		// https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable
+		String excludedPaths = paths.stream().map(Path::toString).map(p -> '"' + p + '"')
+				.collect(Collectors.joining(',' + extraSeparator));
+		final String exclusionType = "ExclusionProcess"; //$NON-NLS-1$
+		return String.join(';' + extraSeparator, "$exclusions=@(" + extraSeparator + excludedPaths + ')', //$NON-NLS-1$
+				"$existingExclusions=[Collections.Generic.HashSet[String]](Get-MpPreference)." + exclusionType, //$NON-NLS-1$
+				"$exclusionsToAdd=[Linq.Enumerable]::ToArray([Linq.Enumerable]::Where($exclusions,[Func[object,bool]]{param($ex)!$existingExclusions.Contains($ex)}))", //$NON-NLS-1$
+				"if($exclusionsToAdd.Length -gt 0){ Add-MpPreference -" + exclusionType + " $exclusionsToAdd }"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	private static void excludeDirectoryFromScanning(IProgressMonitor monitor) throws IOException {
+		String exclusionsCommand = createAddExclusionsPowershellCommand(""); //$NON-NLS-1$
+		// In order to change the Windows Defender configuration a powershell with
+		// Administrator privileges is needed and therefore from a basic powershell
+		// a second one with elevated rights is started and runs the
+		// add-exclusions-command. For a detailed explanation of the Start-process
+		// parameters see
+		// https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/start-process#parameters
+		//
+		// In order to avoid quoting when passing a command through multiple
+		// process-calls/command line processors, the command is passed as
+		// base64-encoded string to the elevated second powershell.
+		// For details about the -EncodedCommand argument see (and the EXAMPLES section)
+		// https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe#-encodedcommand-base64encodedcommand
+		String encodedCommand = Base64.getEncoder()
+				.encodeToString(exclusionsCommand.getBytes(StandardCharsets.UTF_16LE)); // encoding as specified
+		List<String> command = List.of("powershell.exe", //$NON-NLS-1$
+				// Launch child powershell with administrator privileges
+				"Start-Process", "powershell", "-Verb", "RunAs", "-Wait", //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+				"-ArgumentList", "'-EncodedCommand " + encodedCommand + "'"); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
+		runProcess(command, monitor);
+	}
+
+	private static List<String> runProcess(List<String> command, IProgressMonitor monitor) throws IOException {
+		ExecutorService newSingleThreadExecutor = Executors.newSingleThreadExecutor();
+		Process process = new ProcessBuilder(command).start();
+		Future<List<String>> processLines = newSingleThreadExecutor.submit(() -> {
+			try (BufferedReader inputReader = process.inputReader();) {
+				return inputReader.lines().filter(l -> !l.isBlank()).map(String::strip).toList();
+			}
+		});
+		newSingleThreadExecutor.shutdown();
+		try {
+			while (!processLines.isDone()) {
+				if (monitor.isCanceled()) {
+					process.destroy();
+					process.descendants().forEach(ProcessHandle::destroy);
+					processLines.cancel(true);
+					throw new OperationCanceledException();
+				}
+				Thread.onSpinWait();
+				Thread.sleep(5);
+			}
+			if (process.isAlive()) {
+				process.destroyForcibly();
+				process.descendants().forEach(ProcessHandle::destroyForcibly);
+				throw new IOException("Process timed-out and it was attempted to forcefully termiante it"); //$NON-NLS-1$
+			} else if (process.exitValue() != 0) {
+				throw new IOException("Process failed with exit-code " + process.exitValue()); //$NON-NLS-1$
+			}
+			return processLines.get();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new OperationCanceledException();
+		} catch (ExecutionException e) {
+			throw new IOException(e.getCause());
+		}
+	}
+
+}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchMessages.java
@@ -600,6 +600,21 @@ public class WorkbenchMessages extends NLS {
 	public static String CheckedTreeSelectionDialog_select_all;
 	public static String CheckedTreeSelectionDialog_deselect_all;
 
+	public static String WindowsDefenderConfigurator_statusCheck;
+	public static String WindowsDefenderConfigurator_exclusionCheckMessage;
+	public static String WindowsDefenderConfigurator_exclusionInformation;
+	public static String WindowsDefenderConfigurator_scriptShowLabel;
+	public static String WindowsDefenderConfigurator_scriptHideLabel;
+	public static String WindowsDefenderConfigurator_scriptHint;
+	public static String WindowsDefenderConfigurator_performExclusionChoice;
+	public static String WindowsDefenderConfigurator_ignoreThisInstallationChoice;
+	public static String WindowsDefenderConfigurator_ignoreAllChoice;
+	public static String WindowsDefenderConfigurator_detailsAndOptionsLinkText;
+	public static String WindowsDefenderConfigurator_runExclusionFromPreferenceButtonLabel;
+	public static String WindowsDefenderConfigurator_statusInactive;
+	public static String WindowsDefenderConfigurator_statusCheckFailed;
+	public static String WindowsDefenderConfigurator_exclusionFailed;
+
 	// ==============================================================================
 	// Editor Framework
 	// ==============================================================================

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
@@ -568,6 +568,25 @@ CheckedTreeSelectionDialog_nothing_available=No entries available.
 CheckedTreeSelectionDialog_select_all=Select &All
 CheckedTreeSelectionDialog_deselect_all=&Deselect All
 
+WindowsDefenderConfigurator_statusCheck=Windows Defender Exclusion Check
+WindowsDefenderConfigurator_exclusionCheckMessage=Microsoft's Windows Defender is active and could significantly decrease this application's startup and overall performance.\n\
+Select how this installation should be handled by Windows Defender:
+WindowsDefenderConfigurator_exclusionInformation=If Windows Defender is active and scans this application it can significantly slow down its startup and overall performance.\n\
+To prevent a decrease in performance {0} can exclude itself and all files opened from real-time scanning by Windows Defender.\n\
+Be aware that in general adding exclusions could affect this computer's security.
+WindowsDefenderConfigurator_scriptShowLabel=Show Powershell script >>
+WindowsDefenderConfigurator_scriptHideLabel=<< Hide Powershell script
+WindowsDefenderConfigurator_scriptHint=Adding exclusions respectively running the Powershell script to do this requires administrator privileges.
+WindowsDefenderConfigurator_performExclusionChoice=Exclude {0} from being scanned to improve performance.\n\
+(In general adding exclusions may affect the security level of this computer)
+WindowsDefenderConfigurator_ignoreThisInstallationChoice=Keep {0} being scanned by Windows Defender
+WindowsDefenderConfigurator_ignoreAllChoice=Skip exclusion check on startup for all new Eclipse-based installations
+WindowsDefenderConfigurator_detailsAndOptionsLinkText=See '<a>Startup and Shutdown</a>' preference for more details and configuration options.
+WindowsDefenderConfigurator_runExclusionFromPreferenceButtonLabel=Run exclusion check now
+WindowsDefenderConfigurator_statusInactive=Windows Defender is not active on this computer.
+WindowsDefenderConfigurator_statusCheckFailed=Failed to retrieve Windows Defender status.
+WindowsDefenderConfigurator_exclusionFailed=Failed to exclude {0} from being scanned by Windows Defender.
+
 # ==============================================================================
 # Editor Framework
 # ==============================================================================

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -129,10 +129,12 @@ Import-Package: com.ibm.icu.util,
  org.eclipse.e4.ui.workbench.modeling,
  org.eclipse.e4.ui.workbench.renderers.swt,
  org.osgi.service.event;version="[1.2.0,2.0.0)",
+ org.osgi.service.event.propertytypes;version="[1.4.0,2.0.0)",
  org.w3c.dom,
  org.xml.sax
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Capability: osgi.extender;
   filter:="(&(osgi.extender=osgi.component)(version>=1.2)(!(version>=2.0)))"
 Automatic-Module-Name: org.eclipse.ui.workbench
-Service-Component: OSGI-INF/org.eclipse.ui.internal.themes.ColorAndFontProviderImpl.xml
+Service-Component: OSGI-INF/org.eclipse.ui.internal.WindowsDefenderConfigurator.xml,
+ OSGI-INF/org.eclipse.ui.internal.themes.ColorAndFontProviderImpl.xml


### PR DESCRIPTION
Start-up slowdowns on Windows 10 or later due to the Windows Defender are a long standing issue in Eclipse (see [Bug 548443](https://bugs.eclipse.org/bugs/show_bug.cgi?id=548443) or https://github.com/microsoft/java-wdb/issues/9) that is mentioned in the release notes for a while: https://eclipse.dev/eclipse/news/4.13/


💰 This contribution is a [development issue founded by the Eclipse IDE working group](https://gitlab.eclipse.org/eclipse-wg/ide-wg/ide-wg-dev-funded-efforts/ide-wg-dev-funded-program-planning-council-top-issues/-/issues/20) to mitigate these potential startup performance problems on Windows.

This adds a start-up event handler that, if running on Windows and if the Windows Defender is active, shows a pop-up to inform the user about the potential to suffer start-up slow downs due scans by the Defender and to suggest to exclude the current installation directory from being scanned by the Windows Defender.

![grafik](https://github.com/eclipse-platform/eclipse.platform.ui/assets/44067969/9cd4210c-0697-4f55-803b-01256ae2cd0b)

A user can decide to exclude the directories containing the bundles installed in the current eclipse, to skip the exclusion check for this or for all eclipse installations of the current user (the latter is persisted in the user-scope introduced with https://github.com/eclipse-equinox/equinox/pull/446).


The script that is run to exclude the installation can also be shown and can be copied by the user:
![grafik](https://github.com/eclipse-platform/eclipse.platform.ui/assets/44067969/ea67bcb3-5f17-4272-8145-a692fda86060)

This screenshot was done in an Eclipse launched from my development Eclipse, which consequently consists of bundles from many different locations (workspace, target platform with IU und Maven targets) and therefore a lot of directories would be excluded.

Additionally this extends the existing start-up preference page to allow the user to adjust settings for skipping the Windows Defender exclusion check at start-up for the current or all installations

![grafik](https://github.com/eclipse-platform/eclipse.platform.ui/assets/44067969/d65bde1f-df26-4c5c-bf98-d9ccaedf4ef2)

or to run the exclusion check now by clicking on `Run exclusion check now`.

![grafik](https://github.com/eclipse-platform/eclipse.platform.ui/assets/44067969/ede571dc-58d7-441b-88ce-e6210f4754ca)


This PR is a draft of the current state of the work. The open points are:
- [x] Enhance the script to consider existing exclusion and prevent addition of already existing exclusions (Windows then adds them again)
- [x] Decide if the exclusion should be done based on directories or if the entire process should be excluded (see following comment)
- [x] Discuss if the preference group should be moved to a more prominent location, i.e. to the `General` page (usually the first one that opens).
- [ ] Clean up the code and check if labels and texts need to be enhanced

This PR requires as prerequisite (as long as this is not submitted one has to check out that PR as well when reviewing this locally)
- https://github.com/eclipse-equinox/equinox/pull/446

@vogella and @merks AFAIK you are working on Windows too, are you interested in reviewing this?
@HeikoKlare are you or some of your colleges working on Windows and are interested in a review too?

Of everybody else is also invited to review this.
