### PR TITLE
Migrate RCP tests to JUnit 5 and improve startup assertions #1517

### DIFF
--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/ActionBarConfigurerTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/ActionBarConfigurerTest.java
@@ -14,10 +14,10 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.rcp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -25,24 +25,23 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.application.IActionBarConfigurer;
 import org.eclipse.ui.application.WorkbenchAdvisor;
 import org.eclipse.ui.tests.rcp.util.WorkbenchAdvisorObserver;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ActionBarConfigurerTest {
 
 
 	private Display display = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-
 		assertNull(display);
 		display = PlatformUI.createDisplay();
 		assertNotNull(display);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		assertNotNull(display);
 		display.dispose();

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/IWorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/IWorkbenchPageTest.java
@@ -14,11 +14,11 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.rcp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbenchPage;
@@ -29,9 +29,9 @@ import org.eclipse.ui.application.IWorkbenchWindowConfigurer;
 import org.eclipse.ui.application.WorkbenchAdvisor;
 import org.eclipse.ui.tests.rcp.util.EmptyView;
 import org.eclipse.ui.tests.rcp.util.WorkbenchAdvisorObserver;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the behaviour of various IWorkbenchPage methods under different
@@ -42,15 +42,14 @@ public class IWorkbenchPageTest {
 
 	private Display display = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-
 		assertNull(display);
 		display = PlatformUI.createDisplay();
 		assertNotNull(display);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		assertNotNull(display);
 		display.dispose();

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/PlatformUITest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/PlatformUITest.java
@@ -14,26 +14,28 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.rcp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.tests.harness.util.RCPTestWorkbenchAdvisor;
 import org.eclipse.ui.tests.rcp.util.WorkbenchAdvisorObserver;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class PlatformUITest {
 
 
 	/** Make sure workbench is not returned before it is running. */
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testEarlyGetWorkbench() {
 		assertFalse(PlatformUI.isWorkbenchRunning());
-		PlatformUI.getWorkbench();
+		assertThrows(IllegalStateException.class, () -> PlatformUI.getWorkbench());
 	}
 
 	@Test
@@ -58,33 +60,22 @@ public class PlatformUITest {
 		display.dispose();
 		assertTrue(display.isDisposed());
 
-		assertEquals("Async run during startup.  See RCPTestWorkbenchAdvisor.preStartup()",
-				Boolean.FALSE,
-				RCPTestWorkbenchAdvisor.asyncDuringStartup);
-
-		// the following four asserts test the various combinations of Thread +
-		// DisplayAccess + a/sync exec. Anything without a call to DisplayAccess
-		// should be deferred until after startup.
-		assertEquals(
-				"Sync from qualified thread did not run during startup.  See RCPTestWorkbenchAdvisor.preStartup()",
-				Boolean.TRUE,
-				RCPTestWorkbenchAdvisor.syncWithDisplayAccess);
-		assertEquals(
-				"Async from qualified thread did not run during startup.  See RCPTestWorkbenchAdvisor.preStartup()",
-				Boolean.TRUE,
-				RCPTestWorkbenchAdvisor.asyncWithDisplayAccess);
-		assertEquals(
-				"Sync from un-qualified thread ran during startup.  See RCPTestWorkbenchAdvisor.preStartup()",
-				Boolean.FALSE,
-				RCPTestWorkbenchAdvisor.syncWithoutDisplayAccess);
-		assertEquals(
-				"Async from un-qualified thread ran during startup.  See RCPTestWorkbenchAdvisor.preStartup()",
-				Boolean.FALSE,
-				RCPTestWorkbenchAdvisor.asyncWithoutDisplayAccess);
-
-		assertFalse(
-				"DisplayAccess.accessDisplayDuringStartup() in UI thread did not result in exception.",
-				RCPTestWorkbenchAdvisor.displayAccessInUIThreadAllowed);
+		assertAll(//
+				() -> assertFalse(RCPTestWorkbenchAdvisor.asyncDuringStartup,
+						"Async run during startup.  See RCPTestWorkbenchAdvisor.preStartup()"),
+				// the following four asserts test the various combinations of Thread +
+				// DisplayAccess + a/sync exec. Anything without a call to DisplayAccess
+				// should be deferred until after startup.
+				() -> assertTrue(RCPTestWorkbenchAdvisor.syncWithDisplayAccess,
+						"Sync from qualified thread did not run during startup.  See RCPTestWorkbenchAdvisor.preStartup()"),
+				() -> assertTrue(RCPTestWorkbenchAdvisor.asyncWithDisplayAccess,
+						"Async from qualified thread did not run during startup.  See RCPTestWorkbenchAdvisor.preStartup()"),
+				() -> assertFalse(RCPTestWorkbenchAdvisor.syncWithoutDisplayAccess,
+						"Sync from un-qualified thread ran during startup.  See RCPTestWorkbenchAdvisor.preStartup()"),
+				() -> assertFalse(RCPTestWorkbenchAdvisor.asyncWithoutDisplayAccess,
+						"Async from un-qualified thread ran during startup.  See RCPTestWorkbenchAdvisor.preStartup()"),
+				() -> assertFalse(RCPTestWorkbenchAdvisor.displayAccessInUIThreadAllowed,
+						"DisplayAccess.accessDisplayDuringStartup() in UI thread did not result in exception."));
 	}
 
 	/**
@@ -92,7 +83,7 @@ public class PlatformUITest {
 	 * and PlatformUI.isWorkbenchRunning() returns false.
 	 * Regression test for bug 82286.
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public void testCreateAndRunWorkbenchWithExceptionOnStartup() {
 		final Display display = PlatformUI.createDisplay();

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/RcpTestSuite.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/RcpTestSuite.java
@@ -14,22 +14,19 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.rcp;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * The test suite for the RCP APIs in the generic workbench.
  * To run, use a headless JUnit Plug-in Test launcher, configured
  * to have [No Application] as its application.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ PlatformUITest.class, WorkbenchAdvisorTest.class, WorkbenchConfigurerTest.class,
+@Suite
+@SelectClasses({ PlatformUITest.class, WorkbenchAdvisorTest.class, WorkbenchConfigurerTest.class,
 		WorkbenchWindowConfigurerTest.class, ActionBarConfigurerTest.class, IWorkbenchPageTest.class,
 		WorkbenchSaveRestoreStateTest.class, WorkbenchListenerTest.class, WorkbenchTest.class })
 public class RcpTestSuite {
-
-
-
 	public RcpTestSuite() {
 	}
 }

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchAdvisorTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchAdvisorTest.java
@@ -14,11 +14,11 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.rcp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
@@ -31,24 +31,23 @@ import org.eclipse.ui.application.IWorkbenchConfigurer;
 import org.eclipse.ui.application.IWorkbenchWindowConfigurer;
 import org.eclipse.ui.application.WorkbenchAdvisor;
 import org.eclipse.ui.tests.rcp.util.WorkbenchAdvisorObserver;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class WorkbenchAdvisorTest {
 
 
 	private Display display = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
-
 		assertNull(display);
 		display = PlatformUI.createDisplay();
 		assertNotNull(display);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		assertNotNull(display);
 		display.dispose();

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchConfigurerTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchConfigurerTest.java
@@ -14,12 +14,12 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.rcp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 
@@ -38,25 +38,24 @@ import org.eclipse.ui.application.WorkbenchAdvisor;
 import org.eclipse.ui.application.WorkbenchWindowAdvisor;
 import org.eclipse.ui.tests.harness.util.RCPTestWorkbenchAdvisor;
 import org.eclipse.ui.tests.rcp.util.WorkbenchAdvisorObserver;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class WorkbenchConfigurerTest {
 
 
 	private Display display = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
-
 		assertNull(display);
 		display = PlatformUI.createDisplay();
 		assertNotNull(display);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		assertNotNull(display);
 		display.dispose();
@@ -64,7 +63,7 @@ public class WorkbenchConfigurerTest {
 
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testDefaults() {
 		WorkbenchAdvisorObserver wa = new WorkbenchAdvisorObserver(1) {
@@ -96,7 +95,7 @@ public class WorkbenchConfigurerTest {
 		assertEquals(PlatformUI.RETURN_OK, code);
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testEmergencyClose() {
 		WorkbenchAdvisorObserver wa = new WorkbenchAdvisorObserver(2) {

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchListenerTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchListenerTest.java
@@ -14,10 +14,10 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.rcp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,9 +28,9 @@ import org.eclipse.ui.IWorkbenchListener;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.application.WorkbenchAdvisor;
 import org.eclipse.ui.tests.rcp.util.WorkbenchAdvisorObserver;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for IWorkbenchListener API and implementation.
@@ -40,15 +40,14 @@ public class WorkbenchListenerTest {
 
 	private Display display = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-
 		assertNull(display);
 		display = PlatformUI.createDisplay();
 		assertNotNull(display);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		assertNotNull(display);
 		display.dispose();

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchSaveRestoreStateTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchSaveRestoreStateTest.java
@@ -14,11 +14,11 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.rcp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -43,10 +43,10 @@ import org.eclipse.ui.application.IWorkbenchWindowConfigurer;
 import org.eclipse.ui.application.WorkbenchWindowAdvisor;
 import org.eclipse.ui.internal.UIPlugin;
 import org.eclipse.ui.tests.rcp.util.WorkbenchAdvisorObserver;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class WorkbenchSaveRestoreStateTest {
 
@@ -57,15 +57,14 @@ public class WorkbenchSaveRestoreStateTest {
 
 	private Display display = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-
 		assertNull(display);
 		display = PlatformUI.createDisplay();
 		assertNotNull(display);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		assertNotNull(display);
 		display.dispose();
@@ -283,7 +282,7 @@ public class WorkbenchSaveRestoreStateTest {
 	/**
 	 * Test on-demand save/restore state API
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public void testOnDemandSaveRestoreState() {
 

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchTest.java
@@ -22,7 +22,7 @@ import org.eclipse.ui.activities.IActivityManager;
 import org.eclipse.ui.activities.IActivityManagerListener;
 import org.eclipse.ui.application.WorkbenchAdvisor;
 import org.eclipse.ui.tests.harness.util.RCPTestWorkbenchAdvisor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WorkbenchTest {
 	/**

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchWindowConfigurerTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchWindowConfigurerTest.java
@@ -14,12 +14,12 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.rcp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 
@@ -44,24 +44,23 @@ import org.eclipse.ui.application.WorkbenchWindowAdvisor;
 import org.eclipse.ui.internal.WorkbenchWindow;
 import org.eclipse.ui.tests.harness.util.RCPTestWorkbenchAdvisor;
 import org.eclipse.ui.tests.rcp.util.WorkbenchAdvisorObserver;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class WorkbenchWindowConfigurerTest {
 
 
 	private Display display = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-
 		assertNull(display);
 		display = PlatformUI.createDisplay();
 		assertNotNull(display);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		assertNotNull(display);
 		display.dispose();
@@ -161,8 +160,10 @@ public class WorkbenchWindowConfigurerTest {
 			public void eventLoopIdle(Display disp) {
 				IWorkbenchWindow activeWorkbenchWindow = getWorkbenchConfigurer()
 						.getWorkbench().getActiveWorkbenchWindow();
-				assertEquals("testing showCoolBar=" + showCoolBar, showCoolBar, ((WorkbenchWindow)activeWorkbenchWindow).getCoolBarVisible());
-				assertEquals("testing showPerspectiveBar=" + showPerspectiveBar, showPerspectiveBar, ((WorkbenchWindow)activeWorkbenchWindow).getPerspectiveBarVisible());
+				assertEquals(showCoolBar, ((WorkbenchWindow) activeWorkbenchWindow).getCoolBarVisible(),
+						"testing showCoolBar=" + showCoolBar);
+				assertEquals(showPerspectiveBar, ((WorkbenchWindow) activeWorkbenchWindow).getPerspectiveBarVisible(),
+						"testing showPerspectiveBar=" + showPerspectiveBar);
 				super.eventLoopIdle(disp);
 			}
 

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/util/WorkbenchAdvisorObserver.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/util/WorkbenchAdvisorObserver.java
@@ -13,6 +13,11 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.rcp.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -23,7 +28,6 @@ import org.eclipse.ui.application.IActionBarConfigurer;
 import org.eclipse.ui.application.IWorkbenchConfigurer;
 import org.eclipse.ui.application.IWorkbenchWindowConfigurer;
 import org.eclipse.ui.tests.harness.util.RCPTestWorkbenchAdvisor;
-import org.junit.Assert;
 
 /**
  * This utility class is used to record the order in which the hooks are called.
@@ -79,13 +83,13 @@ public class WorkbenchAdvisorObserver extends RCPTestWorkbenchAdvisor {
 	}
 
 	public void assertNextOperation(String expected) {
-		Assert.assertTrue(iterator.hasNext());
-		Assert.assertEquals(expected, iterator.next());
+		assertTrue(iterator.hasNext());
+		assertEquals(expected, iterator.next());
 	}
 
 	public void assertAllOperationsExamined() {
-		Assert.assertNotNull(iterator);
-		Assert.assertFalse(iterator.hasNext());
+		assertNotNull(iterator);
+		assertFalse(iterator.hasNext());
 	}
 
 	private void addOperation(String operation) {

--- a/tests/org.eclipse.ui.tests.rcp/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.rcp/META-INF/MANIFEST.MF
@@ -10,6 +10,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.mockito.mockito-core,
  org.eclipse.test.performance,
  org.eclipse.ui.tests.harness
+Import-Package: org.junit.jupiter.api,
+ org.junit.jupiter.api.function,
+ org.junit.platform.suite.api,
+ org.opentest4j
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.ui.tests.rcp,

--- a/tests/org.eclipse.ui.tests.rcp/RCP Test Suite.launch
+++ b/tests/org.eclipse.ui.tests.rcp/RCP Test Suite.launch
@@ -1,47 +1,50 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.pde.ui.JunitLaunchConfig">
-<stringAttribute key="application" value="org.eclipse.pde.junit.runtime.coretestapplication"/>
-<booleanAttribute key="askclear" value="false"/>
-<booleanAttribute key="automaticAdd" value="true"/>
-<booleanAttribute key="automaticValidate" value="false"/>
-<stringAttribute key="bootstrap" value=""/>
-<stringAttribute key="checked" value="[NONE]"/>
-<booleanAttribute key="clearConfig" value="true"/>
-<booleanAttribute key="clearws" value="true"/>
-<booleanAttribute key="clearwslog" value="false"/>
-<booleanAttribute key="com.mountainminds.eclemma.core.INPLACE_INSTRUMENTATION" value="true"/>
-<listAttribute key="com.mountainminds.eclemma.core.INSTRUMENTATION_PATHS">
-<listEntry value="/org.eclipse.ui/bin"/>
-<listEntry value="/org.eclipse.ui.workbench/bin"/>
-</listAttribute>
-<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
-<booleanAttribute key="default" value="true"/>
-<booleanAttribute key="includeOptional" value="true"/>
-<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/RcpTestSuite.java"/>
-</listAttribute>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="1"/>
-</listAttribute>
-<booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
-<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
-<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
-<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
-<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
-<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.ui.tests.rcp.RcpTestSuite"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.ui.tests.rcp"/>
-<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="pde.version" value="3.3"/>
-<stringAttribute key="product" value="org.eclipse.sdk.ide"/>
-<booleanAttribute key="run_in_ui_thread" value="true"/>
-<booleanAttribute key="show_selected_only" value="false"/>
-<stringAttribute key="templateConfig" value=""/>
-<booleanAttribute key="tracing" value="false"/>
-<booleanAttribute key="useCustomFeatures" value="false"/>
-<booleanAttribute key="useDefaultConfig" value="true"/>
-<booleanAttribute key="useDefaultConfigArea" value="false"/>
-<booleanAttribute key="useProduct" value="false"/>
+    <stringAttribute key="application" value="org.eclipse.pde.junit.runtime.coretestapplication"/>
+    <booleanAttribute key="askclear" value="false"/>
+    <booleanAttribute key="automaticAdd" value="true"/>
+    <booleanAttribute key="automaticValidate" value="false"/>
+    <stringAttribute key="bootstrap" value=""/>
+    <stringAttribute key="checked" value="[NONE]"/>
+    <booleanAttribute key="clearConfig" value="true"/>
+    <booleanAttribute key="clearws" value="true"/>
+    <booleanAttribute key="clearwslog" value="false"/>
+    <booleanAttribute key="com.mountainminds.eclemma.core.INPLACE_INSTRUMENTATION" value="true"/>
+    <listAttribute key="com.mountainminds.eclemma.core.INSTRUMENTATION_PATHS">
+        <listEntry value="/org.eclipse.ui/bin"/>
+        <listEntry value="/org.eclipse.ui.workbench/bin"/>
+    </listAttribute>
+    <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+    <booleanAttribute key="default" value="true"/>
+    <booleanAttribute key="includeOptional" value="true"/>
+    <stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/RcpTestSuite.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+    <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit5"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JRE for JavaSE-17"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.ui.tests.rcp.RcpTestSuite"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.ui.tests.rcp"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+    <stringAttribute key="pde.version" value="3.3"/>
+    <stringAttribute key="product" value="org.eclipse.sdk.ide"/>
+    <booleanAttribute key="run_in_ui_thread" value="true"/>
+    <booleanAttribute key="show_selected_only" value="false"/>
+    <stringAttribute key="templateConfig" value=""/>
+    <booleanAttribute key="tracing" value="false"/>
+    <booleanAttribute key="useCustomFeatures" value="false"/>
+    <booleanAttribute key="useDefaultConfig" value="true"/>
+    <booleanAttribute key="useDefaultConfigArea" value="false"/>
+    <booleanAttribute key="useProduct" value="false"/>
 </launchConfiguration>


### PR DESCRIPTION
This change migrates the (non-performance) tests in `org.eclipse.ui.tests.rcp` to JUnit 5. Assertions are also replaced with JUnit 5 assertions. Since most `assertEquals()` calls contained actual and expected in wrong order, they do not have to be changed as usual when migrating from JUnit 4 to 5 assertions.

In addition, the assertions in `PlatformUITest#testCreateAndRunWorkbench()` are improved so that all of them are evaluated even if multiple of them fail. This serves as a means to ease identifying the reasons for this test case to randomly fail.

Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/1517