### PR TITLE
Fix calculation of minimum characters for view tab titles when 'Always show full titles' preference is enabled

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.renderers.swt;singleton:=true
-Bundle-Version: 0.16.300.qualifier
+Bundle-Version: 0.16.400.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
@@ -20,7 +20,6 @@ package org.eclipse.e4.ui.workbench.renderers.swt;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.Optional;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
@@ -1306,10 +1305,9 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 		boolean showFullText = getShowFullTextForViewTabsPreference();
 		if (!isPartOfEditorStack()) {
 			if (showFullText) {
-				Optional<Integer> lengthOfLongestItemText = Arrays.stream(parent.getItems()).map(CTabItem::getText)
-						.map(String::length)
-						.max(Integer::compare);
-				parent.setMinimumCharacters(lengthOfLongestItemText.orElseGet(() -> MAX_VIEW_CHARS));
+				int lengthOfLongestItemText = Arrays.stream(parent.getItems()).map(CTabItem::getText)
+						.map(String::length).max(Integer::compare).orElse(0);
+				parent.setMinimumCharacters(Math.max(MAX_VIEW_CHARS, lengthOfLongestItemText));
 			} else {
 				parent.setMinimumCharacters(MIN_VIEW_CHARS);
 			}

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
@@ -88,7 +88,7 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 	public static final boolean SHOW_FULL_TEXT_FOR_VIEW_TABS_DEFAULT = false;
 
 	private static int MIN_VIEW_CHARS = 1;
-	private static int MAX_VIEW_CHARS = 999999;
+	private static int MAX_VIEW_CHARS = Integer.MAX_VALUE;
 
 	// Constants for circle drawing
 	static enum CirclePart {

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
@@ -18,7 +18,6 @@
 package org.eclipse.e4.ui.workbench.renderers.swt;
 
 import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.Objects;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
@@ -34,7 +33,6 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabFolderRenderer;
-import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
@@ -90,7 +88,7 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 	public static final boolean SHOW_FULL_TEXT_FOR_VIEW_TABS_DEFAULT = false;
 
 	private static int MIN_VIEW_CHARS = 1;
-	private static int MAX_VIEW_CHARS = 9999;
+	private static int MAX_VIEW_CHARS = 999999;
 
 	// Constants for circle drawing
 	static enum CirclePart {
@@ -1305,9 +1303,7 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 		boolean showFullText = getShowFullTextForViewTabsPreference();
 		if (!isPartOfEditorStack()) {
 			if (showFullText) {
-				int lengthOfLongestItemText = Arrays.stream(parent.getItems()).map(CTabItem::getText)
-						.map(String::length).max(Integer::compare).orElse(0);
-				parent.setMinimumCharacters(Math.max(MAX_VIEW_CHARS, lengthOfLongestItemText));
+				parent.setMinimumCharacters(MAX_VIEW_CHARS);
 			} else {
 				parent.setMinimumCharacters(MIN_VIEW_CHARS);
 			}


### PR DESCRIPTION
Fixes #1715 

- Sets the minimum characters to be Max( Longest tab text length, MAX_VIEW_CHARS), where MAX_VIEW_CHARS = 9999.
- In most cases, the minimum characters would be set to MAX_VIEW_CHARS
- In rare cases, there could be a view tab with text/title length greater than MAX_VIEW_CHARS. 
   - The minimum characters would be set to the longest tab text length.
