### PR TITLE
FindReplaceLogicTest: Fix FindBeforeReplace-Bug for general FindReplaceTarget implementaitons

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -352,7 +352,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 		if (findString != null && !findString.isEmpty()) {
 
 			try {
-				somethingFound = findNext(findString, isActive(SearchOptions.FORWARD));
+				somethingFound = findNext(findString);
 			} catch (PatternSyntaxException ex) {
 				status = new InvalidRegExStatus(ex);
 			} catch (IllegalStateException ex) {
@@ -510,12 +510,11 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	 * options.
 	 *
 	 * @param findString             the string to search for
-	 * @param forwardSearch          the direction of the search
 	 * @return <code>true</code> if the search string can be found using the given
 	 *         options
 	 *
 	 */
-	private boolean findNext(String findString, boolean forwardSearch) {
+	private boolean findNext(String findString) {
 
 		if (target == null) {
 			return false;
@@ -529,7 +528,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 		}
 
 		int findReplacePosition = r.x;
-		if (forwardSearch) {
+		if (isActive(SearchOptions.FORWARD)) {
 			findReplacePosition += r.y;
 		}
 
@@ -542,7 +541,8 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 			return false;
 		}
 
-		if (forwardSearch && index >= findReplacePosition || !forwardSearch && index <= findReplacePosition) {
+		if (isActive(SearchOptions.FORWARD) && index >= findReplacePosition
+				|| !isActive(SearchOptions.FORWARD) && index <= findReplacePosition) {
 			statusLineMessage(""); //$NON-NLS-1$
 		}
 
@@ -565,7 +565,10 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 		if (!isFindStringSelected(findString)) {
 			performSearch(findString);
 		}
-		return replaceSelection(replaceString);
+		if (getStatus().wasSuccessful()) {
+			return replaceSelection(replaceString);
+		}
+		return false;
 	}
 
 	private boolean isFindStringSelected(String findString) {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/FindStatus.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/status/FindStatus.java
@@ -42,9 +42,7 @@ public class FindStatus implements IFindReplaceStatus {
 
 	@Override
 	public boolean wasSuccessful() {
-		// Also report StatusCode.WRAPPED as unsuccessful, because it implicitly
-		// includes NO_MATCH, as before wrapping no further match was found
-		return false;
+		return messageCode == StatusCode.WRAPPED;
 	}
 
 }


### PR DESCRIPTION
Fix bug where in general, FindReplaceLogicTargets might accidentally perform a replacement even though a prior search did not yield any results.

The TextViewer's implementation fixes this bug intrinsically but in doing so, it violates the specification of the interface it implements.

This PR adds a check that there really was a search-result before performing any replacements.