### PR TITLE
PartRenderingEngineTests: fix ThreadDeath

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
@@ -153,8 +153,11 @@ public class PartRenderingEngineTests {
 		try {
 			advisor.eventLoopException(ex);
 		} catch (Throwable t) {
-			if (t instanceof ThreadDeath td) {
-				throw td;
+			// The type ThreadDeath has been deprecated since version 20
+			// and marked for removal
+			if ("ThreadDeath".equals(t.getClass().getSimpleName())) {
+				// don't catch ThreadDeath by accident
+				throw t;
 			}
 			// couldn't handle the exception, print to console
 			t.printStackTrace();


### PR DESCRIPTION
"The type ThreadDeath has been deprecated since version 20 and marked for removal"