### PR TITLE
The label for internet exporer is missing #1870

### DIFF
--- a/bundles/org.eclipse.ui.browser/plugin.properties
+++ b/bundles/org.eclipse.ui.browser/plugin.properties
@@ -30,7 +30,7 @@ commandParameter.openBrowser.browserId.name=Browser Id
 commandParameter.openBrowser.name.name=Browser Name
 commandParameter.openBrowser.tooltip.name=Browser Tooltip
 
-
+browserInternetExplorer=Internet Explorer
 browserMicrosoftEdge=Microsoft Edge
 browserOpera=Opera
 browserChrome=Chrome


### PR DESCRIPTION
This commit will correct the label of Internet Explorer in the browser list on the preference page. It's due to the regression of the old commit

commit 21add1aaf9e11ce8c092f6d981d2775cfb2eefb8
Deleted both Camino and Internet Explorer from Plugin.properties file and Plugin.xml file.

