### PR TITLE
Editor preferences: search for find/replace overlay preferences

### DIFF
--- a/bundles/org.eclipse.ui.editors/plugin.properties
+++ b/bundles/org.eclipse.ui.editors/plugin.properties
@@ -118,7 +118,7 @@ command.showRulerAnnotationInformation.description = Displays annotation informa
 conversionActionSet.label= Convert Line Delimiters
 conversionSubMenu.label= Con&vert Line Delimiters To
 
-preferenceKeywords.general= pop-up text editor tabs spaces undo history ruler overview hyperlink overwrite colors range indicator typing appearance derived navigation smart caret positioning invisible whitespace characters drag drop dnd hovers popup sticky enrich rich
+preferenceKeywords.general= search find replace overlay pop-up text editor tabs spaces undo history ruler overview hyperlink overwrite colors range indicator typing appearance derived navigation smart caret positioning invisible whitespace characters drag drop dnd hovers popup sticky enrich rich
 preferenceKeywords.tabWidth= tab width
 preferenceKeywords.lineSpacing= line space height spacing
 preferenceKeywords.lineNumber= line numbers


### PR DESCRIPTION
Add preference keywords for the preferences of the find/replace overlay

fixes #1953

### How to test
search for the find/replace overlay in the preferences:
![22](https://github.com/eclipse-platform/eclipse.platform.ui/assets/16443184/37cee3b0-66ee-465e-9fd6-b089a76bc986)
