### PR TITLE
Find/Replace Overlay: correctly set scope mode

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -907,7 +907,7 @@ public class FindReplaceOverlay extends Dialog {
 		if (selectionText.isEmpty()) {
 			return;
 		}
-		if (selectionText.contains(System.lineSeparator())) {
+		if (selectionText.contains("\n")) { //$NON-NLS-1$
 			findReplaceLogic.deactivate(SearchOptions.GLOBAL);
 			searchInSelectionButton.setSelection(true);
 		} else {

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
@@ -291,6 +291,20 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		assertThat(fTextViewer.getDocument().get(), is("text" + System.lineSeparator() + System.lineSeparator()));
 	}
 
+	private void assertScopeActivationOnTextInput(String input) {
+		openTextViewer(input);
+		fTextViewer.setSelection(new TextSelection(0, fTextViewer.getDocument().toString().length()));
+		initializeFindReplaceUIForTextViewer();
+
+		dialog.assertUnselected(SearchOptions.GLOBAL);
+	}
+
+	@Test
+	public void testSelectionOnOpenSetsScopedMode() {
+		assertScopeActivationOnTextInput("hello\r\nworld\r\nthis\r\nhas_many_lines");
+		assertScopeActivationOnTextInput("hello\nworld");
+	}
+
 	protected AccessType getDialog() {
 		return dialog;
 	}


### PR DESCRIPTION
Depending on the file format, the line separators are different. This PR allows detecting both when deciding whether to set the scoped search mode or not when opening the Overlay with an active selection.

fixes #2054

To test: use a file formatted on UNIX (line separators: \n), select multiple lines, open overaly

![grafik](https://github.com/eclipse-platform/eclipse.platform.ui/assets/16443184/7893e037-1e09-411d-b9da-046195a02798)
