### PR TITLE
Unify Hover-Behavior Between Light and Dark Theme

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/light/e4-light_tabstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/light/e4-light_tabstyle.css
@@ -30,6 +30,7 @@
 	padding: 0px;
 	color: '#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR';
 	swt-draw-custom-tab-content-background: true;
+	swt-unselected-hot-tab-color-background:'#org-eclipse-ui-workbench-ACTIVE_TAB_BG_START';
 }
 
 .MPartStack.active {


### PR DESCRIPTION
In the "Dark" theme the background color of unselected tabs in CTabFolders changes color when user hovers over them with the mouse cursor. This helps a lot to see where an inactive tab starts and ends.

This change adds the same behavior also for the light theme.