### PR TITLE
[Sticky Scrolling] Fix separator color on windows

### DIFF
--- a/bundles/org.eclipse.ui.editors/plugin.xml
+++ b/bundles/org.eclipse.ui.editors/plugin.xml
@@ -1113,6 +1113,12 @@
           label="%dummy"
           value="0,0,0">
       </colorDefinition>
+      <colorDefinition
+            id="org.eclipse.ui.editors.stickyLinesSeparatorColor"
+            isEditable="false"
+            label="test"
+            value="232,232,232">
+      </colorDefinition>
 
       <theme
 		  id="org.eclipse.ui.ide.systemDefault">

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/EditorsPluginPreferenceInitializer.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/EditorsPluginPreferenceInitializer.java
@@ -59,6 +59,10 @@ public class EditorsPluginPreferenceInitializer extends AbstractPreferenceInitia
 				findRGB(registry,ITextEditorThemeConstants.PRINT_MARGIN_COLOR, new RGB(176, 180 , 185)), fireEvent);
 
 		setDefault(store,
+				ITextEditorThemeConstants.STICKY_LINES_SEPARATOR_COLOR,
+				findRGB(registry, ITextEditorThemeConstants.STICKY_LINES_SEPARATOR_COLOR, new RGB(232, 232, 232)), fireEvent);
+
+		setDefault(store,
 				AbstractDecoratedTextEditorPreferenceConstants.EDITOR_LINE_NUMBER_RULER_COLOR,
 				findRGB(registry, ITextEditorThemeConstants.LINE_NUMBER_RULER_COLOR, new RGB(120, 120, 120)), fireEvent);
 

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/ITextEditorThemeConstants.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/ITextEditorThemeConstants.java
@@ -64,4 +64,9 @@ public interface ITextEditorThemeConstants {
 	 */
 	public static final String PREFERENCE_COLOR_FOREGROUND= "org.eclipse.ui.editors.foregroundColor"; //$NON-NLS-1$
 
+	/**
+	 * Theme constant for the color used to render the sticky lines separator.
+	 */
+	public final static String STICKY_LINES_SEPARATOR_COLOR= "org.eclipse.ui.editors.stickyLinesSeparatorColor"; //$NON-NLS-1$
+
 }

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -40,7 +40,6 @@ import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.ScrollBar;
 
@@ -86,6 +85,8 @@ public class StickyScrollingControl {
 	 */
 	private final static int MIN_VISIBLE_EDITOR_LINES_THRESHOLD= 3;
 
+	private static final String DISABLE_CSS= "org.eclipse.e4.ui.css.disabled"; //$NON-NLS-1$
+
 	private List<StickyLine> stickyLines;
 
 	private ISourceViewer sourceViewer;
@@ -106,9 +107,7 @@ public class StickyScrollingControl {
 
 	private StickyScollingCaretListener caretListener;
 
-	private Label bottomSeparator;
-
-	private final static int BOTTOM_SEPARATOR_SPACING= 2;
+	private Composite bottomSeparator;
 
 	private StickyScrollingHandler stickyScrollingHandler;
 
@@ -148,6 +147,7 @@ public class StickyScrollingControl {
 
 		stickyLineNumber.setBackground(newSettings.stickyLineBackgroundColor());
 		stickyLineText.setBackground(newSettings.stickyLineBackgroundColor());
+		bottomSeparator.setBackground(settings.stickyLinesSeparatorColor());
 
 		updateStickyScrollingControls();
 	}
@@ -187,13 +187,11 @@ public class StickyScrollingControl {
 		stickyLineText.setEnabled(false);
 		stickyLineText.setBackground(settings.stickyLineBackgroundColor());
 
-		bottomSeparator= new Label(stickyLinesCanvas, SWT.SEPARATOR | SWT.SHADOW_OUT | SWT.HORIZONTAL);
-		GridDataFactory.fillDefaults().grab(true, false).span(2, 1).applyTo(bottomSeparator);
+		bottomSeparator= new Composite(stickyLinesCanvas, SWT.NONE);
+		GridDataFactory.fillDefaults().hint(0, 3).grab(true, false).span(2, 1).applyTo(bottomSeparator);
 		bottomSeparator.setEnabled(false);
-
-		bottomSeparator= new Label(stickyLinesCanvas, SWT.SEPARATOR | SWT.SHADOW_OUT | SWT.HORIZONTAL);
-		GridDataFactory.fillDefaults().grab(true, false).indent(0, BOTTOM_SEPARATOR_SPACING).span(2, 1).applyTo(bottomSeparator);
-		bottomSeparator.setEnabled(false);
+		bottomSeparator.setData(DISABLE_CSS, Boolean.TRUE);
+		bottomSeparator.setBackground(settings.stickyLinesSeparatorColor());
 
 		layoutLineNumbers();
 		limitVisibleStickyLinesToTextWidgetHeight(sourceViewer.getTextWidget());
@@ -288,10 +286,10 @@ public class StickyScrollingControl {
 
 	/**
 	 * The line numbers layout is calculated based on the given {@link #verticalRuler}.
-	 * 
+	 *
 	 * If the vertical ruler is an instance of {@link CompositeRuler}, it is tried to align the
 	 * layout with the layout of the {@link LineNumberColumn}.
-	 * 
+	 *
 	 * If the vertical ruler is from another instance, the lines number are align in the center of
 	 * the vertical ruler space.
 	 */
@@ -349,7 +347,7 @@ public class StickyScrollingControl {
 		int numberStickyLines= getNumberStickyLines();
 		int lineHeight= stickyLineText.getLineHeight() * numberStickyLines;
 		int spacingHeight= stickyLineText.getLineSpacing() * (numberStickyLines - 1);
-		int separatorHeight= bottomSeparator.getBounds().height * 2 + BOTTOM_SEPARATOR_SPACING;
+		int separatorHeight= bottomSeparator.getBounds().height;
 
 		int rulerWidth= verticalRuler != null ? verticalRuler.getWidth() : 0;
 		int textWidth= textWidget.getClientArea().width + 1;
@@ -398,7 +396,7 @@ public class StickyScrollingControl {
 
 	/**
 	 * Add several listeners to the source viewer.<br>
-	 * 
+	 *
 	 * textPresentationListener in order to style the sticky lines when the source viewer styling
 	 * has changed.<br>
 	 * <br>

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlSettings.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlSettings.java
@@ -24,6 +24,7 @@ import org.eclipse.swt.graphics.Color;
  * @param lineNumberColor The color used to display line numbers
  * @param stickyLineHoverColor The color used to display sticky lines while hovering over them
  * @param stickyLineBackgroundColor The color used to display sticky lines back ground color
+ * @param stickyLinesSeparatorColor The color used to display sticky lines separator color
  * @param showLineNumbers Specifies if line numbers should be showed for sticky scrolling
  */
 public record StickyScrollingControlSettings(
@@ -31,5 +32,6 @@ public record StickyScrollingControlSettings(
 		Color lineNumberColor,
 		Color stickyLineHoverColor,
 		Color stickyLineBackgroundColor,
+		Color stickyLinesSeparatorColor,
 		boolean showLineNumbers) {
 }

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandler.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandler.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.texteditor.stickyscroll;
 
+import static org.eclipse.ui.internal.texteditor.ITextEditorThemeConstants.STICKY_LINES_SEPARATOR_COLOR;
 import static org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants.EDITOR_CURRENT_LINE_COLOR;
 import static org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants.EDITOR_LINE_NUMBER_RULER;
 import static org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants.EDITOR_LINE_NUMBER_RULER_COLOR;
@@ -23,6 +24,7 @@ import java.time.Duration;
 import java.util.List;
 
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.RGB;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceConverter;
@@ -30,8 +32,11 @@ import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.Throttler;
 
 import org.eclipse.jface.text.IViewportListener;
+import org.eclipse.jface.text.source.ISharedTextColors;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.text.source.IVerticalRuler;
+
+import org.eclipse.ui.internal.editors.text.EditorsPlugin;
 
 /**
  * A sticky scrolling handler that retrieves stick lines from the {@link StickyLinesProvider} and
@@ -94,7 +99,8 @@ public class StickyScrollingHandler implements IViewportListener {
 		preferenceStore= store;
 		propertyChangeListener= e -> {
 			if (e.getProperty().equals(EDITOR_TAB_WIDTH) || e.getProperty().equals(EDITOR_STICKY_SCROLLING_MAXIMUM_COUNT)
-					|| e.getProperty().equals(EDITOR_CURRENT_LINE_COLOR) || e.getProperty().equals(EDITOR_LINE_NUMBER_RULER)) {
+					|| e.getProperty().equals(EDITOR_CURRENT_LINE_COLOR) || e.getProperty().equals(EDITOR_LINE_NUMBER_RULER)
+					|| e.getProperty().equals(STICKY_LINES_SEPARATOR_COLOR)) {
 				if (stickyScrollingControl != null && !sourceViewer.getTextWidget().isDisposed()) {
 					StickyScrollingControlSettings settings= loadSettings(preferenceStore);
 					stickyScrollingControl.applySettings(settings);
@@ -121,8 +127,15 @@ public class StickyScrollingHandler implements IViewportListener {
 
 		boolean showLineNumbers= store.getBoolean(EDITOR_LINE_NUMBER_RULER);
 
+		Color stickyLineSeparatorColor= null;
+		if (EditorsPlugin.getDefault() != null) {
+			RGB rgb= PreferenceConverter.getColor(store, STICKY_LINES_SEPARATOR_COLOR);
+			ISharedTextColors sharedTextColors= EditorsPlugin.getDefault().getSharedTextColors();
+			stickyLineSeparatorColor= sharedTextColors.getColor(rgb);
+		}
+
 		return new StickyScrollingControlSettings(stickyScrollingMaxCount,
-				lineNumberColor, stickyLineHoverColor, stickyLineBackgroundColor, showLineNumbers);
+				lineNumberColor, stickyLineHoverColor, stickyLineBackgroundColor, stickyLineSeparatorColor, showLineNumbers);
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.themes/css/dark/e4-dark_preferencestyle.css
+++ b/bundles/org.eclipse.ui.themes/css/dark/e4-dark_preferencestyle.css
@@ -50,6 +50,7 @@ IEclipsePreferences#org-eclipse-ui-editors:org-eclipse-ui-themes { /* pseudo att
 		'secondaryIPColor=90,90,90'
 		'spellingIndicationColor=253,170,211'
 		'writeOccurrenceIndicationColor=27,98,145'
+		'org.eclipse.ui.editors.stickyLinesSeparatorColor=81,86,88'
 }
 
 IEclipsePreferences#org-eclipse-ui-workbench:org-eclipse-ui-themes { /* pseudo attribute added to allow contributions without replacing this node, see Bug 466075 */

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
@@ -51,6 +51,7 @@ public class StickyScrollingControlTest {
 	private Color lineNumberColor;
 	private Color hoverColor;
 	private Color backgroundColor;
+	private Color separatorColor;
 	private StickyScrollingControl stickyScrollingControl;
 	private CompositeRuler ruler;
 
@@ -67,8 +68,9 @@ public class StickyScrollingControlTest {
 		lineNumberColor = new Color(0, 0, 0);
 		hoverColor = new Color(1, 1, 1);
 		backgroundColor = new Color(2, 2, 2);
+		separatorColor = new Color(3, 3, 3);
 		StickyScrollingControlSettings settings = new StickyScrollingControlSettings(5, lineNumberColor, hoverColor,
-				backgroundColor, true);
+				backgroundColor, separatorColor, true);
 		stickyScrollingControl = new StickyScrollingControl(sourceViewer, ruler, settings, null);
 	}
 
@@ -105,6 +107,9 @@ public class StickyScrollingControlTest {
 
 		StyledText stickyLineText = getStickyLineText();
 		assertEquals(backgroundColor, stickyLineText.getBackground());
+
+		Composite stickyLineSeparator = getStickyLineSeparator();
+		assertEquals(separatorColor, stickyLineSeparator.getBackground());
 	}
 
 	@Test
@@ -113,7 +118,7 @@ public class StickyScrollingControlTest {
 		stickyScrollingControl.setStickyLines(stickyLines);
 
 		StickyScrollingControlSettings settings = new StickyScrollingControlSettings(1, lineNumberColor, hoverColor,
-				backgroundColor, true);
+				backgroundColor, separatorColor, true);
 		stickyScrollingControl.applySettings(settings);
 
 		StyledText stickyLineNumber = getStickyLineNumber();
@@ -141,7 +146,7 @@ public class StickyScrollingControlTest {
 	public void testWithoutVeticalRuler() {
 		sourceViewer = new SourceViewer(shell, null, SWT.None);
 		StickyScrollingControlSettings settings = new StickyScrollingControlSettings(5, lineNumberColor, hoverColor,
-				backgroundColor, true);
+				backgroundColor, separatorColor, true);
 		stickyScrollingControl = new StickyScrollingControl(sourceViewer, settings);
 
 		StyledText stickyLineNumber = getStickyLineNumber();
@@ -265,7 +270,9 @@ public class StickyScrollingControlTest {
 	private Canvas getStickyControlCanvas(Composite composite) {
 		for (Control control : composite.getChildren()) {
 			if (control instanceof Canvas canvas) {
-				if (canvas.getChildren().length == 4) {
+				if (canvas.getChildren().length == 3 && canvas.getChildren()[0] instanceof StyledText
+						&& canvas.getChildren()[1] instanceof StyledText
+						&& canvas.getChildren()[2] instanceof Composite) {
 					return canvas;
 				}
 			}
@@ -284,6 +291,11 @@ public class StickyScrollingControlTest {
 	private StyledText getStickyLineText() {
 		Canvas canvas = getStickyControlCanvas(shell);
 		return (StyledText) canvas.getChildren()[1];
+	}
+
+	private Composite getStickyLineSeparator() {
+		Canvas canvas = getStickyControlCanvas(shell);
+		return (Composite) canvas.getChildren()[2];
 	}
 
 }

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandlerTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandlerTest.java
@@ -175,7 +175,9 @@ public class StickyScrollingHandlerTest {
 	private Canvas getStickyControlCanvas(Composite composite) {
 		for (Control control : composite.getChildren()) {
 			if (control instanceof Canvas canvas) {
-				if (canvas.getChildren().length == 4) {
+				if (canvas.getChildren().length == 3 && canvas.getChildren()[0] instanceof StyledText
+						&& canvas.getChildren()[1] instanceof StyledText
+						&& canvas.getChildren()[2] instanceof Composite) {
 					return canvas;
 				}
 			}


### PR DESCRIPTION
The separator in the sticky lines controls are drawn in a bad color on windows dark theme. With this change, the separator color is aligned with the theme.

Current coloring on windows:
<img width="929" alt="Bildschirmfoto 2024-06-14 um 10 42 22" src="https://github.com/eclipse-platform/eclipse.platform.ui/assets/79514265/1725a976-8bdd-4a34-91f6-dcefc9bb0b03">

How it should look like:
<img width="484" alt="Bildschirmfoto 2024-06-14 um 10 43 20" src="https://github.com/eclipse-platform/eclipse.platform.ui/assets/79514265/7eaff78e-9f82-4b0b-b229-2216204099a3">

This is a follow up for eclipse-platform/eclipse.platform.ui#1894