### PR TITLE
Suppress Windows Defender Autofix startup check in test-runtimes part 2

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WindowsDefenderConfigurator.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WindowsDefenderConfigurator.java
@@ -108,12 +108,19 @@ public class WindowsDefenderConfigurator implements EventHandler {
 
 	private static boolean runStartupCheck() {
 		if (Platform.isRunning() && Platform.OS.isWindows() && !Platform.inDevelopmentMode()) {
-			IProduct product = Platform.getProduct();
-			if (product != null) {
-				return "org.eclipse.ui.ide.workbench".equals(product.getApplication()); //$NON-NLS-1$
-			}
+			return "org.eclipse.ui.ide.workbench".equals(getRunningApplicationId()); //$NON-NLS-1$
 		}
 		return false;
+	}
+
+	private static String getRunningApplicationId() {
+		@SuppressWarnings("restriction")
+		String appId = System.getProperty(org.eclipse.core.internal.runtime.InternalPlatform.PROP_APPLICATION);
+		if (appId != null) {
+			return appId;
+		}
+		IProduct product = Platform.getProduct();
+		return product != null ? product.getApplication() : null;
 	}
 
 	/**


### PR DESCRIPTION
Consider also applications specified on the CLI via the '-application' argument when determining the actually running application. Otherwise always the application defined in the product definition is assumed.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1683