### PR TITLE
Fix remaining javadoc errors

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/src/org/eclipse/e4/ui/workbench/renderers/swt/cocoa/CocoaUIProcessor.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/src/org/eclipse/e4/ui/workbench/renderers/swt/cocoa/CocoaUIProcessor.java
@@ -94,7 +94,7 @@ public class CocoaUIProcessor {
 
 	/**
 	 * Install the Cocoa window handlers. Sadly this has to be done here rather than
-	 * in a <tt>fragments.e4xmi</tt> as the project <tt>Application.e4xmi</tt> may
+	 * in a {@code fragments.e4xmi} as the project {@code Application.e4xmi} may
 	 * (and likely will) use different IDs.
 	 */
 	public void installWindowHandlers() {

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/model/test/util/TestSwitch.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/model/test/util/TestSwitch.java
@@ -57,7 +57,7 @@ public class TestSwitch<T1> extends Switch<T1> {
 	 * Checks whether this is a switch for the given package. <!--
 	 * begin-user-doc --> <!-- end-user-doc -->
 	 *
-	 * @parameter ePackage the package in question.
+	 * @param ePackage the package in question.
 	 * @return whether this is a switch for the given package.
 	 * @generated
 	 */

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug42627Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug42627Test.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.ui.tests.keys;
 
-import org.eclipse.core.runtime.CoreException;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -49,9 +48,6 @@ public class Bug42627Test {
 
 	/**
 	 * Tests that actions with no defined command ID are logged.
-	 *
-	 * @throws CoreException
-	 *            If something fails when trying to open a new project.
 	 */
 	@Test
 	public void testLogUndefined() /*throws CoreException*/{

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug53489Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug53489Test.java
@@ -16,7 +16,6 @@ package org.eclipse.ui.tests.keys;
 
 import static org.junit.Assert.assertTrue;
 
-import java.awt.AWTException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -56,7 +55,6 @@ public class Bug53489Test {
 	 * Tests that pressing delete in a styled text widget (in a running Eclipse)
 	 * does not cause a double delete.
 	 *
-	 * @throws AWTException     If the creation of robot
 	 * @throws CommandException If execution of the handler fails.
 	 * @throws CoreException    If the test project cannot be created and opened.
 	 * @throws IOException      If the file cannot be read.

--- a/tools/bundles/org.eclipse.e4.tools.compatibility.migration/src/org/eclipse/e4/tools/internal/compatibiliy/migration/E4MigrationTool.java
+++ b/tools/bundles/org.eclipse.e4.tools.compatibility.migration/src/org/eclipse/e4/tools/internal/compatibiliy/migration/E4MigrationTool.java
@@ -180,7 +180,6 @@ public final class E4MigrationTool {
 	 *
 	 * @param memento The IMemento to convert
 	 * @return The resulting MApplication
-	 * @throws WorkbenchException Thrown when the xml cannot be parsed
 	 */
 	public static MApplication convert(final IMemento memento) {
 		E4MigrationTool converter = new E4MigrationTool();

--- a/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/ControlFactory.java
+++ b/tools/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/ControlFactory.java
@@ -809,8 +809,8 @@ public class ControlFactory {
 	 * a validator to check if the value exists (OK), or if it is null or empty
 	 * (WARNING), or if the class does not exists (ERROR)
 	 *
-	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id= 412567">Bug
-	 *      412567 </a> *
+	 * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=412567">Bug
+	 *      412567</a>
 	 * @param parent
 	 *            the parent composite
 	 * @param Messages


### PR DESCRIPTION
* Replace `<tt>...</tt>` with `{@code ...}`
* Remove documentation of exception that are actually not thrown
* Replace `@parameter` with `@param`
* Correct faulty URL

This fixes the remaining javadoc errors reported in logs of builds, such as the recent Jenkins master build: https://ci.eclipse.org/platform/job/eclipse.platform.ui/job/master/229