### PR TITLE
Increment versions of org.eclipse.e4.ui.swt.gtk and org.eclipse.ui.cocoa

### DIFF
--- a/bundles/org.eclipse.e4.ui.swt.gtk/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.swt.gtk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.e4.ui.swt.gtk;singleton:=true
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Fragment-Host: org.eclipse.e4.ui.css.swt.theme;bundle-version="0.10.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: fragment-gtk

--- a/bundles/org.eclipse.ui.cocoa/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.cocoa/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.ui.cocoa;singleton:=true
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.ui;bundle-version="[3.5.0,4.0.0)"
 Bundle-Localization: fragment-cocoa


### PR DESCRIPTION
Force a new version so that publishing to Maven Central can update the version without specialized remapping rules.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1882