### PR TITLE
Rename status for find/replace from IStatus to IFindReplaceStatus

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -37,7 +37,7 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.findandreplace.status.FindAllStatus;
 import org.eclipse.ui.internal.findandreplace.status.FindStatus;
-import org.eclipse.ui.internal.findandreplace.status.IStatus;
+import org.eclipse.ui.internal.findandreplace.status.IFindReplaceStatus;
 import org.eclipse.ui.internal.findandreplace.status.InvalidRegExStatus;
 import org.eclipse.ui.internal.findandreplace.status.NoStatus;
 import org.eclipse.ui.internal.findandreplace.status.ReplaceAllStatus;
@@ -47,7 +47,7 @@ import org.eclipse.ui.texteditor.IEditorStatusLine;
 import org.eclipse.ui.texteditor.IFindReplaceTargetExtension2;
 
 public class FindReplaceLogic implements IFindReplaceLogic {
-	private IStatus status;
+	private IFindReplaceStatus status;
 	private IFindReplaceTarget target;
 	private IRegion oldScope;
 	private Point incrementalBaseLocation;
@@ -99,7 +99,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	}
 
 	@Override
-	public IStatus getStatus() {
+	public IFindReplaceStatus getStatus() {
 		if (status == null) {
 			return new NoStatus();
 		}

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicMessageGenerator.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicMessageGenerator.java
@@ -15,17 +15,17 @@ package org.eclipse.ui.internal.findandreplace;
 
 import org.eclipse.ui.internal.findandreplace.status.FindAllStatus;
 import org.eclipse.ui.internal.findandreplace.status.FindStatus;
-import org.eclipse.ui.internal.findandreplace.status.IStatus;
-import org.eclipse.ui.internal.findandreplace.status.IStatusVisitor;
+import org.eclipse.ui.internal.findandreplace.status.IFindReplaceStatus;
+import org.eclipse.ui.internal.findandreplace.status.IFindReplaceStatusVisitor;
 import org.eclipse.ui.internal.findandreplace.status.InvalidRegExStatus;
 import org.eclipse.ui.internal.findandreplace.status.NoStatus;
 import org.eclipse.ui.internal.findandreplace.status.ReplaceAllStatus;
 import org.eclipse.ui.internal.texteditor.NLSUtility;
 
-public class FindReplaceLogicMessageGenerator implements IStatusVisitor<String> {
+public class FindReplaceLogicMessageGenerator implements IFindReplaceStatusVisitor<String> {
 
 	@Override
-	public String visit(IStatus status) {
+	public String visit(IFindReplaceStatus status) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
@@ -17,7 +17,7 @@ import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.jface.text.IFindReplaceTarget;
 
-import org.eclipse.ui.internal.findandreplace.status.IStatus;
+import org.eclipse.ui.internal.findandreplace.status.IFindReplaceStatus;
 
 /**
  * Implements a generalized logic operator for in-file Find/Replace-Operations.
@@ -55,7 +55,7 @@ public interface IFindReplaceLogic {
 	 *
 	 * @return FindAndReplaceMessageStatus
 	 */
-	public IStatus getStatus();
+	public IFindReplaceStatus getStatus();
 
 	/**
 	 * RegEx-Search is not possible on every target. Hence, even after {code

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/FindAllStatus.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/FindAllStatus.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.findandreplace.status;
 
-public class FindAllStatus implements IStatus {
+public class FindAllStatus implements IFindReplaceStatus {
 	private int selectCount;
 
 	public FindAllStatus(int selectCount) {
@@ -25,7 +25,7 @@ public class FindAllStatus implements IStatus {
 	}
 
 	@Override
-	public <T> T accept(IStatusVisitor<T> visitor) {
+	public <T> T accept(IFindReplaceStatusVisitor<T> visitor) {
 		return visitor.visit(this);
 	}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/FindStatus.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/FindStatus.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.findandreplace.status;
 
-public class FindStatus implements IStatus {
+public class FindStatus implements IFindReplaceStatus {
 
 	public enum StatusCode {
 		NO_MATCH,
@@ -31,7 +31,7 @@ public class FindStatus implements IStatus {
 	}
 
 	@Override
-	public <T> T accept(IStatusVisitor<T> visitor) {
+	public <T> T accept(IFindReplaceStatusVisitor<T> visitor) {
 		return visitor.visit(this);
 	}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/IFindReplaceStatus.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/IFindReplaceStatus.java
@@ -17,8 +17,8 @@ package org.eclipse.ui.internal.findandreplace.status;
  * Interface for statuses that can occur while performing
  * Find/Replace-operations.
  */
-public interface IStatus {
-	public <T> T accept(IStatusVisitor<T> visitor);
+public interface IFindReplaceStatus {
+	public <T> T accept(IFindReplaceStatusVisitor<T> visitor);
 
 	/**
 	 * {@return whether the input is valid, e.g., that the find string is valid and

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/IFindReplaceStatusVisitor.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/IFindReplaceStatusVisitor.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.findandreplace.status;
 
-public interface IStatusVisitor<T> {
-	public T visit(IStatus status);
+public interface IFindReplaceStatusVisitor<T> {
+	public T visit(IFindReplaceStatus status);
 
 	public T visit(ReplaceAllStatus status);
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/InvalidRegExStatus.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/InvalidRegExStatus.java
@@ -19,7 +19,7 @@ import java.util.regex.PatternSyntaxException;
  * This class is used as glue to correctly map to the error messages generated
  * by RegEx-Errors which are directly displayed in plain text.
  */
-public class InvalidRegExStatus implements IStatus {
+public class InvalidRegExStatus implements IFindReplaceStatus {
 
 	private PatternSyntaxException regExException;
 
@@ -32,7 +32,7 @@ public class InvalidRegExStatus implements IStatus {
 	}
 
 	@Override
-	public <T> T accept(IStatusVisitor<T> visitor) {
+	public <T> T accept(IFindReplaceStatusVisitor<T> visitor) {
 		return visitor.visit(this);
 	}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/NoStatus.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/NoStatus.java
@@ -16,14 +16,14 @@ package org.eclipse.ui.internal.findandreplace.status;
 /**
  * Represents an "everything worked fine, nothing to display"-status.
  */
-public class NoStatus implements IStatus {
+public class NoStatus implements IFindReplaceStatus {
 
 	public NoStatus() {
 		// do nothing
 	}
 
 	@Override
-	public <T> T accept(IStatusVisitor<T> visitor) {
+	public <T> T accept(IFindReplaceStatusVisitor<T> visitor) {
 		return visitor.visit(this);
 	}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/ReplaceAllStatus.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/ReplaceAllStatus.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.findandreplace.status;
 
-public class ReplaceAllStatus implements IStatus {
+public class ReplaceAllStatus implements IFindReplaceStatus {
 	private int replaceCount;
 
 	public ReplaceAllStatus(int replaceCount) {
@@ -25,7 +25,7 @@ public class ReplaceAllStatus implements IStatus {
 	}
 
 	@Override
-	public <T> T accept(IStatusVisitor<T> visitor) {
+	public <T> T accept(IFindReplaceStatusVisitor<T> visitor) {
 		return visitor.visit(this);
 	}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -70,7 +70,7 @@ import org.eclipse.ui.internal.findandreplace.IFindReplaceLogic;
 import org.eclipse.ui.internal.findandreplace.SearchOptions;
 import org.eclipse.ui.internal.findandreplace.status.FindAllStatus;
 import org.eclipse.ui.internal.findandreplace.status.FindStatus;
-import org.eclipse.ui.internal.findandreplace.status.IStatus;
+import org.eclipse.ui.internal.findandreplace.status.IFindReplaceStatus;
 import org.eclipse.ui.internal.findandreplace.status.InvalidRegExStatus;
 import org.eclipse.ui.internal.findandreplace.status.ReplaceAllStatus;
 import org.eclipse.ui.internal.texteditor.SWTUtil;
@@ -1299,7 +1299,7 @@ class FindReplaceDialog extends Dialog {
 	 * @param allowBeep Whether the evaluation should beep on some codes.
 	 */
 	private void evaluateFindReplaceStatus(boolean allowBeep) {
-		IStatus status = findReplaceLogic.getStatus();
+		IFindReplaceStatus status = findReplaceLogic.getStatus();
 
 		String dialogMessage = status.accept(new FindReplaceLogicMessageGenerator());
 		fStatusLabel.setText(dialogMessage);


### PR DESCRIPTION
To avoid confusion with the existing `IStatus` interface for representing Eclipse operation results, this change renames the specific status interface for find/replace action results from `IStatus` to `IFindReplaceStatus`. It also adapts the `IStatusVisitor` to `IFindReplaceStatusVisitor` accordingly.

See the discussion in #1501.