### PR TITLE
fix warning about java.lang.Class.newInstance()

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.css.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-SymbolicName: org.eclipse.e4.ui.css.core;singleton:=true
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 0.14.400.qualifier
+Bundle-Version: 0.14.500.qualifier
 Export-Package: org.eclipse.e4.ui.css.core;x-internal:=true,
  org.eclipse.e4.ui.css.core.css2;x-friends:="org.eclipse.e4.ui.css.swt.theme,org.eclipse.e4.ui.css.swt,org.eclipse.e4.ui.css.jface",
  org.eclipse.e4.ui.css.core.dom;x-friends:="org.eclipse.e4.ui.css.swt,org.eclipse.ui.views.properties.tabbed,org.eclipse.ui.forms",

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/sac/SACParserFactoryImpl.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/sac/SACParserFactoryImpl.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.css.core.impl.sac;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.e4.ui.css.core.SACConstants;
@@ -49,7 +50,11 @@ public class SACParserFactoryImpl extends SACParserFactory {
 		String classNameParser = parsers.get(name);
 		if (classNameParser != null) {
 			Class<?> classParser = super.getClass().getClassLoader().loadClass(classNameParser);
-			return (Parser) classParser.newInstance();
+			try {
+				return (Parser) classParser.getDeclaredConstructor().newInstance();
+			} catch (InvocationTargetException | NoSuchMethodException e) {
+				throw (InstantiationException) new InstantiationException(classNameParser).initCause(e);
+			}
 		}
 		throw new IllegalAccessException("SAC parser with name=" + name
 				+ " was not registered into SAC parser factory.");

--- a/bundles/org.eclipse.e4.ui.progress/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.progress/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.progress;singleton:=true
-Bundle-Version: 0.4.400.qualifier
+Bundle-Version: 0.4.500.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
'The method newInstance() from the type Class<capture#3-of ?> is deprecated since version 9'

tested by
org.eclipse.e4.ui.tests.css.core.parser.ValueTest