### PR TITLE
Improve activity filtering: Support ActionProvider

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/providers/ActionProvider.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/quickaccess/providers/ActionProvider.java
@@ -61,6 +61,9 @@ public class ActionProvider extends QuickAccessProvider {
 				collectContributions(menu, result);
 				ActionContributionItem[] actions = result.toArray(new ActionContributionItem[result.size()]);
 				for (ActionContributionItem action : actions) {
+					if (!action.isVisible())
+						continue;
+
 					ActionElement actionElement = new ActionElement(action);
 					idToElement.put(actionElement.getId(), actionElement);
 				}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessProvidersTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessProvidersTest.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Advantest Europe GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * 				Raghunandana Murthappa
+ *******************************************************************************/
+
+package org.eclipse.ui.tests.quickaccess;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.activities.IWorkbenchActivitySupport;
+import org.eclipse.ui.internal.WorkbenchWindow;
+import org.eclipse.ui.internal.quickaccess.providers.ActionProvider;
+import org.eclipse.ui.internal.quickaccess.providers.CommandProvider;
+import org.eclipse.ui.quickaccess.QuickAccessElement;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests the quick access providers.
+ */
+@RunWith(JUnit4.class)
+public class QuickAccessProvidersTest {
+	private static final String ACTIVITY_ID = "org.eclipse.ui.tests.activitySupportTest.issue1832";
+	private final String COMMAND_ID = "org.eclipse.ui.tests.activitySupportTest.commands.issue1832";
+	private static final String ACTION_LABEL = "Create Test Markers";
+
+	@Test
+	public void testCommandProvider() {
+		IWorkbenchActivitySupport workbenchActivitySupport = PlatformUI.getWorkbench().getActivitySupport();
+		CommandProvider cmdProvider = new CommandProvider();
+		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		WorkbenchWindow workbenchWindow = (WorkbenchWindow) window;
+		final MWindow model = workbenchWindow.getModel();
+		cmdProvider.setContext(model.getContext().getActiveLeaf());
+
+		QuickAccessElement[] elementsBefore = cmdProvider.getElements();
+		assertCommandAbsent(elementsBefore);
+
+		// enable the test activity id
+		Set<String> enabledActivityIds = workbenchActivitySupport.getActivityManager().getEnabledActivityIds();
+		Set<String> toBeEnabled = new HashSet<>();
+		toBeEnabled.add(ACTIVITY_ID);
+		toBeEnabled.addAll(enabledActivityIds);
+		workbenchActivitySupport.setEnabledActivityIds(toBeEnabled);
+
+		CommandProvider cmdProvider1 = new CommandProvider();
+		cmdProvider1.setContext(model.getContext().getActiveLeaf());
+		QuickAccessElement[] elementsAfter = cmdProvider1.getElements();
+		assertCommandPresent(elementsAfter);
+
+		// restore to previous
+		workbenchActivitySupport.setEnabledActivityIds(enabledActivityIds);
+	}
+
+	@Test
+	public void testActionProvider() {
+		IWorkbenchActivitySupport workbenchActivitySupport = PlatformUI.getWorkbench().getActivitySupport();
+		ActionProvider actionProvider = new ActionProvider();
+		QuickAccessElement[] actionElements = actionProvider.getElements();
+		assertActionAbsent(actionElements);
+
+		// enable the test activity id
+		Set<String> toBeEnabled = new HashSet<>();
+		toBeEnabled.add(ACTIVITY_ID);
+		toBeEnabled.addAll(workbenchActivitySupport.getActivityManager().getEnabledActivityIds());
+		workbenchActivitySupport.setEnabledActivityIds(toBeEnabled);
+
+		ActionProvider actionProvider1 = new ActionProvider();
+		QuickAccessElement[] actionElements1 = actionProvider1.getElements();
+		assertActionPresent(actionElements1);
+	}
+
+	private void assertActionAbsent(QuickAccessElement[] actionElements) {
+		boolean present = false;
+		for (QuickAccessElement quickAccessElement : actionElements) {
+			if (ACTION_LABEL.equals(quickAccessElement.getLabel())) {
+				present = true;
+				break;
+			}
+		}
+		assertFalse("Action present", present);
+
+	}
+
+	private void assertActionPresent(QuickAccessElement[] actionElements) {
+		boolean present = false;
+		for (QuickAccessElement quickAccessElement : actionElements) {
+			if (quickAccessElement.getLabel().equals(ACTION_LABEL)) {
+				present = true;
+				break;
+			}
+		}
+		assertTrue("Action absent", present);
+
+	}
+
+	private void assertCommandAbsent(QuickAccessElement[] elementsBefore) {
+		boolean present = false;
+		for (QuickAccessElement quickAccessElement : elementsBefore) {
+			if (quickAccessElement.getId().equals(COMMAND_ID)) {
+				present = true;
+				break;
+			}
+		}
+		assertFalse("command present", present);
+	}
+
+	private void assertCommandPresent(QuickAccessElement[] elementsAfter) {
+		boolean present = false;
+		for (QuickAccessElement quickAccessElement : elementsAfter) {
+			if (quickAccessElement.getId().equals(COMMAND_ID)) {
+				present = true;
+				break;
+			}
+		}
+		assertTrue("command absent", present);
+	}
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessTestSuite.java
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ CamelUtilTest.class, QuickAccessDialogTest.class, ContentMatchesTest.class })
+@Suite.SuiteClasses({ CamelUtilTest.class, QuickAccessDialogTest.class, ContentMatchesTest.class,
+		QuickAccessProvidersTest.class })
 public class QuickAccessTestSuite {
 }

--- a/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse UI Tests
 Bundle-SymbolicName: org.eclipse.ui.tests; singleton:=true
-Bundle-Version: 3.15.1600.qualifier
+Bundle-Version: 3.15.1700.qualifier
 Eclipse-BundleShape: dir
 Bundle-Activator: org.eclipse.ui.tests.TestPlugin
 Bundle-Vendor: Eclipse.org

--- a/tests/org.eclipse.ui.tests/plugin.xml
+++ b/tests/org.eclipse.ui.tests/plugin.xml
@@ -4794,4 +4794,49 @@
           apply="always">
     </fragment>
  </extension>
+ 
+ <!-- Issue 1832 -->
+ <extension
+      point="org.eclipse.ui.commands">
+   <command
+        id="org.eclipse.ui.tests.activitySupportTest.commands.issue1832"
+        name="Issue 1832 Test" />
+ </extension>
+ <extension
+      point="org.eclipse.ui.handlers">
+   <handler
+   	     commandId="org.eclipse.ui.tests.activitySupportTest.commands.issue1832"
+   	     class="org.eclipse.ui.tests.menus.HelloEHandler">
+   </handler>      
+ </extension>
+
+ <extension
+        point="org.eclipse.ui.activities">
+     <activity
+          name="Issue 1832 Test"
+          description="Testing Issue 1832"
+          id="org.eclipse.ui.tests.activitySupportTest.issue1832">
+     </activity>
+     <activityPatternBinding
+          activityId="org.eclipse.ui.tests.activitySupportTest.issue1832"
+          pattern="org\.eclipse\.ui\.tests/org\.eclipse\.ui\.tests\.activitySupportTest\..*">
+     </activityPatternBinding>
+     
+     <activityPatternBinding
+          activityId="org.eclipse.ui.tests.activitySupportTest.issue1832"
+          pattern="org\.eclipse\.ui\.tests/org\.eclipse\.ui\.tests\.markers\.create.*">
+     </activityPatternBinding>
+            
+     <category
+          name="Issue 1832"
+          description="Issue 1832 desc"
+          id="org.eclipse.ui.tests.issue1832">
+     </category>
+      
+     <categoryActivityBinding
+         activityId="org.eclipse.ui.tests.activitySupportTest.issue1832"
+         categoryId="org.eclipse.ui.tests.issue1832">
+     </categoryActivityBinding>
+ </extension>
+
 </plugin>


### PR DESCRIPTION
ActionProvider is fixed to support activity filtering. Testcases are added for CommandProvider and ActionProvider.

see https://github.com/eclipse-platform/eclipse.platform.ui/issues/1936