### PR TITLE
ltk: fix NPE in TextFileChange.acquireDocument #1646

### DIFF
--- a/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/TextChange.java
+++ b/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/TextChange.java
@@ -309,8 +309,7 @@ public abstract class TextChange extends TextEditBasedChange {
 		try{
 			result= acquireDocument(subMon.newChild(1));
 		} finally {
-			if (result != null)
-				releaseDocument(result, subMon.newChild(1));
+			releaseDocument(result, subMon.newChild(1));
 		}
 		subMon.done();
 		return result;


### PR DESCRIPTION
synchronize concurrent access to TextFileChange.acquireDocument()

https://github.com/eclipse-platform/eclipse.platform.ui/issues/1646