### PR TITLE
Remove unnecessary and unused code

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/sac/CSSDirectAdjacentSelectorImpl.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/sac/CSSDirectAdjacentSelectorImpl.java
@@ -59,7 +59,6 @@ public class CSSDirectAdjacentSelectorImpl extends AbstractSiblingSelector {
 		}
 
 		while ((n = n.getPreviousSibling()) != null && n.getNodeType() != Node.ELEMENT_NODE) {
-			;
 		}
 
 		if (n == null) {
@@ -79,7 +78,6 @@ public class CSSDirectAdjacentSelectorImpl extends AbstractSiblingSelector {
 			return false;
 		}
 		while ((n = n.getPreviousSibling()) != null && n.getNodeType() != Node.ELEMENT_NODE) {
-			;
 		}
 
 		if (n == null) {

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ModelAssembler.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ModelAssembler.java
@@ -795,8 +795,8 @@ public class ModelAssembler {
 					EStructuralFeature feature = featureIterator.feature();
 
 					MApplicationElement el = null;
-					if (importObject instanceof MApplicationElement) {
-						el = importMaps.get((MApplicationElement) importObject);
+					if (importObject instanceof MApplicationElement applicationElement) {
+						el = importMaps.get(applicationElement);
 
 						if (el == null) {
 							log(LogLevel.WARN, "Could not resolve import for {}", //$NON-NLS-1$

--- a/examples/org.eclipse.jface.text.examples/src/org/eclipse/jface/text/examples/codemining/ToEchoWithHeaderAndInlineCodeMiningProvider.java
+++ b/examples/org.eclipse.jface.text.examples/src/org/eclipse/jface/text/examples/codemining/ToEchoWithHeaderAndInlineCodeMiningProvider.java
@@ -47,7 +47,7 @@ public class ToEchoWithHeaderAndInlineCodeMiningProvider extends AbstractCodeMin
 						return true;
 					}
 				});
-		};
+		}
 		return CompletableFuture.completedFuture(res);
 	}
 

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CTabItemTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CTabItemTest.java
@@ -58,7 +58,6 @@ public class CTabItemTest extends CSSSWTTestCase {
 		// Add some delay to allow asynchronous events to come in, but don't get trapped in an endless Display#sleep().
 		for (int i = 0; i < 3; i++) {
 			while (display.readAndDispatch()) {
-				;
 			}
 			try {
 				Thread.sleep(10);

--- a/tests/org.eclipse.ui.ide.application.tests/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisorTest.java
+++ b/tests/org.eclipse.ui.ide.application.tests/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisorTest.java
@@ -236,7 +236,6 @@ public class IDEWorkbenchAdvisorTest {
 	 */
 	private void dispatchDisplay() {
 		while (display.readAndDispatch()) {
-			;
 		}
 	}
 

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/DnDTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/DnDTest.java
@@ -109,7 +109,7 @@ public class DnDTest extends NavigatorTestBase {
 			fail("Should not throw an exception");
 		}
 
-		Control end = (Control) editorPart.getAdapter(Control.class);
+		Control end = editorPart.getAdapter(Control.class);
 
 		TreeItem[] items = _viewer.getTree().getItems();
 
@@ -146,7 +146,7 @@ public class DnDTest extends NavigatorTestBase {
 			fail("Should not throw an exception");
 		}
 
-		Control end = (Control) editorPart.getAdapter(Control.class);
+		Control end = editorPart.getAdapter(Control.class);
 
 		TreeItem[] items = _viewer.getTree().getItems();
 

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchTest.java
@@ -40,7 +40,7 @@ public class WorkbenchTest {
 				IActivityManager activityManager = workbench.getActivitySupport().getActivityManager();
 				activityManager.addActivityManagerListener(activityListener);
 				workbench.close();
-			};
+			}
 		};
 
 		runWorkbench(closeAfterStartupAdvisor);


### PR DESCRIPTION
Applies the following cleanup rules to all project to be conform with defined save actions:
* Remove unused imports
* Remove unnecessary casts
* Remove unused non-NLS tags
* Remove redundant semicolons