### PR TITLE
Fix ignored external folding reconcile strategies

### DIFF
--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ExtensionBasedTextViewerConfiguration.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ExtensionBasedTextViewerConfiguration.java
@@ -272,9 +272,9 @@ public final class ExtensionBasedTextViewerConfiguration extends TextSourceViewe
 				foldingReconcilingStrategies, getContentTypes(sourceViewer.getDocument()));
 		if (!foldingReconcilers.isEmpty()) {
 			reconcilers.addAll(foldingReconcilers);
+		} else if (foldingReconcilingStrategies.isEmpty()) {
+			reconcilers.add(new DefaultFoldingReconciler());
 		}
-		// add default reconciler:
-		reconcilers.add(new DefaultFoldingReconciler());
 
 		reconcilingStrategies.addAll(foldingReconcilingStrategies);
 


### PR DESCRIPTION
Since the change which comes with commit 14f3660 'add always default folding reconciler' is faulty, it should be removed. Reason:
hasExternalFoldingAnnotations is always false because containsExternalFoldingAnnotations() can  never return true, because FoldingAnnotation is a non public class which should not be used by external folding reconciler strategies, like the one provided by LSP4E.

Therefore the external folding strategy provided via extension point is not considered.