### PR TITLE
Fix Link Handler Registration on macOS

### DIFF
--- a/bundles/org.eclipse.ui.ide.application/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide.application/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide.application;singleton:=true
-Bundle-Version: 1.5.400.qualifier
+Bundle-Version: 1.5.500.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui.ide;bundle-version="[3.21.0,4.0.0)",

--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/dialogs/UriSchemeHandlerPreferencePage.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/dialogs/UriSchemeHandlerPreferencePage.java
@@ -11,7 +11,7 @@
 package org.eclipse.ui.internal.ide.application.dialogs;
 
 import static org.eclipse.ui.internal.ide.IDEWorkbenchMessages.UriHandlerPreferencePage_Confirm_Handle;
-import static org.eclipse.ui.internal.ide.IDEWorkbenchMessages.UriHandlerPreferencePage_Warning_OtherApp;
+import static org.eclipse.ui.internal.ide.IDEWorkbenchMessages.UriHandlerPreferencePage_Warning_NotPossible;
 import static org.eclipse.ui.internal.ide.IDEWorkbenchMessages.UriHandlerPreferencePage_Warning_OtherApp_Confirmation;
 import static org.eclipse.ui.internal.ide.IDEWorkbenchMessages.UriHandlerPreferencePage_Warning_OtherApp_Confirmation_Description;
 import static org.eclipse.ui.internal.ide.IDEWorkbenchMessages.UriHandlerPreferencePage_Warning_OtherApp_Description;
@@ -27,6 +27,7 @@ import static org.eclipse.ui.internal.ide.IDEWorkbenchMessages.UrlHandlerPrefere
 import static org.eclipse.ui.internal.ide.IDEWorkbenchMessages.UrlHandlerPreferencePage_LauncherCannotBeDetermined;
 import static org.eclipse.ui.internal.ide.IDEWorkbenchMessages.UrlHandlerPreferencePage_LoadingText;
 import static org.eclipse.ui.internal.ide.IDEWorkbenchMessages.UrlHandlerPreferencePage_Page_Description;
+import static org.eclipse.ui.internal.ide.IDEWorkbenchMessages.UrlHandlerPreferencePage_RegistrationUnsupported;
 import static org.eclipse.ui.internal.ide.IDEWorkbenchMessages.UrlHandlerPreferencePage_UnsupportedOperatingSystem;
 
 import java.util.ArrayList;
@@ -140,6 +141,9 @@ public class UriSchemeHandlerPreferencePage extends PreferencePage implements IW
 			setDataOnTableViewer(Collections.emptyList());
 
 		} else {
+			if (!operatingSystemRegistration.supportsRegistration()) {
+				setErrorMessage(UrlHandlerPreferencePage_RegistrationUnsupported);
+			}
 			setDataOnTableViewer(getLoadingSchemeInformationList());
 			startRegistrationReadingJob();
 		}
@@ -294,6 +298,12 @@ public class UriSchemeHandlerPreferencePage extends PreferencePage implements IW
 
 		private void handleCheckbox(CheckStateChangedEvent event) {
 			UiSchemeInformation schemeInformation = (UiSchemeInformation) event.getElement();
+			if (!operatingSystemRegistration.supportsRegistration()) {
+				messageDialogWrapper.openWarning(getShell(), UriHandlerPreferencePage_Warning_NotPossible,
+						UrlHandlerPreferencePage_RegistrationUnsupported);
+				tableViewer.setChecked(schemeInformation, false);
+				return;
+			}
 			if (event.getChecked() && schemeInformation.information.schemeIsHandledByOther()) {
 				if (operatingSystemRegistration.canOverwriteOtherApplicationsRegistration()) {
 					boolean answer = messageDialogWrapper.openQuestion(getShell(),
@@ -310,7 +320,7 @@ public class UriSchemeHandlerPreferencePage extends PreferencePage implements IW
 					schemeInformation.checked = false;
 					tableViewer.setChecked(schemeInformation, schemeInformation.checked);
 
-					messageDialogWrapper.openWarning(getShell(), UriHandlerPreferencePage_Warning_OtherApp,
+					messageDialogWrapper.openWarning(getShell(), UriHandlerPreferencePage_Warning_NotPossible,
 							NLS.bind(UriHandlerPreferencePage_Warning_OtherApp_Description,
 									schemeInformation.information.getHandlerInstanceLocation(),
 									schemeInformation.information.getName()));

--- a/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide; singleton:=true
-Bundle-Version: 3.22.200.qualifier
+Bundle-Version: 3.22.300.qualifier
 Bundle-Activator: org.eclipse.ui.internal.ide.IDEWorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
@@ -525,7 +525,7 @@ public class IDEWorkbenchMessages extends NLS {
 	public static String WorkbenchPreference_unsupportedEncoding;
 	public static String WorkbenchPreference_encoding_encodingMessage;
 
-	public static String UriHandlerPreferencePage_Warning_OtherApp;
+	public static String UriHandlerPreferencePage_Warning_NotPossible;
 	public static String UriHandlerPreferencePage_Warning_OtherApp_Description;
 
 	public static String UriHandlerPreferencePage_Warning_OtherApp_Confirmation;
@@ -545,6 +545,7 @@ public class IDEWorkbenchMessages extends NLS {
 	public static String UrlHandlerPreferencePage_Error_Reading_Scheme;
 	public static String UrlHandlerPreferencePage_Error_Writing_Scheme;
 	public static String UrlHandlerPreferencePage_UnsupportedOperatingSystem;
+	public static String UrlHandlerPreferencePage_RegistrationUnsupported;
 	public static String UrlHandlerPreferencePage_LauncherCannotBeDetermined;
 
 	// ---workspace ---

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
@@ -505,7 +505,7 @@ WorkbenchPreference_unsupportedEncoding = The selected encoding is not supported
 WorkbenchPreference_encoding_encodingMessage = Byte Order Mark is {0}
 
 # --- Link Handler Preference Page ---
-UriHandlerPreferencePage_Warning_OtherApp=Action not possible
+UriHandlerPreferencePage_Warning_NotPossible=Action not possible
 UriHandlerPreferencePage_Warning_OtherApp_Description=Another application ({0}) handles the "{1}" scheme.\n\nRemove the "{1}" scheme in the other application first.
 UriHandlerPreferencePage_Warning_OtherApp_Confirmation=Confirm Handler Change
 UriHandlerPreferencePage_Warning_OtherApp_Confirmation_Description=The other application ({0}) will no longer handle the "{1}" scheme.\n\nShould this application handle the "{1}" scheme?
@@ -522,6 +522,7 @@ UrlHandlerPreferencePage_Column_Handler_Text_Other_Application=Other application
 UrlHandlerPreferencePage_Error_Reading_Scheme=Error while reading scheme information from operating system 
 UrlHandlerPreferencePage_Error_Writing_Scheme=Error while writing scheme information to operating system 
 UrlHandlerPreferencePage_UnsupportedOperatingSystem=Operating system {0} is not supported.
+UrlHandlerPreferencePage_RegistrationUnsupported=Link Handlers cannot be registered as the application is signed.
 UrlHandlerPreferencePage_LauncherCannotBeDetermined=Eclipse launcher path cannot be determined.
 
 # ---Workspace

--- a/bundles/org.eclipse.urischeme/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.urischeme/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.urischeme;singleton:=true
-Bundle-Version: 1.3.300.qualifier
+Bundle-Version: 1.3.400.qualifier
 Automatic-Module-Name: org.eclipse.urischeme
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.8.0,4.0.0)",

--- a/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/AutoRegisterSchemeHandlersJob.java
+++ b/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/AutoRegisterSchemeHandlersJob.java
@@ -79,8 +79,7 @@ public class AutoRegisterSchemeHandlersJob extends Job {
 			return Status.OK_STATUS;
 		}
 
-		IOperatingSystemRegistration osRegistration = testOsRegistration != null ? testOsRegistration
-				: IOperatingSystemRegistration.getInstance();
+		IOperatingSystemRegistration osRegistration = getOsRegistration();
 		try {
 			toProcessSchemes = osRegistration.getSchemesInformation(toProcessSchemes).stream() //
 					.filter(scheme -> !scheme.schemeIsHandledByOther()) //
@@ -103,9 +102,16 @@ public class AutoRegisterSchemeHandlersJob extends Job {
 		return Status.OK_STATUS;
 	}
 
+	private IOperatingSystemRegistration getOsRegistration() {
+		IOperatingSystemRegistration osRegistration = testOsRegistration != null ? testOsRegistration
+				: IOperatingSystemRegistration.getInstance();
+		return osRegistration;
+	}
+
 	@Override
 	public boolean shouldSchedule() {
+		IOperatingSystemRegistration osRegistration = getOsRegistration();
 		return !(alreadyTriggered || Platform.getPreferencesService().getBoolean(UriSchemeExtensionReader.PLUGIN_ID,
-				SKIP_PREFERENCE, false, null));
+				SKIP_PREFERENCE, false, null) || osRegistration.supportsRegistration());
 	}
 }

--- a/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/IOperatingSystemRegistration.java
+++ b/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/IOperatingSystemRegistration.java
@@ -83,4 +83,13 @@ public interface IOperatingSystemRegistration {
 	 */
 	boolean canOverwriteOtherApplicationsRegistration();
 
+	/**
+	 * This method returns if the current operating system allows to register uri
+	 * schemes at all.
+	 *
+	 * @return <code>true</code> if the registration of uri schemes is supported -
+	 *         <code>false</code> otherwise.
+	 */
+	boolean supportsRegistration();
+
 }

--- a/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/internal/registration/RegistrationLinux.java
+++ b/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/internal/registration/RegistrationLinux.java
@@ -57,6 +57,9 @@ public class RegistrationLinux implements IOperatingSystemRegistration {
 
 	@Override
 	public void handleSchemes(Collection<IScheme> toAdd, Collection<IScheme> toRemove) throws Exception {
+		if (!supportsRegistration()) {
+			return;
+		}
 		String desktopFileName = getDesktopFileName();
 
 		changeDesktopFile(toAdd, toRemove, PATH_TO_LOCAL_SHARE_APPS + desktopFileName);
@@ -179,5 +182,10 @@ public class RegistrationLinux implements IOperatingSystemRegistration {
 	@Override
 	public boolean canOverwriteOtherApplicationsRegistration() {
 		return false;
+	}
+
+	@Override
+	public boolean supportsRegistration() {
+		return true;
 	}
 }

--- a/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/internal/registration/RegistrationMacOsX.java
+++ b/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/internal/registration/RegistrationMacOsX.java
@@ -131,6 +131,9 @@ public class RegistrationMacOsX implements IOperatingSystemRegistration {
 	}
 
 	private void changePlistFile(Collection<IScheme> toAdd, Collection<IScheme> toRemove, String pathToEclipseApp) {
+		if (!supportsRegistration()) {
+			return;
+		}
 		String plistPath = pathToEclipseApp + PLIST_PATH_SUFFIX;
 
 		PlistFileWriter writer = getPlistFileWriter(plistPath);
@@ -185,5 +188,14 @@ public class RegistrationMacOsX implements IOperatingSystemRegistration {
 	@Override
 	public boolean canOverwriteOtherApplicationsRegistration() {
 		return false;
+	}
+
+	@Override
+	public boolean supportsRegistration() {
+		// if the application is signed we cannot register URI schemes because this
+		// would break the signature of the applications
+		// applications with broken signature cannot be executed any more (at least on
+		// newer macOS versions).
+		return !fileProvider.fileExists(getPathToEclipseApp() + "/Contents/_CodeSignature"); //$NON-NLS-1$
 	}
 }

--- a/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/internal/registration/RegistrationWindows.java
+++ b/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/internal/registration/RegistrationWindows.java
@@ -56,6 +56,9 @@ public class RegistrationWindows implements IOperatingSystemRegistration {
 
 	@Override
 	public void handleSchemes(Collection<IScheme> toAdd, Collection<IScheme> toRemove) throws Exception {
+		if (!supportsRegistration()) {
+			return;
+		}
 		String eclipseLauncher = getEclipseLauncher();
 		if (eclipseLauncher != null) {
 			for (IScheme scheme : toAdd) {
@@ -114,6 +117,11 @@ public class RegistrationWindows implements IOperatingSystemRegistration {
 	 */
 	@Override
 	public boolean canOverwriteOtherApplicationsRegistration() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsRegistration() {
 		return true;
 	}
 

--- a/tests/org.eclipse.tests.urischeme/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.tests.urischeme/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-Vendor: %Plugin.Providername
 Bundle-SymbolicName: org.eclipse.tests.urischeme
-Bundle-Version: 1.2.400.qualifier
+Bundle-Version: 1.2.500.qualifier
 Bundle-Localization: plugin
 Fragment-Host: org.eclipse.urischeme;bundle-version="1.1.100"
 Automatic-Module-Name: org.eclipse.urischeme.tests

--- a/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitRegistrationMacOsX.java
+++ b/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitRegistrationMacOsX.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 public class TestUnitRegistrationMacOsX {
 
 	private static final String OWN_APP_PLIST_PATH = "/Users/myuser/Applications/Eclipse.app/Contents/Info.plist";
+	private static final String PATH_TO_CODE_SIGNATURE = "/Users/myuser/Applications/Eclipse.app/Contents/_CodeSignature";
 	private static final String OTHER_APP_PLIST_PATH = "/Users/myuser/Applications/OtherApp.app/Contents/Info.plist";
 	private static final String OTHER_APP_BUNDLE_PATH = "/Users/myuser/Applications/OtherApp.app";
 
@@ -62,11 +63,13 @@ public class TestUnitRegistrationMacOsX {
 	public void setup() {
 		fileProvider = new FileProviderMock();
 		fileProvider.writer = new StringWriter();
+		fileProvider.fileExistsAnswers.put(PATH_TO_CODE_SIGNATURE, false);
 
 		processStub = new ProcessSpy();
 
 		System.setProperty("eclipse.home.location", "file:/Users/myuser/Applications/Eclipse.app/Contents/Eclipse/");
 		System.setProperty("eclipse.launcher", "/Users/myuser/Applications/Eclipse.app/Contents/MacOS/eclipse");
+
 
 		registration = new RegistrationMacOsX(fileProvider, processStub);
 
@@ -265,6 +268,17 @@ public class TestUnitRegistrationMacOsX {
 		assertEquals("adt", infos.get(0).getName());
 		assertFalse(infos.get(0).isHandled());
 		assertEquals(OTHER_APP_BUNDLE_PATH, infos.get(0).getHandlerInstanceLocation());
+	}
+
+	@Test
+	public void doesSupportRegistrationIfAppIsNotSigned() throws Exception {
+		assertTrue(registration.supportsRegistration());
+	}
+
+	@Test
+	public void doesNotSupportRegistrationIfAppIsSigned() throws Exception {
+		fileProvider.fileExistsAnswers.put(PATH_TO_CODE_SIGNATURE, true);
+		assertFalse(registration.supportsRegistration());
 	}
 
 	private void assertFilePathIs(String filePath) {

--- a/tests/org.eclipse.ui.ide.application.tests/src/org/eclipse/ui/internal/ide/application/dialogs/UriSchemeHandlerPreferencePageTest.java
+++ b/tests/org.eclipse.ui.ide.application.tests/src/org/eclipse/ui/internal/ide/application/dialogs/UriSchemeHandlerPreferencePageTest.java
@@ -125,7 +125,7 @@ public class UriSchemeHandlerPreferencePageTest {
 
 		MessageDialogWrapperSpy spy = (MessageDialogWrapperSpy) page.messageDialogWrapper;
 
-		assertEquals(IDEWorkbenchMessages.UriHandlerPreferencePage_Warning_OtherApp, spy.title);
+		assertEquals(IDEWorkbenchMessages.UriHandlerPreferencePage_Warning_NotPossible, spy.title);
 
 		String expected = NLS.bind(IDEWorkbenchMessages.UriHandlerPreferencePage_Warning_OtherApp_Description,
 				OTHER_ECLIPSE_HANDLER_LOCATION, "hello2");
@@ -133,6 +133,22 @@ public class UriSchemeHandlerPreferencePageTest {
 
 		assertScheme(getTableItem(2), false, otherAppSchemeInfo);
 		assertHandlerTextForSelection(page, 2, OTHER_ECLIPSE_HANDLER_LOCATION);
+	}
+
+	@Test
+	public void checkSchemeOnRegistrationNotSupportedGivesWarningAndRevertsClick() throws Exception {
+		this.page.createContents(this.page.getShell());
+		waitForJob();
+		operatingSystemRegistration.supportsRegistration = false;
+
+		clickTableViewerCheckbox(0, true);
+
+		MessageDialogWrapperSpy spy = (MessageDialogWrapperSpy) page.messageDialogWrapper;
+		assertEquals(IDEWorkbenchMessages.UriHandlerPreferencePage_Warning_NotPossible, spy.title);
+		String expected = NLS.bind(IDEWorkbenchMessages.UrlHandlerPreferencePage_RegistrationUnsupported,
+				OTHER_ECLIPSE_HANDLER_LOCATION, "hello");
+		assertEquals(expected, spy.message);
+		assertScheme(getTableItem(0), false, noAppSchemeInfo);
 	}
 
 	@Test
@@ -512,6 +528,7 @@ public class UriSchemeHandlerPreferencePageTest {
 		public Collection<IScheme> removedSchemes = Collections.emptyList();
 		public boolean canOverwriteOtherApplicationsRegistration = false;
 		public String launcherPath = THIS_ECLIPSE_HANDLER_LOCATION;
+		public boolean supportsRegistration = true;
 
 		public OperatingSystemRegistrationMock(List<ISchemeInformation> schemeInformations) {
 			this.schemeInformations = schemeInformations;
@@ -542,6 +559,11 @@ public class UriSchemeHandlerPreferencePageTest {
 		@Override
 		public boolean canOverwriteOtherApplicationsRegistration() {
 			return canOverwriteOtherApplicationsRegistration;
+		}
+
+		@Override
+		public boolean supportsRegistration() {
+			return supportsRegistration;
 		}
 
 	}


### PR DESCRIPTION
When registering a link handler on macOS the info.plist file of the eclipse application needs to be changed. If the eclipse application is signed this breaks the signature of the eclipse application. Breaking the signature has the effect that the eclipse application cannot be started any more (at least after an reboot of the operating system).

This means we cannot register any additional link handlers at runtime for signed macOS applications. Changes the behavior for singed macOS applications to the following:

- Don't run automatic registration at startup of the application
- Disable the "Apply" function on the "Link Handlers" preference page
- Show error message on the "Link Handlers" preference page

Contributes to #1901