### PR TITLE
Custom window size not considered for second opened window

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/Workbench.java
@@ -1477,7 +1477,14 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 				windowWhileInit = getActiveWorkbenchWindow();
 
 				if (newWindow) {
-					Point size = result.getWindowConfigurer().getInitialSize();
+					WorkbenchWindowConfigurer windowConfigurer;
+					WorkbenchWindow existingWindow = (WorkbenchWindow) windowWhileInit;
+					if (existingWindow != null) {
+						windowConfigurer = existingWindow.getWindowConfigurer();
+					} else {
+						windowConfigurer = result.getWindowConfigurer();
+					}
+					Point size = windowConfigurer.getInitialSize();
 					window.setWidth(size.x);
 					window.setHeight(size.y);
 


### PR DESCRIPTION
If a new window should be created, read initial window size from the window configurer of already existing window (if any), and not from the not yet properly initialized window configurer of the "to be created" window.

This avoids extra shell.setBounds() call during WorkbenchWindow.setup() that may cause troubles on not yet opened shell instance depending on the timing.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1868