### PR TITLE
simplify collection emptiness check

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ModelAssembler.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ModelAssembler.java
@@ -526,7 +526,7 @@ public class ModelAssembler {
 			log(LogLevel.DEBUG, "Nothing to merge for fragment {} of {}", contributorURI, //$NON-NLS-1$
 					contributorName);
 		}
-		if (evalImports && fragmentsContainer.getImports().size() > 0) {
+		if (evalImports && !fragmentsContainer.getImports().isEmpty()) {
 			resolveImports(fragmentsContainer.getImports(), addedElements);
 		}
 	}

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ModelServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ModelServiceImpl.java
@@ -450,7 +450,7 @@ public class ModelServiceImpl implements EModelService {
 		}
 
 		List<MUIElement> elements = findElements(searchRoot, id, MUIElement.class);
-		if (elements.size() > 0) {
+		if (!elements.isEmpty()) {
 			return elements.get(0);
 		}
 		return null;

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartActivationHistory.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartActivationHistory.java
@@ -323,7 +323,7 @@ class PartActivationHistory {
 
 		List<MPart> activeCandidates = modelService.findElements(perspective, null, MPart.class,
 				singletonList(EPartService.ACTIVE_ON_CLOSE_TAG));
-		if (activeCandidates.size() > 0) {
+		if (!activeCandidates.isEmpty()) {
 			activeCandidates.get(0).getTags().remove(EPartService.ACTIVE_ON_CLOSE_TAG);
 			MPart candidate = activeCandidates.get(0);
 			if (partService.isInContainer(perspective, candidate)

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartServiceImpl.java
@@ -453,7 +453,7 @@ public class PartServiceImpl implements EPartService {
 	@Override
 	public MPart findPart(String id) {
 		List<MPart> parts = getParts(MPart.class, id);
-		return parts.size() > 0 ? parts.get(0) : null;
+		return parts.isEmpty() ? null : parts.get(0);
 	}
 
 	private <T> List<T> getParts(Class<T> cls, String id) {
@@ -1020,7 +1020,7 @@ public class PartServiceImpl implements EPartService {
 				} else {
 					// Find the first visible stack in the area
 					List<MPartStack> sharedStacks = modelService.findElements(area, null, MPartStack.class);
-					if (sharedStacks.size() > 0) {
+					if (!sharedStacks.isEmpty()) {
 						for (MPartStack stack : sharedStacks) {
 							if (stack.isToBeRendered()) {
 								stack.getChildren().add(providedPart);
@@ -1085,7 +1085,7 @@ public class PartServiceImpl implements EPartService {
 			descId += ":*"; //$NON-NLS-1$
 			List<MPlaceholder> phList = modelService.findElements(workbenchWindow, descId,
 					MPlaceholder.class, null, EModelService.PRESENTATION);
-			if (phList.size() > 0) {
+			if (!phList.isEmpty()) {
 				MUIElement phParent = phList.get(0).getParent();
 				if (phParent instanceof MPartStack) {
 					MPartStack theStack = (MPartStack) phParent;


### PR DESCRIPTION
Use isEmpty() API of collections to simplify the emptiness check. reduces one extra comparison.