### PR TITLE
avoid overwrite popup when possible

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/datatransfer/ImportOperation.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/datatransfer/ImportOperation.java
@@ -266,16 +266,16 @@ public class ImportOperation extends WorkspaceModifyOperation {
 
 			IFolder folder = getFolder(newDestination);
 			if (folder != null) {
-				if (policy != POLICY_FORCE_OVERWRITE) {
+				if (provider.isFolder(nextSource) && this.overwriteState == OVERWRITE_ALL) {
+					collectExistingReadonlyFiles(newDestinationPath, provider.getChildren(nextSource), noOverwrite,
+							overwriteReadonly, POLICY_FORCE_OVERWRITE, subMonitor.split(100));
+				}
+				else if (policy != POLICY_FORCE_OVERWRITE) {
 					if (this.overwriteState == OVERWRITE_NONE
 							|| !queryOverwrite(newDestinationPath)) {
 						noOverwrite.add(folder);
 						continue;
 					}
-				}
-				if (provider.isFolder(nextSource)) {
-					collectExistingReadonlyFiles(newDestinationPath, provider.getChildren(nextSource), noOverwrite,
-							overwriteReadonly, POLICY_FORCE_OVERWRITE, subMonitor.split(100));
 				}
 			} else {
 				IFile file = getFile(newDestination);


### PR DESCRIPTION
When files are copied as part of project import , the overwrite flag is set for certain files but was never in effect- the prompt logic was hiding the overwrite check. To fix flip the order

Fixes: #617 