### PR TITLE
Make test cases in FindReplaceDialogTest independent from each other

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -209,6 +209,7 @@ class FindReplaceDialog extends Dialog {
 	public FindReplaceDialog(Shell parentShell) {
 		super(parentShell);
 		findReplaceLogic = new FindReplaceLogic();
+		findReplaceLogic.activate(SearchOptions.GLOBAL);
 		fParentShell = null;
 		fDialogPositionInit = null;
 


### PR DESCRIPTION
The test cases in `FindReplaceDialogTest` currently depend on each other. The class defines the tests to be executed in lexicographic order, as test cases may not reset settings in the `FindReplaceDialog` they have changed during execution. In addition, the tests do not only use reflection to access the SWT controls but also to call internal logic as selection events are not simulated properly.

In order to ensure proper test isolation and make tests run (and potentially fail) in a reproducible and runtime-equivalent setup, this change makes the `FindReplaceDialog` settings being reset on each execution and adds assertions for a proper setup in each test case. It also ensures that selection events are executed properly without calling internal methods of the `FindReplaceDialog`. Finally, the change also adds a missing default setup for the search scope in the FindReplaceDialog that was revealed by the improved test setup.