### PR TITLE
Extract testing framework from Find/Replace overlay PR #1192

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
@@ -1,0 +1,345 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ui.workbench.texteditor.tests;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.junit.Rule;
+import org.junit.rules.TestName;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Combo;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Shell;
+
+import org.eclipse.text.tests.Accessor;
+
+import org.eclipse.jface.util.Util;
+
+import org.eclipse.jface.text.IFindReplaceTarget;
+import org.eclipse.jface.text.IFindReplaceTargetExtension;
+
+import org.eclipse.ui.internal.findandreplace.FindReplaceLogic;
+import org.eclipse.ui.internal.findandreplace.IFindReplaceLogic;
+import org.eclipse.ui.internal.findandreplace.SearchOptions;
+
+class DialogAccess implements IFindReplaceUIAccess {
+
+	FindReplaceLogic findReplaceLogic;
+
+	Combo findCombo;
+
+	Combo replaceCombo;
+
+	Button forwardRadioButton;
+
+	Button globalRadioButton;
+
+	Button searchInRangeRadioButton;
+
+	Button caseCheckBox;
+
+	Button wrapCheckBox;
+
+	Button wholeWordCheckBox;
+
+	Button incrementalCheckBox;
+
+	Button regExCheckBox;
+
+	Button findButton;
+
+	Button replaceButton;
+
+	Button replaceFindButton;
+
+	Button replaceAllButton;
+
+	private Supplier<Shell> shellRetriever;
+
+	private Runnable closeOperation;
+
+	Accessor dialogAccessor;
+
+	DialogAccess(Accessor findReplaceDialogAccessor) {
+		dialogAccessor= findReplaceDialogAccessor;
+		findReplaceLogic= (FindReplaceLogic) findReplaceDialogAccessor.get("findReplaceLogic");
+		findCombo= (Combo) findReplaceDialogAccessor.get("fFindField");
+		replaceCombo= (Combo) findReplaceDialogAccessor.get("fReplaceField");
+		forwardRadioButton= (Button) findReplaceDialogAccessor.get("fForwardRadioButton");
+		globalRadioButton= (Button) findReplaceDialogAccessor.get("fGlobalRadioButton");
+		searchInRangeRadioButton= (Button) findReplaceDialogAccessor.get("fSelectedRangeRadioButton");
+		caseCheckBox= (Button) findReplaceDialogAccessor.get("fCaseCheckBox");
+		wrapCheckBox= (Button) findReplaceDialogAccessor.get("fWrapCheckBox");
+		wholeWordCheckBox= (Button) findReplaceDialogAccessor.get("fWholeWordCheckBox");
+		incrementalCheckBox= (Button) findReplaceDialogAccessor.get("fIncrementalCheckBox");
+		regExCheckBox= (Button) findReplaceDialogAccessor.get("fIsRegExCheckBox");
+		shellRetriever= () -> ((Shell) findReplaceDialogAccessor.get("fActiveShell"));
+		closeOperation= () -> findReplaceDialogAccessor.invoke("close", null);
+		findButton= (Button) findReplaceDialogAccessor.get("fFindNextButton");
+		replaceButton= (Button) findReplaceDialogAccessor.get("fReplaceSelectionButton");
+		replaceFindButton= (Button) findReplaceDialogAccessor.get("fReplaceFindButton");
+		replaceAllButton= (Button) findReplaceDialogAccessor.get("fReplaceAllButton");
+	}
+
+	void restoreInitialConfiguration() {
+		findCombo.setText("");
+		select(SearchOptions.FORWARD);
+		select(SearchOptions.GLOBAL);
+		select(SearchOptions.WRAP);
+		unselect(SearchOptions.INCREMENTAL);
+		unselect(SearchOptions.REGEX);
+		unselect(SearchOptions.CASE_SENSITIVE);
+		unselect(SearchOptions.WHOLE_WORD);
+	}
+
+	@Override
+	public Button getButtonForSearchOption(SearchOptions option) {
+		switch (option) {
+			case CASE_SENSITIVE:
+				return caseCheckBox;
+			case FORWARD:
+				return forwardRadioButton;
+			case GLOBAL:
+				return globalRadioButton;
+			case INCREMENTAL:
+				return incrementalCheckBox;
+			case REGEX:
+				return regExCheckBox;
+			case WHOLE_WORD:
+				return wholeWordCheckBox;
+			case WRAP:
+				return wrapCheckBox;
+			default:
+				return null;
+		}
+	}
+
+	@Override
+	public void select(SearchOptions option) {
+		Button button= getButtonForSearchOption(option);
+		button.setSelection(true);
+		button.notifyListeners(SWT.Selection, null);
+	}
+
+	@Override
+	public void unselect(SearchOptions option) {
+		Button button= getButtonForSearchOption(option);
+		if (option == SearchOptions.GLOBAL) {
+			button= searchInRangeRadioButton;
+			button.setSelection(true);
+			globalRadioButton.setSelection(false);
+		} else {
+			button.setSelection(false);
+		}
+		button.notifyListeners(SWT.Selection, null);
+	}
+
+
+	@Override
+	public void closeAndRestore() {
+		restoreInitialConfiguration();
+		assertInitialConfiguration();
+		closeOperation.run();
+	}
+
+	@Override
+	public void close() {
+		closeOperation.run();
+	}
+
+	@Rule
+	public TestName name= new TestName();
+
+	@Override
+	public void ensureHasFocusOnGTK() {
+		if (Util.isGtk()) {
+			// Ensure workbench has focus on GTK
+			FindReplaceUITest.runEventQueue();
+			if (shellRetriever.get() == null) {
+				String screenshotPath= ScreenshotTest.takeScreenshot(FindReplaceUITest.class, name.getMethodName(), System.out);
+				fail("this test does not work on GTK unless the runtime workbench has focus. Screenshot: " + screenshotPath);
+			}
+		}
+	}
+
+	@Override
+	public void simulateEnterInFindInputField(boolean shiftPressed) {
+		simulateKeyPressInFindInputField(SWT.CR, shiftPressed);
+	}
+
+	@Override
+	public void simulateKeyPressInFindInputField(int keyCode, boolean shiftPressed) {
+		final Event event= new Event();
+		event.type= SWT.Traverse;
+		event.detail= SWT.TRAVERSE_RETURN;
+		event.character= (char) keyCode;
+		if (shiftPressed) {
+			event.stateMask= SWT.SHIFT;
+		}
+		findCombo.traverse(SWT.TRAVERSE_RETURN, event);
+		FindReplaceUITest.runEventQueue();
+	}
+
+
+	@Override
+	public String getReplaceText() {
+		return replaceCombo.getText();
+	}
+
+	@Override
+	public void setFindText(String text) {
+		findCombo.setText(text);
+		findCombo.notifyListeners(SWT.Modify, null);
+	}
+
+	@Override
+	public void setReplaceText(String text) {
+		replaceCombo.setText(text);
+	}
+
+	@Override
+	public IFindReplaceTarget getTarget() {
+		return findReplaceLogic.getTarget();
+	}
+
+	@Override
+	public String getFindText() {
+		return findCombo.getText();
+	}
+
+	public Combo getFindCombo() {
+		return findCombo;
+	}
+
+	@Override
+	public Set<SearchOptions> getEnabledOptions() {
+		HashSet<SearchOptions> ret= new HashSet<>();
+
+		for (SearchOptions option : SearchOptions.values()) {
+			if (getButtonForSearchOption(option).isEnabled()) {
+				ret.add(option);
+			}
+		}
+
+		return ret;
+	}
+
+	@Override
+	public Set<SearchOptions> getSelectedOptions() {
+		Set<SearchOptions> ret= new HashSet<>();
+
+		for (SearchOptions option : SearchOptions.values()) {
+			if (getButtonForSearchOption(option).getSelection()) {
+				ret.add(option);
+			}
+		}
+
+		return ret;
+	}
+
+	@Override
+	public IFindReplaceLogic getFindReplaceLogic() {
+		return findReplaceLogic;
+	}
+
+	@Override
+	public void performReplaceAll() {
+		replaceAllButton.notifyListeners(SWT.Selection, null);
+	}
+
+	@Override
+	public void performReplace() {
+		replaceButton.notifyListeners(SWT.Selection, null);
+	}
+
+	@Override
+	public void performReplaceAndFind() {
+		replaceFindButton.notifyListeners(SWT.Selection, null);
+	}
+
+	@Override
+	public void assertInitialConfiguration() {
+		assertTrue(findReplaceLogic.isActive(SearchOptions.FORWARD));
+		assertFalse(findReplaceLogic.isActive(SearchOptions.CASE_SENSITIVE));
+		assertTrue(findReplaceLogic.isActive(SearchOptions.WRAP));
+		assertFalse(findReplaceLogic.isActive(SearchOptions.INCREMENTAL));
+		assertFalse(findReplaceLogic.isActive(SearchOptions.REGEX));
+		assertFalse(findReplaceLogic.isActive(SearchOptions.WHOLE_WORD));
+
+		assertSelected(SearchOptions.FORWARD);
+		if (!doesTextViewerHaveMultiLineSelection(findReplaceLogic.getTarget())) {
+			assertSelected(SearchOptions.GLOBAL);
+			assertTrue(findReplaceLogic.isActive(SearchOptions.GLOBAL));
+		} else {
+			assertUnselected(SearchOptions.GLOBAL);
+			assertFalse(findReplaceLogic.isActive(SearchOptions.GLOBAL));
+		}
+		assertSelected(SearchOptions.WRAP);
+
+		assertEnabled(SearchOptions.WRAP);
+		assertEnabled(SearchOptions.CASE_SENSITIVE);
+		assertEnabled(SearchOptions.REGEX);
+		assertEnabled(SearchOptions.INCREMENTAL);
+
+		assertUnselected(SearchOptions.CASE_SENSITIVE);
+		assertUnselected(SearchOptions.REGEX);
+		assertUnselected(SearchOptions.INCREMENTAL);
+
+		String findString= getFindText();
+		if (getEnabledOptions().contains(SearchOptions.WHOLE_WORD)) {
+			assertFalse(findString.isEmpty());
+			assertFalse(findString.contains(" "));
+		}
+	}
+
+	private boolean doesTextViewerHaveMultiLineSelection(IFindReplaceTarget target) {
+		if (target instanceof IFindReplaceTargetExtension scopeProvider) {
+			return scopeProvider.getScope() != null; // null is returned for global scope
+		}
+		return false;
+	}
+
+	@Override
+	public void assertEnabled(SearchOptions option) {
+		Set<SearchOptions> enabled= getEnabledOptions();
+		assertThat(enabled, hasItems(option));
+	}
+
+	@Override
+	public void assertDisabled(SearchOptions option) {
+		Set<SearchOptions> enabled= getEnabledOptions();
+		assertThat(enabled, not(hasItems(option)));
+	}
+
+	@Override
+	public void assertSelected(SearchOptions option) {
+		Set<SearchOptions> enabled= getSelectedOptions();
+		assertThat(enabled, hasItems(option));
+	}
+
+	@Override
+	public void assertUnselected(SearchOptions option) {
+		Set<SearchOptions> enabled= getSelectedOptions();
+		assertThat(enabled, not(hasItems(option)));
+	}
+
+}

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
@@ -13,25 +13,15 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.ResourceBundle;
-import java.util.function.Supplier;
 
-import org.junit.After;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
-import org.eclipse.swt.widgets.Combo;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
 
@@ -39,250 +29,42 @@ import org.eclipse.text.tests.Accessor;
 
 import org.eclipse.jface.util.Util;
 
-import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IFindReplaceTarget;
 import org.eclipse.jface.text.TextViewer;
 
-import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.internal.findandreplace.FindReplaceLogic;
 import org.eclipse.ui.internal.findandreplace.SearchOptions;
 
-/**
- * Tests the FindReplaceDialog.
- *
- * @since 3.1
- */
-public class FindReplaceDialogTest {
+public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 
-	@Rule
-	public TestName testName= new TestName();
+    @Override
+	public DialogAccess openUIFromTextViewer(TextViewer viewer) {
+		TextViewer textViewer= getTextViewer();
+        Accessor fFindReplaceAction;
 
-	private TextViewer fTextViewer;
+        fFindReplaceAction= new Accessor("org.eclipse.ui.texteditor.FindReplaceAction", getClass().getClassLoader(),
+                new Class[] { ResourceBundle.class, String.class, Shell.class, IFindReplaceTarget.class },
+				new Object[] { ResourceBundle.getBundle("org.eclipse.ui.texteditor.ConstructedEditorMessages"), "Editor.FindReplace.", textViewer.getControl().getShell(),
+						textViewer.getFindReplaceTarget() });
+        fFindReplaceAction.invoke("run", null);
 
-	private static void runEventQueue() {
-		Display display= PlatformUI.getWorkbench().getDisplay();
-		for (int i= 0; i < 10; i++) { // workaround for https://bugs.eclipse.org/323272
-			while (display.readAndDispatch()) {
-				// do nothing
-			}
-			try {
-				Thread.sleep(100);
-			} catch (InterruptedException e) {
-				// do nothing
-			}
-		}
-	}
+        Object fFindReplaceDialogStub= fFindReplaceAction.get("fgFindReplaceDialogStub");
+        if (fFindReplaceDialogStub == null)
+            fFindReplaceDialogStub= fFindReplaceAction.get("fgFindReplaceDialogStubShell");
+        Accessor fFindReplaceDialogStubAccessor= new Accessor(fFindReplaceDialogStub, "org.eclipse.ui.texteditor.FindReplaceAction$FindReplaceDialogStub", getClass().getClassLoader());
 
-	private DialogAccess dialog;
+        Accessor dialogAccessor= new Accessor(fFindReplaceDialogStubAccessor.invoke("getDialog", null), "org.eclipse.ui.texteditor.FindReplaceDialog", getClass().getClassLoader());
+		return new DialogAccess(dialogAccessor);
+    }
 
-	private class DialogAccess {
-		FindReplaceLogic findReplaceLogic;
-
-		Combo findCombo;
-
-		Button forwardRadioButton;
-
-		Button globalRadioButton;
-
-		Button caseCheckBox;
-
-		Button wrapCheckBox;
-
-		Button wholeWordCheckBox;
-
-		Button incrementalCheckBox;
-
-		Button regExCheckBox;
-
-		Button replaceFindButton;
-
-		private Supplier<Shell> shellRetriever;
-
-		private Runnable closeOperation;
-
-		public Button replaceAllButton;
-
-
-		DialogAccess(Accessor findReplaceDialogAccessor, boolean checkInitialConfiguration) {
-			findReplaceLogic= (FindReplaceLogic) findReplaceDialogAccessor.get("findReplaceLogic");
-			findCombo= (Combo) findReplaceDialogAccessor.get("fFindField");
-			forwardRadioButton= (Button) findReplaceDialogAccessor.get("fForwardRadioButton");
-			globalRadioButton= (Button) findReplaceDialogAccessor.get("fGlobalRadioButton");
-			caseCheckBox= (Button) findReplaceDialogAccessor.get("fCaseCheckBox");
-			wrapCheckBox= (Button) findReplaceDialogAccessor.get("fWrapCheckBox");
-			wholeWordCheckBox= (Button) findReplaceDialogAccessor.get("fWholeWordCheckBox");
-			incrementalCheckBox= (Button) findReplaceDialogAccessor.get("fIncrementalCheckBox");
-			regExCheckBox= (Button) findReplaceDialogAccessor.get("fIsRegExCheckBox");
-			replaceFindButton= (Button) findReplaceDialogAccessor.get("fReplaceFindButton");
-			replaceAllButton= (Button) findReplaceDialogAccessor.get("fReplaceAllButton");
-			shellRetriever= () -> ((Shell) findReplaceDialogAccessor.get("fActiveShell"));
-			closeOperation= () -> findReplaceDialogAccessor.invoke("close", null);
-			if (checkInitialConfiguration) {
-				assertInitialConfiguration();
-			}
-		}
-
-		void restoreInitialConfiguration() {
-			findCombo.setText("");
-			select(forwardRadioButton);
-			select(globalRadioButton);
-			unselect(incrementalCheckBox);
-			unselect(regExCheckBox);
-			unselect(caseCheckBox);
-			unselect(wholeWordCheckBox);
-			select(wrapCheckBox);
-		}
-
-		private void assertInitialConfiguration() {
-			assertTrue(findReplaceLogic.isActive(SearchOptions.FORWARD));
-			assertTrue(forwardRadioButton.getSelection());
-			assertTrue(findReplaceLogic.isActive(SearchOptions.GLOBAL));
-			assertTrue(globalRadioButton.getSelection());
-			assertFalse(findReplaceLogic.isActive(SearchOptions.CASE_SENSITIVE));
-			assertTrue(caseCheckBox.isEnabled());
-			assertFalse(caseCheckBox.getSelection());
-			assertTrue(findReplaceLogic.isActive(SearchOptions.WRAP));
-			assertTrue(wrapCheckBox.isEnabled());
-			assertTrue(wrapCheckBox.getSelection());
-			assertFalse(findReplaceLogic.isActive(SearchOptions.WHOLE_WORD));
-			String searchString= findCombo.getText();
-			assertEquals(wholeWordCheckBox.isEnabled(), !searchString.isEmpty() && !searchString.contains(" "));
-			assertFalse(wholeWordCheckBox.getSelection());
-			assertFalse(findReplaceLogic.isActive(SearchOptions.INCREMENTAL));
-			assertTrue(incrementalCheckBox.isEnabled());
-			assertFalse(incrementalCheckBox.getSelection());
-			assertFalse(findReplaceLogic.isActive(SearchOptions.REGEX));
-			assertTrue(regExCheckBox.isEnabled());
-			assertFalse(regExCheckBox.getSelection());
-		}
-
-		void closeAndRestore() {
-			restoreInitialConfiguration();
-			assertInitialConfiguration();
-			close();
-		}
-
-		void close() {
-			closeOperation.run();
-		}
-
-		private void ensureHasFocusOnGTK() {
-			if (Util.isGtk()) {
-				// Ensure workbench has focus on GTK
-				runEventQueue();
-				if (shellRetriever.get() == null) {
-					String screenshotPath= ScreenshotTest.takeScreenshot(FindReplaceDialogTest.class, testName.getMethodName(), System.out);
-					fail("this test does not work on GTK unless the runtime workbench has focus. Screenshot: " + screenshotPath);
-				}
-			}
-		}
-
-	}
-
-	private void openFindReplaceDialog() {
-		Shell shell= PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
-		Accessor dialogAccessor= new Accessor("org.eclipse.ui.texteditor.FindReplaceDialog", getClass().getClassLoader(), new Object[] { shell });
-		dialogAccessor.invoke("create", null);
-		dialog= new DialogAccess(dialogAccessor, true);
-	}
-
-	private void openTextViewerAndFindReplaceDialog() {
-		openTextViewerAndFindReplaceDialog("line\nline\nline");
-	}
-
-	private void openTextViewerAndFindReplaceDialog(String content) {
-		openTextViewer(content);
-		openFindReplaceDialogForTextViewer();
-	}
-
-	private void openTextViewer(String content) {
-		fTextViewer= new TextViewer(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
-		fTextViewer.setDocument(new Document(content));
-		fTextViewer.getControl().setFocus();
-	}
-
-	private void openFindReplaceDialogForTextViewer() {
-		openFindReplaceDialogForTextViewer(true);
-	}
-
-	private void openFindReplaceDialogForTextViewer(boolean checkInitialConfiguration) {
-		Accessor fFindReplaceAction;
-		fFindReplaceAction= new Accessor("org.eclipse.ui.texteditor.FindReplaceAction", getClass().getClassLoader(),
-				new Class[] { ResourceBundle.class, String.class, Shell.class, IFindReplaceTarget.class },
-				new Object[] { ResourceBundle.getBundle("org.eclipse.ui.texteditor.ConstructedEditorMessages"), "Editor.FindReplace.", fTextViewer.getControl().getShell(),
-						fTextViewer.getFindReplaceTarget() });
-		fFindReplaceAction.invoke("run", null);
-
-		Object fFindReplaceDialogStub= fFindReplaceAction.get("fgFindReplaceDialogStub");
-		if (fFindReplaceDialogStub == null)
-			fFindReplaceDialogStub= fFindReplaceAction.get("fgFindReplaceDialogStubShell");
-		Accessor fFindReplaceDialogStubAccessor= new Accessor(fFindReplaceDialogStub, "org.eclipse.ui.texteditor.FindReplaceAction$FindReplaceDialogStub", getClass().getClassLoader());
-
-		Accessor dialogAccessor= new Accessor(fFindReplaceDialogStubAccessor.invoke("getDialog", null), "org.eclipse.ui.texteditor.FindReplaceDialog", getClass().getClassLoader());
-		dialog= new DialogAccess(dialogAccessor, checkInitialConfiguration);
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		if (dialog != null) {
-			dialog.closeAndRestore();
-			dialog= null;
-		}
-
-		if (fTextViewer != null) {
-			fTextViewer.getControl().dispose();
-			fTextViewer= null;
-		}
-	}
-
-	@Test
-	public void testInitialButtonState() {
-		openFindReplaceDialog();
-	}
-
-	@Test
-	public void testDisableWholeWordIfRegEx() {
-		openFindReplaceDialog();
-		fTextViewer= new TextViewer(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
-		fTextViewer.setDocument(new Document("line\nline\nline"));
-		fTextViewer.getControl().setFocus();
-
-		dialog.findCombo.setText("word");
-		assertTrue(dialog.regExCheckBox.isEnabled());
-		assertTrue(dialog.wholeWordCheckBox.isEnabled());
-
-		dialog.findReplaceLogic.updateTarget(fTextViewer.getFindReplaceTarget(), false);
-		select(dialog.wholeWordCheckBox);
-		select(dialog.regExCheckBox);
-		assertTrue(dialog.regExCheckBox.isEnabled());
-		assertFalse(dialog.wholeWordCheckBox.isEnabled());
-		assertTrue(dialog.wholeWordCheckBox.getSelection());
-	}
-
-	@Test
-	public void testDisableWholeWordIfNotWord() {
-		openFindReplaceDialog();
-		select(dialog.wholeWordCheckBox);
-
-		dialog.findCombo.setText("word");
-		assertTrue(dialog.regExCheckBox.isEnabled());
-		assertTrue(dialog.wholeWordCheckBox.isEnabled());
-		assertTrue(dialog.wholeWordCheckBox.getSelection());
-
-		dialog.findCombo.setText("no word");
-		assertTrue(dialog.regExCheckBox.isEnabled());
-		assertFalse(dialog.wholeWordCheckBox.isEnabled());
-		assertTrue(dialog.wholeWordCheckBox.getSelection());
-	}
-
-	@Test
-	public void testFocusNotChangedWhenEnterPressed() {
-		openTextViewerAndFindReplaceDialog();
+    @Test
+    public void testFocusNotChangedWhenEnterPressed() {
+		initializeTextViewerWithFindReplaceUI("line\nline\nline");
+		DialogAccess dialog= getDialog();
 
 		dialog.findCombo.setFocus();
-		dialog.findCombo.setText("line");
-		simulateEnterInFindInputField(false);
-		dialog.ensureHasFocusOnGTK();
+		dialog.setFindText("line");
+        dialog.simulateEnterInFindInputField(false);
+        dialog.ensureHasFocusOnGTK();
 
 		if (Util.isMac()) {
 			/* On the Mac, checkboxes only take focus if "Full Keyboard Access" is enabled in the System Preferences.
@@ -290,222 +72,81 @@ public class FindReplaceDialogTest {
 			return;
 		}
 
-		assertTrue(dialog.findCombo.isFocusControl());
+        assertTrue(dialog.getFindCombo().isFocusControl());
 
-		dialog.wrapCheckBox.setFocus();
-		simulateEnterInFindInputField(false);
-		assertTrue(dialog.wrapCheckBox.isFocusControl());
+        Button wrapCheckBox = dialog.getButtonForSearchOption(SearchOptions.WRAP);
+        Button globalRadioButton= dialog.getButtonForSearchOption(SearchOptions.GLOBAL);
+        wrapCheckBox.setFocus();
+        dialog.simulateEnterInFindInputField(false);
+        assertTrue(wrapCheckBox.isFocusControl());
 
-		dialog.globalRadioButton.setFocus();
-		simulateEnterInFindInputField(false);
-		assertTrue(dialog.globalRadioButton.isFocusControl());
-	}
+        globalRadioButton.setFocus();
+        dialog.simulateEnterInFindInputField(false);
+        assertTrue(globalRadioButton.isFocusControl());
+    }
 
-	@Test
-	public void testFocusNotChangedWhenButtonMnemonicPressed() {
-		if (Util.isMac())
-			return; // Mac doesn't support mnemonics.
+    @Test
+    public void testFocusNotChangedWhenButtonMnemonicPressed() {
+        if (Util.isMac())
+            return; // Mac doesn't support mnemonics.
 
-		openTextViewerAndFindReplaceDialog();
+        initializeTextViewerWithFindReplaceUI("");
+		DialogAccess dialog= getDialog();
 
-		dialog.findCombo.setText("line");
-		dialog.ensureHasFocusOnGTK();
+		dialog.setFindText("line");
+        dialog.ensureHasFocusOnGTK();
 
-		dialog.wrapCheckBox.setFocus();
-		final Event event= new Event();
-		event.detail= SWT.TRAVERSE_MNEMONIC;
-		event.character= 'n';
-		event.doit= false;
-		dialog.wrapCheckBox.traverse(SWT.TRAVERSE_MNEMONIC, event);
-		runEventQueue();
-		assertTrue(dialog.wrapCheckBox.isFocusControl());
+		Button wrapCheckBox= dialog.getButtonForSearchOption(SearchOptions.WRAP);
+        wrapCheckBox.setFocus();
+        final Event event= new Event();
+        event.detail= SWT.TRAVERSE_MNEMONIC;
+        event.character= 'n';
+        event.doit= false;
+        wrapCheckBox.traverse(SWT.TRAVERSE_MNEMONIC, event);
+        runEventQueue();
+        assertTrue(wrapCheckBox.isFocusControl());
 
-		dialog.globalRadioButton.setFocus();
-		event.detail= SWT.TRAVERSE_MNEMONIC;
-		event.doit= false;
-		dialog.globalRadioButton.traverse(SWT.TRAVERSE_MNEMONIC, event);
-		runEventQueue();
-		assertTrue(dialog.globalRadioButton.isFocusControl());
+		Button globalRadioButton= dialog.getButtonForSearchOption(SearchOptions.GLOBAL);
+		globalRadioButton.setFocus();
+        event.detail= SWT.TRAVERSE_MNEMONIC;
+        event.doit= false;
+		globalRadioButton.traverse(SWT.TRAVERSE_MNEMONIC, event);
+        runEventQueue();
+		assertTrue(globalRadioButton.isFocusControl());
 
-		event.detail= SWT.TRAVERSE_MNEMONIC;
-		event.character= 'r';
-		event.doit= false;
-		dialog.globalRadioButton.traverse(SWT.TRAVERSE_MNEMONIC, event);
-		runEventQueue();
-		assertTrue(dialog.globalRadioButton.isFocusControl());
-	}
+        event.detail= SWT.TRAVERSE_MNEMONIC;
+        event.character= 'r';
+        event.doit= false;
+		globalRadioButton.traverse(SWT.TRAVERSE_MNEMONIC, event);
+        runEventQueue();
+		assertTrue(globalRadioButton.isFocusControl());
+    }
 
-	@Test
-	public void testShiftEnterReversesSearchDirection() {
-		openTextViewerAndFindReplaceDialog();
+    @Test
+    public void testShiftEnterReversesSearchDirectionDialogSpecific() {
+        initializeTextViewerWithFindReplaceUI("line\nline\nline");
+		DialogAccess dialog= getDialog();
 
-		dialog.findCombo.setText("line");
-		dialog.ensureHasFocusOnGTK();
-		IFindReplaceTarget target= dialog.findReplaceLogic.getTarget();
+		dialog.setFindText("line");
+        dialog.ensureHasFocusOnGTK();
+        IFindReplaceTarget target= dialog.getTarget();
 
-		simulateEnterInFindInputField(false);
-		assertEquals(0, (target.getSelection()).x);
-		assertEquals(4, (target.getSelection()).y);
+		dialog.simulateEnterInFindInputField(false);
+        assertEquals(0, (target.getSelection()).x);
+        assertEquals(4, (target.getSelection()).y);
 
-		simulateEnterInFindInputField(false);
-		assertEquals(5, (target.getSelection()).x);
-		assertEquals(4, (target.getSelection()).y);
+        dialog.simulateEnterInFindInputField(false);
+        assertEquals(5, (target.getSelection()).x);
+        assertEquals(4, (target.getSelection()).y);
 
-		simulateEnterInFindInputField(true);
-		assertEquals(0, (target.getSelection()).x);
-		assertEquals(4, (target.getSelection()).y);
+        dialog.simulateEnterInFindInputField(true);
+        assertEquals(0, (target.getSelection()).x);
+        assertEquals(4, (target.getSelection()).y);
 
-		unselect(dialog.forwardRadioButton);
-		simulateEnterInFindInputField(true);
-		assertEquals(5, (target.getSelection()).x);
-	}
-
-	@Test
-	public void testChangeInputForIncrementalSearch() {
-		openTextViewerAndFindReplaceDialog();
-		select(dialog.incrementalCheckBox);
-
-		dialog.findCombo.setText("lin");
-		IFindReplaceTarget target= dialog.findReplaceLogic.getTarget();
-		assertEquals(0, (target.getSelection()).x);
-		assertEquals(dialog.findCombo.getText().length(), (target.getSelection()).y);
-
-		dialog.findCombo.setText("line");
-		assertEquals(0, (target.getSelection()).x);
-		assertEquals(dialog.findCombo.getText().length(), (target.getSelection()).y);
-	}
-
-	@Test
-	public void testFindWithWholeWordEnabledWithMultipleWords() {
-		openTextViewerAndFindReplaceDialog("two words");
-		dialog.findCombo.setText("two");
-		select(dialog.wholeWordCheckBox);
-		IFindReplaceTarget target= dialog.findReplaceLogic.getTarget();
-		assertEquals(0, (target.getSelection()).x);
-		assertEquals(0, (target.getSelection()).y);
-
-		dialog.findCombo.setText("two wo");
-		assertFalse(dialog.wholeWordCheckBox.getEnabled());
-		assertTrue(dialog.wholeWordCheckBox.getSelection());
-
-		simulateEnterInFindInputField(false);
-		assertEquals(0, (target.getSelection()).x);
-		assertEquals(dialog.findCombo.getText().length(), (target.getSelection()).y);
-	}
-
-	@Test
-	public void testReplaceAndFindAfterInitializingFindWithSelectedString() {
-		openTextViewer("text text text");
-		fTextViewer.setSelectedRange(0, 4);
-		openFindReplaceDialogForTextViewer();
-
-		IFindReplaceTarget target= dialog.findReplaceLogic.getTarget();
-		assertEquals(0, (target.getSelection()).x);
-		assertEquals(4, (target.getSelection()).y);
-		select(dialog.replaceFindButton);
-
-		assertEquals(" text text", fTextViewer.getDocument().get());
-		assertEquals(1, (target.getSelection()).x);
-		assertEquals(4, (target.getSelection()).y);
-	}
-
-	@Test
-	public void testActivateWholeWordsAndSearchForTwoWords() {
-		openTextViewer("text text text");
-		openFindReplaceDialogForTextViewer();
-
-		dialog.wholeWordCheckBox.setSelection(true);
-
-		dialog.findCombo.setText("text text");
-		assertTrue(dialog.wholeWordCheckBox.getSelection());
-		assertFalse(dialog.wholeWordCheckBox.getEnabled());
-
-		dialog.findCombo.setText("text");
-		assertTrue(dialog.wholeWordCheckBox.getSelection());
-		assertTrue(dialog.wholeWordCheckBox.getEnabled());
-
-		dialog.regExCheckBox.setSelection(true);
-		dialog.regExCheckBox.notifyListeners(SWT.Selection, null);
-		runEventQueue();
-		assertTrue(dialog.wholeWordCheckBox.getSelection());
-		assertFalse(dialog.wholeWordCheckBox.getEnabled());
-	}
-
-	@Test
-	public void testActivateDialogWithSelectionActive() {
-		openTextViewer("text" + System.lineSeparator() + "text" + System.lineSeparator() + "text");
-		fTextViewer.setSelectedRange(4 + System.lineSeparator().length(), 8 + System.lineSeparator().length());
-		openFindReplaceDialogForTextViewer(false);
-
-		assertFalse(dialog.globalRadioButton.getSelection());
-		dialog.findCombo.setText("text");
-		select(dialog.replaceAllButton);
-
-		assertThat(fTextViewer.getDocument().get(), is("text" + System.lineSeparator() + System.lineSeparator()));
-	}
-
-	@Test
-	public void testIncrementalSearchOnlyEnabledWhenAllowed() {
-		openTextViewer("text text text");
-		openFindReplaceDialogForTextViewer();
-
-		dialog.incrementalCheckBox.setSelection(true);
-		select(dialog.regExCheckBox);
-		runEventQueue();
-		assertTrue(dialog.incrementalCheckBox.getSelection());
-		assertFalse(dialog.incrementalCheckBox.getEnabled());
-	}
-
-	/*
-	 * Test for https://github.com/eclipse-platform/eclipse.platform.ui/pull/1805#pullrequestreview-1993772378
-	 */
-	@Test
-	public void testIncrementalSearchOptionRecoveredCorrectly() {
-		openTextViewer("text text text");
-		openFindReplaceDialogForTextViewer();
-
-		select(dialog.incrementalCheckBox);
-		assertTrue(dialog.incrementalCheckBox.getSelection());
-		assertTrue(dialog.incrementalCheckBox.getEnabled());
-
-		dialog.close();
-		openFindReplaceDialogForTextViewer(false);
-
-		assertTrue(dialog.incrementalCheckBox.getSelection());
-		assertTrue(dialog.incrementalCheckBox.getEnabled());
-
-		select(dialog.incrementalCheckBox);
-		select(dialog.regExCheckBox);
-		assertTrue(dialog.incrementalCheckBox.getSelection());
-		assertFalse(dialog.incrementalCheckBox.getEnabled());
-
-		dialog.close();
-		openFindReplaceDialogForTextViewer(false);
-
-		assertTrue(dialog.incrementalCheckBox.getSelection());
-		assertFalse(dialog.incrementalCheckBox.getEnabled());
-	}
-
-	private static void select(Button button) {
-		button.setSelection(true);
-		button.notifyListeners(SWT.Selection, null);
-	}
-
-	private static void unselect(Button button) {
-		button.setSelection(false);
-		button.notifyListeners(SWT.Selection, null);
-	}
-
-	private void simulateEnterInFindInputField(boolean shiftPressed) {
-		final Event event= new Event();
-		event.type= SWT.Traverse;
-		event.detail= SWT.TRAVERSE_RETURN;
-		event.character= SWT.CR;
-		if (shiftPressed) {
-			event.stateMask= SWT.SHIFT;
-		}
-		dialog.findCombo.traverse(SWT.TRAVERSE_RETURN, event);
-		runEventQueue();
-	}
-
+        // This part only makes sense for the FindReplaceDialog since not every UI might have stored
+        // the search direction as a state
+        dialog.unselect(SearchOptions.FORWARD);
+        dialog.simulateEnterInFindInputField(true);
+        assertEquals(5, (target.getSelection()).x);
+    }
 }

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceUITest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceUITest.java
@@ -1,0 +1,351 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.workbench.texteditor.tests;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Display;
+
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IFindReplaceTarget;
+import org.eclipse.jface.text.TextSelection;
+import org.eclipse.jface.text.TextViewer;
+
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.findandreplace.SearchOptions;
+
+public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess> {
+	@Rule
+	public TestName testName= new TestName();
+
+	private TextViewer fTextViewer;
+
+	static void runEventQueue() {
+		Display display= PlatformUI.getWorkbench().getDisplay();
+		for (int i= 0; i < 10; i++) { // workaround for https://bugs.eclipse.org/323272
+			while (display.readAndDispatch()) {
+				// do nothing
+			}
+			try {
+				Thread.sleep(50);
+			} catch (InterruptedException e) {
+				// do nothing
+			}
+		}
+	}
+
+	private AccessType dialog;
+
+	protected final void initializeTextViewerWithFindReplaceUI(String content) {
+		openTextViewer(content);
+		initializeFindReplaceUIForTextViewer();
+		dialog.assertInitialConfiguration();
+	}
+
+	private void openTextViewer(String content) {
+		fTextViewer= new TextViewer(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
+		fTextViewer.setDocument(new Document(content));
+		fTextViewer.getControl().setFocus();
+	}
+
+	private void initializeFindReplaceUIForTextViewer() {
+		dialog= openUIFromTextViewer(fTextViewer);
+	}
+
+	protected abstract AccessType openUIFromTextViewer(TextViewer viewer);
+
+	@After
+	public void tearDown() throws Exception {
+		if (dialog != null) {
+			dialog.closeAndRestore();
+			dialog= null;
+		}
+
+		if (fTextViewer != null) {
+			fTextViewer.getControl().dispose();
+			fTextViewer= null;
+		}
+	}
+
+	@Test
+	public void testInitialButtonState() {
+		initializeTextViewerWithFindReplaceUI("");
+	}
+
+	@Test
+	public void testDisableWholeWordIfRegEx() {
+		initializeTextViewerWithFindReplaceUI("");
+		fTextViewer= new TextViewer(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
+		fTextViewer.setDocument(new Document("line" + System.lineSeparator() + "line" + System.lineSeparator() + "line"));
+		fTextViewer.getControl().setFocus();
+
+		dialog.setFindText("word");
+		dialog.assertEnabled(SearchOptions.REGEX);
+		dialog.assertEnabled(SearchOptions.WHOLE_WORD);
+
+		dialog.getFindReplaceLogic().updateTarget(fTextViewer.getFindReplaceTarget(), false);
+		dialog.select(SearchOptions.WHOLE_WORD);
+		dialog.select(SearchOptions.REGEX);
+		dialog.assertEnabled(SearchOptions.REGEX);
+		dialog.assertDisabled(SearchOptions.WHOLE_WORD);
+		dialog.assertSelected(SearchOptions.WHOLE_WORD);
+
+		dialog.unselect(SearchOptions.REGEX);
+		dialog.assertEnabled(SearchOptions.REGEX);
+		dialog.assertUnselected(SearchOptions.REGEX);
+		dialog.assertEnabled(SearchOptions.WHOLE_WORD);
+		dialog.assertSelected(SearchOptions.WHOLE_WORD);
+	}
+
+	@Test
+	public void testDisableWholeWordIfNotWord() {
+		initializeTextViewerWithFindReplaceUI("");
+		dialog.select(SearchOptions.WHOLE_WORD);
+
+		dialog.setFindText("word");
+		dialog.assertEnabled(SearchOptions.REGEX);
+		dialog.assertEnabled(SearchOptions.WHOLE_WORD);
+		dialog.assertSelected(SearchOptions.WHOLE_WORD);
+
+		dialog.setFindText("no word");
+		dialog.assertEnabled(SearchOptions.REGEX);
+		dialog.assertDisabled(SearchOptions.WHOLE_WORD);
+		dialog.assertSelected(SearchOptions.WHOLE_WORD);
+
+		dialog.setFindText("word_again");
+		dialog.assertEnabled(SearchOptions.REGEX);
+		dialog.assertEnabled(SearchOptions.WHOLE_WORD);
+		dialog.assertSelected(SearchOptions.WHOLE_WORD);
+	}
+
+	@Test
+	public void testShiftEnterReversesSearchDirection() {
+		initializeTextViewerWithFindReplaceUI("line\nline\nline");
+
+		dialog.select(SearchOptions.INCREMENTAL);
+		dialog.setFindText("line");
+		dialog.ensureHasFocusOnGTK();
+		IFindReplaceTarget target= dialog.getTarget();
+
+		assertEquals(0, (target.getSelection()).x);
+		assertEquals(4, (target.getSelection()).y);
+
+		dialog.simulateEnterInFindInputField(false);
+		assertEquals(5, (target.getSelection()).x);
+		assertEquals(4, (target.getSelection()).y);
+
+		dialog.simulateEnterInFindInputField(true);
+		assertEquals(0, (target.getSelection()).x);
+		assertEquals(4, (target.getSelection()).y);
+
+		// Keypad-Enter is also valid for navigating
+		dialog.simulateKeyPressInFindInputField(SWT.KEYPAD_CR, false);
+		assertEquals(5, (target.getSelection()).x);
+		assertEquals(4, (target.getSelection()).y);
+
+		dialog.simulateKeyPressInFindInputField(SWT.KEYPAD_CR, true);
+		assertEquals(0, (target.getSelection()).x);
+		assertEquals(4, (target.getSelection()).y);
+	}
+
+	@Test
+	public void testChangeInputForIncrementalSearch() {
+		initializeTextViewerWithFindReplaceUI("line\nline\nline");
+		dialog.select(SearchOptions.INCREMENTAL);
+
+		dialog.setFindText("lin");
+		IFindReplaceTarget target= dialog.getTarget();
+		assertEquals(0, (target.getSelection()).x);
+		assertEquals(dialog.getFindText().length(), (target.getSelection()).y);
+
+		dialog.setFindText("line");
+		assertEquals(0, (target.getSelection()).x);
+		assertEquals(dialog.getFindText().length(), (target.getSelection()).y);
+	}
+
+	@Test
+	public void testFindWithWholeWordEnabledWithMultipleWords() {
+		initializeTextViewerWithFindReplaceUI("two words two");
+		dialog.setFindText("two");
+		dialog.select(SearchOptions.WHOLE_WORD);
+		dialog.select(SearchOptions.WRAP);
+		IFindReplaceTarget target= dialog.getTarget();
+		assertEquals(0, (target.getSelection()).x);
+		assertEquals(0, (target.getSelection()).y);
+
+		dialog.setFindText("two wo");
+		dialog.assertDisabled(SearchOptions.WHOLE_WORD);
+		dialog.assertSelected(SearchOptions.WHOLE_WORD);
+
+		dialog.simulateEnterInFindInputField(false);
+		assertThat(target.getSelectionText(), is(dialog.getFindText()));
+		assertEquals(0, (target.getSelection()).x);
+		assertEquals(dialog.getFindText().length(), (target.getSelection()).y);
+	}
+
+	@Test
+	public void testReplaceAndFindAfterInitializingFindWithSelectedString() {
+		openTextViewer("text text text");
+		fTextViewer.setSelectedRange(0, 4);
+		initializeFindReplaceUIForTextViewer();
+
+		IFindReplaceTarget target= dialog.getTarget();
+		assertEquals(0, (target.getSelection()).x);
+		assertEquals(4, (target.getSelection()).y);
+
+		dialog.performReplaceAndFind();
+
+		assertEquals(" text text", fTextViewer.getDocument().get());
+		assertEquals(1, (target.getSelection()).x);
+		assertEquals(4, (target.getSelection()).y);
+	}
+
+	@Test
+	public void testRegExSearch() {
+		initializeTextViewerWithFindReplaceUI("abc");
+		dialog.select(SearchOptions.REGEX);
+		dialog.setFindText("(a|bc)");
+		IFindReplaceTarget target= dialog.getTarget();
+		dialog.simulateEnterInFindInputField(false);
+		assertEquals(0, (target.getSelection()).x);
+		assertEquals(1, (target.getSelection()).y);
+
+		dialog.simulateEnterInFindInputField(false);
+		assertEquals(1, (target.getSelection()).x);
+		assertEquals(2, (target.getSelection()).y);
+	}
+
+	@Test
+	public void testSimpleReplace() {
+		initializeTextViewerWithFindReplaceUI("ABCD ABCD ABCD");
+		dialog.setFindText("ABCD");
+		dialog.setReplaceText("abcd");
+		dialog.performReplace();
+		assertThat(fTextViewer.getDocument().get(), is("abcd ABCD ABCD"));
+
+		dialog.performReplaceAll();
+		assertThat(fTextViewer.getDocument().get(), is("abcd abcd abcd"));
+
+		dialog.select(SearchOptions.REGEX);
+		dialog.setFindText("(ab|cd)");
+		dialog.setReplaceText("o");
+		dialog.performReplaceAll();
+		assertThat(fTextViewer.getDocument().get(), is("oo oo oo"));
+	}
+
+	@Test
+	public void testReplaceAllInSelection() {
+		fTextViewer= new TextViewer(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
+		fTextViewer.setDocument(new Document("line" + System.lineSeparator() + "line" + System.lineSeparator() + "line"));
+		fTextViewer.getControl().setFocus();
+		fTextViewer.setSelection(new TextSelection(4 + System.lineSeparator().length(), 8 + System.lineSeparator().length()));
+
+		dialog= openUIFromTextViewer(fTextViewer);
+		dialog.assertInitialConfiguration();
+		dialog.unselect(SearchOptions.GLOBAL);
+		dialog.unselect(SearchOptions.WHOLE_WORD);
+
+		dialog.setFindText("line");
+		dialog.setReplaceText("");
+		dialog.performReplaceAll();
+
+		assertThat(fTextViewer.getDocument().get(), is("line" + System.lineSeparator() + System.lineSeparator()));
+	}
+
+	@Test
+	public void testActivateWholeWordsAndSearchForTwoWords() {
+		initializeTextViewerWithFindReplaceUI("text text text");
+		dialog.select(SearchOptions.WHOLE_WORD);
+
+		dialog.setFindText("text text");
+		dialog.assertDisabled(SearchOptions.WHOLE_WORD);
+		dialog.assertSelected(SearchOptions.WHOLE_WORD);
+
+		dialog.setFindText("text");
+		dialog.assertEnabled(SearchOptions.WHOLE_WORD);
+		dialog.assertSelected(SearchOptions.WHOLE_WORD);
+
+		dialog.select(SearchOptions.REGEX);
+		dialog.assertDisabled(SearchOptions.WHOLE_WORD);
+		dialog.assertSelected(SearchOptions.WHOLE_WORD);
+	}
+
+	@Test
+	public void testActivateDialogWithSelectionActive() {
+		openTextViewer("text" + System.lineSeparator() + "text" + System.lineSeparator() + "text");
+		fTextViewer.setSelection(new TextSelection(4 + System.lineSeparator().length(), 8 + System.lineSeparator().length()));
+		initializeFindReplaceUIForTextViewer();
+
+		dialog.assertUnselected(SearchOptions.GLOBAL);
+		dialog.setFindText("text");
+		dialog.performReplaceAll();
+
+		assertThat(fTextViewer.getDocument().get(), is("text" + System.lineSeparator() + System.lineSeparator()));
+	}
+
+	@Test
+	public void testIncrementalSearchOnlyEnabledWhenAllowed() {
+		initializeTextViewerWithFindReplaceUI("text text text");
+
+		dialog.select(SearchOptions.INCREMENTAL);
+		dialog.select(SearchOptions.REGEX);
+
+		dialog.assertSelected(SearchOptions.INCREMENTAL);
+		dialog.assertDisabled(SearchOptions.INCREMENTAL);
+	}
+
+	/*
+	 * Test for https://github.com/eclipse-platform/eclipse.platform.ui/pull/1805#pullrequestreview-1993772378
+	 */
+	@Test
+	public void testIncrementalSearchOptionRecoveredCorrectly() {
+		initializeTextViewerWithFindReplaceUI("text text text");
+
+		dialog.select(SearchOptions.INCREMENTAL);
+		dialog.assertSelected(SearchOptions.INCREMENTAL);
+		dialog.assertEnabled(SearchOptions.INCREMENTAL);
+
+		dialog.close();
+		initializeFindReplaceUIForTextViewer();
+
+		dialog.assertSelected(SearchOptions.INCREMENTAL);
+		dialog.assertEnabled(SearchOptions.INCREMENTAL);
+
+		dialog.select(SearchOptions.REGEX);
+		dialog.assertSelected(SearchOptions.INCREMENTAL);
+		dialog.assertDisabled(SearchOptions.INCREMENTAL);
+
+		dialog.close();
+		initializeFindReplaceUIForTextViewer();
+
+		dialog.assertSelected(SearchOptions.INCREMENTAL);
+		dialog.assertDisabled(SearchOptions.INCREMENTAL);
+	}
+
+	protected AccessType getDialog() {
+		return dialog;
+	}
+
+	protected TextViewer getTextViewer() {
+		return fTextViewer;
+	}
+}

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/IFindReplaceUIAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/IFindReplaceUIAccess.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ui.workbench.texteditor.tests;
+
+import java.util.Set;
+
+import org.eclipse.swt.widgets.Widget;
+
+import org.eclipse.jface.text.IFindReplaceTarget;
+
+import org.eclipse.ui.internal.findandreplace.IFindReplaceLogic;
+import org.eclipse.ui.internal.findandreplace.SearchOptions;
+
+
+/**
+ * Wraps UI-Access for different Find/Replace-UIs
+ */
+interface IFindReplaceUIAccess {
+
+	IFindReplaceTarget getTarget();
+
+	void closeAndRestore();
+
+	void close();
+
+	void ensureHasFocusOnGTK();
+
+	void unselect(SearchOptions option);
+
+	void select(SearchOptions option);
+
+	void simulateEnterInFindInputField(boolean shiftPressed);
+
+	void simulateKeyPressInFindInputField(int keyCode, boolean shiftPressed);
+
+	String getFindText();
+
+	String getReplaceText();
+
+	void setFindText(String text);
+
+	void setReplaceText(String text);
+
+	Widget getButtonForSearchOption(SearchOptions option);
+
+	Set<SearchOptions> getEnabledOptions();
+
+	Set<SearchOptions> getSelectedOptions();
+
+	IFindReplaceLogic getFindReplaceLogic();
+
+	void performReplaceAll();
+
+	void performReplace();
+
+	void performReplaceAndFind();
+
+	abstract void assertInitialConfiguration();
+
+	void assertUnselected(SearchOptions option);
+
+	void assertSelected(SearchOptions option);
+
+	void assertDisabled(SearchOptions option);
+
+	void assertEnabled(SearchOptions option);
+
+}


### PR DESCRIPTION
This commit extracts the testing framework for the find/Replace overlay. It introduces an abstract test class which abstractly tests interfaces for find/replace. For that, this commit provides an abstract "interface access" class which allows for abstract access to the underlying nature of find/replace interfaces.

This commit makes most sense when viewed together with the unit tests for the find/replace overlay. I have extracted this refactoring because a lot of small pre-PRs introduce new unit tests. Extracting these tests means that I do not need to port them to a new infrastructure later on.

Extracted from #1192