### PR TITLE
Future-proof workaround for flipped splash screen in macOS Sonoma

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/Workbench.java
@@ -851,7 +851,7 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 		if (splashLoc != null) {
 			try (InputStream input = new BufferedInputStream(new FileInputStream(splashLoc))) {
 				background = getImage(display, input);
-			} catch (SWTException | IOException e) {
+			} catch (SWTException | IOException | NumberFormatException e) {
 				StatusManager.getManager().handle(StatusUtil.newStatus(WorkbenchPlugin.PI_WORKBENCH, e));
 			}
 		}
@@ -867,7 +867,7 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 			 * (https://github.com/eclipse-platform/eclipse.platform.swt/issues/772) ,Splash
 			 * Screen gets flipped.As a workaround the image is flipped and returned.
 			 */
-			if (System.getProperty("os.version").startsWith("14")) { //$NON-NLS-1$ //$NON-NLS-2$
+			if (Integer.parseInt(System.getProperty("os.version").split(".")[0]) >= 14) { //$NON-NLS-1$ //$NON-NLS-2$
 				GC gc = new GC(image);
 				Transform tr = new Transform(display);
 				tr.setElements(1, 0, 0, -1, 0, 0);


### PR DESCRIPTION
The workaround should keep working even when macOS major version moves beyond 14.

Follow-up on #1355.