### PR TITLE
Find/Replace overlay: consistent handling of incremental base location (#1913 #1914)

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
@@ -71,21 +71,6 @@ public interface IFindReplaceLogic {
 	public boolean isIncrementalSearchAvailable();
 
 	/**
-	 * Updates the search result after the Text was Modified. Used in combination
-	 * with <code>setIncrementalSearch(true)</code>. This method specifically allows
-	 * for "search-as-you-type"
-	 *
-	 * "Search-as-you-type" is not compatible with RegEx-search. This will
-	 * initialize the base-location for search (if not initialized already) but will
-	 * not update it, meaning that incrementally searching the same string twice in
-	 * a row will always yield the same result, unless the Base location was
-	 * modified (eg., by performing "find next")
-	 *
-	 * @param searchString the String that is to be searched
-	 */
-	public void performIncrementalSearch(String searchString);
-
-	/**
 	 * Replaces all occurrences of the user's findString with the replace string.
 	 * Indicate to the user the number of replacements that occur.
 	 *
@@ -102,7 +87,11 @@ public interface IFindReplaceLogic {
 	public void performSelectAll(String findString);
 
 	/**
-	 * Locates the user's findString in the target
+	 * Locates the user's findString in the target. If incremental search is
+	 * activated, the search will be performed starting from an incremental search
+	 * position, which can be reset using {@link #resetIncrementalBaseLocation()}.
+	 * If incremental search is activated and RegEx search is activated, nothing
+	 * happens.
 	 *
 	 * @param searchString the String to search for
 	 * @return Whether the string was found in the target
@@ -173,5 +162,11 @@ public interface IFindReplaceLogic {
 	 * @return <code>true</code> if the search can be restricted to whole words
 	 */
 	public boolean isWholeWordSearchAvailable(String findString);
+
+	/**
+	 * Initializes the anchor used as starting point for incremental searching.
+	 * Subsequent incremental searches will start from the current selection.
+	 */
+	void resetIncrementalBaseLocation();
 
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -606,11 +606,19 @@ public class FindReplaceOverlay extends Dialog {
 
 			@Override
 			public void focusGained(FocusEvent e) {
-				// we want to update the base-location of where we start incremental search
-				// to the currently selected position in the target
-				// when coming back into the dialog
-				findReplaceLogic.deactivate(SearchOptions.INCREMENTAL);
+				findReplaceLogic.resetIncrementalBaseLocation();
 				findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+				if (getFindString().isEmpty()) {
+					return;
+				}
+				updateSelectionWithIncrementalSearch();
+			}
+
+			private void updateSelectionWithIncrementalSearch() {
+				boolean foundSearchString = findReplaceLogic.performSearch(getFindString());
+				if (foundSearchString) {
+					searchBar.setSelection(0, getFindString().length());
+				}
 			}
 
 			@Override
@@ -629,7 +637,7 @@ public class FindReplaceOverlay extends Dialog {
 		if (findReplaceLogic.getTarget() instanceof IFindReplaceTargetExtension targetExtension) {
 			targetExtension.setSelection(targetExtension.getLineSelection().x, 0);
 		}
-		findReplaceLogic.performIncrementalSearch(getFindString());
+		findReplaceLogic.performSearch(getFindString());
 		evaluateFindReplaceStatus();
 	}
 
@@ -855,8 +863,8 @@ public class FindReplaceOverlay extends Dialog {
 		activateInFindReplacerIf(SearchOptions.FORWARD, forward);
 		findReplaceLogic.deactivate(SearchOptions.INCREMENTAL);
 		findReplaceLogic.performSearch(getFindString());
-		activateInFindReplacerIf(SearchOptions.FORWARD, oldForwardSearchSetting);
 		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+		activateInFindReplacerIf(SearchOptions.FORWARD, oldForwardSearchSetting);
 	}
 
 	private void updateFromTargetSelection() {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayFirstTimePopup.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayFirstTimePopup.java
@@ -96,7 +96,6 @@ public class FindReplaceOverlayFirstTimePopup {
 							true)
 					.delay(POPUP_VANISH_TIME.toMillis()).open();
 		}
-
 	}
 
 	private static Control createFirstTimeNotification(Composite composite) {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -142,7 +142,9 @@ class FindReplaceDialog extends Dialog {
 				return;
 			}
 
-			findReplaceLogic.performIncrementalSearch(getFindString());
+			if (findReplaceLogic.isActive(SearchOptions.INCREMENTAL)) {
+				findReplaceLogic.performSearch(getFindString());
+			}
 			evaluateFindReplaceStatus();
 
 			updateButtonState(!findReplaceLogic.isActive(SearchOptions.INCREMENTAL));
@@ -292,9 +294,12 @@ class FindReplaceDialog extends Dialog {
 						setupFindReplaceLogic();
 						boolean eventRequiresInverseSearchDirection = (e.stateMask & SWT.MODIFIER_MASK) == SWT.SHIFT;
 						boolean forwardSearchActivated = findReplaceLogic.isActive(SearchOptions.FORWARD);
+						boolean incrementalSearchActivated = findReplaceLogic.isActive(SearchOptions.INCREMENTAL);
 						activateInFindReplaceLogicIf(SearchOptions.FORWARD,
 								eventRequiresInverseSearchDirection != forwardSearchActivated);
+						findReplaceLogic.deactivate(SearchOptions.INCREMENTAL);
 						boolean somethingFound = findReplaceLogic.performSearch(getFindString());
+						activateInFindReplaceLogicIf(SearchOptions.INCREMENTAL, incrementalSearchActivated);
 						activateInFindReplaceLogicIf(SearchOptions.FORWARD, forwardSearchActivated);
 
 						writeSelection();

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -662,6 +662,58 @@ public class FindReplaceLogicTest {
 		assertThat(findReplaceLogic.getStatus(), instanceOf(NoStatus.class));
 	}
 
+	/**
+	 * Test for https://github.com/eclipse-platform/eclipse.platform.ui/issues/1914
+	 */
+	@Test
+	public void testActivateRegexInIncrementalIncrementalBaseLocationUpdated() {
+		TextViewer textViewer= setupTextViewer("Test Test Test Test");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+		findReplaceLogic.activate(SearchOptions.REGEX);
+		findReplaceLogic.activate(SearchOptions.FORWARD);
+
+		findReplaceLogic.deactivate(SearchOptions.INCREMENTAL);
+		findReplaceLogic.performSearch("Test");
+		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+
+		assertThat(findReplaceLogic.getTarget().getSelection().x, is(0));
+		assertThat(findReplaceLogic.getTarget().getSelection().y, is(4));
+
+		findReplaceLogic.deactivate(SearchOptions.INCREMENTAL);
+		findReplaceLogic.performSearch("Test");
+		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+
+		assertThat(findReplaceLogic.getTarget().getSelection().x, is(5));
+		assertThat(findReplaceLogic.getTarget().getSelection().y, is(4));
+
+		findReplaceLogic.deactivate(SearchOptions.REGEX);
+		findReplaceLogic.performSearch("Test");
+
+		assertThat(findReplaceLogic.getTarget().getSelection().x, is(10));
+		assertThat(findReplaceLogic.getTarget().getSelection().y, is(4));
+	}
+
+	@Test
+	public void testPerformIncrementalSearch() {
+		TextViewer textViewer= setupTextViewer("Test Test Test Test");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+		findReplaceLogic.activate(SearchOptions.FORWARD);
+
+		findReplaceLogic.performSearch("Test");
+		assertThat(findReplaceLogic.getTarget().getSelection().x, is(0));
+		assertThat(findReplaceLogic.getTarget().getSelection().y, is(4));
+
+		findReplaceLogic.performSearch("Test"); // incremental search is idempotent
+		assertThat(findReplaceLogic.getTarget().getSelection().x, is(0));
+		assertThat(findReplaceLogic.getTarget().getSelection().y, is(4));
+
+		findReplaceLogic.performSearch(""); // this clears the incremental search, but the "old search" still remains active
+		assertThat(findReplaceLogic.getTarget().getSelection().x, is(0));
+		assertThat(findReplaceLogic.getTarget().getSelection().y, is(4));
+	}
+
 	private void expectStatusIsCode(IFindReplaceLogic findReplaceLogic, FindStatus.StatusCode code) {
 		assertThat(findReplaceLogic.getStatus(), instanceOf(FindStatus.class));
 		assertThat(((FindStatus) findReplaceLogic.getStatus()).getMessageCode(), equalTo(code));

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
@@ -154,13 +154,17 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		dialog.select(SearchOptions.REGEX);
 		dialog.setFindText("text"); // with RegEx enabled, there is no incremental search!
 		dialog.pressSearch(true);
+		assertThat(dialog.getTarget().getSelection().x, is(0));
 		assertThat(dialog.getTarget().getSelection().y, is(4));
 		dialog.pressSearch(true);
 		assertThat(dialog.getTarget().getSelection().x, is("text ".length()));
+		assertThat(dialog.getTarget().getSelection().y, is(4));
 		dialog.pressSearch(true);
 		assertThat(dialog.getTarget().getSelection().x, is("text text ".length()));
+		assertThat(dialog.getTarget().getSelection().y, is(4));
 		dialog.pressSearch(false);
 		assertThat(dialog.getTarget().getSelection().x, is("text ".length()));
+		assertThat(dialog.getTarget().getSelection().y, is(4));
 	}
 
 }

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
@@ -231,4 +231,19 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(dialog.getFindText().length(), (target.getSelection()).y);
 	}
+
+	@Test
+	public void testFindNextDespiteIncrementalEnabled() {
+		initializeTextViewerWithFindReplaceUI("test test test test");
+		DialogAccess dialog= getDialog();
+		dialog.select(SearchOptions.INCREMENTAL);
+
+		dialog.setFindText("test");
+		assertThat(dialog.getTarget().getSelection().x, is(0));
+		assertThat(dialog.getTarget().getSelection().y, is(4));
+
+		dialog.simulateEnterInFindInputField(false);
+		assertThat(dialog.getTarget().getSelection().x, is(5));
+		assertThat(dialog.getTarget().getSelection().y, is(4));
+	}
 }


### PR DESCRIPTION
Increment the incremental base location consistently, remove method for
"performIncrementalSearch" as it only called "performSearch" and lead to
semantic confusion while calling "performSearch".
- "SearchOptions.REGEX" will now correctly update the incremental base
location once it is disabled.
- Added a method for updating the incremental base location manually
  from outside

fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1914
fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1913
fixes #1915