### PR TITLE
Use diamond operator wherever applicable

### DIFF
--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/DecoratingObservableCollection.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/DecoratingObservableCollection.java
@@ -81,7 +81,7 @@ public class DecoratingObservableCollection<E> extends DecoratingObservable impl
 	public Iterator<E> iterator() {
 		getterCalled();
 		final Iterator<E> decoratedIterator = decorated.iterator();
-		return new Iterator<E>() {
+		return new Iterator<>() {
 			@Override
 			public void remove() {
 				decoratedIterator.remove();

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/Diffs.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/Diffs.java
@@ -249,7 +249,7 @@ public class Diffs {
 	 */
 	public static <E> ListDiff<E> computeLazyListDiff(final List<? extends E> oldList,
 			final List<? extends E> newList) {
-		return new ListDiff<E>() {
+		return new ListDiff<>() {
 			ListDiff<E> lazyDiff;
 
 			@Override
@@ -401,7 +401,7 @@ public class Diffs {
 	 * @since 1.3
 	 */
 	public static <E> SetDiff<E> computeLazySetDiff(final Set<? extends E> oldSet, final Set<? extends E> newSet) {
-		return new SetDiff<E>() {
+		return new SetDiff<>() {
 
 			private SetDiff<E> lazyDiff;
 
@@ -468,7 +468,7 @@ public class Diffs {
 		for (K newKey : addedKeys) {
 			newValues.put(newKey, newMap.get(newKey));
 		}
-		return new MapDiff<K, V>() {
+		return new MapDiff<>() {
 			@Override
 			public Set<K> getAddedKeys() {
 				return addedKeys;
@@ -514,7 +514,7 @@ public class Diffs {
 	 */
 	public static <K, V> MapDiff<K, V> computeLazyMapDiff(final Map<? extends K, ? extends V> oldMap,
 			final Map<? extends K, ? extends V> newMap) {
-		return new MapDiff<K, V>() {
+		return new MapDiff<>() {
 
 			private MapDiff<K, V> lazyDiff;
 
@@ -562,7 +562,7 @@ public class Diffs {
 	 * @return a value diff
 	 */
 	public static <T> ValueDiff<T> createValueDiff(final T oldValue, final T newValue) {
-		return new ValueDiff<T>() {
+		return new ValueDiff<>() {
 
 			@Override
 			public T getOldValue() {
@@ -588,7 +588,7 @@ public class Diffs {
 				.unmodifiableSet(additions);
 		final Set<E> unmodifiableRemovals = Collections
 				.unmodifiableSet(removals);
-		return new SetDiff<E>() {
+		return new SetDiff<>() {
 
 			@Override
 			public Set<E> getAdditions() {
@@ -642,7 +642,7 @@ public class Diffs {
 	 */
 	@SafeVarargs
 	public static <E> ListDiff<E> createListDiff(final ListDiffEntry<E>... differences) {
-		return new ListDiff<E>() {
+		return new ListDiff<>() {
 			@Override
 			public ListDiffEntry<E>[] getDifferences() {
 				return differences;
@@ -662,7 +662,7 @@ public class Diffs {
 	 */
 	public static <E> ListDiff<E> createListDiff(final List<ListDiffEntry<E>> differences) {
 		final ListDiffEntry<E>[] differencesArray = differences.toArray(new ListDiffEntry[differences.size()]);
-		return new ListDiff<E>() {
+		return new ListDiff<>() {
 			@Override
 			public ListDiffEntry<E>[] getDifferences() {
 				return differencesArray;
@@ -680,7 +680,7 @@ public class Diffs {
 	 */
 	public static <E> ListDiffEntry<E> createListDiffEntry(final int position,
 			final boolean isAddition, final E element) {
-		return new ListDiffEntry<E>() {
+		return new ListDiffEntry<>() {
 
 			@Override
 			public int getPosition() {
@@ -710,7 +710,7 @@ public class Diffs {
 	 */
 	public static <K, V> MapDiff<K, V> createMapDiffSingleAdd(final K addedKey,
 			final V newValue) {
-		return new MapDiff<K, V>() {
+		return new MapDiff<>() {
 
 			@Override
 			public Set<K> getAddedKeys() {
@@ -749,7 +749,7 @@ public class Diffs {
 	 */
 	public static <K, V> MapDiff<K, V> createMapDiffSingleChange(
 			final K existingKey, final V oldValue, final V newValue) {
-		return new MapDiff<K, V>() {
+		return new MapDiff<>() {
 
 			@Override
 			public Set<K> getAddedKeys() {
@@ -787,7 +787,7 @@ public class Diffs {
 	 */
 	public static <K, V> MapDiff<K, V> createMapDiffSingleRemove(
 			final K removedKey, final V oldValue) {
-		return new MapDiff<K, V>() {
+		return new MapDiff<>() {
 
 			@Override
 			public Set<K> getAddedKeys() {
@@ -824,7 +824,7 @@ public class Diffs {
 	 */
 	public static <K, V> MapDiff<K, V> createMapDiffRemoveAll(
 			final Map<K, V> copyOfOldMap) {
-		return new MapDiff<K, V>() {
+		return new MapDiff<>() {
 
 			@Override
 			public Set<K> getAddedKeys() {
@@ -870,7 +870,7 @@ public class Diffs {
 		final Set<K> finalRemovedKeys = Collections.unmodifiableSet(removedKeys);
 		final Set<K> finalChangedKeys = Collections.unmodifiableSet(changedKeys);
 
-		return new MapDiff<K, V>() {
+		return new MapDiff<>() {
 			@Override
 			public Set<K> getAddedKeys() {
 				return finalAddedKeys;

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/Observables.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/Observables.java
@@ -461,7 +461,7 @@ public class Observables {
 	 */
 	public static <E> IObservableSet<E> staticObservableSet(Realm realm,
 			Set<E> set, Object elementType) {
-		return new ObservableSet<E>(realm, set, elementType) {
+		return new ObservableSet<>(realm, set, elementType) {
 			@Override
 			public synchronized void addChangeListener(IChangeListener listener) {
 			}
@@ -619,7 +619,7 @@ public class Observables {
 	 */
 	public static <E> IObservableList<E> staticObservableList(Realm realm,
 			List<E> list, Object elementType) {
-		return new ObservableList<E>(realm, list, elementType) {
+		return new ObservableList<>(realm, list, elementType) {
 			@Override
 			public synchronized void addChangeListener(IChangeListener listener) {
 			}

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/list/AbstractObservableList.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/list/AbstractObservableList.java
@@ -248,7 +248,7 @@ public abstract class AbstractObservableList<E> extends AbstractList<E>
 	public Iterator<E> iterator() {
 		getterCalled();
 		final Iterator<E> wrappedIterator = super.iterator();
-		return new Iterator<E>() {
+		return new Iterator<>() {
 			@Override
 			public void remove() {
 				wrappedIterator.remove();

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/list/ComputedList.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/list/ComputedList.java
@@ -104,7 +104,7 @@ public abstract class ComputedList<E> extends AbstractObservableList<E> {
 	 */
 	public static <E> IObservableList<E> create(Supplier<List<E>> supplier) {
 		Objects.requireNonNull(supplier);
-		return new ComputedList<E>() {
+		return new ComputedList<>() {
 			@Override
 			protected List<E> calculate() {
 				return supplier.get();

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/list/DecoratingObservableList.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/list/DecoratingObservableList.java
@@ -148,7 +148,7 @@ public class DecoratingObservableList<E> extends
 	public ListIterator<E> listIterator(int index) {
 		getterCalled();
 		final ListIterator<E> iterator = decorated.listIterator(index);
-		return new ListIterator<E>() {
+		return new ListIterator<>() {
 
 			@Override
 			public void add(E o) {

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/list/ObservableList.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/list/ObservableList.java
@@ -118,7 +118,7 @@ public abstract class ObservableList<E> extends AbstractObservable implements
 	public Iterator<E> iterator() {
 		getterCalled();
 		final Iterator<E> wrappedIterator = wrappedList.iterator();
-		return new Iterator<E>() {
+		return new Iterator<>() {
 
 			@Override
 			public void remove() {
@@ -205,7 +205,7 @@ public abstract class ObservableList<E> extends AbstractObservable implements
 	public ListIterator<E> listIterator(int index) {
 		getterCalled();
 		final ListIterator<E> wrappedIterator = wrappedList.listIterator(index);
-		return new ListIterator<E>() {
+		return new ListIterator<>() {
 
 			@Override
 			public int nextIndex() {
@@ -260,7 +260,7 @@ public abstract class ObservableList<E> extends AbstractObservable implements
 		if (fromIndex < 0 || fromIndex > toIndex || toIndex > size()) {
 			throw new IndexOutOfBoundsException();
 		}
-		return new AbstractObservableList<E>(getRealm()) {
+		return new AbstractObservableList<>(getRealm()) {
 
 			@Override
 			public Object getElementType() {

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/list/WritableList.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/list/WritableList.java
@@ -60,7 +60,7 @@ public class WritableList<E> extends ObservableList<E> {
 	 *            the observable's realm
 	 */
 	public WritableList(Realm realm) {
-		this(realm, new ArrayList<E>(), null);
+		this(realm, new ArrayList<>(), null);
 	}
 
 	/**

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/map/CompositeMap.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/map/CompositeMap.java
@@ -286,7 +286,7 @@ public class CompositeMap<K, I, V> extends ObservableMap<K, V> {
 	 */
 	public CompositeMap(IObservableMap<K, I> firstMap,
 			IObservableFactory<? super IObservableSet<I>, ? extends IObservableMap<I, V>> secondMapFactory) {
-		super(firstMap.getRealm(), new HashMap<K, V>());
+		super(firstMap.getRealm(), new HashMap<>());
 		this.firstMap = new BidiObservableMap<>(firstMap);
 		this.firstMap.addMapChangeListener(firstMapListener);
 		rangeSet.addAll(this.firstMap.values());

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/map/ComputedObservableMap.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/map/ComputedObservableMap.java
@@ -86,7 +86,7 @@ public abstract class ComputedObservableMap<K, V> extends AbstractObservableMap<
 		@Override
 		public Iterator<Map.Entry<K, V>> iterator() {
 			final Iterator<K> keyIterator = keySet.iterator();
-			return new Iterator<Map.Entry<K, V>>() {
+			return new Iterator<>() {
 
 				@Override
 				public boolean hasNext() {
@@ -96,7 +96,7 @@ public abstract class ComputedObservableMap<K, V> extends AbstractObservableMap<
 				@Override
 				public Map.Entry<K, V> next() {
 					final K key = keyIterator.next();
-					return new Map.Entry<K, V>() {
+					return new Map.Entry<>() {
 
 						@Override
 						public K getKey() {

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/map/DecoratingObservableMap.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/map/DecoratingObservableMap.java
@@ -181,7 +181,7 @@ public class DecoratingObservableMap<K, V> extends DecoratingObservable
 		@Override
 		public Iterator<E> iterator() {
 			final Iterator<E> iterator = collection.iterator();
-			return new Iterator<E>() {
+			return new Iterator<>() {
 				@Override
 				public boolean hasNext() {
 					getterCalled();

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/map/MapDiff.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/map/MapDiff.java
@@ -157,7 +157,7 @@ public abstract class MapDiff<K, V> implements IDiff {
 
 		@Override
 		public Iterator<Map.Entry<K, V>> iterator() {
-			return new Iterator<Map.Entry<K, V>>() {
+			return new Iterator<>() {
 				Iterator<Map.Entry<K, V>> origEntries = map.entrySet().iterator();
 				Iterator<? extends K> addedKeys = diff.getAddedKeys().iterator();
 

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/map/WritableMap.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/map/WritableMap.java
@@ -84,7 +84,7 @@ public class WritableMap<K, V> extends ObservableMap<K, V> {
 	 * @since 1.2
 	 */
 	public WritableMap(Realm realm, Object keyType, Object valueType) {
-		super(realm, new HashMap<K, V>());
+		super(realm, new HashMap<>());
 		this.keyType = keyType;
 		this.valueType = valueType;
 	}

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/set/AbstractObservableSet.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/set/AbstractObservableSet.java
@@ -110,7 +110,7 @@ public abstract class AbstractObservableSet<E> extends AbstractObservable
 	public Iterator<E> iterator() {
 		getterCalled();
 		final Iterator<E> wrappedIterator = getWrappedSet().iterator();
-		return new Iterator<E>() {
+		return new Iterator<>() {
 
 			@Override
 			public void remove() {

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/set/ComputedSet.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/set/ComputedSet.java
@@ -100,7 +100,7 @@ public abstract class ComputedSet<E> extends AbstractObservableSet<E> {
 	 */
 	public static <E> IObservableSet<E> create(Supplier<Set<E>> supplier) {
 		Objects.requireNonNull(supplier);
-		return new ComputedSet<E>() {
+		return new ComputedSet<>() {
 			@Override
 			protected Set<E> calculate() {
 				return supplier.get();

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/set/ListToSetAdapter.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/set/ListToSetAdapter.java
@@ -65,7 +65,7 @@ public class ListToSetAdapter<E> extends ObservableSet<E> {
 	 * @param list the list to adapt
 	 */
 	public ListToSetAdapter(IObservableList<E> list) {
-		super(list.getRealm(), new HashSet<E>(), list.getElementType());
+		super(list.getRealm(), new HashSet<>(), list.getElementType());
 		this.list = list;
 		wrappedSet.addAll(list);
 		this.list.addListChangeListener(listener);

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/set/ObservableSet.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/set/ObservableSet.java
@@ -110,7 +110,7 @@ public abstract class ObservableSet<E> extends AbstractObservable implements
 	public Iterator<E> iterator() {
 		getterCalled();
 		final Iterator<E> wrappedIterator = wrappedSet.iterator();
-		return new Iterator<E>() {
+		return new Iterator<>() {
 
 			@Override
 			public void remove() {

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/set/SetDiff.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/set/SetDiff.java
@@ -94,7 +94,7 @@ public abstract class SetDiff<E> implements IDiff {
 
 		@Override
 		public Iterator<E> iterator() {
-			return new Iterator<E>() {
+			return new Iterator<>() {
 				Iterator<E> orig = original.iterator();
 				Iterator<E> add = diff.getAdditions().iterator();
 

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/set/WritableSet.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/set/WritableSet.java
@@ -60,7 +60,7 @@ public class WritableSet<E> extends ObservableSet<E> {
 	 *            can be <code>null</code>
 	 */
 	public WritableSet(Collection<? extends E> c, Object elementType) {
-		this(Realm.getDefault(), new HashSet<E>(c), elementType);
+		this(Realm.getDefault(), new HashSet<>(c), elementType);
 	}
 
 	/**
@@ -70,7 +70,7 @@ public class WritableSet<E> extends ObservableSet<E> {
 	 * @param realm the realm
 	 */
 	public WritableSet(Realm realm) {
-		this(realm, new HashSet<E>(), null);
+		this(realm, new HashSet<>(), null);
 	}
 
 	/**
@@ -85,7 +85,7 @@ public class WritableSet<E> extends ObservableSet<E> {
 	 *            can be <code>null</code>
 	 */
 	public WritableSet(Realm realm, Collection<? extends E> c, Object elementType) {
-		super(realm, new HashSet<E>(c), elementType);
+		super(realm, new HashSet<>(c), elementType);
 		this.elementType = elementType;
 	}
 

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/value/ComputedValue.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/value/ComputedValue.java
@@ -106,7 +106,7 @@ public abstract class ComputedValue<T> extends AbstractObservableValue<T> {
 	 */
 	public static <T> IObservableValue<T> create(Supplier<T> supplier) {
 		Objects.requireNonNull(supplier);
-		return new ComputedValue<T>() {
+		return new ComputedValue<>() {
 			@Override
 			protected T calculate() {
 				return supplier.get();

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/value/DuplexingObservableValue.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/databinding/observable/value/DuplexingObservableValue.java
@@ -61,7 +61,7 @@ public abstract class DuplexingObservableValue<T> extends AbstractObservableValu
 	 */
 	public static <T> DuplexingObservableValue<T> withDefaults(
 			IObservableList<T> target, final T emptyValue, final T multiValue) {
-		return new DuplexingObservableValue<T>(target) {
+		return new DuplexingObservableValue<>(target) {
 			@Override
 			protected T coalesceElements(Collection<T> elements) {
 				if (elements.isEmpty())

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/internal/databinding/identity/IdentityMap.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/internal/databinding/identity/IdentityMap.java
@@ -85,7 +85,7 @@ public class IdentityMap<K, V> implements Map<K, V> {
 	public Set<Map.Entry<K, V>> entrySet() {
 		final Set<Map.Entry<IdentityWrapper<K>, V>> wrappedEntrySet = wrappedMap
 				.entrySet();
-		return new Set<Map.Entry<K, V>>() {
+		return new Set<>() {
 			@Override
 			public boolean add(Map.Entry<K, V> o) {
 				throw new UnsupportedOperationException();
@@ -125,7 +125,7 @@ public class IdentityMap<K, V> implements Map<K, V> {
 			@Override
 			public Iterator<Map.Entry<K, V>> iterator() {
 				final Iterator<Map.Entry<IdentityWrapper<K>, V>> wrappedIterator = wrappedEntrySet.iterator();
-				return new Iterator<Map.Entry<K, V>>() {
+				return new Iterator<>() {
 					@Override
 					public boolean hasNext() {
 						return wrappedIterator.hasNext();
@@ -135,7 +135,7 @@ public class IdentityMap<K, V> implements Map<K, V> {
 					public Map.Entry<K, V> next() {
 						final Map.Entry<IdentityWrapper<K>, V> wrappedEntry = wrappedIterator
 								.next();
-						return new Map.Entry<K, V>() {
+						return new Map.Entry<>() {
 							@Override
 							public K getKey() {
 								return wrappedEntry.getKey().unwrap();
@@ -298,7 +298,7 @@ public class IdentityMap<K, V> implements Map<K, V> {
 	@Override
 	public Set<K> keySet() {
 		final Set<IdentityWrapper<K>> wrappedKeySet = wrappedMap.keySet();
-		return new Set<K>() {
+		return new Set<>() {
 			@Override
 			public boolean add(K o) {
 				throw new UnsupportedOperationException();
@@ -336,7 +336,7 @@ public class IdentityMap<K, V> implements Map<K, V> {
 			public Iterator<K> iterator() {
 				final Iterator<IdentityWrapper<K>> wrappedIterator = wrappedKeySet
 						.iterator();
-				return new Iterator<K>() {
+				return new Iterator<>() {
 					@Override
 					public boolean hasNext() {
 						return wrappedIterator.hasNext();

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/internal/databinding/identity/IdentityObservableSet.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/internal/databinding/identity/IdentityObservableSet.java
@@ -75,7 +75,7 @@ public class IdentityObservableSet<E> extends AbstractObservableSet<E> {
 	public Iterator<E> iterator() {
 		getterCalled();
 		final Iterator<E> wrappedIterator = wrappedSet.iterator();
-		return new Iterator<E>() {
+		return new Iterator<>() {
 			E last;
 
 			@Override

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/internal/databinding/identity/IdentitySet.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/internal/databinding/identity/IdentitySet.java
@@ -100,7 +100,7 @@ public class IdentitySet<E> implements Set<E> {
 	public Iterator<E> iterator() {
 		final Iterator<IdentityWrapper<E>> wrappedIterator = wrappedSet
 				.iterator();
-		return new Iterator<E>() {
+		return new Iterator<>() {
 			@Override
 			public boolean hasNext() {
 				return wrappedIterator.hasNext();

--- a/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/internal/databinding/observable/masterdetail/MapDetailValueObservableMap.java
+++ b/bundles/org.eclipse.core.databinding.observable/src/org/eclipse/core/internal/databinding/observable/masterdetail/MapDetailValueObservableMap.java
@@ -331,7 +331,7 @@ public class MapDetailValueObservableMap<K, M, E> extends
 		@Override
 		public Iterator<Map.Entry<K, E>> iterator() {
 			final Iterator<K> keyIterator = keySet().iterator();
-			return new Iterator<Map.Entry<K, E>>() {
+			return new Iterator<>() {
 
 				@Override
 				public boolean hasNext() {

--- a/bundles/org.eclipse.core.databinding.property/src/org/eclipse/core/internal/databinding/property/list/SimplePropertyObservableList.java
+++ b/bundles/org.eclipse.core.databinding.property/src/org/eclipse/core/internal/databinding/property/list/SimplePropertyObservableList.java
@@ -211,7 +211,7 @@ public class SimplePropertyObservableList<S, E> extends AbstractObservableList<E
 	@Override
 	public Iterator<E> iterator() {
 		getterCalled();
-		return new Iterator<E>() {
+		return new Iterator<>() {
 			int expectedModCount = simplePropertyModCount;
 			List<E> list = new ArrayList<>(getList());
 			ListIterator<E> iterator = list.listIterator();
@@ -307,7 +307,7 @@ public class SimplePropertyObservableList<S, E> extends AbstractObservableList<E
 	@Override
 	public ListIterator<E> listIterator(final int index) {
 		getterCalled();
-		return new ListIterator<E>() {
+		return new ListIterator<>() {
 			int expectedModCount = simplePropertyModCount;
 			List<E> list = new ArrayList<>(getList());
 			ListIterator<E> iterator = list.listIterator(index);

--- a/bundles/org.eclipse.core.databinding.property/src/org/eclipse/core/internal/databinding/property/set/SimplePropertyObservableSet.java
+++ b/bundles/org.eclipse.core.databinding.property/src/org/eclipse/core/internal/databinding/property/set/SimplePropertyObservableSet.java
@@ -176,7 +176,7 @@ public class SimplePropertyObservableSet<S, E> extends AbstractObservableSet<E>
 	@Override
 	public Iterator<E> iterator() {
 		getterCalled();
-		return new Iterator<E>() {
+		return new Iterator<>() {
 			int expectedModCount = modCount;
 			Set<E> set = new HashSet<>(getSet());
 			Iterator<E> iterator = set.iterator();

--- a/bundles/org.eclipse.core.databinding.property/src/org/eclipse/core/internal/databinding/property/value/ListDelegatingValueObservableList.java
+++ b/bundles/org.eclipse.core.databinding.property/src/org/eclipse/core/internal/databinding/property/value/ListDelegatingValueObservableList.java
@@ -89,7 +89,7 @@ public class ListDelegatingValueObservableList<S, T extends S, E> extends Abstra
 		super(masterList.getRealm());
 		this.masterList = masterList;
 		this.detailProperty = valueProperty;
-		this.cache = new DelegatingCache<S, T, E>(getRealm(), valueProperty) {
+		this.cache = new DelegatingCache<>(getRealm(), valueProperty) {
 			@Override
 			void handleValueChange(T masterElement, E oldValue, E newValue) {
 				fireListChange(indicesOf(masterElement), oldValue, newValue);
@@ -154,7 +154,7 @@ public class ListDelegatingValueObservableList<S, T extends S, E> extends Abstra
 	@Override
 	public Iterator<E> iterator() {
 		getterCalled();
-		return new Iterator<E>() {
+		return new Iterator<>() {
 			Iterator<T> it = masterList.iterator();
 
 			@Override
@@ -239,7 +239,7 @@ public class ListDelegatingValueObservableList<S, T extends S, E> extends Abstra
 	@Override
 	public ListIterator<E> listIterator(final int index) {
 		getterCalled();
-		return new ListIterator<E>() {
+		return new ListIterator<>() {
 			ListIterator<T> it = masterList.listIterator(index);
 			T lastMasterElement;
 			E lastElement;

--- a/bundles/org.eclipse.core.databinding.property/src/org/eclipse/core/internal/databinding/property/value/ListSimpleValueObservableList.java
+++ b/bundles/org.eclipse.core.databinding.property/src/org/eclipse/core/internal/databinding/property/value/ListSimpleValueObservableList.java
@@ -240,7 +240,7 @@ public class ListSimpleValueObservableList<S, M extends S, T> extends AbstractOb
 	@Override
 	public Iterator<T> iterator() {
 		getterCalled();
-		return new Iterator<T>() {
+		return new Iterator<>() {
 			Iterator<M> it = masterList.iterator();
 
 			@Override
@@ -327,7 +327,7 @@ public class ListSimpleValueObservableList<S, M extends S, T> extends AbstractOb
 	@Override
 	public ListIterator<T> listIterator(final int index) {
 		getterCalled();
-		return new ListIterator<T>() {
+		return new ListIterator<>() {
 			ListIterator<M> it = masterList.listIterator(index);
 			M lastMasterElement;
 			T lastElement;

--- a/bundles/org.eclipse.core.databinding.property/src/org/eclipse/core/internal/databinding/property/value/MapDelegatingValueObservableMap.java
+++ b/bundles/org.eclipse.core.databinding.property/src/org/eclipse/core/internal/databinding/property/value/MapDelegatingValueObservableMap.java
@@ -57,7 +57,7 @@ public class MapDelegatingValueObservableMap<S, K, I extends S, V> extends Abstr
 	class EntrySet extends AbstractSet<Map.Entry<K, V>> {
 		@Override
 		public Iterator<Map.Entry<K, V>> iterator() {
-			return new Iterator<Map.Entry<K, V>>() {
+			return new Iterator<>() {
 				Iterator<Map.Entry<K, I>> it = masterMap.entrySet().iterator();
 
 				@Override
@@ -141,7 +141,7 @@ public class MapDelegatingValueObservableMap<S, K, I extends S, V> extends Abstr
 		}
 	}
 
-	private IMapChangeListener<K, I> masterListener = new IMapChangeListener<K, I>() {
+	private IMapChangeListener<K, I> masterListener = new IMapChangeListener<>() {
 		@Override
 		public void handleMapChange(final MapChangeEvent<? extends K, ? extends I> event) {
 			if (isDisposed())
@@ -203,7 +203,7 @@ public class MapDelegatingValueObservableMap<S, K, I extends S, V> extends Abstr
 		super(map.getRealm());
 		this.masterMap = map;
 		this.detailProperty = valueProperty;
-		this.cache = new DelegatingCache<S, I, V>(getRealm(), valueProperty) {
+		this.cache = new DelegatingCache<>(getRealm(), valueProperty) {
 			@Override
 			void handleValueChange(I masterElement, V oldValue, V newValue) {
 				fireMapChange(keysFor(masterElement), oldValue, newValue);

--- a/bundles/org.eclipse.core.databinding.property/src/org/eclipse/core/internal/databinding/property/value/MapSimpleValueObservableMap.java
+++ b/bundles/org.eclipse.core.databinding.property/src/org/eclipse/core/internal/databinding/property/value/MapSimpleValueObservableMap.java
@@ -219,7 +219,7 @@ public class MapSimpleValueObservableMap<S, K, I extends S, V> extends AbstractO
 	class EntrySet extends AbstractSet<Map.Entry<K, V>> {
 		@Override
 		public Iterator<Map.Entry<K, V>> iterator() {
-			return new Iterator<Map.Entry<K, V>>() {
+			return new Iterator<>() {
 				Iterator<Map.Entry<K, I>> it = masterMap.entrySet().iterator();
 
 				@Override

--- a/bundles/org.eclipse.core.databinding.property/src/org/eclipse/core/internal/databinding/property/value/SetDelegatingValueObservableMap.java
+++ b/bundles/org.eclipse.core.databinding.property/src/org/eclipse/core/internal/databinding/property/value/SetDelegatingValueObservableMap.java
@@ -55,7 +55,7 @@ public class SetDelegatingValueObservableMap<S, K extends S, V> extends Abstract
 	class EntrySet extends AbstractSet<Map.Entry<K, V>> {
 		@Override
 		public Iterator<Map.Entry<K, V>> iterator() {
-			return new Iterator<Map.Entry<K, V>>() {
+			return new Iterator<>() {
 				final Iterator<K> it = masterSet.iterator();
 
 				@Override
@@ -134,7 +134,7 @@ public class SetDelegatingValueObservableMap<S, K extends S, V> extends Abstract
 		}
 	}
 
-	private ISetChangeListener<K> masterListener = new ISetChangeListener<K>() {
+	private ISetChangeListener<K> masterListener = new ISetChangeListener<>() {
 		@Override
 		public void handleSetChange(SetChangeEvent<? extends K> event) {
 			if (isDisposed())
@@ -173,7 +173,7 @@ public class SetDelegatingValueObservableMap<S, K extends S, V> extends Abstract
 		super(keySet.getRealm());
 		this.masterSet = keySet;
 		this.detailProperty = valueProperty;
-		this.cache = new DelegatingCache<S, K, V>(getRealm(), valueProperty) {
+		this.cache = new DelegatingCache<>(getRealm(), valueProperty) {
 			@Override
 			void handleValueChange(K masterElement, V oldValue, V newValue) {
 				fireMapChange(Diffs.createMapDiffSingleChange(masterElement,

--- a/bundles/org.eclipse.core.databinding/src/org/eclipse/core/databinding/ValueBinding.java
+++ b/bundles/org.eclipse.core.databinding/src/org/eclipse/core/databinding/ValueBinding.java
@@ -39,7 +39,7 @@ class ValueBinding<M, T> extends Binding {
 
 	private boolean updatingTarget;
 	private boolean updatingModel;
-	private IValueChangeListener<T> targetChangeListener = new IValueChangeListener<T>() {
+	private IValueChangeListener<T> targetChangeListener = new IValueChangeListener<>() {
 		@Override
 		public void handleValueChange(ValueChangeEvent<? extends T> event) {
 			if (!updatingTarget && !Util.equals(event.diff.getOldValue(), event.diff.getNewValue())) {

--- a/bundles/org.eclipse.core.databinding/src/org/eclipse/core/databinding/conversion/IConverter.java
+++ b/bundles/org.eclipse.core.databinding/src/org/eclipse/core/databinding/conversion/IConverter.java
@@ -69,7 +69,7 @@ public interface IConverter<F, T> {
 	 * @since 1.6
 	 */
 	public static <F, T> IConverter<F, T> create(Object fromType, Object toType, Function<F, T> conversion) {
-		return new IConverter<F, T>() {
+		return new IConverter<>() {
 			@Override
 			public Object getFromType() {
 				return fromType;

--- a/bundles/org.eclipse.core.databinding/src/org/eclipse/core/internal/databinding/IdentitySet.java
+++ b/bundles/org.eclipse.core.databinding/src/org/eclipse/core/internal/databinding/IdentitySet.java
@@ -99,7 +99,7 @@ public class IdentitySet<E> implements Set<E> {
 	@Override
 	public Iterator<E> iterator() {
 		final Iterator<IdentityWrapper<E>> wrappedIterator = wrappedSet.iterator();
-		return new Iterator<E>() {
+		return new Iterator<>() {
 			@Override
 			public boolean hasNext() {
 				return wrappedIterator.hasNext();

--- a/bundles/org.eclipse.core.databinding/src/org/eclipse/core/internal/databinding/ValidationStatusMap.java
+++ b/bundles/org.eclipse.core.databinding/src/org/eclipse/core/internal/databinding/ValidationStatusMap.java
@@ -75,7 +75,7 @@ public class ValidationStatusMap extends ObservableMap<Binding, IStatus> {
 		removeElementChangeListener();
 		final Map<Binding, IStatus> oldMap = wrappedMap;
 		// lazy computation of diff
-		MapDiff<Binding, IStatus> mapDiff = new MapDiff<Binding, IStatus>() {
+		MapDiff<Binding, IStatus> mapDiff = new MapDiff<>() {
 			private MapDiff<Binding, IStatus> cachedDiff = null;
 
 			private void ensureCached() {

--- a/bundles/org.eclipse.core.databinding/src/org/eclipse/core/internal/databinding/validation/ValidatedObservableList.java
+++ b/bundles/org.eclipse.core.databinding/src/org/eclipse/core/internal/databinding/validation/ValidatedObservableList.java
@@ -209,7 +209,7 @@ public class ValidatedObservableList<E> extends ObservableList<E> {
 	public Iterator<E> iterator() {
 		getterCalled();
 		final ListIterator<E> wrappedIterator = wrappedList.listIterator();
-		return new Iterator<E>() {
+		return new Iterator<>() {
 			E last = null;
 
 			@Override
@@ -242,7 +242,7 @@ public class ValidatedObservableList<E> extends ObservableList<E> {
 	public ListIterator<E> listIterator(int index) {
 		getterCalled();
 		final ListIterator<E> wrappedIterator = wrappedList.listIterator(index);
-		return new ListIterator<E>() {
+		return new ListIterator<>() {
 			int lastIndex = -1;
 			E last = null;
 

--- a/bundles/org.eclipse.core.databinding/src/org/eclipse/core/internal/databinding/validation/ValidatedObservableSet.java
+++ b/bundles/org.eclipse.core.databinding/src/org/eclipse/core/internal/databinding/validation/ValidatedObservableSet.java
@@ -193,7 +193,7 @@ public class ValidatedObservableSet<E> extends ObservableSet<E> {
 	public Iterator<E> iterator() {
 		getterCalled();
 		final Iterator<E> wrappedIterator = wrappedSet.iterator();
-		return new Iterator<E>() {
+		return new Iterator<>() {
 			E last = null;
 
 			@Override

--- a/bundles/org.eclipse.e4.core.commands/src/org/eclipse/e4/core/commands/internal/HandlerServiceHandler.java
+++ b/bundles/org.eclipse.e4.core.commands/src/org/eclipse/e4/core/commands/internal/HandlerServiceHandler.java
@@ -44,7 +44,7 @@ public class HandlerServiceHandler extends AbstractHandlerWithState {
 
 	protected final String commandId;
 	// Remove state from currentStateHandler when it goes out of scope
-	protected WeakReference<IObjectWithState> currentStateHandler = new WeakReference<IObjectWithState>(null);
+	protected WeakReference<IObjectWithState> currentStateHandler = new WeakReference<>(null);
 
 	public HandlerServiceHandler(String commandId) {
 		this.commandId = commandId;

--- a/bundles/org.eclipse.jface.databinding/src/org/eclipse/jface/databinding/viewers/ObservableListTreeContentProvider.java
+++ b/bundles/org.eclipse.jface.databinding/src/org/eclipse/jface/databinding/viewers/ObservableListTreeContentProvider.java
@@ -120,7 +120,7 @@ public class ObservableListTreeContentProvider<E> implements ITreeContentProvide
 				if (suspendRedraw[0])
 					viewer.getControl().setRedraw(false);
 				try {
-					event.diff.accept(new ListDiffVisitor<Object>() {
+					ListDiffVisitor<Object> viewerUpdateVisitor = new ListDiffVisitor<>() {
 						@Override
 						public void handleAdd(int index, Object child) {
 							viewerUpdater.insert(parentElement, child, index);
@@ -144,7 +144,8 @@ public class ObservableListTreeContentProvider<E> implements ITreeContentProvide
 							viewerUpdater.move(parentElement, child, oldIndex,
 									newIndex);
 						}
-					});
+					};
+					event.diff.accept(viewerUpdateVisitor);
 				} finally {
 					if (suspendRedraw[0])
 						viewer.getControl().setRedraw(true);

--- a/bundles/org.eclipse.jface.databinding/src/org/eclipse/jface/internal/databinding/swt/VisibleProperty.java
+++ b/bundles/org.eclipse.jface.databinding/src/org/eclipse/jface/internal/databinding/swt/VisibleProperty.java
@@ -46,7 +46,7 @@ public abstract class VisibleProperty<S extends Widget> extends WidgetBooleanVal
 
 	@Override
 	public INativePropertyListener<S> adaptListener(ISimplePropertyListener<S, ValueDiff<? extends Boolean>> listener) {
-		return new WidgetListener<S, ValueDiff<? extends Boolean>>(this, listener, EVENT_TYPES, null) {
+		return new WidgetListener<>(this, listener, EVENT_TYPES, null) {
 			@Override
 			public void handleEvent(Event event) {
 				event.widget.setData(CACHED_VALUE_KEY, event.type == SWT.Show);

--- a/bundles/org.eclipse.jface.databinding/src/org/eclipse/jface/internal/databinding/viewers/CheckableCheckedElementsObservableSet.java
+++ b/bundles/org.eclipse.jface.databinding/src/org/eclipse/jface/internal/databinding/viewers/CheckableCheckedElementsObservableSet.java
@@ -182,7 +182,7 @@ public class CheckableCheckedElementsObservableSet<E> extends AbstractObservable
 	public Iterator<E> iterator() {
 		getterCalled();
 		final Iterator<E> wrappedIterator = wrappedSet.iterator();
-		return new Iterator<E>() {
+		return new Iterator<>() {
 			private E last = null;
 
 			@Override

--- a/bundles/org.eclipse.jface.databinding/src/org/eclipse/jface/internal/databinding/viewers/ObservableViewerElementSet.java
+++ b/bundles/org.eclipse.jface.databinding/src/org/eclipse/jface/internal/databinding/viewers/ObservableViewerElementSet.java
@@ -85,7 +85,7 @@ public class ObservableViewerElementSet<E> extends AbstractObservableSet<E> {
 	public Iterator<E> iterator() {
 		getterCalled();
 		final Iterator<E> wrappedIterator = wrappedSet.iterator();
-		return new Iterator<E>() {
+		return new Iterator<>() {
 			E last;
 
 			@Override

--- a/bundles/org.eclipse.jface.databinding/src/org/eclipse/jface/internal/databinding/viewers/ViewerElementMap.java
+++ b/bundles/org.eclipse.jface.databinding/src/org/eclipse/jface/internal/databinding/viewers/ViewerElementMap.java
@@ -92,7 +92,7 @@ public class ViewerElementMap<K, V> implements Map<K, V> {
 	@Override
 	public Set<Entry<K, V>> entrySet() {
 		final Set<Entry<ViewerElementWrapper<K>, V>> wrappedEntrySet = wrappedMap.entrySet();
-		return new Set<Entry<K, V>>() {
+		return new Set<>() {
 			@Override
 			public boolean add(Entry<K, V> o) {
 				throw new UnsupportedOperationException();
@@ -132,7 +132,7 @@ public class ViewerElementMap<K, V> implements Map<K, V> {
 			@Override
 			public Iterator<Entry<K, V>> iterator() {
 				final Iterator<Entry<ViewerElementWrapper<K>, V>> wrappedIterator = wrappedEntrySet.iterator();
-				return new Iterator<Entry<K, V>>() {
+				return new Iterator<>() {
 					@Override
 					public boolean hasNext() {
 						return wrappedIterator.hasNext();
@@ -141,7 +141,7 @@ public class ViewerElementMap<K, V> implements Map<K, V> {
 					@Override
 					public Entry<K, V> next() {
 						final Entry<ViewerElementWrapper<K>, V> wrappedEntry = wrappedIterator.next();
-						return new Entry<K, V>() {
+						return new Entry<>() {
 							@Override
 							public K getKey() {
 								return wrappedEntry.getKey().unwrap();
@@ -302,7 +302,7 @@ public class ViewerElementMap<K, V> implements Map<K, V> {
 	@Override
 	public Set<K> keySet() {
 		final Set<ViewerElementWrapper<K>> wrappedKeySet = wrappedMap.keySet();
-		return new Set<K>() {
+		return new Set<>() {
 			@Override
 			public boolean add(Object o) {
 				throw new UnsupportedOperationException();
@@ -339,7 +339,7 @@ public class ViewerElementMap<K, V> implements Map<K, V> {
 			@Override
 			public Iterator<K> iterator() {
 				final Iterator<ViewerElementWrapper<K>> wrappedIterator = wrappedKeySet.iterator();
-				return new Iterator<K>() {
+				return new Iterator<>() {
 					@Override
 					public boolean hasNext() {
 						return wrappedIterator.hasNext();

--- a/bundles/org.eclipse.jface.databinding/src/org/eclipse/jface/internal/databinding/viewers/ViewerElementSet.java
+++ b/bundles/org.eclipse.jface.databinding/src/org/eclipse/jface/internal/databinding/viewers/ViewerElementSet.java
@@ -114,7 +114,7 @@ public class ViewerElementSet<E> implements Set<E> {
 	@Override
 	public Iterator<E> iterator() {
 		final Iterator<ViewerElementWrapper<E>> wrappedIterator = wrappedSet.iterator();
-		return new Iterator<E>() {
+		return new Iterator<>() {
 			@Override
 			public boolean hasNext() {
 				return wrappedIterator.hasNext();

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/AutoEditStrategyRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/AutoEditStrategyRegistry.java
@@ -69,7 +69,7 @@ public class AutoEditStrategyRegistry {
 		return this.extensions.values().stream()
 			.filter(ext -> contentTypes.contains(ext.targetContentType))
 			.filter(ext -> ext.matches(sourceViewer, editor))
-			.sorted(new ContentTypeSpecializationComparator<IAutoEditStrategy>())
+			.sorted(new ContentTypeSpecializationComparator<>())
 			.map(GenericContentTypeRelatedExtension<IAutoEditStrategy>::createDelegate)
 			.collect(Collectors.toList());
 	}
@@ -81,7 +81,7 @@ public class AutoEditStrategyRegistry {
 			toRemoveExtensions.remove(extension);
 			if (!this.extensions.containsKey(extension)) {
 				try {
-					this.extensions.put(extension, new GenericContentTypeRelatedExtension<IAutoEditStrategy>(extension));
+					this.extensions.put(extension, new GenericContentTypeRelatedExtension<>(extension));
 				} catch (Exception ex) {
 					GenericEditorPlugin.getDefault().getLog()
 							.log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/CharacterPairMatcherRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/CharacterPairMatcherRegistry.java
@@ -64,7 +64,7 @@ public class CharacterPairMatcherRegistry {
 		}
 		return this.extensions.values().stream().filter(ext -> contentTypes.contains(ext.targetContentType))
 				.filter(ext -> ext.matches(sourceViewer, editor))
-				.sorted(new ContentTypeSpecializationComparator<ICharacterPairMatcher>())
+				.sorted(new ContentTypeSpecializationComparator<>())
 				.map(GenericContentTypeRelatedExtension<ICharacterPairMatcher>::createDelegate)
 				.collect(Collectors.toList());
 	}
@@ -77,7 +77,7 @@ public class CharacterPairMatcherRegistry {
 			if (!this.extensions.containsKey(extension)) {
 				try {
 					this.extensions.put(extension,
-							new GenericContentTypeRelatedExtension<ICharacterPairMatcher>(extension));
+							new GenericContentTypeRelatedExtension<>(extension));
 				} catch (Exception ex) {
 					GenericEditorPlugin.getDefault().getLog()
 							.log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ContentAssistProcessorRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ContentAssistProcessorRegistry.java
@@ -153,7 +153,7 @@ public class ContentAssistProcessorRegistry {
 		return this.extensions.values().stream()
 			.filter(ext -> contentTypes.contains(ext.targetContentType))
 			.filter(ext -> ext.matches(sourceViewer, editor))
-			.sorted(new ContentTypeSpecializationComparator<IContentAssistProcessor>())
+			.sorted(new ContentTypeSpecializationComparator<>())
 			.map(GenericContentTypeRelatedExtension<IContentAssistProcessor>::createDelegate)
 			.collect(Collectors.toList());
 	}
@@ -164,7 +164,7 @@ public class ContentAssistProcessorRegistry {
 			toRemoveExtensions.remove(extension);
 			if (!this.extensions.containsKey(extension)) {
 				try {
-					this.extensions.put(extension, new GenericContentTypeRelatedExtension<IContentAssistProcessor>(extension));
+					this.extensions.put(extension, new GenericContentTypeRelatedExtension<>(extension));
 				} catch (Exception ex) {
 					GenericEditorPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));
 				}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/PresentationReconcilerRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/PresentationReconcilerRegistry.java
@@ -65,7 +65,7 @@ public class PresentationReconcilerRegistry {
 		return this.extensions.values().stream()
 			.filter(ext -> contentTypes.contains(ext.targetContentType))
 			.filter(ext -> ext.matches(sourceViewer, editor))
-			.sorted(new ContentTypeSpecializationComparator<IPresentationReconciler>())
+			.sorted(new ContentTypeSpecializationComparator<>())
 			.map(GenericContentTypeRelatedExtension<IPresentationReconciler>::createDelegate)
 			.collect(Collectors.toList());
 	}
@@ -76,7 +76,7 @@ public class PresentationReconcilerRegistry {
 			toRemoveExtensions.remove(extension);
 			if (!this.extensions.containsKey(extension)) {
 				try {
-					this.extensions.put(extension, new GenericContentTypeRelatedExtension<IPresentationReconciler>(extension));
+					this.extensions.put(extension, new GenericContentTypeRelatedExtension<>(extension));
 				} catch (Exception ex) {
 					GenericEditorPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));
 				}

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/QuickAssistProcessorRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/QuickAssistProcessorRegistry.java
@@ -56,7 +56,7 @@ public class QuickAssistProcessorRegistry {
 		return this.extensions.values().stream()
 				.filter(ext -> contentTypes.contains(ext.targetContentType))
 				.filter(ext -> ext.matches(sourceViewer, editor))
-				.sorted(new ContentTypeSpecializationComparator<IQuickAssistProcessor>())
+				.sorted(new ContentTypeSpecializationComparator<>())
 				.map(GenericContentTypeRelatedExtension<IQuickAssistProcessor>::createDelegate)
 				.collect(Collectors.toList());
 	}
@@ -69,7 +69,7 @@ public class QuickAssistProcessorRegistry {
 			if (!this.extensions.containsKey(extension)) {
 				try {
 					this.extensions.put(extension,
-							new GenericContentTypeRelatedExtension<IQuickAssistProcessor>(extension));
+							new GenericContentTypeRelatedExtension<>(extension));
 				} catch (Exception ex) {
 					GenericEditorPlugin.getDefault().getLog()
 							.log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/TextDoubleClickStrategyRegistry.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/TextDoubleClickStrategyRegistry.java
@@ -58,7 +58,7 @@ public class TextDoubleClickStrategyRegistry {
 		}
 		return this.extensions.values().stream().filter(ext -> contentTypes.contains(ext.targetContentType))
 				.filter(ext -> ext.matches(sourceViewer, editor))
-				.sorted(new ContentTypeSpecializationComparator<ITextDoubleClickStrategy>()).findFirst()
+				.sorted(new ContentTypeSpecializationComparator<>()).findFirst()
 				.map(GenericContentTypeRelatedExtension<ITextDoubleClickStrategy>::createDelegate);
 	}
 
@@ -70,7 +70,7 @@ public class TextDoubleClickStrategyRegistry {
 			if (!this.extensions.containsKey(extension)) {
 				try {
 					this.extensions.put(extension,
-							new GenericContentTypeRelatedExtension<ITextDoubleClickStrategy>(extension));
+							new GenericContentTypeRelatedExtension<>(extension));
 				} catch (Exception ex) {
 					GenericEditorPlugin.getDefault().getLog()
 							.log(new Status(IStatus.ERROR, GenericEditorPlugin.BUNDLE_ID, ex.getMessage(), ex));

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/navigator/WizardActionGroup.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/navigator/WizardActionGroup.java
@@ -260,7 +260,7 @@ public final class WizardActionGroup extends ActionGroup {
 							descriptor.getMenuGroupId() : CommonWizardDescriptor.DEFAULT_MENU_GROUP_ID;
 			sortedWizards = groups.get(menuGroupId);
 			if(sortedWizards == null) {
-				groups.put(descriptor.getMenuGroupId(), sortedWizards = new TreeSet<IAction>(ActionComparator.INSTANCE));
+				groups.put(descriptor.getMenuGroupId(), sortedWizards = new TreeSet<>(ActionComparator.INSTANCE));
 			}
 			if ((action = getAction(descriptor.getWizardId())) != null) {
 				sortedWizards.add(action);

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/ListBindingTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/ListBindingTest.java
@@ -129,7 +129,7 @@ public class ListBindingTest extends AbstractDefaultRealmTestCase {
 
 	@Test
 	public void testAddValidationStatusContainsMultipleStatuses() throws Exception {
-		UpdateListStrategy<String, String> strategy = new UpdateListStrategy<String, String>() {
+		UpdateListStrategy<String, String> strategy = new UpdateListStrategy<>() {
 			@Override
 			protected IStatus doAdd(IObservableList<? super String> observableList, String element, int index) {
 				super.doAdd(observableList, element, index);
@@ -163,7 +163,7 @@ public class ListBindingTest extends AbstractDefaultRealmTestCase {
 		List<String> items = Arrays.asList(new String[] { "1", "2" });
 		model.addAll(items);
 
-		UpdateListStrategy<String, String> strategy = new UpdateListStrategy<String, String>() {
+		UpdateListStrategy<String, String> strategy = new UpdateListStrategy<>() {
 			int count;
 			@Override
 			protected IStatus doRemove(IObservableList<? super String> observableList, int index) {
@@ -249,7 +249,7 @@ public class ListBindingTest extends AbstractDefaultRealmTestCase {
 	 */
 	@Test
 	public void testErrorDuringRemove() {
-		IObservableList<String> target = new WritableList<String>() {
+		IObservableList<String> target = new WritableList<>() {
 			@Override
 			public String remove(int index) {
 				throw new IllegalArgumentException();
@@ -279,7 +279,7 @@ public class ListBindingTest extends AbstractDefaultRealmTestCase {
 	 */
 	@Test
 	public void testErrorDuringMove() {
-		IObservableList<String> target = new WritableList<String>() {
+		IObservableList<String> target = new WritableList<>() {
 			@Override
 			public String move(int index, int index2) {
 				throw new IllegalArgumentException();
@@ -309,7 +309,7 @@ public class ListBindingTest extends AbstractDefaultRealmTestCase {
 	 */
 	@Test
 	public void testErrorDuringReplace() {
-		IObservableList<String> target = new WritableList<String>() {
+		IObservableList<String> target = new WritableList<>() {
 			@Override
 			public String set(int index, String element) {
 				throw new IllegalArgumentException();

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/SetBindingTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/SetBindingTest.java
@@ -131,7 +131,7 @@ public class SetBindingTest extends AbstractDefaultRealmTestCase {
 	 */
 	@Test
 	public void testErrorDuringRemoveIsLogged() {
-		IObservableSet<String> target = new WritableSet<String>() {
+		IObservableSet<String> target = new WritableSet<>() {
 			@Override
 			public boolean remove(Object elem) {
 				throw new IllegalArgumentException();

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/SideEffectTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/SideEffectTest.java
@@ -269,7 +269,7 @@ public class SideEffectTest extends AbstractDefaultRealmTestCase {
 	public void testConsumeOnceDoesntPassNullToConsumer() throws Exception {
 		AtomicBoolean consumerHasRun = new AtomicBoolean();
 		WritableValue<Object> makesThingsDirty = new WritableValue<>(null, null);
-		ComputedValue<Object> value = new ComputedValue<Object>() {
+		ComputedValue<Object> value = new ComputedValue<>() {
 			@Override
 			protected Object calculate() {
 				makesThingsDirty.getValue();
@@ -294,7 +294,7 @@ public class SideEffectTest extends AbstractDefaultRealmTestCase {
 		AtomicInteger numberOfRuns = new AtomicInteger();
 		WritableValue<Object> makesThingsDirty = new WritableValue<>(null, null);
 		WritableValue<Object> returnValue = new WritableValue<>(null, null);
-		ComputedValue<Object> value = new ComputedValue<Object>() {
+		ComputedValue<Object> value = new ComputedValue<>() {
 			@Override
 			protected Object calculate() {
 				makesThingsDirty.getValue();

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/ValueBindingTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/ValueBindingTest.java
@@ -187,7 +187,7 @@ public class ValueBindingTest extends AbstractDefaultRealmTestCase {
 
 	@Test
 	public void testStatusesFromEveryPhaseAreReturned() throws Exception {
-		UpdateValueStrategy<Object, String> strategy = new UpdateValueStrategy<Object, String>() {
+		UpdateValueStrategy<Object, String> strategy = new UpdateValueStrategy<>() {
 			@Override
 			protected IStatus doSet(IObservableValue<? super String> observableValue, String value) {
 				super.doSet(observableValue, value);
@@ -423,7 +423,7 @@ public class ValueBindingTest extends AbstractDefaultRealmTestCase {
 	}
 
 	private <F, T> IConverter<F, T> loggingConverter(final List<String> log, final String message) {
-		return new Converter<F, T>(null, null) {
+		return new Converter<>(null, null) {
 			@SuppressWarnings("unchecked")
 			@Override
 			public T convert(F fromObject) {

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/observable/DiffsTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/observable/DiffsTest.java
@@ -30,7 +30,7 @@ public class DiffsTest {
 	 */
 	@Test
 	public void test_SetDiff() {
-		SetDiff<?> diff = new SetDiff<Object>() {
+		SetDiff<?> diff = new SetDiff<>() {
 			@Override
 			public Set<Object> getAdditions() {
 				return null;
@@ -51,7 +51,7 @@ public class DiffsTest {
 	 */
 	@Test
 	public void test_ValueDiff() {
-		ValueDiff<?> diff = new ValueDiff<Object>() {
+		ValueDiff<?> diff = new ValueDiff<>() {
 			@Override
 			public Object getNewValue() {
 				return null;

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/observable/Diffs_ListDiffTests.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/observable/Diffs_ListDiffTests.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 public class Diffs_ListDiffTests {
 	@Test
 	public void testListDiffEntryToStringDoesNotThrowNPEForNullListDiffEntry() {
-		ListDiffEntry<?> entry = new ListDiffEntry<Object>() {
+		ListDiffEntry<?> entry = new ListDiffEntry<>() {
 			@Override
 			public Object getElement() {
 				return null;
@@ -55,7 +55,7 @@ public class Diffs_ListDiffTests {
 
 	@Test
 	public void testListDiffToStringDoesNotThrowNPEForNullListDiff() {
-		ListDiff<?> diff = new ListDiff<Object>() {
+		ListDiff<?> diff = new ListDiff<>() {
 			@Override
 			public ListDiffEntry<Object>[] getDifferences() {
 				return null;
@@ -67,7 +67,7 @@ public class Diffs_ListDiffTests {
 
 	@Test
 	public void testListDiffToStringDoesNotThrowNPEForNullListDiffEntry() {
-		ListDiff<?> diff = new ListDiff<Object>() {
+		ListDiff<?> diff = new ListDiff<>() {
 			@SuppressWarnings("unchecked")
 			@Override
 			public ListDiffEntry<Object>[] getDifferences() {
@@ -272,7 +272,7 @@ public class Diffs_ListDiffTests {
 		ListDiff<?> diff = Diffs.computeListDiff(oldList, newList);
 
 		final List<Object> list = new ArrayList<>(oldList);
-		diff.accept(new ListDiffVisitor<Object>() {
+		ListDiffVisitor<Object> listDiffVisitor = new ListDiffVisitor<>() {
 			@Override
 			public void handleAdd(int index, Object element) {
 				list.add(index, element);
@@ -287,7 +287,8 @@ public class Diffs_ListDiffTests {
 			public void handleReplace(int index, Object oldElement, Object newElement) {
 				assertEquals(oldElement, list.set(index, newElement));
 			}
-		});
+		};
+		diff.accept(listDiffVisitor);
 
 		assertEquals("Applying diff to old list should make it equal to new list", newList, list);
 	}

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/observable/list/ComputedListTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/observable/list/ComputedListTest.java
@@ -110,7 +110,7 @@ public class ComputedListTest extends AbstractDefaultRealmTestCase {
 	}
 
 	static class ComputedListStub<E> extends ComputedList<E> {
-		List<E> nextComputation = new ArrayList<E>();
+		List<E> nextComputation = new ArrayList<>();
 		ObservableStub dependency;
 
 		ComputedListStub() {
@@ -125,7 +125,7 @@ public class ComputedListTest extends AbstractDefaultRealmTestCase {
 		@Override
 		protected List<E> calculate() {
 			ObservableTracker.getterCalled(dependency);
-			return new ArrayList<E>(nextComputation);
+			return new ArrayList<>(nextComputation);
 		}
 	}
 

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/observable/list/MultiListTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/observable/list/MultiListTest.java
@@ -44,7 +44,7 @@ public class MultiListTest extends AbstractDefaultRealmTestCase {
 	public void setUp() throws Exception {
 		super.setUp();
 		@SuppressWarnings("unchecked")
-		WritableList<Object>[] lists = new WritableList[] { new WritableList<Object>(), new WritableList<Object>() };
+		WritableList<Object>[] lists = new WritableList[] { new WritableList<>(), new WritableList<>() };
 		multiList = new MultiListStub(Realm.getDefault(), lists);
 	}
 
@@ -140,8 +140,8 @@ public class MultiListTest extends AbstractDefaultRealmTestCase {
 		public IObservableCollection<Object> createObservableCollection(Realm realm,
 				int elementCount) {
 			@SuppressWarnings("unchecked")
-			WritableList<Object>[] subLists = new WritableList[] { new WritableList<Object>(realm),
-					new WritableList<Object>(realm) };
+			WritableList<Object>[] subLists = new WritableList[] { new WritableList<>(realm),
+					new WritableList<>(realm) };
 			final MultiListStub list = new MultiListStub(realm, subLists);
 			for (int i = 0; i < elementCount; i++)
 				list.subLists[0].add(createElement(list));

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/observable/list/WritableListTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/observable/list/WritableListTest.java
@@ -201,7 +201,7 @@ public class WritableListTest {
 	@Test
 	public void testCollectionConstructorsCopy_2() {
 		List<String> list = new ArrayList<>(Arrays.asList("a", "b", "c"));
-		WritableList<String> wlist = new WritableList<String>(new CurrentRealm(true), (Collection<String>) list,
+		WritableList<String> wlist = new WritableList<>(new CurrentRealm(true), (Collection<String>) list,
 				Object.class);
 		wlist.remove(1);
 		assertEquals(3, list.size());

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/observable/value/ComputedValueTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/observable/value/ComputedValueTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 public class ComputedValueTest extends AbstractDefaultRealmTestCase {
 	@Test
 	public void testValueType() throws Exception {
-		ComputedValue<Integer> cv = new ComputedValue<Integer>(Integer.TYPE) {
+		ComputedValue<Integer> cv = new ComputedValue<>(Integer.TYPE) {
 			@Override
 			protected Integer calculate() {
 				return Integer.valueOf(42);
@@ -46,7 +46,7 @@ public class ComputedValueTest extends AbstractDefaultRealmTestCase {
 		};
 		assertEquals("value type should be the type that was set", Integer.TYPE, cv.getValueType());
 
-		cv = new ComputedValue<Integer>() {
+		cv = new ComputedValue<>() {
 			@Override
 			protected Integer calculate() {
 				// TODO Auto-generated method stub
@@ -59,7 +59,7 @@ public class ComputedValueTest extends AbstractDefaultRealmTestCase {
 
 	@Test
 	public void test_getValue() throws Exception {
-		ComputedValue<Integer> cv = new ComputedValue<Integer>() {
+		ComputedValue<Integer> cv = new ComputedValue<>() {
 			@Override
 			protected Integer calculate() {
 				return Integer.valueOf(42);
@@ -72,7 +72,7 @@ public class ComputedValueTest extends AbstractDefaultRealmTestCase {
 	public void testDependencyValueChange() throws Exception {
 		final WritableValue<Integer> value = new WritableValue<>(Integer.valueOf(42), Integer.TYPE);
 
-		ComputedValue<Integer> cv = new ComputedValue<Integer>() {
+		ComputedValue<Integer> cv = new ComputedValue<>() {
 			@Override
 			protected Integer calculate() {
 				return value.getValue();
@@ -110,7 +110,7 @@ public class ComputedValueTest extends AbstractDefaultRealmTestCase {
 	public void testHookAndUnhookDependantObservables() throws Exception {
 		final List<WritableValue<Integer>> values = new ArrayList<>();
 
-		ComputedValue<Integer> cv = new ComputedValue<Integer>() {
+		ComputedValue<Integer> cv = new ComputedValue<>() {
 			@Override
 			protected Integer calculate() {
 				int sum = 0;
@@ -149,7 +149,7 @@ public class ComputedValueTest extends AbstractDefaultRealmTestCase {
 
 	@Test
 	public void testSetValueUnsupportedOperationException() throws Exception {
-		ComputedValue<Object> cv = new ComputedValue<Object>() {
+		ComputedValue<Object> cv = new ComputedValue<>() {
 			@Override
 			protected Object calculate() {
 				return null;

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/observable/value/DuplexingObservableValueTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/observable/value/DuplexingObservableValueTest.java
@@ -44,7 +44,7 @@ public class DuplexingObservableValueTest extends AbstractDefaultRealmTestCase {
 
 	@Test
 	public void testValueType_InheritFromTargetList() throws Exception {
-		observable = new DuplexingObservableValue<String>(list) {
+		observable = new DuplexingObservableValue<>(list) {
 			@Override
 			protected String coalesceElements(Collection<String> elements) {
 				return null;
@@ -57,7 +57,7 @@ public class DuplexingObservableValueTest extends AbstractDefaultRealmTestCase {
 
 	@Test
 	public void testValueType_ProvidedInConstructor() throws Exception {
-		observable = new DuplexingObservableValue<String>(list, Object.class) {
+		observable = new DuplexingObservableValue<>(list, Object.class) {
 			@Override
 			protected String coalesceElements(Collection<String> elements) {
 				return null;

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/internal/databinding/DifferentRealmsBindingTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/internal/databinding/DifferentRealmsBindingTest.java
@@ -141,7 +141,7 @@ public class DifferentRealmsBindingTest {
 	@Test
 	public void testBindComputedListToWritableListInDifferentRealm() {
 		final IObservableValue<String> modelValue = new WritableValue<>(mainThread);
-		final IObservableList<String> model = new ComputedList<String>(mainThread) {
+		final IObservableList<String> model = new ComputedList<>(mainThread) {
 			@Override
 			protected List<String> calculate() {
 				return Collections.singletonList(modelValue.getValue());
@@ -160,7 +160,7 @@ public class DifferentRealmsBindingTest {
 	@Test
 	public void testBindComputedSetToWritableSetInDifferentRealm() {
 		final IObservableValue<String> modelValue = new WritableValue<>(mainThread);
-		final IObservableSet<String> model = new ComputedSet<String>(mainThread) {
+		final IObservableSet<String> model = new ComputedSet<>(mainThread) {
 			@Override
 			protected Set<String> calculate() {
 				return Collections.singleton(modelValue.getValue());
@@ -179,7 +179,7 @@ public class DifferentRealmsBindingTest {
 	@Test
 	public void testBindComputedValueToWritableValueInDifferentRealm() {
 		final IObservableValue<String> modelValue = new WritableValue<>(mainThread);
-		final IObservableValue<String> model = new ComputedValue<String>(mainThread) {
+		final IObservableValue<String> model = new ComputedValue<>(mainThread) {
 			@Override
 			protected String calculate() {
 				return modelValue.getValue();

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/internal/databinding/IdentityMapTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/internal/databinding/IdentityMapTest.java
@@ -50,7 +50,7 @@ public class IdentityMapTest {
 		map = new IdentityMap<>();
 		key = new Object();
 		value = new Object();
-		entry = new Map.Entry<Object, Object>() {
+		entry = new Map.Entry<>() {
 			@Override
 			public Object getKey() {
 				return key;


### PR DESCRIPTION
Applies the cleanup rule for using the diamond operator where applicable in all projects to be conform with defined save actions.

Cleanup is explicitly _not_ applied to generated EMF code.