### PR TITLE
Activate and Fix FindReplaceLogicTest

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -153,8 +153,8 @@ public class FindReplaceLogicTest {
 
 		findReplaceLogic.performReplaceAll("[", "", parentShell.getDisplay());
 		assertThat(textViewer.getDocument().get(), equalTo("almost@an_email"));
-		expectStatusIsMessageWithString(findReplaceLogic, "Unclosed character class near index 0\r\n"
-				+ "[\r\n"
+		expectStatusIsMessageWithString(findReplaceLogic, "Unclosed character class near index 0" + System.lineSeparator()
+				+ "[" + System.lineSeparator()
 				+ "^");
 
 	}
@@ -176,8 +176,8 @@ public class FindReplaceLogicTest {
 
 		findReplaceLogic.performReplaceAll("[", "", parentShell.getDisplay());
 		assertThat(textViewer.getDocument().get(), equalTo("almost@an_email"));
-		expectStatusIsMessageWithString(findReplaceLogic, "Unclosed character class near index 0\r\n"
-				+ "[\r\n"
+		expectStatusIsMessageWithString(findReplaceLogic, "Unclosed character class near index 0" + System.lineSeparator()
+				+ "[" + System.lineSeparator()
 				+ "^");
 	}
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/WorkbenchTextEditorTestSuite.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/WorkbenchTextEditorTestSuite.java
@@ -17,6 +17,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import org.eclipse.ui.internal.findandreplace.FindReplaceLogicTest;
+
 import org.eclipse.ui.workbench.texteditor.tests.minimap.MinimapPageTest;
 import org.eclipse.ui.workbench.texteditor.tests.minimap.MinimapWidgetTest;
 import org.eclipse.ui.workbench.texteditor.tests.revisions.ChangeRegionTest;
@@ -44,7 +46,8 @@ import org.eclipse.ui.workbench.texteditor.tests.rulers.RulerTestSuite;
 		MinimapPageTest.class,
 		MinimapWidgetTest.class,
 		TextEditorPluginTest.class,
-		TextViewerDeleteLineTargetTest.class
+		TextViewerDeleteLineTargetTest.class,
+		FindReplaceLogicTest.class,
 })
 public class WorkbenchTextEditorTestSuite {
 	// see @SuiteClasses


### PR DESCRIPTION
The FindReplaceLogic was not included in the TestSuite and thus not executed by CI. Additionally, I fixed a bug where the tests would not run correctly on linux and mac because windows-style line-breaks were assumed in the Strings.