### PR TITLE
Remove one indirection level in orbit repository access

### DIFF
--- a/releng/org.eclipse.ui.releng/platformUiTools.p2f
+++ b/releng/org.eclipse.ui.releng/platformUiTools.p2f
@@ -24,32 +24,32 @@
     </iu>
     <iu id='org.easymock' name='org.easymock' version='2.4.0'>
       <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/downloads/latest-I'/>
+        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
       </repositories>
     </iu>
     <iu id='org.bouncycastle.bcpg' name='org.bouncycastle.bcpg' version='1.69.0'>
       <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/downloads/latest-I'/>
+        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
       </repositories>
     </iu>
     <iu id='org.bouncycastle.bcpkix' name='org.bouncycastle.bcpkix' version='1.69.0'>
       <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/downloads/latest-I'/>
+        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
       </repositories>
     </iu>
     <iu id='org.bouncycastle.bcprov' name='org.bouncycastle.bcprov' version='1.69.0'>
       <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/downloads/latest-I'/>
+        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
       </repositories>
     </iu>
     <iu id='org.apache.sshd.osgi' name='org.apache.sshd.osgi' version='2.8.0'>
       <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/downloads/latest-I'/>
+        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
       </repositories>
     </iu>
     <iu id='org.apache.sshd.sftp' name='org.apache.sshd.sftp' version='2.8.0'>
       <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/downloads/latest-I'/>
+        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
       </repositories>
     </iu>
     <iu id='javax.annotation' name='javax.annotation' version='1.3.5'>
@@ -124,7 +124,7 @@
     </iu>
     <iu id='org.mockito' name='Java Mocking and Stubbing Framework' version='2.23.0'>
         <repositories size='1'>
-            <repository location='https://download.eclipse.org/tools/orbit/downloads/latest-I'/>
+            <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
         </repositories>
     </iu>
     <iu id='org.mockito.mockito-core' name='Mockito Core' version='0.0.0'>
@@ -184,42 +184,42 @@
     </iu>
     <iu id='org.osgi.namespace.service' name='org.osgi.namespace.service' version='0.0.0'>
       <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/downloads/latest-I'/>
+        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
       </repositories>
     </iu>
     <iu id='org.osgi.namespace.extender' name='org.osgi.namespace.extender' version='0.0.0'>
       <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/downloads/latest-I'/>
+        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
       </repositories>
     </iu>
     <iu id='org.osgi.namespace.contract' name='org.osgi.namespace.contract' version='0.0.0'>
       <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/downloads/latest-I'/>
+        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
       </repositories>
     </iu>
     <iu id='bndtools.api' name='bndtools.api' version='0.0.0'>
       <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/downloads/latest-I'/>
+        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
       </repositories>
     </iu>
     <iu id='org.bndtools.headless.build.manager' name='org.bndtools.headless.build.manager' version='0.0.0'>
       <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/downloads/latest-I'/>
+        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
       </repositories>
     </iu>
     <iu id='org.bndtools.versioncontrol.ignores.manager' name='org.bndtools.versioncontrol.ignores.manager' version='0.0.0'>
       <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/downloads/latest-I'/>
+        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
       </repositories>
     </iu>
     <iu id='org.bndtools.headless.build.plugin.gradle' name='org.bndtools.headless.build.plugin.gradle' version='0.0.0'>
       <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/downloads/latest-I'/>
+        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
       </repositories>
     </iu>
     <iu id='org.bndtools.versioncontrol.ignores.plugin.git' name='org.bndtools.versioncontrol.ignores.plugin.git' version='0.0.0'>
       <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/downloads/latest-I'/>
+        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
       </repositories>
     </iu>
   </ius>


### PR DESCRIPTION
Switched from
https://download.eclipse.org/tools/orbit/downloads/latest-I to
https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest as recommended in
https://github.com/eclipse-platform/eclipse.platform.ui/pull/1763#issuecomment-2006609758