### PR TITLE
Navigation - Issue #1780

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AbstractTextEditor.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AbstractTextEditor.java
@@ -6340,9 +6340,10 @@ public abstract class AbstractTextEditor extends EditorPart implements ITextEdit
 	 */
 	protected void editorSaved() {
 		IEditorInput input= getEditorInput();
+		String id = getEditorSite().getId();
 		for (INavigationLocation location2 : getSite().getPage().getNavigationHistory().getLocations()) {
 			if (location2 instanceof TextSelectionNavigationLocation) {
-				if(input.equals(location2.getInput())) {
+				if (input.equals(location2.getInput()) && id.equals(location2.getId())) {
 					TextSelectionNavigationLocation location= (TextSelectionNavigationLocation) location2;
 					location.partSaved(this);
 				}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/INavigationLocation.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/INavigationLocation.java
@@ -78,6 +78,14 @@ public interface INavigationLocation {
 	Object getInput();
 
 	/**
+	 * Returns the id used for this location.
+	 *
+	 * @return the id for this location
+	 * @since 3.132
+	 */
+	String getId();
+
+	/**
 	 * Returns the display name for this location. This name is used in the
 	 * navigation history list.
 	 *
@@ -94,6 +102,17 @@ public interface INavigationLocation {
 	 * @param input the editor input.
 	 */
 	void setInput(Object input);
+
+	/**
+	 * Sets the location's id.
+	 * <p>
+	 * Should not be called by clients.
+	 * </p>
+	 *
+	 * @param id the editor id.
+	 * @since 3.132
+	 */
+	void setId(String id);
 
 	/**
 	 * The message <code>update</code> is sent to the active location before another

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/NavigationLocation.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/NavigationLocation.java
@@ -25,6 +25,8 @@ public abstract class NavigationLocation implements INavigationLocation {
 
 	private IEditorInput input;
 
+	private String editorId;
+
 	/**
 	 * Constructs a NavigationLocation with its editor part.
 	 *
@@ -32,6 +34,7 @@ public abstract class NavigationLocation implements INavigationLocation {
 	 */
 	protected NavigationLocation(IEditorPart editorPart) {
 		this.page = editorPart.getSite().getPage();
+		this.editorId = editorPart.getSite().getId();
 		this.input = editorPart.getEditorInput();
 	}
 
@@ -43,13 +46,26 @@ public abstract class NavigationLocation implements INavigationLocation {
 	protected IEditorPart getEditorPart() {
 		if (input == null) {
 			return null;
+		} else if (editorId == null) {
+			return page.findEditor(input);
+		} else {
+			IEditorReference[] editorReferences = page.findEditors(input, editorId,
+					IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
+			if (editorReferences.length > 0) {
+				return editorReferences[0].getEditor(false);
+			}
+			return null;
 		}
-		return page.findEditor(input);
 	}
 
 	@Override
 	public Object getInput() {
 		return input;
+	}
+
+	@Override
+	public String getId() {
+		return editorId;
 	}
 
 	@Override
@@ -64,6 +80,11 @@ public abstract class NavigationLocation implements INavigationLocation {
 	@Override
 	public void setInput(Object input) {
 		this.input = (IEditorInput) input;
+	}
+
+	@Override
+	public void setId(String id) {
+		this.editorId = id;
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/NavigationHistoryEntry.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/NavigationHistoryEntry.java
@@ -65,7 +65,8 @@ public class NavigationHistoryEntry {
 	void restoreLocation() {
 		if (editorInfo.editorInput != null && editorInfo.editorID != null) {
 			try {
-				IEditorPart editor = page.openEditor(editorInfo.editorInput, editorInfo.editorID, true);
+				IEditorPart editor = page.openEditor(editorInfo.editorInput, editorInfo.editorID, true,
+						IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
 				if (location == null) {
 					if (editor instanceof INavigationLocationProvider) {
 						location = ((INavigationLocationProvider) editor).createEmptyNavigationLocation();
@@ -75,6 +76,7 @@ public class NavigationHistoryEntry {
 				if (location != null) {
 					if (locationMemento != null) {
 						location.setInput(editorInfo.editorInput);
+						location.setId(editorInfo.editorID);
 						location.restoreState(locationMemento);
 						locationMemento = null;
 					}

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.131.200.qualifier
+Bundle-Version: 3.132.0.qualifier
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/tests/org.eclipse.ui.tests.navigator/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.navigator/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: org.eclipse.core.resources,
  org.eclipse.ui.navigator.resources,
  org.eclipse.ui.tests.harness,
  org.eclipse.ui.editors,
- org.eclipse.jdt.ui
+ org.eclipse.jdt.ui,
+ org.eclipse.ui.genericeditor
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.ui.tests.navigator;x-internal:=true

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/GoBackForwardsTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/GoBackForwardsTest.java
@@ -1,0 +1,244 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2020 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Louis Detweiler <greg.detweiler42@gmail.com> - Issue #1780
+ *******************************************************************************/
+package org.eclipse.ui.tests.navigator;
+
+import java.io.IOException;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.INavigationLocation;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.NavigationHistoryAction;
+import org.eclipse.ui.intro.IIntroPart;
+import org.eclipse.ui.part.FileEditorInput;
+import org.eclipse.ui.tests.harness.util.EditorTestHelper;
+import org.eclipse.ui.tests.harness.util.FileTool;
+import org.eclipse.ui.tests.harness.util.FileUtil;
+import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.eclipse.ui.texteditor.AbstractTextEditor;
+import org.eclipse.ui.texteditor.TextSelectionNavigationLocation;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @since 3.3
+ *
+ */
+public class GoBackForwardsTest extends UITestCase {
+
+	private static final String TEST_NAME = "GoBackForwardsTest";
+
+	public GoBackForwardsTest() {
+		super(TEST_NAME);
+	}
+
+	private static final String PROJECT_NAME = "GoBackForwardsTestProject";
+	private static final String FILE_NAME = "GoBackForwardsTestFile.java";
+	private static final String FILE_CONTENTS = "public class GoBackForwardsTestFile {\n"
+			+ "    public static void main(String[] args) {\n" + "        System.out.println(\"Hello world!\");\n"
+			+ "    }\n" + "}";
+	private static final String JAVA_EDITOR_ID = "org.eclipse.jdt.ui.CompilationUnitEditor";
+	private static final String TEXT_EDITOR_ID = "org.eclipse.ui.genericeditor.GenericEditor";
+	private static final String SELECTION_STRING = "Selection<offset: 10, length: 5>";
+
+	private IProject project;
+	private IFile file;
+
+	@Override
+	public void doSetUp() {
+		try {
+			project = FileUtil.createProject(PROJECT_NAME);
+			file = FileUtil.createFile(FILE_NAME, project);
+			StringBuilder stringBuilder = new StringBuilder();
+			stringBuilder.append(FILE_CONTENTS);
+			FileTool.writeFromBuilder(file.getLocation().toOSString(), stringBuilder);
+		} catch (CoreException e) {
+			fail("Should not throw an exception");
+		} catch (IOException e) {
+			fail("Should not throw an exception");
+		}
+
+	}
+
+	@Test
+	public void testNavigationHistoryNavigation() {
+		IIntroPart introPart = PlatformUI.getWorkbench().getIntroManager().getIntro();
+		PlatformUI.getWorkbench().getIntroManager().closeIntro(introPart);
+
+		Condition javaEditorNoSelection = currentNavigationHistoryLocationCondition(JAVA_EDITOR_ID, false);
+		Condition javaEditorSelection = currentNavigationHistoryLocationCondition(JAVA_EDITOR_ID, true);
+		Condition textEditorNoSelection = currentNavigationHistoryLocationCondition(TEXT_EDITOR_ID, false);
+		Condition textEditorSelection = currentNavigationHistoryLocationCondition(TEXT_EDITOR_ID, true);
+
+		FileEditorInput editorInput = new FileEditorInput(file);
+
+		openJavaEditor(editorInput);
+
+		if (!processEventsUntil(javaEditorNoSelection, 30000)) {
+			fail("Timeout during navigation.");
+		}
+
+		selectInJavaEditor(editorInput);
+
+		if (!processEventsUntil(javaEditorSelection, 30000)) {
+			fail("Timeout during navigation.");
+		}
+
+		openTextEditor(editorInput);
+
+		if (!processEventsUntil(textEditorNoSelection, 30000)) {
+			fail("Timeout during navigation.");
+		}
+
+		selectInTextEditor(editorInput);
+
+		if (!processEventsUntil(textEditorSelection, 30000)) {
+			fail("Timeout during navigation.");
+		}
+
+		openJavaEditor(editorInput);
+
+		if (!processEventsUntil(javaEditorSelection, 30000)) {
+			fail("Timeout during navigation.");
+		}
+
+		openTextEditor(editorInput);
+
+		if (!processEventsUntil(textEditorSelection, 30000)) {
+			fail("Timeout during navigation.");
+		}
+
+		// Navigate backward from text editor to java editor
+		goBackward(EditorTestHelper.getActiveWorkbenchWindow(), javaEditorSelection);
+		Assert.assertEquals("Failed to correctly navigate backward from text editor to java editor.", JAVA_EDITOR_ID,
+				getActiveEditorId());
+
+		// Navigate backward from java editor to text editor
+		goBackward(EditorTestHelper.getActiveWorkbenchWindow(), textEditorSelection);
+		Assert.assertEquals("Failed to correctly navigate backward from java editor to test editor.", TEXT_EDITOR_ID,
+				getActiveEditorId());
+
+		// Navigate backward from text editor to text editor
+		goBackward(EditorTestHelper.getActiveWorkbenchWindow(), textEditorNoSelection);
+		Assert.assertEquals("Failed to correctly navigate backward from text editor to text editor.", TEXT_EDITOR_ID,
+				getActiveEditorId());
+
+		// Navigate backward from java editor to java editor
+		goBackward(EditorTestHelper.getActiveWorkbenchWindow(), javaEditorSelection);
+		goBackward(EditorTestHelper.getActiveWorkbenchWindow(), javaEditorNoSelection);
+		Assert.assertEquals("Failed to correctly navigate backward from java editor to java editor.", JAVA_EDITOR_ID,
+				getActiveEditorId());
+
+		// Navigate forward from java editor to java editor
+		goForward(EditorTestHelper.getActiveWorkbenchWindow(), javaEditorSelection);
+		Assert.assertEquals("Failed to correctly navigate forward from java editor to java editor.", JAVA_EDITOR_ID,
+				getActiveEditorId());
+
+		// Navigate forward from text editor to text editor
+		goForward(EditorTestHelper.getActiveWorkbenchWindow(), textEditorNoSelection);
+		goForward(EditorTestHelper.getActiveWorkbenchWindow(), textEditorSelection);
+		Assert.assertEquals("Failed to correctly navigate forward from java editor to java editor.", TEXT_EDITOR_ID,
+				getActiveEditorId());
+
+		// Navigate forward from text editor to java editor
+		goForward(EditorTestHelper.getActiveWorkbenchWindow(), javaEditorSelection);
+		Assert.assertEquals("Failed to correctly navigate forward from text editor to java editor.", JAVA_EDITOR_ID,
+				getActiveEditorId());
+
+		// Navigate forward from java editor to text editor
+		goForward(EditorTestHelper.getActiveWorkbenchWindow(), textEditorSelection);
+		Assert.assertEquals("Failed to correctly navigate forward from java editor to text editor.", TEXT_EDITOR_ID,
+				getActiveEditorId());
+	}
+
+	private Condition currentNavigationHistoryLocationCondition(String editorId, boolean selection) {
+		return new Condition() {
+
+			@Override
+			public boolean compute() {
+				INavigationLocation location = EditorTestHelper.getActiveWorkbenchWindow().getActivePage()
+						.getNavigationHistory().getCurrentLocation();
+				if (location instanceof TextSelectionNavigationLocation) {
+					return editorId.equals(location.getId())
+							&& (!selection || SELECTION_STRING.equals(location.toString()));
+				}
+				return false;
+			}
+
+		};
+	}
+
+	private void openJavaEditor(IEditorInput editorInput) {
+		try {
+			EditorTestHelper.getActivePage().openEditor(editorInput, JAVA_EDITOR_ID, true,
+					IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
+		} catch (PartInitException e) {
+			fail("Should not throw an exception");
+		}
+	}
+
+	private void selectInJavaEditor(IEditorInput editorInput) {
+		try {
+			AbstractTextEditor editor = (AbstractTextEditor) EditorTestHelper.getActivePage().openEditor(editorInput,
+					JAVA_EDITOR_ID, true, IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
+			editor.selectAndReveal(10, 5);
+		} catch (PartInitException e) {
+			fail("Should not throw an exception");
+		}
+	}
+
+	private void selectInTextEditor(IEditorInput editorInput) {
+		try {
+			AbstractTextEditor editor = (AbstractTextEditor) EditorTestHelper.getActivePage().openEditor(editorInput,
+					TEXT_EDITOR_ID, true, IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
+			editor.selectAndReveal(10, 5);
+		} catch (PartInitException e) {
+			fail("Should not throw an exception");
+		}
+	}
+
+	private void openTextEditor(IEditorInput editorInput) {
+		try {
+			EditorTestHelper.getActivePage().openEditor(editorInput, TEXT_EDITOR_ID, true,
+					IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
+		} catch (PartInitException e) {
+			fail("Should not throw an exception");
+		}
+	}
+
+	private void goForward(IWorkbenchWindow window, Condition condition) {
+		NavigationHistoryAction action = new NavigationHistoryAction(window, true);
+		action.run();
+		if (!processEventsUntil(condition, 30000)) {
+			fail("Timeout during navigation.");
+		}
+	}
+
+	private void goBackward(IWorkbenchWindow window, Condition condition) {
+		NavigationHistoryAction action = new NavigationHistoryAction(window, false);
+		action.run();
+		if (!processEventsUntil(condition, 30000)) {
+			fail("Timeout during navigation.");
+		}
+	}
+
+	private String getActiveEditorId() {
+		return EditorTestHelper.getActivePage().getActiveEditor().getEditorSite().getId();
+	}
+}

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/NavigatorTestSuite.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/NavigatorTestSuite.java
@@ -35,7 +35,8 @@ import org.junit.runners.Suite.SuiteClasses;
 		LabelProviderTest.class, SorterTest.class, ViewerTest.class, CdtTest.class, M12Tests.class,
 		FirstClassM1Tests.class, LinkHelperTest.class, ShowInTest.class, ResourceTransferTest.class,
 		EvaluationCacheTest.class,
-		NestedResourcesTests.class, PathComparatorTest.class, FoldersAsProjectsContributionTest.class
+		NestedResourcesTests.class, PathComparatorTest.class, FoldersAsProjectsContributionTest.class,
+		GoBackForwardsTest.class
 		// DnDTest.class, // DnDTest.testSetDragOperation() fails
 		// PerformanceTest.class // Does not pass on all platforms see bug 264449
 })


### PR DESCRIPTION
Updates the restoreLocation() method of the NavigationHistoryEntry class to match the editor ID as well as the editor input when opening the editor. Also updates the getEditorPart() method of the NavigationLocation class to return the IEditorPart based on the editor ID as well as the editor input, if both are available.