### PR TITLE
Fix unknown javadoc tags

### DIFF
--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/legacy/StatusUtil.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/legacy/StatusUtil.java
@@ -22,8 +22,8 @@ import org.eclipse.e4.ui.progress.internal.ProgressMessages;
 /**
  * Utility class to create status objects.
  *
- * @private - This class is an internal implementation class and should
- * not be referenced or subclassed outside of the workbench
+ * @noreference This class is an internal implementation class and should not be
+ *              referenced or subclassed outside of the workbench
  */
 public class StatusUtil {
 

--- a/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringStatusViewer.java
+++ b/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringStatusViewer.java
@@ -179,8 +179,7 @@ public class RefactoringStatusViewer extends SashForm {
 	}
 
 	/**
-	 * Returns the currently used <tt>RefactoringStatus</tt>.
-	 * @return the <tt>RefactoringStatus</tt>
+	 * @return the currently used {@link RefactoringStatus}
 	 */
 	public RefactoringStatus getStatus() {
 		return fStatus;

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/IWorkbenchHelpContextIds.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/IWorkbenchHelpContextIds.java
@@ -24,10 +24,8 @@ import org.eclipse.ui.PlatformUI;
  * This interface contains constants only; it is not intended to be implemented
  * or extended.
  * </p>
- *
- * @issue this class has been xcloned to org.eclipse.ui.internal.ide package;
- *        remove all IDE-specific constants from here
  */
+// TODO This class has been xcloned to org.eclipse.ui.internal.ide package; remove all IDE-specific constants from here
 public interface IWorkbenchHelpContextIds {
 	String PREFIX = PlatformUI.PLUGIN_ID + "."; //$NON-NLS-1$
 

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchPlugin.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchPlugin.java
@@ -160,9 +160,8 @@ public class WorkbenchPlugin extends AbstractUIPlugin {
 
 	/**
 	 * The workbench plugin ID.
-	 *
-	 * @issue we should just drop this constant and use PlatformUI.PLUGIN_ID instead
 	 */
+	// TODO we should just drop this constant and use PlatformUI.PLUGIN_ID instead
 	public static String PI_WORKBENCH = PlatformUI.PLUGIN_ID;
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/misc/StatusUtil.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/misc/StatusUtil.java
@@ -28,8 +28,8 @@ import org.eclipse.ui.statushandlers.StatusManager;
 /**
  * Utility class to create status objects.
  *
- * @private - This class is an internal implementation class and should not be
- *          referenced or subclassed outside of the workbench
+ * @noreference This class is an internal implementation class and should not be
+ *              referenced or subclassed outside of the workbench
  */
 public class StatusUtil {
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/misc/TestPartListener.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/misc/TestPartListener.java
@@ -23,9 +23,8 @@ import org.eclipse.ui.IWorkbenchPart;
 public class TestPartListener implements IPartListener {
 	/**
 	 * TestPartListener constructor comment.
-	 *
-	 * @issue seems like garbage - no one using it
 	 */
+	// TODO seems like garbage - no one using it
 	public TestPartListener() {
 		super();
 	}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/registry/EditorDescriptor.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/registry/EditorDescriptor.java
@@ -555,9 +555,8 @@ public final class EditorDescriptor implements IEditorDescriptor, Serializable, 
 	 * Sets the open mode of this editor descriptor.
 	 *
 	 * @param mode the open mode
-	 *
-	 * @issue this method is public as a temporary fix for bug 47600
 	 */
+	// TODO this method is public as a temporary fix for bug 47600
 	public void setOpenMode(int mode) {
 		openMode = mode;
 	}

--- a/examples/org.eclipse.ui.examples.job/src/org/eclipse/ui/examples/jobs/BusyShowWhileDialog.java
+++ b/examples/org.eclipse.ui.examples.job/src/org/eclipse/ui/examples/jobs/BusyShowWhileDialog.java
@@ -27,9 +27,6 @@ import org.eclipse.ui.PlatformUI;
  * BusyShowWhileDialog is a test of busyShowWhile in a modal dialog.
  */
 public class BusyShowWhileDialog extends IconAndMessageDialog {
-	/**
-	 * @todo Generated comment
-	 */
 	public BusyShowWhileDialog(Shell parentShell) {
 		super(parentShell);
 		message = "Busy While Test"; //$NON-NLS-1$

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/jface/tests/internal/databinding/swt/DateTimeCalendarObservableValueTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/jface/tests/internal/databinding/swt/DateTimeCalendarObservableValueTest.java
@@ -33,7 +33,6 @@ import org.junit.Test;
 
 /**
  * @since 3.2
- * @no
  */
 public class DateTimeCalendarObservableValueTest extends AbstractSWTTestCase {
 	private DateTime dateTime;

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/jface/tests/internal/databinding/swt/DateTimeDateObservableValueTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/jface/tests/internal/databinding/swt/DateTimeDateObservableValueTest.java
@@ -33,7 +33,6 @@ import org.junit.Test;
 
 /**
  * @since 3.2
- * @no
  */
 public class DateTimeDateObservableValueTest extends AbstractSWTTestCase {
 	private DateTime dateTime;

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/jface/tests/internal/databinding/swt/DateTimeTimeObservableValueTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/jface/tests/internal/databinding/swt/DateTimeTimeObservableValueTest.java
@@ -33,7 +33,6 @@ import org.junit.Test;
 
 /**
  * @since 3.2
- * @no
  */
 public class DateTimeTimeObservableValueTest extends AbstractSWTTestCase {
 	private DateTime dateTime;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/DataTransferTestStub.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/DataTransferTestStub.java
@@ -20,7 +20,8 @@ package org.eclipse.ui.tests.dialogs;
  * <code>org.eclipse.ui.wizards.datatransfer</code>.  For the purpose
  * of testing.
  * </p>
- * @private
+ *
+ * @noreference
  */
 public class DataTransferTestStub {
 	//Prevent instantiation

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/NavigatorTestStub.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/NavigatorTestStub.java
@@ -20,7 +20,8 @@ package org.eclipse.ui.tests.dialogs;
  * <code>org.eclipse.ui.views.navigator</code>.  For the purpose of
  * testing.
  * </p>
- * @private
+ *
+ * @noreference
  */
 
 public class NavigatorTestStub {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/TaskListTestStub.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/TaskListTestStub.java
@@ -20,7 +20,8 @@ package org.eclipse.ui.tests.dialogs;
  * <code>org.eclipse.ui.views.tasklist</code>.  For the purpose
  * of testing.
  * </p>
- * @private
+ *
+ * @noreference
  */
 public class TaskListTestStub {
 	//Prevent instantiation

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/TextEditorTestStub.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/TextEditorTestStub.java
@@ -17,12 +17,11 @@ package org.eclipse.ui.tests.dialogs;
  * FOR USE BY TESTS ONLY!
  * <p>
  * Stub class that provides access to classes visible to the package
- * <code>org.eclipse.ui.texteditor</code>.  For the purpose of
- * testing.
+ * <code>org.eclipse.ui.texteditor</code>. For the purpose of testing.
  * </p>
- * @private
+ *
+ * @noreference
  */
-
 public class TextEditorTestStub {
 	//Prevent instantiation
 	private TextEditorTestStub() {


### PR DESCRIPTION
Fixes all logged "unknown tag" and "tag not supported" errors in javadoc in the following way:
* `@private` -> `@noreference`
* `@issue` -> `// TODO`
* `@no` removed
* `<tt>...</tt>` -> `{@code ...}`