### PR TITLE
[WiP] Use WorkspaceTestRule in UITestCase #291

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.harness/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Eclipse-BundleShape: dir
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.junit,
- org.eclipse.core.resources
+ org.eclipse.core.resources,
+ org.eclipse.core.tests.resources
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.ui.tests.harness,
  org.eclipse.ui.tests.harness.tests,

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
@@ -28,6 +28,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.tests.resources.WorkspaceTestRule;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceMemento;
 import org.eclipse.swt.SWT;
@@ -57,6 +58,9 @@ import junit.framework.TestCase;
  * windows when the tearDown method is called.
  */
 public abstract class UITestCase extends TestCase {
+
+	@Rule
+	public WorkspaceTestRule workspaceRule = new WorkspaceTestRule();
 
 	/**
 	 * Returns the workbench page input to use for newly created windows.

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourceInitialSelectionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourceInitialSelectionTest.java
@@ -382,9 +382,6 @@ public class ResourceInitialSelectionTest extends UITestCase {
 		if (dialog != null) {
 			dialog.close();
 		}
-		if (project != null) {
-			project.delete(true, null);
-		}
 		super.doTearDown();
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/navigator/AbstractNavigatorTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/navigator/AbstractNavigatorTest.java
@@ -80,18 +80,11 @@ public abstract class AbstractNavigatorTest extends UITestCase {
 
 	@Override
 	protected void doTearDown() throws Exception {
-		if (testProject != null) {
-			try {
-				testProject.delete(true, null);
-			} catch (CoreException e) {
-				fail(e.toString());
-			}
-			testProject = null;
-			testFolder = null;
-			testFile = null;
-		}
-		super.doTearDown();
+		testProject = null;
+		testFolder = null;
+		testFile = null;
 		navigator = null;
+		super.doTearDown();
 	}
 
 }


### PR DESCRIPTION
⚠️ This is not to be merged. It is currently only supposed to provide an overview of side effects when applying the general `WorkspaceTestRule` for uniform workspace cleanup after test execution to all `UITestCase` implementations. ⚠️

All specializations of UITestCase operate on a workspace, for which the JUnit 4 WorkspaceTestRule exist to ensure proper workspace cleanup, including deletion of all projects and restoring workspace default settings. Currently, such cleanup is up to the individual test case and not performed uniformly and consistently.

With this change, the WorkspaceTestRule is applied to all specializations of WorkspaceTestRule. As a first direct application, the manual project deletion in ResourceInitialSelectionTest, which is currently failing randomly, is removed and replaced by the general cleanup functionality.

May fix https://github.com/eclipse-platform/eclipse.platform.ui/issues/294