### PR TITLE
Fix dialog bound settings for wizards.

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/WizardDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/WizardDialog.java
@@ -1571,7 +1571,7 @@ public class WizardDialog extends TitleAreaDialog implements IWizardContainer2, 
 
 	@Override
 	protected IDialogSettings getDialogBoundsSettings() {
-		String name = getClass().getSimpleName() + ".dialogBounds"; //$NON-NLS-1$
+		String name = getWizard().getClass().getSimpleName() + ".dialogBounds"; //$NON-NLS-1$
 		IDialogSettings dialogSettings = getWizard().getDialogSettings();
 		if (dialogSettings == null) {
 			return null;


### PR DESCRIPTION
Issue: https://github.com/eclipse-platform/eclipse.platform.ui/issues/1511

Als refer to Issue
https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1082

The dialog settings for wizards needs to be saved using a unique identifier per wizard. E.g. New Java Class wizard has other settings than New Java Project.