### PR TITLE
TextViewer: use Throttler for firePostSelectionChanged #1695

### DIFF
--- a/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.text
-Bundle-Version: 3.25.0.qualifier
+Bundle-Version: 3.25.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiVariablePageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiVariablePageTest.java
@@ -150,7 +150,7 @@ public class MultiVariablePageTest extends UITestCase {
 		IPostSelectionProvider postProvider = (IPostSelectionProvider) sp;
 
 		fPostCalled = 0;
-		ISelectionChangedListener listener = event -> ++fPostCalled;
+		ISelectionChangedListener listener = event -> fPostCalled += sp != event.getSelectionProvider() ? 1 : 0;
 
 		try {
 			postProvider.addPostSelectionChangedListener(listener);

--- a/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse UI Tests
 Bundle-SymbolicName: org.eclipse.ui.tests; singleton:=true
-Bundle-Version: 3.15.1500.qualifier
+Bundle-Version: 3.15.1600.qualifier
 Eclipse-BundleShape: dir
 Bundle-Activator: org.eclipse.ui.tests.TestPlugin
 Bundle-Vendor: Eclipse.org


### PR DESCRIPTION
Avoids a 500ms delay after changing the selection, like higlighting the
selected word.

https://github.com/eclipse-platform/eclipse.platform.ui/issues/1695