### PR TITLE
Find/Replace overlay: hide if target editor is too shallow

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -831,7 +831,27 @@ public class FindReplaceOverlay extends Dialog {
 		getShell().setLocation(newPosition);
 		getShell().layout(true);
 
+		hideIfTargetWidgetTooShallow();
 		repositionTextSelection();
+	}
+
+	private void hideIfTargetWidgetTooShallow() {
+		StatusTextEditor textEditor = (StatusTextEditor) targetPart;
+		Control targetWidget = textEditor.getAdapter(ITextViewer.class).getTextWidget();
+		int shellHeight = getShell().getBounds().height;
+		int targetHeight = targetWidget.getBounds().height;
+
+		if (((Scrollable) targetWidget).getHorizontalBar() != null) {
+			targetHeight -= ((Scrollable) targetWidget).getHorizontalBar().getSize().y;
+		}
+
+		if (targetHeight < shellHeight) {
+			getShell().setVisible(false);
+		} else {
+			if (isPartCurrentlyDisplayedInPartSash()) {
+				getShell().setVisible(true);
+			}
+		}
 	}
 
 	private String getFindString() {


### PR DESCRIPTION
Hide the overlay if the targeted overlay is too shallow to fully contain the overlay, show the overlay again as soon as the targetted overlay is high enough again.

fixes #1989
![26](https://github.com/eclipse-platform/eclipse.platform.ui/assets/16443184/e95c60cb-1b72-456e-acf5-d679bb61f831)
