### PR TITLE
Move activation logic for SearchOptions.WHOLE_WORDS to FindReplaceLogic

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
@@ -166,4 +166,14 @@ public interface IFindReplaceLogic {
 	 */
 	public IFindReplaceTarget getTarget();
 
+	/**
+	 * Returns <code>true</code> if searching can be restricted to entire words,
+	 * <code>false</code> if not. Searching for whole words requires the given find
+	 * string to be an entire word and the regex search option to be disabled.
+	 *
+	 * @param findString the string that is currently being searched for.
+	 * @return <code>true</code> if the search can be restricted to whole words
+	 */
+	public boolean isWholeWordSearchAvailable(String findString);
+
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -733,7 +733,7 @@ class FindReplaceDialog extends Dialog {
 			}
 		});
 		storeButtonWithMnemonicInMap(fIsRegExCheckBox);
-		fWholeWordCheckBox.setEnabled(!findReplaceLogic.isRegExSearchAvailableAndActive());
+		fWholeWordCheckBox.setEnabled(findReplaceLogic.isWholeWordSearchAvailable(getFindString()));
 		fWholeWordCheckBox.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
@@ -1065,7 +1065,7 @@ class FindReplaceDialog extends Dialog {
 			boolean isSelectionGoodForReplace = selectionString != "" //$NON-NLS-1$
 					|| !isRegExSearchAvailableAndActive;
 
-			fWholeWordCheckBox.setEnabled(isWord(str) && !isRegExSearchAvailableAndActive);
+			fWholeWordCheckBox.setEnabled(findReplaceLogic.isWholeWordSearchAvailable(getFindString()));
 			fFindNextButton.setEnabled(enable && isFindStringSet);
 			fSelectAllButton.setEnabled(enable && isFindStringSet && (target instanceof IFindReplaceTargetExtension4));
 			fReplaceSelectionButton.setEnabled(
@@ -1076,23 +1076,6 @@ class FindReplaceDialog extends Dialog {
 		}
 	}
 
-	/**
-	 * Tests whether each character in the given string is a letter.
-	 *
-	 * @param str the string to check
-	 * @return <code>true</code> if the given string is a word
-	 * @since 3.0
-	 */
-	private boolean isWord(String str) {
-		if (str == null || str.isEmpty())
-			return false;
-
-		for (int i = 0; i < str.length(); i++) {
-			if (!Character.isJavaIdentifierPart(str.charAt(i)))
-				return false;
-		}
-		return true;
-	}
 
 	/**
 	 * Updates the given combo with the given content.
@@ -1178,7 +1161,7 @@ class FindReplaceDialog extends Dialog {
 		}
 
 		if (okToUse(fWholeWordCheckBox)) {
-			fWholeWordCheckBox.setEnabled(!findReplaceLogic.isRegExSearchAvailableAndActive());
+			fWholeWordCheckBox.setEnabled(findReplaceLogic.isWholeWordSearchAvailable(getFindString()));
 		}
 
 		if (okToUse(fIncrementalCheckBox)) {
@@ -1280,8 +1263,7 @@ class FindReplaceDialog extends Dialog {
 		activateInFindReplaceLogicIf(SearchOptions.FORWARD, fForwardRadioButton.getSelection());
 		activateInFindReplaceLogicIf(SearchOptions.CASE_SENSITIVE, fCaseCheckBox.getSelection());
 		activateInFindReplaceLogicIf(SearchOptions.REGEX, fIsRegExCheckBox.getSelection());
-		activateInFindReplaceLogicIf(SearchOptions.WHOLE_WORD,
-				fWholeWordCheckBox.getEnabled() && fWholeWordCheckBox.getSelection());
+		activateInFindReplaceLogicIf(SearchOptions.WHOLE_WORD, fWholeWordCheckBox.getSelection());
 		activateInFindReplaceLogicIf(SearchOptions.INCREMENTAL,
 				fIncrementalCheckBox.getEnabled() && fIncrementalCheckBox.getSelection());
 	}

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -452,6 +452,28 @@ public class FindReplaceLogicTest {
 		assertThat(textViewer.getTextWidget().getText(), is("lie1\nine2\nine3"));
 	}
 
+	@Test
+	public void testWholeWordSearchAvailable() {
+		TextViewer textViewer= setupTextViewer("line1\nline2\nline3");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+
+		assertThat(findReplaceLogic.isWholeWordSearchAvailable("oneword"), is(true));
+		assertThat(findReplaceLogic.isWholeWordSearchAvailable("stilläoneäword"), is(true));
+		assertThat(findReplaceLogic.isWholeWordSearchAvailable("two.words"), is(false));
+		assertThat(findReplaceLogic.isWholeWordSearchAvailable("two words"), is(false));
+		assertThat(findReplaceLogic.isWholeWordSearchAvailable("oneword"), is(true));
+		assertThat(findReplaceLogic.isWholeWordSearchAvailable("twöwords"), is(true));
+
+		findReplaceLogic.activate(SearchOptions.REGEX);
+
+		assertThat(findReplaceLogic.isWholeWordSearchAvailable("oneword"), is(false));
+		assertThat(findReplaceLogic.isWholeWordSearchAvailable("stilläoneöword"), is(false));
+		assertThat(findReplaceLogic.isWholeWordSearchAvailable("two.words"), is(false));
+		assertThat(findReplaceLogic.isWholeWordSearchAvailable("two words"), is(false));
+
+		assertThat(findReplaceLogic.isWholeWordSearchAvailable(""), is(false));
+	}
+
 	private void expectStatusEmpty(IFindReplaceLogic findReplaceLogic) {
 		assertThat(findReplaceLogic.getStatus(), instanceOf(NoStatus.class));
 	}

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
@@ -392,6 +392,28 @@ public class FindReplaceDialogTest {
 		assertEquals(4, (target.getSelection()).y);
 	}
 
+	@Test
+	public void testActivateWholeWordsAndSearchForTwoWords() {
+		openTextViewer("text text text");
+		openFindReplaceDialogForTextViewer();
+
+		dialog.wholeWordCheckBox.setSelection(true);
+
+		dialog.findCombo.setText("text text");
+		assertTrue(dialog.wholeWordCheckBox.getSelection());
+		assertFalse(dialog.wholeWordCheckBox.getEnabled());
+
+		dialog.findCombo.setText("text");
+		assertTrue(dialog.wholeWordCheckBox.getSelection());
+		assertTrue(dialog.wholeWordCheckBox.getEnabled());
+
+		dialog.regExCheckBox.setSelection(true);
+		dialog.regExCheckBox.notifyListeners(SWT.Selection, null);
+		runEventQueue();
+		assertTrue(dialog.wholeWordCheckBox.getSelection());
+		assertFalse(dialog.wholeWordCheckBox.getEnabled());
+	}
+
 	private static void select(Button button) {
 		button.setSelection(true);
 		button.notifyListeners(SWT.Selection, null);


### PR DESCRIPTION
when "whole words" is selected but a find-string was entered that is not a whole word, the dialog/overlay will disable the option for "whole words". However, the dialog/overlay will keep the selection of the button in it's internal state. By passing the findString to this method, we can make sure that we don't try to perform a whole-words search for a string that isn't a whole word.

See https://github.com/eclipse-platform/eclipse.platform.ui/pull/1192#discussion_r1548564603

Extracted from
https://github.com/eclipse-platform/eclipse.platform.ui/pull/1192