### PR TITLE
Fix LogView staying empty on invalid log entry

### DIFF
--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogReader.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogReader.java
@@ -18,7 +18,6 @@ package org.eclipse.ui.internal.views.log;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.text.ParseException;
 import java.util.*;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -121,7 +120,7 @@ class LogReader {
 						setNewParent(parents, entry, 0);
 						current = entry;
 						addEntry(current, entries, memento);
-					} catch (ParseException pe) {
+					} catch (IllegalArgumentException pe) {
 						//do nothing, just toss the entry
 					}
 					break;
@@ -135,7 +134,7 @@ class LogReader {
 							current = entry;
 							LogEntry parent = parents.get(depth - 1);
 							parent.addChild(entry);
-						} catch (ParseException pe) {
+						} catch (IllegalArgumentException pe) {
 							//do nothing, just toss the bad entry
 						}
 					}

--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogView.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogView.java
@@ -131,7 +131,7 @@ public class LogView extends ViewPart implements LogListener {
 	private Text fTextLabel;
 	private Shell fTextShell;
 
-	private boolean fFirstEvent = true;
+	private volatile boolean fFirstEvent = true;
 
 	private TreeColumn fColumn1;
 	private TreeColumn fColumn2;
@@ -1092,11 +1092,17 @@ public class LogView extends ViewPart implements LogListener {
 			}
 			return;
 		}
+		boolean shouldReadLog;
+		synchronized (batchedEntries) {
+			shouldReadLog = fFirstEvent || (currentSession == null);
+			if (shouldReadLog) {
+				fFirstEvent = false;
+			}
+		}
 
-		if (fFirstEvent || (currentSession == null)) {
+		if (shouldReadLog) {
 			readLogFile();
 			asyncRefresh(true);
-			fFirstEvent = false;
 		} else {
 			LogEntry entry = betterInput != null ? createLogEntry(betterInput) : createLogEntry(input);
 


### PR DESCRIPTION
Logging something like the exception from the line below breaks Error log view and it silently refuses loading log file (and will stay empty forever):

![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/964108/b2a3f9ee-0517-4225-8d33-ea733861957f)


`throw new CoreException(new Status(IStatus.ERROR, "Failed to read file", PLUGIN_ID, e));`

Additionally fixed multiple log reads on startup.