### PR TITLE
Find/Replace overlay: escape RegEx on init

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -51,6 +51,7 @@ import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.resource.JFaceColors;
 import org.eclipse.jface.window.Window;
 
+import org.eclipse.jface.text.FindReplaceDocumentAdapter;
 import org.eclipse.jface.text.IFindReplaceTarget;
 import org.eclipse.jface.text.IFindReplaceTargetExtension;
 import org.eclipse.jface.text.ITextViewer;
@@ -902,16 +903,19 @@ public class FindReplaceOverlay extends Dialog {
 	}
 
 	private void updateFromTargetSelection() {
-		String initText = findReplaceLogic.getTarget().getSelectionText();
-		if (initText.isEmpty()) {
+		String selectionText = findReplaceLogic.getTarget().getSelectionText();
+		if (selectionText.isEmpty()) {
 			return;
 		}
-		if (initText.contains(System.lineSeparator())) { // $NON-NLS-1$
+		if (selectionText.contains(System.lineSeparator())) {
 			findReplaceLogic.deactivate(SearchOptions.GLOBAL);
 			searchInSelectionButton.setSelection(true);
 		} else {
-			searchBar.setText(initText);
-			searchBar.setSelection(0, initText.length());
+			if (findReplaceLogic.isRegExSearchAvailableAndActive()) {
+				selectionText = FindReplaceDocumentAdapter.escapeForRegExPattern(selectionText);
+			}
+			searchBar.setText(selectionText);
+			searchBar.setSelection(0, selectionText.length());
 		}
 	}
 


### PR DESCRIPTION
When initializing the search text from the selection in the editor, escape the text if it should be interpreted as RegEx

fixes #2053

![29](https://github.com/eclipse-platform/eclipse.platform.ui/assets/16443184/c520b305-47e4-4ab1-9e85-509d71279435)
