### PR TITLE
deprecate org.eclipse.ui.keys for removal

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/CharacterKey.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/CharacterKey.java
@@ -16,7 +16,6 @@ package org.eclipse.ui.keys;
 
 import java.util.SortedMap;
 import java.util.TreeMap;
-
 import org.eclipse.jface.bindings.keys.IKeyLookup;
 import org.eclipse.jface.bindings.keys.KeyLookupFactory;
 
@@ -34,7 +33,7 @@ import org.eclipse.jface.bindings.keys.KeyLookupFactory;
  *             org.eclipse.jface.bindings.keys.KeyLookupFactory
  * @since 3.0
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2024-03")
 public final class CharacterKey extends NaturalKey {
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/IKeyFormatter.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/IKeyFormatter.java
@@ -23,7 +23,7 @@ package org.eclipse.ui.keys;
  * @deprecated Please use org.eclipse.jface.bindings.keys.IKeyFormatter
  * @since 3.0
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2024-03")
 public interface IKeyFormatter {
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/Key.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/Key.java
@@ -43,7 +43,7 @@ import org.eclipse.ui.internal.util.Util;
  * @since 3.0
  * @noextend This class is not intended to be subclassed by clients.
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2024-03")
 public abstract class Key implements Comparable {
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/KeyFormatterFactory.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/KeyFormatterFactory.java
@@ -27,7 +27,7 @@ import org.eclipse.ui.internal.keys.FormalKeyFormatter;
  * @since 3.0
  * @see org.eclipse.ui.keys.IKeyFormatter
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2024-03")
 public final class KeyFormatterFactory {
 	private static final IKeyFormatter COMPACT_KEY_FORMATTER = new CompactKeyFormatter();
 

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/KeySequence.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/KeySequence.java
@@ -48,7 +48,7 @@ import org.eclipse.ui.internal.util.Util;
  * @deprecated Please use org.eclipse.jface.bindings.keys.KeySequence
  * @since 3.0
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2024-03")
 public final class KeySequence implements Comparable {
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/KeyStroke.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/KeyStroke.java
@@ -54,7 +54,7 @@ import org.eclipse.ui.internal.util.Util;
  * @see org.eclipse.ui.keys.ModifierKey
  * @see org.eclipse.ui.keys.NaturalKey
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2024-03")
 public final class KeyStroke implements Comparable {
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/ModifierKey.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/ModifierKey.java
@@ -36,7 +36,7 @@ import org.eclipse.jface.util.Util;
  * @since 3.0
  * @see org.eclipse.ui.keys.NaturalKey
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2024-03")
 public final class ModifierKey extends Key {
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/NaturalKey.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/NaturalKey.java
@@ -32,7 +32,7 @@ package org.eclipse.ui.keys;
  * @since 3.0
  * @noextend This class is not intended to be subclassed by clients.
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2024-03")
 public abstract class NaturalKey extends Key {
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/ParseException.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/ParseException.java
@@ -27,7 +27,7 @@ package org.eclipse.ui.keys;
  * @deprecated Please use org.eclipse.jface.bindings.keys.ParseException
  * @since 3.0
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2024-03")
 public final class ParseException extends Exception {
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/SWTKeySupport.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/SWTKeySupport.java
@@ -28,7 +28,7 @@ import org.eclipse.ui.internal.keys.NativeKeyFormatter;
  * @deprecated Please use {@link org.eclipse.jface.bindings.keys.SWTKeySupport}
  * @since 3.0
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2024-03")
 public final class SWTKeySupport {
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/SpecialKey.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/keys/SpecialKey.java
@@ -37,7 +37,7 @@ import org.eclipse.jface.bindings.keys.KeyLookupFactory;
  *             org.eclipse.jface.bindings.keys.KeyLookupFactory
  * @since 3.0
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "2024-03")
 public final class SpecialKey extends NaturalKey {
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug42035Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug42035Test.java
@@ -28,6 +28,7 @@ import org.junit.Test;
  *
  * @since 3.0
  */
+@SuppressWarnings("removal")
 public class Bug42035Test {
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43800Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43800Test.java
@@ -26,6 +26,7 @@ import org.junit.Test;
  *
  * @since 3.0
  */
+@SuppressWarnings("removal")
 public class Bug43800Test {
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageKeyBindingTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageKeyBindingTest.java
@@ -40,6 +40,7 @@ import org.junit.runners.JUnit4;
  *
  * @since 3.0
  */
+@SuppressWarnings("removal")
 @RunWith(JUnit4.class)
 @Ignore("Focus issues, see Commit c28efd634f53c9de7bb31b756ffc755b8faf0ffe")
 public class MultiPageKeyBindingTest extends UITestCase {


### PR DESCRIPTION
(except IBindingService)

Those classes have been deprecated with Bug 82854 (memory issues), replacing Objects with primitives.They are only used internal in org.eclipse.ui.internal.keys and tests

https://bugs.eclipse.org/bugs/show_bug.cgi?id=82854