### PR TITLE
Fix NPE in UndoManager2.addUndo fixes #2004

### DIFF
--- a/bundles/org.eclipse.core.commands/src/org/eclipse/core/commands/operations/TriggeredOperations.java
+++ b/bundles/org.eclipse.core.commands/src/org/eclipse/core/commands/operations/TriggeredOperations.java
@@ -295,10 +295,11 @@ public final class TriggeredOperations extends AbstractOperation implements
 	}
 
 	/**
-	 * Return the operation that triggered the other operations in this
-	 * composite.
+	 * Return the operation that triggered the other operations in this composite.
 	 *
-	 * @return the IUndoableOperation that triggered the other children.
+	 * @return the IUndoableOperation that triggered the other children or
+	 *         <code>null</code> if the triggeringOperation was removed
+	 * @see TriggeredOperations#remove(IUndoableOperation)
 	 */
 	public IUndoableOperation getTriggeringOperation() {
 		return triggeringOperation;

--- a/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/internal/core/refactoring/UndoManager2.java
+++ b/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/internal/core/refactoring/UndoManager2.java
@@ -173,9 +173,10 @@ public class UndoManager2 implements IUndoManager {
 	@Override
 	public void addUndo(String name, Change change) {
 		if (fActiveOperation != null) {
-			UndoableOperation2ChangeAdapter operation= (UndoableOperation2ChangeAdapter)fActiveOperation.getTriggeringOperation();
-			operation.setUndoChange(change);
-			operation.setLabel(name);
+			if (fActiveOperation.getTriggeringOperation() instanceof UndoableOperation2ChangeAdapter operation) {
+				operation.setUndoChange(change);
+				operation.setLabel(name);
+			}
 			fOperationHistory.add(fActiveOperation);
 			fActiveOperation= null;
 		}


### PR DESCRIPTION
TriggeredOperations.getTriggeringOperation() can return null after TriggeredOperations.remove()

https://github.com/eclipse-platform/eclipse.platform.ui/issues/2004