### PR TITLE
Changed Orbit from nightly to milestone to avoid bcpg related errors

### DIFF
--- a/releng/org.eclipse.ui.releng/platformUiTools.p2f
+++ b/releng/org.eclipse.ui.releng/platformUiTools.p2f
@@ -12,44 +12,9 @@
         <repository location='https://download.eclipse.org/modeling/emf/emf/builds/nightly/latest'/>
       </repositories>
     </iu>
-    <iu id='org.apache.commons.lang' name='org.apache.commons.lang' version='0.0.0'>
-      <repositories size='1'>
-        <repository location='https://download.eclipse.org/releases/latest/'/>
-      </repositories>
-    </iu>
-    <iu id='org.apache.commons.lang.source' name='org.apache.commons.lang.source' version='0.0.0'>
-      <repositories size='1'>
-        <repository location='https://download.eclipse.org/releases/latest/'/>
-      </repositories>
-    </iu>
     <iu id='org.easymock' name='org.easymock' version='2.4.0'>
       <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
-      </repositories>
-    </iu>
-    <iu id='org.bouncycastle.bcpg' name='org.bouncycastle.bcpg' version='1.69.0'>
-      <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
-      </repositories>
-    </iu>
-    <iu id='org.bouncycastle.bcpkix' name='org.bouncycastle.bcpkix' version='1.69.0'>
-      <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
-      </repositories>
-    </iu>
-    <iu id='org.bouncycastle.bcprov' name='org.bouncycastle.bcprov' version='1.69.0'>
-      <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
-      </repositories>
-    </iu>
-    <iu id='org.apache.sshd.osgi' name='org.apache.sshd.osgi' version='2.8.0'>
-      <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
-      </repositories>
-    </iu>
-    <iu id='org.apache.sshd.sftp' name='org.apache.sshd.sftp' version='2.8.0'>
-      <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
+        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest'/>
       </repositories>
     </iu>
     <iu id='javax.annotation' name='javax.annotation' version='1.3.5'>
@@ -87,11 +52,6 @@
             <repository location='https://download.eclipse.org/technology/swtbot/snapshots/'/>
         </repositories>
     </iu>
-    <iu id='org.eclipse.swtbot.ide.feature.group' name='SWTBot IDE Features (incubation)' version='0.0.0'>
-        <repositories size='1'>
-            <repository location='https://download.eclipse.org/technology/swtbot/snapshots/'/>
-        </repositories>
-    </iu>
     <iu id='org.eclipse.swtbot.eclipse.test.junit.feature.group' name='SWTBot JUnit Headless launchers for Eclipse (incubation)' version='0.0.0'>
         <repositories size='1'>
             <repository location='https://download.eclipse.org/technology/swtbot/snapshots/'/>
@@ -102,29 +62,9 @@
             <repository location='https://download.eclipse.org/eclemma/updates-master/'/>
         </repositories>
     </iu>
-    <iu id='org.apache.commons.compress' name='Apache Commons Compress Plug-in' version='0.0.0'>
-        <repositories size='1'>
-            <repository location='https://download.eclipse.org/releases/latest/'/>
-        </repositories>
-    </iu>
     <iu id='org.kohsuke.args4j' name='Args4j' version='2.33.0'>
         <repositories size='1'>
             <repository location='https://download.eclipse.org/releases/latest/'/>
-        </repositories>
-    </iu>
-    <iu id='javaewah' name='JavaEWAH' version='0.0.0'>
-        <repositories size='1'>
-            <repository location='https://download.eclipse.org/releases/latest/'/>
-        </repositories>
-    </iu>
-    <iu id='org.objenesis' name='org.objenesis' version='0.0.0'>
-        <repositories size='1'>
-            <repository location='https://download.eclipse.org/releases/latest/'/>
-        </repositories>
-    </iu>
-    <iu id='org.mockito' name='Java Mocking and Stubbing Framework' version='2.23.0'>
-        <repositories size='1'>
-            <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
         </repositories>
     </iu>
     <iu id='org.mockito.mockito-core' name='Mockito Core' version='0.0.0'>
@@ -181,46 +121,6 @@
         <repositories size='1'>
             <repository location='https://download.eclipse.org/eclipse/updates/I-builds'/>
         </repositories>
-    </iu>
-    <iu id='org.osgi.namespace.service' name='org.osgi.namespace.service' version='0.0.0'>
-      <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
-      </repositories>
-    </iu>
-    <iu id='org.osgi.namespace.extender' name='org.osgi.namespace.extender' version='0.0.0'>
-      <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
-      </repositories>
-    </iu>
-    <iu id='org.osgi.namespace.contract' name='org.osgi.namespace.contract' version='0.0.0'>
-      <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
-      </repositories>
-    </iu>
-    <iu id='bndtools.api' name='bndtools.api' version='0.0.0'>
-      <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
-      </repositories>
-    </iu>
-    <iu id='org.bndtools.headless.build.manager' name='org.bndtools.headless.build.manager' version='0.0.0'>
-      <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
-      </repositories>
-    </iu>
-    <iu id='org.bndtools.versioncontrol.ignores.manager' name='org.bndtools.versioncontrol.ignores.manager' version='0.0.0'>
-      <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
-      </repositories>
-    </iu>
-    <iu id='org.bndtools.headless.build.plugin.gradle' name='org.bndtools.headless.build.plugin.gradle' version='0.0.0'>
-      <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
-      </repositories>
-    </iu>
-    <iu id='org.bndtools.versioncontrol.ignores.plugin.git' name='org.bndtools.versioncontrol.ignores.plugin.git' version='0.0.0'>
-      <repositories size='1'>
-        <repository location='https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest'/>
-      </repositories>
     </iu>
   </ius>
 </p2f>


### PR DESCRIPTION
From
https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest to
https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest

and also removed some bundles not needed anymore.

See discussion on
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1968

Latest bcpg-jdk18on_1.78.0 seem to be cause some troubles.