### PR TITLE
Use consistent key bindings in FindReplaceOverlay on MacOS #2007

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceMessages.properties
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceMessages.properties
@@ -46,18 +46,19 @@ FindReplace_SelectAllButton_label=&Select All
 FindReplace_CloseButton_label=Close
 
 # Messages for the find/replace overlay
-FindReplaceOverlay_closeButton_toolTip=Close (Esc)
-FindReplaceOverlay_upSearchButton_toolTip=Search backward (Shift + Enter)
-FindReplaceOverlay_downSearchButton_toolTip=Search forward (Enter)
-FindReplaceOverlay_searchAllButton_toolTip=Search all (Ctrl + Enter)
-FindReplaceOverlay_searchInSelectionButton_toolTip=Only search in selected area (Ctrl + Shift + A)
-FindReplaceOverlay_regexSearchButton_toolTip=Match regular expression pattern (Ctrl + Shift + P)
-FindReplaceOverlay_caseSensitiveButton_toolTip=Match case (Ctrl + Shift + C)
-FindReplaceOverlay_wholeWordsButton_toolTip=Match whole word (Ctrl + Shift + W)
-FindReplaceOverlay_replaceButton_toolTip=Replace (Enter)
-FindReplaceOverlay_replaceAllButton_toolTip=Replace all (Ctrl + Enter)
+FindReplaceOverlay_closeButton_toolTip=Close
+# Messages for the "new" Find-Replace-Overlay
+FindReplaceOverlay_upSearchButton_toolTip=Search backward
+FindReplaceOverlay_downSearchButton_toolTip=Search forward
+FindReplaceOverlay_searchAllButton_toolTip=Search all
+FindReplaceOverlay_searchInSelectionButton_toolTip=Only search in selected area
+FindReplaceOverlay_regexSearchButton_toolTip=Match regular expression pattern
+FindReplaceOverlay_caseSensitiveButton_toolTip=Match case
+FindReplaceOverlay_wholeWordsButton_toolTip=Match whole word
+FindReplaceOverlay_replaceButton_toolTip=Replace
+FindReplaceOverlay_replaceAllButton_toolTip=Replace all
 FindReplaceOverlay_searchBar_message=Find
 FindReplaceOverlay_replaceBar_message=Replace
-FindReplaceOverlay_replaceToggle_toolTip=Toggle input for replace (Ctrl + R)
+FindReplaceOverlay_replaceToggle_toolTip=Toggle input for replace
 FindReplaceOverlayFirstTimePopup_FindReplaceOverlayFirstTimePopup_message=Find and replace can now be done using an overlay embedded inside the editor. If you prefer the dialog, you can disable the overlay in the preferences or <a>disable it now</a>.
 FindReplaceOverlayFirstTimePopup_FindReplaceOverlayFirstTimePopup_title=New Find/Replace Overlay


### PR DESCRIPTION
Currently, the opening action for the find/replace overlay uses a key binding with the OS-dependent "modifier 1" (mapping to CTRL on Windows and CMD on MacOS), while all key bindings within the overlay (such as activating search options) use key bindings with CTRL as a modifier.

In order to unify the key bindings, this change adapts the key bindings within the overlay to also use the OS-dependent "modifier 1", such that on MacOS the CMD modifier is used. The change also adapts the tooltips to (1) reflect the changed keys and (2) represent the MacOS modifier keys via icons like at all other places.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2007