### PR TITLE
fix warning about Field.isAccessible()

### DIFF
--- a/bundles/org.eclipse.core.commands/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.commands/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.commands
-Bundle-Version: 3.12.100.qualifier
+Bundle-Version: 3.12.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.commands,

--- a/bundles/org.eclipse.core.commands/src/org/eclipse/core/internal/commands/util/Util.java
+++ b/bundles/org.eclipse.core.commands/src/org/eclipse/core/internal/commands/util/Util.java
@@ -255,14 +255,16 @@ public final class Util {
 
 		String contextId = null;
 		if (method != null) {
-			boolean accessible = method.isAccessible();
-			method.setAccessible(true);
-			try {
-				contextId = (String) method.invoke(command);
-			} catch (Exception e) {
-				// do nothing
+			boolean accessible = method.canAccess(command);
+			if (method.trySetAccessible()) {
+				try {
+					contextId = (String) method.invoke(command);
+				} catch (Exception ignored) {
+					// do nothing
+				} finally {
+					method.setAccessible(accessible);
+				}
 			}
-			method.setAccessible(accessible);
 		}
 		return contextId;
 	}

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.renderers.swt;singleton:=true
-Bundle-Version: 0.16.400.qualifier
+Bundle-Version: 0.16.500.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
@@ -1254,14 +1254,15 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 		protected Object getFieldValue(Field field) {
 			Object value = null;
 			if (field != null) {
-				boolean accessible = field.isAccessible();
-				try {
-					field.setAccessible(true);
-					value = field.get(instance);
-				} catch (Exception exc) {
-					// do nothing
-				} finally {
-					field.setAccessible(accessible);
+				boolean accessible = field.canAccess(instance);
+				if (field.trySetAccessible()) {
+					try {
+						value = field.get(instance);
+					} catch (Exception ignored) {
+						// do nothing
+					} finally {
+						field.setAccessible(accessible);
+					}
 				}
 			}
 			return value;


### PR DESCRIPTION
'The method isAccessible() from the type AccessibleObject is deprecated since version 9'

tested with
 WorkbenchThemeChangedHandlerTest,
 org.eclipse.ui.tests.commands.HelpContextIdTest.testHelpContextId()