### PR TITLE
Ensure that colors from registry are not null

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/OwnerDrawLabelProvider.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/OwnerDrawLabelProvider.java
@@ -170,10 +170,11 @@ public abstract class OwnerDrawLabelProvider extends CellLabelProvider {
 	/**
 	 * Handle the erase event. The default implementation colors the background of
 	 * selected areas with "org.eclipse.ui.workbench.SELECTED_CELL_BACKGROUND" and
-	 * foregrounds with "org.eclipse.ui.workbench.SELECTED_CELL_FOREGROUND". Note
-	 * that this implementation causes non-native behavior on some platforms.
-	 * Subclasses should override this method and <b>not</b> call the super
-	 * implementation.
+	 * foregrounds with "org.eclipse.ui.workbench.SELECTED_CELL_FOREGROUND" if these
+	 * colors are available, if not {@link SWT#COLOR_LIST_SELECTION} and
+	 * {@link SWT#COLOR_LIST_SELECTION_TEXT} is used. Note that this implementation
+	 * causes non-native behavior on some platforms. Subclasses should override this
+	 * method and <b>not</b> call the super implementation.
 	 *
 	 * @param event   the erase event
 	 * @param element the model object
@@ -189,11 +190,27 @@ public abstract class OwnerDrawLabelProvider extends CellLabelProvider {
 
 			ColorRegistry colorRegistry = JFaceResources.getColorRegistry();
 			if (event.widget instanceof Control control && control.isFocusControl()) {
-				event.gc.setBackground(colorRegistry.get("org.eclipse.ui.workbench.SELECTED_CELL_BACKGROUND")); //$NON-NLS-1$
-				event.gc.setForeground(colorRegistry.get("org.eclipse.ui.workbench.SELECTED_CELL_FOREGROUND")); //$NON-NLS-1$
+				Color background = colorRegistry.get("org.eclipse.ui.workbench.SELECTED_CELL_BACKGROUND"); //$NON-NLS-1$
+				if (background == null) {
+					background = event.item.getDisplay().getSystemColor(SWT.COLOR_LIST_SELECTION);
+				}
+				Color foreground = colorRegistry.get("org.eclipse.ui.workbench.SELECTED_CELL_FOREGROUND"); //$NON-NLS-1$
+				if (foreground == null) {
+					foreground = event.item.getDisplay().getSystemColor(SWT.COLOR_LIST_SELECTION_TEXT);
+				}
+				event.gc.setBackground(background);
+				event.gc.setForeground(foreground);
 			} else {
-				event.gc.setBackground(colorRegistry.get("org.eclipse.ui.workbench.SELECTED_CELL_BACKGROUND_NO_FOCUS")); //$NON-NLS-1$
-				event.gc.setForeground(colorRegistry.get("org.eclipse.ui.workbench.SELECTED_CELL_FOREGROUND_NO_FOCUS")); //$NON-NLS-1$
+				Color background = colorRegistry.get("org.eclipse.ui.workbench.SELECTED_CELL_BACKGROUND_NO_FOCUS"); //$NON-NLS-1$
+				if (background == null) {
+					background = event.item.getDisplay().getSystemColor(SWT.COLOR_LIST_SELECTION);
+				}
+				Color foreground = colorRegistry.get("org.eclipse.ui.workbench.SELECTED_CELL_FOREGROUND_NO_FOCUS"); //$NON-NLS-1$
+				if (foreground == null) {
+					foreground = event.item.getDisplay().getSystemColor(SWT.COLOR_LIST_SELECTION_TEXT);
+				}
+				event.gc.setBackground(background);
+				event.gc.setForeground(foreground);
 			}
 			event.gc.fillRectangle(bounds);
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/internal/ColumnViewerSelectionColorListener.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/internal/ColumnViewerSelectionColorListener.java
@@ -18,6 +18,7 @@ import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.viewers.FocusCellOwnerDrawHighlighter;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
@@ -63,11 +64,27 @@ public class ColumnViewerSelectionColorListener implements Listener {
 		GC gc = event.gc;
 		ColorRegistry colorRegistry = JFaceResources.getColorRegistry();
 		if (event.widget instanceof Control control && control.isFocusControl()) {
-			gc.setBackground(colorRegistry.get("org.eclipse.ui.workbench.SELECTED_CELL_BACKGROUND")); //$NON-NLS-1$
-			gc.setForeground(colorRegistry.get("org.eclipse.ui.workbench.SELECTED_CELL_FOREGROUND")); //$NON-NLS-1$
+			Color background = colorRegistry.get("org.eclipse.ui.workbench.SELECTED_CELL_BACKGROUND"); //$NON-NLS-1$
+			if (background == null) {
+				background = event.item.getDisplay().getSystemColor(SWT.COLOR_LIST_SELECTION);
+			}
+			Color foreground = colorRegistry.get("org.eclipse.ui.workbench.SELECTED_CELL_FOREGROUND"); //$NON-NLS-1$
+			if (foreground == null) {
+				foreground = event.item.getDisplay().getSystemColor(SWT.COLOR_LIST_SELECTION_TEXT);
+			}
+			event.gc.setBackground(background);
+			event.gc.setForeground(foreground);
 		} else {
-			gc.setBackground(colorRegistry.get("org.eclipse.ui.workbench.SELECTED_CELL_BACKGROUND_NO_FOCUS")); //$NON-NLS-1$
-			gc.setForeground(colorRegistry.get("org.eclipse.ui.workbench.SELECTED_CELL_FOREGROUND_NO_FOCUS")); //$NON-NLS-1$
+			Color background = colorRegistry.get("org.eclipse.ui.workbench.SELECTED_CELL_BACKGROUND_NO_FOCUS"); //$NON-NLS-1$
+			if (background == null) {
+				background = event.item.getDisplay().getSystemColor(SWT.COLOR_LIST_SELECTION);
+			}
+			Color foreground = colorRegistry.get("org.eclipse.ui.workbench.SELECTED_CELL_FOREGROUND_NO_FOCUS"); //$NON-NLS-1$
+			if (foreground == null) {
+				foreground = event.item.getDisplay().getSystemColor(SWT.COLOR_LIST_SELECTION_TEXT);
+			}
+			event.gc.setBackground(background);
+			event.gc.setForeground(foreground);
 		}
 
 		int width = event.width;


### PR DESCRIPTION
The workbench colors will not always be initialized in the JFace area, for example if the workbench is not started. To make sure there are no NPE, the system colors are used as default.

Fixes #1955, https://github.com/eclipse-platform/eclipse.platform.swt/issues/1275