### PR TITLE
LineHeaderCodeMining supports multi line label

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/codemining/LineHeaderCodeMining.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/codemining/LineHeaderCodeMining.java
@@ -16,7 +16,11 @@ package org.eclipse.jface.text.codemining;
 
 import java.util.function.Consumer;
 
+import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Point;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -73,4 +77,22 @@ public abstract class LineHeaderCodeMining extends AbstractCodeMining {
 		super(position, provider, action);
 	}
 
+	@Override
+	public Point draw(GC gc, StyledText textWidget, Color color, int x, int y) {
+		String title= getLabel() != null ? getLabel() : "no command"; //$NON-NLS-1$
+		String[] lines= title.split("\\r?\\n|\\r"); //$NON-NLS-1$
+		if (lines.length > 1) {
+			Point result= new Point(0, 0);
+			for (String line : lines) {
+				gc.drawString(line, x, y, true);
+				Point ext= gc.stringExtent(line);
+				result.x= Math.max(result.x, ext.x);
+				result.y+= ext.y;
+				y+= result.y + textWidget.getLineSpacing();
+			}
+			return result;
+		} else {
+			return super.draw(gc, textWidget, color, x, y);
+		}
+	}
 }

--- a/examples/org.eclipse.jface.text.examples/src/org/eclipse/jface/text/examples/codemining/CodeMiningDemo.java
+++ b/examples/org.eclipse.jface.text.examples/src/org/eclipse/jface/text/examples/codemining/CodeMiningDemo.java
@@ -69,7 +69,9 @@ public class CodeMiningDemo {
 						+ "class 5\n" //
 						+ "new 5\n" //
 						+ "new 5\n" //
-						+ "new 5\n"),
+						+ "new 5\n" //
+						+ "multiline \n" //
+						+ "multiline \n\n"),
 				new AnnotationModel());
 		GridDataFactory.fillDefaults().grab(true, true).applyTo(sourceViewer.getTextWidget());
 		// Add AnnotationPainter (required by CodeMining)
@@ -79,6 +81,7 @@ public class CodeMiningDemo {
 				new ClassReferenceCodeMiningProvider(), //
 				new ClassImplementationsCodeMiningProvider(), //
 				new ToEchoWithHeaderAndInlineCodeMiningProvider("echo"), //
+				new MultilineCodeMiningProvider(), //
 				new EmptyLineCodeMiningProvider(), //
 				new EchoAtEndOfLineCodeMiningProvider(endOfLineString) });
 		// Execute codemining in a reconciler

--- a/examples/org.eclipse.jface.text.examples/src/org/eclipse/jface/text/examples/codemining/MultilineCodeMiningProvider.java
+++ b/examples/org.eclipse.jface.text.examples/src/org/eclipse/jface/text/examples/codemining/MultilineCodeMiningProvider.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ *  Copyright (c) 2024, SAP.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jface.text.examples.codemining;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.codemining.AbstractCodeMining;
+import org.eclipse.jface.text.codemining.AbstractCodeMiningProvider;
+import org.eclipse.jface.text.codemining.ICodeMining;
+import org.eclipse.jface.text.codemining.LineHeaderCodeMining;
+
+public class MultilineCodeMiningProvider extends AbstractCodeMiningProvider {
+
+	@Override
+	public CompletableFuture<List<? extends ICodeMining>> provideCodeMinings(ITextViewer viewer,
+			IProgressMonitor monitor) {
+		String multiLineText = "multiline";
+		IDocument document = viewer.getDocument();
+		List<ICodeMining> res = new ArrayList<>();
+		int index = 0;
+		while ((index = document.get().indexOf(multiLineText, index)) != -1) {
+			index += multiLineText.length();
+			res.add(new AbstractCodeMining(new Position(index, 1), this, null) {
+				@Override
+				public String getLabel() {
+					return "multiline first part in same line";
+				}
+			});
+			try {
+				int line = document.getLineOfOffset(index);
+				String lineDelimiter = document.getLineDelimiter(line);
+				res.add(new LineHeaderCodeMining(line + 1, document, this) {
+					@Override
+					public String getLabel() {
+						return "multiline second line" + lineDelimiter + "multiline third line";
+					}
+				});
+			} catch (BadLocationException e) {
+				e.printStackTrace();
+			}
+		}
+		return CompletableFuture.completedFuture(res);
+	}
+
+}


### PR DESCRIPTION
LineHeaderCodeMining contributions can now provide multi line labels.
Please take a look at the modified org.eclipse.jface.text.examples.codemining.CodeMiningDemo application in project org.eclipse.jface.text.examples in this change which shows how the multiline labels are rendered.

Following screenshot shows the simplest case when one LineHeaderCodeMining needs to be rendered.
![multi_line_is_the_only_mining](https://github.com/eclipse-platform/eclipse.platform.ui/assets/10373336/3d6837e7-a9d9-467b-8385-d3c0b13dd0f2)
Two minings are rendered, one AbstractCodeMining instance with the single line text "multiline first part in same line" at the end of the first line and one LineHeaderCodeMining instance with a text of two lines "multiline second line" and "multiline third line".


The next screenshot shows a scenario where two LineHeaderCodeMining instances need to be rendered at the second line where the first mining has a multiline label.
![multi_line_is_first_mining](https://github.com/eclipse-platform/eclipse.platform.ui/assets/10373336/838c04b6-ccd7-418d-98b5-b33c64827b83)

The next screenshot shows a scenario where two LineHeaderCodeMining instances need to be rendered at the second line where the second mining has a multiline label.
![multi_line_is_second_mining](https://github.com/eclipse-platform/eclipse.platform.ui/assets/10373336/59e2c04a-5b51-4582-b30e-ca662b58c55e)


I think that I have found a bug in StyledText#getBounds implementation on Windows during implementation of the example application where minings are rendered on top of each other.  You should also see this effect if you start the application with this change.
![bug_in_styled_text_getTextBounds](https://github.com/eclipse-platform/eclipse.platform.ui/assets/10373336/2cb9369a-d6aa-475a-9c63-d39ed5808647)

After adding following lines
```
if (left == 0x7fffffff) {
  left = 0;
}
```
in StyledText#getTextBounds at line 4921, the multiline minings should be rendered properly. I will create a separate bug report for this issue.

What do you think? Does this change make sense? I think that this enhancement can be easily used to show multiline AI based code completions (ghost text completions) like in VSCode.
