### PR TITLE
Find/Replace: add test case for find string initialization with regex

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
@@ -317,6 +317,20 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		assertScopeActivationOnTextInput("hello\nworld");
 	}
 
+	@Test
+	public void testActivateDialogSelectionActive_withRegExOptionActivated() {
+		openTextViewer("test text.*;");
+		initializeFindReplaceUIForTextViewer();
+		dialog.select(SearchOptions.REGEX);
+		fTextViewer.setSelection(new TextSelection("test ".length(), "text.*".length()));
+		reopenFindReplaceUIForTextViewer();
+		dialog.assertSelected(SearchOptions.REGEX);
+		assertEquals("text\\.\\*", dialog.getFindText());
+
+		dialog.performReplaceAll();
+		assertThat(fTextViewer.getDocument().get(), is("test ;"));
+	}
+
 	protected AccessType getDialog() {
 		return dialog;
 	}


### PR DESCRIPTION
When opening the FindReplaceOverlay or FindReplaceDialog with regex option enabled, the current selection in the target editor is escaped to represent a regex before being inserted into the find input field. This adds an according test case.