### PR TITLE
Fix malformed HTML in javadoc

### DIFF
--- a/bundles/org.eclipse.e4.core.commands/src/org/eclipse/e4/core/commands/ECommandService.java
+++ b/bundles/org.eclipse.e4.core.commands/src/org/eclipse/e4/core/commands/ECommandService.java
@@ -51,7 +51,7 @@ import org.eclipse.core.commands.ParameterizedCommand;
  *
  * Command command = cs.getCommand(commandId);
  * if (command.isDefined()) {
- *	Map<String, Object> parameters = new HashMap<String, Object>();
+ *	Map&lt;String, Object&gt; parameters = new HashMap&lt;String, Object&gt;();
  *	parameters.put("parm1", "hello, world");
  *	ParameterizedCommand parmCmd = cs.createCommand(commandId, parameters);
  *	if (hs.canExecute(parmCmd)) {

--- a/bundles/org.eclipse.e4.core.commands/src/org/eclipse/e4/core/commands/EHandlerService.java
+++ b/bundles/org.eclipse.e4.core.commands/src/org/eclipse/e4/core/commands/EHandlerService.java
@@ -50,7 +50,7 @@ import org.eclipse.e4.core.contexts.IEclipseContext;
  *
  * Command command = cs.getCommand(commandId);
  * if (command.isDefined()) {
- *	Map<String, Object> parameters = new HashMap<String, Object>();
+ *	Map&lt;String Object&gt; parameters = new HashMap&lt;String, Object&gt;();
  *	parameters.put("parm1", "hello, world");
  *	ParameterizedCommand parmCmd = cs.createCommand(commandId, parameters);
  *	if (hs.canExecute(parmCmd)) {

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/contentassist/BarContentAssistProcessor.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/contentassist/BarContentAssistProcessor.java
@@ -145,7 +145,7 @@ public class BarContentAssistProcessor implements IContentAssistProcessorExtensi
 	}
 
 	/**
-	 * Creates context info "idx= <word index in #PROPOSAL>" at the end of a word.
+	 * Creates context info "idx= &lt;word index in #PROPOSAL&gt;" at the end of a word.
 	 **/
 	@Override
 	public IContextInformation[] computeContextInformation(ITextViewer viewer, int offset) {

--- a/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/StringMatcher.java
+++ b/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/StringMatcher.java
@@ -98,7 +98,8 @@ public class StringMatcher {
 	}
 
 	/**
-	 * Find the first occurrence of the pattern between <code>start</code )(inclusive) and <code>end</code>(exclusive).
+	 * Find the first occurrence of the pattern between
+	 * <code>start</code> (inclusive) and <code>end</code> (exclusive).
 	 *
 	 * @param text
 	 *            the String object to search in


### PR DESCRIPTION
Fixes javadoc errors: `malformed HTML`