### PR TITLE
Use boolean value rather than comparison against true/false

### DIFF
--- a/bundles/org.eclipse.core.commands/src/org/eclipse/core/internal/commands/util/Util.java
+++ b/bundles/org.eclipse.core.commands/src/org/eclipse/core/internal/commands/util/Util.java
@@ -78,7 +78,7 @@ public final class Util {
 	 *         <code>false</code>
 	 */
 	public static final int compare(final boolean left, final boolean right) {
-		return left == false ? (right == true ? -1 : 0) : (right == true ? 0 : 1);
+		return !left ? (right ? -1 : 0) : (right ? 0 : 1);
 	}
 
 	/**

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/serializers/CSSSerializer.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/serializers/CSSSerializer.java
@@ -128,7 +128,7 @@ public class CSSSerializer {
 	 * Generate start selector.
 	 */
 	protected void startSelector(Writer writer, String selectorName, boolean firstSelector) throws IOException {
-		if (firstSelector == false) {
+		if (!firstSelector) {
 			writer.write("\n\n");
 		}
 		writer.write(selectorName + " {");

--- a/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/ThemeEngine.java
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/ThemeEngine.java
@@ -348,7 +348,7 @@ public class ThemeEngine implements IThemeEngine {
 			if (stylesheetPluginExtensionList != null && stylesheetPluginExtensionList.size() > 0) {
 				s = new ArrayList<>(s);
 				for (String styleSheet : stylesheetPluginExtensionList) {
-					if (s.contains(styleSheet) == false) {
+					if (!s.contains(styleSheet)) {
 						s.add(styleSheet);
 					}
 				}

--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressServiceImpl.java
@@ -155,7 +155,7 @@ public class ProgressServiceImpl implements IProgressService {
 	public void run(boolean fork, boolean cancelable,
 			IRunnableWithProgress runnable) throws InvocationTargetException,
 			InterruptedException {
-		if (fork == false || cancelable == false) {
+		if (!fork || !cancelable) {
 			// backward compatible code
 			final ProgressMonitorJobsDialog dialog = new ProgressMonitorJobsDialog(
 					null, this, progressManager, contentProviderFactory,

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/Util.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/Util.java
@@ -91,7 +91,7 @@ public final class Util {
 	 *         <code>0</code>.
 	 */
 	public static int compare(final boolean left, final boolean right) {
-		return left == false ? (right == true ? -1 : 0) : 1;
+		return !left ? (right ? -1 : 0) : 1;
 	}
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/ToolBarContributionItem.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/ToolBarContributionItem.java
@@ -331,7 +331,7 @@ public class ToolBarContributionItem extends ContributionItem implements IToolBa
 	private void handleChevron(SelectionEvent event) {
 		CoolItem item = (CoolItem) event.widget;
 		Control control = item.getControl();
-		if ((control instanceof ToolBar) == false) {
+		if (!(control instanceof ToolBar)) {
 			return;
 		}
 		CoolBar coolBar = item.getParent();

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/fieldassist/DecoratedField.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/fieldassist/DecoratedField.java
@@ -776,7 +776,7 @@ public class DecoratedField {
 			data.label.setImage(decoration.getImage());
 			// If the decoration is being shown, and a hover is active,
 			// update the hover text to display the new description.
-			if (data.label.getVisible() == true && hover != null) {
+			if (data.label.getVisible() && hover != null) {
 				showHoverText(decoration.getDescription(), data.label);
 			}
 		}

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/PreferenceStore.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/PreferenceStore.java
@@ -606,7 +606,6 @@ public class PreferenceStore extends EventManager implements
 	 */
 	private void setValue(Properties p, String name, boolean value) {
 		Assert.isTrue(p != null);
-		p.put(name, value == true ? IPreferenceStore.TRUE
-				: IPreferenceStore.FALSE);
+		p.put(name, value ? IPreferenceStore.TRUE : IPreferenceStore.FALSE);
 	}
 }

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/util/Util.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/util/Util.java
@@ -104,7 +104,7 @@ public final class Util {
 	 *         is true. If they are equal, then it returns <code>0</code>.
 	 */
 	public static int compare(final boolean left, final boolean right) {
-		return left == false ? (right == true ? -1 : 0) : 1;
+		return !left ? (right ? -1 : 0) : 1;
 	}
 
 	/**

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/text/NavigatorDragAdapter.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/text/NavigatorDragAdapter.java
@@ -72,7 +72,7 @@ public class NavigatorDragAdapter extends DragSourceAdapter {
 	public void dragFinished(DragSourceEvent event) {
 		LocalSelectionTransfer.getTransfer().setSelection(null);
 
-		if (event.doit == false) {
+		if (!event.doit) {
 			return;
 		}
 

--- a/bundles/org.eclipse.text/src/org/eclipse/jface/text/link/LinkedPositionGroup.java
+++ b/bundles/org.eclipse.text/src/org/eclipse/jface/text/link/LinkedPositionGroup.java
@@ -304,7 +304,7 @@ public class LinkedPositionGroup {
 		Assert.isTrue(!fIsSealed);
 		fIsSealed= true;
 
-		if (fHasCustomIteration == false && !fPositions.isEmpty()) {
+		if (!fHasCustomIteration && !fPositions.isEmpty()) {
 			fPositions.get(0).setSequenceNumber(0);
 		}
 	}

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/DetailsPart.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/DetailsPart.java
@@ -220,7 +220,7 @@ public final class DetailsPart implements IFormPart, IPartSelectionListener {
 			for (Object obj : currentSelection) {
 				if (key == null)
 					key = getKey(obj);
-				else if (getKey(obj).equals(key) == false) {
+				else if (!getKey(obj).equals(key)) {
 					key = null;
 					break;
 				}

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/editor/FormEditor.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/editor/FormEditor.java
@@ -467,7 +467,7 @@ public abstract class FormEditor extends MultiPageEditorPart  {
 				&& oldPageIndex != newPageIndex) {
 			// Check the old page
 			IFormPage oldFormPage = (IFormPage) pages.get(oldPageIndex);
-			if (oldFormPage.canLeaveThePage() == false) {
+			if (!oldFormPage.canLeaveThePage()) {
 				setActivePage(oldPageIndex);
 				return;
 			}
@@ -660,7 +660,7 @@ public abstract class FormEditor extends MultiPageEditorPart  {
 		}
 		if (page instanceof IFormPage) {
 			IFormPage fpage = (IFormPage) page;
-			if (fpage.isEditor() == false)
+			if (!fpage.isEditor())
 				fpage.init(getEditorSite(), getEditorInput());
 		}
 	}

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/FormToolkit.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/FormToolkit.java
@@ -773,7 +773,7 @@ public class FormToolkit {
 		}
 		isDisposed = true;
 		boldFontHolder.dispose();
-		if (colors.isShared() == false) {
+		if (!colors.isShared()) {
 			colors.dispose();
 			colors = null;
 		}

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/TableWrapLayout.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/TableWrapLayout.java
@@ -311,7 +311,7 @@ public final class TableWrapLayout extends Layout implements ILayoutExtension {
 			rowHeights[i] = 0;
 			for (int j = 0; j < numColumns; j++) {
 				TableWrapData td = row[j];
-				if (td.isItemData == false) {
+				if (!td.isItemData) {
 					continue;
 				}
 				Control child = children[td.childIndex];
@@ -651,7 +651,7 @@ public final class TableWrapLayout extends Layout implements ILayoutExtension {
 			int rowHeight = 0;
 			for (int j = 0; j < numColumns; j++) {
 				TableWrapData td = row[j];
-				if (td.isItemData == false) {
+				if (!td.isItemData) {
 					continue;
 				}
 				Control child = children[td.childIndex];
@@ -765,8 +765,9 @@ public final class TableWrapLayout extends Layout implements ILayoutExtension {
 		for (TableWrapData[] row : grid) {
 			for (int j = 0; j < numColumns; j++) {
 				TableWrapData td = row[j];
-				if (td.isItemData == false)
+				if (!td.isItemData) {
 					continue;
+				}
 
 				if (td.colspan>1) {
 					// we will not do controls with multiple column span
@@ -798,8 +799,9 @@ public final class TableWrapLayout extends Layout implements ILayoutExtension {
 		for (TableWrapData[] row : grid) {
 			for (int j = 0; j < numColumns; j++) {
 				TableWrapData td = row[j];
-				if (td.isItemData == false || td.colspan==1)
+				if (!td.isItemData || td.colspan == 1) {
 					continue;
+				}
 
 				SizeCache childCache = cache.getCache(td.childIndex);
 				int width = max?childCache.computeMaximumWidth():childCache.computeMinimumWidth();

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/AddTaskAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/AddTaskAction.java
@@ -93,7 +93,7 @@ public class AddTaskAction extends SelectionListenerAction {
 
 		if (resource != null && resource instanceof IProject) {
 			IProject project = (IProject) resource;
-			if (project.isOpen() == false) {
+			if (!project.isOpen()) {
 				resource = null;
 			}
 		}

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CopyFilesAndFoldersOperation.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CopyFilesAndFoldersOperation.java
@@ -222,7 +222,7 @@ public class CopyFilesAndFoldersOperation {
 				IStatus.OK, getProblemsMessage(), null);
 
 		for (IFileStore store : stores) {
-			if (store.fetchInfo().exists() == false) {
+			if (!store.fetchInfo().exists()) {
 				String message = NLS.bind(IDEWorkbenchMessages.CopyFilesAndFoldersOperation_resourceDeleted,
 								store.getName());
 				IStatus status = new Status(IStatus.ERROR, PlatformUI.PLUGIN_ID, IStatus.OK, message, null);
@@ -249,7 +249,7 @@ public class CopyFilesAndFoldersOperation {
 				String message = null;
 				if (location != null) {
 					IFileInfo info = IDEResourceInfoUtils.getFileInfo(location);
-					if (info == null || info.exists() == false) {
+					if (info == null || !info.exists()) {
 						if (resource.isLinked()) {
 							message = NLS
 									.bind(
@@ -464,8 +464,8 @@ public class CopyFilesAndFoldersOperation {
 					delete(existing, iterationMonitor.split(10));
 					iterationMonitor.setWorkRemaining(100);
 
-					if ((createLinks || createVirtualFoldersAndLinks) && (resource.isLinked() == false)
-							&& (resource.isVirtual() == false)) {
+					if ((createLinks || createVirtualFoldersAndLinks) && !resource.isLinked()
+							&& !resource.isVirtual()) {
 						if (resource.getType() == IResource.FILE) {
 							IFile file = workspaceRoot.getFile(destinationPath);
 							file.createLink(createRelativePath(resource.getLocationURI(), file), 0,
@@ -1157,8 +1157,7 @@ public class CopyFilesAndFoldersOperation {
 		boolean isSourceLinked = source.isLinked();
 		boolean isDestinationLinked = destination.isLinked();
 
-		return (isSourceLinked && isDestinationLinked || isSourceLinked == false
-				&& isDestinationLinked == false);
+		return isSourceLinked && isDestinationLinked || !isSourceLinked && !isDestinationLinked;
 	}
 
 	/**
@@ -1439,7 +1438,7 @@ public class CopyFilesAndFoldersOperation {
 		for (IResource sourceResource : sourceResources) {
 			if (firstParent == null) {
 				firstParent = sourceResource.getParent();
-			} else if (firstParent.equals(sourceResource.getParent()) == false) {
+			} else if (!firstParent.equals(sourceResource.getParent())) {
 				// Resources must have common parent. Fixes bug 33398.
 				return IDEWorkbenchMessages.CopyFilesAndFoldersOperation_parentNotEqual;
 			}
@@ -1518,7 +1517,7 @@ public class CopyFilesAndFoldersOperation {
 			IWorkspace workspace = ResourcesPlugin.getWorkspace();
 			IStatus status = workspace.validateEdit(files, messageShell);
 
-			canceled = status.isOK() == false;
+			canceled = !status.isOK();
 			return status.isOK();
 		}
 		return true;
@@ -1623,7 +1622,7 @@ public class CopyFilesAndFoldersOperation {
 	 */
 	private String validateLinkedResource(IContainer destination,
 			IResource source) {
-		if ((source.isLinked() == false) || source.isVirtual()) {
+		if (!source.isLinked() || source.isVirtual()) {
 			return null;
 		}
 		IWorkspace workspace = destination.getWorkspace();
@@ -1635,7 +1634,7 @@ public class CopyFilesAndFoldersOperation {
 			return locationStatus.getMessage();
 		}
 		IPath sourceLocation = source.getLocation();
-		if (source.getProject().equals(destination.getProject()) == false
+		if (!source.getProject().equals(destination.getProject())
 				&& source.getType() == IResource.FOLDER
 				&& sourceLocation != null) {
 			// prevent merging linked folders that point to the same
@@ -1702,8 +1701,8 @@ public class CopyFilesAndFoldersOperation {
 			IResource newResource = workspaceRoot.findMember(destinationPath);
 			if (newResource != null) {
 				if (overwrite != IDialogConstants.YES_TO_ALL_ID
-						|| (newResource.getType() == IResource.FOLDER && homogenousResources(
-								resource, destination) == false)) {
+						|| (newResource.getType() == IResource.FOLDER && !homogenousResources(
+								resource, destination))) {
 					overwrite = checkOverwrite(resource, newResource);
 				}
 				if (overwrite == IDialogConstants.YES_ID
@@ -1753,7 +1752,7 @@ public class CopyFilesAndFoldersOperation {
 					displayError(IDEWorkbenchMessages.CopyFilesAndFoldersOperation_nameCollision);
 					return;
 				}
-				if (validateEdit(container, copyResources) == false) {
+				if (!validateEdit(container, copyResources)) {
 					return;
 				}
 			}

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/RenameResourceAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/RenameResourceAction.java
@@ -524,7 +524,7 @@ public class RenameResourceAction extends WorkspaceAction {
 	 *            the resource to move.
 	 */
 	private void saveChangesAndDispose(IResource resource) {
-		if (saving == true) {
+		if (saving) {
 			return;
 		}
 

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/NewFolderDialog.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/NewFolderDialog.java
@@ -143,7 +143,7 @@ public class NewFolderDialog extends SelectionStatusDialog {
 	protected void createAdvancedControls(Composite parent) {
 		Preferences preferences = ResourcesPlugin.getPlugin().getPluginPreferences();
 
-		if (preferences.getBoolean(ResourcesPlugin.PREF_DISABLE_LINKING) == false && isValidContainer()) {
+		if (!preferences.getBoolean(ResourcesPlugin.PREF_DISABLE_LINKING) && isValidContainer()) {
 			linkedResourceParent = new Composite(parent, SWT.NONE);
 			linkedResourceParent.setFont(parent.getFont());
 			linkedResourceParent.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
@@ -331,7 +331,7 @@ public class NewFolderDialog extends SelectionStatusDialog {
 
 			for (String natureId : natureIds) {
 				IProjectNatureDescriptor descriptor = workspace.getNatureDescriptor(natureId);
-				if (descriptor != null && descriptor.isLinkingAllowed() == false) {
+				if (descriptor != null && !descriptor.isLinkingAllowed()) {
 					return false;
 				}
 			}
@@ -385,7 +385,7 @@ public class NewFolderDialog extends SelectionStatusDialog {
 				getOkButton().setEnabled(false);
 			}
 
-			if (status.isOK() == false) {
+			if (!status.isOK()) {
 				updateStatus(status);
 			}
 		} else {
@@ -408,7 +408,7 @@ public class NewFolderDialog extends SelectionStatusDialog {
 			updateStatus(IStatus.ERROR, IDEWorkbenchMessages.NewFolderDialog_folderNameEmpty);
 			return false;
 		}
-		if (nameStatus.isOK() == false) {
+		if (!nameStatus.isOK()) {
 			updateStatus(nameStatus);
 			return false;
 		}

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/WizardNewFileCreationPage.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/WizardNewFileCreationPage.java
@@ -164,7 +164,7 @@ public class WizardNewFileCreationPage extends WizardPage implements Listener {
 	protected void createAdvancedControls(Composite parent) {
 		Preferences preferences = ResourcesPlugin.getPlugin().getPluginPreferences();
 
-		if (preferences.getBoolean(ResourcesPlugin.PREF_DISABLE_LINKING) == false) {
+		if (!preferences.getBoolean(ResourcesPlugin.PREF_DISABLE_LINKING)) {
 			linkedResourceParent = new Composite(parent, SWT.NONE);
 			linkedResourceParent.setFont(parent.getFont());
 			linkedResourceParent.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/WizardNewFolderMainPage.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/WizardNewFolderMainPage.java
@@ -158,7 +158,7 @@ public class WizardNewFolderMainPage extends WizardPage implements Listener {
 	protected void createAdvancedControls(Composite parent) {
 		Preferences preferences = ResourcesPlugin.getPlugin().getPluginPreferences();
 
-		if (preferences.getBoolean(ResourcesPlugin.PREF_DISABLE_LINKING) == false) {
+		if (!preferences.getBoolean(ResourcesPlugin.PREF_DISABLE_LINKING)) {
 			advancedComposite = new Composite(parent, SWT.NONE);
 			advancedComposite.setFont(parent.getFont());
 			advancedComposite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/WizardNewLinkPage.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/WizardNewLinkPage.java
@@ -194,7 +194,7 @@ public class WizardNewLinkPage extends WizardPage {
 	 *         not to create a link.
 	 */
 	public String getLinkTarget() {
-		if (createLink && linkTargetField != null && linkTargetField.isDisposed() == false) {
+		if (createLink && linkTargetField != null && !linkTargetField.isDisposed()) {
 			return linkTargetField.getText();
 		}
 		return null;
@@ -278,7 +278,7 @@ public class WizardNewLinkPage extends WizardPage {
 	 */
 	public void setLinkTarget(String target) {
 		initialLinkTarget = target;
-		if (linkTargetField != null && linkTargetField.isDisposed() == false) {
+		if (linkTargetField != null && !linkTargetField.isDisposed()) {
 			linkTargetField.setText(target);
 		}
 	}
@@ -319,7 +319,7 @@ public class WizardNewLinkPage extends WizardPage {
 			valid = false;
 		} else {
 			IPath path = IPath.fromOSString("");//$NON-NLS-1$
-			if (path.isValidPath(linkTargetName) == false) {
+			if (!path.isValidPath(linkTargetName)) {
 				setErrorMessage(IDEWorkbenchMessages.WizardNewLinkPage_linkTargetInvalid);
 				valid = false;
 			}
@@ -349,7 +349,7 @@ public class WizardNewLinkPage extends WizardPage {
 				} else {
 					IStatus locationStatus = workspace.validateLinkLocation(container, IPath.fromOSString(linkTargetName));
 
-					if (locationStatus.isOK() == false) {
+					if (!locationStatus.isOK()) {
 						setErrorMessage(IDEWorkbenchMessages.WizardNewLinkPage_linkTargetLocationInvalid);
 						valid = false;
 					} else {

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/ide/undo/WorkspaceUndoUtil.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/ide/undo/WorkspaceUndoUtil.java
@@ -353,8 +353,7 @@ public class WorkspaceUndoUtil {
 							iterationProgress.split(1),
 							uiInfo, false);
 					iterationProgress.setWorkRemaining(100);
-					if ((createLinks || createVirtual) && (source.isLinked() == false)
-							&& (source.isVirtual() == false)) {
+					if ((createLinks || createVirtual) && !source.isLinked() && !source.isVirtual()) {
 						IFolder folder = workspaceRoot.getFolder(destinationPath);
 						if (createVirtual) {
 							folder.create(IResource.VIRTUAL, true, iterationProgress.split(1));
@@ -377,8 +376,7 @@ public class WorkspaceUndoUtil {
 			} else {
 				if (existing != null) {
 					// source is a FILE and destination EXISTS
-					if ((createLinks || createVirtual)
-							&& (source.isLinked() == false)) {
+					if ((createLinks || createVirtual) && !source.isLinked()) {
 						// we create a linked file, and overwrite the
 						// destination
 						IResourceSnapshot<? extends IResource>[] deleted = delete(
@@ -440,8 +438,7 @@ public class WorkspaceUndoUtil {
 						parentPath = destination.removeLastSegments(1);
 					}
 					IContainer generatedParent = generateContainers(parentPath);
-					if ((createLinks || createVirtual)
-							&& (source.isLinked() == false)) {
+					if ((createLinks || createVirtual) && !source.isLinked()) {
 						if (source.getType() == IResource.FILE) {
 							IFile file = workspaceRoot.getFile(destinationPath);
 							file.createLink(createRelativePath(

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/LinkedResourceDecorator.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/LinkedResourceDecorator.java
@@ -94,7 +94,7 @@ public class LinkedResourceDecorator implements ILightweightLabelDecorator {
 	@Override
 	public void decorate(Object element, IDecoration decoration) {
 
-		if (element instanceof IResource == false) {
+		if (!(element instanceof IResource)) {
 			return;
 		}
 		IResource resource = (IResource) element;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ResourceFilterDecorator.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ResourceFilterDecorator.java
@@ -39,7 +39,7 @@ public class ResourceFilterDecorator implements ILightweightLabelDecorator {
 	@Override
 	public void decorate(Object element, IDecoration decoration) {
 
-		if (element instanceof IContainer == false) {
+		if (!(element instanceof IContainer)) {
 			return;
 		}
 		IContainer container = (IContainer) element;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/CreateLinkedResourceGroup.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/CreateLinkedResourceGroup.java
@@ -407,7 +407,7 @@ public class CreateLinkedResourceGroup {
 	 * Disposes the group's widgets.
 	 */
 	public void dispose() {
-		if (groupComposite != null && groupComposite.isDisposed() == false) {
+		if (groupComposite != null && !groupComposite.isDisposed()) {
 			groupComposite.dispose();
 		}
 	}
@@ -654,7 +654,7 @@ public class CreateLinkedResourceGroup {
 	 */
 	public void setLinkTarget(String target) {
 		linkTarget = target;
-		if (linkTargetField != null && linkTargetField.isDisposed() == false) {
+		if (linkTargetField != null && !linkTargetField.isDisposed()) {
 			linkTargetField.setText(target);
 		}
 	}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/FileFolderSelectionDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/FileFolderSelectionDialog.java
@@ -87,7 +87,7 @@ public class FileFolderSelectionDialog extends ElementTreeSelectionDialog {
 		 */
 		public FileContentProvider(final boolean showFiles) {
 			fileFilter = file -> {
-				if (!file.fetchInfo().isDirectory() && showFiles == false) {
+				if (!file.fetchInfo().isDirectory() && !showFiles) {
 					return false;
 				}
 				return true;
@@ -177,15 +177,14 @@ public class FileFolderSelectionDialog extends ElementTreeSelectionDialog {
 			int nSelected = selection.length;
 			String pluginId = IDEWorkbenchPlugin.IDE_WORKBENCH;
 
-			if (nSelected == 0 || (nSelected > 1 && multiSelect == false)) {
+			if (nSelected == 0 || (nSelected > 1 && !multiSelect)) {
 				return new Status(IStatus.ERROR, pluginId, IStatus.ERROR,
 						IDEResourceInfoUtils.EMPTY_STRING, null);
 			}
 			for (Object currentSelection : selection) {
 				if (currentSelection instanceof IFileStore) {
 					IFileStore file = (IFileStore) currentSelection;
-					if (acceptFolders == false
-							&& file.fetchInfo().isDirectory()) {
+					if (!acceptFolders && file.fetchInfo().isDirectory()) {
 						return new Status(IStatus.ERROR, pluginId,
 								IStatus.ERROR,
 								IDEResourceInfoUtils.EMPTY_STRING, null);

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/PathVariableDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/PathVariableDialog.java
@@ -581,7 +581,7 @@ public class PathVariableDialog extends TitleAreaDialog {
 		}
 		// only set the message here if it is not going to be set in
 		// validateVariableValue to avoid flashing.
-		if (allowFinish == false) {
+		if (!allowFinish) {
 			setMessage(validationMessage, validationStatus);
 		}
 		return allowFinish;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/PathVariablesGroup.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/PathVariablesGroup.java
@@ -599,7 +599,7 @@ public class PathVariablesGroup {
 					if (value != null) {
 						boolean isFile = value.toFile().isFile();
 						if ((isFile && (variableType & IResource.FILE) != 0)
-								|| (isFile == false && (variableType & IResource.FOLDER) != 0)) {
+								|| (!isFile && (variableType & IResource.FOLDER) != 0)) {
 
 							tempPathVariables.put(varName, value);
 						}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ResourceWorkingSetPage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/ResourceWorkingSetPage.java
@@ -172,7 +172,7 @@ public class ResourceWorkingSetPage extends WizardPage implements IWorkingSetPag
 			@Override
 			public void treeExpanded(TreeExpansionEvent event) {
 				final Object element = event.getElement();
-				if (tree.getGrayed(element) == false) {
+				if (!tree.getGrayed(element)) {
 					BusyIndicator.showWhile(getShell().getDisplay(),
 							() -> setSubtreeChecked((IContainer) element, tree.getChecked(element), false));
 				}
@@ -369,9 +369,9 @@ public class ResourceWorkingSetPage extends WizardPage implements IWorkingSetPag
 					setSubtreeChecked(container, true, true);
 				}
 				IResource resource = Adapters.adapt(item, IResource.class);
-				if (resource != null && resource.isAccessible() == false) {
+				if (resource != null && !resource.isAccessible()) {
 					IProject project = resource.getProject();
-					if (tree.getChecked(project) == false) {
+					if (!tree.getChecked(project)) {
 						tree.setGrayChecked(project, true);
 					}
 				} else {
@@ -413,8 +413,7 @@ public class ResourceWorkingSetPage extends WizardPage implements IWorkingSetPag
 	 */
 	private void setSubtreeChecked(IContainer container, boolean state, boolean checkExpandedState) {
 		// checked state is set lazily on expand, don't set it if container is collapsed
-		if (container.isAccessible() == false
-				|| (tree.getExpandedState(container) == false && state && checkExpandedState)) {
+		if (!container.isAccessible() || (!tree.getExpandedState(container) && state && checkExpandedState)) {
 			return;
 		}
 		IResource[] members = null;
@@ -480,7 +479,7 @@ public class ResourceWorkingSetPage extends WizardPage implements IWorkingSetPag
 		String infoMessage = null;
 		String newText = text.getText();
 
-		if (newText.equals(newText.trim()) == false) {
+		if (!newText.equals(newText.trim())) {
 			errorMessage = IDEWorkbenchMessages.ResourceWorkingSetPage_warning_nameWhitespace;
 		}
 		if (newText.isEmpty()) {
@@ -492,7 +491,7 @@ public class ResourceWorkingSetPage extends WizardPage implements IWorkingSetPag
 			errorMessage = IDEWorkbenchMessages.ResourceWorkingSetPage_warning_nameMustNotBeEmpty;
 		}
 		firstCheck = false;
-		if (errorMessage == null && (workingSet == null || newText.equals(workingSet.getName()) == false)) {
+		if (errorMessage == null && (workingSet == null || !newText.equals(workingSet.getName()))) {
 			for (IWorkingSet set : PlatformUI.getWorkbench().getWorkingSetManager().getWorkingSets()) {
 				if (newText.equals(set.getName())) {
 					errorMessage = IDEWorkbenchMessages.ResourceWorkingSetPage_warning_workingSetExists;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/misc/FileInfoAttributesMatcher.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/misc/FileInfoAttributesMatcher.java
@@ -194,8 +194,8 @@ public class FileInfoAttributesMatcher extends AbstractFileInfoMatcher {
 			argument = decodeArguments(arguments);
 			type = getTypeForKey(argument.key, argument.operator);
 			if (type.equals(String.class)) {
-				if (argument.regularExpression == false)
-					stringMatcher = new StringMatcher(argument.pattern, argument.caseSensitive == false, false);
+				if (!argument.regularExpression)
+					stringMatcher = new StringMatcher(argument.pattern, !argument.caseSensitive, false);
 				else
 					regExPattern = Pattern.compile(argument.pattern, argument.caseSensitive ? 0:Pattern.CASE_INSENSITIVE);
 			}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/misc/ResourceAndContainerGroup.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/misc/ResourceAndContainerGroup.java
@@ -338,7 +338,7 @@ public class ResourceAndContainerGroup implements Listener {
 		String resource = resourceNameField.getText();
 		if ((resourceExtension != null) && (resourceExtension.length() > 0)
 				&& (resource.length() > 0)
-				&& (resource.endsWith('.' + resourceExtension) == false)) {
+				&& !resource.endsWith('.' + resourceExtension)) {
 			return true;
 		}
 		return false;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/QuickFixPage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/QuickFixPage.java
@@ -347,7 +347,7 @@ public class QuickFixPage extends WizardPage {
 		});
 
 		markersTable.addCheckStateListener(event -> {
-			if (event.getChecked() == true) {
+			if (event.getChecked()) {
 				setPageComplete(true);
 			} else {
 				setPageComplete(markersTable.getCheckedElements().length > 0);

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ScopeArea.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ScopeArea.java
@@ -104,7 +104,7 @@ public class ScopeArea extends GroupFilterConfigurationArea {
 						} else {
 							setWorkingSet(null);
 						}
-						if (getSelection() == false) {
+						if (!getSelection()) {
 							setSelection(true);
 						}
 					}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/WizardFileSystemResourceImportPage1.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/WizardFileSystemResourceImportPage1.java
@@ -852,7 +852,7 @@ public class WizardFileSystemResourceImportPage1 extends WizardResourceImportPag
 		boolean shouldImportTopLevelFoldersRecursively = selectionGroup.isEveryItemChecked() &&
 													!createTopLevelFolderCheckbox.getSelection() &&
 													(createLinksInWorkspaceButton != null && createLinksInWorkspaceButton.getSelection()) &&
-													(createVirtualFoldersButton != null && createVirtualFoldersButton.getSelection() == false);
+													(createVirtualFoldersButton != null && !createVirtualFoldersButton.getSelection());
 
 		File sourceDirectory = getSourceDirectory();
 		if (createTopLevelFolderCheckbox.getSelection() && sourceDirectory.getParentFile() != null)
@@ -1258,7 +1258,7 @@ public class WizardFileSystemResourceImportPage1 extends WizardResourceImportPag
 				setErrorMessage(DataTransferMessages.FileImport_cannotImportFilesUnderAVirtualFolder);
 				return false;
 			}
-			if (createLinksInWorkspaceButton == null || createLinksInWorkspaceButton.getSelection() == false) {
+			if (createLinksInWorkspaceButton == null || !createLinksInWorkspaceButton.getSelection()) {
 				setMessage(null);
 				setErrorMessage(DataTransferMessages.FileImport_haveToCreateLinksUnderAVirtualFolder);
 				return false;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/datatransfer/ImportOperation.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/wizards/datatransfer/ImportOperation.java
@@ -462,7 +462,7 @@ public class ImportOperation extends WorkspaceModifyOperation {
 
 		IStatus[] status = multiStatus.getChildren();
 		for (int i = 0; i < status.length; i++) {
-			if (status[i].isOK() == false) {
+			if (!status[i].isOK()) {
 				errorTable.add(status[i]);
 				filteredFiles.add(files[i].getFullPath());
 			}

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/GotoResourceAction.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/GotoResourceAction.java
@@ -51,7 +51,7 @@ public class GotoResourceAction extends Action {
 		dialog.open();
 		Object[] result = dialog.getResult();
 		if (result == null || result.length == 0
-				|| result[0] instanceof IResource == false) {
+				|| !(result[0] instanceof IResource)) {
 			return;
 		}
 

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/PasteAction.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/PasteAction.java
@@ -194,8 +194,7 @@ import org.eclipse.ui.part.ResourceTransfer;
 			for (IResource resource : resourceData) {
 				// make sure all resource data are open projects
 				// can paste open projects regardless of selection
-				if (resource.getType() != IResource.PROJECT
-						|| ((IProject) resource).isOpen() == false) {
+				if (resource.getType() != IResource.PROJECT || !((IProject) resource).isOpen()) {
 					return false;
 				}
 			}

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/NavigatorSiteEditor.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/NavigatorSiteEditor.java
@@ -210,7 +210,7 @@ public class NavigatorSiteEditor implements INavigatorSiteEditor {
 		// text widget to lose focus and trigger this method).
 		Runnable editRunnable = () -> {
 			disposeTextWidget();
-			if (newText.length() > 0 && newText.equals(text) == false) {
+			if (newText.length() > 0 && !newText.equals(text)) {
 				text = newText;
 				runnable.run();
 			}

--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/ImportLogAction.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/ImportLogAction.java
@@ -133,7 +133,7 @@ public class ImportLogAction extends Action implements IMenuCreator {
 			}
 		}
 
-		if (result == true) {
+		if (result) {
 			actions = currActions;
 
 			if (toolbarMenu != null) {

--- a/bundles/org.eclipse.ui.views.properties.tabbed/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views.properties.tabbed/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.views.properties.tabbed;singleton:=true
-Bundle-Version: 3.10.200.qualifier
+Bundle-Version: 3.10.300.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.internal.views.properties.tabbed;x-internal:=true,

--- a/bundles/org.eclipse.ui.views.properties.tabbed/src/org/eclipse/ui/internal/views/properties/tabbed/view/TabbedPropertyRegistryClassSectionFilter.java
+++ b/bundles/org.eclipse.ui.views.properties.tabbed/src/org/eclipse/ui/internal/views/properties/tabbed/view/TabbedPropertyRegistryClassSectionFilter.java
@@ -62,7 +62,7 @@ public class TabbedPropertyRegistryClassSectionFilter {
 			ISelection selection) {
 
 		if (selection instanceof IStructuredSelection &&
-				selection.isEmpty() == false) {
+				!selection.isEmpty()) {
 
 			if (descriptor.getEnablesFor() != ISectionDescriptor.ENABLES_FOR_ANY &&
 					((IStructuredSelection) selection).size() != descriptor
@@ -79,7 +79,7 @@ public class TabbedPropertyRegistryClassSectionFilter {
 			if (filter != null) {
 				for (Object object : (IStructuredSelection) selection) {
 
-					if (filter.select(object) == false) {
+					if (!filter.select(object)) {
 						/**
 						 * filter fails so section does not apply to the
 						 * selection, do not display section.
@@ -105,7 +105,7 @@ public class TabbedPropertyRegistryClassSectionFilter {
 				if (effectiveTypes.add(remapType)) {
 
 					// the effective types of the selection
-					if (appliesToEffectiveType(descriptor, remapType) == false) {
+					if (!appliesToEffectiveType(descriptor, remapType)) {
 						return false;
 					}
 				}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/SelectionEnabler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/SelectionEnabler.java
@@ -255,7 +255,7 @@ public final class SelectionEnabler {
 		Object obj = sel;
 		int count = sel.isEmpty() ? 0 : 1;
 
-		if (verifySelectionCount(count) == false) {
+		if (!verifySelectionCount(count)) {
 			return false;
 		}
 
@@ -270,7 +270,7 @@ public final class SelectionEnabler {
 		}
 		if (obj instanceof IAdaptable) {
 			IAdaptable element = (IAdaptable) obj;
-			if (verifyElement(element) == false) {
+			if (!verifyElement(element)) {
 				return false;
 			}
 		} else {
@@ -285,7 +285,7 @@ public final class SelectionEnabler {
 	 * registry for this action.
 	 */
 	private boolean isEnabledFor(ISelection sel, int count) {
-		if (verifySelectionCount(count) == false) {
+		if (!verifySelectionCount(count)) {
 			return false;
 		}
 
@@ -313,7 +313,7 @@ public final class SelectionEnabler {
 	private boolean isEnabledFor(IStructuredSelection ssel) {
 		int count = ssel.size();
 
-		if (verifySelectionCount(count) == false) {
+		if (!verifySelectionCount(count)) {
 			return false;
 		}
 
@@ -329,7 +329,7 @@ public final class SelectionEnabler {
 		for (Object obj : ssel) {
 			if (obj instanceof IAdaptable) {
 				IAdaptable element = (IAdaptable) obj;
-				if (verifyElement(element) == false) {
+				if (!verifyElement(element)) {
 					return false;
 				}
 			} else {
@@ -475,7 +475,7 @@ public final class SelectionEnabler {
 					break;
 				}
 			}
-			if (match == true) {
+			if (match) {
 				break;
 			}
 			// get the superclass
@@ -493,7 +493,7 @@ public final class SelectionEnabler {
 			return true;
 		}
 		for (SelectionClass sc : classes) {
-			if (verifyClass(element, sc.className) == false) {
+			if (!verifyClass(element, sc.className)) {
 				continue;
 			}
 			if (sc.nameFilter == null) {

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/AbstractWorkingSetManager.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/AbstractWorkingSetManager.java
@@ -515,7 +515,7 @@ public abstract class AbstractWorkingSetManager extends EventManager
 			WorkbenchPlugin.log("Unable to restore working set - cannot instantiate working set: " + factoryID); //$NON-NLS-1$
 			return null;
 		}
-		if ((adaptable[0] instanceof IWorkingSet) == false) {
+		if (!(adaptable[0] instanceof IWorkingSet)) {
 			WorkbenchPlugin.log("Unable to restore working set - element is not an IWorkingSet: " + factoryID); //$NON-NLS-1$
 			return null;
 		}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/ActivityPersistanceHelper.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/ActivityPersistanceHelper.java
@@ -77,11 +77,11 @@ final class ActivityPersistanceHelper {
 			// if we're turning an activity off we'll need to create its dependency tree to
 			// ensuure that all dependencies are also disabled.
 			Set<String> set = new HashSet<>(activityManager.getEnabledActivityIds());
-			if (enabled == false) {
+			if (enabled) {
+				set.add(activityId);
+			} else {
 				Set<String> dependencies = buildDependencies(activityManager, activityId);
 				set.removeAll(dependencies);
-			} else {
-				set.add(activityId);
 			}
 			support.setEnabledActivityIds(set);
 		}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/EditorHistoryItem.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/EditorHistoryItem.java
@@ -174,7 +174,7 @@ public class EditorHistoryItem {
 			return result;
 		}
 		IAdaptable adaptable = factory.createElement(persistableMemento);
-		if (adaptable == null || (adaptable instanceof IEditorInput) == false) {
+		if (adaptable == null || !(adaptable instanceof IEditorInput)) {
 			return result;
 		}
 		input = (IEditorInput) adaptable;

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/ObjectContributorManager.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/ObjectContributorManager.java
@@ -277,7 +277,7 @@ public abstract class ObjectContributorManager implements IExtensionChangeHandle
 	 */
 	public boolean isApplicableTo(IStructuredSelection selection, IObjectContributor contributor) {
 		for (Object element : selection) {
-			if (contributor.isApplicableTo(element) == false) {
+			if (!contributor.isApplicableTo(element)) {
 				return false;
 			}
 		}
@@ -295,7 +295,7 @@ public abstract class ObjectContributorManager implements IExtensionChangeHandle
 
 	public boolean isApplicableTo(List list, IObjectContributor contributor) {
 		for (Object element : list) {
-			if (contributor.isApplicableTo(element) == false) {
+			if (!contributor.isApplicableTo(element)) {
 				return false;
 			}
 		}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/WorkingSetSelectionDialog.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/WorkingSetSelectionDialog.java
@@ -370,7 +370,7 @@ public class WorkingSetSelectionDialog extends AbstractWorkingSetDialog {
 		for (IWorkingSet editedWorkingSet : getEditedWorkingSets().keySet()) {
 			IWorkingSet originalWorkingSet = getEditedWorkingSets().get(editedWorkingSet);
 
-			if (editedWorkingSet.getName().equals(originalWorkingSet.getName()) == false) {
+			if (!editedWorkingSet.getName().equals(originalWorkingSet.getName())) {
 				editedWorkingSet.setName(originalWorkingSet.getName());
 			}
 			if (!Arrays.equals(editedWorkingSet.getElements(), originalWorkingSet.getElements())) {

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/WorkingSetTypePage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/WorkingSetTypePage.java
@@ -180,7 +180,7 @@ public class WorkingSetTypePage extends WizardPage {
 	 */
 	private void handleSelectionChanged() {
 		IStructuredSelection selection = typesListViewer.getStructuredSelection();
-		boolean hasSelection = selection != null && selection.isEmpty() == false;
+		boolean hasSelection = selection != null && !selection.isEmpty();
 
 		WorkingSetDescriptor descriptor = getSelectedWorkingSet();
 		setDescription(descriptor == null ? "" : descriptor.getDescription()); //$NON-NLS-1$

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/keys/KeysPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/keys/KeysPreferencePage.java
@@ -1434,7 +1434,7 @@ public final class KeysPreferencePage extends PreferencePage implements IWorkben
 	 */
 	@Override
 	public void setVisible(final boolean visible) {
-		if (visible == true) {
+		if (visible) {
 			Map<String, Set<Context>> contextsByName = new HashMap<>();
 
 			for (Iterator<String> iterator = contextService.getDefinedContextIds().iterator(); iterator.hasNext();) {

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/keys/NewKeysPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/keys/NewKeysPreferencePage.java
@@ -418,12 +418,12 @@ public class NewKeysPreferencePage extends PreferencePage implements IWorkbenchP
 
 	private static String getBindingUserText(BindingElement bindingElement) {
 		if (bindingElement.getUserDelta().intValue() == Binding.USER) {
-			if (bindingElement.getConflict().equals(Boolean.TRUE)) {
+			if (bindingElement.getConflict()) {
 				return "CU"; //$NON-NLS-1$
 			}
 			return " U"; //$NON-NLS-1$
 		}
-		if (bindingElement.getConflict().equals(Boolean.TRUE)) {
+		if (bindingElement.getConflict()) {
 			return "C "; //$NON-NLS-1$
 		}
 		return " "; //$NON-NLS-1$

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/keys/model/ContextModel.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/keys/model/ContextModel.java
@@ -102,7 +102,7 @@ public class ContextModel extends CommonModel {
 		// Remove undesired contexts
 		for (ContextElement contextElement : contexts) {
 			boolean removeContext = false;
-			if (actionSets == true && contextElement.getId().equalsIgnoreCase(CONTEXT_ID_ACTION_SETS)) {
+			if (actionSets && contextElement.getId().equalsIgnoreCase(CONTEXT_ID_ACTION_SETS)) {
 				removeContext = true;
 			} else {
 				String parentId;
@@ -119,7 +119,7 @@ public class ContextModel extends CommonModel {
 				}
 			}
 
-			if (internal == true && contextElement.getId().contains(CONTEXT_ID_INTERNAL)) {
+			if (internal && contextElement.getId().contains(CONTEXT_ID_INTERNAL)) {
 				removeContext = true;
 			}
 
@@ -138,7 +138,7 @@ public class ContextModel extends CommonModel {
 			ContextElement contextElement = contextIdToFilteredContexts.get(iterator.next());
 
 			try {
-				if (actionSets == false) {
+				if (!actionSets) {
 					if (contextElement.getId().equalsIgnoreCase(CONTEXT_ID_ACTION_SETS)) {
 						restoreContext = true;
 					} else {
@@ -151,7 +151,7 @@ public class ContextModel extends CommonModel {
 			} catch (NotDefinedException e) {
 				// No parentId to check
 			}
-			if (internal == false && contextElement.getId().contains(CONTEXT_ID_INTERNAL)) {
+			if (!internal && contextElement.getId().contains(CONTEXT_ID_INTERNAL)) {
 				restoreContext = true;
 			}
 

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/registry/PreferencePageRegistryReader.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/registry/PreferencePageRegistryReader.java
@@ -148,7 +148,7 @@ public class PreferencePageRegistryReader extends CategorizedPageRegistryReader 
 	 */
 	@Override
 	protected boolean readElement(IConfigurationElement element) {
-		if (element.getName().equals(TAG_PAGE) == false) {
+		if (!element.getName().equals(TAG_PAGE)) {
 			return false;
 		}
 		WorkbenchPreferenceNode node = createNode(element);

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/statushandlers/WorkbenchStatusDialogManagerImpl.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/statushandlers/WorkbenchStatusDialogManagerImpl.java
@@ -181,7 +181,7 @@ public class WorkbenchStatusDialogManagerImpl implements KeptJobsListener {
 	 * @param statusAdapter the status adapter
 	 */
 	public void addStatusAdapter(final StatusAdapter statusAdapter, final boolean modal) {
-		if (ErrorDialog.AUTOMATED_MODE == true) {
+		if (ErrorDialog.AUTOMATED_MODE) {
 			return;
 		}
 		try {

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/util/Util.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/util/Util.java
@@ -80,7 +80,7 @@ public final class Util {
 	}
 
 	public static int compare(boolean left, boolean right) {
-		return left == false ? (right == true ? -1 : 0) : 1;
+		return !left ? (right ? -1 : 0) : 1;
 	}
 
 	public static int compare(Comparable left, Comparable right) {

--- a/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/internal/registration/DesktopFileWriter.java
+++ b/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/internal/registration/DesktopFileWriter.java
@@ -223,7 +223,7 @@ public class DesktopFileWriter {
 	private void assertDesktopEntryPresent(Map<String, String> props) {
 		Iterator<Entry<String, String>> iterator = props.entrySet().iterator();
 		String firstLine = iterator.next().getKey();
-		if ("[Desktop Entry]".equals(firstLine) == false) { //$NON-NLS-1$
+		if (!"[Desktop Entry]".equals(firstLine)) { //$NON-NLS-1$
 			throw new IllegalStateException("File seems not to be a 'desktop' file"); //$NON-NLS-1$
 		}
 	}

--- a/examples/org.eclipse.jface.examples.databinding/src/org/eclipse/jface/examples/databinding/radioGroup/RadioGroup.java
+++ b/examples/org.eclipse.jface.examples.databinding/src/org/eclipse/jface/examples/databinding/radioGroup/RadioGroup.java
@@ -413,7 +413,7 @@ public class RadioGroup {
 	 */
 	public int getSelectionIndex () {
 		for (int i = 0; i < buttons.length; i++) {
-			if (buttons[i].getSelection() == true) {
+			if (buttons[i].getSelection()) {
 				return i;
 			}
 		}

--- a/examples/org.eclipse.ui.examples.propertysheet/Eclipse UI Examples PropertySheet/org/eclipse/ui/examples/propertysheet/UserElement.java
+++ b/examples/org.eclipse.ui.examples.propertysheet/Eclipse UI Examples PropertySheet/org/eclipse/ui/examples/propertysheet/UserElement.java
@@ -383,7 +383,7 @@ public class UserElement extends OrganizationElement {
 		if (propKey.equals(P_ID_EMAIL))
 			return getEmailAddress();
 		if (propKey.equals(P_ID_COOP))
-			return getCoop().equals(Boolean.TRUE) ? P_VALUE_TRUE
+			return getCoop() ? P_VALUE_TRUE
 					: P_VALUE_FALSE;
 		if (propKey.equals(P_ID_BDAY))
 			return getBirthday();

--- a/examples/org.eclipse.ui.examples.propertysheet/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.propertysheet/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.examples.propertysheet; singleton:=true
-Bundle-Version: 3.5.300.qualifier
+Bundle-Version: 3.5.400.qualifier
 Bundle-Activator: org.eclipse.ui.examples.propertysheet.PropertySheetPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/examples/org.eclipse.ui.examples.readmetool/Eclipse UI Examples Readme Tool/org/eclipse/ui/examples/readmetool/ReadmeModelFactory.java
+++ b/examples/org.eclipse.ui.examples.readmetool/Eclipse UI Examples Readme Tool/org/eclipse/ui/examples/readmetool/ReadmeModelFactory.java
@@ -119,7 +119,7 @@ public class ReadmeModelFactory {
 	 * @return an element collection representing the table of contents
 	 */
 	private MarkElement[] getToc(IFile file) {
-		if (registryLoaded == false)
+		if (!registryLoaded)
 			loadParser();
 		return parser.parse(file);
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IDeprecatedWorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IDeprecatedWorkbenchPageTest.java
@@ -72,10 +72,10 @@ public class IDeprecatedWorkbenchPageTest extends UITestCase {
 	@Test
 	public void testGet_SetEditorAreaVisible() throws Throwable {
 		fActivePage.setEditorAreaVisible(true);
-		assertTrue(fActivePage.isEditorAreaVisible() == true);
+		assertTrue(fActivePage.isEditorAreaVisible());
 
 		fActivePage.setEditorAreaVisible(false);
-		assertTrue(fActivePage.isEditorAreaVisible() == false);
+		assertFalse(fActivePage.isEditorAreaVisible());
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IFileEditorMappingTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IFileEditorMappingTest.java
@@ -65,7 +65,7 @@ public class IFileEditorMappingTest {
 
 		for (IFileEditorMapping fMapping : fMappings) {
 			editors = fMapping.getEditors();
-			assertTrue(ArrayUtil.checkNotNull(editors) == true);
+			assertTrue(ArrayUtil.checkNotNull(editors));
 		}
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPageTest.java
@@ -499,10 +499,10 @@ public class IWorkbenchPageTest extends UITestCase {
 	@Test
 	public void testGet_SetEditorAreaVisible() throws Throwable {
 		fActivePage.setEditorAreaVisible(true);
-		assertTrue(fActivePage.isEditorAreaVisible() == true);
+		assertTrue(fActivePage.isEditorAreaVisible());
 
 		fActivePage.setEditorAreaVisible(false);
-		assertTrue(fActivePage.isEditorAreaVisible() == false);
+		assertFalse(fActivePage.isEditorAreaVisible());
 	}
 
 	/**


### PR DESCRIPTION
Applies the cleanup rule to use boolean values in conditions directly instead of comparing them against true or false to all project in order to be conform with defined save actions.