### PR TITLE
Add support for Windows on Arm64 (WoA) platform build.

### DIFF
--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -218,6 +218,13 @@
          version="0.0.0"/>
 
    <plugin
+         id="org.eclipse.equinox.launcher.win32.win32.aarch64"
+         os="win32"
+         ws="win32"
+         arch="aarch64"
+         version="0.0.0"/>
+
+   <plugin
          id="org.eclipse.equinox.launcher.win32.win32.x86_64"
          os="win32"
          ws="win32"
@@ -226,6 +233,13 @@
 
    <plugin
          id="org.eclipse.swt"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.swt.win32.win32.aarch64"
+         os="win32"
+         ws="win32"
+         arch="aarch64"
          version="0.0.0"/>
 
    <plugin

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
                     <plugin id="org.eclipse.equinox.launcher.gtk.linux.ppc64le" />
                     <plugin id="org.eclipse.equinox.launcher.gtk.linux.aarch64" />
                     <plugin id="org.eclipse.equinox.launcher.gtk.linux.x86_64" />
+                    <plugin id="org.eclipse.equinox.launcher.win32.win32.aarch64" />
                     <plugin id="org.eclipse.equinox.launcher.win32.win32.x86_64" />
                   </excludes>
                 </configuration>


### PR DESCRIPTION
The following new Equinox plug-ins for WoA are added to the existing `org.eclipse.e4.rcp` feature:
```
org.eclipse.equinox.launcher.win32.win32.aarch64
org.eclipse.equinox.swt.win32.win32.aarch64
```
