### PR TITLE
Fix faulty <li> tags in javadoc

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/ModelAssemblerFragmentOrderingTests.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/ModelAssemblerFragmentOrderingTests.java
@@ -129,10 +129,11 @@ public class ModelAssemblerFragmentOrderingTests {
 	 * Empty application.
 	 * <p>
 	 * Contributed fragments:
-	 * <li>fragment1 - menu item a
-	 * <li>fragment2 - menu item b
-	 * <li>fragment3 - menu item c
-	 * <p>
+	 * <ul>
+	 * <li>fragment1 - menu item a</li>
+	 * <li>fragment2 - menu item b</li>
+	 * <li>fragment3 - menu item c</li>
+	 * </ul>
 	 * Expected result: a, b, c.
 	 */
 	@Test
@@ -339,10 +340,11 @@ public class ModelAssemblerFragmentOrderingTests {
 	 * Empty application.
 	 * <p>
 	 * Contributed fragments:
-	 * <li>fragment1 - menu item a - index:1
-	 * <li>fragment2 - menu item b - index:2
-	 * <li>fragment3 - menu item c - index:3
-	 * <p>
+	 * <ul>
+	 * <li>fragment1 - menu item a - index:1</li>
+	 * <li>fragment2 - menu item b - index:2</li>
+	 * <li>fragment3 - menu item c - index:3</li>
+	 * </ul>
 	 * Expected result: a, b, c.
 	 */
 	@Test
@@ -394,10 +396,11 @@ public class ModelAssemblerFragmentOrderingTests {
 	 * Empty application.
 	 * <p>
 	 * Contributed fragments:
-	 * <li>fragment1 - menu item a - index:3
-	 * <li>fragment2 - menu item b - index:2
-	 * <li>fragment3 - menu item c - index:1
-	 * <p>
+	 * <ul>
+	 * <li>fragment1 - menu item a - index:3</li>
+	 * <li>fragment2 - menu item b - index:2</li>
+	 * <li>fragment3 - menu item c - index:1</li>
+	 * </ul>
 	 * Expected result: c, b, a.
 	 */
 	@Test
@@ -450,10 +453,11 @@ public class ModelAssemblerFragmentOrderingTests {
 	 * Empty application.
 	 * <p>
 	 * Contributed fragments:
-	 * <li>fragment1 - menu item a - index:3
-	 * <li>fragment2 - menu item b - index:1
-	 * <li>fragment3 - menu item c - index:2
-	 * <p>
+	 * <ul>
+	 * <li>fragment1 - menu item a - index:3</li>
+	 * <li>fragment2 - menu item b - index:1</li>
+	 * <li>fragment3 - menu item c - index:2</li>
+	 * </ul>
 	 * Expected result: c, b, a.
 	 */
 	@Test
@@ -506,11 +510,12 @@ public class ModelAssemblerFragmentOrderingTests {
 	 * Application with menu items x y z .
 	 * <p>
 	 * Contributed fragments:
-	 * <li>fragment1 - menu item a - index:9
-	 * <li>fragment2 - menu item b - index:1
-	 * <li>fragment3 - menu item c - index:0
-	 * <li>fragment4 - menu item d - index:3
-	 * <p>
+	 * <ul>
+	 * <li>fragment1 - menu item a - index:9</li>
+	 * <li>fragment2 - menu item b - index:1</li>
+	 * <li>fragment3 - menu item c - index:0</li>
+	 * <li>fragment4 - menu item d - index:3</li>
+	 * </ul>
 	 * Expected result: c, b, x, d, y, z, a
 	 */
 	@Test

--- a/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/common/ResourceSearchScope.java
+++ b/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/common/ResourceSearchScope.java
@@ -16,9 +16,9 @@ package org.eclipse.e4.tools.emf.ui.common;
 
 /**
  * Specifies the scope when searching for a resource. This differs from the PDE
- * search functions in that <li>more than just java objects can be queried. <li>
- * Searches can specify the current project only, current workspace, non bundle
- * projects, and target platform.
+ * search functions in that more than just java objects can be queried. Searches
+ * can specify the current project only, current workspace, non bundle projects,
+ * and target platform.
  *
  * @author Steven Spungin
  */

--- a/tools/bundles/org.eclipse.e4.tools.jdt.templates/src/org/eclipse/e4/internal/tools/jdt/templates/E4ContextType.java
+++ b/tools/bundles/org.eclipse.e4.tools.jdt.templates/src/org/eclipse/e4/internal/tools/jdt/templates/E4ContextType.java
@@ -17,13 +17,13 @@ import org.eclipse.jdt.internal.corext.template.java.AbstractJavaContextType;
 import org.eclipse.jdt.internal.corext.template.java.IJavaContext;
 
 /**
- * The context type for templates inside e4 code.
- * The same class is used for several context types:
- * <dl>
+ * The context type for templates inside e4 code. The same class is used for
+ * several context types:
+ * <ul>
  * <li>templates for all Java code locations</li>
  * <li>templates for member locations</li>
  * <li>templates for statement locations</li>
- * </dl>
+ * </ul>
  */
 @SuppressWarnings("restriction")
 public class E4ContextType extends AbstractJavaContextType {


### PR DESCRIPTION
Fixes: `tag not allowed here: <li>`