### PR TITLE
Remove unnecessary methods from IFindReplaceUIAccess

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
@@ -17,9 +17,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.HashSet;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.junit.Rule;
 import org.junit.rules.TestName;
@@ -231,32 +232,6 @@ class DialogAccess implements IFindReplaceUIAccess {
 	}
 
 	@Override
-	public Set<SearchOptions> getEnabledOptions() {
-		HashSet<SearchOptions> ret= new HashSet<>();
-
-		for (SearchOptions option : SearchOptions.values()) {
-			if (getButtonForSearchOption(option).isEnabled()) {
-				ret.add(option);
-			}
-		}
-
-		return ret;
-	}
-
-	@Override
-	public Set<SearchOptions> getSelectedOptions() {
-		Set<SearchOptions> ret= new HashSet<>();
-
-		for (SearchOptions option : SearchOptions.values()) {
-			if (getButtonForSearchOption(option).getSelection()) {
-				ret.add(option);
-			}
-		}
-
-		return ret;
-	}
-
-	@Override
 	public IFindReplaceLogic getFindReplaceLogic() {
 		return findReplaceLogic;
 	}
@@ -340,6 +315,18 @@ class DialogAccess implements IFindReplaceUIAccess {
 	public void assertUnselected(SearchOptions option) {
 		Set<SearchOptions> enabled= getSelectedOptions();
 		assertThat(enabled, not(hasItems(option)));
+	}
+
+	private Set<SearchOptions> getEnabledOptions() {
+		return Arrays.stream(SearchOptions.values())
+				.filter(option -> getButtonForSearchOption(option).isEnabled())
+				.collect(Collectors.toSet());
+	}
+
+	private Set<SearchOptions> getSelectedOptions() {
+		return Arrays.stream(SearchOptions.values())
+				.filter(option -> getButtonForSearchOption(option).getSelection())
+				.collect(Collectors.toSet());
 	}
 
 }

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/IFindReplaceUIAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/IFindReplaceUIAccess.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests;
 
-import java.util.Set;
-
 import org.eclipse.swt.widgets.Widget;
 
 import org.eclipse.jface.text.IFindReplaceTarget;
@@ -19,9 +17,8 @@ import org.eclipse.jface.text.IFindReplaceTarget;
 import org.eclipse.ui.internal.findandreplace.IFindReplaceLogic;
 import org.eclipse.ui.internal.findandreplace.SearchOptions;
 
-
 /**
- * Wraps UI-Access for different Find/Replace-UIs
+ * Wraps UI access for different find/replace UIs
  */
 interface IFindReplaceUIAccess {
 
@@ -51,10 +48,6 @@ interface IFindReplaceUIAccess {
 
 	Widget getButtonForSearchOption(SearchOptions option);
 
-	Set<SearchOptions> getEnabledOptions();
-
-	Set<SearchOptions> getSelectedOptions();
-
 	IFindReplaceLogic getFindReplaceLogic();
 
 	void performReplaceAll();
@@ -63,7 +56,7 @@ interface IFindReplaceUIAccess {
 
 	void performReplaceAndFind();
 
-	abstract void assertInitialConfiguration();
+	void assertInitialConfiguration();
 
 	void assertUnselected(SearchOptions option);
 


### PR DESCRIPTION
Simplify the test interface and the implementation of now non-public methods.

Follow-up of #1840.