### PR TITLE
Mark COPY_LINE_UP and COPY_LINE_DOWN as state dependent

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AbstractTextEditor.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AbstractTextEditor.java
@@ -5976,10 +5976,12 @@ public abstract class AbstractTextEditor extends EditorPart implements ITextEdit
 		markAsStateDependentAction(ITextEditorActionConstants.DELETE_LINE_TO_END, true);
 		markAsStateDependentAction(ITextEditorActionConstants.MOVE_LINE_UP, true);
 		markAsStateDependentAction(ITextEditorActionConstants.MOVE_LINE_DOWN, true);
+		markAsStateDependentAction(ITextEditorActionConstants.COPY_LINE_UP, true);
+		markAsStateDependentAction(ITextEditorActionConstants.COPY_LINE_DOWN, true);
 		markAsStateDependentAction(ITextEditorActionConstants.CUT_LINE, true);
 		markAsStateDependentAction(ITextEditorActionConstants.CUT_LINE_TO_BEGINNING, true);
 		markAsStateDependentAction(ITextEditorActionConstants.CUT_LINE_TO_END, true);
-
+		markAsStateDependentAction(ITextEditorActionConstants.JOIN_LINES, true);
 		setActionActivationCode(ITextEditorActionConstants.SHIFT_RIGHT_TAB,'\t', -1, SWT.NONE);
 		setActionActivationCode(ITextEditorActionConstants.SHIFT_LEFT, '\t', -1, SWT.SHIFT);
 	}


### PR DESCRIPTION
We found that the "copy lines up" and "copy lines down" commands are disabled in our editors, and we found that this is because the editor is not modifiable when it is created. The commands do not become enabled when the editor does become modifiable, which happens once the file being edited is synchronized.

The solution is to mark this commands state dependent, as other similar commands such as move line up/down or the different cut line variants (and others just see the lines which are close to my additions).