### PR TITLE
TitleAreaDialog: fix Widget is disposed on close #1094

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/TitleAreaDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/TitleAreaDialog.java
@@ -685,7 +685,7 @@ public class TitleAreaDialog extends TrayDialog {
 	public void setTitleImage(Image newTitleImage) {
 
 		titleAreaImage = newTitleImage;
-		if (titleImageLabel != null) {
+		if (titleImageLabel != null && !titleImageLabel.isDisposed()) {
 			titleImageLabel.setImage(newTitleImage);
 			determineTitleImageLargest();
 			Control top;


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.ui/issues/1094