### PR TITLE
[Sticky Scrolling] Limit visible sticky lines to text widget height

### DIFF
--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
@@ -62,6 +62,7 @@ public class StickyScrollingControlTest {
 		ruler = new CompositeRuler();
 		sourceViewer = new SourceViewer(shell, ruler, SWT.V_SCROLL | SWT.H_SCROLL);
 		sourceViewer.setDocument(new Document());
+		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
 
 		lineNumberColor = new Color(0, 0, 0);
 		hoverColor = new Color(1, 1, 1);
@@ -116,12 +117,10 @@ public class StickyScrollingControlTest {
 		stickyScrollingControl.applySettings(settings);
 
 		StyledText stickyLineNumber = getStickyLineNumber();
-		String expLineNumber = """
-				10""";
+		String expLineNumber = "10";
 		assertEquals(expLineNumber, stickyLineNumber.getText());
 		StyledText stickyLineText = getStickyLineText();
-		String expStickyLineText = """
-				line 10""";
+		String expStickyLineText = "line 10";
 		assertEquals(expStickyLineText, stickyLineText.getText());
 	}
 
@@ -215,6 +214,7 @@ public class StickyScrollingControlTest {
 
 	@Test
 	public void testVerticalScrollingIsDispatched() {
+		sourceViewer.getTextWidget().setBounds(0, 0, 200, 0);
 		Canvas stickyControlCanvas = getStickyControlCanvas(shell);
 		String text = """
 				line 1
@@ -232,6 +232,7 @@ public class StickyScrollingControlTest {
 
 	@Test
 	public void testHorizontalScrollingIsDispatched() {
+		sourceViewer.getTextWidget().setBounds(0, 0, 0, 200);
 		Canvas stickyControlCanvas = getStickyControlCanvas(shell);
 		String text = """
 				line 1
@@ -245,6 +246,20 @@ public class StickyScrollingControlTest {
 		stickyControlCanvas.notifyListeners(SWT.MouseHorizontalWheel, event);
 
 		assertEquals(10, sourceViewer.getTextWidget().getHorizontalPixel());
+	}
+
+	@Test
+	public void limitStickyLinesToTextWidgetHeight() {
+		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
+		List<StickyLine> stickyLines = List.of(new StickyLine("line 2", 1));
+		stickyScrollingControl.setStickyLines(stickyLines);
+
+		StyledText stickyLineText = getStickyLineText();
+		assertEquals("line 2", stickyLineText.getText());
+
+		sourceViewer.getTextWidget().setBounds(0, 0, 200, 20);
+		stickyLineText = getStickyLineText();
+		assertEquals("", stickyLineText.getText());
 	}
 
 	private Canvas getStickyControlCanvas(Composite composite) {

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandlerTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandlerTest.java
@@ -64,6 +64,7 @@ public class StickyScrollingHandlerTest {
 		ruler = new CompositeRuler();
 		sourceViewer = new SourceViewer(shell, ruler, SWT.None);
 		sourceViewer.setDocument(new Document());
+		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
 
 		lineNumberColor = new Color(0, 0, 0);
 		hoverColor = new Color(1, 1, 1);


### PR DESCRIPTION
When the editor is very small, the sticky lines should not be displayed or the amount of sticky lines should be reduced so that the original source code can be seen.

With this change the sticky lines are automatically reduced on resize of the editor:
![2024-07-11_14-48-03](https://github.com/eclipse-platform/eclipse.platform.ui/assets/79514265/f267ad73-5438-432d-a952-725c054875ab)

### Testing
1. Open a editor
2. Enable sticky scrolling
3. Scroll down so that some sticky lines are shown
4. Reduce the size of the source code editor