### PR TITLE
Convert functional interface instances into lambda expressions

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/addons/CommandProcessingAddon.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/addons/CommandProcessingAddon.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.eclipse.core.commands.Category;
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.CommandManager;
-import org.eclipse.core.commands.CommandManagerEvent;
 import org.eclipse.core.commands.ICommandManagerListener;
 import org.eclipse.core.commands.IParameter;
 import org.eclipse.core.commands.ParameterType;
@@ -144,28 +143,25 @@ public class CommandProcessingAddon {
 	}
 
 	private void registerCommandListener() {
-		cmListener = new ICommandManagerListener() {
-			@Override
-			public void commandManagerChanged(CommandManagerEvent commandManagerEvent) {
-				if (commandManagerEvent.isCommandChanged()) {
-					if (commandManagerEvent.isCommandDefined()) {
-						final String commandId = commandManagerEvent.getCommandId();
-						if (findCommand(commandId) != null) {
-							return;
-						}
-						final Command command = commandManagerEvent.getCommandManager().getCommand(
-								commandId);
-						if (command.getHandler() == null) {
-							command.setHandler(HandlerServiceImpl.getHandler(commandId));
-						}
-						try {
-							MCategory categoryModel = findCategory(command.getCategory().getId());
-							final MCommand createdCommand = createCommand(command, modelService,
-									categoryModel);
-							application.getCommands().add(createdCommand);
-						} catch (NotDefinedException e) {
-							ILog.get().error("Failed to create command " + commandId, e); //$NON-NLS-1$
-						}
+		cmListener = commandManagerEvent -> {
+			if (commandManagerEvent.isCommandChanged()) {
+				if (commandManagerEvent.isCommandDefined()) {
+					final String commandId = commandManagerEvent.getCommandId();
+					if (findCommand(commandId) != null) {
+						return;
+					}
+					final Command command = commandManagerEvent.getCommandManager().getCommand(
+							commandId);
+					if (command.getHandler() == null) {
+						command.setHandler(HandlerServiceImpl.getHandler(commandId));
+					}
+					try {
+						MCategory categoryModel = findCategory(command.getCategory().getId());
+						final MCommand createdCommand = createCommand(command, modelService,
+								categoryModel);
+						application.getCommands().add(createdCommand);
+					} catch (NotDefinedException e) {
+						ILog.get().error("Failed to create command " + commandId, e); //$NON-NLS-1$
 					}
 				}
 			}

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/ColorSelector.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/ColorSelector.java
@@ -27,7 +27,6 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
-import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Button;
@@ -176,30 +175,28 @@ public class ColorSelector extends EventManager {
 		}
 
 		final Display display = fButton.getDisplay();
-
-		fImage = new Image(display, new ImageDataProvider() {
-
-			@Override
-			public ImageData getImageData(int zoom) {
-				Image image = new Image(display, fExtent.x, fExtent.y);
-				GC gc = new GC(image);
-
-				RGB color = getColorValue();
-				gc.setForeground(display.getSystemColor(SWT.COLOR_WIDGET_BORDER));
-				if (color != null) {
-					gc.setBackground(new Color(display, color));
-					gc.fillRectangle(image.getBounds());
-				}
-				gc.setLineWidth(2);
-				gc.drawRectangle(image.getBounds());
-				gc.dispose();
-
-				ImageData data = image.getImageData(zoom);
-				image.dispose();
-				return data;
-			}
-		});
+		fImage = new Image(display, this::getImageData);
 		fButton.setImage(fImage);
+	}
+
+	private ImageData getImageData(int zoom) {
+		final Display display = fButton.getDisplay();
+		Image image = new Image(display, fExtent.x, fExtent.y);
+		GC gc = new GC(image);
+
+		RGB color = getColorValue();
+		gc.setForeground(display.getSystemColor(SWT.COLOR_WIDGET_BORDER));
+		if (color != null) {
+			gc.setBackground(new Color(display, color));
+			gc.fillRectangle(image.getBounds());
+		}
+		gc.setLineWidth(2);
+		gc.drawRectangle(image.getBounds());
+		gc.dispose();
+
+		ImageData data = image.getImageData(zoom);
+		image.dispose();
+		return data;
 	}
 
 	/**

--- a/bundles/org.eclipse.search.core/search/org/eclipse/search/internal/core/DirtyFileSearchParticipantServiceTracker.java
+++ b/bundles/org.eclipse.search.core/search/org/eclipse/search/internal/core/DirtyFileSearchParticipantServiceTracker.java
@@ -16,7 +16,6 @@ package org.eclipse.search.internal.core;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -45,17 +44,14 @@ public class DirtyFileSearchParticipantServiceTracker
 		ServiceReference<DirtyFileProvider>[] allRefs = getServiceReferences();
 		if (allRefs != null && allRefs.length > 0) {
 			List<ServiceReference<DirtyFileProvider>> l = Arrays.asList(allRefs);
-			Collections.sort(l, new Comparator<ServiceReference<DirtyFileProvider>>() {
-				@Override
-				public int compare(ServiceReference<DirtyFileProvider> o1, ServiceReference<DirtyFileProvider> o2) {
-					Object o1Weight = o1.getProperty(PROPERTY_WEIGHT);
-					Object o2Weight = o2.getProperty(PROPERTY_WEIGHT);
-					int o1Val = o1Weight == null ? 0
-							: o1Weight instanceof Integer ? ((Integer) o1Weight).intValue() : 0;
-					int o2Val = o2Weight == null ? 0
-							: o2Weight instanceof Integer ? ((Integer) o2Weight).intValue() : 0;
-					return o2Val - o1Val;
-				}
+			Collections.sort(l, (o1, o2) -> {
+				Object o1Weight = o1.getProperty(PROPERTY_WEIGHT);
+				Object o2Weight = o2.getProperty(PROPERTY_WEIGHT);
+				int o1Val = o1Weight == null ? 0
+						: o1Weight instanceof Integer ? ((Integer) o1Weight).intValue() : 0;
+				int o2Val = o2Weight == null ? 0
+						: o2Weight instanceof Integer ? ((Integer) o2Weight).intValue() : 0;
+				return o2Val - o1Val;
 			});
 			if (l.size() > 0) {
 				return getService(l.get(0));

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/views/WorkbenchViewerSetup.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/views/WorkbenchViewerSetup.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.util.IPropertyChangeListener;
-import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.jface.viewers.ColumnViewer;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.swt.events.DisposeEvent;
@@ -39,25 +38,21 @@ public class WorkbenchViewerSetup {
 
 	static Map<DisposeListener, ColumnViewer> registeredViewers = new ConcurrentHashMap<>();
 
-	static final IPropertyChangeListener propertyChangeListener = new IPropertyChangeListener() {
-
-		@Override
-		public void propertyChange(PropertyChangeEvent event) {
-			if (!IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT.equals(event.getProperty())) {
-				return;
-			}
-			int itemsLimit = getItemsLimit();
-			registeredViewers.values().forEach(v -> {
-				v.setDisplayIncrementally(itemsLimit);
-				Object input = v.getInput();
-				if (input != null) {
-					v.setInput(null);
-					v.setInput(input);
-				} else {
-					v.refresh();
-				}
-			});
+	static final IPropertyChangeListener propertyChangeListener = event -> {
+		if (!IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT.equals(event.getProperty())) {
+			return;
 		}
+		int itemsLimit = getItemsLimit();
+		registeredViewers.values().forEach(v -> {
+			v.setDisplayIncrementally(itemsLimit);
+			Object input = v.getInput();
+			if (input != null) {
+				v.setInput(null);
+				v.setInput(input);
+			} else {
+				v.refresh();
+			}
+		});
 	};
 
 	static {

--- a/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet047VirtualBigTreeViewer.java
+++ b/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet047VirtualBigTreeViewer.java
@@ -172,25 +172,20 @@ public class Snippet047VirtualBigTreeViewer {
 
 	public static void main(String[] args) {
 
-		Thread thread = new Thread(new Runnable() {
-
-			@Override
-			public void run() {
-
-				try {
-					long last = 0;
-					while (true) {
-						TimeUnit.SECONDS.sleep(1);
-						long current = rendered.get();
-						if (current != last) {
-							last = current;
-							System.out.println("Total render requests: " + current + ", " + updated.get()
-									+ " update elements, " + childcount.get() + " update childcounts");
-						}
+		Thread thread = new Thread(() -> {
+			try {
+				long last = 0;
+				while (true) {
+					TimeUnit.SECONDS.sleep(1);
+					long current = rendered.get();
+					if (current != last) {
+						last = current;
+						System.out.println("Total render requests: " + current + ", " + updated.get()
+								+ " update elements, " + childcount.get() + " update childcounts");
 					}
-				} catch (InterruptedException e) {
-					return;
 				}
+			} catch (InterruptedException e) {
+				return;
 			}
 		});
 		thread.setDaemon(true);

--- a/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet069TreeViewerWithLimit.java
+++ b/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet069TreeViewerWithLimit.java
@@ -17,11 +17,9 @@ package org.eclipse.jface.snippets.viewers;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.LabelProvider;
-import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TreeSelection;
 import org.eclipse.jface.viewers.TreeViewer;
@@ -199,13 +197,9 @@ public class Snippet069TreeViewerWithLimit {
 		root = createModel();
 		viewer.setInput(root);
 
-		viewer.addSelectionChangedListener(new ISelectionChangedListener() {
-
-			@Override
-			public void selectionChanged(SelectionChangedEvent event) {
-				if (event.getSelection() instanceof TreeSelection) {
-					curSel = ((TreeSelection) event.getSelection()).getFirstElement();
-				}
+		viewer.addSelectionChangedListener(event -> {
+			if (event.getSelection() instanceof TreeSelection) {
+				curSel = ((TreeSelection) event.getSelection()).getFirstElement();
 			}
 		});
 

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningProjectionViewerTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningProjectionViewerTest.java
@@ -29,8 +29,6 @@ import org.junit.Test;
 import org.osgi.framework.Bundle;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
@@ -54,7 +52,6 @@ import org.eclipse.jface.text.contentassist.ContentAssistant;
 import org.eclipse.jface.text.contentassist.IContentAssistant;
 import org.eclipse.jface.text.source.AnnotationPainter;
 import org.eclipse.jface.text.source.IAnnotationAccess;
-import org.eclipse.jface.text.source.ISharedTextColors;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.text.source.SourceViewerConfiguration;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
@@ -109,12 +106,7 @@ public class CodeMiningProjectionViewerTest {
 		fViewer.setCodeMiningAnnotationPainter(painter);
 		// projection/folding
 		fViewer.setDocument(new Document(), new ProjectionAnnotationModel());
-		ProjectionSupport projectionSupport = new ProjectionSupport(fViewer, annotationAccess, new ISharedTextColors() {
-			@Override
-			public Color getColor(RGB rgb) {
-				return null;
-			}
-		});
+		ProjectionSupport projectionSupport = new ProjectionSupport(fViewer, annotationAccess, rgb -> null);
 		projectionSupport.install();
 		fViewer.doOperation(ProjectionViewer.TOGGLE);
 	}

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/participants/CancelingParticipantTests.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/participants/CancelingParticipantTests.java
@@ -133,12 +133,7 @@ public class CancelingParticipantTests {
 
 	@Before
 	public void setUp() {
-		fLogListener= new ILogListener() {
-			@Override
-			public void logging(IStatus status, String plugin) {
-				fLogEntries.add(status);
-			}
-		};
+		fLogListener= (status, plugin) -> fLogEntries.add(status);
 		Platform.addLogListener(fLogListener);
 		fLogEntries= new ArrayList<>();
 	}

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/participants/FailingParticipantTests.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/participants/FailingParticipantTests.java
@@ -46,12 +46,7 @@ public class FailingParticipantTests {
 
 	@Before
 	public void setUp() {
-		fLogListener= new ILogListener() {
-			@Override
-			public void logging(IStatus status, String plugin) {
-				fLogEntries.add(status);
-			}
-		};
+		fLogListener= (status, plugin) -> fLogEntries.add(status);
 		Platform.addLogListener(fLogListener);
 	}
 

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/GoBackForwardsTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/GoBackForwardsTest.java
@@ -178,19 +178,14 @@ public class GoBackForwardsTest extends UITestCase {
 	}
 
 	private Condition currentNavigationHistoryLocationCondition(String editorId, boolean selection) {
-		return new Condition() {
-
-			@Override
-			public boolean compute() {
-				INavigationLocation location = EditorTestHelper.getActiveWorkbenchWindow().getActivePage()
-						.getNavigationHistory().getCurrentLocation();
-				if (location instanceof TextSelectionNavigationLocation) {
-					return editorId.equals(location.getId())
-							&& (!selection || SELECTION_STRING.equals(location.toString()));
-				}
-				return false;
+		return () -> {
+			INavigationLocation location = EditorTestHelper.getActiveWorkbenchWindow().getActivePage()
+					.getNavigationHistory().getCurrentLocation();
+			if (location instanceof TextSelectionNavigationLocation) {
+				return editorId.equals(location.getId())
+						&& (!selection || SELECTION_STRING.equals(location.toString()));
 			}
-
+			return false;
 		};
 	}
 


### PR DESCRIPTION
Apply cleanup to convert functional interface instances into simple lambda expression in all projects to align with defined save actions. Store lambda expression result in local variable where reasonable.