### PR TITLE
Fix the links in the Rich Client Platform Book markdown page

### DIFF
--- a/docs/Rich_Client_Platform/Rich_Client_Platform_Book.md
+++ b/docs/Rich_Client_Platform/Rich_Client_Platform_Book.md
@@ -1,5 +1,3 @@
-
-
 Rich Client Platform/Book
 =========================
 
@@ -40,13 +38,11 @@ Authors: Jeff McAffer, Jean-Michel Lemieux, Chris Aniszczyk
 
 Date of publication: April 15, 2010 (second edition), October 11, 2005 (first edition)
 
-Book website: [http://eclipsercp.org](http://eclipsercp.org)
-
 Purchase on Amazon and reviews: [Eclipse Rich Client Platform, Second Edition on Amazon.com](http://amzn.to/fK3Tky)
 
 Publisher: Addison-Wesley Professional ([AW book page](http://www.awprofessional.com/title/0321334612))
 
-In Eclipse [Rich Client Platform](/Rich_Client_Platform "Rich Client Platform"), Second Edition, three Eclipse Rich Client Platform (RCP) project leaders show how to use Eclipse 3.5 (""[Galileo](/Galileo "Galileo")") to rapidly deliver cross-platform applications with rich, native-feel GUIs.
+In Eclipse Rich Client Platform, Second Edition, three Eclipse Rich Client Platform (RCP) project leaders show how to use Eclipse 3.5 to rapidly deliver cross-platform applications with rich, native-feel GUIs.
 
 The authors fully reveal the power of Eclipse as a desktop application development platform; introduce important new improvements in Eclipse 3.5; and walk through developing a full-featured, branded RCP application for Windows, Linux, Mac, and other platforms—including handheld devices and kiosks.
 
@@ -54,24 +50,10 @@ Drawing on their extensive experience, the authors cover building, refining, and
 
 For Java programmers at all levels of experience, this book
 
-*   Introduces important new RCP features such as [p2](/P2 "P2"), Commands, and Databinding
-*   Thoroughly covers key RCP-related technologies such as [Equinox](/Equinox "Equinox"), [SWT](/SWT "SWT"), [JFace](/JFace "JFace"), and [OSGi](/OSGi "OSGi")
+*   Introduces important new RCP features such as p2, Commands, and Databinding
+*   Thoroughly covers key RCP-related technologies such as Equinox, SWT, JFace, and OSGi
 *   Shows how to effectively brand and customize RCP application look-and-feel
-*   Walks through user interface testing for RCP applications with [SWTBot](/SWTBot "SWTBot")
+*   Walks through user interface testing for RCP applications with SWTBot
 *   Illuminates key similarities and differences between RCP and conventional plug-in development
 *   Hands-on, pragmatic, and comprehensive, this book offers all the real-world, nontrivial code example working developers need—as well as "deep dives" into key technical areas that are essential to your success.
-
-Free excerpts:
-
-*   [Foreword by Jeff Norris from NASA/JPL](http://eclipsercp.org/book/chapters/RCP_Foreward2.pdf)
-*   [Chapter 2](http://eclipsercp.org/book/chapters/RCP_Chapter02.pdf)
-
-More Information
-----------------
-
-1.  [http://eclipsercp.org/2010/04/eclipse-rcp-2nd-edition-going-to-press/](http://eclipsercp.org/2010/04/eclipse-rcp-2nd-edition-going-to-press/)
-
-*   [Book review](http://www.eclipsezone.com/articles/rcp-review) by [Wayne Beaton](http://wbeaton.blogspot.com)
-
-[Nick Edgar](/Nick_Edgar "Nick Edgar")'s opinion: This book is essential reading if you're doing or planning any development with the [Rich Client Platform](/Rich_Client_Platform "Rich Client Platform"). The book also has a nice forward by Jeff Norris of NASA/JPL, where they are building their next generation mission planning platform on top of RCP.
 


### PR DESCRIPTION
Link to Book website http://eclipsercp.org deleted, because of 403 error

Link to Publisher: Addison-Wesley Professional deleted, because it is broken.

Remove outdated and broken links