### PR TITLE
[Generic Editor] Derive the file name from storage instead from the editor name # 1872

### DIFF
--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ExtensionBasedTextViewerConfiguration.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/ExtensionBasedTextViewerConfiguration.java
@@ -37,6 +37,8 @@ import java.util.stream.Collectors;
 
 import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.filebuffers.ITextFileBuffer;
+import org.eclipse.core.resources.IStorage;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IPath;
@@ -75,6 +77,7 @@ import org.eclipse.jface.text.reconciler.IReconcilingStrategy;
 import org.eclipse.jface.text.reconciler.Reconciler;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.editors.text.TextSourceViewerConfiguration;
 import org.eclipse.ui.internal.editors.text.EditorsPlugin;
 import org.eclipse.ui.internal.genericeditor.folding.DefaultFoldingReconciler;
@@ -174,7 +177,8 @@ public final class ExtensionBasedTextViewerConfiguration extends TextSourceViewe
 	private String getCurrentFileName(IDocument documentParam) {
 		String fileName = null;
 		if (this.editor != null) {
-			fileName = editor.getEditorInput().getName();
+			IEditorInput editorInput = editor.getEditorInput();
+			fileName = Adapters.of(editorInput, IStorage.class).map(IStorage::getName).orElseGet(editorInput::getName);
 		}
 		if (fileName == null) {
 			ITextFileBuffer buffer = getCurrentBuffer(documentParam);

--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/AbstratGenericEditorTest.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/AbstratGenericEditorTest.java
@@ -15,6 +15,7 @@ package org.eclipse.ui.genericeditor.tests;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
 
 import org.junit.After;
 import org.junit.Before;
@@ -29,6 +30,7 @@ import org.eclipse.text.tests.Accessor;
 
 import org.eclipse.jface.text.source.SourceViewer;
 
+import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor;
@@ -79,11 +81,22 @@ public class AbstratGenericEditorTest {
 	 * @since 1.1
 	 */
 	protected void createAndOpenFile(String name, String contents) throws Exception {
+		createAndOpenFile(name, contents, () -> new FileEditorInput(file));
+	}
+
+	/**
+	 * Creates a new file in the project, opens it, and associate that file with the test state
+	 * @param name name of the file in the project
+	 * @param contents content of the file
+	 * @param inputCreator creates the input for the editor
+	 * @throws Exception ex
+	 */
+	protected void createAndOpenFile(String name, String contents, Supplier<? extends IEditorInput> inputCreator) throws Exception {
 		this.file = project.getFile(name);
 		this.file.create(new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8)), true, null);
 		this.file.setCharset(StandardCharsets.UTF_8.name(), null);
 		this.editor = (ExtensionBasedTextEditor) PlatformUI.getWorkbench().getActiveWorkbenchWindow()
-				.getActivePage().openEditor(new FileEditorInput(this.file), "org.eclipse.ui.genericeditor.GenericEditor");
+				.getActivePage().openEditor(inputCreator.get(), "org.eclipse.ui.genericeditor.GenericEditor");
 		UITestCase.processEvents();
 	}
 

--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/HighlightTest.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/HighlightTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 
 import org.eclipse.swt.widgets.Display;
 
+import org.eclipse.core.resources.IStorage;
+
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.source.Annotation;
@@ -31,6 +33,7 @@ import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.jface.text.tests.util.DisplayHelper;
 
 import org.eclipse.ui.genericeditor.tests.contributions.EnabledPropertyTester;
+import org.eclipse.ui.part.FileEditorInput;
 
 import org.eclipse.ui.texteditor.IDocumentProvider;
 
@@ -50,6 +53,26 @@ public class HighlightTest extends AbstratGenericEditorTest {
 	@Test
 	public void testCustomHighlightReconciler() throws Exception {
 		createAndOpenFile("bar.txt", "bar 'bar'");
+
+		checkHighlightForCaretOffset(0, "'bar'", 1);
+	}
+
+	@Test
+	public void testCustomHighlightReconcilerForFileFromHistory() throws Exception {
+		createAndOpenFile("bar.txt", "bar 'bar'", () -> new FileEditorInput(file) {
+			@Override
+			public String getName() {
+				// append a revision number
+				return super.getName() + " 61e418fdac6";
+			}
+
+			@SuppressWarnings("unchecked")
+			@Override
+			public <T> T getAdapter(Class<T> adapter) {
+				// adapt to IStorage as in FileRevisionEditorInput
+				return adapter == IStorage.class ? (T) getStorage() : super.getAdapter(adapter);
+			}
+		});
 
 		checkHighlightForCaretOffset(0, "'bar'", 1);
 	}


### PR DESCRIPTION
Fixes #1872 

When possible, derive the file name from the underlying storage. This ensures that the file is not appended with a revision identifier and content type determination works when opening an editor from the History View.