### PR TITLE
Fix: Correct layout of sticky lines after breadcrumb

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -184,6 +184,7 @@ public class StickyScrollingControl {
 		GridDataFactory.fillDefaults().grab(true, false).indent(0, BOTTOM_SEPARATOR_SPACING).span(2, 1).applyTo(bottomSeparator);
 		bottomSeparator.setEnabled(false);
 
+		stickyLinesCanvas.pack();
 		stickyLinesCanvas.moveAbove(null);
 	}
 
@@ -268,7 +269,6 @@ public class StickyScrollingControl {
 		layoutLineNumbers();
 
 		stickyLinesCanvas.setVisible(true);
-		stickyLinesCanvas.pack();
 		calculateAndSetStickyLinesCanvasBounds();
 	}
 

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
@@ -17,7 +17,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 
 import java.util.List;
 
@@ -190,7 +189,7 @@ public class StickyScrollingControlTest {
 		assertEquals(0, boundsAfterResize.x);
 		assertEquals(0, boundsAfterResize.y);
 		assertThat(boundsAfterResize.width, greaterThan(0));
-		assertNotEquals(boundsAfterResize.width, boundsBeforeResize.width);
+		assertThat(boundsBeforeResize.width, greaterThan(boundsAfterResize.width));
 		assertEquals(boundsAfterResize.height, boundsBeforeResize.height);
 	}
 


### PR DESCRIPTION
When the Breadcrumb feature is toggled on Windows, the sticky lines control layout was messed up:
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/79514265/e5ff876d-502a-44a0-b93f-0045440a04d7)

### How to test

1. **On windows**, open a java class and scroll so that a sticky line is visible
2. Activate and deactivate the breadcrumb via the action in the tool bar
3. Check that the size of the sticky lines is correctly calculated

Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/issues/1954#issuecomment-2160885541