### PR TITLE
Fix broken links after wiki migration

### DIFF
--- a/docs/Accessibility_Features.md
+++ b/docs/Accessibility_Features.md
@@ -6,7 +6,7 @@ Accessibility Best Practises in the Eclipse UI
 
 Since Eclipse 2.0 the Eclipse UI has tried to be as accessible as possible. There are two focusses here - making the IDE accessible and making it possible to write an accessible application using the Eclipse API with a minimum of work. This entry will focus on what you get without any extra work to be done on your part.
 
-Most of the accessibility support comes direct from SWT. If you don't use any custom widgets and follow good accessibility practises (see the [IBM Accessibility checklist](http://w3-03.ibm.com/able/devtest/software.html)) then you will get thier support as well.
+Most of the accessibility support comes direct from SWT. If you don't use any custom widgets and follow good accessibility practises then you will get thier support as well.
 
 Having said that there are places within the Platform UI that have been given some accessibility features.
 

--- a/docs/Eclipse4_RCP_Dependency_Injection.md
+++ b/docs/Eclipse4_RCP_Dependency_Injection.md
@@ -82,7 +82,7 @@ Eclipse injector was originally based on the annotations defined in JSR 330 and 
 ---------------------------------------------------------------------------------------------------
 
 @Inject marks a constructor, method, or field as being available for injection. 
-If you inject OSGi Services, it is possible to filter or reference multiple Services see [https://www.eclipse.org/eclipse/news/4.7/platform_isv.php#di-extension-service](https://www.eclipse.org/eclipse/news/4.7/platform_isv.php#di-extension-service)
+If you inject OSGi Services, it is possible to filter or reference multiple Services see [here](https://www.eclipse.org/eclipse/news/4.7/platform_isv.php#di-extension-service) for more information
 
 @Named (jakarta.inject)
 -------------------------------------------------------------------------------------------------

--- a/docs/EclipsePluginDevelopmentFAQ.md
+++ b/docs/EclipsePluginDevelopmentFAQ.md
@@ -173,7 +173,6 @@ Also, Eclipse can handle jars within jars. It expands them into a temporary loca
 
 The articles below may be of your interest.
 
-*   [What is IAdaptable](http://www.eclipsezone.com/articles/what-is-iadaptable/)
 *   [Adapters](http://www.eclipse.org/articles/article.php?file=Article-Adapters/index.html)
 
 ### How do I read from a file that I've included in my bundle/plug-in?

--- a/docs/Eclipse_Corner.md
+++ b/docs/Eclipse_Corner.md
@@ -116,7 +116,7 @@ Eclipse setup instructions on a new Linux (or other OS) computer
 ----------------------------------------------------------------
 
 *   Direct download link is here: [Eclipse setup instructions on a new Linux (or other OS) computer.pdf](https://github.com/ElectricRCAircraftGuy/eRCaGuy_dotfiles/blob/master/eclipse/Eclipse%20setup%20instructions%20on%20a%20new%20Linux%20(or%20other%20OS)%20computer.pdf) (PDF).
-*   It is part of this larger project here: [https://github.com/ElectricRCAircraftGuy/eRCaGuy_dotfiles](https://github.com/ElectricRCAircraftGuy/eRCaGuy_dotfiles).
+*   It is part of this larger project [here](https://github.com/ElectricRCAircraftGuy/eRCaGuy_dotfiles).
 
   
 Getting started with Eclipse as a beginner is difficult. This document _significantly_ eases that transition. Even for experienced Eclipse users, getting it to work perfectly and bug-free on large projects requires several advanced tricks, all of which are documented carefully in this document with the words "\[IMPORTANT TO PREVENT FREEZES\]". This is unofficial documentation to help Eclipse users get Eclipse installed and configured on any operating system, with a particular emphasis on using Eclipse on Linux. It details getting it to work well and crash-free on any OS when working with small or gigantic projects.
@@ -624,7 +624,6 @@ Designing Accessible Plug-ins in Eclipse
 
 Accessibility for disabled users is now a priority in application development as advances in techniques and support within operating systems have now made this possible. This article covers the Eclipse accessibility support, general tips for creating accessible plug-ins, and the types of disabilities that the Eclipse accessibility support assists. This is all illustrated using an example of making a view accessible.
 
-*   [Original article](http://www.eclipse.org/articles/Article-Accessibility/accessibility.html)
 *   [Updated for Eclipse Platform 3.5](http://www.eclipse.org/articles/article.php?file=Article-Accessibility351/index.html)
 
   

--- a/docs/JFaceDataBinding.md
+++ b/docs/JFaceDataBinding.md
@@ -301,7 +301,9 @@ Use the following URL to clone the repository via File -> Import -> Git reposito
 
 *   [http://anonymous@git.eclipse.org/gitroot/platform/eclipse.platform.ui.git](http://anonymous@git.eclipse.org/gitroot/platform/eclipse.platform.ui.git)
 
-After you cloned the project the clone wizard will allow you to import the included projects. For the databinding examples you only have to import the "org.eclipse.jface.examples.databinding" project. For an introduction into EGit please see [EGit](http://www.vogella.de/articles/EGit/article.html)
+After you cloned the project the clone wizard will allow you to import the included projects. 
+For the databinding examples you only have to import the "org.eclipse.jface.examples.databinding" project. 
+For an introduction into EGit please see [EGit](https://www.vogella.com/tutorials/EclipseGit/article.html)
 
 Most of the examples provide a main method, you can run it as a Java Application to see what happens.  
 

--- a/docs/JFaceSnippets.md
+++ b/docs/JFaceSnippets.md
@@ -101,7 +101,8 @@ Demonstrates usage of Icons in Buttons of Dialogs
 
 Drop these icons also in the same package
 
-![Filesave.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/docs/images/Filesave.png)![Cancel.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/docs/images/Cancel.png)
+![Filesave.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/docs/images/Filesave.png)
+![Cancel.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/docs/images/Cancel.png)
 
 ### [Snippet082 - Color Selector](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/dialogs/Snippet082ColorSelectDialog.java)
 
@@ -136,7 +137,9 @@ Layout
   
 Demonstrates usage of the GridLayoutFactory to enhance readability
 
-![Snippet013 Shell1.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/docs/images/Snippet013_Shell1.png)![Snippet013 Shell2.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/docs/images/Snippet013_Shell2.png)![Snippet013 Shell3.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/docs/images/Snippet013_Shell3.png)
+![Snippet013 Shell1.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/docs/images/Snippet013_Shell1.png)
+![Snippet013 Shell2.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/docs/images/Snippet013_Shell2.png)
+![Snippet013 Shell3.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/docs/images/Snippet013_Shell3.png)
 
 ### [Snippet016 - Table Layout](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/layout/Snippet016TableLayout.java)
 
@@ -258,18 +261,18 @@ Demonstrates usage of custom tooltip support in 3.3 used to provide a tooltip fo
 
 ![Snippet011.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/docs/images/Snippet011.png)
 
-### [Snippet013 - Table Viewer No Mandatory Label Provider](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/viewers/Snippet013TableViewerNoMandatoryLabelProvider.java)\]
+### [Snippet013 - Table Viewer No Mandatory Label Provider](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/viewers/Snippet013TableViewerNoMandatoryLabelProvider.java)
 
-*   [Snippet013 - Table Viewer No Mandatory Label Provider](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/viewers/Snippet013TableViewerNoMandatoryLabelProvider.java)\]
+*   [Snippet013 - Table Viewer No Mandatory Label Provider](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/viewers/Snippet013TableViewerNoMandatoryLabelProvider.java)
 
   
 Demonstrates usage of none mandatory LabelProviders in TableViewers to set colors and fonts with 3.2-API
 
 ![Jfacesnippet013.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/docs/images/Jfacesnippet013.png)
 
-### [Snippet014 - Tree Viewer No Mandatory Label Provider](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/viewers/Snippet014TreeViewerNoMandatoryLabelProvider.java)\]
+### [Snippet014 - Tree Viewer No Mandatory Label Provider](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/viewers/Snippet014TreeViewerNoMandatoryLabelProvider.java)
 
-*   [Snippet014 - Tree Viewer No Mandatory Label Provider](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/viewers/Snippet014TreeViewerNoMandatoryLabelProvider.java)\]
+*   [Snippet014 - Tree Viewer No Mandatory Label Provider](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/viewers/Snippet014TreeViewerNoMandatoryLabelProvider.java)
 
   
 Demonstrates usage of none mandatory LabelProviders in TreeViewers to set colors and font with 3.2-API
@@ -355,9 +358,9 @@ Demonstrates usage of JFace-Viewers in "virtual" mode with an ordinary content p
   
 Demonstrates usage of JFace-Viewer virtual mode with a lazy content provider
 
-### [Snippet031 - Table Viewer Custom Tooltips Multi Selection](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/viewers/Snippet031TableViewerCustomTooltipsMultiSelection.java)\]
+### [Snippet031 - Table Viewer Custom Tooltips Multi Selection](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/viewers/Snippet031TableViewerCustomTooltipsMultiSelection.java)
 
-*   [Snippet031 - Table Viewer Custom Tooltips Multi Selection](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/viewers/Snippet031TableViewerCustomTooltipsMultiSelection.java)\]
+*   [Snippet031 - Table Viewer Custom Tooltips Multi Selection](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/viewers/Snippet031TableViewerCustomTooltipsMultiSelection.java)
 
   
 Demonstrates creation of tooltips for cells for pre 3.3 users
@@ -493,7 +496,7 @@ Demonstrates the usage of ILazyContentProvider in conjunction with a Virtual-Tre
   
 Demonstrates how to overcome a limitation when it comes to key-navigation and CheckBoxEditors in 3.3.1.
 
-This is a workaround for bug [https://bugs.eclipse.org/bugs/show_bug.cgi?id=198502](https://bugs.eclipse.org/bugs/show_bug.cgi?id=198502)
+This is a workaround for [Bug #198502](https://bugs.eclipse.org/bugs/show_bug.cgi?id=198502)
 
 ![Snippet048TreeViewerTabWithCheckboxFor3 3.png](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/docs/images/Snippet048TreeViewerTabWithCheckboxFor3_3.png)
 

--- a/docs/PlatformCommandFramework.md
+++ b/docs/PlatformCommandFramework.md
@@ -4,49 +4,29 @@ Platform Command Framework
 Contents
 --------
 
-*   [1 Architecture Overview](#Architecture-Overview)
-*   [2 Eclipse Commands Tutorial](#Eclipse-Commands-Tutorial)
-*   [3 Other Resources](#Other-Resources)
-*   [4 Commands](#Commands)
-    *   [4.1 Executing a command with parameters](#Executing-a-command-with-parameters)
-    *   [4.2 Using an IActionDelegate to execute a command](#Using-an-IActionDelegate-to-execute-a-command)
-        *   [4.2.1 Generic Command Action Delegate](#Generic-Command-Action-Delegate)
-*   [5 Handlers](#Handlers)
-*   [6 KeyBindings](#KeyBindings)
-*   [7 Contexts](#Contexts)
-*   [8 Menu Contributions](#Menu-Contributions)
-*   [9 Tracing Option](#Tracing-Option)
+*   [1 Eclipse Commands Tutorial](#Eclipse-Commands-Tutorial)
+*   [2 Other Resources](#Other-Resources)
+*   [3 Commands](#Commands)
+    *   [3.1 Executing a command with parameters](#Executing-a-command-with-parameters)
+    *   [3.2 Using an IActionDelegate to execute a command](#Using-an-IActionDelegate-to-execute-a-command)
+        *   [3.2.1 Generic Command Action Delegate](#Generic-Command-Action-Delegate)
+*   [4 Handlers](#Handlers)
+*   [5 KeyBindings](#KeyBindings)
+*   [6 Contexts](#Contexts)
+*   [7 Tracing Option](#Tracing-Option)
 
-Architecture Overview
-=====================
-
-[http://dev.eclipse.org/viewcvs/index.cgi/~checkout~/platform-ui-home/R3\_1/contributions-proposal/requestForComments\_html_m41374bdb.png](http://dev.eclipse.org/viewcvs/index.cgi/~checkout~/platform-ui-home/R3_1/contributions-proposal/requestForComments_html_m41374bdb.png)
-
-Figure 1: High Level Architecture
 
 Eclipse Commands Tutorial
 =========================
 
-[http://www.vogella.de/articles/EclipseCommands/article.html](http://www.vogella.de/articles/EclipseCommands/article.html) Tutorial about using Eclipse Commands by Lars Vogel
+[https://www.vogella.com/tutorials/EclipseCommands/article.html](https://www.vogella.com/tutorials/EclipseCommands/article.html) Tutorial about using Eclipse Commands by Lars Vogel
 
 Other Resources
 ===============
 
-[Commands in Action](http://blog.eclipse-tips.com/search/label/Commands) by [Prakash G.R.](http://blog.eclipse-tips.com/):
+[Command Core Expressions](https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/docs/Command_Core_Expressions.md)
 
-*   [Commands Part 1: Actions Vs Commands](http://blog.eclipse-tips.com/2009/01/commands-part-1-actions-vs-commands.html)
-*   [Commands Part 2: Selection and Enablement of IHandlers](http://blog.eclipse-tips.com/2009/01/commands-part-2-selection-and.html)
-*   [Commands Part 3: Parameters for Commands](http://blog.eclipse-tips.com/2008/12/commands-part-3-parameters-for-commands.html)
-*   [Commands Part 4: Misc items ...](http://blog.eclipse-tips.com/2009/01/commands-part-4-misc-items.html)
-*   [Commands Part 5: Authentication in RCP applications](http://blog.eclipse-tips.com/2009/02/commands-part-5-authentication-in-rcp.html)
-*   [Commands Part 6: Toggle & Radio menu contributions](http://blog.eclipse-tips.com/2009/03/commands-part-6-toggle-radio-menu.html)
-*   [Commands Part 7: Adding standard commands](http://blog.eclipse-tips.com/2009/05/commands-part-7-adding-standard.html)
-*   [Keyboard accessibility thru Command Framework](http://blog.eclipse-tips.com/2009/06/keyboard-accessibility-thru-command.html)
-*   [Toggle Commands the toggle other contributions](http://blog.eclipse-tips.com/2009/12/toggle-commands-toggle-other.html)
-
-[Command Core Expressions](http://wiki.eclipse.org/Command_Core_Expressions)
-
-[Platform Expression Framework](http://wiki.eclipse.org/Platform_Expression_Framework)
+[Platform Expression Framework](https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/docs/Platform_Expression_Framework.md)
 
 Commands
 ========
@@ -423,7 +403,11 @@ We'll need a more robust implementation, but in 3.2 your action delegate needs t
 Handlers
 ========
 
-Handlers are managed by the **org.eclipse.ui.handlers** extension point and the IHandlerService. Many Handlers can register for a command. At any give time, either 0 or 1 handlers will be active for the command. A handler's active state and enabled state can be controlled declaratively. See [Command Core Expressions](/Command_Core_Expressions "Command Core Expressions") for a more complex description of the declarative expressions. Handlers are responsible for interpreting any optional command parameters using the ExecutionEvent parameter.
+Handlers are managed by the **org.eclipse.ui.handlers** extension point and the IHandlerService. 
+Many Handlers can register for a command. At any give time, either 0 or 1 handlers will be active for the command. 
+A handler's active state and enabled state can be controlled declaratively. 
+See [Command Core Expressions](https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/docs/Command_Core_Expressions.md) for a more complex description of the declarative expressions. 
+Handlers are responsible for interpreting any optional command parameters using the ExecutionEvent parameter.
 
     <extension
            point="org.eclipse.ui.handlers">
@@ -533,11 +517,6 @@ Programmatically, you can create contexts:
     }
 
 Note, however, that a plugin that programmatically defines contexts is responsible for cleaning them up if the plugin is ever unloaded.
-
-Menu Contributions
-==================
-
-See [Menu Contributions](/Menu_Contributions "Menu Contributions")
 
 Tracing Option
 ==============

--- a/docs/Platform_Expression_Framework.md
+++ b/docs/Platform_Expression_Framework.md
@@ -39,7 +39,7 @@ Where they are useful
 
 Expressions are used in extension points that have to decide things based on a context, but without loading the plugin implementing that decision. 
 The most popular examples where they are used are the [Platform Command Framework](https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/docs/PlatformCommandFramework.md), and the 
-[Common Navigator Framework](https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/docs/Common_Navigator_Framework.md"). 
+[Common Navigator Framework](https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/docs/Common_Navigator_Framework.md). 
 Depending on the extension implementation, expressions are used to decide any number of things. 
 Examples:
 
@@ -373,11 +373,4 @@ This allows for two plugins (siblings) to define the same property without ambig
 
 The concrete implementation of the property tester has to extend `PropertyTester`. 
 Look around, you will find existing property testers to get you started with your own.
-
-  
-
-Links
-=====
-
-*   [http://help.eclipse.org/index.jsp?topic=/org.eclipse.platform.doc.isv/guide/workbench\_cmd\_expressions.htm](http://help.eclipse.org/index.jsp?topic=/org.eclipse.platform.doc.isv/guide/workbench_cmd_expressions.htm)
 

--- a/docs/Rich_Client_Platform.md
+++ b/docs/Rich_Client_Platform.md
@@ -93,8 +93,8 @@ Applications
 
 Several applications have been built using the Rich Client Platform.
 
-*   The [RCP Applications](http://eclipse.org/community/rcp.php) section of the [Eclipse Community page](http://eclipse.org/community) lists several apps, including case studies of a few.
-*   NASA/JPL is using Eclipse RCP as the foundation of their next version of Maestro, and more. See the [case study](http://eclipse.org/community/casestudies/NASAfinal.pdf), session [11.3 - "A Martian Eclipse"](http://www.eclipsecon.org/2005/sessions.php) at EclipseCon 2005, and Scott Schram's [blog entry](http://weblogs.java.net/blog/scottschram/archive/2005/03/nasa_explores_e.html) on the presentation. Jeff Norris from NASA/JPL also wrote a nice foreword to the [RCP Book](https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/docs/Rich_Client_Platform/Rich_Client_Platform_Book.md).
+*   The RCP Catalog section of the [Eclipse Community page](http://eclipse.org/community) lists several apps, including case studies of a few.
+*   NASA/JPL is using Eclipse RCP as the foundation of their next version of Maestro, and more. See the [case study](http://eclipse.org/community/casestudies/NASAfinal.pdf), session [11.3 - "A Martian Eclipse"](http://www.eclipsecon.org/2005/sessions.php) at EclipseCon 2005. Jeff Norris from NASA/JPL also wrote a nice foreword to the [RCP Book](https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/docs/Rich_Client_Platform/Rich_Client_Platform_Book.md).
 
 Blogs
 -----

--- a/docs/Rich_Client_Platform/Rich_Client_Platform_Book.md
+++ b/docs/Rich_Client_Platform/Rich_Client_Platform_Book.md
@@ -29,7 +29,7 @@ Author: Lars Vogel
 More Information
 ----------------
 
-[http://www.vogella.com/books/eclipsercp.html](http://www.vogella.com/books/eclipsercp.html)
+[Eclipse RCP book](https://www.vogella.com/books/eclipsercp.html)
 
 Book: "Eclipse Rich Client Platform : Designing, Coding, and Packaging Java™ Applications, Second Edition"
 ==========================================================================================================
@@ -40,7 +40,7 @@ Date of publication: April 15, 2010 (second edition), October 11, 2005 (first ed
 
 Purchase on Amazon and reviews: [Eclipse Rich Client Platform, Second Edition on Amazon.com](http://amzn.to/fK3Tky)
 
-Publisher: Addison-Wesley Professional ([AW book page](http://www.awprofessional.com/title/0321334612))
+Publisher: Addison-Wesley Professional
 
 In Eclipse Rich Client Platform, Second Edition, three Eclipse Rich Client Platform (RCP) project leaders show how to use Eclipse 3.5 to rapidly deliver cross-platform applications with rich, native-feel GUIs.
 

--- a/docs/Rich_Client_Platform/Rich_Client_Platform_FAQ.md
+++ b/docs/Rich_Client_Platform/Rich_Client_Platform_FAQ.md
@@ -52,7 +52,7 @@ Many people that have built, or are building, RCP applications state that the ma
 
 For a nice description of the benefits of RCP, see [Jeff Norris' forward on NASA/JPL's use of RCP](http://web.archive.org/web/20100307050224/eclipsercp.org/book/chapters/RCP_Foreward2.pdf) (archived link), a free excerpt from the [RCP Book](/RCP_Book "RCP Book").
 
-See also the case studies available on the [RCP Community page](http://www.eclipse.org/community/rcp.php).
+See also the case studies available on the [RCP Community page](https://www.eclipse.org/community/).
 
 What is included in the Rich Client Platform?
 ---------------------------------------------
@@ -222,7 +222,9 @@ Note that views with a secondaryId will not match placeholders specifying just t
 How can I deploy my RCP app?
 ----------------------------
 
-[Lars Vogel's RCP tutorial](http://www.vogella.de/articles/EclipseRCP/article.html) discusses this in the section entitled _Products and Branding_.
+The currently best way to deploy your RCP app is to use [Tycho](https://github.com/eclipse-tycho/tycho). 
+See [Tycho tutorial](https://www.vogella.com/tutorials/EclipseTycho/article.html) for an example.
+
 
 When I try running, nothing happens, or it complains that the application could not be found in the registry, or that other plug-ins are missing. How can I track the problem down?
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -372,7 +374,7 @@ TIP: the contents of the `jre_linux/` directory is a single directory called `jr
 
 Conclusion: With this configuration the "jre/" directory tree is copied to the root of my distribution and the java executable at jre/bin/java is run by default, even if my system has other java's on its $PATH. And it wasn't necessary to set any "-vm path" to the launcher.
 
-More options for the build.properties file can be found at [http://help.eclipse.org/help32/index.jsp?topic=/org.eclipse.pde.doc.user/reference/pde\_feature\_generating_build.htm](http://help.eclipse.org/help32/index.jsp?topic=/org.eclipse.pde.doc.user/reference/pde_feature_generating_build.htm)
+More options for the build.properties file can be found [here](http://help.eclipse.org/help32/index.jsp?topic=/org.eclipse.pde.doc.user/reference/pde_feature_generating_build.htm)
 
 How to add menu item, command and handler?
 ------------------------------------------

--- a/docs/Rich_Client_Platform/Rich_Client_Platform_How_to.md
+++ b/docs/Rich_Client_Platform/Rich_Client_Platform_How_to.md
@@ -39,7 +39,7 @@ Contents
 IDE
 ---
 
-[http://www.eclipse.org/downloads/](http://www.eclipse.org/downloads/)
+[Eclipse Download site](http://www.eclipse.org/downloads/)
 
 Link "Eclipse for RCP/Plug-in Developers"
 
@@ -52,16 +52,17 @@ Open PDE (Plug-in Development Environment) perspective: Window > Open Perspectiv
 Target
 ------
 
-Target Platform is used to run the applications/plugins you build with Eclipse RCP. Although it is possible to run your applications/plugins using your Eclipse IDE installation, this is not recommended.
+Target Platform is used to run the applications/plugins you build with Eclipse RCP. 
+Although it is possible to run your applications/plugins using your Eclipse IDE installation, this is not recommended.
 
 Create directory _target_ in a folder of your choice.
 
-[http://download.eclipse.org/eclipse/downloads](http://download.eclipse.org/eclipse/downloads)
+[The Eclipse Project Downloads](http://download.eclipse.org/eclipse/downloads)
 
 Download and unzip in _target_: eclipse-RCP-SDK-*.zip, eclipse-*-delta-pack.zip
 
 *   Delta pack is needed for building to other platforms, or for automated [build](#Build).
-*   If Help or Update feature is needed, either replace RCP-SDK with platform-SDK, or download individual features from [http://www.eclipse.org/platform/](http://www.eclipse.org/platform/)
+*   If Help or Update feature is needed, either replace RCP-SDK with platform-SDK, or download individual features from [here](http://www.eclipse.org/platform/)
 *   eclipse-RCP-SDK-*.zip is needed rather than eclipse-RCP-*.zip else extensions won't work in plug-in editor.
 
 Window > Preferences > Plug-in Development > Target Platform > Browse > _target_/eclipse > OK > Reload
@@ -222,7 +223,7 @@ Alternately (tested under Helios 3.6), you can run the Externalize Strings Wizar
 
 Move the various .properties files from that project fragment to the source project (e.g. move "myproject.nl1/plugin\_fr.properties" to "myproject/plugin\_fr.properties", and likewise for any .properties files in subfolders such as OSGI-INF or src). You should then have essentially nothing left in the project fragment, so you can delete it.
 
-Now install the Resource Bundle Editor (RBE) plug-in (from [http://sourceforge.net/projects/eclipse-rbe/](http://sourceforge.net/projects/eclipse-rbe/)) by unzipping its plugins directory into your eclipse/plugins directory (restart Eclipse once this is done). Go to Window: Preferences: General: Editors: File Associations, and assign RBE as the default editor for .properties files.
+Now install the Resource Bundle Editor (RBE) plug-in (from [here](http://sourceforge.net/projects/eclipse-rbe/)) by unzipping its plugins directory into your eclipse/plugins directory (restart Eclipse once this is done). Go to Window: Preferences: General: Editors: File Associations, and assign RBE as the default editor for .properties files.
 
 You will now be able to open the .properties files that need localization and edit them accordingly. By keeping matching .properties files co-located, RBE is able to display the original (English) and target language string values side by side, which makes translation less of a chore. RBE is being integrated into Eclipse's Babel project, so it will eventually no longer be necessary to move the .properties files as described earlier: you'll be able to edit them right in the project fragments. Project fragments are nice if you do not want to ship your project with all the various localizations in it (strings, icons, images, help files, etc.), but would rather ship each localization separately.
 
@@ -230,7 +231,7 @@ If you do not use RBE, be aware that .properties files _must_ use ISO 8859-1 cha
 
 ### RCP
 
-[http://download.eclipse.org/technology/babel/babel\_language\_packs/](http://download.eclipse.org/technology/babel/babel_language_packs/)
+[Download Eclipse](http://download.eclipse.org/technology/babel/babel_language_packs/)
 
 Unzip BabelLanguagePack-eclipse-*.zip into _target_
 
@@ -247,7 +248,7 @@ Preferences
 
 If no need for preference scopes
 
-[http://www.eclipse.org/eclipse/platform-core/documents/user_settings/faq.html](http://www.eclipse.org/eclipse/platform-core/documents/user_settings/faq.html)
+See [User Settings FAQ](https://eclipse.dev/eclipse/platform-core/documents/user_settings/faq.html)
 
 Get preference value:
 


### PR DESCRIPTION
It applies to several migrated markdown pages.
Links which lead to a 404 error were deleted.

Chapter Architecture overview deleted because it was only a reference to a picture which doesnt exist

Link to vogella tutorial corrected as pointing to wrong site

Link to [Commands in
Action](http://blog.eclipse-tips.com/search/label/Commands) and [Prakash G.R.](http://blog.eclipse-tips.com/)deleted as sites dont exist

Link to Menu Contributions removed because Menu Contributions is just a proposal for placing menu items for 3.3 and the last update is from 2012