### PR TITLE
Fix correctly setting Find-Scopes when opening Find/Replace-Dialog #1819

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -946,6 +946,7 @@ class FindReplaceDialog extends Dialog {
 		} else {
 			fGlobalRadioButton.setSelection(false);
 			fSelectedRangeRadioButton.setSelection(true);
+			findReplaceLogic.deactivate(SearchOptions.GLOBAL);
 		}
 	}
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -98,6 +100,8 @@ public class FindReplaceDialogTest {
 
 		private Runnable closeOperation;
 
+		public Button replaceAllButton;
+
 
 		DialogAccess(Accessor findReplaceDialogAccessor, boolean checkInitialConfiguration) {
 			findReplaceLogic= (FindReplaceLogic) findReplaceDialogAccessor.get("findReplaceLogic");
@@ -110,6 +114,7 @@ public class FindReplaceDialogTest {
 			incrementalCheckBox= (Button) findReplaceDialogAccessor.get("fIncrementalCheckBox");
 			regExCheckBox= (Button) findReplaceDialogAccessor.get("fIsRegExCheckBox");
 			replaceFindButton= (Button) findReplaceDialogAccessor.get("fReplaceFindButton");
+			replaceAllButton= (Button) findReplaceDialogAccessor.get("fReplaceAllButton");
 			shellRetriever= () -> ((Shell) findReplaceDialogAccessor.get("fActiveShell"));
 			closeOperation= () -> findReplaceDialogAccessor.invoke("close", null);
 			if (checkInitialConfiguration) {
@@ -424,6 +429,19 @@ public class FindReplaceDialogTest {
 		runEventQueue();
 		assertTrue(dialog.wholeWordCheckBox.getSelection());
 		assertFalse(dialog.wholeWordCheckBox.getEnabled());
+	}
+
+	@Test
+	public void testActivateDialogWithSelectionActive() {
+		openTextViewer("text" + System.lineSeparator() + "text" + System.lineSeparator() + "text");
+		fTextViewer.setSelectedRange(4 + System.lineSeparator().length(), 8 + System.lineSeparator().length());
+		openFindReplaceDialogForTextViewer(false);
+
+		assertFalse(dialog.globalRadioButton.getSelection());
+		dialog.findCombo.setText("text");
+		select(dialog.replaceAllButton);
+
+		assertThat(fTextViewer.getDocument().get(), is("text" + System.lineSeparator() + System.lineSeparator()));
 	}
 
 	@Test


### PR DESCRIPTION
This PR correctly disables SearchOptions.GLOBAL in the FindReplaceLogic object of the Dialog if a multiline-selection was selected while opening the Find/Replace-Dialog.

This PR also provides a unit-test for this behavior.

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/1819