### PR TITLE
Add Active Part Indicator to Light Theme

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/light/e4-light_tabstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/light/e4-light_tabstyle.css
@@ -54,6 +54,14 @@ CTabFolder.MArea {
 	padding: 0px;
 }
 
+CTabFolder {
+    swt-selected-tab-highlight: none;
+}
+
+CTabFolder.active {
+    swt-selected-tab-highlight: rgb(103,145,230);
+    swt-selected-highlight-top: false;
+}
 
 .MPartStack.active.noFocus > CTabItem:selected {
 	color: '#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_TEXT_COLOR';


### PR DESCRIPTION
The dark theme already has such an indicator. It adds a blue underline on the active tab.

This change aligns the dark/light theme and adds the blue underline also to the light theme.

Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/issues/1651