### PR TITLE
Extend BadLocationException by illegal argument information

### DIFF
--- a/bundles/org.eclipse.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.text
-Bundle-Version: 3.14.0.qualifier
+Bundle-Version: 3.14.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.text/src/org/eclipse/jface/text/AbstractDocument.java
+++ b/bundles/org.eclipse.text/src/org/eclipse/jface/text/AbstractDocument.java
@@ -1075,8 +1075,12 @@ public abstract class AbstractDocument implements IDocument, IDocumentExtension,
 
 	@Override
 	public void replace(int pos, int length, String text, long modificationStamp) throws BadLocationException {
-		if ((0 > pos) || (0 > length) || (pos + length > getLength()))
-			throw new BadLocationException();
+		if (pos + length > getLength())
+			throw new BadLocationException("end > length: " + (pos + length) + " > " + getLength());  //$NON-NLS-1$//$NON-NLS-2$
+		if (length < 0)
+			throw new BadLocationException("length < 0: " +pos);  //$NON-NLS-1$
+		if (pos < 0)
+			throw new BadLocationException("pos < 0: " +pos);  //$NON-NLS-1$
 
 		DocumentEvent e= new DocumentEvent(this, pos, length, text);
 		fireDocumentAboutToBeChanged(e);

--- a/bundles/org.eclipse.text/src/org/eclipse/jface/text/ListLineTracker.java
+++ b/bundles/org.eclipse.text/src/org/eclipse/jface/text/ListLineTracker.java
@@ -174,8 +174,10 @@ abstract class ListLineTracker implements ILineTracker {
 	public final IRegion getLineInformation(int line) throws BadLocationException {
 		int lines= fLines.size();
 
-		if (line < 0 || line > lines)
-			throw new BadLocationException();
+		if (line > lines)
+			throw new BadLocationException("line > lines: " + line + " > " + lines);  //$NON-NLS-1$//$NON-NLS-2$
+		if (line < 0)
+			throw new BadLocationException("line < 0: " +line);  //$NON-NLS-1$
 
 		if (lines == 0)
 			return new Line(0, 0);


### PR DESCRIPTION
As logged for example during
ConsoleDocumentAdapterTests.testInvalidInvocations()