### PR TITLE
Support running Windows Defender Autofix startup check in custom apps

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
@@ -569,14 +569,14 @@ CheckedTreeSelectionDialog_select_all=Select &All
 CheckedTreeSelectionDialog_deselect_all=&Deselect All
 
 WindowsDefenderConfigurator_statusCheck=Windows Defender Exclusion Check
-WindowsDefenderConfigurator_exclusionCheckMessage=Microsoft's Windows Defender is active and could significantly decrease this application's startup and overall performance.\n\
+WindowsDefenderConfigurator_exclusionCheckMessage=Microsoft''s Windows Defender is active and could significantly decrease the startup and overall performance of {0}.\n\
 Select how this installation should be handled by Windows Defender:
-WindowsDefenderConfigurator_exclusionInformation=If Windows Defender is active and scans this application it can significantly slow down its startup and overall performance.\n\
+WindowsDefenderConfigurator_exclusionInformation=If Windows Defender is active and scans {0} it can significantly slow down its startup and overall performance.\n\
 To prevent a decrease in performance {0} can exclude itself and all files opened from real-time scanning by Windows Defender.\n\
-Be aware that in general adding exclusions could affect this computer's security.
+Be aware that in general adding exclusions could affect this computer''s security.
 WindowsDefenderConfigurator_scriptShowLabel=Show Powershell script >>
 WindowsDefenderConfigurator_scriptHideLabel=<< Hide Powershell script
-WindowsDefenderConfigurator_scriptHint=Adding exclusions respectively running the Powershell script to do this requires administrator privileges.
+WindowsDefenderConfigurator_scriptHint=Adding exclusions respectively running the Powershell script to do it requires administrator privileges.
 WindowsDefenderConfigurator_performExclusionChoice=Exclude {0} from being scanned to improve performance.\n\
 (In general adding exclusions may affect the security level of this computer)
 WindowsDefenderConfigurator_ignoreThisInstallationChoice=Keep {0} being scanned by Windows Defender.


### PR DESCRIPTION
Currently the startup check for the Windows Defender Autofix only runs for the `org.eclipse.ui.ide.workbench`.
This adds the possibility to permit the startup check for other applications by setting the preference
`windows.defender.startup.check.app` to the permitted appId.

This is a follow-up for https://github.com/eclipse-platform/eclipse.platform.ui/pull/1685 to further enhance the possible configuration of the Windows Defender autofix implemented in https://github.com/eclipse-platform/eclipse.platform.ui/pull/1453.

@merks I guess Oomph uses a custom application to run the Installer, doesn't it?
With this you could add `org.eclipse.ui/windows.defender.startup.check.app=<Oomph-Installer-app-id>` to the Installer's `preferenceCustomization` properties file, if you want to enable the startup check for the installer itself.
In order to make it then run this would require that the `UIEvents.UILifeCycle.APP_STARTUP_COMPLETE` event is fired in the installer, but I don't know if that's the case or if the installer uses the E4 UI workbench as well or a completely custom UI.
In case of the latter you could simply instantiate the WindowsDefenderConfigurator class directly.
