### PR TITLE
Make "Select All" in FindReplaceDialog work for read-only targets #1029

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -289,6 +289,15 @@ public class FindReplaceLogicTest {
 	}
 
 	@Test
+	public void testPerformSelectAllOnReadonlyTarget() {
+		TextViewer textViewer= setupTextViewer("Ab Ab");
+		textViewer.setEditable(false);
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.performSelectAll("Ab", Display.getCurrent());
+		expectStatusIsFindAllWithCount(findReplaceLogic, 2);
+	}
+
+	@Test
 	public void testSelectWholeWords() {
 		TextViewer textViewer= setupTextViewer("Hello World of get and getters, set and setters");
 		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);


### PR DESCRIPTION
The `FindReplaceDialog` does currently not find any results when performing a "Select All" operation for read-only targets, such as a console view. The reason is that the initial implementation reused "Replace All" functionality, including the check for the target of being editable. While this is reasonable for replace operations, it is not for select-only operations.

This change enables "Select All" functionality for read-only targets. It refactors the "Select All" and "Replace All" functionalities to reuse their common logic why adapting both for their specific purpose. It also adds a regression test for performing "Select All" operations on read-only targets.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1029