### PR TITLE
Fix possible NPE if method aboutToStart is accessed early

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/WizardDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/WizardDialog.java
@@ -397,7 +397,7 @@ public class WizardDialog extends TitleAreaDialog implements IWizardContainer2, 
 			Display d = getShell().getDisplay();
 			setDisplayCursor(d.getSystemCursor(SWT.CURSOR_WAIT));
 
-			if (useCustomProgressMonitorPart) {
+			if (useCustomProgressMonitorPart && cancelButton != null) {
 				cancelButton.removeSelectionListener(cancelListener);
 				// Set the arrow cursor to the cancel component.
 				cancelButton.setCursor(d.getSystemCursor(SWT.CURSOR_ARROW));
@@ -409,7 +409,7 @@ public class WizardDialog extends TitleAreaDialog implements IWizardContainer2, 
 				savedState.put(FOCUS_CONTROL, focusControl);
 			}
 			// Activate cancel behavior.
-			if (needsProgressMonitor) {
+			if (needsProgressMonitor && progressMonitorPart != null) {
 				if (enableCancelButton || useCustomProgressMonitorPart) {
 					progressMonitorPart.attachToCancelComponent(cancelButton);
 				}
@@ -1293,14 +1293,14 @@ public class WizardDialog extends TitleAreaDialog implements IWizardContainer2, 
 	 */
 	private void stopped(Map<String, Object> savedState) {
 		if (getShell() != null && !getShell().isDisposed()) {
-			if (wizard.needsProgressMonitor()) {
+			if (wizard.needsProgressMonitor() && progressMonitorPart != null) {
 				progressMonitorPart.setVisible(false);
 				progressMonitorPart.removeFromCancelComponent(cancelButton);
 			}
 
 			restoreUIState(savedState);
 			setDisplayCursor(null);
-			if (useCustomProgressMonitorPart) {
+			if (useCustomProgressMonitorPart && cancelButton != null) {
 				cancelButton.addSelectionListener(cancelListener);
 				cancelButton.setCursor(null);
 			}


### PR DESCRIPTION
WizardDialog#aboutToStart might be accessed earlier than the U is created, in such case a NPE can occur, this adds some check before accessing possible null members.

Fix https://github.com/eclipse-pde/eclipse.pde/issues/1097