### PR TITLE
Unminimize Event Details Dialog on update

### DIFF
--- a/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.ui.views.log;singleton:=true
-Bundle-Version: 1.4.400.qualifier
+Bundle-Version: 1.4.500.qualifier
 Bundle-Activator: org.eclipse.ui.internal.views.log.Activator
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/EventDetailsDialogAction.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/EventDetailsDialogAction.java
@@ -19,6 +19,7 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.actions.SelectionProviderAction;
 
@@ -88,6 +89,11 @@ public class EventDetailsDialogAction extends SelectionProviderAction {
 	public void run() {
 		if (propertyDialog != null && propertyDialog.isOpen()) {
 			resetSelection();
+			Shell shell = propertyDialog.getShell();
+			if (shell != null && shell.getMinimized()) {
+				shell.setMinimized(false);
+			}
+
 			return;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2019

When the Event Details Dialog is minimized, it is brought back up when the user Double-Clicks a new entry in the Error Log