### PR TITLE
Unify access to static members

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/CSSRenderingUtils.java
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/CSSRenderingUtils.java
@@ -232,7 +232,7 @@ public class CSSRenderingUtils {
 			return null;
 		}
 		if (classId != null)
-			ControlElement.setCSSClass(styleControl, classId);
+			WidgetElement.setCSSClass(styleControl, classId);
 
 		CSSStyleDeclaration styleDeclarations = csseng.getViewCSS()
 				.getComputedStyle(tempEment, "");

--- a/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/dialogs/Snippet070GenericSelectionDialog.java
+++ b/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/dialogs/Snippet070GenericSelectionDialog.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.jface.dialogs.AbstractSelectionDialog;
-import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -27,6 +26,7 @@ import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.ListViewer;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.widgets.WidgetFactory;
+import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
@@ -49,7 +49,7 @@ public class Snippet070GenericSelectionDialog {
 				"SelectionDialog with generics", "Select one or more of the Model elements");
 
 		int open = genericSelectionDialog.open();
-		if (Dialog.OK == open) {
+		if (Window.OK == open) {
 			Collection<Model> result = genericSelectionDialog.getResult();
 			text.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 			text.setText(result.stream().map(Object::toString)

--- a/examples/org.eclipse.ui.forms.examples/src/org/eclipse/ui/forms/examples/internal/rcp/ErrorMessagesPage.java
+++ b/examples/org.eclipse.ui.forms.examples/src/org/eclipse/ui/forms/examples/internal/rcp/ErrorMessagesPage.java
@@ -40,6 +40,7 @@ import org.eclipse.ui.forms.editor.FormEditor;
 import org.eclipse.ui.forms.editor.FormPage;
 import org.eclipse.ui.forms.events.HyperlinkAdapter;
 import org.eclipse.ui.forms.events.HyperlinkEvent;
+import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.forms.widgets.Form;
 import org.eclipse.ui.forms.widgets.FormText;
 import org.eclipse.ui.forms.widgets.FormToolkit;
@@ -126,7 +127,7 @@ public class ErrorMessagesPage extends FormPage {
 		TableWrapLayout layout = new TableWrapLayout();
 		form.getBody().setLayout(layout);
 		Section section = toolkit.createSection(form.getBody(),
-				Section.TITLE_BAR);
+				ExpandableComposite.TITLE_BAR);
 		section.setText("Local field messages");
 		Composite sbody = toolkit.createComposite(section);
 		section.setClient(sbody);

--- a/examples/org.eclipse.ui.forms.examples/src/org/eclipse/ui/forms/examples/internal/rcp/FreeFormPage.java
+++ b/examples/org.eclipse.ui.forms.examples/src/org/eclipse/ui/forms/examples/internal/rcp/FreeFormPage.java
@@ -108,7 +108,7 @@ public class FreeFormPage extends FormPage {
 		Section section =
 			toolkit.createSection(
 				form.getBody(),
-				Section.TWISTIE | Section.DESCRIPTION);
+				ExpandableComposite.TWISTIE | Section.DESCRIPTION);
 		section.setActiveToggleColor(
 			toolkit.getHyperlinkGroup().getActiveForeground());
 		section.setToggleColor(

--- a/examples/org.eclipse.ui.forms.examples/src/org/eclipse/ui/forms/examples/internal/rcp/NewStylePage.java
+++ b/examples/org.eclipse.ui.forms.examples/src/org/eclipse/ui/forms/examples/internal/rcp/NewStylePage.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.ControlContribution;
+import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.SWT;
@@ -502,7 +503,7 @@ public class NewStylePage extends FormPage {
 
 	private void addToolBar(FormToolkit toolkit, ScrolledForm form, boolean add) {
 		if (add) {
-			Action haction = new Action("hor", Action.AS_RADIO_BUTTON) {
+			Action haction = new Action("hor", IAction.AS_RADIO_BUTTON) {
 				@Override
 				public void run() {
 				}
@@ -512,7 +513,7 @@ public class NewStylePage extends FormPage {
 			haction.setImageDescriptor(ExamplesPlugin.getDefault()
 					.getImageRegistry().getDescriptor(
 							ExamplesPlugin.IMG_HORIZONTAL));
-			Action vaction = new Action("ver", Action.AS_RADIO_BUTTON) {
+			Action vaction = new Action("ver", IAction.AS_RADIO_BUTTON) {
 				@Override
 				public void run() {
 				}
@@ -542,7 +543,7 @@ public class NewStylePage extends FormPage {
 
 	private void addMenu(FormToolkit toolkit, ScrolledForm form, boolean add) {
 		if (add) {
-			Action haction = new Action("hor", Action.AS_RADIO_BUTTON) {
+			Action haction = new Action("hor", IAction.AS_RADIO_BUTTON) {
 				@Override
 				public void run() {
 				}
@@ -553,7 +554,7 @@ public class NewStylePage extends FormPage {
 			haction.setImageDescriptor(ExamplesPlugin.getDefault()
 					.getImageRegistry().getDescriptor(
 							ExamplesPlugin.IMG_HORIZONTAL));
-			Action vaction = new Action("ver", Action.AS_RADIO_BUTTON) {
+			Action vaction = new Action("ver", IAction.AS_RADIO_BUTTON) {
 				@Override
 				public void run() {
 				}

--- a/examples/org.eclipse.ui.forms.examples/src/org/eclipse/ui/forms/examples/internal/rcp/ScrolledPropertiesBlock.java
+++ b/examples/org.eclipse.ui.forms.examples/src/org/eclipse/ui/forms/examples/internal/rcp/ScrolledPropertiesBlock.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.forms.examples.internal.rcp;
 import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.viewers.IStructuredContentProvider;
 import org.eclipse.jface.viewers.ITableLabelProvider;
 import org.eclipse.jface.viewers.LabelProvider;
@@ -117,7 +118,7 @@ public class ScrolledPropertiesBlock extends MasterDetailsBlock {
 	@Override
 	protected void createToolBarActions(IManagedForm managedForm) {
 		final ScrolledForm form = managedForm.getForm();
-		Action haction = new Action("hor", Action.AS_RADIO_BUTTON) {
+		Action haction = new Action("hor", IAction.AS_RADIO_BUTTON) {
 			@Override
 			public void run() {
 				sashForm.setOrientation(SWT.HORIZONTAL);
@@ -129,7 +130,7 @@ public class ScrolledPropertiesBlock extends MasterDetailsBlock {
 		haction.setImageDescriptor(ExamplesPlugin.getDefault()
 				.getImageRegistry()
 				.getDescriptor(ExamplesPlugin.IMG_HORIZONTAL));
-		Action vaction = new Action("ver", Action.AS_RADIO_BUTTON) {
+		Action vaction = new Action("ver", IAction.AS_RADIO_BUTTON) {
 			@Override
 			public void run() {
 				sashForm.setOrientation(SWT.VERTICAL);

--- a/examples/org.eclipse.ui.forms.examples/src/org/eclipse/ui/forms/examples/internal/rcp/SecondPage.java
+++ b/examples/org.eclipse.ui.forms.examples/src/org/eclipse/ui/forms/examples/internal/rcp/SecondPage.java
@@ -61,8 +61,8 @@ public class SecondPage extends FormPage {
 
 	private Section createTableSection(final ScrolledForm form,
 			FormToolkit toolkit, String title, boolean addTextClient) {
-		Section section = toolkit.createSection(form.getBody(), Section.TWISTIE
-				| Section.TITLE_BAR);
+		Section section = toolkit.createSection(form.getBody(), ExpandableComposite.TWISTIE
+				| ExpandableComposite.TITLE_BAR);
 		section.setActiveToggleColor(toolkit.getHyperlinkGroup()
 				.getActiveForeground());
 		section.setToggleColor(toolkit.getColors().getColor(

--- a/examples/org.eclipse.ui.forms.examples/src/org/eclipse/ui/forms/examples/internal/rcp/SingleHeaderEditor.java
+++ b/examples/org.eclipse.ui.forms.examples/src/org/eclipse/ui/forms/examples/internal/rcp/SingleHeaderEditor.java
@@ -16,6 +16,7 @@ package org.eclipse.ui.forms.examples.internal.rcp;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.ControlContribution;
+import org.eclipse.jface.action.IAction;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -82,7 +83,7 @@ public class SingleHeaderEditor extends SharedHeaderFormEditor {
 	}
 
 	private void addToolBar(Form form) {
-		Action haction = new Action("hor", Action.AS_RADIO_BUTTON) {
+		Action haction = new Action("hor", IAction.AS_RADIO_BUTTON) {
 			@Override
 			public void run() {
 			}
@@ -92,7 +93,7 @@ public class SingleHeaderEditor extends SharedHeaderFormEditor {
 		haction.setImageDescriptor(ExamplesPlugin.getDefault()
 				.getImageRegistry()
 				.getDescriptor(ExamplesPlugin.IMG_HORIZONTAL));
-		Action vaction = new Action("ver", Action.AS_RADIO_BUTTON) {
+		Action vaction = new Action("ver", IAction.AS_RADIO_BUTTON) {
 			@Override
 			public void run() {
 			}

--- a/examples/org.eclipse.ui.forms.examples/src/org/eclipse/ui/forms/examples/internal/rcp/ThirdPage.java
+++ b/examples/org.eclipse.ui.forms.examples/src/org/eclipse/ui/forms/examples/internal/rcp/ThirdPage.java
@@ -121,8 +121,8 @@ public class ThirdPage extends FormPage {
 			String desc, int numColumns) {
 		final ScrolledForm form = mform.getForm();
 		FormToolkit toolkit = mform.getToolkit();
-		Section section = toolkit.createSection(form.getBody(), Section.TWISTIE
-				| Section.SHORT_TITLE_BAR | Section.DESCRIPTION | Section.EXPANDED);
+		Section section = toolkit.createSection(form.getBody(), ExpandableComposite.TWISTIE
+				| ExpandableComposite.SHORT_TITLE_BAR | Section.DESCRIPTION | ExpandableComposite.EXPANDED);
 		section.setText(title);
 		section.setDescription(desc);
 		Composite client = toolkit.createComposite(section);

--- a/examples/org.eclipse.ui.forms.examples/src/org/eclipse/ui/forms/examples/views/FormView.java
+++ b/examples/org.eclipse.ui.forms.examples/src/org/eclipse/ui/forms/examples/views/FormView.java
@@ -155,7 +155,7 @@ public class FormView extends ViewPart {
 				form.reflow(true);
 			}
 		});
-		Section section = toolkit.createSection(form.getBody(), Section.DESCRIPTION|Section.TWISTIE|Section.EXPANDED);
+		Section section = toolkit.createSection(form.getBody(), Section.DESCRIPTION|ExpandableComposite.TWISTIE|ExpandableComposite.EXPANDED);
 		td = new TableWrapData(TableWrapData.FILL);
 		td.colspan = 2;
 		section.setLayoutData(td);

--- a/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/ValueTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.core/src/org/eclipse/e4/ui/tests/css/core/parser/ValueTest.java
@@ -130,11 +130,11 @@ public class ValueTest {
 		}
 		assertEquals(CSSPrimitiveValue.CSS_NUMBER,
 				((Measure) list.item(0)).getPrimitiveType());
-		assertEquals(CSSPrimitiveValue.CSS_CUSTOM,
+		assertEquals(CSSValue.CSS_CUSTOM,
 				((Measure) list.item(1)).getPrimitiveType());
 		assertEquals(CSSPrimitiveValue.CSS_NUMBER,
 				((Measure) list.item(2)).getPrimitiveType());
-		assertEquals(CSSPrimitiveValue.CSS_CUSTOM,
+		assertEquals(CSSValue.CSS_CUSTOM,
 				((Measure) list.item(3)).getPrimitiveType());
 		assertEquals(CSSPrimitiveValue.CSS_NUMBER,
 				((Measure) list.item(4)).getPrimitiveType());

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/forms/SectionTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/forms/SectionTest.java
@@ -24,6 +24,7 @@ import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.forms.widgets.Section;
 import org.eclipse.ui.forms.widgets.ToggleHyperlink;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,7 @@ public class SectionTest extends CSSSWTTestCase {
 		Composite compositeToTest = new Composite(shell, SWT.NONE);
 		compositeToTest.setLayout(new FillLayout());
 
-		Section test = new Section(shell, Section.TITLE_BAR | Section.TWISTIE | Section.EXPANDED);
+		Section test = new Section(shell, ExpandableComposite.TITLE_BAR | ExpandableComposite.TWISTIE | ExpandableComposite.EXPANDED);
 
 		// Apply styles
 		engine.applyStyles(shell, true);

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CTabFolderTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CTabFolderTest.java
@@ -18,7 +18,7 @@ package org.eclipse.e4.ui.tests.css.swt;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
-import org.eclipse.e4.ui.css.swt.dom.CTabFolderElement;
+import org.eclipse.e4.ui.css.swt.dom.WidgetElement;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
@@ -304,14 +304,14 @@ public class CTabFolderTest extends CSSSWTTestCase {
 		ToolBar barB = toolBars[1];
 		ToolBar barC = toolBars[2];
 
-		CTabFolderElement.setCSSClass(barA.getParent(), "special");
+		WidgetElement.setCSSClass(barA.getParent(), "special");
 		engine.applyStyles(barA.getShell(), true);
 
 		assertEquals(RED, barA.getBackground().getRGB());
 		assertEquals(GREEN, barB.getBackground().getRGB());
 		assertEquals(BLUE, barC.getBackground().getRGB());
 
-		CTabFolderElement.setCSSClass(barA.getParent(), "extraordinary");
+		WidgetElement.setCSSClass(barA.getParent(), "extraordinary");
 		engine.applyStyles(barA.getShell(), true);
 
 		assertEquals(WHITE, barA.getBackground().getRGB());

--- a/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/tests/forms/performance/FormsPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/tests/forms/performance/FormsPerformanceTest.java
@@ -157,7 +157,7 @@ public class FormsPerformanceTest extends PerformanceTestCase {
 				//form.reflow(true);
 			}
 		});
-		Section section = toolkit.createSection(form.getBody(), Section.DESCRIPTION|Section.TWISTIE|Section.EXPANDED);
+		Section section = toolkit.createSection(form.getBody(), Section.DESCRIPTION|ExpandableComposite.TWISTIE|ExpandableComposite.EXPANDED);
 		td = new TableWrapData(TableWrapData.FILL);
 		td.colspan = 2;
 		section.setLayoutData(td);

--- a/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/tests/forms/widgets/SectionFactoryTest.java
+++ b/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/tests/forms/widgets/SectionFactoryTest.java
@@ -21,6 +21,7 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.forms.events.ExpansionEvent;
+import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.forms.widgets.Section;
 import org.eclipse.ui.forms.widgets.SectionFactory;
 import org.eclipse.ui.forms.widgets.Twistie;
@@ -69,7 +70,7 @@ public class SectionFactoryTest {
 	@Test
 	public void addsSectionExpandListeners() {
 		final ExpansionEvent[] raisedEvents = new ExpansionEvent[1];
-		Section section = SectionFactory.newSection(Section.TWISTIE).onExpanded(e -> raisedEvents[0] = e)
+		Section section = SectionFactory.newSection(ExpandableComposite.TWISTIE).onExpanded(e -> raisedEvents[0] = e)
 				.create(shell);
 		Control twistie = section.getChildren()[0];
 		assertTrue("Expected a twistie", twistie instanceof Twistie);
@@ -81,7 +82,7 @@ public class SectionFactoryTest {
 	@Test
 	public void addsSectionExpandingListener() {
 		final ExpansionEvent[] raisedEvents = new ExpansionEvent[1];
-		Section section = SectionFactory.newSection(Section.TWISTIE).onExpanding(e -> raisedEvents[0] = e)
+		Section section = SectionFactory.newSection(ExpandableComposite.TWISTIE).onExpanding(e -> raisedEvents[0] = e)
 				.create(shell);
 		Control twistie = section.getChildren()[0];
 		assertTrue("Expected a twistie", twistie instanceof Twistie);

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/NestedResourcesTests.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/NestedResourcesTests.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.eclipse.core.internal.resources.Marker;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
@@ -160,7 +159,7 @@ public class NestedResourcesTests {
 			marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
 		}, monitor);
 		assertTrue(DisplayHelper.waitForCondition(Display.getDefault(), TIMEOUT,
-				() -> Marker.SEVERITY_WARNING == labelProvider.getHighestProblemSeverity(parentProject)));
+				() -> IMarker.SEVERITY_WARNING == labelProvider.getHighestProblemSeverity(parentProject)));
 		//
 		root.getWorkspace().run(aMonitor -> {
 			IMarker marker = secondChildProject.createMarker(IMarker.PROBLEM);


### PR DESCRIPTION
Applies the following cleanup rules concerning static member access to all projects in order to be conform with defined save actions:
* change non-static accesses to static members using declaring type
* change indirect accesses to static members to direct accesses