### PR TITLE
Force signing of split package bundles to use new certificate

### DIFF
--- a/bundles/org.eclipse.jface.text/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.jface.text/forceQualifierUpdate.txt
@@ -5,3 +5,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/11
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/bundles/org.eclipse.text/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.text/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Pick up new signing certificate
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/bundles/org.eclipse.ui.browser/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.browser/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 511251 - Comparator errors in I20170127-2200
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/bundles/org.eclipse.ui.editors/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.editors/forceQualifierUpdate.txt
@@ -6,3 +6,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/13
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1979
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/bundles/org.eclipse.ui.ide/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.ide/forceQualifierUpdate.txt
@@ -8,3 +8,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/11
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1750
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/bundles/org.eclipse.ui.views/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.views/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Pick up new signing certificate
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/bundles/org.eclipse.ui.win32/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.win32/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/bundles/org.eclipse.ui.workbench.texteditor/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.workbench.texteditor/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 509931: Comparator errors in M20170104-0545
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/bundles/org.eclipse.ui.workbench/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.workbench/forceQualifierUpdate.txt
@@ -15,3 +15,4 @@ Bug 578351 - Lambda generation order is unstable in ecj
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1750
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/bundles/org.eclipse.ui/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 416898 - Some Platform UI bundles need to be touched to get API descriptions back
 Pick up new signing certificate
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044