### PR TITLE
Fix HTMLPrinter.insertPageProlog(StringBuffer, int, RGB, RGB, String)

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/html/HTMLPrinter.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/html/HTMLPrinter.java
@@ -130,7 +130,7 @@ public class HTMLPrinter {
 	 */
 	@Deprecated
 	public static void insertPageProlog(StringBuffer buffer, int position, RGB fgRGB, RGB bgRGB, String styleSheet) {
-		runOp(buffer, (sb) -> CORE.insertPageProlog(sb, position, fromRGB(fgRGB), fromRGB(fgRGB), styleSheet));
+		runOp(buffer, (sb) -> CORE.insertPageProlog(sb, position, fromRGB(fgRGB), fromRGB(bgRGB), styleSheet));
 	}
 
 	/**


### PR DESCRIPTION
- The implementation uses the fgRGB where it should be using the bgRGB instead.