### PR TITLE
draw code minings at end of line before or after the eol character

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationDrawingStrategy.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationDrawingStrategy.java
@@ -13,9 +13,6 @@
  */
 package org.eclipse.jface.text.source.inlined;
 
-import org.eclipse.jface.text.ITextViewer;
-import org.eclipse.jface.text.source.Annotation;
-import org.eclipse.jface.text.source.AnnotationPainter.IDrawingStrategy;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
@@ -26,6 +23,10 @@ import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.GlyphMetrics;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
+
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.AnnotationPainter.IDrawingStrategy;
 
 /**
  * {@link IDrawingStrategy} implementation to render {@link AbstractInlinedAnnotation}.
@@ -115,7 +116,7 @@ class InlinedAnnotationDrawingStrategy implements IDrawingStrategy {
 		}
 		int widgetFontHeight = widget.getFont().getFontData()[0].getHeight();
 		int annotationFontHeight = annotationFont.getFontData()[0].getHeight();
-		return annotationFontHeight == widgetFontHeight; 
+		return annotationFontHeight == widgetFontHeight;
 	}
 
 	/**
@@ -201,7 +202,7 @@ class InlinedAnnotationDrawingStrategy implements IDrawingStrategy {
 	 */
 	private static void draw(LineContentAnnotation annotation, GC gc, StyledText textWidget, int widgetOffset, int length,
 			Color color) {
-		if (annotation.isEndOfLine(widgetOffset, textWidget)) {
+		if (annotation.isEmptyLine(widgetOffset, textWidget)) {
 			drawAfterLine(annotation, gc, textWidget, widgetOffset, length, color);
 		} else if (LineContentAnnotation.drawRightToPreviousChar(widgetOffset, textWidget)) {
 			drawAsRightOfPreviousCharacter(annotation, gc, textWidget, widgetOffset, length, color);

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineContentAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineContentAnnotation.java
@@ -13,17 +13,18 @@
  */
 package org.eclipse.jface.text.source.inlined;
 
-import org.eclipse.jface.text.ITextViewer;
-import org.eclipse.jface.text.ITextViewerExtension5;
-import org.eclipse.jface.text.Position;
-import org.eclipse.jface.text.TextPresentation;
-import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontMetrics;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.GlyphMetrics;
+
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.ITextViewerExtension5;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.TextPresentation;
+import org.eclipse.jface.text.source.ISourceViewer;
 
 /**
  * Inlined annotation which is drawn in the line content and which takes some place with a given
@@ -162,14 +163,12 @@ public class LineContentAnnotation extends AbstractInlinedAnnotation {
 				textWidget.getLineAtOffset(widgetOffset) == textWidget.getLineAtOffset(widgetOffset - 1);
 	}
 
-	boolean isEndOfLine(int widgetOffset, StyledText text) {
+	boolean isEmptyLine(int widgetOffset, StyledText text) {
 		if (text.getCharCount() <= widgetOffset) { // Assuming widgetOffset >= 0
 			return true;
 		}
 		int line= text.getLineAtOffset(widgetOffset);
-		int startOfLine= text.getOffsetAtLine(line);
-		int offsetInLine= widgetOffset - startOfLine;
-		return offsetInLine >= text.getLine(line).length();
+		String lineStr= text.getLine(line);
+		return lineStr.length() == 0;
 	}
-
 }


### PR DESCRIPTION
We would like to implement a ghost text like completion functionality like in vscode and want to re-use the existing eclipse code mining implementation.  

It works quite well as long the completion trigger offset is not the last character of the line.
Following screenshot shows a scenario where the user has pressed the character "e" and the keyword "entity" is then proposed. The code mining consists of the rest of the word "ntity".
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/10373336/2ab793b7-1856-4eea-a9b0-efe186fbdda3)

If the cursor is at the end of the line, the code mining is shown with some space next to the (invisible) line break character which does not look that nice.
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/10373336/57d1a7ff-177f-45c0-9f0d-1b55b8f59cfd)

This change introduces method
AbstractCodeMining#miningToBeDrawnAfterLineBreakCharacterIfAtEndOfLine so that mining implementors can decide where the code mining should be drawn: before or after the (invisible) end of line character.

Here a screenshot where miningToBeDrawnAfterLineBreakCharacterIfAtEndOfLine returns false.
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/10373336/601c5da5-314f-4166-a7d6-f4e733f49b57)

What do you think? Does this change make sense? Do you see any issues?