### PR TITLE
Link GenericEditorMergeViewer to generic editor id

### DIFF
--- a/bundles/org.eclipse.ui.genericeditor/plugin.xml
+++ b/bundles/org.eclipse.ui.genericeditor/plugin.xml
@@ -244,6 +244,7 @@
          point="org.eclipse.compare.contentMergeViewers">
       <viewer
             class="org.eclipse.ui.internal.genericeditor.compare.CompareViewerCreator"
+            linkedEditor="org.eclipse.ui.genericeditor.GenericEditor"
             id="org.eclipse.ui.genericeditor.compareViewer">
       </viewer>
    </extension>

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/Messages.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/Messages.java
@@ -24,6 +24,7 @@ public class Messages extends NLS {
 
 	public static String GotoMatchingBracket_error_noMatchingBracket;
 	public static String GotoMatchingBracket_error_bracketOutsideSelectedElement;
+	public static String GenericEditorMergeViewer_title;
 
 	static {
 		// initialize resource bundle

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/compare/GenericEditorMergeViewer.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/compare/GenericEditorMergeViewer.java
@@ -25,15 +25,18 @@ import org.eclipse.jface.text.ITextInputListener;
 import org.eclipse.jface.text.TextViewer;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.text.source.SourceViewer;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.editors.text.EditorsUI;
 import org.eclipse.ui.internal.genericeditor.ExtensionBasedTextViewerConfiguration;
 import org.eclipse.ui.internal.genericeditor.GenericEditorPlugin;
+import org.eclipse.ui.internal.genericeditor.Messages;
 import org.eclipse.ui.texteditor.ChainedPreferenceStore;
 
 public class GenericEditorMergeViewer extends TextMergeViewer {
 
 	private final Set<IContentType> fallbackContentTypes = new LinkedHashSet<>();
+	private String title;
 
 	public GenericEditorMergeViewer(Composite parent, CompareConfiguration configuration) {
 		super(parent, configuration);
@@ -60,13 +63,22 @@ public class GenericEditorMergeViewer extends TextMergeViewer {
 
 	@Override
 	protected void configureTextViewer(TextViewer textViewer) {
-		if (textViewer.getDocument() != null && textViewer instanceof ISourceViewer) {
+		if (textViewer.getDocument() != null && textViewer instanceof ISourceViewer sourceViewer) {
 			ExtensionBasedTextViewerConfiguration configuration = new ExtensionBasedTextViewerConfiguration(null,
 					new ChainedPreferenceStore(new IPreferenceStore[] { EditorsUI.getPreferenceStore(),
 							GenericEditorPlugin.getDefault().getPreferenceStore() }));
 			configuration.setFallbackContentTypes(fallbackContentTypes);
-			((ISourceViewer) textViewer).configure(configuration);
+			sourceViewer.configure(configuration);
+			Set<IContentType> contentTypes = configuration.getContentTypes(sourceViewer.getDocument());
+			if (!contentTypes.isEmpty()) {
+				IContentType contentType = contentTypes.iterator().next();
+				title = NLS.bind(Messages.GenericEditorMergeViewer_title, contentType.getName());
+			}
 		}
 	}
 
+	@Override
+	public String getTitle() {
+		return title != null ? title : super.getTitle();
+	}
 }

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/messages.properties
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/messages.properties
@@ -18,3 +18,5 @@ TextViewer_open_hyperlink_error_message=The operation is not applicable to the c
 
 GotoMatchingBracket_error_noMatchingBracket=No matching bracket found
 GotoMatchingBracket_error_bracketOutsideSelectedElement=Matching bracket is outside the selected element
+
+GenericEditorMergeViewer_title={0} Compare


### PR DESCRIPTION
This allows GenericEditorMergeViewer be used by compare editor for content types associated with the generic editor.

Additionally implemented getTitle() to provide more specific compare editor description, so instead of default "Text Compare" one would see "XML Compare" etc. This avoids the problem of duplicated "Text Compare" options shown for different compare viewers (default one for plain text and the one for generic editor).

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/1747

See https://github.com/eclipse-platform/eclipse.platform/pull/1277