### PR TITLE
Fix faulty test name access in FindReplaceDialogTest utilities

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
@@ -10,20 +10,17 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests;
 
+import static org.eclipse.ui.workbench.texteditor.tests.FindReplaceTestUtil.runEventQueue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import org.junit.Rule;
-import org.junit.rules.TestName;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
@@ -32,8 +29,6 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.text.tests.Accessor;
-
-import org.eclipse.jface.util.Util;
 
 import org.eclipse.jface.text.IFindReplaceTarget;
 import org.eclipse.jface.text.IFindReplaceTargetExtension;
@@ -167,19 +162,9 @@ class DialogAccess implements IFindReplaceUIAccess {
 		closeOperation.run();
 	}
 
-	@Rule
-	public TestName name= new TestName();
-
 	@Override
-	public void ensureHasFocusOnGTK() {
-		if (Util.isGtk()) {
-			// Ensure workbench has focus on GTK
-			FindReplaceUITest.runEventQueue();
-			if (shellRetriever.get() == null) {
-				String screenshotPath= ScreenshotTest.takeScreenshot(FindReplaceUITest.class, name.getMethodName(), System.out);
-				fail("this test does not work on GTK unless the runtime workbench has focus. Screenshot: " + screenshotPath);
-			}
-		}
+	public Shell getActiveShell() {
+		return shellRetriever.get();
 	}
 
 	@Override
@@ -197,7 +182,7 @@ class DialogAccess implements IFindReplaceUIAccess {
 			event.stateMask= SWT.SHIFT;
 		}
 		findCombo.traverse(SWT.TRAVERSE_RETURN, event);
-		FindReplaceUITest.runEventQueue();
+		runEventQueue();
 	}
 
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests;
 
+import static org.eclipse.ui.workbench.texteditor.tests.FindReplaceTestUtil.runEventQueue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
@@ -67,7 +68,7 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		dialog.findCombo.setFocus();
 		dialog.setFindText("line");
 		dialog.simulateEnterInFindInputField(false);
-		dialog.ensureHasFocusOnGTK();
+		ensureHasFocusOnGTK();
 
 		assertTrue(dialog.getFindCombo().isFocusControl());
 
@@ -90,7 +91,7 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		DialogAccess dialog= getDialog();
 
 		dialog.setFindText("line");
-		dialog.ensureHasFocusOnGTK();
+		ensureHasFocusOnGTK();
 
 		Button wrapCheckBox= dialog.getButtonForSearchOption(SearchOptions.WRAP);
 		wrapCheckBox.setFocus();
@@ -124,7 +125,7 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		DialogAccess dialog= getDialog();
 
 		dialog.setFindText("line");
-		dialog.ensureHasFocusOnGTK();
+		ensureHasFocusOnGTK();
 		IFindReplaceTarget target= dialog.getTarget();
 
 		dialog.simulateEnterInFindInputField(false);

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceTestUtil.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceTestUtil.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.workbench.texteditor.tests;
+
+import org.eclipse.swt.widgets.Display;
+
+import org.eclipse.ui.PlatformUI;
+
+public final class FindReplaceTestUtil {
+
+	private FindReplaceTestUtil() {
+	}
+
+	public static void runEventQueue() {
+		Display display= PlatformUI.getWorkbench().getDisplay();
+		for (int i= 0; i < 10; i++) { // workaround for https://bugs.eclipse.org/323272
+			while (display.readAndDispatch()) {
+				// do nothing
+			}
+			try {
+				Thread.sleep(50);
+			} catch (InterruptedException e) {
+				// do nothing
+			}
+		}
+	}
+
+}

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/IFindReplaceUIAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/IFindReplaceUIAccess.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests;
 
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Widget;
 
 import org.eclipse.jface.text.IFindReplaceTarget;
@@ -28,8 +29,6 @@ interface IFindReplaceUIAccess {
 
 	void close();
 
-	void ensureHasFocusOnGTK();
-
 	void unselect(SearchOptions option);
 
 	void select(SearchOptions option);
@@ -45,6 +44,8 @@ interface IFindReplaceUIAccess {
 	void setFindText(String text);
 
 	void setReplaceText(String text);
+
+	Shell getActiveShell();
 
 	Widget getButtonForSearchOption(SearchOptions option);
 


### PR DESCRIPTION
The DialogAccess class used for FindReplaceDialogTest currently tried to access the test name via a test rule, but since it is not a test class, that one is not assigned correctly.

This change moves the functionality depending on the test information to an actual test class and also moves the runEventQueue() utility method to a proper utility class.