### PR TITLE
Find/Replace overlay: handle the case when moving editor between windows

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -882,6 +882,15 @@ public class FindReplaceOverlay extends Dialog {
 			getShell().setVisible(false);
 			return;
 		}
+		if (isInvalidTargetShell()) {
+			getShell().getDisplay().syncExec(() -> {
+				close();
+				setParentShell(targetPart.getSite().getShell());
+				open();
+				targetPart.setFocus();
+			});
+			return;
+		}
 		getShell().requestLayout();
 		if (!(targetPart instanceof StatusTextEditor textEditor)) {
 			return;
@@ -900,6 +909,17 @@ public class FindReplaceOverlay extends Dialog {
 		updateVisibility(targetControlBounds, overlayBounds);
 
 		repositionTextSelection();
+	}
+
+	private boolean isInvalidTargetPart() {
+		return targetPart == null || targetPart.getSite() == null || targetPart.getSite().getShell() == null;
+	}
+
+	private boolean isInvalidTargetShell() {
+		if (isInvalidTargetPart()) {
+			return false;
+		}
+		return getShell() == null || !targetPart.getSite().getShell().equals(getShell().getParent());
 	}
 
 	private Rectangle calculateAbsoluteControlBounds(Control control) {


### PR DESCRIPTION
When moving the targeted editor between different windows, the overlay is closed to allow a retargetting.
![8](https://github.com/eclipse-platform/eclipse.platform.ui/assets/16443184/adf8108d-450d-4078-a245-7aa0053f40ce)

fixes #1945