### PR TITLE
Add Bundle-Vendor to o.e.jface.text.examples

### DIFF
--- a/examples/org.eclipse.jface.text.examples/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.jface.text.examples/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: CodeMinig Examples
 Bundle-SymbolicName: org.eclipse.jface.text.examples
 Bundle-Version: 1.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-Vendor: Eclipse.org
 Require-Bundle: org.eclipse.jface.text,
  org.eclipse.core.runtime,
  org.eclipse.swt,


### PR DESCRIPTION
Fixes warning in maven build:
07:58:43.534 [WARNING] Bundle-Vendor header not found in /home/jenkins/agent/workspace/eclipse.platform.ui_master/examples/org.eclipse.jface.text.examples/META-INF/MANIFEST.MF, fallback to 'unknown' for source bundle