### PR TITLE
Fix NPE in legacyActionLabelSupport

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/HandledContributionItem.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/HandledContributionItem.java
@@ -339,7 +339,7 @@ public class HandledContributionItem extends AbstractContributionItem {
 
 	private String legacyActionLabelSupport(String text, ParameterizedCommand command) {
 
-		return java.util.Optional.of(command).map(ParameterizedCommand::getCommand).map(Command::getHandler)
+		return java.util.Optional.ofNullable(command).map(ParameterizedCommand::getCommand).map(Command::getHandler)
 				.map(IHandler::getHandlerLabel).filter(Objects::nonNull).orElse(text);
 	}
 


### PR DESCRIPTION
If command is null a NPE occurs even though from the code it seems this should be handled by a fallback.

This replaces Optional.of with Optional.ofNullable to account for that case.