### PR TITLE
Keep theme coloring of cells in FocusCellOwnerDrawHighlighter

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -37,8 +37,7 @@ Export-Package: org.eclipse.jface,
 Require-Bundle: org.eclipse.swt;bundle-version="[3.111.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.commands;bundle-version="[3.4.0,4.0.0)";visibility:=reexport,
  org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)",
- org.eclipse.equinox.bidi;bundle-version="[0.10.0,2.0.0)";resolution:=optional,
- org.eclipse.core.runtime;bundle-version="[3.31.0,4.0.0)"
+ org.eclipse.equinox.bidi;bundle-version="[0.10.0,2.0.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: javax.xml.parsers,
  org.osgi.framework;version="[1.8.0,2.0.0)",

--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -37,7 +37,8 @@ Export-Package: org.eclipse.jface,
 Require-Bundle: org.eclipse.swt;bundle-version="[3.111.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.commands;bundle-version="[3.4.0,4.0.0)";visibility:=reexport,
  org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)",
- org.eclipse.equinox.bidi;bundle-version="[0.10.0,2.0.0)";resolution:=optional
+ org.eclipse.equinox.bidi;bundle-version="[0.10.0,2.0.0)";resolution:=optional,
+ org.eclipse.core.runtime;bundle-version="[3.31.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: javax.xml.parsers,
  org.osgi.framework;version="[1.8.0,2.0.0)",

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/FocusCellOwnerDrawHighlighter.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/FocusCellOwnerDrawHighlighter.java
@@ -17,6 +17,7 @@
 package org.eclipse.jface.viewers;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
@@ -106,9 +107,13 @@ public class FocusCellOwnerDrawHighlighter extends FocusCellHighlighter {
 
 	private void removeSelectionInformation(Event event, ViewerCell cell) {
 		GC gc = event.gc;
-		gc.setAlpha(0);// Don't draw background to keep cell coloring of theme
+		if (Platform.WS_GTK.equals(Platform.getWS())) {
+			// On GTK, the line is highlighted even though the SELECTED flag is removed. To
+			// fix this issue, the background must be overwridden
+			gc.setBackground(cell.getViewerRow().getBackground(cell.getColumnIndex()));
+			gc.fillRectangle(cell.getBounds());
+		}
 		gc.setForeground(cell.getViewerRow().getForeground(cell.getColumnIndex()));
-		gc.fillRectangle(cell.getBounds());
 		event.detail &= ~SWT.SELECTED;
 	}
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/FocusCellOwnerDrawHighlighter.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/FocusCellOwnerDrawHighlighter.java
@@ -17,7 +17,6 @@
 package org.eclipse.jface.viewers;
 
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
@@ -107,7 +106,7 @@ public class FocusCellOwnerDrawHighlighter extends FocusCellHighlighter {
 
 	private void removeSelectionInformation(Event event, ViewerCell cell) {
 		GC gc = event.gc;
-		if (Platform.WS_GTK.equals(Platform.getWS())) {
+		if ("gtk".equals(SWT.getPlatform())) { //$NON-NLS-1$
 			// On GTK, the line is highlighted even though the SELECTED flag is removed. To
 			// fix this issue, the background must be overwridden
 			gc.setBackground(cell.getViewerRow().getBackground(cell.getColumnIndex()));

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/FocusCellOwnerDrawHighlighter.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/FocusCellOwnerDrawHighlighter.java
@@ -106,7 +106,7 @@ public class FocusCellOwnerDrawHighlighter extends FocusCellHighlighter {
 
 	private void removeSelectionInformation(Event event, ViewerCell cell) {
 		GC gc = event.gc;
-		gc.setBackground(cell.getViewerRow().getBackground(cell.getColumnIndex()));
+		gc.setAlpha(0);// Don't draw background to keep cell coloring of theme
 		gc.setForeground(cell.getViewerRow().getForeground(cell.getColumnIndex()));
 		gc.fillRectangle(cell.getBounds());
 		event.detail &= ~SWT.SELECTED;


### PR DESCRIPTION
In dark theme, the cell back ground color are colored in light colors when using a FocusCellOwnerDrawHighlighter. By setting the background color alpha to 0, the color is not even draw and the initial color is kept.

**Coloring on macOS before the fix:**
<img width="276" alt="Bildschirmfoto 2024-02-16 um 10 20 47" src="https://github.com/eclipse-platform/eclipse.platform.ui/assets/79514265/efacab16-9ff7-4d1b-88ba-1eaf7bc28d4f">

**Coloring on macOS after the fix:**
<img width="277" alt="Bildschirmfoto 2024-02-16 um 10 21 38" src="https://github.com/eclipse-platform/eclipse.platform.ui/assets/79514265/3dcf09e5-d761-4307-a799-ee937c5d0804">

**Reproduce/Test**
To test the issue on your platform, import the project [focusCellDemo.zip](https://github.com/eclipse-platform/eclipse.platform.ui/files/14308999/focusCellDemo.zip) and execute command "Open focus cell demo" to open a dialog with a demo viewer.

