### PR TITLE
Find/Replace overlay: fix Ctrl+F6 crash on Linux

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -247,21 +247,17 @@ public class FindReplaceOverlay extends Dialog {
 	private IPartListener partListener = new IPartListener() {
 		@Override
 		public void partActivated(IWorkbenchPart part) {
-			if (getShell() != null) {
-				getShell().setVisible(isPartCurrentlyDisplayedInPartSash());
-			}
+			getShell().getDisplay().asyncExec(this::adaptToPartActivationChange);
 		}
 
 		@Override
 		public void partDeactivated(IWorkbenchPart part) {
-			// Do nothing
+			getShell().getDisplay().asyncExec(this::adaptToPartActivationChange);
 		}
 
 		@Override
 		public void partBroughtToTop(IWorkbenchPart part) {
-			if (getShell() != null) {
-				getShell().setVisible(isPartCurrentlyDisplayedInPartSash());
-			}
+			getShell().getDisplay().asyncExec(this::adaptToPartActivationChange);
 		}
 
 		@Override
@@ -272,6 +268,35 @@ public class FindReplaceOverlay extends Dialog {
 		@Override
 		public void partOpened(IWorkbenchPart part) {
 			// Do nothing
+		}
+
+		private void adaptToPartActivationChange() {
+			if (getShell() == null || targetPart.getSite().getPart() == null) {
+				return;
+			}
+
+			boolean isOverlayVisible = isPartCurrentlyDisplayedInPartSash();
+
+			getShell().setVisible(isOverlayVisible);
+
+			if (isOverlayVisible) {
+				targetPart.getSite().getShell().setActive();
+				targetPart.setFocus();
+				getShell().getDisplay().asyncExec(this::focusTargetWidget);
+			}
+		}
+
+		private void focusTargetWidget() {
+			if (getShell() == null || targetPart.getSite().getPart() == null) {
+				return;
+			}
+			if (!(targetPart instanceof StatusTextEditor)) {
+				return;
+			}
+			StatusTextEditor textEditor = (StatusTextEditor) targetPart;
+			Control targetWidget = textEditor.getAdapter(ITextViewer.class).getTextWidget();
+
+			targetWidget.forceFocus();
 		}
 	};
 


### PR DESCRIPTION
Avoid being stuck in an event loop by reacting asynchronously to part activation events.
Additionally, manually give focus to the editor part after switching. This behavior is default on windows but not consistent on Linux.

### how to test

after pressing Ctrl+F in a few different Editors,
(on Ubuntu), press Ctrl+6 repeatedly to switch between Editor parts. We (quite obviously) don't expect anything to crash!

fixes #1951