### PR TITLE
Clean up progress info items after tests

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressTestCase.java
@@ -23,6 +23,7 @@ import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.internal.progress.FinishedJobs;
 import org.eclipse.ui.internal.progress.ProgressView;
 import org.eclipse.ui.tests.harness.util.UITestCase;
 
@@ -42,6 +43,17 @@ public abstract class ProgressTestCase extends UITestCase {
 	protected void doSetUp() throws Exception {
 		super.doSetUp();
 		window = openTestWindow("org.eclipse.ui.resourcePerspective");
+
+		// Remove progress info items before running the tests to prevent random
+		// failings
+		FinishedJobs.getInstance().clearAll();
+	}
+
+	@Override
+	protected void doTearDown() throws Exception {
+		super.doTearDown();
+		// Remove progress info items
+		FinishedJobs.getInstance().clearAll();
 	}
 
 	/**


### PR DESCRIPTION
Clean up progress info items before and after `ProgressTestCase`

Improve tests isolation in order to prevent random test failures.

Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/370