### PR TITLE
VirtualTableViewerTest: improve table update + force active shell #1005

### DIFF
--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualLazyTableViewerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/VirtualLazyTableViewerTest.java
@@ -50,7 +50,6 @@ public class VirtualLazyTableViewerTest extends VirtualTableViewerTest {
 	public void setUp() {
 		updatedElements = new ArrayList<>();
 		super.setUp();
-		processEvents();
 	}
 
 	@Override


### PR DESCRIPTION
Several test cases of VirtualTableViewerTest randomly fail. This includes explicit failures of testRenameWithSorter() and testContains() and silent failures of other test cases that simply return successfully even if the test actually failed. The reason is a missing processing of an update of the table data, which is most likely caused by the shell not having focus.

With this change, the test execution ensures that in cases where an update of the table data is expected, the shell is forced active. In addition, early returns producing silent failures are replaced by assertions leading to explicit failures in case the condition is still not met.

In case tests that previously failed silently now start to fail explicitly despite the changes, I propose to disable them completely (which does make a difference to the current state, see https://github.com/eclipse-platform/eclipse.platform.ui/issues/1583).

Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/1583

May fix https://github.com/eclipse-platform/eclipse.platform.ui/issues/1005