### PR TITLE
Clean-up WindowsDefenderConfigurator after subsequent check refinements

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
@@ -568,25 +568,25 @@ CheckedTreeSelectionDialog_nothing_available=No entries available.
 CheckedTreeSelectionDialog_select_all=Select &All
 CheckedTreeSelectionDialog_deselect_all=&Deselect All
 
-WindowsDefenderConfigurator_statusCheck=Windows Defender Exclusion Check
-WindowsDefenderConfigurator_exclusionCheckMessage=Microsoft''s Windows Defender is active and could significantly decrease the startup and overall performance of {0}.\n\
-Select how this installation should be handled by Windows Defender:
-WindowsDefenderConfigurator_exclusionInformation=If Windows Defender is active and scans {0} it can significantly slow down its startup and overall performance.\n\
-To prevent a decrease in performance {0} can exclude itself and all files opened from real-time scanning by Windows Defender.\n\
+WindowsDefenderConfigurator_statusCheck=Microsoft Defender Exclusion Check
+WindowsDefenderConfigurator_exclusionCheckMessage=Microsoft Windows Defender is active and could significantly decrease the startup and overall performance of {0}.\n\
+Select how this installation should be handled by Microsoft Defender:
+WindowsDefenderConfigurator_exclusionInformation=If Microsoft Defender is active on Windows 10 or later and scans {0} it can significantly slow down its startup and overall performance.\n\
+To prevent a decrease in performance {0} can exclude its process and consequently all files touched by it from real-time scanning by the Defender.\n\
 Be aware that in general adding exclusions could affect this computer''s security.
 WindowsDefenderConfigurator_scriptShowLabel=Show Powershell script >>
 WindowsDefenderConfigurator_scriptHideLabel=<< Hide Powershell script
 WindowsDefenderConfigurator_scriptHint=Adding exclusions respectively running the Powershell script to do it requires administrator privileges.
 WindowsDefenderConfigurator_performExclusionChoice=Exclude {0} from being scanned to improve performance.\n\
 (In general adding exclusions may affect the security level of this computer)
-WindowsDefenderConfigurator_ignoreThisInstallationChoice=Keep {0} being scanned by Windows Defender.
+WindowsDefenderConfigurator_ignoreThisInstallationChoice=Keep {0} being scanned by Microsoft Defender.
 WindowsDefenderConfigurator_ignoreAllChoice=Skip exclusion check on startup for all new Eclipse-based installations
 WindowsDefenderConfigurator_detailsAndOptionsLinkText=See '<a>Startup and Shutdown</a>' preference for more details and configuration options.
 WindowsDefenderConfigurator_runExclusionFromPreferenceButtonLabel=Run exclusion check now
-WindowsDefenderConfigurator_statusInactive=Windows Defender is not active on this computer.
-WindowsDefenderConfigurator_statusCheckFailed=Failed to retrieve Windows Defender status.
-WindowsDefenderConfigurator_exclusionFailed=Failed to exclude {0} from being scanned by Windows Defender.
-WindowsDefenderConfigurator_exclusionFailed_Protected=Cannot exclude {0} from being scanned by Windows Defender.\nTamper protection for antivirus exclusions is enabled.
+WindowsDefenderConfigurator_statusInactive=Microsoft Defender is not active on this computer.
+WindowsDefenderConfigurator_statusCheckFailed=Failed to retrieve Microsoft Defender status.
+WindowsDefenderConfigurator_exclusionFailed=Failed to exclude {0} from being scanned by Microsoft Defender.
+WindowsDefenderConfigurator_exclusionFailed_Protected=Cannot exclude {0} from being scanned by Microsoft Defender.\nTamper protection for antivirus exclusions is enabled.
 
 # ==============================================================================
 # Editor Framework


### PR DESCRIPTION
Follow-up for https://github.com/eclipse-platform/eclipse.platform.ui/pull/1453. These clean-ups where hold back to reduce the risk for regressions late in the release cycle.
Some explanations also added in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1832 could also be added to the preference page.