### PR TITLE
show fully resolved ws path in launcher dialog

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceDialog.java
@@ -49,6 +49,7 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.BorderData;
 import org.eclipse.swt.layout.BorderLayout;
+import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.layout.RowData;
@@ -58,6 +59,7 @@ import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.DirectoryDialog;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
@@ -94,6 +96,7 @@ public class ChooseWorkspaceDialog extends TitleAreaDialog {
 	private Form recentWorkspacesForm;
 
 	private Button defaultButton;
+
 
 	/**
 	 * Create a modal dialog on the argument shell, using and updating the
@@ -447,11 +450,14 @@ public class ChooseWorkspaceDialog extends TitleAreaDialog {
 	}
 
 	protected Combo createPathCombo(Composite panel) {
-		text = new Combo(panel, SWT.BORDER | SWT.LEAD | SWT.DROP_DOWN);
+		Composite c = new Composite(panel, SWT.NONE);
+		FillLayout layout = new FillLayout(SWT.VERTICAL);
+		c.setLayout(layout);
+		text = new Combo(c, SWT.BORDER | SWT.LEAD | SWT.DROP_DOWN);
 		new DirectoryProposalContentAssist().apply(text);
 		text.setTextDirection(SWT.AUTO_TEXT_DIRECTION);
 		text.setFocus();
-		text.setLayoutData(new GridData(400, SWT.DEFAULT));
+		Label label = new Label(c, SWT.BORDER | SWT.LEAD);
 		text.addModifyListener(e -> {
 			Button okButton = getButton(Window.OK);
 			if(okButton != null && !okButton.isDisposed()) {
@@ -464,6 +470,30 @@ public class ChooseWorkspaceDialog extends TitleAreaDialog {
 					}
 				}
 				okButton.setEnabled(nonWhitespaceFound);
+
+				File location = new File(characters);
+				String normalisedPath = location.getAbsoluteFile().toPath().normalize().toString();
+				String normalisedPathWithSeperator = normalisedPath + File.separator;
+				if (!characters.equalsIgnoreCase(normalisedPath)
+						&& !characters.equalsIgnoreCase(normalisedPathWithSeperator)) {
+				label.setText(
+						IDEWorkbenchMessages.ChooseWorkspaceDialog_ResolvedAbsolutePath0
+								+ location.getAbsoluteFile().toPath().normalize());
+				}
+				else {
+					label.setText(""); //$NON-NLS-1$
+				}
+				if (normalisedPath.indexOf("~") != -1) //$NON-NLS-1$
+				{
+					label.setText(IDEWorkbenchMessages.ChooseWorkspaceDialog_TildeNonExpandedWarning0
+							+ IDEWorkbenchMessages.ChooseWorkspaceDialog_ResolvedAbsolutePath0
+							+ location.getAbsoluteFile().toPath().normalize());
+
+				}
+
+
+
+
 			}
 		});
 		setInitialTextValues(text);

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceDialog.java
@@ -483,7 +483,7 @@ public class ChooseWorkspaceDialog extends TitleAreaDialog {
 				else {
 					label.setText(""); //$NON-NLS-1$
 				}
-				if (normalisedPath.indexOf("~") != -1) //$NON-NLS-1$
+				if (normalisedPath.startsWith("~")) //$NON-NLS-1$
 				{
 					label.setText(IDEWorkbenchMessages.ChooseWorkspaceDialog_TildeNonExpandedWarning0
 							+ IDEWorkbenchMessages.ChooseWorkspaceDialog_ResolvedAbsolutePath0

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceDialog.java
@@ -488,12 +488,7 @@ public class ChooseWorkspaceDialog extends TitleAreaDialog {
 					label.setText(IDEWorkbenchMessages.ChooseWorkspaceDialog_TildeNonExpandedWarning0
 							+ IDEWorkbenchMessages.ChooseWorkspaceDialog_ResolvedAbsolutePath0
 							+ location.getAbsoluteFile().toPath().normalize());
-
 				}
-
-
-
-
 			}
 		});
 		setInitialTextValues(text);

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
@@ -1020,6 +1020,10 @@ public class IDEWorkbenchMessages extends NLS {
 	public static String ChooseWorkspaceDialog_directoryBrowserMessage;
 	public static String ChooseWorkspaceDialog_removeWorkspaceSelection;
 	public static String ChooseWorkspaceDialog_recentWorkspaces;
+
+	public static String ChooseWorkspaceDialog_ResolvedAbsolutePath0;
+
+	public static String ChooseWorkspaceDialog_TildeNonExpandedWarning0;
 	public static String ChooseWorkspaceDialog_useDefaultMessage;
 
 	public static String ChooseWorkspaceWithSettingsDialog_SettingsGroupName;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
@@ -1044,6 +1044,8 @@ ChooseWorkspaceDialog_directoryBrowserTitle=Select Workspace Directory
 ChooseWorkspaceDialog_directoryBrowserMessage=Select the workspace directory to use.
 ChooseWorkspaceDialog_removeWorkspaceSelection=Remove from launcher selection
 ChooseWorkspaceDialog_recentWorkspaces=&Recent Workspaces
+ChooseWorkspaceDialog_ResolvedAbsolutePath0=Resolved absolute path: 
+ChooseWorkspaceDialog_TildeNonExpandedWarning0=\u26A0\uFE0F '~' is not expanded, 
 ChooseWorkspaceDialog_useDefaultMessage=&Use this as the default and do not ask again
 
 ChooseWorkspaceWithSettingsDialog_SettingsGroupName=&Copy Settings


### PR DESCRIPTION
Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/issues/279

with normal relative path referencing (good case):
<img width="684" alt="image" src="https://github.com/eclipse-platform/eclipse.platform.ui/assets/122080218/aca33e07-4293-4ab0-8877-aa29e7c82a95">

with `~` in the path referencing (bad case) :
<img width="679" alt="image" src="https://github.com/eclipse-platform/eclipse.platform.ui/assets/122080218/eda5227f-192f-48a6-b7a6-77bdc2195a5f">
