### PR TITLE
Additional Completion Information: remove delay & timeout #1695

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/AdditionalInfoController.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/AdditionalInfoController.java
@@ -52,7 +52,9 @@ class AdditionalInfoController extends AbstractInformationControlManager {
 	 * @since 3.2
 	 */
 	private static abstract class Timer {
-		private static final int DELAY_UNTIL_JOB_IS_SCHEDULED= 50;
+		/** delay until additional information is calculated **/
+		private static final int DELAY_UNTIL_JOB_IS_SCHEDULED= 0;
+ 
 
 		/**
 		 * A <code>Task</code> is {@link Task#run() run} when {@link #delay()} milliseconds have
@@ -324,11 +326,12 @@ class AdditionalInfoController extends AbstractInformationControlManager {
 
 		private void schedule(Task task, long current) {
 			fTask= task;
-			long nextWakeup= current + task.delay();
-			if (nextWakeup <= current)
+			long delay= task.delay();
+			if (delay == Long.MAX_VALUE)
+				// sleep until notify
 				fNextWakeup= Long.MAX_VALUE;
 			else
-				fNextWakeup= nextWakeup;
+				fNextWakeup= current + delay;
 		}
 
 		private boolean isExt5(ICompletionProposal p) {
@@ -376,7 +379,11 @@ class AdditionalInfoController extends AbstractInformationControlManager {
 
 		void allowShowing() {
 			fAllowShowing= true;
-			triggerShowing();
+			// triggerShowing() with fCurrentInfo==null would implicitly disallow any later showing
+			if (fCurrentInfo != null) {
+				// only if information is already available:
+				triggerShowing();
+			}
 		}
 	}
 	/**

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/ContentAssistant.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/ContentAssistant.java
@@ -75,7 +75,6 @@ import org.eclipse.jface.contentassist.ISubjectControlContentAssistProcessor;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.preference.JFacePreferences;
 import org.eclipse.jface.util.Geometry;
-import org.eclipse.jface.util.OpenStrategy;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 
 import org.eclipse.jface.text.BadLocationException;
@@ -1580,8 +1579,11 @@ public class ContentAssistant implements IContentAssistant, IContentAssistantExt
 		fInternalListener= new InternalListener();
 
 		AdditionalInfoController controller= null;
-		if (fInformationControlCreator != null)
-			controller= new AdditionalInfoController(fInformationControlCreator, OpenStrategy.getPostSelectionDelay());
+		if (fInformationControlCreator != null) {
+			/** delay until each additional information is shown **/
+			int delay= 0;		
+			controller= new AdditionalInfoController(fInformationControlCreator, delay);
+		}
 
 		fContextInfoPopup= fContentAssistSubjectControlAdapter.createContextInfoPopup(this);
 		fProposalPopup= fContentAssistSubjectControlAdapter.createCompletionProposalPopup(this, controller, fAsynchronous);

--- a/tests/org.eclipse.ui.genericeditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.genericeditor.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.genericeditor.tests;singleton:=true
-Bundle-Version: 1.3.400.qualifier
+Bundle-Version: 1.3.500.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.genericeditor.tests,

--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/CompletionTest.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/CompletionTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assume.assumeFalse;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Hashtable;
 import java.util.LinkedList;
@@ -212,16 +213,19 @@ public class CompletionTest extends AbstratGenericEditorTest {
 	}
 
 	public static Shell findNewShell(Set<Shell> beforeShells, Display display, boolean expectShell) {
-		Shell[] afterShells = Arrays.stream(display.getShells())
-				.filter(Shell::isVisible)
-				.filter(shell -> !beforeShells.contains(shell))
-				.toArray(Shell[]::new);
+		Shell[] afterShells = findNewShells(beforeShells, display).toArray(Shell[]::new);
 		if (expectShell) {
 			assertEquals("No new shell found", 1, afterShells.length);
 		}
 		return afterShells.length > 0 ? afterShells[0] : null;
 	}
-
+	public static Collection<Shell> findNewShells(Set<Shell> beforeShells, Display display) {
+		List<Shell> result= Arrays.stream(display.getShells())
+				.filter(Shell::isVisible)
+				.filter(shell -> !beforeShells.contains(shell))
+				.toList();
+		return result;
+	}
 	@Test
 	public void testCompletionFreeze_bug521484() throws Exception {
 		assumeFalse("test fails on Mac, see https://github.com/eclipse-platform/eclipse.platform.ui/issues/906", Util.isMac());
@@ -248,7 +252,7 @@ public class CompletionTest extends AbstratGenericEditorTest {
 		emulatePressLeftArrowKey();
 		final Set<Shell> beforeShells = Arrays.stream(editor.getSite().getShell().getDisplay().getShells()).filter(Shell::isVisible).collect(Collectors.toSet());
 		DisplayHelper.sleep(editor.getSite().getShell().getDisplay(), 200);
-		this.completionShell= findNewShell(beforeShells, editor.getSite().getShell().getDisplay(), true);
+		this.completionShell= findNewShells(beforeShells, editor.getSite().getShell().getDisplay()).stream().filter(s->Arrays.stream(s.getChildren()).allMatch(w->w instanceof Table) ).findFirst().get();
 		final Table completionProposalList = findCompletionSelectionControl(this.completionShell);
 		checkCompletionContent(completionProposalList);
 	}


### PR DESCRIPTION
Removes 500ms lag for javadoc information in the completion dialog. Sets related delays to 0 and fix code to handle such short delays.

https://github.com/eclipse-platform/eclipse.platform.ui/issues/1695