### PR TITLE
Refresh option only available for projects eclipse-platform#1904

### DIFF
--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/ResourceMgmtActionProvider.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/ResourceMgmtActionProvider.java
@@ -145,8 +145,10 @@ public class ResourceMgmtActionProvider extends CommonActionProvider {
 			buildAction.selectionChanged(selection);
 			menu.appendToGroup(ICommonMenuConstants.GROUP_BUILD, buildAction);
 		}
-		// To refresh, even if one project is open
-		if (hasOpenProjects) {
+		// Add the 'refresh' item if any selection is either (a) an open project, or (b)
+               	// a non-project selection (so the 'refresh' item is not shown if all selections
+               	// are closed projects)
+               	if (hasOpenProjects || !isProjectSelection) {
 			refreshAction.selectionChanged(selection);
 			menu.appendToGroup(ICommonMenuConstants.GROUP_BUILD, refreshAction);
 		}


### PR DESCRIPTION
Returns functionality whereby open projects _and_ non-project resources get the 'refresh' contextual menu (option was removed for non-project resources via the fix @ https://github.com/eclipse-platform/eclipse.platform/issues/876 ).