### PR TITLE
Ignore additional parameter

### DIFF
--- a/bundles/org.eclipse.core.commands/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.commands/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.commands
-Bundle-Version: 3.12.200.qualifier
+Bundle-Version: 3.12.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.commands,

--- a/bundles/org.eclipse.core.commands/src/org/eclipse/core/commands/ParameterizedCommand.java
+++ b/bundles/org.eclipse.core.commands/src/org/eclipse/core/commands/ParameterizedCommand.java
@@ -311,7 +311,7 @@ public final class ParameterizedCommand implements Comparable {
 				IParameter parameter = command.getParameter(key);
 				// if the parameter is defined add it to the parameter list
 				if (parameter == null) {
-					return null;
+					continue;
 				}
 				ParameterType parameterType = command.getParameterType(key);
 				if (parameterType == null) {


### PR DESCRIPTION
Currently if one passes more parameters as the command accepts (e.g. a parameter was removed from the command), this suddenly leads to commands no longer being found as null is returned.

Instead now ignore additional parameters and simply continue the loop over the map.