### PR TITLE
Find/Replace Overlay: store overlay options

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
@@ -291,6 +291,34 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		assertThat(fTextViewer.getDocument().get(), is("text" + System.lineSeparator() + System.lineSeparator()));
 	}
 
+	@Test
+	public void testOptionsRestoredCorrectly() {
+		openTextViewer("text");
+		initializeFindReplaceUIForTextViewer();
+
+		dialog.select(SearchOptions.REGEX);
+		dialog.select(SearchOptions.CASE_SENSITIVE);
+
+		reopenFindReplaceUIForTextViewer();
+
+		dialog.assertSelected(SearchOptions.REGEX);
+		dialog.assertSelected(SearchOptions.CASE_SENSITIVE);
+	}
+
+	@Test
+	public void testWholeWordOptionRestoredCorrectly() {
+		openTextViewer("text");
+		initializeFindReplaceUIForTextViewer();
+
+		dialog.setFindText("text");
+		dialog.select(SearchOptions.WHOLE_WORD);
+
+		dialog.close();
+		fTextViewer.setSelectedRange(0, 4);
+		dialog= openUIFromTextViewer(fTextViewer);
+		dialog.assertSelected(SearchOptions.WHOLE_WORD);
+	}
+
 	protected AccessType getDialog() {
 		return dialog;
 	}

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
@@ -96,7 +96,7 @@ class OverlayAccess implements IFindReplaceUIAccess {
 	}
 
 	private void restoreInitialConfiguration() {
-		find.setText("");
+		find.setText("word");
 		select(SearchOptions.GLOBAL);
 		unselect(SearchOptions.REGEX);
 		unselect(SearchOptions.CASE_SENSITIVE);


### PR DESCRIPTION
Stores the search options of the overlay and actively reloads them, even when switching between overlays.

fixes #2055
![30](https://github.com/eclipse-platform/eclipse.platform.ui/assets/16443184/f3c8d73a-ee49-47f2-a8a1-a2a967d99be4)
