### PR TITLE
Centralize functionality for creating and identifying editor stacks

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
@@ -25,12 +25,9 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChang
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.e4.ui.internal.css.swt.ICTabRendering;
+import org.eclipse.e4.ui.internal.workbench.PartStackUtil;
 import org.eclipse.e4.ui.internal.workbench.swt.AbstractPartRenderer;
-import org.eclipse.e4.ui.model.application.ui.MContext;
 import org.eclipse.e4.ui.model.application.ui.MUIElement;
-import org.eclipse.e4.ui.workbench.modeling.EModelService;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabFolderRenderer;
@@ -1329,15 +1326,7 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 
 	private boolean isPartOfEditorStack() {
 		MUIElement element = (MUIElement) parent.getData(AbstractPartRenderer.OWNING_ME);
-		EObject root = EcoreUtil.getRootContainer((EObject) element, true);
-		if (root instanceof MContext context) {
-			EModelService eModelService = context.getContext().get(EModelService.class);
-			if (eModelService != null) {
-				int location = eModelService.getElementLocation(element);
-				return (location & EModelService.IN_SHARED_AREA) != 0;
-			}
-		}
-		return false;
+		return PartStackUtil.isEditorStack(element);
 	}
 
 	private boolean getSwtRendererPreference(String prefName, boolean defaultValue) {

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
@@ -43,6 +43,7 @@ import org.eclipse.e4.ui.css.swt.dom.WidgetElement;
 import org.eclipse.e4.ui.di.UIEventTopic;
 import org.eclipse.e4.ui.di.UISynchronize;
 import org.eclipse.e4.ui.internal.workbench.OpaqueElementUtil;
+import org.eclipse.e4.ui.internal.workbench.PartStackUtil;
 import org.eclipse.e4.ui.internal.workbench.renderers.swt.BasicPartList;
 import org.eclipse.e4.ui.internal.workbench.renderers.swt.SWTRenderersMessages;
 import org.eclipse.e4.ui.internal.workbench.swt.AbstractPartRenderer;
@@ -127,8 +128,6 @@ public class StackRenderer extends LazyStackRenderer {
 	private static final String ONBOARDING_COMPOSITE = "EditorStack.OnboardingComposite"; //$NON-NLS-1$
 	private static final String ONBOARDING_IMAGE = "EditorStack.OnboardingImage"; //$NON-NLS-1$
 	private static final String ONBOARDING_TEXT = "EditorStack.OnboardingText"; //$NON-NLS-1$
-
-	private static final String EDITOR_STACK_ID = "EditorStack"; //$NON-NLS-1$
 
 	/**
 	 * Id of a a control.
@@ -703,7 +702,7 @@ public class StackRenderer extends LazyStackRenderer {
 		int location = modelService.getElementLocation(element);
 		boolean isInSharedArea = (location & EModelService.IN_SHARED_AREA) != 0;
 		if (isInSharedArea) {
-			pStack.getTags().add(EDITOR_STACK_ID);
+			PartStackUtil.makeEditorStack(pStack);
 		}
 
 		Composite parentComposite = (Composite) parent;
@@ -717,7 +716,7 @@ public class StackRenderer extends LazyStackRenderer {
 		int styleOverride = getStyleOverride(pStack);
 		int style = styleOverride == -1 ? SWT.BORDER : styleOverride;
 		CTabFolder tabFolder = new CTabFolder(parentComposite, style);
-		if (pStack.getTags().contains("EditorStack")) { //$NON-NLS-1$
+		if (PartStackUtil.isEditorStack(element)) {
 			createOnboardingControls(tabFolder);
 			initializeOnboardingInformationInEditorStack(tabFolder);
 		}
@@ -1926,7 +1925,8 @@ public class StackRenderer extends LazyStackRenderer {
 		Predicate<Object> tabFolders = CTabFolder.class::isInstance;
 		Function<Object, CTabFolder> toTabFolder = CTabFolder.class::cast;
 
-		List<MPartStack> elements = modelService.findElements(perspective, null, MPartStack.class, List.of(EDITOR_STACK_ID));
+		List<MPartStack> elements = modelService.findElements(perspective, null, MPartStack.class,
+				List.of(PartStackUtil.EDITOR_STACK_TAG));
 		return elements.stream().map(MUIElement::getWidget).filter(tabFolders).map(toTabFolder);
 	}
 

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartStackUtil.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartStackUtil.java
@@ -28,10 +28,8 @@ public final class PartStackUtil {
 	 * @param partStack the part stack to make the primary data stack
 	 */
 	public static void initializeAsPrimaryDataStack(MPartStack partStack) {
+		makeEditorStack(partStack);
 		partStack.getTags().add(PRIMARY_DATA_STACK_ID);
-		if (!partStack.getTags().contains(EDITOR_STACK_TAG)) {
-			partStack.getTags().add(EDITOR_STACK_TAG);
-		}
 		partStack.setElementId(PRIMARY_DATA_STACK_ID);
 	}
 
@@ -42,4 +40,26 @@ public final class PartStackUtil {
 	public static boolean isPrimaryDataStack(MApplicationElement element) {
 		return element instanceof MPartStack && PRIMARY_DATA_STACK_ID.equals(element.getElementId());
 	}
+
+	/**
+	 * @param element the element to check for being an editor stack
+	 * @return whether the given element is marked as an editor stack
+	 */
+	public static boolean isEditorStack(MApplicationElement element) {
+		return element instanceof MPartStack && element.getTags().contains(EDITOR_STACK_TAG);
+	}
+
+	/**
+	 * Marks the given part stack as an editor stack. In consequence calling
+	 * {{@link #isEditorStack(MApplicationElement)} for the element will return
+	 * {@code true}.
+	 *
+	 * @param partStack the part stack to mark as an editor stack
+	 */
+	public static void makeEditorStack(MPartStack partStack) {
+		if (!partStack.getTags().contains(EDITOR_STACK_TAG)) {
+			partStack.getTags().add(EDITOR_STACK_TAG);
+		}
+	}
+
 }

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/e4/compatibility/ModeledPageLayout.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/e4/compatibility/ModeledPageLayout.java
@@ -74,7 +74,6 @@ public class ModeledPageLayout implements IPageLayout {
 	public static final String PERSP_SHORTCUT_TAG = "persp.perspSC:"; //$NON-NLS-1$
 	public static final String SHOW_IN_PART_TAG = "persp.showIn:"; //$NON-NLS-1$
 	public static final String SHOW_VIEW_TAG = "persp.viewSC:"; //$NON-NLS-1$
-	public static final String EDITOR_STACK_TAG = "EditorStack"; //$NON-NLS-1$
 	public static final String HIDDEN_MENU_PREFIX = "persp.hideMenuSC:"; //$NON-NLS-1$
 	public static final String HIDDEN_TOOLBAR_PREFIX = "persp.hideToolbarSC:"; //$NON-NLS-1$
 	public static final String HIDDEN_ACTIONSET_PREFIX = "persp.hideActionSetSC:"; //$NON-NLS-1$

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRendererTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRendererTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.ui.internal.workbench.PartStackUtil;
 import org.eclipse.e4.ui.internal.workbench.swt.CSSConstants;
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.descriptor.basic.MPartDescriptor;
@@ -411,7 +412,7 @@ public class StackRendererTest {
 
 	@Test
 	public void testOnboardingRenderedWithCorrectSizeForEditorStack() {
-		partStack.getTags().add("EditorStack");
+		PartStackUtil.makeEditorStack(partStack);
 
 		contextRule.createAndRunWorkbench(window);
 
@@ -445,7 +446,7 @@ public class StackRendererTest {
 	@Test
 	public void testOnboardingIsFilled() {
 		MPerspective perspective = createPerspective();
-		partStack.getTags().add("EditorStack");
+		PartStackUtil.makeEditorStack(partStack);
 
 		contextRule.createAndRunWorkbench(window);
 		switchToPerspective(perspective);
@@ -500,13 +501,13 @@ public class StackRendererTest {
 	@Test
 	public void testOnboardingIsFilledForEveryEditorStack() {
 		MPerspective perspective = createPerspective();
-		partStack.getTags().add("EditorStack");
+		PartStackUtil.makeEditorStack(partStack);
 
 		contextRule.createAndRunWorkbench(window);
 
 		// Create second editor stack
 		MPartStack secondPartStack = ems.createModelElement(MPartStack.class);
-		secondPartStack.getTags().add("EditorStack");
+		PartStackUtil.makeEditorStack(secondPartStack);
 		MPlaceholder placeholder = ems.createModelElement(MPlaceholder.class);
 		placeholder.setRef(secondPartStack);
 		perspective.getChildren().add(placeholder);
@@ -520,7 +521,7 @@ public class StackRendererTest {
 
 	@Test
 	public void testOnboardingIsHiddenWhenEditorOpened() {
-		partStack.getTags().add("EditorStack");
+		PartStackUtil.makeEditorStack(partStack);
 
 		contextRule.createAndRunWorkbench(window);
 


### PR DESCRIPTION
The functionality for creating and identifying editor stacks based on the "EditorStack" tag is scattered across several code places. This change centralizes the according functionality in the recently introduced `PartStackUtil`. This utility class currently contains functionality related to the primary data stack, which also relies on being an editor stack.

In addition, this change reverts the preliminary fix for visible names of open editors being to short (#1712) as this became obsolete with the recent improvements of handling primary data stacks and editor stacks (#1775, #1778).

Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/1570
Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/1773