### PR TITLE
remove unnecessary casts

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.addons.swt;singleton:=true
-Bundle-Version: 1.5.400.qualifier
+Bundle-Version: 1.5.500.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/minmax/MinMaxAddonUtil.java
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/minmax/MinMaxAddonUtil.java
@@ -347,7 +347,7 @@ public class MinMaxAddonUtil {
 		// null since it's not in the 'children' hierarchy
 		while (parent != null && !(parent instanceof MWindow)) {
 			if (parent.getTags().contains(MIN_MAXIMIZEABLE_CHILDREN_AREA_TAG) && parent instanceof MArea) {
-				parent = ((MArea) parent).getCurSharedRef();
+				parent = parent.getCurSharedRef();
 			} else {
 				parent = parent.getParent();
 			}

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/SashLayout.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/SashLayout.java
@@ -163,7 +163,7 @@ public class SashLayout extends Layout {
 
 		Rectangle bounds = composite.getBounds();
 		if (composite instanceof Shell)
-			bounds = ((Shell) composite).getClientArea();
+			bounds = composite.getClientArea();
 		else {
 			bounds.x = 0;
 			bounds.y = 0;

--- a/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench;singleton:=true
-Bundle-Version: 1.15.400.qualifier
+Bundle-Version: 1.15.500.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/LocaleChangeServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/LocaleChangeServiceImpl.java
@@ -25,7 +25,6 @@ import org.eclipse.e4.core.services.nls.ILocaleChangeService;
 import org.eclipse.e4.core.services.translation.TranslationService;
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.ui.MElementContainer;
-import org.eclipse.e4.ui.model.application.ui.MLocalizable;
 import org.eclipse.e4.ui.model.application.ui.MUIElement;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
@@ -142,7 +141,7 @@ public class LocaleChangeServiceImpl implements ILocaleChangeService {
 				}
 			}
 
-			((MLocalizable) element).updateLocalization();
+			element.updateLocalization();
 		}
 	}
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/util/ConfigureColumns.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/util/ConfigureColumns.java
@@ -172,9 +172,9 @@ public class ConfigureColumns {
 
 		private Image getColumnImage(Item item) {
 			if (item instanceof TableColumn) {
-				return ((TableColumn) item).getImage();
+				return item.getImage();
 			} else if (item instanceof TreeColumn) {
-				return ((TreeColumn) item).getImage();
+				return item.getImage();
 			}
 			return null;
 		}
@@ -301,12 +301,12 @@ public class ConfigureColumns {
 		private String getColumnName(Item item) {
 			String result = ""; //$NON-NLS-1$
 			if (item instanceof TableColumn) {
-				result = ((TableColumn) item).getText();
+				result = item.getText();
 				if (result.trim().isEmpty()) {
 					result = ((TableColumn) item).getToolTipText();
 				}
 			} else if (item instanceof TreeColumn) {
-				result = ((TreeColumn) item).getText();
+				result = item.getText();
 				if (result.trim().isEmpty()) {
 					result = ((TreeColumn) item).getToolTipText();
 				}

--- a/bundles/org.eclipse.ltk.core.refactoring/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ltk.core.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.ltk.core.refactoring
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ltk.core.refactoring; singleton:=true
-Bundle-Version: 3.14.400.qualifier
+Bundle-Version: 3.14.500.qualifier
 Bundle-Activator: org.eclipse.ltk.internal.core.refactoring.RefactoringCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/participants/ProcessorBasedRefactoring.java
+++ b/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/participants/ProcessorBasedRefactoring.java
@@ -430,7 +430,7 @@ public class ProcessorBasedRefactoring extends Refactoring {
 
 	private void addToTextChangeMap(Change change) {
 		if (change instanceof TextChange) {
-			Object element= ((TextChange) change).getModifiedElement();
+			Object element= change.getModifiedElement();
 			if (element != null) {
 				fTextChangeMap.put(element, (TextChange) change);
 			}

--- a/bundles/org.eclipse.search/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search; singleton:=true
-Bundle-Version: 3.16.200.qualifier
+Bundle-Version: 3.16.300.qualifier
 Bundle-Activator: org.eclipse.search.internal.ui.SearchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchPageDescriptor.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchPageDescriptor.java
@@ -34,7 +34,6 @@ import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 
 import org.eclipse.jface.dialogs.IDialogSettings;
@@ -336,7 +335,7 @@ class SearchPageDescriptor implements IPluginContribution, Comparable<SearchPage
 
 			IResource resource= ((IAdaptable)element).getAdapter(IResource.class);
 			if (resource != null && resource.getType() == IResource.FILE) {
-				String extension= ((IFile)resource).getFileExtension();
+				String extension= resource.getFileExtension();
 				if (extension != null)
 					score= Math.max(score, getScoreForFileExtension(extension));
 			}

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/LineNumberColumn.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/LineNumberColumn.java
@@ -530,7 +530,7 @@ public class LineNumberColumn extends AbstractContributedRulerColumn implements 
 		modelExtension.addAnnotationModel(IChangeRulerColumn.QUICK_DIFF_MODEL_ID, newDiffer);
 
 		if (fDelegate instanceof IChangeRulerColumn)
-			((IChangeRulerColumn) fDelegate).setModel(annotationModel); // picks up the new model attachment
+			fDelegate.setModel(annotationModel); // picks up the new model attachment
 
 		return true;
 	}
@@ -543,7 +543,7 @@ public class LineNumberColumn extends AbstractContributedRulerColumn implements 
 	private void installChangeRulerModel(IVerticalRulerColumn column) {
 		if (column instanceof IChangeRulerColumn) {
 			IAnnotationModel model= getAnnotationModelWithDiffer();
-			((IChangeRulerColumn) column).setModel(model);
+			column.setModel(model);
 			if (model != null) {
 				ISourceViewer viewer= fViewer;
 				if (viewer != null && viewer.getAnnotationModel() == null && column.getControl() != null)
@@ -559,7 +559,7 @@ public class LineNumberColumn extends AbstractContributedRulerColumn implements 
 	 */
 	private void uninstallChangeRulerModel(IVerticalRulerColumn column) {
 		if (column instanceof IChangeRulerColumn)
-			((IChangeRulerColumn) column).setModel(null);
+			column.setModel(null);
 		IAnnotationModel model= getDiffer();
 		if (model instanceof ILineDifferExtension)
 			((ILineDifferExtension) model).suspend();

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/texteditor/AddMarkerAction.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/texteditor/AddMarkerAction.java
@@ -331,7 +331,7 @@ public class AddMarkerAction extends TextEditorAction {
 		ITextEditor editor= getTextEditor();
 		if (editor != null) {
 			IEditorInput input= editor.getEditorInput();
-			return ((IAdaptable) input).getAdapter(IResource.class);
+			return input.getAdapter(IResource.class);
 		}
 		return null;
 	}

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CloseUnrelatedProjectsAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CloseUnrelatedProjectsAction.java
@@ -162,7 +162,7 @@ public class CloseUnrelatedProjectsAction extends CloseResourceAction {
 			IResource firstSelected = selection.get(0);
 			String projectName = null;
 			if (firstSelected instanceof IProject) {
-				projectName = ((IProject) firstSelected).getName();
+				projectName = firstSelected.getName();
 			}
 			message = NLS.bind(IDEWorkbenchMessages.CloseUnrelatedProjectsAction_confirmMsg1, projectName);
 		} else // if more then one project is selected then print there number

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CopyResourceAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CopyResourceAction.java
@@ -288,7 +288,7 @@ public class CopyResourceAction extends SelectionListenerAction implements
 		if (selectedResources.isEmpty()) {
 			return false;
 		}
-		IContainer firstParent = ((IResource) selectedResources.get(0))
+		IContainer firstParent = selectedResources.get(0)
 				.getParent();
 		if (firstParent == null) {
 			return false;

--- a/bundles/org.eclipse.ui.navigator.resources/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.navigator.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.navigator.resources; singleton:=true
-Bundle-Version: 3.9.300.qualifier
+Bundle-Version: 3.9.400.qualifier
 Bundle-Activator: org.eclipse.ui.internal.navigator.resources.plugin.WorkbenchNavigatorPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/PasteAction.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/PasteAction.java
@@ -187,7 +187,7 @@ import org.eclipse.ui.part.ResourceTransfer;
 		}
 
 		if (selection.get(0) instanceof IFile) {
-			return ((IFile) selection.get(0)).getParent();
+			return selection.get(0).getParent();
 		}
 		return (IContainer) selection.get(0);
 	}

--- a/bundles/org.eclipse.ui.navigator/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.navigator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.navigator; singleton:=true
-Bundle-Version: 3.12.400.qualifier
+Bundle-Version: 3.12.500.qualifier
 Bundle-Activator: org.eclipse.ui.internal.navigator.NavigatorPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/NavigatorContentServiceContentProvider.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/NavigatorContentServiceContentProvider.java
@@ -441,7 +441,7 @@ public class NavigatorContentServiceContentProvider implements ITreeContentProvi
 			ITreePathContentProvider tpcp = cp;
 			return tpcp.hasChildren((TreePath) anElementOrPath);
 		}
-		return ((ITreeContentProvider) cp).hasChildren(anElement);
+		return cp.hasChildren(anElement);
 	}
 
 	private boolean pipelineHasChildren(Object anElementOrPath, Object anElement,
@@ -632,8 +632,8 @@ public class NavigatorContentServiceContentProvider implements ITreeContentProvi
 
 					if (!isOverridingDescriptorInSet(foundExtension.getDescriptor(), descriptors)) {
 						if (foundExtension.internalGetContentProvider().isTreePath()) {
-							TreePath[] parentTreePaths = ((ITreePathContentProvider) foundExtension
-									.internalGetContentProvider()).getParents(anElement);
+							TreePath[] parentTreePaths = foundExtension
+									.internalGetContentProvider().getParents(anElement);
 
 							for (TreePath parentTreePath : parentTreePaths) {
 

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/NavigatorPipelineService.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/NavigatorPipelineService.java
@@ -25,7 +25,6 @@ import org.eclipse.osgi.util.NLS;
 import org.eclipse.ui.internal.navigator.extensions.NavigatorContentExtension;
 import org.eclipse.ui.navigator.INavigatorContentDescriptor;
 import org.eclipse.ui.navigator.INavigatorPipelineService;
-import org.eclipse.ui.navigator.IPipelinedTreeContentProvider;
 import org.eclipse.ui.navigator.PipelinedShapeModification;
 import org.eclipse.ui.navigator.PipelinedViewerUpdate;
 
@@ -79,8 +78,8 @@ public class NavigatorPipelineService implements INavigatorPipelineService {
 						SafeRunner.run(new NavigatorSafeRunnable() {
 							@Override
 							public void run() throws Exception {
-								((IPipelinedTreeContentProvider) extension
-										.internalGetContentProvider())
+								extension
+										.internalGetContentProvider()
 										.interceptAdd(anAddModification);
 							}
 
@@ -139,8 +138,8 @@ public class NavigatorPipelineService implements INavigatorPipelineService {
 				SafeRunner.run(new NavigatorSafeRunnable() {
 					@Override
 					public void run() throws Exception {
-						((IPipelinedTreeContentProvider) overridingExtension
-								.internalGetContentProvider()).interceptRemove(aRemoveModification);
+						overridingExtension
+								.internalGetContentProvider().interceptRemove(aRemoveModification);
 					}
 
 					@Override
@@ -189,8 +188,8 @@ public class NavigatorPipelineService implements INavigatorPipelineService {
 				SafeRunner.run(new NavigatorSafeRunnable() {
 					@Override
 					public void run() throws Exception {
-						intercepted[0] |= ((IPipelinedTreeContentProvider) nceLocal
-								.internalGetContentProvider())
+						intercepted[0] |= nceLocal
+								.internalGetContentProvider()
 								.interceptRefresh(aRefreshSynchronization);
 
 						if (nceLocal.getDescriptor().hasOverridingExtensions())
@@ -242,8 +241,8 @@ public class NavigatorPipelineService implements INavigatorPipelineService {
 				SafeRunner.run(new NavigatorSafeRunnable() {
 					@Override
 					public void run() throws Exception {
-						intercepted[0] |= ((IPipelinedTreeContentProvider) nceLocal
-								.internalGetContentProvider())
+						intercepted[0] |= nceLocal
+								.internalGetContentProvider()
 								.interceptUpdate(anUpdateSynchronization);
 
 						if (nceLocal.getDescriptor().hasOverridingExtensions())

--- a/bundles/org.eclipse.ui.views/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.views; singleton:=true
-Bundle-Version: 3.12.300.qualifier
+Bundle-Version: 3.12.400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.internal.views.contentoutline;x-internal:=true,

--- a/bundles/org.eclipse.ui.views/src/org/eclipse/ui/views/properties/PropertySheetEntry.java
+++ b/bundles/org.eclipse.ui.views/src/org/eclipse/ui/views/properties/PropertySheetEntry.java
@@ -553,7 +553,7 @@ public class PropertySheetEntry extends EventManager implements IPropertySheetEn
 
 		// Dispose of entries which are no longer needed
 		for (PropertySheetEntry element : entriesToDispose) {
-			((IPropertySheetEntry) element).dispose();
+			element.dispose();
 		}
 	}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -1003,7 +1003,7 @@ class FindReplaceDialog extends Dialog {
 	private void setGridData(Control component, int horizontalAlignment, boolean grabExcessHorizontalSpace,
 			int verticalAlignment, boolean grabExcessVerticalSpace) {
 		GridData gd;
-		if (component instanceof Button && (((Button) component).getStyle() & SWT.PUSH) != 0) {
+		if (component instanceof Button && (component.getStyle() & SWT.PUSH) != 0) {
 			SWTUtil.setButtonDimensionHint((Button) component);
 			gd = (GridData) component.getLayoutData();
 		} else {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/templates/AbstractTemplatesPage.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/templates/AbstractTemplatesPage.java
@@ -1510,7 +1510,7 @@ public abstract class AbstractTemplatesPage extends Page implements ITemplatesPa
 			public void drop(DropTargetEvent event) {
 				if (event.item == null)
 					return;
-				Object object= ((TreeItem) event.item).getData();
+				Object object= event.item.getData();
 				final String contextId;
 				if (object instanceof TemplateContextType)
 					contextId= ((TemplateContextType) object).getId();

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/PluginActionSetBuilder.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/PluginActionSetBuilder.java
@@ -619,7 +619,7 @@ public class PluginActionSetBuilder extends PluginActionBuilder {
 				if (item instanceof IToolBarManager) {
 					revokeActionSetFromToolbar((IToolBarManager) item, actionsetId);
 				} else if (item instanceof IToolBarContributionItem) {
-					id = ((IToolBarContributionItem) item).getId();
+					id = item.getId();
 					if (actionsetId.equals(id)) {
 						itemsToRemove.add(item);
 					}

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchPage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchPage.java
@@ -1030,13 +1030,13 @@ public class WorkbenchPage implements IWorkbenchPage {
 
 		for (ViewReference reference : viewReferences) {
 			if (part == reference.getPart(false)) {
-				return ((WorkbenchPartReference) reference).getModel();
+				return reference.getModel();
 			}
 		}
 
 		for (EditorReference reference : editorReferences) {
 			if (part == reference.getPart(false)) {
-				return ((WorkbenchPartReference) reference).getModel();
+				return reference.getModel();
 			}
 		}
 		return null;

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/databinding/MultiSelectionProperty.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/databinding/MultiSelectionProperty.java
@@ -36,9 +36,9 @@ public class MultiSelectionProperty<S extends ISelectionService, E> extends Simp
 	protected List<E> doGetList(S source) {
 		ISelection selection;
 		if (partId != null) {
-			selection = ((ISelectionService) source).getSelection(partId);
+			selection = source.getSelection(partId);
 		} else {
-			selection = ((ISelectionService) source).getSelection();
+			selection = source.getSelection();
 		}
 		if (selection instanceof IStructuredSelection) {
 			List<E> list = ((IStructuredSelection) selection).toList();

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/databinding/SingleSelectionProperty.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/databinding/SingleSelectionProperty.java
@@ -28,9 +28,9 @@ public class SingleSelectionProperty<S extends ISelectionService, T> extends Sim
 	protected T doGetValue(S source) {
 		ISelection selection;
 		if (partId != null) {
-			selection = ((ISelectionService) source).getSelection(partId);
+			selection = source.getSelection(partId);
 		} else {
-			selection = ((ISelectionService) source).getSelection();
+			selection = source.getSelection();
 		}
 		if (selection instanceof IStructuredSelection) {
 			T elem = (T) ((IStructuredSelection) selection).getFirstElement();

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/FilteredPreferenceDialog.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/FilteredPreferenceDialog.java
@@ -359,7 +359,7 @@ public abstract class FilteredPreferenceDialog extends PreferenceDialog implemen
 			exportButton.setToolTipText(WorkbenchMessages.Preference_export);
 			exportButton.addListener(SWT.Selection, e -> openExportWizard(parent));
 		} else if (control instanceof Link) {
-			Composite linkParent = ((Link) control).getParent();
+			Composite linkParent = control.getParent();
 			Link importLink = new Link(linkParent, SWT.WRAP | SWT.NO_FOCUS);
 			((GridLayout) parent.getLayout()).numColumns++;
 			importLink.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_CENTER));

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/SelectAllHandler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/SelectAllHandler.java
@@ -51,7 +51,7 @@ public class SelectAllHandler extends WidgetMethodHandler {
 				final int numParams = methodToExecute.getParameterTypes().length;
 
 				if ((focusControl instanceof Composite)
-						&& ((((Composite) focusControl).getStyle() & SWT.EMBEDDED) != 0)) {
+						&& ((focusControl.getStyle() & SWT.EMBEDDED) != 0)) {
 
 					// we only support selectAll for swing components
 					if (numParams != 0) {

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/WidgetMethodHandler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/WidgetMethodHandler.java
@@ -70,7 +70,7 @@ public class WidgetMethodHandler extends AbstractHandler implements IExecutableE
 			try {
 				final Control focusControl = Display.getCurrent().getFocusControl();
 				if ((focusControl instanceof Composite)
-						&& ((((Composite) focusControl).getStyle() & SWT.EMBEDDED) != 0)) {
+						&& ((focusControl.getStyle() & SWT.EMBEDDED) != 0)) {
 					/*
 					 * Okay. Have a seat. Relax a while. This is going to be a bumpy ride. If it is
 					 * an embedded widget, then it *might* be a Swing widget. At the point where
@@ -210,7 +210,7 @@ public class WidgetMethodHandler extends AbstractHandler implements IExecutableE
 		}
 
 		if ((method == null) && (focusControl instanceof Composite)
-				&& ((((Composite) focusControl).getStyle() & SWT.EMBEDDED) != 0)) {
+				&& ((focusControl.getStyle() & SWT.EMBEDDED) != 0)) {
 			/*
 			 * We couldn't find the appropriate method on the current focus control. It is
 			 * possible that the current focus control is an embedded SWT composite, which

--- a/tests/org.eclipse.jface.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.jface.tests
-Bundle-Version: 1.4.500.qualifier
+Bundle-Version: 1.4.600.qualifier
 Automatic-Module-Name: org.eclipse.jface.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.12.0",

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TestModelContentProvider.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TestModelContentProvider.java
@@ -143,7 +143,7 @@ public class TestModelContentProvider implements ITestModelListener, ITreeConten
 
 		StructuredSelection selection = new StructuredSelection(change.getChildren());
 		if ((change.getModifiers() & TestModelChange.SELECT) != 0) {
-			((StructuredViewer) fViewer).setSelection(selection);
+			fViewer.setSelection(selection);
 		}
 		if ((change.getModifiers() & TestModelChange.REVEAL) != 0) {
 			Object element = selection.getFirstElement();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/WorkingSetTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/WorkingSetTestCase.java
@@ -20,7 +20,6 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.resources.mapping.ResourceMapping;
 import org.eclipse.core.resources.mapping.ResourceTraversal;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.ui.IResourceActionFilter;
 import org.eclipse.ui.IWorkingSet;
@@ -42,11 +41,11 @@ public class WorkingSetTestCase extends UITestCase {
 	}
 
 	private ResourceMapping getResourceMapping(IWorkingSet set) {
-		return ((IAdaptable) set).getAdapter(ResourceMapping.class);
+		return set.getAdapter(ResourceMapping.class);
 	}
 
 	private IWorkbenchAdapter getWorkbenchAdapter(IWorkingSet set) {
-		return ((IAdaptable) set).getAdapter(IWorkbenchAdapter.class);
+		return set.getAdapter(IWorkbenchAdapter.class);
 	}
 
 	private void assertMatches(ResourceMapping mapping, IResource[] resources) throws CoreException {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourcePathCopyTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourcePathCopyTest.java
@@ -150,7 +150,7 @@ public class ResourcePathCopyTest extends UITestCase {
 			// for getting location value
 			Control control = children[5];
 			// for button click
-			((Button) childElement).notifyListeners(SWT.Selection, new Event());
+			childElement.notifyListeners(SWT.Selection, new Event());
 			assertNotNull(Toolkit.getDefaultToolkit().getSystemClipboard()
 					.getData(DataFlavor.stringFlavor));
 			assertEquals(((Text) control).getText(), Toolkit.getDefaultToolkit()


### PR DESCRIPTION
When https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2471 is merged, ecj will signal more casts as unnecessary.

With this PR I suggest to remove affected casts before new errors/warnings will show up in the build.