### PR TITLE
Windows Defender autofix preference adjustments

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WindowsDefenderConfigurator.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WindowsDefenderConfigurator.java
@@ -240,7 +240,11 @@ public class WindowsDefenderConfigurator implements EventHandler {
 
 	public static void savePreference(IScopeContext scope, String key, String value) throws CoreException {
 		IEclipsePreferences preferences = getPreference(scope);
-		preferences.put(key, value);
+		if (value != null) {
+			preferences.put(key, value);
+		} else {
+			preferences.remove(key);
+		}
 		try {
 			preferences.flush();
 		} catch (BackingStoreException e) {

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/StartupPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/StartupPreferencePage.java
@@ -237,7 +237,8 @@ public class StartupPreferencePage extends PreferencePage implements IWorkbenchP
 
 		windowsDefenderIgnore.forEach((scope, button) -> {
 			try {
-				String skip = Boolean.toString(button.getSelection());
+				// If disabled remove the node to allow higher-level scopes to be considered
+				String skip = button.getSelection() ? Boolean.TRUE.toString() : null;
 				WindowsDefenderConfigurator.savePreference(scope, PREFERENCE_STARTUP_CHECK_SKIP, skip);
 			} catch (CoreException e) {
 				WorkbenchPlugin.log("Failed to save Windows Defender exclusion check preferences", e); //$NON-NLS-1$

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/StartupPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/StartupPreferencePage.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.dialogs;
 
+import static org.eclipse.ui.internal.WindowsDefenderConfigurator.PREFERENCE_STARTUP_CHECK_SKIP;
+import static org.eclipse.ui.internal.WindowsDefenderConfigurator.PREFERENCE_STARTUP_CHECK_SKIP_DEFAULT;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
@@ -198,8 +201,7 @@ public class StartupPreferencePage extends PreferencePage implements IWorkbenchP
 	private void updateWindowsDefenderHandlingOptions() {
 		windowsDefenderIgnore.forEach((scope, button) -> {
 			IEclipsePreferences node = WindowsDefenderConfigurator.getPreference(scope);
-			boolean ignore = node.getBoolean(WindowsDefenderConfigurator.PREFERENCE_SKIP,
-					WindowsDefenderConfigurator.PREFERENCE_SKIP_DEFAULT);
+			boolean ignore = node.getBoolean(PREFERENCE_STARTUP_CHECK_SKIP, PREFERENCE_STARTUP_CHECK_SKIP_DEFAULT);
 			button.setSelection(ignore);
 		});
 	}
@@ -214,8 +216,7 @@ public class StartupPreferencePage extends PreferencePage implements IWorkbenchP
 		IPreferenceStore store = PrefUtil.getInternalPreferenceStore();
 		store.setToDefault(IPreferenceConstants.PLUGINS_NOT_ACTIVATED_ON_STARTUP);
 		updateCheckState();
-		windowsDefenderIgnore.values()
-				.forEach(b -> b.setSelection(WindowsDefenderConfigurator.PREFERENCE_SKIP_DEFAULT));
+		windowsDefenderIgnore.values().forEach(b -> b.setSelection(PREFERENCE_STARTUP_CHECK_SKIP_DEFAULT));
 		updateWindowsDefenderHandlingOptions();
 	}
 
@@ -237,7 +238,7 @@ public class StartupPreferencePage extends PreferencePage implements IWorkbenchP
 		windowsDefenderIgnore.forEach((scope, button) -> {
 			try {
 				String skip = Boolean.toString(button.getSelection());
-				WindowsDefenderConfigurator.savePreference(scope, WindowsDefenderConfigurator.PREFERENCE_SKIP, skip);
+				WindowsDefenderConfigurator.savePreference(scope, PREFERENCE_STARTUP_CHECK_SKIP, skip);
 			} catch (CoreException e) {
 				WorkbenchPlugin.log("Failed to save Windows Defender exclusion check preferences", e); //$NON-NLS-1$
 			}


### PR DESCRIPTION
This PR enhances the Windows Defneder autofix implemented in https://github.com/eclipse-platform/eclipse.platform.ui/pull/1453 in two parts
- Make Windows Defender Autofix preference names more expressive
- Remove win.defender.startup.check.skip preference if disabled for all
Removing the preference node from the user-scope instead of setting the value to false (if it was true before) allows the preference service to consider the value of higher-level scopes like the default scope defined in a product.
