### PR TITLE
Fix faulty <p> / </p> tags in javadoc

### DIFF
--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/internal/PositionInfo.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/internal/PositionInfo.java
@@ -110,7 +110,6 @@ public final class PositionInfo {
 	 * <li><code>after:org.eclipse.test.id</code> - place an element in a list
 	 * after the element with the ID "org.eclipse.test.id"</li>
 	 * </ul>
-	 * </p>
 	 *
 	 * @param positionInfo
 	 *          the positioning string

--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/IJobRunnable.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/IJobRunnable.java
@@ -32,7 +32,6 @@ public interface IJobRunnable {
 	 * finish its execution at the earliest convenience and return a result
 	 * status of severity <code>IStatus.CANCEL</code>. The singleton cancel
 	 * status <code>Status.CANCEL_STATUS</code> can be used for this purpose.
-	 * <p>
 	 *
 	 * @param monitor
 	 *            the monitor to be used for reporting progress and responding

--- a/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/util/ViewerPane.java
+++ b/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/util/ViewerPane.java
@@ -25,7 +25,6 @@ import org.eclipse.jface.action.ToolBarManager;
 /**
  * A <code>ViewerPane</code> is a convenience class which installs a
  * <code>CLabel</code> and a <code>Toolbar</code> in a <code>ViewForm</code>.
- * <P>
  */
 public final class ViewerPane extends ViewForm {
 

--- a/bundles/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/core/priority/PrioriTree.java
+++ b/bundles/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/core/priority/PrioriTree.java
@@ -91,7 +91,6 @@ public class PrioriTree extends DefaultPriorityFunction {
 	 * <p>
 	 * THe picture below illustrates: # marks a target node * marks nodes that implicitly
 	 * also get set. And '-' marks nodes that are unaffected.
-	 * <p>
 	 * <pre>
 	 *                                       *
 	 *                                     /   \

--- a/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/TextAction.java
+++ b/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/TextAction.java
@@ -41,8 +41,7 @@ public class TextAction extends Action {
 	/**
 	 * Copies the selected text to the clipboard.  The text will be put in the
 	 * clipboard in plain text format.
-	 * <p>
-	 *
+	 * 
 	 * @exception SWTException <ul>
 	 *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
 	 *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
@@ -69,7 +68,6 @@ public class TextAction extends Action {
 	/**
 	 * Moves the selected text to the clipboard.  The text will be put in the
 	 * clipboard in plain text format and RTF format.
-	 * <p>
 	 *
 	 * @exception SWTException <ul>
 	 *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
@@ -105,7 +103,6 @@ public class TextAction extends Action {
 	 * If the widget has the SWT.SINGLE style and the clipboard text contains
 	 * more than one line, only the first line without line delimiters is
 	 * inserted in the widget.
-	 * <p>
 	 *
 	 * @exception SWTException <ul>
 	 *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/IPreferenceConstants.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/IPreferenceConstants.java
@@ -229,7 +229,6 @@ public interface IPreferenceConstants {
 
 	/**
 	 * Preference is not supported anymore
-	 * </p>
 	 *
 	 * @since 3.4
 	 *

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/menus/DynamicMenuContributionItem.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/menus/DynamicMenuContributionItem.java
@@ -34,7 +34,6 @@ import org.eclipse.ui.services.IServiceLocator;
  * <p>
  * It currently supports placement in menus.
  * </p>
- * <p>
  *
  * @author Prakash G.R.
  *

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/menus/DynamicToolBarContributionItem.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/menus/DynamicToolBarContributionItem.java
@@ -32,7 +32,6 @@ import org.eclipse.ui.services.IServiceLocator;
  * <p>
  * It currently supports placement in menus.
  * </p>
- * <p>
  *
  * @author Prakash G.R.
  *

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/registry/ActionSetDescriptor.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/registry/ActionSetDescriptor.java
@@ -121,7 +121,6 @@ public class ActionSetDescriptor implements IActionSetDescriptor, IAdaptable, IW
 	/**
 	 * Returns this action set's id. This is the value of its <code>"id"</code>
 	 * attribute.
-	 * <p>
 	 *
 	 * @return the action set id
 	 */

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dnd/DetachedWindowDragTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dnd/DetachedWindowDragTest.java
@@ -26,7 +26,7 @@ import org.eclipse.ui.tests.autotests.AbstractTestLogger;
  * In some cases the sources and targets may overlap with non-detached tests so in order to avoid
  * name clashes in the tests we add a suffix, "(Detached)", to the test's 'name' when the target is
  * 'Detached'.
- * <p>
+ *
  * @since 3.1
  */
 public class DetachedWindowDragTest	extends DragTest {


### PR DESCRIPTION
Fixes the following javadoc errors:
* `empty <p> tag`
* `unexpected end tag: </p>`