### PR TITLE
Filter commands based on activity enablement in quick access dialog.

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/registry/PerspectiveParameterValues.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/registry/PerspectiveParameterValues.java
@@ -16,10 +16,10 @@ package org.eclipse.ui.internal.registry;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.eclipse.core.commands.IParameterValues;
 import org.eclipse.ui.IPerspectiveDescriptor;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.activities.WorkbenchActivityHelper;
 
 /**
  * Provides the parameter values for the show perspective command.
@@ -35,6 +35,9 @@ public final class PerspectiveParameterValues implements IParameterValues {
 		final IPerspectiveDescriptor[] perspectives = PlatformUI.getWorkbench().getPerspectiveRegistry()
 				.getPerspectives();
 		for (final IPerspectiveDescriptor perspective : perspectives) {
+			if (WorkbenchActivityHelper.filterItem(perspective)) {
+				continue;
+			}
 			values.put(perspective.getLabel(), perspective.getId());
 		}
 

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/registry/PreferencePageParameterValues.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/registry/PreferencePageParameterValues.java
@@ -21,6 +21,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.preference.IPreferenceNode;
 import org.eclipse.jface.preference.PreferenceManager;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.activities.WorkbenchActivityHelper;
 import org.eclipse.ui.internal.WorkbenchMessages;
 
 /**
@@ -68,6 +69,9 @@ public final class PreferencePageParameterValues implements IParameterValues {
 			final String namePrefix) {
 
 		for (final IPreferenceNode preferenceNode : preferenceNodes) {
+			if (WorkbenchActivityHelper.filterItem(preferenceNode)) {
+				continue;
+			}
 			final String name;
 			if (namePrefix == null) {
 				name = preferenceNode.getLabelText();

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/registry/ViewParameterValues.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/registry/ViewParameterValues.java
@@ -16,9 +16,9 @@ package org.eclipse.ui.internal.registry;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.eclipse.core.commands.IParameterValues;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.activities.WorkbenchActivityHelper;
 import org.eclipse.ui.views.IViewDescriptor;
 
 /**
@@ -34,6 +34,9 @@ public final class ViewParameterValues implements IParameterValues {
 
 		final IViewDescriptor[] views = PlatformUI.getWorkbench().getViewRegistry().getViews();
 		for (final IViewDescriptor view : views) {
+			if (WorkbenchActivityHelper.filterItem(view)) {
+				continue;
+			}
 			values.put(view.getLabel(), view.getId());
 		}
 

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/registry/WizardParameterValues.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/registry/WizardParameterValues.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.core.commands.IParameterValues;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.activities.WorkbenchActivityHelper;
 import org.eclipse.ui.wizards.IWizardCategory;
 import org.eclipse.ui.wizards.IWizardDescriptor;
 import org.eclipse.ui.wizards.IWizardRegistry;
@@ -65,6 +66,9 @@ public abstract class WizardParameterValues implements IParameterValues {
 	private void addParameterValues(Map values, IWizardCategory wizardCategory) {
 
 		for (final IWizardDescriptor wizardDescriptor : wizardCategory.getWizards()) {
+			if (WorkbenchActivityHelper.filterItem(wizardDescriptor)) {
+				continue;
+			}
 
 			// Note: using description instead of label for the name
 			// to reduce possibilities of key collision in the map


### PR DESCRIPTION
There was no filter support at all for commands. This leaked the commands which are filtered by activity support to be accessed via QuickAccessDialog.

see https://github.com/eclipse-platform/eclipse.platform.ui/issues/1828

How to test:
1. Window->Preferences->General->Capabilities: Then uncheck Development/Java Development.
2. Open Quick Access(Ctrl+3)->Type search keyword `Java`. No Java commands should be available under commands.