### PR TITLE
Don't use IFileInfo.toString() in UI, use IFileStore.toString()

### DIFF
--- a/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide; singleton:=true
-Bundle-Version: 3.22.200.qualifier
+Bundle-Version: 3.22.300.qualifier
 Bundle-Activator: org.eclipse.ui.internal.ide.IDEWorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/RefreshAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/RefreshAction.java
@@ -16,11 +16,13 @@
 package org.eclipse.ui.actions;
 
 import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.core.filesystem.IFileInfo;
+import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceRuleFactory;
@@ -113,11 +115,13 @@ public class RefreshAction extends WorkspaceAction {
 		if (!project.exists()) {
 			return;
 		}
-		IFileInfo location = IDEResourceInfoUtils.getFileInfo(project.getLocationURI());
+		URI locationURI = project.getLocationURI();
+		IFileInfo location = IDEResourceInfoUtils.getFileInfo(locationURI);
 		if (!location.exists()) {
+			String displayedProjectPath = toDisplayPath(locationURI);
 			String message = NLS.bind(
 					IDEWorkbenchMessages.RefreshAction_locationDeletedMessage,
-					project.getName(), location.toString());
+					project.getName(), displayedProjectPath);
 
 			final MessageDialog dialog = new MessageDialog(getShell(),
 					IDEWorkbenchMessages.RefreshAction_dialogTitle, // dialog
@@ -141,6 +145,11 @@ public class RefreshAction extends WorkspaceAction {
 				project.delete(true, true, null);
 			}
 		}
+	}
+
+	private static String toDisplayPath(URI locationURI) {
+		IFileStore fileStore = IDEResourceInfoUtils.getFileStore(locationURI);
+		return fileStore != null ? fileStore.toString() : locationURI.toString();
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
@@ -327,8 +327,8 @@ RefreshAction_toolTip = Refresh
 RefreshAction_progressMessage = Refreshing...
 RefreshAction_problemTitle = Refresh Problems
 RefreshAction_problemMessage = Problems occurred refreshing the selected resources.
-RefreshAction_locationDeletedMessage = The location for project ''{0}'' ({1}) has been deleted.\nDelete ''{0}'' from the workspace?
-RefreshAction_dialogTitle = Project location has been deleted
+RefreshAction_locationDeletedMessage = Directory ''{1}'' has been deleted.\nDelete also project ''{0}'' from the workspace?
+RefreshAction_dialogTitle = Project has been deleted on file system
 
 SelectWorkingSetAction_text= Select &Working Set...
 


### PR DESCRIPTION
The `IFileInfo.toString()` isn't intended to be shown to user, it has no
information interesting for users.

The `IFileStore.toString()` should be used in cases if information about
deleted resources need to be shown in UI.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/1404