### PR TITLE
fix deprecated getSubjectDN()

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/about/BundleSigningInfo.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/about/BundleSigningInfo.java
@@ -207,7 +207,7 @@ public class BundleSigningInfo {
 			if (!(e instanceof X509Certificate)) {
 				continue;
 			}
-			Properties cert = parseCert(((X509Certificate) e).getSubjectDN().getName());
+			Properties cert = parseCert(((X509Certificate) e).getSubjectX500Principal().getName());
 			if (cert != null)
 				certs.add(cert);
 		}


### PR DESCRIPTION
The method getSubjectDN() from the type X509Certificate is deprecated since version 16