### PR TITLE
[Sticky Scrolling] Fix: Correctly align line numbers in sticky lines control

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -184,6 +184,8 @@ public class StickyScrollingControl {
 		GridDataFactory.fillDefaults().grab(true, false).indent(0, BOTTOM_SEPARATOR_SPACING).span(2, 1).applyTo(bottomSeparator);
 		bottomSeparator.setEnabled(false);
 
+		layoutLineNumbers();
+
 		stickyLinesCanvas.pack();
 		stickyLinesCanvas.moveAbove(null);
 	}
@@ -210,7 +212,7 @@ public class StickyScrollingControl {
 	}
 
 	private String fillLineNumberWithLeadingSpaces(int lineNumber) {
-		int lineCount= sourceViewer.getTextWidget().getLineCount();
+		int lineCount= sourceViewer.getDocument().getNumberOfLines();
 		int lineNumberLength= String.valueOf(lineCount).length();
 		String formatString= "%" + lineNumberLength + "d"; //$NON-NLS-1$ //$NON-NLS-2$
 		return String.format(formatString, lineNumber);

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
@@ -61,6 +61,7 @@ public class StickyScrollingControlTest {
 		shell.setLayout(new FillLayout());
 		ruler = new CompositeRuler();
 		sourceViewer = new SourceViewer(shell, ruler, SWT.V_SCROLL | SWT.H_SCROLL);
+		sourceViewer.setDocument(new Document());
 
 		lineNumberColor = new Color(0, 0, 0);
 		hoverColor = new Color(1, 1, 1);
@@ -126,7 +127,7 @@ public class StickyScrollingControlTest {
 
 	@Test
 	public void testCopyStyleRanges() {
-		sourceViewer.getTextWidget().setText("line 1");
+		sourceViewer.setInput(new Document("line 1"));
 		sourceViewer.getTextWidget().setStyleRange(new StyleRange(0, 6, lineNumberColor, backgroundColor));
 
 		List<StickyLine> stickyLines = List.of(new StickyLine("line 1", 0));
@@ -198,9 +199,8 @@ public class StickyScrollingControlTest {
 		String text = """
 				line 1
 				line 2""";
-		sourceViewer.getTextWidget().setText(text);
+		sourceViewer.setInput(new Document(text));
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
-		sourceViewer.setDocument(new Document(text));
 
 		List<StickyLine> stickyLines = List.of(new StickyLine("line 2", 1));
 		stickyScrollingControl.setStickyLines(stickyLines);
@@ -219,7 +219,7 @@ public class StickyScrollingControlTest {
 		String text = """
 				line 1
 				line 2""";
-		sourceViewer.getTextWidget().setText(text);
+		sourceViewer.setInput(new Document(text));
 		sourceViewer.getTextWidget().getVerticalBar().setIncrement(10);
 		assertEquals(0, sourceViewer.getTextWidget().getTopPixel());
 
@@ -236,7 +236,7 @@ public class StickyScrollingControlTest {
 		String text = """
 				line 1
 				line 2""";
-		sourceViewer.getTextWidget().setText(text);
+		sourceViewer.setInput(new Document(text));
 		sourceViewer.getTextWidget().getHorizontalBar().setIncrement(10);
 		assertEquals(0, sourceViewer.getTextWidget().getHorizontalPixel());
 

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandlerTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandlerTest.java
@@ -43,6 +43,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceStore;
 
+import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.source.CompositeRuler;
 import org.eclipse.jface.text.source.SourceViewer;
 
@@ -62,6 +63,7 @@ public class StickyScrollingHandlerTest {
 		shell = new Shell(Display.getDefault());
 		ruler = new CompositeRuler();
 		sourceViewer = new SourceViewer(shell, ruler, SWT.None);
+		sourceViewer.setDocument(new Document());
 
 		lineNumberColor = new Color(0, 0, 0);
 		hoverColor = new Color(1, 1, 1);


### PR DESCRIPTION
The line number in the sticky lines control was not aligned with the line numbers in the editor if the amount of lines in the document and the amount of lines in the text widget did have different amount of digits. 

### Testing
Open UIPlugin with default code folding enabled, the document has 103 lines, but only 97 are visible. 

Before the change:
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/79514265/739d079c-9bee-4466-82b6-c0d50ca9e683)

After the change:
![image](https://github.com/eclipse-platform/eclipse.platform.ui/assets/79514265/d79bac35-9f02-47e8-9c03-1aecb1f34199)

Fixes #1965