### PR TITLE
Automatically Expand Paths of single children in the Project-Explorer #1063

### DIFF
--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/navigator/resources/ProjectExplorer.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/navigator/resources/ProjectExplorer.java
@@ -28,6 +28,7 @@ import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.SafeRunner;
+import org.eclipse.jface.viewers.AbstractTreeViewer;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -83,6 +84,14 @@ import org.eclipse.ui.views.WorkbenchViewerSetup;
  */
 @SuppressWarnings("restriction")
 public final class ProjectExplorer extends CommonNavigator implements ISecondarySaveableSource {
+
+	/**
+	 * Number of levels to automatically expand when an element only has a single
+	 * child.
+	 *
+	 * @see AbstractTreeViewer#setAutoExpandOnSingleChildLevels(int)
+	 */
+	private static final int AUTO_EXPAND_ON_SINGLE_CHILD_LEVEL_COUNT = 10;
 
 	/**
 	 * Provides a constant for the standard instance of the Common Navigator.
@@ -164,6 +173,7 @@ public final class ProjectExplorer extends CommonNavigator implements ISecondary
 		if (this.userFilters.stream().anyMatch(UserFilter::isEnabled)) {
 			getCommonViewer().refresh();
 		}
+		getCommonViewer().setAutoExpandOnSingleChildLevels(AUTO_EXPAND_ON_SINGLE_CHILD_LEVEL_COUNT);
 	}
 
 	@Override


### PR DESCRIPTION
Allows a user to automatically fully open nested paths that consist of only one expandable folder at each level.

![grafik](https://github.com/eclipse-platform/eclipse.platform.ui/assets/16443184/c09887f1-1845-4e15-ab8d-30f588b3b0a6)
(click on src automatically opens all levels shown below src)

I have set the auto-expansion to be at most 10 nodes deep:
I don't want infinite expansion to avoid loading a lot of lazy-loaded nodes. I think 10 nodes is enough to have a realistic benefit while not becoming too much.

For reference, this is how other tools handle this case:
- IntelliJ will auto-expand to infinite depth (tested with 106 nested folders)
- VScode will auto-expand the entire depth but will not actually display the folders and rather show the entire path in the folder-node: like so: "\a\...\a\a\a\a"

A few things are yet to be discussed (help wanted!):

- Should this be always enabled by default or should there be a preference to toggle this behavior?
- What should be the default "auto-expansion-depth"? 10 Nodes? Or infinitely many? Should there be a preference for those values?