### PR TITLE
Handle the case when application has no focus in ApplicationPartService

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench;singleton:=true
-Bundle-Version: 1.16.0.qualifier
+Bundle-Version: 1.16.100.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
Currently when the application has no focus there is also no active window child and in this case several actions still fail even though a part is available for perform actions.

This now handles the case of an application without focus with an empty optional to allow fall back to the part context. If that context has still no suitable part service implementation as a last resort the containing window context is used.