### PR TITLE
Improve Double Separator Handling

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/MenuManager.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/MenuManager.java
@@ -740,28 +740,17 @@ public class MenuManager extends ContributionManager implements IMenuManager {
 	protected void update(boolean force, boolean recursive) {
 		if (isDirty() || force) {
 			if (menuExist()) {
-				// clean contains all active items without double separators
 				IContributionItem[] items = getItems();
+
+				// clean contains all active items
 				List<IContributionItem> clean = new ArrayList<>(items.length);
-				IContributionItem separator = null;
+
 				for (IContributionItem item : items) {
 					IContributionItem ci = item;
 					if (!isChildVisible(ci)) {
 						continue;
 					}
-					if (ci.isSeparator()) {
-						// delay creation until necessary
-						// (handles both adjacent separators, and separator at end)
-						separator = ci;
-					} else {
-						if (separator != null) {
-							if (clean.size() > 0) {
-								clean.add(separator);
-							}
-							separator = null;
-						}
-						clean.add(ci);
-					}
+					clean.add(ci);
 				}
 
 				// remove obsolete (removed or non active)
@@ -831,6 +820,28 @@ public class MenuManager extends ContributionManager implements IMenuManager {
 				// remove any old menu items not accounted for
 				for (; srcIx < mi.length; srcIx++) {
 					mi[srcIx].dispose();
+				}
+
+				mi = getMenuItems();
+
+				// Remove double Separator
+				for (int i = 1; i < mi.length; i++) {
+					if (mi[i].getData() instanceof Separator && mi[i - 1].getData() instanceof Separator) {
+						mi[i - 1].dispose();
+					}
+				}
+
+				mi = getMenuItems();
+				if (mi.length > 0) {
+					// Remove leading Separator if present
+					if (mi[0].getData() instanceof Separator) {
+						mi[0].dispose();
+					}
+
+					// Remove trailing Separator if present
+					if (mi[mi.length - 1].getData() instanceof Separator) {
+						mi[mi.length - 1].dispose();
+					}
 				}
 
 				setDirty(false);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/DoubleSeparatorTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/DoubleSeparatorTest.java
@@ -1,0 +1,163 @@
+package org.eclipse.ui.tests.menus;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.jface.action.ActionContributionItem;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.action.MenuManager;
+import org.eclipse.jface.action.Separator;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Menu;
+import org.eclipse.ui.internal.menus.DynamicMenuContributionItem;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * @since 3.5
+ *
+ */
+@RunWith(JUnit4.class)
+public class DoubleSeparatorTest extends MenuTestCase {
+
+
+	public DoubleSeparatorTest() {
+		super(DoubleSeparatorTest.class.getSimpleName());
+	}
+
+	@Test
+	public void testDoubleSeperatorWithDynamic() {
+
+		MenuManager menuManager = new MenuManager();
+
+		ActionContributionItem action1 = new ActionContributionItem(mock(IAction.class));
+		Separator separator1 = new Separator();
+		DynamicMenuContributionItem dynamic1 = mock(DynamicMenuContributionItem.class);
+		Separator separator2 = new Separator();
+		ActionContributionItem action2 = new ActionContributionItem(mock(IAction.class));
+
+		when(dynamic1.isVisible()).thenReturn(true);
+
+		menuManager.add(action1);
+		menuManager.add(separator1);
+		menuManager.add(dynamic1);
+		menuManager.add(separator2);
+		menuManager.add(action2);
+
+		Menu contextMenu = menuManager.createContextMenu(window.getShell());
+		contextMenu.notifyListeners(SWT.Show, null);
+		processEvents();
+
+		assertEquals(3, contextMenu.getItemCount());
+		assertEquals(action1, contextMenu.getItems()[0].getData());
+		assertEquals(separator2, contextMenu.getItems()[1].getData());
+		assertEquals(action2, contextMenu.getItems()[2].getData());
+	}
+
+	@Test
+	public void testDoubleSeperator() {
+
+		MenuManager menuManager = new MenuManager();
+
+		ActionContributionItem action1 = new ActionContributionItem(mock(IAction.class));
+		Separator separator1 = new Separator();
+		Separator separator2 = new Separator();
+		ActionContributionItem action2 = new ActionContributionItem(mock(IAction.class));
+
+		menuManager.add(action1);
+		menuManager.add(separator1);
+		menuManager.add(separator2);
+		menuManager.add(action2);
+
+		Menu contextMenu = menuManager.createContextMenu(window.getShell());
+		contextMenu.notifyListeners(SWT.Show, null);
+		processEvents();
+
+		assertEquals(3, contextMenu.getItemCount());
+		assertEquals(action1, contextMenu.getItems()[0].getData());
+		assertEquals(separator2, contextMenu.getItems()[1].getData());
+		assertEquals(action2, contextMenu.getItems()[2].getData());
+	}
+
+	@Test
+	public void testLeadingSeparatorWithDynamic() {
+		MenuManager menuManager = new MenuManager();
+
+		DynamicMenuContributionItem dynamic1 = mock(DynamicMenuContributionItem.class);
+		Separator separator1 = new Separator();
+		ActionContributionItem action1 = new ActionContributionItem(mock(IAction.class));
+
+		when(dynamic1.isVisible()).thenReturn(true);
+
+		menuManager.add(dynamic1);
+		menuManager.add(separator1);
+		menuManager.add(action1);
+
+		Menu contextMenu = menuManager.createContextMenu(window.getShell());
+		contextMenu.notifyListeners(SWT.Show, null);
+		processEvents();
+
+		assertEquals(1, contextMenu.getItemCount());
+		assertEquals(action1, contextMenu.getItems()[0].getData());
+	}
+
+	@Test
+	public void testLeadingSeparator() {
+		MenuManager menuManager = new MenuManager();
+
+		Separator separator1 = new Separator();
+		ActionContributionItem action1 = new ActionContributionItem(mock(IAction.class));
+
+		menuManager.add(separator1);
+		menuManager.add(action1);
+
+		Menu contextMenu = menuManager.createContextMenu(window.getShell());
+		contextMenu.notifyListeners(SWT.Show, null);
+		processEvents();
+
+		assertEquals(1, contextMenu.getItemCount());
+		assertEquals(action1, contextMenu.getItems()[0].getData());
+	}
+
+	@Test
+	public void testTrainlingSeparatorWithDynamic() {
+		MenuManager menuManager = new MenuManager();
+
+		ActionContributionItem action1 = new ActionContributionItem(mock(IAction.class));
+		Separator separator1 = new Separator();
+		DynamicMenuContributionItem dynamic1 = mock(DynamicMenuContributionItem.class);
+
+		when(dynamic1.isVisible()).thenReturn(true);
+
+		menuManager.add(action1);
+		menuManager.add(separator1);
+		menuManager.add(dynamic1);
+
+		Menu contextMenu = menuManager.createContextMenu(window.getShell());
+		contextMenu.notifyListeners(SWT.Show, null);
+		processEvents();
+
+		assertEquals(1, contextMenu.getItemCount());
+		assertEquals(action1, contextMenu.getItems()[0].getData());
+	}
+
+	@Test
+	public void testTrainlingSeparator() {
+		MenuManager menuManager = new MenuManager();
+
+		ActionContributionItem action1 = new ActionContributionItem(mock(IAction.class));
+		Separator separator1 = new Separator();
+
+		menuManager.add(action1);
+		menuManager.add(separator1);
+
+		Menu contextMenu = menuManager.createContextMenu(window.getShell());
+		contextMenu.notifyListeners(SWT.Show, null);
+		processEvents();
+
+		assertEquals(1, contextMenu.getItemCount());
+		assertEquals(action1, contextMenu.getItems()[0].getData());
+	}
+
+}


### PR DESCRIPTION
Fixes #1668

The Double Separator Handling is improved to support cases where empty contributions where located between separators

Steps to reproduce:
Create a menu looking like this:
* Action
* Separator
* Dynamic Contribution (not contributing anything)
* Separator
* Action