### PR TITLE
[memory] optimize e4 ClassUtils.getSimpleName()

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.css.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-SymbolicName: org.eclipse.e4.ui.css.core;singleton:=true
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 0.14.300.qualifier
+Bundle-Version: 0.14.400.qualifier
 Export-Package: org.eclipse.e4.ui.css.core;x-internal:=true,
  org.eclipse.e4.ui.css.core.css2;x-friends:="org.eclipse.e4.ui.css.swt.theme,org.eclipse.e4.ui.css.swt,org.eclipse.e4.ui.css.jface",
  org.eclipse.e4.ui.css.core.dom;x-friends:="org.eclipse.e4.ui.css.swt,org.eclipse.ui.views.properties.tabbed,org.eclipse.ui.forms",

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/utils/ClassUtils.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/utils/ClassUtils.java
@@ -13,22 +13,31 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.css.core.utils;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * Class utils.
  */
 public class ClassUtils {
 
+	private static final Map<Class<?>, String> simpleNames = new ConcurrentHashMap<>();
 	/**
-	 * Return the simple name of Class <code>c</code>.
+	 * Return a simple name of Class <code>c</code>. For inner classes, the hyphen
+	 * is used, e.g., for Outer$Inner, the return value is "Outer-Inner"
 	 */
 	public static String getSimpleName(Class<?> c) {
+		return simpleNames.computeIfAbsent(c, ClassUtils::computeSimpleName);
+	}
+
+	private static String computeSimpleName(Class<?> c) {
 		String name = c.getName();
 		int index = name.lastIndexOf('.');
 		if (index > 0) {
 			name = name.substring(index + 1, name.length());
 		}
 
-		return name.replace('$', '-');
+		return name.replace('$', '-').intern();
 	}
 
 	/**


### PR DESCRIPTION
to return always the same string instance
Saves all duplicate Strings in
org.eclipse.e4.ui.css.swt.dom.WidgetElement.localName