### PR TITLE
Feature/batch encapsulate field

### DIFF
--- a/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/ui/refactoring/RefactoringWizardPage.java
+++ b/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/ui/refactoring/RefactoringWizardPage.java
@@ -45,6 +45,10 @@ public abstract class RefactoringWizardPage extends WizardPage {
 
 	/** Does the page belong to a conventional wizard? */
 	private final boolean fConventionalWizard;
+	/**
+	 * @since 3.13
+	 */
+	protected Refactoring fRefactoring;
 
 	/**
 	 * Creates a new refactoring wizard page.
@@ -98,10 +102,11 @@ public abstract class RefactoringWizardPage extends WizardPage {
 	 *  or <code>null</code>
 	 */
 	protected Refactoring getRefactoring() {
-		RefactoringWizard wizard= getRefactoringWizard();
-		if (wizard == null)
-			return null;
-		return wizard.getRefactoring();
+		return fRefactoring != null
+				? fRefactoring
+				: getRefactoringWizard() != null
+					? getRefactoringWizard().getRefactoring()
+					: null;
 	}
 
 	/**


### PR DESCRIPTION
Issue: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1080

Note: This is linked to https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1081

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Currently with Refactoring -> Encapsulate, encapsulating only one field at a time is possible. With this PR, it allows to select multiple fields and perform encapsulation on them in a batch.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Select multiple fields at a time and click on Refactor -> Encapsulate fields in the menu. A wizard would appear to select the fields and specify how to perform the operation. Once done, click okay. This should encapsulate all the selected fields.

## Current Limitations:
Since this work is an improvement over the current state, there are some limitations to the extra feature.
- In the preview, there is not a unified view for all the fields. Each fields can be selected separately and then the preview is available. This is because of the way batch encapsulation works right now. It takes the input from user at once and executes each refactoring one by one. This is the current approach and we are not executing all the chnages together because the changes are supposed to be written in the file at the same place of the fields and every refactoring needs to read the state of the AST before executing so that it has the right context of the field it is encapsulating. In case of wrapping all the changes and executing it all together, these references are lost and we end up with a faulty refactor.
For example: if we have `int a, b, c;` and we want to refactor a and b, it becomes something like:
```
private int a;
private int b;
// getters and setters
```
We must notice that a and b are in the same line and after a has been refactored the context of b changes since the refactoring of a has added extra lines whose information is not present in the change object of b. Thus we went with the loop approach where after execution of every refactoring, the next refactoring checks the initial condition and then executes. Thus we dont have a unified preview at the moment.

- The next limitation is also related to this loop based execution. Since we perform multiple refactoring operations in a loop. there are multiple undo operations registered per refactoring. Hence to undo everything where n number of fields were refactored, one must undo n times. I tried to accumulate all the undo objects created from each refactoring and store them as a compositeChange object and then put that in the undo manager. But after that, on undoing it tells me that the source code has changed and that undo cant take place.
![image](https://github.com/eclipse-jdt/eclipse.jdt.ui/assets/46150646/6cead6a3-af7f-4bee-b41f-3eed6670d1ae)


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
