### PR TITLE
Fix race condition in WorkbenchPluginTest #1891

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/WorkbenchPluginTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/WorkbenchPluginTest.java
@@ -73,8 +73,8 @@ public class WorkbenchPluginTest {
 		TestBarrier2 displayCreationBarrier = new TestBarrier2();
 		new Thread(() -> {
 			Display display = new Display();
-			displayCreationBarrier.setStatus(TestBarrier2.STATUS_DONE);
 			displayReference.set(display);
+			displayCreationBarrier.setStatus(TestBarrier2.STATUS_DONE);
 			while (!display.isDisposed()) {
 				if (!display.readAndDispatch()) {
 					display.sleep();


### PR DESCRIPTION
Test test case testGetImageRegistryFromAdditionalDisplay() in org.eclipse.ui.tests.api.WorkbenchPluginTest randomly fails because of a race condition. A display is initialized in another thread, but the initialization logic may access the value before it has actually been set by the other thread. This is fixed by reordering the instructions.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1891