### PR TITLE
Fix faulty javadoc references

### DIFF
--- a/bundles/org.eclipse.e4.ui.di/src/org/eclipse/e4/ui/di/AboutToHide.java
+++ b/bundles/org.eclipse.e4.ui.di/src/org/eclipse/e4/ui/di/AboutToHide.java
@@ -24,10 +24,13 @@ import java.lang.annotation.Target;
  * Use this annotation to act on to the list of dynamically shown entries within
  * a DynamicMenuContributionItem. Usage in contribution class:
  * <p>
+ * <code>
  * {@literal @}AboutToHide<br>
  * public void aboutToHide(List&lt;MMenuElement&gt; items) { }
+ * </code>
+ * <p>
+ * See {@code org.eclipse.jface.action.IMenuListener2}
  *
- * @see org.eclipse.jface.action.IMenuListener2
  * @since 1.0
  */
 @Documented

--- a/bundles/org.eclipse.e4.ui.di/src/org/eclipse/e4/ui/di/AboutToShow.java
+++ b/bundles/org.eclipse.e4.ui.di/src/org/eclipse/e4/ui/di/AboutToShow.java
@@ -21,13 +21,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Use this annotation to provide MMenuElements to the list of dynamically shown entries
- * within a DynamicMenuContributionItem. Usage in contribution class:
+ * Use this annotation to provide MMenuElements to the list of dynamically shown
+ * entries within a DynamicMenuContributionItem. Usage in contribution class:
  * <p>
+ * <code>
  * {@literal @}AboutToShow<br>
  * public void aboutToShow(List&lt;MMenuElement&gt; items) { }
+ * </code>
+ * <p>
+ * See {@code org.eclipse.jface.action.IMenuListener}
  *
- * @see org.eclipse.jface.action.IMenuListener
  * @since 1.0
  */
 @Documented

--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/IElementCollector.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/IElementCollector.java
@@ -17,11 +17,12 @@ import org.eclipse.core.runtime.IProgressMonitor;
 
 /**
  * IElementCollector is a type that allows for the incremental update of a
- * collection of objects. This used for updating trees incrementally with
- * a progress monitor so that the update can be reported.
+ * collection of objects. This used for updating trees incrementally with a
+ * progress monitor so that the update can be reported.
+ * <p>
+ * See {@code org.eclipse.ui.progress.IDeferredWorkbenchAdapter}<br>
+ * See {@code org.eclipse.ui.progress.DeferredTreeContentManager}
  *
- * @see org.eclipse.ui.progress.IDeferredWorkbenchAdapter
- * @see org.eclipse.ui.progress.DeferredTreeContentManager
  * @since 3.0
  */
 public interface IElementCollector {

--- a/bundles/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/ui/QuickSearchDialog.java
+++ b/bundles/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/ui/QuickSearchDialog.java
@@ -1418,7 +1418,7 @@ public class QuickSearchDialog extends SelectionStatusDialog {
 
 	/**
 	 * Get the control where the search pattern is entered. Any filtering should
-	 * be done using an {@link ItemsFilter}. This control should only be
+	 * be done using an {@code ItemsFilter}. This control should only be
 	 * accessed for listeners that wish to handle events that do not affect
 	 * filtering such as custom traversal.
 	 *

--- a/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/IBrowserDescriptorWorkingCopy.java
+++ b/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/IBrowserDescriptorWorkingCopy.java
@@ -12,12 +12,14 @@
  *     IBM Corporation - Initial API and implementation
  *******************************************************************************/
 package org.eclipse.ui.internal.browser;
+
 /**
  * A working copy of an external web browser.
  * <p>
  * This interface is not intended to be implemented by clients.
  * </p>
- * @see org.eclipse.ui.internal.browser.IWebBrowser
+ *
+ * @see org.eclipse.ui.browser.IWebBrowser
  * @see IBrowserDescriptor
  * @since 1.0
  */

--- a/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/TextAction.java
+++ b/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/TextAction.java
@@ -42,7 +42,7 @@ public class TextAction extends Action {
 	 * Copies the selected text to the clipboard.  The text will be put in the
 	 * clipboard in plain text format.
 	 * 
-	 * @exception SWTException <ul>
+	 * @exception org.eclipse.swt.SWTException <ul>
 	 *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
 	 *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
 	 * </ul>
@@ -69,7 +69,7 @@ public class TextAction extends Action {
 	 * Moves the selected text to the clipboard.  The text will be put in the
 	 * clipboard in plain text format and RTF format.
 	 *
-	 * @exception SWTException <ul>
+	 * @exception org.eclipse.swt.SWTException <ul>
 	 *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
 	 *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
 	 * </ul>
@@ -104,7 +104,7 @@ public class TextAction extends Action {
 	 * more than one line, only the first line without line delimiters is
 	 * inserted in the widget.
 	 *
-	 * @exception SWTException <ul>
+	 * @exception org.eclipse.swt.SWTException <ul>
 	 *    <li>ERROR_WIDGET_DISPOSED - if the receiver has been disposed</li>
 	 *    <li>ERROR_THREAD_INVALID_ACCESS - if not called from the thread that created the receiver</li>
 	 * </ul>

--- a/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/WebBrowserUIPlugin.java
+++ b/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/WebBrowserUIPlugin.java
@@ -66,10 +66,11 @@ public class WebBrowserUIPlugin extends AbstractUIPlugin {
 	/**
 	 * Returns an array of all known browers.
 	 * <p>
-	 * A new array is returned on each call, so clients may store or modify the result.
+	 * A new array is returned on each call, so clients may store or modify the
+	 * result.
 	 * </p>
 	 *
-	 * @return a possibly-empty array of browser instances {@link IClient}
+	 * @return a possibly-empty array of browser instances
 	 */
 	public static IBrowserExt[] getBrowsers() {
 		if (browsers == null)

--- a/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/macosx/DefaultBrowser.java
+++ b/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/macosx/DefaultBrowser.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.browser.macosx;
 
-import java.io.*;
+import java.io.IOException;
 import java.net.URL;
 
 import org.eclipse.ui.browser.AbstractWebBrowser;
@@ -25,9 +25,6 @@ public class DefaultBrowser extends AbstractWebBrowser {
 		super(id);
 	}
 
-	/**
-	 * @see org.eclipse.help.browser.IBrowser#displayURL(String)
-	 */
 	@Override
 	public void openURL(URL url2) {
 		String url = url2.toExternalForm();

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/CharacterPairMatcherRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/CharacterPairMatcherRegistry.java
@@ -48,8 +48,8 @@ public class CharacterPairMatcherRegistry {
 	}
 
 	/**
-	 * Get the contributed {@link IPresentationReconciliers}s that are relevant to
-	 * hook on source viewer according to document content types.
+	 * Get the contributed {@link ICharacterPairMatcher}s that are relevant to hook
+	 * on source viewer according to document content types.
 	 *
 	 * @param sourceViewer the source viewer we're hooking completion to.
 	 * @param editor       the text editor

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/PresentationReconcilerRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/PresentationReconcilerRegistry.java
@@ -50,8 +50,9 @@ public class PresentationReconcilerRegistry {
 	}
 
 	/**
-	 * Get the contributed {@link IPresentationReconciliers}s that are relevant to hook on source viewer according
-	 * to document content types.
+	 * Get the contributed {@link IPresentationReconciler}s that are relevant to
+	 * hook on source viewer according to document content types.
+	 * 
 	 * @param sourceViewer the source viewer we're hooking completion to.
 	 * @param editor the text editor
 	 * @param contentTypes the content types of the document we're editing.

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ReconcilerRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ReconcilerRegistry.java
@@ -67,7 +67,7 @@ public class ReconcilerRegistry {
 	}
 
 	/**
-	 * Get the contributed {@link IReconciliers}s that are relevant to hook on
+	 * Get the contributed {@link IReconciler}s that are relevant to hook on
 	 * source viewer according to document content types.
 	 *
 	 * @param sourceViewer         the source viewer we're hooking completion to.
@@ -86,7 +86,7 @@ public class ReconcilerRegistry {
 	}
 
 	/**
-	 * Get the contributed highlight {@link IReconciliers}s that are relevant to
+	 * Get the contributed highlight {@link IReconciler}s that are relevant to
 	 * hook on source viewer according to document content types.
 	 *
 	 * @param sourceViewer         the source viewer we're hooking completion to.
@@ -106,7 +106,7 @@ public class ReconcilerRegistry {
 	}
 
 	/**
-	 * Get the contributed folding {@link IReconciliers}s that are relevant to hook
+	 * Get the contributed folding {@link IReconciler}s that are relevant to hook
 	 * on source viewer according to document content types.
 	 *
 	 * @param sourceViewer         the source viewer we're hooking completion to.

--- a/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/monitoring/StackSample.java
+++ b/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/monitoring/StackSample.java
@@ -31,8 +31,7 @@ public class StackSample {
 	 *
 	 * @param timestamp time in milliseconds since January 1, 1970 UTC when the thread stacks
 	 *     were sampled
-	 * @param traces thread information for either all threads or just the display thread,
-	 *     depending on the value of the {@link PreferenceConstants#DUMP_ALL_THREADS} preference
+	 * @param traces thread information for either all threads or just the display thread
 	 */
 	public StackSample(long timestamp, ThreadInfo[] traces) {
 		this.timestamp = timestamp;

--- a/examples/org.eclipse.e4.ui.examples.job/src/org/eclipse/e4/ui/examples/jobs/views/JobsView.java
+++ b/examples/org.eclipse.e4.ui.examples.job/src/org/eclipse/e4/ui/examples/jobs/views/JobsView.java
@@ -163,9 +163,6 @@ public class JobsView {
 		}
 	}
 
-	/**
-	 * @see ViewPart#createPartControl(Composite)
-	 */
 	@PostConstruct
 	public void createPartControl(Composite parent) {
 		this.parent = parent;
@@ -559,9 +556,6 @@ else
 		}
 	}
 
-	/**
-	 * @see ViewPart#setFocus()
-	 */
 	@Focus
 	public void setFocus() {
 		if (durationField != null && !durationField.isDisposed())

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/internal/databinding/conversion/ObjectToPrimitiveValidatorTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/internal/databinding/conversion/ObjectToPrimitiveValidatorTest.java
@@ -36,8 +36,7 @@ public class ObjectToPrimitiveValidatorTest {
 	}
 
 	/**
-	 * Test method for
-	 * {@link org.eclipse.jface.internal.databinding.provisional.validation.ObjectToPrimitiveValidator#isValid(java.lang.Object)}.
+	 * Test method for {@link ObjectToPrimitiveValidator#validate(Object)}.
 	 */
 	@Test
 	public void testIsValid() {

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/FileUtil.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/FileUtil.java
@@ -67,8 +67,7 @@ public class FileUtil {
 	 * a runnable)<br/>
 	 * <br/>
 	 * This method was copied from
-	 * {@link org.eclipse.jdt.internal.ui.util.CoreUtility#createFolder(IFolder, boolean, boolean, IProgressMonitor)
-	 * CoreUtility#createFolder}.
+	 * {@code org.eclipse.jdt.internal.ui.util.CoreUtility#createFolder(IFolder, boolean, boolean, IProgressMonitor)}.
 	 *
 	 * @param folder  the folder to create
 	 * @param force   a flag controlling how to deal with resources that are not in

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/cdt/CNavigatorLabelProvider.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/cdt/CNavigatorLabelProvider.java
@@ -23,9 +23,9 @@ import org.eclipse.ui.navigator.ICommonLabelProvider;
 /**
  * A label provider suitable for the Common Navigator providing also status
  * message text for the current selected item.
- *
- * @see org.eclipse.cdt.internal.ui.cview.CView#createLabelProvider
- * @see org.eclipse.cdt.internal.ui.cview.CView#getStatusLineMessage
+ * <p>
+ * See {@code org.eclipse.cdt.internal.ui.cview.CView#createLabelProvider}<br>
+ * See {@code org.eclipse.cdt.internal.ui.cview.CView#getStatusLineMessage}
  */
 public class CNavigatorLabelProvider extends LabelProvider implements
 		ICommonLabelProvider {

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/BasicPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/BasicPerformanceTest.java
@@ -140,10 +140,11 @@ public abstract class BasicPerformanceTest extends UITestCase {
 	}
 
 	/**
-	 * Called from within a test case immediately before the code to measure is
-	 * run. It starts capturing of performance data. Must be followed by a call
-	 * to {@link PerformanceTestCase#stopMeasuring()}before subsequent calls to
-	 * this method or {@link PerformanceTestCase#commitMeasurements()}.
+	 * Called from within a test case immediately before the code to measure is run.
+	 * It starts capturing of performance data. Must be followed by a call to
+	 * {@link org.eclipse.test.performance.PerformanceTestCase#stopMeasuring()}before
+	 * subsequent calls to this method or
+	 * {@link org.eclipse.test.performance.PerformanceTestCase#commitMeasurements()}.
 	 */
 	public void startMeasuring() {
 		tester.startMeasuring();

--- a/tests/org.eclipse.ui.tests.views.properties.tabbed/src/org/eclipse/ui/tests/views/properties/tabbed/override/items/IOverrideTestsItem.java
+++ b/tests/org.eclipse.ui.tests.views.properties.tabbed/src/org/eclipse/ui/tests/views/properties/tabbed/override/items/IOverrideTestsItem.java
@@ -52,9 +52,11 @@ public interface IOverrideTestsItem {
 	public Composite getComposite();
 
 	/**
-	 * Get the kind of {@link Element} that this item applies to.
+	 * Get the kind of
+	 * {@link org.eclipse.ui.tests.views.properties.tabbed.model.Element} that this
+	 * item applies to.
 	 *
-	 * @return the kind of {@link Element} that this item applies to.
+	 * @return the kind of element that this item applies to.
 	 */
 	public Class getElement();
 

--- a/tests/org.eclipse.ui.tests.views.properties.tabbed/src/org/eclipse/ui/tests/views/properties/tabbed/sections/NameSection.java
+++ b/tests/org.eclipse.ui.tests.views.properties.tabbed/src/org/eclipse/ui/tests/views/properties/tabbed/sections/NameSection.java
@@ -41,10 +41,6 @@ public class NameSection
 
 	private Text nameText;
 
-	/**
-	 * @see org.eclipse.ui.views.properties.tabbed.ITabbedPropertySection#createControls(org.eclipse.swt.widgets.Composite,
-	 *      org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetPage)
-	 */
 	@Override
 	public void createControls(Composite parent,
 			TabbedPropertySheetPage tabbedPropertySheetPage) {
@@ -80,9 +76,6 @@ public class NameSection
 		return treeNode;
 	}
 
-	/*
-	 * @see org.eclipse.ui.views.properties.tabbed.view.ITabbedPropertySection#refresh()
-	 */
 	@Override
 	public void refresh() {
 		Element element = (Element) getTreeNode().getValue();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/TestAdaptableWorkbenchAdapter.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/TestAdaptableWorkbenchAdapter.java
@@ -69,13 +69,13 @@ public class TestAdaptableWorkbenchAdapter extends LabelProvider implements
 	}
 
 	/**
-	 * Returns an image descriptor that is based on the given descriptor,
-	 * but decorated with additional information relating to the state
-	 * of the provided object.
+	 * Returns an image descriptor that is based on the given descriptor, but
+	 * decorated with additional information relating to the state of the provided
+	 * object.
 	 *
-	 * Subclasses may reimplement this method to decorate an object's
-	 * image.
-	 * @see org.eclipse.jface.resource.CompositeImage
+	 * Subclasses may reimplement this method to decorate an object's image.
+	 *
+	 * @see org.eclipse.jface.resource.CompositeImageDescriptor
 	 */
 	protected ImageDescriptor decorateImage(ImageDescriptor input,
 			Object element) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorActionDelegateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorActionDelegateTest.java
@@ -57,18 +57,12 @@ public class IEditorActionDelegateTest extends IActionDelegateTest {
 				"setActiveEditor", "selectionChanged", "run" }));
 	}
 
-	/**
-	 * @see IActionDelegateTest#createActionWidget()
-	 */
 	@Override
 	protected Object createActionWidget() throws Throwable {
 		editor = openEditor(fPage, "X");
 		return editor;
 	}
 
-	/**
-	 * @see IActionDelegateTest#runAction()
-	 */
 	@Override
 	protected void runAction(Object widget) throws Throwable {
 		MockEditorPart editor = (MockEditorPart) widget;
@@ -78,9 +72,6 @@ public class IEditorActionDelegateTest extends IActionDelegateTest {
 		ActionUtil.runActionWithLabel(this, mgr, "Mock Action");
 	}
 
-	/**
-	 * @see IActionDelegateTest#fireSelection()
-	 */
 	@Override
 	protected void fireSelection(Object widget) throws Throwable {
 		MockEditorPart editor = (MockEditorPart) widget;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IViewActionDelegateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IViewActionDelegateTest.java
@@ -50,17 +50,11 @@ public class IViewActionDelegateTest extends IActionDelegateTest {
 				"selectionChanged", "run" }));
 	}
 
-	/**
-	 * @see IActionDelegateTest#createActionWidget()
-	 */
 	@Override
 	protected Object createActionWidget() throws Throwable {
 		return fPage.showView(TEST_VIEW_ID);
 	}
 
-	/**
-	 * @see IActionDelegateTest#runAction()
-	 */
 	@Override
 	protected void runAction(Object widget) throws Throwable {
 		MockViewPart view = (MockViewPart) widget;
@@ -68,9 +62,6 @@ public class IViewActionDelegateTest extends IActionDelegateTest {
 		ActionUtil.runActionWithLabel(this, mgr, "Mock Action");
 	}
 
-	/**
-	 * @see IActionDelegateTest#fireSelection()
-	 */
 	@Override
 	protected void fireSelection(Object widget) throws Throwable {
 		MockViewPart view = (MockViewPart) widget;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchWindowActionDelegateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchWindowActionDelegateTest.java
@@ -115,26 +115,17 @@ public class IWorkbenchWindowActionDelegateTest extends IActionDelegateTest {
 		assertFalse(mockWWinActionDelegate.callHistory.verifyOrder(new String[] {"dispose", "dispose"}));
 	}
 
-	/**
-	 * @see IActionDelegateTest#createActionWidget()
-	 */
 	@Override
 	protected Object createActionWidget() throws Throwable {
 		fPage.showActionSet("org.eclipse.ui.tests.api.MockActionSet");
 		return null;
 	}
 
-	/**
-	 * @see IActionDelegateTest#runAction()
-	 */
 	@Override
 	protected void runAction(Object widget) throws Throwable {
 		ActionUtil.runActionWithLabel(this, fWindow, "Mock Action");
 	}
 
-	/**
-	 * @see IActionDelegateTest#fireSelection()
-	 */
 	@Override
 	protected void fireSelection(Object widget) throws Throwable {
 		MockViewPart view = (MockViewPart) fPage.showView(MockViewPart.ID);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/MockActionDelegate.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/MockActionDelegate.java
@@ -32,32 +32,20 @@ public class MockActionDelegate implements IWorkbenchWindowActionDelegate {
 		lastMockActionDelegate = this;
 	}
 
-	/*
-	 * @see IWorkbenchWindowActionDelegate#init(IWorkbenchWindow)
-	 */
 	@Override
 	public void init(IWorkbenchWindow window) {
 	}
 
-	/**
-	 * @see IActionDelegate#run(IAction)
-	 */
 	@Override
 	public void run(IAction action) {
 		callHistory.add("run");
 	}
 
-	/**
-	 * @see IActionDelegate#selectionChanged(IAction, ISelection)
-	 */
 	@Override
 	public void selectionChanged(IAction action, ISelection selection) {
 		callHistory.add("selectionChanged");
 	}
 
-	/*
-	 * @see IWorkbenchWindowActionDelegate#dispose()
-	 */
 	@Override
 	public void dispose() {
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/MockEditorActionBarContributor.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/MockEditorActionBarContributor.java
@@ -40,9 +40,6 @@ public class MockEditorActionBarContributor extends EditorActionBarContributor {
 		return callHistory;
 	}
 
-	/**
-	 * @see IEditorActionBarContributor#init(IActionBars)
-	 */
 	@Override
 	public void init(IActionBars bars) {
 		callHistory.add("init");
@@ -56,9 +53,6 @@ public class MockEditorActionBarContributor extends EditorActionBarContributor {
 		super.init(bars);
 	}
 
-	/**
-	 * @see EditorActionBarContributor#contributeToToolBar(IToolBarManager)
-	 */
 	@Override
 	public void contributeToToolBar(IToolBarManager toolBarManager) {
 		for (MockAction action : actions) {
@@ -66,9 +60,6 @@ public class MockEditorActionBarContributor extends EditorActionBarContributor {
 		}
 	}
 
-	/**
-	 * @see IEditorActionBarContributor#setActiveEditor(IEditorPart)
-	 */
 	@Override
 	public void setActiveEditor(IEditorPart targetEditor) {
 		callHistory.add("setActiveEditor");

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/PerspectiveViewsBug120934.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/PerspectiveViewsBug120934.java
@@ -19,8 +19,8 @@ import org.eclipse.ui.IPerspectiveFactory;
 
 /**
  * A layout that can trigger an problem interaction between
- * {@link org.eclipse.ui.internal.presentations.util.PresentablePartFolder}
- * and {@link org.eclipse.ui.internal.presentations.defaultpresentation.EmptyTabFolder}.
+ * {@code org.eclipse.ui.internal.presentations.util.PresentablePartFolder} and
+ * {@code org.eclipse.ui.internal.presentations.defaultpresentation.EmptyTabFolder}.
  *
  * @since 3.2
  */

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/contexts/ContextPage.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/contexts/ContextPage.java
@@ -28,7 +28,7 @@ import org.eclipse.ui.part.Page;
  * This class may be instantiated; it is not intended to be subclassed.
  * </p>
  *
- * @see PageBookView
+ * @see org.eclipse.ui.part.PageBookView
  */
 public class ContextPage extends Page {
 	public static final String TEST_CONTEXT_ID = "org.eclipse.ui.tests.contexts.Page";

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/databinding/WorkbenchDatabindingTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/databinding/WorkbenchDatabindingTest.java
@@ -235,9 +235,9 @@ public class WorkbenchDatabindingTest {
 	}
 
 	/**
-	 * {@link WorkbenchProperties#activeEditorReference} is implemented using
-	 * {@link WorkbenchProperties#activePartReference}, so we only need to verify
-	 * that the conversion works.
+	 * {@link WorkbenchProperties#activePartAsEditorReference()} is implemented
+	 * using {@link WorkbenchProperties#activePartReference()}, so we only need to
+	 * verify that the conversion works.
 	 */
 	@Test
 	public void testActiveEditorReference() {
@@ -262,11 +262,6 @@ public class WorkbenchDatabindingTest {
 		assertEquals(IEditorReference.class, WorkbenchProperties.activePartAsEditorReference().getValueType());
 	}
 
-	/**
-	 * {@link WorkbenchProperties#activeEditorReference} is implemented using
-	 * {@link WorkbenchProperties#activePartReference}, so we only need to verify
-	 * that the conversion works.
-	 */
 	@Test
 	public void testEditorInput() {
 		IEditorPart editor = mock(IEditorPart.class);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/decorators/NullImageDecorator.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/decorators/NullImageDecorator.java
@@ -19,7 +19,7 @@ import org.eclipse.jface.viewers.ILightweightLabelDecorator;
 import org.eclipse.ui.tests.internal.ForcedException;
 
 /**
- * @see ILabelDecorator
+ * @see org.eclipse.jface.viewers.ILabelDecorator
  */
 public class NullImageDecorator implements ILightweightLabelDecorator {
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/JobInfoTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/JobInfoTest.java
@@ -86,8 +86,8 @@ public class JobInfoTest {
 	}
 
 	/**
-	 * Test that {@link org.eclipse.ui.internal.progress.JobInfo#compareTo(Object)}
-	 * is valid implemented and complies to the interface method contract.
+	 * Test that {@link JobSnapshot#compareTo(JobSnapshot)} is valid implemented and
+	 * complies to the interface method contract.
 	 */
 	@Test
 	public void testCompareToContractCompliance() {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertyPages/TableResizePropertyPage.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertyPages/TableResizePropertyPage.java
@@ -72,9 +72,6 @@ public class TableResizePropertyPage extends PropertyPage {
 
 	}
 
-	/**
-	 * @see PreferencePage#createContents(Composite)
-	 */
 	@Override
 	protected Control createContents(Composite parent) {
 		Composite composite = new Composite(parent, SWT.NONE);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertyPages/TreeResizePropertyPage.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertyPages/TreeResizePropertyPage.java
@@ -73,9 +73,6 @@ public class TreeResizePropertyPage extends PropertyPage {
 
 	}
 
-	/**
-	 * @see PreferencePage#createContents(Composite)
-	 */
 	@Override
 	protected Control createContents(Composite parent) {
 		Composite composite = new Composite(parent, SWT.NONE);

--- a/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/imp/ModelImportWizard.java
+++ b/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/imp/ModelImportWizard.java
@@ -85,7 +85,6 @@ public class ModelImportWizard extends Wizard {
 	 * @return the extension point name associated with the {@link MApplicationElement} that is passed in the
 	 *         constructor of
 	 *         this wizard.
-	 * @see #MAPPING_EXTENSION
 	 * @see #getApplicationElement()
 	 */
 	protected String getExtensionPointName() {
@@ -96,7 +95,6 @@ public class ModelImportWizard extends Wizard {
 	 * @return the extension point id associated with the {@link MApplicationElement} that is passed in the constructor
 	 *         of
 	 *         this wizard.
-	 * @see #MAPPING_EXTENSION
 	 * @see #getApplicationElement()
 	 */
 	protected String getExtensionPoint() {
@@ -106,7 +104,6 @@ public class ModelImportWizard extends Wizard {
 	/**
 	 * @return the attribute name of the {@link IConfigurationElement} that
 	 *         contains the description that you want to see in the wizard page.
-	 * @see #MAPPING_NAME
 	 */
 	protected String getMappingName() {
 		return RegistryUtil.getStruct(applicationElement, getHint()).getMappingName();
@@ -115,8 +112,6 @@ public class ModelImportWizard extends Wizard {
 	/**
 	 * Returns the list of {@link MApplicationElement}s of the type passed in
 	 * the constructor of the wizard.
-	 *
-	 *
 	 *
 	 * @return an array of {@link MApplicationElement}
 	 */


### PR DESCRIPTION
Fixes all logged javadoc errors of type "reference not found":
* Remove faulty or outdated javadoc containing faulty reference
* Remove obsolete `@see SUPERCLASS_DOCUMENTATION` javadoc for overwritten methods
* Correct faulty references to types and types if they are accessible
* Replace type links with code tags in case a references type is accessible (i.e., not on the bundle's classpath)