### PR TITLE
NPE in StickyScrollControl.getStickyLineStyleRanges #1964

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -217,6 +217,9 @@ public class StickyScrollingControl {
 
 	private void styleStickyLines() {
 		StyledText textWidget= sourceViewer.getTextWidget();
+		if (textWidget == null || textWidget.isDisposed()) {
+			return;
+		}
 
 		List<StyleRange> stickyLinesStyleRanges= new ArrayList<>();
 		int stickyLineTextOffset= 0;


### PR DESCRIPTION
When the sticky lines are styled, the linked text widget could already be disposed or null. In this case, the sticky lines must not be styled.

Fixes #1964