### PR TITLE
Allow user select default editor per content type

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/IPreferenceConstants.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/IPreferenceConstants.java
@@ -99,6 +99,9 @@ public interface IPreferenceConstants {
 	// Preference key for default editors
 	String DEFAULT_EDITORS_CACHE = "defaultEditorsCache"; //$NON-NLS-1$
 
+	// Preference key prefix for default editor associated with a content type
+	String DEFAULT_EDITOR_FOR_CONTENT_TYPE = "defaultEditorForContentType_"; //$NON-NLS-1$
+
 	// Tab width = tab height * scalar value
 	String EDITOR_TAB_WIDTH = "EDITOR_TAB_WIDTH"; //$NON-NLS-1$
 

--- a/tests/org.eclipse.ui.tests/plugin.xml
+++ b/tests/org.eclipse.ui.tests/plugin.xml
@@ -753,6 +753,30 @@
          <contentTypeBinding contentTypeId="org.eclipse.ui.tests.content-type2"/>
       </editor>
       <editor
+            class="org.eclipse.ui.tests.api.MockEditorPart"
+            default="false"
+            icon="icons/anything.gif"
+            id="org.eclipse.ui.tests.contentType3Editor1"
+            name="org.eclipse.ui.tests.contentType3Editor1">
+         <contentTypeBinding contentTypeId="org.eclipse.ui.tests.content-type3"/>
+      </editor>
+      <editor
+            class="org.eclipse.ui.tests.api.MockEditorPart"
+            default="false"
+            icon="icons/anything.gif"
+            id="org.eclipse.ui.tests.contentType3Editor2"
+            name="org.eclipse.ui.tests.contentType3Editor2">
+         <contentTypeBinding contentTypeId="org.eclipse.ui.tests.content-type3"/>
+      </editor>
+      <editor
+            class="org.eclipse.ui.tests.api.MockEditorPart"
+            default="false"
+            icon="icons/anything.gif"
+            id="org.eclipse.ui.tests.contentType3Editor3"
+            name="org.eclipse.ui.tests.contentType3Editor3">
+         <contentTypeBinding contentTypeId="org.eclipse.ui.tests.content-type3"/>
+      </editor>
+      <editor
             class="org.eclipse.ui.tests.multieditor.TiledEditor"
             default="false"
             icon="icons/binary_co.gif"
@@ -1199,6 +1223,13 @@
              <describer class="org.eclipse.core.runtime.content.XMLRootElementContentDescriber">
 				<parameter name="element" value="contentType1" />
 			</describer>
+       </content-type>
+       <content-type
+             file-extensions="content-type3"
+             file-names="content-type3.blah"
+             id="content-type3"
+             name="org.eclipse.ui.tests.content-type3"
+             priority="normal">
        </content-type>
        <content-type
              file-extensions="defaultedContentType"


### PR DESCRIPTION
Extended "Content Types" preference page with possibility to set one of the editors configured for a content type to "default" editor.

The preference will be saved into `org.eclipse.ui.workbench` preference store.

The key is a combination of a prefix with content type id, the value is the editor id, for example to associate base XML content type with generic editor, following is saved:

`defaultEditorForContentType_org.eclipse.core.runtime.xml=org.eclipse.ui.genericeditor.GenericEditor`

By default nothing is changed for IDE, but products can set defaults using the product customization, e.g. for the example above it would be:

`org.eclipse.ui.workbench/defaultEditorForContentType_org.eclipse.core.runtime.xml=org.eclipse.ui.genericeditor.GenericEditor`

![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/964108/28329bed-f9cb-458b-aad2-2ddd90d20987)


Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1659