### PR TITLE
Find/Replace: streamline editability checking and improve tests

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -155,9 +155,7 @@ public class FindReplaceOverlay extends Dialog {
 		if ((e.stateMask & SWT.CTRL) != 0 && (e.keyCode == 'F' || e.keyCode == 'f')) {
 			close();
 		} else if ((e.stateMask & SWT.CTRL) != 0 && (e.keyCode == 'R' || e.keyCode == 'r')) {
-			if (findReplaceLogic.getTarget().isEditable()) {
-				toggleReplace();
-			}
+			toggleReplace();
 		} else if ((e.stateMask & SWT.CTRL) != 0 && (e.keyCode == 'W' || e.keyCode == 'w')) {
 			toggleToolItem(wholeWordSearchButton);
 		} else if ((e.stateMask & SWT.CTRL) != 0 && (e.keyCode == 'P' || e.keyCode == 'p')) {
@@ -377,7 +375,7 @@ public class FindReplaceOverlay extends Dialog {
 
 	private void restoreOverlaySettings() {
 		Boolean shouldOpenReplaceBar = getDialogSettings().getBoolean(REPLACE_BAR_OPEN_DIALOG_SETTING);
-		if (shouldOpenReplaceBar && replaceToggle != null) {
+		if (shouldOpenReplaceBar) {
 			toggleReplace();
 		}
 	}
@@ -678,9 +676,7 @@ public class FindReplaceOverlay extends Dialog {
 		GridLayoutFactory.fillDefaults().numColumns(2).equalWidth(false).margins(2, 2).spacing(2, 0).applyTo(container);
 		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(container);
 
-		if (findReplaceLogic.getTarget().isEditable()) {
-			createReplaceToggle();
-		}
+		createReplaceToggle();
 
 		contentGroup = new Composite(container, SWT.NULL);
 		GridLayoutFactory.fillDefaults().numColumns(1).equalWidth(false).spacing(2, 3).applyTo(contentGroup);
@@ -697,7 +693,7 @@ public class FindReplaceOverlay extends Dialog {
 	}
 
 	private void toggleReplace() {
-		if (!replaceBarOpen) {
+		if (!replaceBarOpen && findReplaceLogic.getTarget().isEditable()) {
 			createReplaceDialog();
 			replaceToggle.setImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_CLOSE_REPLACE_AREA));
 		} else {
@@ -740,8 +736,9 @@ public class FindReplaceOverlay extends Dialog {
 		if (!okayToUse(replaceToggle)) {
 			return;
 		}
-		((GridData) replaceToggle.getLayoutData()).exclude = !enable;
-		replaceToggle.setVisible(enable);
+		boolean visible = enable && findReplaceLogic.getTarget().isEditable();
+		((GridData) replaceToggle.getLayoutData()).exclude = !visible;
+		replaceToggle.setVisible(visible);
 	}
 
 	private void enableReplaceTools(boolean enable) {

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
@@ -19,6 +19,8 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.util.ResourceBundle;
+
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,13 +39,21 @@ import org.eclipse.ui.PlatformUI;
 
 import org.eclipse.ui.workbench.texteditor.tests.ScreenshotTest;
 
+import org.eclipse.ui.texteditor.FindReplaceAction;
+
 public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess> {
 	@Rule
 	public TestName testName= new TestName();
 
 	private TextViewer fTextViewer;
 
+	private FindReplaceAction findReplaceAction;
+
 	private AccessType dialog;
+
+	protected FindReplaceAction getFindReplaceAction() {
+		return findReplaceAction;
+	}
 
 	protected final void initializeTextViewerWithFindReplaceUI(String content) {
 		openTextViewer(content);
@@ -54,6 +64,8 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		fTextViewer= new TextViewer(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
 		fTextViewer.setDocument(new Document(content));
 		fTextViewer.getControl().setFocus();
+		findReplaceAction= new FindReplaceAction(ResourceBundle.getBundle("org.eclipse.ui.texteditor.ConstructedEditorMessages"), "Editor.FindReplace.", fTextViewer.getControl().getShell(),
+				fTextViewer.getFindReplaceTarget());
 	}
 
 	protected void initializeFindReplaceUIForTextViewer() {
@@ -312,4 +324,5 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 	protected TextViewer getTextViewer() {
 		return fTextViewer;
 	}
+
 }

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
@@ -17,11 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
-import java.util.ResourceBundle;
-
 import org.junit.Test;
-
-import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.text.tests.Accessor;
 
@@ -31,22 +27,16 @@ import org.eclipse.jface.text.TextViewer;
 import org.eclipse.ui.internal.findandreplace.FindReplaceUITest;
 import org.eclipse.ui.internal.findandreplace.SearchOptions;
 
+import org.eclipse.ui.texteditor.FindReplaceAction;
+
 public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 
 	@Override
 	public OverlayAccess openUIFromTextViewer(TextViewer viewer) {
-		OverlayAccess ret;
-
-		Accessor fFindReplaceAction;
-		fFindReplaceAction= new Accessor("org.eclipse.ui.texteditor.FindReplaceAction", getClass().getClassLoader(),
-				new Class[] { ResourceBundle.class, String.class, Shell.class, IFindReplaceTarget.class },
-				new Object[] { ResourceBundle.getBundle("org.eclipse.ui.texteditor.ConstructedEditorMessages"), "Editor.FindReplace.", viewer.getControl().getShell(),
-						getTextViewer().getFindReplaceTarget() });
-		fFindReplaceAction.invoke("showOverlayInEditor", null);
-		Accessor overlayAccessor= new Accessor(fFindReplaceAction.get("overlay"), "org.eclipse.ui.internal.findandreplace.overlay.FindReplaceOverlay", getClass().getClassLoader());
-
-		ret= new OverlayAccess(overlayAccessor);
-		return ret;
+		Accessor actionAccessor= new Accessor(getFindReplaceAction(), FindReplaceAction.class);
+		actionAccessor.invoke("showOverlayInEditor", null);
+		Accessor overlayAccessor= new Accessor(actionAccessor.get("overlay"), "org.eclipse.ui.internal.findandreplace.overlay.FindReplaceOverlay", getClass().getClassLoader());
+		return new OverlayAccess(overlayAccessor);
 	}
 
 	@Test
@@ -118,6 +108,7 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		OverlayAccess dialog= getDialog();
 
 		dialog.openReplaceDialog();
+		assertThat(dialog.isReplaceDialogOpen(), is(false));
 		reopenFindReplaceUIForTextViewer();
 		dialog= getDialog();
 		assertThat(dialog.isReplaceDialogOpen(), is(false));

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
@@ -20,14 +20,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
-import java.util.ResourceBundle;
-
 import org.junit.Test;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.text.tests.Accessor;
 
@@ -39,21 +36,18 @@ import org.eclipse.jface.text.TextViewer;
 import org.eclipse.ui.internal.findandreplace.FindReplaceUITest;
 import org.eclipse.ui.internal.findandreplace.SearchOptions;
 
+import org.eclipse.ui.texteditor.FindReplaceAction;
+
 public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 	@Override
 	public DialogAccess openUIFromTextViewer(TextViewer viewer) {
-		TextViewer textViewer= getTextViewer();
-		Accessor fFindReplaceAction;
+		Accessor findActionAccessor= new Accessor(getFindReplaceAction(), FindReplaceAction.class);
+		findActionAccessor.invoke("showDialog", null);
 
-		fFindReplaceAction= new Accessor("org.eclipse.ui.texteditor.FindReplaceAction", getClass().getClassLoader(),
-				new Class[] { ResourceBundle.class, String.class, Shell.class, IFindReplaceTarget.class },
-				new Object[] { ResourceBundle.getBundle("org.eclipse.ui.texteditor.ConstructedEditorMessages"), "Editor.FindReplace.", textViewer.getControl().getShell(),
-						textViewer.getFindReplaceTarget() });
-		fFindReplaceAction.invoke("run", null);
-
-		Object fFindReplaceDialogStub= fFindReplaceAction.get("fgFindReplaceDialogStub");
-		if (fFindReplaceDialogStub == null)
-			fFindReplaceDialogStub= fFindReplaceAction.get("fgFindReplaceDialogStubShell");
+		Object fFindReplaceDialogStub= findActionAccessor.get("fgFindReplaceDialogStub");
+		if (fFindReplaceDialogStub == null) {
+			fFindReplaceDialogStub= findActionAccessor.get("fgFindReplaceDialogStubShell");
+		}
 		Accessor fFindReplaceDialogStubAccessor= new Accessor(fFindReplaceDialogStub, "org.eclipse.ui.texteditor.FindReplaceAction$FindReplaceDialogStub", getClass().getClassLoader());
 
 		Accessor dialogAccessor= new Accessor(fFindReplaceDialogStubAccessor.invoke("getDialog", null), "org.eclipse.ui.texteditor.FindReplaceDialog", getClass().getClassLoader());


### PR DESCRIPTION
The logic for checking editability of the target of a FindReplaceOverlay is slightly scattered, resulting in not being capable of dealing with a change in the editability of the target editor.
This change streamlines the editability checking by dynamically adapting visibility replace-related widgets visibility instead of static (non-)creation of the widget.
To test this functionality, the test classes for the FindReplaceDialog and FindReplaceOverlay are adapted to properly reuse a FindReplaceAction once instantiated for a target instead of recreating it.