### PR TITLE
Always inject FinishedJobs instance into ProgressServiceImpl #1887

### DIFF
--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressServiceImpl.java
@@ -58,7 +58,6 @@ public class ProgressServiceImpl implements IProgressService {
 	ProgressManager progressManager;
 
 	@Inject
-	@Optional
 	FinishedJobs finishedJobs;
 
 	@Inject


### PR DESCRIPTION
The "finishedJobs" variable isn´t injected, thus is always null, when used from a progress dialog. Since the `@Optional` field in combination with `@Inject` only refers to already created instances of FinishedJobs. But, this does not happen in this flow.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1887