### PR TITLE
Enforce correct auto-build settings for import wizard tests #811 #1827

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingProjectsWizardTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingProjectsWizardTest.java
@@ -17,6 +17,8 @@
 package org.eclipse.ui.tests.datatransfer;
 
 import static org.eclipse.jface.dialogs.IMessageProvider.WARNING;
+import static org.eclipse.ui.tests.datatransfer.ImportTestUtils.restoreWorkspaceConfiguration;
+import static org.eclipse.ui.tests.datatransfer.ImportTestUtils.setWorkspaceAutoBuild;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -102,6 +104,7 @@ public class ImportExistingProjectsWizardTest extends UITestCase {
 						ResourcesPlugin.PREF_AUTO_REFRESH);
 		ResourcesPlugin.getPlugin().getPluginPreferences().setValue(
 				ResourcesPlugin.PREF_AUTO_REFRESH, true);
+		setWorkspaceAutoBuild(true);
 	}
 
 	@Override
@@ -133,6 +136,7 @@ public class ImportExistingProjectsWizardTest extends UITestCase {
 
 		ResourcesPlugin.getPlugin().getPluginPreferences().setValue(
 				ResourcesPlugin.PREF_AUTO_REFRESH, originalRefreshSetting);
+		restoreWorkspaceConfiguration();
 		super.doTearDown();
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportTestUtils.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportTestUtils.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ui.tests.datatransfer;
 
+import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.ZipFile;
 
+import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
@@ -54,7 +56,6 @@ public class ImportTestUtils {
 		static List<Integer> otherBuildTriggerTypes = new ArrayList<>();
 
 		public TestBuilder() {
-			resetCallCount();
 			instantiationCount.incrementAndGet();
 		}
 
@@ -145,6 +146,16 @@ public class ImportTestUtils {
 			description.setAutoBuilding(autobuildOn);
 			workspace.setDescription(description);
 		}
+		waitForAutoBuild();
+	}
+
+	static void restoreWorkspaceConfiguration() throws CoreException {
+		ResourcesPlugin.getWorkspace().setDescription(Workspace.defaultWorkspaceDescription());
+		waitForAutoBuild();
+	}
+
+	static void waitForAutoBuild() {
+		((Workspace) getWorkspace()).getBuildManager().waitForAutoBuild();
 	}
 
 	static void waitForBuild() throws InterruptedException {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/SmartImportTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/SmartImportTests.java
@@ -14,6 +14,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.datatransfer;
 
+import static org.eclipse.ui.tests.datatransfer.ImportTestUtils.restoreWorkspaceConfiguration;
+import static org.eclipse.ui.tests.datatransfer.ImportTestUtils.setWorkspaceAutoBuild;
+
 import java.io.CharArrayReader;
 import java.io.CharArrayWriter;
 import java.io.File;
@@ -87,6 +90,7 @@ public class SmartImportTests extends UITestCase {
 		super.doSetUp();
 		ImportMeProjectConfigurator.configuredProjects.clear();
 		clearAll();
+		setWorkspaceAutoBuild(true);
 	}
 
 	@Override
@@ -94,6 +98,7 @@ public class SmartImportTests extends UITestCase {
 		ImportMeProjectConfigurator.configuredProjects.clear();
 		try {
 			clearAll();
+			restoreWorkspaceConfiguration();
 		} finally {
 			super.doTearDown();
 		}


### PR DESCRIPTION
The test cases `SmartImportTests.testConfigurationFullBuildAfterImportedProjects` and `ImportExistingProjectsWizardTest.test20FullBuildAfterImportedProjectsZipFile` (as well as subsequent tests cases in `ImportExistingProjectsWizardTest`) randomly fail because the test builder is not triggered as expected. Potential reasons for this are race conditions (because the test builder resets its counters on its own, even though its consumers also do that) and missing test isolation (auto-building not being enabled as required).

This change addresses the potential reasons:
* Remove the unnecessary and potentially conflicting reset of counters within the TestBuilder
* Ensure enabled auto-build via test setup (and properly restore default settings afterwards)

May fix https://github.com/eclipse-platform/eclipse.platform.ui/issues/811

May fix https://github.com/eclipse-platform/eclipse.platform.ui/issues/1827