### PR TITLE
Find/Replace Overlay: close when escape is pressed in the editor

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -302,6 +302,11 @@ public class FindReplaceOverlay extends Dialog {
 			targetWidget.forceFocus();
 		}
 	};
+	private KeyListener closeOnTargetEscapeListener = KeyListener.keyPressedAdapter(c -> {
+		if (c.keyCode == SWT.ESC) {
+			this.close();
+		}
+	});
 
 	private boolean isPartCurrentlyDisplayedInPartSash() {
 		IWorkbenchPage activePage = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
@@ -409,6 +414,7 @@ public class FindReplaceOverlay extends Dialog {
 			if (targetWidget != null) {
 				targetWidget.getShell().removeControlListener(shellMovementListener);
 				targetWidget.removePaintListener(widgetMovementListener);
+				targetWidget.removeKeyListener(closeOnTargetEscapeListener);
 				targetPart.getSite().getPage().removePartListener(partListener);
 			}
 		}
@@ -421,6 +427,7 @@ public class FindReplaceOverlay extends Dialog {
 
 			targetWidget.getShell().addControlListener(shellMovementListener);
 			targetWidget.addPaintListener(widgetMovementListener);
+			targetWidget.addKeyListener(closeOnTargetEscapeListener);
 			targetPart.getSite().getPage().addPartListener(partListener);
 		}
 	}


### PR DESCRIPTION
When escape is pressed inside of the editor which is targeted by the find/replace overlay, the overly now closes.

fixes #2033

![23](https://github.com/eclipse-platform/eclipse.platform.ui/assets/16443184/106ceabd-cffb-4e69-8467-31a95ec4a5f0)
