### PR TITLE
Use optionally computed content type from CompareConfiguration

### DIFF
--- a/bundles/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Require-Bundle: org.eclipse.ui.workbench.texteditor;bundle-version="3.10.0",
  org.eclipse.ui.ide;bundle-version="3.12.0",
  org.eclipse.core.resources;bundle-version="3.11.0",
  org.eclipse.core.expressions;bundle-version="3.6.0",
- org.eclipse.compare;resolution:=optional
+ org.eclipse.compare;bundle-version="3.11.0";resolution:=optional
 Export-Package: org.eclipse.ui.internal.genericeditor;x-internal:=true,
  org.eclipse.ui.internal.genericeditor.hover;x-internal:=true,
  org.eclipse.ui.internal.genericeditor.markers;x-internal:=true,

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/compare/GenericEditorMergeViewer.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/compare/GenericEditorMergeViewer.java
@@ -18,6 +18,7 @@ import java.util.Set;
 
 import org.eclipse.compare.CompareConfiguration;
 import org.eclipse.compare.contentmergeviewer.TextMergeViewer;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.IDocument;
@@ -40,6 +41,16 @@ public class GenericEditorMergeViewer extends TextMergeViewer {
 
 	public GenericEditorMergeViewer(Composite parent, CompareConfiguration configuration) {
 		super(parent, configuration);
+		if (configuration != null) {
+			Object id = configuration.getProperty(CompareConfiguration.CONTENT_TYPE);
+			if (id instanceof String contentTypeId) {
+				IContentType contentType = Platform.getContentTypeManager().getContentType(contentTypeId);
+				while (contentType != null) {
+					fallbackContentTypes.add(contentType);
+					contentType = contentType.getBaseType();
+				}
+			}
+		}
 	}
 
 	@Override
@@ -48,8 +59,10 @@ public class GenericEditorMergeViewer extends TextMergeViewer {
 		res.addTextInputListener(new ITextInputListener() {
 			@Override
 			public void inputDocumentChanged(IDocument oldInput, IDocument newInput) {
-				fallbackContentTypes
-						.addAll(new ExtensionBasedTextViewerConfiguration(null, null).getContentTypes(newInput));
+				if (fallbackContentTypes.isEmpty()) {
+					fallbackContentTypes
+							.addAll(new ExtensionBasedTextViewerConfiguration(null, null).getContentTypes(newInput));
+				}
 				configureTextViewer(res);
 			}
 


### PR DESCRIPTION
Detected content type id could be retrieved now from the CompareConfiguration with the CONTENT_TYPE key (see https://github.com/eclipse-platform/eclipse.platform/pull/1294).

Use this value (if available) as fallbackContentTypes in ExtensionBasedTextViewerConfiguration.

The allows GenericEditorMergeViewer to know for which content type was it actually created and so use that in cases where the content type can't be derived from the input (like data from git revisions that don't have regular files or buffers associated to the viewer).

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1747