### PR TITLE
Avoid unnecessary search after cancelation

### DIFF
--- a/bundles/org.eclipse.search.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.search.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search.core;singleton:=true
-Bundle-Version: 3.16.100.qualifier
+Bundle-Version: 3.16.200.qualifier
 Bundle-Activator: org.eclipse.search.internal.core.SearchCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.search.core/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
+++ b/bundles/org.eclipse.search.core/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
@@ -472,8 +472,9 @@ public class TextSearchVisitor {
 	private List<TextSearchMatchAccess> locateMatches(IFile file, CharSequence searchInput, Matcher matcher, IProgressMonitor monitor) throws CoreException {
 		List<TextSearchMatchAccess> occurences= null;
 		matcher.reset(searchInput);
-		int k= 0;
-		while (matcher.find()) {
+		// Check for cancellation before calling matcher.find() since that call
+		// can be very expensive
+		while (!monitor.isCanceled() && matcher.find()) {
 			if (occurences == null) {
 				occurences= new ArrayList<>();
 			}
@@ -487,10 +488,6 @@ public class TextSearchVisitor {
 				if (!res) {
 					return occurences; // no further reporting requested
 				}
-			}
-			// Periodically check for cancellation and quit working on the current file if the job has been cancelled.
-			if (k++ % 20 == 0 && monitor.isCanceled()) {
-				break;
 			}
 		}
 		if (occurences == null) {


### PR DESCRIPTION
Check the `monitor` provided to `org.eclipse.search.internal.core.text.TextSearchVisitor.locateMatches(...)` more often in order to avoid unnecessary calls to the expensive method `java.util.regex.Matcher.find()`

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1801