### PR TITLE
Incremental Search: extract logic for disabling on RegEx-Search #1791

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -115,10 +115,14 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	}
 
 	@Override
+	public boolean isIncrementalSearchAvailable() {
+		return !isRegExSearchAvailableAndActive();
+	}
+
+	@Override
 	public boolean isWholeWordSearchAvailable(String findString) {
 		return !isRegExSearchAvailableAndActive() && isWord(findString);
 	}
-
 	/**
 	 * Tests whether each character in the given string is a letter.
 	 *
@@ -686,7 +690,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	public void performIncrementalSearch(String searchString) {
 		resetStatus();
 
-		if (isActive(SearchOptions.INCREMENTAL) && !isRegExSearchAvailableAndActive()) {
+		if (isActive(SearchOptions.INCREMENTAL) && isIncrementalSearchAvailable()) {
 			if (searchString.equals("") && target != null) { //$NON-NLS-1$
 				// empty selection at base location
 				int offset = incrementalBaseLocation.x;

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
@@ -67,6 +67,12 @@ public interface IFindReplaceLogic {
 	public boolean isRegExSearchAvailableAndActive();
 
 	/**
+	 * {@return whether incremental search may be performed by the
+	 * find/replace-logic based on the currently active options}
+	 */
+	public boolean isIncrementalSearchAvailable();
+
+	/**
 	 * Updates the search result after the Text was Modified. Used in combination
 	 * with <code>setIncrementalSearch(true)</code>. This method specifically allows
 	 * for "search-as-you-type"

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -725,11 +725,11 @@ class FindReplaceDialog extends Dialog {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				boolean newState = fIsRegExCheckBox.getSelection();
-				fIncrementalCheckBox.setEnabled(!newState);
 				setupFindReplaceLogic();
 				storeSettings();
 				updateButtonState();
 				setContentAssistsEnablement(newState);
+				fIncrementalCheckBox.setEnabled(findReplaceLogic.isIncrementalSearchAvailable());
 			}
 		});
 		storeButtonWithMnemonicInMap(fIsRegExCheckBox);
@@ -740,7 +740,7 @@ class FindReplaceDialog extends Dialog {
 				updateButtonState();
 			}
 		});
-		fIncrementalCheckBox.setEnabled(!findReplaceLogic.isRegExSearchAvailableAndActive());
+		fIncrementalCheckBox.setEnabled(findReplaceLogic.isIncrementalSearchAvailable());
 		return panel;
 	}
 
@@ -1165,7 +1165,7 @@ class FindReplaceDialog extends Dialog {
 		}
 
 		if (okToUse(fIncrementalCheckBox)) {
-			fIncrementalCheckBox.setEnabled(!findReplaceLogic.isRegExSearchAvailableAndActive());
+			fIncrementalCheckBox.setEnabled(findReplaceLogic.isIncrementalSearchAvailable());
 		}
 
 		if (okToUse(fReplaceLabel)) {
@@ -1264,8 +1264,7 @@ class FindReplaceDialog extends Dialog {
 		activateInFindReplaceLogicIf(SearchOptions.CASE_SENSITIVE, fCaseCheckBox.getSelection());
 		activateInFindReplaceLogicIf(SearchOptions.REGEX, fIsRegExCheckBox.getSelection());
 		activateInFindReplaceLogicIf(SearchOptions.WHOLE_WORD, fWholeWordCheckBox.getSelection());
-		activateInFindReplaceLogicIf(SearchOptions.INCREMENTAL,
-				fIncrementalCheckBox.getEnabled() && fIncrementalCheckBox.getSelection());
+		activateInFindReplaceLogicIf(SearchOptions.INCREMENTAL, fIncrementalCheckBox.getSelection());
 	}
 
 	/**


### PR DESCRIPTION
when "incremental search" is selected and "RegEx-Search" is as well, the dialog/overlay will disable the option for "whole words". This PR extracts that functionality into the Find/Replace-Logic.

Extracted from a Review-Comment in #1791