### PR TITLE
Remove wrong javadoc param

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/FilterHelpTestView.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/FilterHelpTestView.java
@@ -37,9 +37,6 @@ public class FilterHelpTestView extends MarkerSupportView {
 
 	static boolean showHelp = false;
 
-	/**
-	 * @param contentGeneratorId
-	 */
 	public FilterHelpTestView() {
 		super(CONTENT_GEN_ID);
 	}


### PR DESCRIPTION
There is no param at all aka totally wrong and just generates warning in the build.