### PR TITLE
Use primitive types instead of wrapper types

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/IntegerFieldEditor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/IntegerFieldEditor.java
@@ -130,8 +130,8 @@ public class IntegerFieldEditor extends StringFieldEditor {
 	protected void doStore() {
 		Text text = getTextControl();
 		if (text != null) {
-			Integer i = Integer.valueOf(text.getText());
-			getPreferenceStore().setValue(getPreferenceName(), i.intValue());
+			int i = Integer.parseInt(text.getText());
+			getPreferenceStore().setValue(getPreferenceName(), i);
 		}
 	}
 


### PR DESCRIPTION
Applies the cleanup rule for using primitive instead of wrapper types in all projects to be conform with defined save actions.