### PR TITLE
Find/Replace Overlay: add help context to Overlay

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -65,6 +65,7 @@ import org.eclipse.ui.internal.findandreplace.FindReplaceMessages;
 import org.eclipse.ui.internal.findandreplace.SearchOptions;
 import org.eclipse.ui.internal.findandreplace.status.IFindReplaceStatus;
 
+import org.eclipse.ui.texteditor.IAbstractTextEditorHelpContextIds;
 import org.eclipse.ui.texteditor.StatusTextEditor;
 
 /**
@@ -414,6 +415,9 @@ public class FindReplaceOverlay extends Dialog {
 
 	@Override
 	public Control createContents(Composite parent) {
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(getShell(),
+				IAbstractTextEditorHelpContextIds.FIND_REPLACE_OVERLAY);
+
 		backgroundToUse = new Color(getShell().getDisplay(), new RGBA(0, 0, 0, 0));
 		return createDialog(parent);
 	}

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/IAbstractTextEditorHelpContextIds.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/IAbstractTextEditorHelpContextIds.java
@@ -292,6 +292,15 @@ public interface IAbstractTextEditorHelpContextIds {
 	String FIND_REPLACE_DIALOG= PREFIX + "find_replace_dialog_context"; //$NON-NLS-1$
 
 	/**
+	 * Help context id for the overlay which may be shown instead of the
+	 * find/replace dialog.
+	 * <code>"org.eclipse.ui.find_replace_overlay_context"</code>
+	 *
+	 * @since 3.17
+	 */
+	String FIND_REPLACE_OVERLAY = PREFIX + "find_replace_overlay_context"; //$NON-NLS-1$
+
+	/**
 	 * Help context id for the action.
 	 * Value: <code>"org.eclipse.ui.goto_last_edit_position_action_context"</code>
 	 * @since 2.1


### PR DESCRIPTION
Add the find/replace help context to the overlay which was also used for the find/replace dialog. In particular, display help for find/replace with regex patterns.

fixes #1994
![24](https://github.com/eclipse-platform/eclipse.platform.ui/assets/16443184/20dd06d3-a388-4fdd-ab9a-2698c524fe96)
