### PR TITLE
increase transparency of showKeyPopUp

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/keys/show/ShowKeysUI.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/keys/show/ShowKeysUI.java
@@ -223,7 +223,7 @@ public class ShowKeysUI implements IDisposable {
 
 			Color color = JFaceResources.getColorRegistry().get(POPUP_COLOR_BG);
 			newShell.setBackground(color);
-			newShell.setAlpha(170);
+			newShell.setAlpha(130);
 		}
 
 		@Override


### PR DESCRIPTION
Fixes: #48 

<img width="937" alt="image" src="https://github.com/eclipse-platform/eclipse.platform.ui/assets/122080218/83287745-cb6e-401d-81b6-9fe024fad198">

The text behind is partly visible now though at the expanse of transparency to the key shortcut text
