### PR TITLE
Fix faulty braces around @return

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/internal/ExpandableNode.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/internal/ExpandableNode.java
@@ -92,7 +92,7 @@ public class ExpandableNode {
 	 * this node up to this offset (but not including it). In other worlds, this is
 	 * the index of first invisible element under this node.
 	 *
-	 * {@return current offset in the original list of elements}
+	 * @return current offset in the original list of elements
 	 */
 	public int getOffset() {
 		return startOffSet;
@@ -109,8 +109,8 @@ public class ExpandableNode {
 	 * This method returns those children of the current node which are supposed to
 	 * be not created / shown yet in the viewer.
 	 *
-	 * {@return all remaining elements from original array starting with the element
-	 * at offset index}
+	 * @return all remaining elements from original array starting with the element
+	 *         at offset index
 	 */
 	public Object[] getRemainingElements() {
 		if (addedElements.size() > 0) {


### PR DESCRIPTION
Braces around @return are only valid if no description is provided, as the return description is then used for the general description.

This adresses the two javadoc warnings reported in Jenkins:
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/755472/98b7fce9-05a2-4272-a097-ae3731bb3e69)
