### PR TITLE
PDE: Restarting development eclipse does not relaunch

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/Workbench.java
@@ -2553,7 +2553,11 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 
 	@Override
 	public boolean restart(boolean useCurrrentWorkspace) {
-		if (useCurrrentWorkspace) {
+		if (Platform.inDevelopmentMode()) {
+			// In development mode, command line parameters cannot be changed and restart
+			// will always be EXIT_RESTART. Also see setRestartArguments method
+			System.setProperty(PROP_EXIT_CODE, IApplication.EXIT_RESTART.toString());
+		} else if (useCurrrentWorkspace) {
 			URL instanceUrl = Platform.getInstanceLocation().getURL();
 			if (instanceUrl != null) {
 				try {


### PR DESCRIPTION
- In development mode, changing restart parameters is not allowed, hence exit code 24 is not supported. Previously Workbench.buildCommandLine(..) used to return null for development mode, hence exit code was not set by Workbench.restart(..). And IDEApplication.start(..) used to take care of restarting development mode eclipse with exit code 23.
- Now in [PR#1307](https://github.com/eclipse-platform/eclipse.platform.ui/pull/1307), Workbench.buildCommandLine(..) does not check for development mode, hence Workbench.restart(..) is setting return code 24.

Fix:
====
Similar to Workbench.setRestartArguments(..), Workbench.restart(..) also checks for development mode and explicitly sets the exit code 23

Related to https://github.com/eclipse-equinox/p2/issues/166