### PR TITLE
Move busy indicator handling for find/replace from business logic to UI

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -21,9 +21,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.jface.text.IFindReplaceTarget;
 import org.eclipse.jface.text.IFindReplaceTargetExtension;
@@ -219,27 +217,12 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	}
 
 	@Override
-	public void performReplaceAll(String findString, String replaceString, Display display) {
+	public void performReplaceAll(String findString, String replaceString) {
 		resetStatus();
 
-		int replaceCount = 0;
-
 		if (findString != null && !findString.isEmpty()) {
-
-			class ReplaceAllRunnable implements Runnable {
-				public int numberOfOccurrences;
-
-				@Override
-				public void run() {
-					numberOfOccurrences = replaceAll(findString, replaceString == null ? "" : replaceString); //$NON-NLS-1$
-				}
-			}
-
 			try {
-				ReplaceAllRunnable runnable = new ReplaceAllRunnable();
-				BusyIndicator.showWhile(display, runnable);
-				replaceCount = runnable.numberOfOccurrences;
-
+				int replaceCount = replaceAll(findString, replaceString == null ? "" : replaceString); //$NON-NLS-1$
 				if (replaceCount != 0) {
 					if (replaceCount == 1) { // not plural
 						statusLineMessage(FindReplaceMessages.FindReplace_Status_replacement_label);
@@ -264,27 +247,12 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	}
 
 	@Override
-	public void performSelectAll(String findString, Display display) {
+	public void performSelectAll(String findString) {
 		resetStatus();
 
-		int selectCount = 0;
-
 		if (findString != null && !findString.isEmpty()) {
-
-			class SelectAllRunnable implements Runnable {
-				public int numberOfOccurrences;
-
-				@Override
-				public void run() {
-					numberOfOccurrences = selectAll(findString);
-				}
-			}
-
 			try {
-				SelectAllRunnable runnable = new SelectAllRunnable();
-				BusyIndicator.showWhile(display, runnable);
-				selectCount = runnable.numberOfOccurrences;
-
+				int selectCount = selectAll(findString);
 				if (selectCount != 0) {
 					if (selectCount == 1) { // not plural
 						statusLineMessage(FindReplaceMessages.FindReplace_Status_selection_label);

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.findandreplace;
 
-import org.eclipse.swt.widgets.Display;
-
 import org.eclipse.jface.text.IFindReplaceTarget;
 
 import org.eclipse.ui.internal.findandreplace.status.IFindReplaceStatus;
@@ -93,21 +91,15 @@ public interface IFindReplaceLogic {
 	 *
 	 * @param findString    The string that will be replaced
 	 * @param replaceString The string that will replace the findString
-	 * @param display       the display on which the busy feedback should be
-	 *                      displayed. If the display is null, the Display for the
-	 *                      current thread will be used. If there is no Display for
-	 *                      the current thread,the runnable code will be executed
-	 *                      and no busy feedback will be displayed.y
 	 */
-	public void performReplaceAll(String findString, String replaceString, Display display);
+	public void performReplaceAll(String findString, String replaceString);
 
 	/**
 	 * Selects all occurrences of findString.
 	 *
 	 * @param findString The String to find and select
-	 * @param display    The UI's Display The UI's Display
 	 */
-	public void performSelectAll(String findString, Display display);
+	public void performSelectAll(String findString);
 
 	/**
 	 * Locates the user's findString in the target

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import org.osgi.framework.FrameworkUtil;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.events.ControlAdapter;
 import org.eclipse.swt.events.ControlEvent;
@@ -38,6 +39,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
@@ -307,7 +309,8 @@ class FindReplaceDialog extends Dialog {
 				new SelectionAdapter() {
 					@Override
 					public void widgetSelected(SelectionEvent e) {
-						findReplaceLogic.performSelectAll(getFindString(), fActiveShell.getDisplay());
+						BusyIndicator.showWhile(fActiveShell != null ? fActiveShell.getDisplay() : Display.getCurrent(),
+								() -> findReplaceLogic.performSelectAll(getFindString()));
 						writeSelection();
 						updateButtonState();
 						updateFindAndReplaceHistory();
@@ -351,8 +354,8 @@ class FindReplaceDialog extends Dialog {
 				new SelectionAdapter() {
 					@Override
 					public void widgetSelected(SelectionEvent e) {
-						findReplaceLogic.performReplaceAll(getFindString(), getReplaceString(),
-								fActiveShell.getDisplay());
+						BusyIndicator.showWhile(fActiveShell != null ? fActiveShell.getDisplay() : Display.getCurrent(),
+								() -> findReplaceLogic.performReplaceAll(getFindString(), getReplaceString()));
 						writeSelection();
 						updateButtonState();
 						updateFindAndReplaceHistory();

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.jface.text.Document;
@@ -100,31 +99,30 @@ public class FindReplaceLogicTest {
 	 *            operates
 	 */
 	private void performReplaceAllBaseTestcases(IFindReplaceLogic findReplaceLogic, TextViewer textViewer) {
-		Display display= parentShell.getDisplay();
 		textViewer.setDocument(new Document("aaaa"));
 
-		findReplaceLogic.performReplaceAll("a", "b", display);
+		findReplaceLogic.performReplaceAll("a", "b");
 		assertThat(textViewer.getDocument().get(), equalTo("bbbb"));
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 4);
 
-		findReplaceLogic.performReplaceAll("b", "aa", display);
+		findReplaceLogic.performReplaceAll("b", "aa");
 		assertThat(textViewer.getDocument().get(), equalTo("aaaaaaaa"));
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 4);
 
-		findReplaceLogic.performReplaceAll("b", "c", display);
+		findReplaceLogic.performReplaceAll("b", "c");
 		assertThat(textViewer.getDocument().get(), equalTo("aaaaaaaa"));
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 
-		findReplaceLogic.performReplaceAll("aaaaaaaa", "d", display); // https://github.com/eclipse-platform/eclipse.platform.ui/issues/1203
+		findReplaceLogic.performReplaceAll("aaaaaaaa", "d"); // https://github.com/eclipse-platform/eclipse.platform.ui/issues/1203
 		assertThat(textViewer.getDocument().get(), equalTo("d"));
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
 
-		findReplaceLogic.performReplaceAll("d", null, display);
+		findReplaceLogic.performReplaceAll("d", null);
 		assertThat(textViewer.getDocument().get(), equalTo(""));
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
 
 		textViewer.getDocument().set("f");
-		findReplaceLogic.performReplaceAll("f", "", display);
+		findReplaceLogic.performReplaceAll("f", "");
 		assertThat(textViewer.getDocument().get(), equalTo(""));
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
 
@@ -133,7 +131,7 @@ public class FindReplaceLogicTest {
 		Mockito.when(mockFindReplaceTarget.isEditable()).thenReturn(false);
 
 		findReplaceLogic.updateTarget(mockFindReplaceTarget, false);
-		findReplaceLogic.performReplaceAll("a", "b", display);
+		findReplaceLogic.performReplaceAll("a", "b");
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 	}
 
@@ -144,15 +142,15 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.activate(SearchOptions.REGEX);
 		findReplaceLogic.activate(SearchOptions.FORWARD);
 
-		findReplaceLogic.performReplaceAll(".+\\@.+\\.com", "", parentShell.getDisplay());
+		findReplaceLogic.performReplaceAll(".+\\@.+\\.com", "");
 		assertThat(textViewer.getDocument().get(), equalTo(" looks.almost@like_an_email"));
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
 
-		findReplaceLogic.performReplaceAll("( looks.)|(like_)", "", parentShell.getDisplay());
+		findReplaceLogic.performReplaceAll("( looks.)|(like_)", "");
 		assertThat(textViewer.getDocument().get(), equalTo("almost@an_email"));
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 2);
 
-		findReplaceLogic.performReplaceAll("[", "", parentShell.getDisplay());
+		findReplaceLogic.performReplaceAll("[", "");
 		assertThat(textViewer.getDocument().get(), equalTo("almost@an_email"));
 		expectStatusIsMessageWithString(findReplaceLogic, "Unclosed character class near index 0" + System.lineSeparator()
 				+ "[" + System.lineSeparator()
@@ -167,15 +165,15 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.activate(SearchOptions.REGEX);
 		findReplaceLogic.activate(SearchOptions.FORWARD);
 
-		findReplaceLogic.performReplaceAll(".+\\@.+\\.com", "", parentShell.getDisplay());
+		findReplaceLogic.performReplaceAll(".+\\@.+\\.com", "");
 		assertThat(textViewer.getDocument().get(), equalTo(" looks.almost@like_an_email"));
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
 
-		findReplaceLogic.performReplaceAll("( looks.)|(like_)", "", parentShell.getDisplay());
+		findReplaceLogic.performReplaceAll("( looks.)|(like_)", "");
 		assertThat(textViewer.getDocument().get(), equalTo("almost@an_email"));
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 2);
 
-		findReplaceLogic.performReplaceAll("[", "", parentShell.getDisplay());
+		findReplaceLogic.performReplaceAll("[", "");
 		assertThat(textViewer.getDocument().get(), equalTo("almost@an_email"));
 		expectStatusIsMessageWithString(findReplaceLogic, "Unclosed character class near index 0" + System.lineSeparator()
 				+ "[" + System.lineSeparator()
@@ -366,15 +364,15 @@ public class FindReplaceLogicTest {
 		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
 		findReplaceLogic.activate(SearchOptions.FORWARD);
 
-		findReplaceLogic.performSelectAll("c", parentShell.getDisplay());
+		findReplaceLogic.performSelectAll("c");
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 
-		findReplaceLogic.performSelectAll("b", parentShell.getDisplay());
+		findReplaceLogic.performSelectAll("b");
 		expectStatusIsFindAllWithCount(findReplaceLogic, 4);
 		// I don't have access to getAllSelectionPoints or similar (not yet implemented), so I cannot really test for correct behavior
 		// related to https://github.com/eclipse-platform/eclipse.platform.ui/issues/1047
 
-		findReplaceLogic.performSelectAll("AbAbAbAb", parentShell.getDisplay());
+		findReplaceLogic.performSelectAll("AbAbAbAb");
 		expectStatusIsFindAllWithCount(findReplaceLogic, 1);
 	}
 
@@ -385,13 +383,13 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.activate(SearchOptions.FORWARD);
 		findReplaceLogic.activate(SearchOptions.REGEX);
 
-		findReplaceLogic.performSelectAll("c.*", parentShell.getDisplay());
+		findReplaceLogic.performSelectAll("c.*");
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 
-		findReplaceLogic.performSelectAll("(Ab)*", parentShell.getDisplay());
+		findReplaceLogic.performSelectAll("(Ab)*");
 		expectStatusIsFindAllWithCount(findReplaceLogic, 1);
 
-		findReplaceLogic.performSelectAll("Ab(Ab)+Ab(Ab)+(Ab)+", parentShell.getDisplay());
+		findReplaceLogic.performSelectAll("Ab(Ab)+Ab(Ab)+(Ab)+");
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 	}
 
@@ -402,12 +400,12 @@ public class FindReplaceLogicTest {
 		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
 		findReplaceLogic.deactivate(SearchOptions.FORWARD);
 
-		findReplaceLogic.performSelectAll("b", parentShell.getDisplay());
+		findReplaceLogic.performSelectAll("b");
 		expectStatusIsFindAllWithCount(findReplaceLogic, 4);
 		// I don't have access to getAllSelectionPoints or similar (not yet implemented), so I cannot really test for correct behavior
 		// related to https://github.com/eclipse-platform/eclipse.platform.ui/issues/1047
 
-		findReplaceLogic.performSelectAll("AbAbAbAb", parentShell.getDisplay());
+		findReplaceLogic.performSelectAll("AbAbAbAb");
 		expectStatusIsFindAllWithCount(findReplaceLogic, 1);
 	}
 
@@ -416,7 +414,7 @@ public class FindReplaceLogicTest {
 		TextViewer textViewer= setupTextViewer("Ab Ab");
 		textViewer.setEditable(false);
 		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
-		findReplaceLogic.performSelectAll("Ab", Display.getCurrent());
+		findReplaceLogic.performSelectAll("Ab");
 		expectStatusIsFindAllWithCount(findReplaceLogic, 2);
 	}
 
@@ -439,14 +437,14 @@ public class FindReplaceLogicTest {
 		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
 		textViewer.setSelection(new TextSelection(6, 11));
 		findReplaceLogic.deactivate(SearchOptions.GLOBAL);
-		findReplaceLogic.performReplaceAll("l", "", Display.getCurrent());
+		findReplaceLogic.performReplaceAll("l", "");
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 2);
 
 		findReplaceLogic.activate(SearchOptions.GLOBAL);
 		textViewer.setSelection(new TextSelection(0, 5));
 		findReplaceLogic.deactivate(SearchOptions.GLOBAL);
 
-		findReplaceLogic.performReplaceAll("n", "", Display.getCurrent());
+		findReplaceLogic.performReplaceAll("n", "");
 		expectStatusIsReplaceAllWithCount(findReplaceLogic, 1);
 
 		assertThat(textViewer.getTextWidget().getText(), is("lie1\nine2\nine3"));


### PR DESCRIPTION
The IFindReplaceLogic and its implementation currently accept a Display instance in the `performReplaceAll()` and `performSelectAll()` methods. This is used to show a busy indicator in case the operation takes too long. Showing a busy indicator is, however, the responsibility of the UI.

This change removes the Display instance from the logic interface and moves the responsibility of showing a busy indicator for the two operations to the UI consumer, i.e., the FindReplaceDialog class. It also ensures that in case the active shell of the dialog is null (e.g., because setting the shell has not been processed by the GTK event queue), no exception is thrown.