### PR TITLE
Fix equals for elements containing null #1851

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredSelection.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredSelection.java
@@ -146,16 +146,18 @@ public class StructuredSelection implements IStructuredSelection {
 		if (myLen != s2.elements.length) {
 			return false;
 		}
+
 		//element comparison
-		for (int i = 0; i < myLen; i++) {
-			if (useComparer) {
+		if (useComparer) {
+			for (int i = 0; i < myLen; i++) {
 				if (!comparer.equals(elements[i], s2.elements[i])) {
 					return false;
 				}
-			} else if (!elements[i].equals(s2.elements[i])) {
-				return false;
 			}
+		} else {
+			return Arrays.equals(elements, s2.elements);
 		}
+
 		return true;
 	}
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/StructuredSelectionTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/StructuredSelectionTest.java
@@ -137,6 +137,20 @@ public class StructuredSelectionTest {
 	}
 
 	@Test
+	public void testEqualsFalseWithElementsContainingNull() {
+		StructuredSelection s1 = new StructuredSelection(new Object[] { "element 1", null });
+		StructuredSelection s2 = new StructuredSelection(new Object[] { "element 1", "element 2" });
+		assertFalse(s1.equals(s2));
+	}
+
+	@Test
+	public void testEqualsTrueWithElementsContainingNull() {
+		StructuredSelection s1 = new StructuredSelection(new Object[] { "element 1", null });
+		StructuredSelection s2 = new StructuredSelection(new Object[] { "element 1", null });
+		assertTrue(s1.equals(s2));
+	}
+
+	@Test
 	public void testEqualsWithComparer1() {
 		doTestEqualsWithComparer1(JAVA_LANG_OBJECT_COMPARER);
 		doTestEqualsWithComparer1(IDENTITY_COMPARER);


### PR DESCRIPTION
Fixes #1851 

- use Arrays.equals if no comparer is set
- add test cases for elements containing null