### PR TITLE
Properly use selected string for replacements in FindReplaceDialog #1754

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
@@ -92,6 +92,8 @@ public class FindReplaceDialogTest {
 
 		Button regExCheckBox;
 
+		Button replaceFindButton;
+
 		private Supplier<Shell> shellRetriever;
 
 		private Runnable closeOperation;
@@ -106,6 +108,7 @@ public class FindReplaceDialogTest {
 			wholeWordCheckBox= (Button) findReplaceDialogAccessor.get("fWholeWordCheckBox");
 			incrementalCheckBox= (Button) findReplaceDialogAccessor.get("fIncrementalCheckBox");
 			regExCheckBox= (Button) findReplaceDialogAccessor.get("fIsRegExCheckBox");
+			replaceFindButton= (Button) findReplaceDialogAccessor.get("fReplaceFindButton");
 			shellRetriever= () -> ((Shell) findReplaceDialogAccessor.get("fActiveShell"));
 			closeOperation= () -> findReplaceDialogAccessor.invoke("close", null);
 			assertInitialConfiguration();
@@ -176,10 +179,17 @@ public class FindReplaceDialogTest {
 	}
 
 	private void openTextViewerAndFindReplaceDialog(String content) {
+		openTextViewer(content);
+		openFindReplaceDialogForTextViewer();
+	}
+
+	private void openTextViewer(String content) {
 		fTextViewer= new TextViewer(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
 		fTextViewer.setDocument(new Document(content));
 		fTextViewer.getControl().setFocus();
+	}
 
+	private void openFindReplaceDialogForTextViewer() {
 		Accessor fFindReplaceAction;
 		fFindReplaceAction= new Accessor("org.eclipse.ui.texteditor.FindReplaceAction", getClass().getClassLoader(),
 				new Class[] { ResourceBundle.class, String.class, Shell.class, IFindReplaceTarget.class },
@@ -364,6 +374,22 @@ public class FindReplaceDialogTest {
 		simulateEnterInFindInputField(false);
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(dialog.findCombo.getText().length(), (target.getSelection()).y);
+	}
+
+	@Test
+	public void testReplaceAndFindAfterInitializingFindWithSelectedString() {
+		openTextViewer("text text text");
+		fTextViewer.setSelectedRange(0, 4);
+		openFindReplaceDialogForTextViewer();
+
+		IFindReplaceTarget target= dialog.findReplaceLogic.getTarget();
+		assertEquals(0, (target.getSelection()).x);
+		assertEquals(4, (target.getSelection()).y);
+		select(dialog.replaceFindButton);
+
+		assertEquals(" text text", fTextViewer.getDocument().get());
+		assertEquals(1, (target.getSelection()).x);
+		assertEquals(4, (target.getSelection()).y);
 	}
 
 	private static void select(Button button) {


### PR DESCRIPTION
When opening the FindReplaceDialog with an active selection in a text viewer, the input field for the find string is filled with the content of that selection. In addition, the replace functionality of the dialog is activated. Currently, using the replace functionality does not work because it requires a find operation to be executed before, which is currently not done.

With this change, initializing the dialog with the current selection performs the missing find operation before executing a replace operation. The according functionality is refactored and a regression test is added.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1754