### PR TITLE
Move identification of find/replace operation success to status object

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/FindAllStatus.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/FindAllStatus.java
@@ -34,4 +34,9 @@ public class FindAllStatus implements IFindReplaceStatus {
 		return true;
 	}
 
+	@Override
+	public boolean wasSuccessful() {
+		return selectCount > 0;
+	}
+
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/FindStatus.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/FindStatus.java
@@ -40,4 +40,11 @@ public class FindStatus implements IFindReplaceStatus {
 		return messageCode != StatusCode.READONLY;
 	}
 
+	@Override
+	public boolean wasSuccessful() {
+		// Also report StatusCode.WRAPPED as unsuccessful, because it implicitly
+		// includes NO_MATCH, as before wrapping no further match was found
+		return false;
+	}
+
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/IFindReplaceStatus.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/IFindReplaceStatus.java
@@ -14,8 +14,8 @@
 package org.eclipse.ui.internal.findandreplace.status;
 
 /**
- * Interface for statuses that can occur while performing
- * Find/Replace-operations.
+ * Interface for statuses that can occur while performing find/replace
+ * operations.
  */
 public interface IFindReplaceStatus {
 	public <T> T accept(IFindReplaceStatusVisitor<T> visitor);
@@ -25,4 +25,10 @@ public interface IFindReplaceStatus {
 	 * that the target is writable on replace operations}
 	 */
 	public boolean isInputValid();
+
+	/**
+	 * {@return whether the find/replace operation was successful, i.e., whether
+	 * some matching string was found or replaced}
+	 */
+	public boolean wasSuccessful();
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/InvalidRegExStatus.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/InvalidRegExStatus.java
@@ -41,4 +41,9 @@ public class InvalidRegExStatus implements IFindReplaceStatus {
 		return false;
 	}
 
+	@Override
+	public boolean wasSuccessful() {
+		return false;
+	}
+
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/NoStatus.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/NoStatus.java
@@ -32,4 +32,9 @@ public class NoStatus implements IFindReplaceStatus {
 		return true;
 	}
 
+	@Override
+	public boolean wasSuccessful() {
+		return true;
+	}
+
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/ReplaceAllStatus.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/ReplaceAllStatus.java
@@ -34,4 +34,9 @@ public class ReplaceAllStatus implements IFindReplaceStatus {
 		return true;
 	}
 
+	@Override
+	public boolean wasSuccessful() {
+		return replaceCount > 0;
+	}
+
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -68,11 +68,7 @@ import org.eclipse.ui.internal.findandreplace.FindReplaceMessages;
 import org.eclipse.ui.internal.findandreplace.HistoryStore;
 import org.eclipse.ui.internal.findandreplace.IFindReplaceLogic;
 import org.eclipse.ui.internal.findandreplace.SearchOptions;
-import org.eclipse.ui.internal.findandreplace.status.FindAllStatus;
-import org.eclipse.ui.internal.findandreplace.status.FindStatus;
 import org.eclipse.ui.internal.findandreplace.status.IFindReplaceStatus;
-import org.eclipse.ui.internal.findandreplace.status.InvalidRegExStatus;
-import org.eclipse.ui.internal.findandreplace.status.ReplaceAllStatus;
 import org.eclipse.ui.internal.texteditor.SWTUtil;
 
 /**
@@ -1310,18 +1306,8 @@ class FindReplaceDialog extends Dialog {
 			fStatusLabel.setForeground(JFaceColors.getErrorText(fStatusLabel.getDisplay()));
 		}
 
-		if (status instanceof FindStatus statusMessage || status instanceof InvalidRegExStatus invalidRegexStatus) {
+		if (!status.wasSuccessful()) {
 			tryToBeep(allowBeep);
-		}
-		if (status instanceof ReplaceAllStatus replaceAllStatus) {
-			if (replaceAllStatus.getReplaceCount() == 0) {
-				tryToBeep(allowBeep);
-			}
-		}
-		if (status instanceof FindAllStatus selectAllStatus) {
-			if (selectAllStatus.getSelectCount() == 0) {
-				tryToBeep(allowBeep);
-			}
 		}
 	}
 


### PR DESCRIPTION
The recently introduced `IStatus` objects used by the `FindReplaceLogic` to notify consumers (like the `FindReplaceDialog`) about the result of a find/replace operation only provide the information about the success of an operation implicitly. This is why the FindReplaceDialog currently needs to consider the type of an `IStatus` to extract this information.

With this change, the `IStatus` objects provide success information via a `wasSuccessful()` method, which relieves the `FindReplaceDialog` from manually distinguishing and processing different types of status objects.

This is a deferred design improvement (see https://github.com/eclipse-platform/eclipse.platform.ui/pull/1132#pullrequestreview-1820230660) as a planned follow-up to #1132, 