### PR TITLE
Suppress Windows Defender Autofix startup check in test-runtimes

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WindowsDefenderConfigurator.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WindowsDefenderConfigurator.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProduct;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Platform;
@@ -83,7 +84,7 @@ public class WindowsDefenderConfigurator implements EventHandler {
 
 	@Override
 	public void handleEvent(Event event) {
-		if (isRelevant()) {
+		if (runStartupCheck()) {
 			Job job = Job.create(WorkbenchMessages.WindowsDefenderConfigurator_statusCheck, m -> {
 				SubMonitor monitor = SubMonitor.convert(m, 10);
 				if (preferences.getBoolean(PI_WORKBENCH, PREFERENCE_SKIP, PREFERENCE_SKIP_DEFAULT, null)) {
@@ -105,8 +106,14 @@ public class WindowsDefenderConfigurator implements EventHandler {
 		}
 	}
 
-	public static boolean isRelevant() {
-		return Platform.OS_WIN32.equals(Platform.getOS()) && !Platform.inDevelopmentMode();
+	private static boolean runStartupCheck() {
+		if (Platform.isRunning() && Platform.OS.isWindows() && !Platform.inDevelopmentMode()) {
+			IProduct product = Platform.getProduct();
+			if (product != null) {
+				return "org.eclipse.ui.ide.workbench".equals(product.getApplication()); //$NON-NLS-1$
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/StartupPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/StartupPreferencePage.java
@@ -92,7 +92,7 @@ public class StartupPreferencePage extends PreferencePage implements IWorkbenchP
 	}
 
 	protected void createExtraContent(Composite composite) {
-		if (WindowsDefenderConfigurator.isRelevant()) {
+		if (Platform.OS.isWindows()) {
 			new Label(composite, SWT.NONE); // add spacer
 
 			GridDataFactory grapHorizontalSpace = GridDataFactory.swtDefaults().align(SWT.FILL, SWT.BEGINNING)


### PR DESCRIPTION
Only run the startup check if the running application is `org.eclipse.ui.ide.workbench`, which runs in a usual Eclipse IDE. Requiring this specific app-id prevents the start-up check and consequently a pop-up in test applications launched by PDE or Tycho for OSGi Junit tests or general console applications (that still have the `o.e.ui.workbench` plugin installed) on Windows.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1683