### PR TITLE
[Sticky Scrolling] Dispatch scrolling to source viewer

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandler.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandler.java
@@ -85,7 +85,7 @@ public class StickyScrollingHandler implements IViewportListener {
 		this.stickyLinesProvider= stickyLinesProvider;
 
 		StickyScrollingControlSettings settings= loadAndListenForProperties(preferenceStore);
-		stickyScrollingControl= new StickyScrollingControl(sourceViewer, verticalRuler, settings);
+		stickyScrollingControl= new StickyScrollingControl(sourceViewer, verticalRuler, settings, this);
 
 		sourceViewer.addViewportListener(this);
 	}


### PR DESCRIPTION
Scrolling on the sticky lines control is dispatched to the linked source viewer. With this change the source viewer's scrolling behavior remains consistent, regardless of whether sticky scrolling is enalbed or not.

Follow up for #1894