### PR TITLE
Guard against IEditorReference.getEditor(true) returning null

### DIFF
--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/ScopePart.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/ScopePart.java
@@ -244,6 +244,9 @@ public class ScopePart {
 				}
 				// May trigger editor init
 				IEditorPart editor = ref.getEditor(true);
+				if (editor == null) {
+					continue;
+				}
 				resource = editor.getAdapter(IResource.class);
 				if (resource != null) {
 					resources.add(resource);


### PR DESCRIPTION
The getEditor(true) method is called by ScopePart.selectedResourcesFromEditors() and the method is documented as "Returns <code>null</code> if the editor was not instantiated or it failed to be restored." so the null case must be considered.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1151