### PR TITLE
Fix NPE in Windows Defender autofix Powershell script on first exclusion

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WindowsDefenderConfigurator.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WindowsDefenderConfigurator.java
@@ -281,6 +281,7 @@ public class WindowsDefenderConfigurator implements EventHandler {
 		final String exclusionType = "ExclusionProcess"; //$NON-NLS-1$
 		return String.join(';' + extraSeparator, "$exclusions=@(" + extraSeparator + excludedPaths + ')', //$NON-NLS-1$
 				"$existingExclusions=[Collections.Generic.HashSet[String]](Get-MpPreference)." + exclusionType, //$NON-NLS-1$
+				"if($existingExclusions -eq $null) { $existingExclusions = New-Object Collections.Generic.HashSet[String] }", //$NON-NLS-1$
 				"$exclusionsToAdd=[Linq.Enumerable]::ToArray([Linq.Enumerable]::Where($exclusions,[Func[object,bool]]{param($ex)!$existingExclusions.Contains($ex)}))", //$NON-NLS-1$
 				"if($exclusionsToAdd.Length -gt 0){ Add-MpPreference -" + exclusionType + " $exclusionsToAdd }"); //$NON-NLS-1$ //$NON-NLS-2$
 	}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
@@ -579,7 +579,7 @@ WindowsDefenderConfigurator_scriptHideLabel=<< Hide Powershell script
 WindowsDefenderConfigurator_scriptHint=Adding exclusions respectively running the Powershell script to do this requires administrator privileges.
 WindowsDefenderConfigurator_performExclusionChoice=Exclude {0} from being scanned to improve performance.\n\
 (In general adding exclusions may affect the security level of this computer)
-WindowsDefenderConfigurator_ignoreThisInstallationChoice=Keep {0} being scanned by Windows Defender
+WindowsDefenderConfigurator_ignoreThisInstallationChoice=Keep {0} being scanned by Windows Defender.
 WindowsDefenderConfigurator_ignoreAllChoice=Skip exclusion check on startup for all new Eclipse-based installations
 WindowsDefenderConfigurator_detailsAndOptionsLinkText=See '<a>Startup and Shutdown</a>' preference for more details and configuration options.
 WindowsDefenderConfigurator_runExclusionFromPreferenceButtonLabel=Run exclusion check now


### PR DESCRIPTION
If a user has no process-exclusion defined in its Windows Defender configuration yet, the expression
`(Get-MpPreference).ExclusionProcess` returns null in the Powershell script to perform the exclusion.
If a null reference is read, the variable is now initialized with an empty set.