### PR TITLE
Dialog Images: suppress removal warning

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageRegistry.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageRegistry.java
@@ -158,6 +158,7 @@ public class ImageRegistry {
 	 * @param key the key
 	 * @return the image, or <code>null</code> if none
 	 */
+	@SuppressWarnings({ "removal", "deprecation" })
 	public Image get(String key) {
 
 		// can be null

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/ImageRegistryTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/ImageRegistryTest.java
@@ -39,6 +39,7 @@ public class ImageRegistryTest {
 		assertNull("Registry should handle null", result);
 	}
 
+	@SuppressWarnings("removal")
 	@Test
 	public void testGetString() {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/LazyResourceManagerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/LazyResourceManagerTest.java
@@ -119,6 +119,7 @@ public class LazyResourceManagerTest {
 
 	}
 
+	@SuppressWarnings("removal")
 	@Test
 	public void testDefaultImage() {
 		// note, we must touch the class to ensure the static initialer runs


### PR DESCRIPTION
The field Dialog.DLG_IMG_ERROR has been deprecated since version 2023-12 and marked for removal