### PR TITLE
Jenkinsfile: disable javadoc, maven issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
 					archiveArtifacts artifacts: '*.log,*/target/work/data/.metadata/*.log,*/tests/target/work/data/.metadata/*.log,apiAnalyzer-workspace/.metadata/*.log', allowEmptyArchive: true
 					junit '**/target/surefire-reports/TEST-*.xml'
 					discoverGitReferenceBuild referenceJob: 'eclipse.platform.ui/master'
-					recordIssues publishAllIssues: true, tools: [eclipse(pattern: '**/target/compilelogs/*.xml'), mavenConsole(), javaDoc()]
+					recordIssues publishAllIssues:false, tool: eclipse(pattern: '**/target/compilelogs/*.xml'), qualityGates: [[threshold: 1, type: 'DELTA', unstable: true]]
 				}
 			}
 		}


### PR DESCRIPTION
`- publishAllIssues: false - to disable unrelated warnings in PRs`
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/51790620/f7f97dbd-21c7-451b-93ec-f9b5270367fa)
`- maven: wrongly collects "API WARNING"s without resolving filename`
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/51790620/281b433c-e08d-4973-8f50-1405c20d2cd2)
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/51790620/5ab76afe-7481-4cad-bd2c-d1eededb3f10)
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/51790620/d8701885-7455-408f-97ff-c1f1305c2a27)

`- javadoc: it is currently not used`
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/51790620/2f2e9175-88b9-4c51-afbf-e0d39341696b)

`* eclipse: ecj info markers work fine with parsing xml files`