### PR TITLE
Find/Replace overlay: immediate replace after selected text #2011

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -944,6 +944,7 @@ public class FindReplaceOverlay extends Dialog {
 				selectionText = FindReplaceDocumentAdapter.escapeForRegExPattern(selectionText);
 			}
 			searchBar.setText(selectionText);
+			findReplaceLogic.findAndSelect(findReplaceLogic.getTarget().getSelection().x, searchBar.getText());
 		}
 		searchBar.setSelection(0, searchBar.getText().length());
 	}

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
@@ -353,6 +353,18 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		assertThat(fTextViewer.getDocument().get(), is("test ;"));
 	}
 
+	@Test
+	public void testReplaceIfSelectedOnStart() {
+		openTextViewer("abcdefg");
+		fTextViewer.setSelection(new TextSelection(2, 2));
+		initializeFindReplaceUIForTextViewer();
+
+		dialog.setReplaceText("aa");
+		dialog.performReplace();
+
+		assertThat(fTextViewer.getDocument().get(), is("abaaefg"));
+	}
+
 	protected AccessType getDialog() {
 		return dialog;
 	}


### PR DESCRIPTION
Work around for a bug of the Editor's implementation of the
FindReplaceTargetExtension3; when initializing the search with an
already selected string, force the overlay to search for it again so
that the Editor can then later replace it if required.

fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2011