### PR TITLE
Touch bundles affected by compiler implementation change

### DIFF
--- a/bundles/org.eclipse.ui.ide/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.ide/forceQualifierUpdate.txt
@@ -6,3 +6,4 @@ Bug 534597 - Unanticipated comparator errors in I20180511-2000
 Bug 572789 - Comparator errors in I20210412-1800 after moving to compiler from 4.20 M1
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1750

--- a/bundles/org.eclipse.ui.workbench/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.workbench/forceQualifierUpdate.txt
@@ -13,3 +13,4 @@ Bug 568058 - Comparator errors in I20201020-1800
 Bug 572789 - Comparator errors in I20210412-1800 after moving to compiler from 4.20 M1
 Bug 578351 - Lambda generation order is unstable in ecj 
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1750


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1750