### PR TITLE
Don't wait for jobs in SmartImportTests

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportRootWizardPage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportRootWizardPage.java
@@ -180,7 +180,7 @@ public class SmartImportRootWizardPage extends WizardPage {
 		public String getText(Object o) {
 			File file = (File) o;
 			Path filePath = file.toPath();
-			Path rootPath = getWizard().getImportJob().getRoot().toPath();
+			Path rootPath = getWizard().createOrGetConfiguredImportJob().getRoot().toPath();
 			if (filePath.startsWith(rootPath)) {
 				Path parent = rootPath.getParent();
 				if (parent != null) {
@@ -738,9 +738,9 @@ public class SmartImportRootWizardPage extends WizardPage {
 
 	@Override
 	public boolean isPageComplete() {
-		return sourceIsValid() && getWizard().getImportJob() != null
-				&& (getWizard().getImportJob().getDirectoriesToImport() == null
-						|| !getWizard().getImportJob().getDirectoriesToImport().isEmpty());
+		return sourceIsValid() && getWizard().createOrGetConfiguredImportJob() != null
+				&& (getWizard().createOrGetConfiguredImportJob().getDirectoriesToImport() == null
+						|| !getWizard().createOrGetConfiguredImportJob().getDirectoriesToImport().isEmpty());
 	}
 
 	private boolean sourceIsValid() {
@@ -785,10 +785,10 @@ public class SmartImportRootWizardPage extends WizardPage {
 	}
 
 	private void proposalsSelectionChanged() {
-		if (getWizard().getImportJob() != null) {
+		if (getWizard().createOrGetConfiguredImportJob() != null) {
 			if (potentialProjects.size() == 1 && potentialProjects.values().iterator().next().isEmpty()) {
-				getWizard().getImportJob().setDirectoriesToImport(null);
-				getWizard().getImportJob().setExcludedDirectories(null);
+				getWizard().createOrGetConfiguredImportJob().setDirectoriesToImport(null);
+				getWizard().createOrGetConfiguredImportJob().setExcludedDirectories(null);
 
 				selectionSummary.setText(NLS.bind(DataTransferMessages.SmartImportProposals_selectionSummary,
 						directoriesToImport.size(), 1));
@@ -797,8 +797,8 @@ public class SmartImportRootWizardPage extends WizardPage {
 				for (File directory : this.directoriesToImport) {
 					excludedDirectories.remove(directory);
 				}
-				getWizard().getImportJob().setDirectoriesToImport(directoriesToImport);
-				getWizard().getImportJob().setExcludedDirectories(excludedDirectories);
+				getWizard().createOrGetConfiguredImportJob().setDirectoriesToImport(directoriesToImport);
+				getWizard().createOrGetConfiguredImportJob().setExcludedDirectories(excludedDirectories);
 				selectionSummary.setText(NLS.bind(DataTransferMessages.SmartImportProposals_selectionSummary,
 						directoriesToImport.size(),
 						potentialProjects.size()));
@@ -837,7 +837,7 @@ public class SmartImportRootWizardPage extends WizardPage {
 			TreeItem computingItem = new TreeItem(tree.getTree(), SWT.DEFAULT);
 			computingItem
 					.setText(NLS.bind(DataTransferMessages.SmartImportJob_inspecting, selection.getAbsolutePath()));
-			final SmartImportJob importJob = getWizard().getImportJob();
+			final SmartImportJob importJob = getWizard().createOrGetConfiguredImportJob();
 			refreshProposalsJob = new Job(
 					NLS.bind(DataTransferMessages.SmartImportJob_inspecting, selection.getAbsolutePath())) {
 				@Override
@@ -879,7 +879,7 @@ public class SmartImportRootWizardPage extends WizardPage {
 							IStatus result = event.getResult();
 							if (!control.isDisposed() && result.isOK()) {
 								computingItem.dispose();
-								if (sourceIsValid() && getWizard().getImportJob() == importJob) {
+								if (sourceIsValid() && getWizard().createOrGetConfiguredImportJob() == importJob) {
 									proposalsUpdated();
 								}
 								tree.getTree().setEnabled(potentialProjects.size() > 1);

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportWizard.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportWizard.java
@@ -241,7 +241,7 @@ public class SmartImportWizard extends Wizard implements IImportWizard {
 			System.arraycopy(previousProposals, 0, newProposals, 1, previousProposals.length);
 			getDialogSettings().put(SmartImportRootWizardPage.IMPORTED_SOURCES, newProposals);
 		}
-		SmartImportJob job = getImportJob();
+		SmartImportJob job = createOrGetConfiguredImportJob();
 		boolean runInBackground = WorkbenchPlugin.getDefault().getPreferenceStore()
 				.getBoolean(IPreferenceConstants.RUN_IN_BACKGROUND);
 		job.setProperty(IProgressConstants.PROPERTY_IN_DIALOG, runInBackground);
@@ -250,12 +250,20 @@ public class SmartImportWizard extends Wizard implements IImportWizard {
 	}
 
 	/**
-	 * Get the import job that will be processed by this wizard. Can be null (if
-	 * provided directory is invalid).
+	 * Get or create the import job that will be processed by this wizard. Can be
+	 * <code>null</code> (if the provided directory is invalid).
 	 *
-	 * @return the import job
+	 * <strong>IMPORTANT:</strong> If there was already a job but it didn't match
+	 * the current configuration of the wizard then a new job will be created and
+	 * returned.
+	 *
+	 * Regardless of whether or not the job was created, some configurations will be
+	 * applied to it.
+	 *
+	 * @return the (newly created) import job
+	 * @see #getCurrentImportJob()
 	 */
-	public SmartImportJob getImportJob() {
+	public SmartImportJob createOrGetConfiguredImportJob() {
 		final File root = this.projectRootPage.getSelectedRoot();
 		if (root == null) {
 			return null;
@@ -270,16 +278,29 @@ public class SmartImportWizard extends Wizard implements IImportWizard {
 		} else {
 			return null;
 		}
+
 		if (this.easymportJob == null || !matchesPage(this.easymportJob, this.projectRootPage)) {
 			this.easymportJob = new SmartImportJob(this.directoryToImport, projectRootPage.getSelectedWorkingSets(),
 					projectRootPage.isConfigureProjects(), projectRootPage.isDetectNestedProject());
 		}
-		if (this.easymportJob != null) {
-			// always update working set on request as the job isn't updated on
-			// WS change automatically
-			this.easymportJob.setWorkingSets(projectRootPage.getSelectedWorkingSets());
-			this.easymportJob.setCloseProjectsAfterImport(projectRootPage.isCloseProjectsAfterImport());
-		}
+
+		// always update working set on request as the job isn't updated on
+		// WS change automatically
+		this.easymportJob.setWorkingSets(projectRootPage.getSelectedWorkingSets());
+		this.easymportJob.setCloseProjectsAfterImport(projectRootPage.isCloseProjectsAfterImport());
+
+		return this.easymportJob;
+	}
+
+	/**
+	 * Gets the current import job but it will not create it if it's
+	 * <code>null</code>. If you need to create the job based on the current
+	 * configuration of the wizard then you can call {@link #createOrGetConfiguredImportJob()}
+	 *
+	 * @return The current import job (it might be <code>null</code>).
+	 * @see #createOrGetConfiguredImportJob()
+	 */
+	public SmartImportJob getCurrentImportJob() {
 		return this.easymportJob;
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/SmartImportTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/SmartImportTests.java
@@ -150,10 +150,7 @@ public class SmartImportTests extends UITestCase {
 			final Button okButton = getFinishButton(dialog.buttonBar);
 			assertNotNull(okButton);
 			processEventsUntil(() -> okButton.isEnabled(), -1);
-			wizard.performFinish();
-			waitForJobs(100, 1000); // give the job framework time to schedule the job
-			wizard.getImportJob().join();
-			waitForJobs(100, 5000); // give some time for asynchronous workspace jobs to complete
+			finishWizard(wizard);
 		} finally {
 			if (!dialog.getShell().isDisposed()) {
 				dialog.close();
@@ -442,10 +439,7 @@ public class SmartImportTests extends UITestCase {
 			combo.notifyListeners(SWT.Selection, e);
 			processEvents();
 			processEventsUntil(() -> okButton.isEnabled(), -1);
-			wizard.performFinish();
-			waitForJobs(100, 1000); // give the job framework time to schedule the job
-			wizard.getImportJob().join();
-			waitForJobs(100, 5000); // give some time for asynchronous workspace jobs to complete
+			finishWizard(wizard);
 			assertEquals("WorkingSet2 should be selected", Collections.singleton(workingSet2),
 					page.getSelectedWorkingSets());
 			assertEquals("Projects were not added to working set", 1, workingSet2.getElements().length);
@@ -457,6 +451,11 @@ public class SmartImportTests extends UITestCase {
 			workingSetManager.removeWorkingSet(workingSet);
 			workingSetManager.removeWorkingSet(workingSet2);
 		}
+	}
+
+	private void finishWizard(SmartImportWizard wizard) throws InterruptedException {
+		wizard.performFinish();
+		wizard.getCurrentImportJob().join();
 	}
 
 	/**


### PR DESCRIPTION
Remove calls to `waitForJobs(...)` in `SmartImportTests` and only join the (now correct) `SmartImportJob` instead.

Rename `SmartImportWizard::getImportJob` to `createOrGetConfiguredImportJob` and change its javadoc (the method was doing a lot more than simply retrieving a Job, which is what broke the tests in the first place).
Add a new method `SmartImportWizard::getCurrentImportJob` that merely returns the current job and join **that** job in the tests. Before this PR, a new job was being created and joined, which didn't make sense since that job was never started in the first place.

Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/issues/1427
Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/issues/1807