### PR TITLE
Force qualifier to resign bundles signed with an expired certificate

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Bug 429101 - [Metadata] comparator errors in most recent I-builds
 Bug 562167 - Comparator errors in I20200415-0620
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1979
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/tests/org.eclipse.ui.tests/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ui.tests/forceQualifierUpdate.txt
@@ -13,3 +13,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/14
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044