### PR TITLE
Disable VirtualLazyTreeViewerTest#testContains() on Mac #1183

### DIFF
--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualLazyTreeViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualLazyTreeViewerTest.java
@@ -48,7 +48,8 @@ public class VirtualLazyTreeViewerTest extends TreeViewerTest {
 	@Override
 	public void setUp() {
 		super.setUp();
-		// process events because the content provider uses an asyncExec to set the item count of the tree
+		// process events because the content provider uses an asyncExec to set the item
+		// count of the tree
 		processEvents();
 	}
 
@@ -239,5 +240,17 @@ public class VirtualLazyTreeViewerTest extends TreeViewerTest {
 			return;
 		}
 		super.testWorldChanged();
+	}
+
+	@Override
+	public void testContains() {
+		if (disableTestsBug347491) {
+			return;
+		}
+		if (setDataCalls == 0) {
+			System.err.println("SWT.SetData is not received. Cancelled test " + testName.getMethodName());
+			return;
+		}
+		super.testContains();
 	}
 }


### PR DESCRIPTION
The test case `org.eclipse.jface.tests.viewers.VirtualLazyTreeViewerTest.testContains` is randomly failing on Mac. Several other test cases accessing the data of items in a tree viewer with lazy content provider have been disabled on Mac due to some issue with the availability of the item data (bug 347491).

Since there is no value in executing this test when the functionality is known to be broken and thus other related test cases are already disabled, this change disables the random failing test.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1183