### PR TITLE
Fix replace behavior of FindReplaceLogic/Dialog for RegEx search #1540

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import org.eclipse.swt.custom.BusyIndicator;
@@ -582,11 +583,24 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	@Override
 	public boolean performSelectAndReplace(String findString, String replaceString) {
 		resetStatus();
-		boolean needToSelectFirst = !getCurrentSelection().equals(findString);
-		if (needToSelectFirst) {
+		if (!isFindStringSelected(findString)) {
 			performSearch(findString);
 		}
 		return replaceSelection(replaceString);
+	}
+
+	private boolean isFindStringSelected(String findString) {
+		String selectedString = getCurrentSelection();
+		if (isRegExSearchAvailableAndActive()) {
+			int patternFlags = 0;
+			if (!isActive(SearchOptions.CASE_SENSITIVE)) {
+				patternFlags |= Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;
+			}
+			Pattern pattern = Pattern.compile(findString, patternFlags);
+			return pattern.matcher(selectedString).find();
+		} else {
+			return getCurrentSelection().equals(findString);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
The replace functionality of the `FindAndReplaceLogic` checks whether the current selection fits to the current search string and otherwise performs a find operation first. To this end, it compares the text selection with the search string, even if regex search is used. In regex search mode, this check will usually fail and a find operation is performed even though a correct string is already selected. This results in the replacement of the next instead of the current match.

With this change, the check for whether the currently selected string fits to the search string properly considers regex search mode. In consequence, all replace operations consider the current selection for replacement if fitting. It also adds according regression tests.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1540