### PR TITLE
Position find/replace overlay correctly when unmaximizing the window

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -221,12 +221,12 @@ public class FindReplaceOverlay extends Dialog {
 	private ControlListener shellMovementListener = new ControlListener() {
 		@Override
 		public void controlMoved(ControlEvent e) {
-			positionToPart();
+			getShell().getDisplay().asyncExec(() -> positionToPart());
 		}
 
 		@Override
 		public void controlResized(ControlEvent e) {
-			positionToPart();
+			getShell().getDisplay().asyncExec(() -> positionToPart());
 		}
 	};
 


### PR DESCRIPTION
### how to test

1) maximize window
2) open overlay
3) double-click window title (unmaximize)
4) see that overlay position is still good

