### PR TITLE
Apply theme color to status message in FindReplaceDialog

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -1304,8 +1304,9 @@ class FindReplaceDialog extends Dialog {
 
 		String dialogMessage = status.accept(new FindReplaceLogicMessageGenerator());
 		fStatusLabel.setText(dialogMessage);
-		fStatusLabel.setForeground(null);
-		if (!status.isInputValid()) {
+		if (status.isInputValid()) {
+			fStatusLabel.setForeground(fReplaceLabel.getForeground());
+		} else {
 			fStatusLabel.setForeground(JFaceColors.getErrorText(fStatusLabel.getDisplay()));
 		}
 


### PR DESCRIPTION
The status shown in the `FindReplaceDialog` is currently written in red (on input error) or in black. When setting the black font color, it does not consider the theme style applied to the dialog.

With this change, the status message color is properly set to the themed one used by the dialog. When using light theme, nothing changes.

Before:
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/755472/b448453c-8b1c-406b-b326-533f62f045a2)

After:
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/755472/b8728267-84d1-4f0b-8c3e-ece23a44e9da)

Light theme:
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/755472/c3931b6b-4cb2-4341-9063-24ecd22da3c7)
