### PR TITLE
Remove obsolete annotations from the build.properties

### DIFF
--- a/bundles/org.eclipse.jface/build.properties
+++ b/bundles/org.eclipse.jface/build.properties
@@ -20,7 +20,6 @@ bin.includes = plugin.properties,\
 src.includes = about.html
 source.. = src/
 output.. = bin/
-additional.bundles = org.eclipse.pde.api.tools.annotations
 
 # Maven properties, see https://github.com/eclipse/tycho/wiki/Tycho-Pomless
 pom.model.property.code.ignoredWarnings = -warn:-deprecation,raw,unchecked


### PR DESCRIPTION
These are no longer required as Tycho+PDE add them automatically