### PR TITLE
Find/Replace overlay: reorder buttons

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -437,9 +437,9 @@ public class FindReplaceOverlay extends Dialog {
 		searchTools = new AccessibleToolBar(searchContainer);
 		GridDataFactory.fillDefaults().grab(false, true).align(GridData.CENTER, GridData.END).applyTo(searchTools);
 
-		createWholeWordsButton();
 		createCaseSensitiveButton();
 		createRegexSearchButton();
+		createWholeWordsButton();
 		createAreaSearchButton();
 
 		@SuppressWarnings("unused")


### PR DESCRIPTION
reorder buttons such that the "whole words" button is not in front,
making the taborder more intuitive in the case that whole word search is
not supported in the current state.

fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1998

### how to test
Ensure that the whole words button is not first in line
![grafik](https://github.com/eclipse-platform/eclipse.platform.ui/assets/16443184/fe2ee8cf-75a4-4a3a-b780-9c6fcd805fd9)
