### PR TITLE
Remove last from from org.eclipse.text.releng

### DIFF
--- a/releng/org.eclipse.text.releng/.settings/org.eclipse.core.resources.prefs
+++ b/releng/org.eclipse.text.releng/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8


### PR DESCRIPTION
The .project was removed, but .settings/org.eclipse.core.resources.prefs remains