### PR TITLE
Fix: "Search-scopes don't update #1740"

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -33,6 +33,7 @@ import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IFindReplaceTarget;
+import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.text.TextViewer;
 
 import org.eclipse.ui.internal.findandreplace.status.FindAllStatus;
@@ -430,6 +431,25 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.performSearch("get");
 		findReplaceLogic.performSearch("get");
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
+	}
+
+	@Test
+	public void testSelectInSearchScope() {
+		TextViewer textViewer= setupTextViewer("line1\nline2\nline3");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		textViewer.setSelection(new TextSelection(6, 11));
+		findReplaceLogic.deactivate(SearchOptions.GLOBAL);
+		findReplaceLogic.performReplaceAll("l", "", Display.getCurrent());
+		expectStatusIsReplaceAllWithCount(findReplaceLogic, 2);
+
+		findReplaceLogic.activate(SearchOptions.GLOBAL);
+		textViewer.setSelection(new TextSelection(0, 5));
+		findReplaceLogic.deactivate(SearchOptions.GLOBAL);
+
+		findReplaceLogic.performReplaceAll("n", "", Display.getCurrent());
+		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
+
+		assertThat(textViewer.getTextWidget().getText(), is("lie1\nine2\nine3"));
 	}
 
 	private void expectStatusEmpty(IFindReplaceLogic findReplaceLogic) {


### PR DESCRIPTION
Updates the search-scopes when a new selection is created. Also implements a regression-test to the FindReplaceDialogTest-class.
This test will be re-implemented to test the behaviour in both the FindReplaceOverlay and the FindReplaceDialog.