### PR TITLE
Avoid NPE from find/replace overlay when closing workbench

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -221,12 +221,16 @@ public class FindReplaceOverlay extends Dialog {
 	private ControlListener shellMovementListener = new ControlListener() {
 		@Override
 		public void controlMoved(ControlEvent e) {
-			getShell().getDisplay().asyncExec(() -> positionToPart());
+			if (getShell() != null) {
+				getShell().getDisplay().asyncExec(() -> positionToPart());
+			}
 		}
 
 		@Override
 		public void controlResized(ControlEvent e) {
-			getShell().getDisplay().asyncExec(() -> positionToPart());
+			if (getShell() != null) {
+				getShell().getDisplay().asyncExec(() -> positionToPart());
+			}
 		}
 	};
 


### PR DESCRIPTION
A missing null check when performing an asynchronous execution on the display of the find/replace overlay's shell leads to a NullPointerException at least when closing a workbench. This change adds an according null check.

```
java.lang.NullPointerException: Cannot invoke "org.eclipse.swt.widgets.Shell.getDisplay()" because the return value of "org.eclipse.ui.internal.findandreplace.overlay.FindReplaceOverlay.getShell()" is null
	at org.eclipse.ui.internal.findandreplace.overlay.FindReplaceOverlay$1.controlResized(FindReplaceOverlay.java:229)
	at org.eclipse.swt.widgets.TypedListener.handleEvent(TypedListener.java:252)
```