### PR TITLE
Improve styling of expand/collapse button in find/replace overlay #2018 

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -687,7 +687,7 @@ public class FindReplaceOverlay extends Dialog {
 	}
 
 	private void createReplaceToggle() {
-		replaceToggle = new Button(container, SWT.PUSH);
+		replaceToggle = new Button(container, SWT.FLAT | SWT.PUSH);
 		GridDataFactory.fillDefaults().grab(false, true).align(GridData.BEGINNING, GridData.FILL)
 				.applyTo(replaceToggle);
 		replaceToggle.setToolTipText(FindReplaceMessages.FindReplaceOverlay_replaceToggle_toolTip);


### PR DESCRIPTION
The button for expanding the find/replace overlay to show the replace bar it quite large on MacOS and also changes its size upon different events, such activating options and scrolling in the editor target.

With this change, the button style is changed to "FLAT". It results in a less space-consuming layout and fixes its size so that it does not resize on events like scrolling in the target editor.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2018

## Appearance on MacOS

### Existing
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/755472/608a3543-4885-42b6-ac23-4b5c0edbb7ec)
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/755472/beaa9397-6c28-4ab7-9aa1-5349c65ecdf6)
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/755472/9aecf544-19df-49d6-8463-f0d39bf227e0)

### New
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/755472/46b46d08-1806-4358-864a-9cd2b7b76498)
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/755472/b9aa3933-8746-4cde-94af-11b6c5037cd4)
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/755472/2d48140b-489c-4be8-9f2b-616badb9e232)

## Appearance on Windows and Linux

The change has no effect on Windows and Linux.
