### PR TITLE
Clear all the ExpandableNode's on input set.

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnViewer.java
@@ -1088,4 +1088,10 @@ public abstract class ColumnViewer extends StructuredViewer {
 		// by default return given selection.
 		return selection;
 	}
+
+	@Override
+	protected void unmapAllElements() {
+		expandableNodes.clear();
+		super.unmapAllElements();
+	}
 }


### PR DESCRIPTION
When client sets the input multiple times, previously maintained expandableNodes are not cleared.
unmapAllElements() is called for every input set to clear element->item mapping. So overriding and clearing the expandableNodes there.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1520