### PR TITLE
Find/replace: always select text when search input receives focus #2012

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -332,11 +332,11 @@ public class FindReplaceOverlay extends Dialog {
 		overlayOpen = true;
 		applyOverlayColors(backgroundToUse, true);
 		updateFromTargetSelection();
+		searchBar.forceFocus();
 
 		getShell().layout();
 		updatePlacementAndVisibility();
 
-		searchBar.forceFocus();
 		return returnCode;
 	}
 
@@ -936,19 +936,16 @@ public class FindReplaceOverlay extends Dialog {
 
 	private void updateFromTargetSelection() {
 		String selectionText = findReplaceLogic.getTarget().getSelectionText();
-		if (selectionText.isEmpty()) {
-			return;
-		}
 		if (selectionText.contains("\n")) { //$NON-NLS-1$
 			findReplaceLogic.deactivate(SearchOptions.GLOBAL);
 			searchInSelectionButton.setSelection(true);
-		} else {
+		} else if (!selectionText.isEmpty()) {
 			if (findReplaceLogic.isRegExSearchAvailableAndActive()) {
 				selectionText = FindReplaceDocumentAdapter.escapeForRegExPattern(selectionText);
 			}
 			searchBar.setText(selectionText);
-			searchBar.setSelection(0, selectionText.length());
 		}
+		searchBar.setSelection(0, searchBar.getText().length());
 	}
 
 	private void evaluateFindReplaceStatus() {

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
@@ -166,20 +166,20 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(4, (target.getSelection()).y);
 
-		dialog.simulateEnterInFindInputField(false);
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		assertEquals(5, (target.getSelection()).x);
 		assertEquals(4, (target.getSelection()).y);
 
-		dialog.simulateEnterInFindInputField(true);
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, true);
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(4, (target.getSelection()).y);
 
 		// Keypad-Enter is also valid for navigating
-		dialog.simulateKeyPressInFindInputField(SWT.KEYPAD_CR, false);
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.KEYPAD_CR, false);
 		assertEquals(5, (target.getSelection()).x);
 		assertEquals(4, (target.getSelection()).y);
 
-		dialog.simulateKeyPressInFindInputField(SWT.KEYPAD_CR, true);
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.KEYPAD_CR, true);
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(4, (target.getSelection()).y);
 	}
@@ -214,7 +214,7 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		dialog.assertDisabled(SearchOptions.WHOLE_WORD);
 		dialog.assertSelected(SearchOptions.WHOLE_WORD);
 
-		dialog.simulateEnterInFindInputField(false);
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		assertThat(target.getSelectionText(), is(dialog.getFindText()));
 
 		assertEquals(0, (target.getSelection()).x);
@@ -228,11 +228,11 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		dialog.setFindText("(a|bc)");
 
 		IFindReplaceTarget target= dialog.getTarget();
-		dialog.simulateEnterInFindInputField(false);
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(1, (target.getSelection()).y);
 
-		dialog.simulateEnterInFindInputField(false);
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		assertEquals(1, (target.getSelection()).x);
 		assertEquals(2, (target.getSelection()).y);
 	}
@@ -301,6 +301,28 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		dialog.performReplaceAll();
 
 		assertThat(fTextViewer.getDocument().get(), is("text" + System.lineSeparator() + System.lineSeparator()));
+	}
+
+	@Test
+	public void testSearchTextSelectedWhenOpeningDialog() {
+		openTextViewer("test");
+		fTextViewer.setSelection(new TextSelection(0, 4));
+		initializeFindReplaceUIForTextViewer();
+		assertEquals("test", dialog.getFindText());
+
+		dialog.simulateKeystrokeInFindInputField('w');
+		assertEquals("w", dialog.getFindText());
+	}
+
+	@Test
+	public void testSearchTextSelectedWhenSwitchingFocusToDialog() {
+		openTextViewer("");
+		initializeFindReplaceUIForTextViewer();
+		dialog.setFindText("text");
+		reopenFindReplaceUIForTextViewer();
+
+		dialog.simulateKeystrokeInFindInputField('w');
+		assertEquals("w", dialog.getFindText());
 	}
 
 	private void assertScopeActivationOnTextInput(String input) {

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/IFindReplaceUIAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/IFindReplaceUIAccess.java
@@ -30,9 +30,9 @@ public interface IFindReplaceUIAccess {
 
 	void select(SearchOptions option);
 
-	void simulateEnterInFindInputField(boolean shiftPressed);
+	void simulateKeyboardInteractionInFindInputField(int keyCode, boolean shiftPressed);
 
-	void simulateKeyPressInFindInputField(int keyCode, boolean shiftPressed);
+	void simulateKeystrokeInFindInputField(char character);
 
 	String getFindText();
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.findandreplace.overlay;
 
+import static org.eclipse.ui.internal.findandreplace.FindReplaceTestUtil.runEventQueue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -36,7 +37,6 @@ import org.eclipse.jface.text.IFindReplaceTarget;
 import org.eclipse.jface.text.IFindReplaceTargetExtension;
 
 import org.eclipse.ui.internal.findandreplace.FindReplaceLogic;
-import org.eclipse.ui.internal.findandreplace.FindReplaceTestUtil;
 import org.eclipse.ui.internal.findandreplace.IFindReplaceLogic;
 import org.eclipse.ui.internal.findandreplace.IFindReplaceUIAccess;
 import org.eclipse.ui.internal.findandreplace.SearchOptions;
@@ -142,21 +142,24 @@ class OverlayAccess implements IFindReplaceUIAccess {
 	}
 
 	@Override
-	public void simulateEnterInFindInputField(boolean shiftPressed) {
-		simulateKeyPressInFindInputField(SWT.CR, shiftPressed);
-	}
-
-	@Override
-	public void simulateKeyPressInFindInputField(int keyCode, boolean shiftPressed) {
+	public void simulateKeyboardInteractionInFindInputField(int keyCode, boolean shiftPressed) {
 		final Event event= new Event();
 		event.type= SWT.KeyDown;
-		event.keyCode= keyCode;
 		if (shiftPressed) {
 			event.stateMask= SWT.SHIFT;
 		}
+		event.keyCode= keyCode;
 		find.notifyListeners(SWT.KeyDown, event);
-		find.traverse(SWT.TRAVERSE_RETURN, event);
-		FindReplaceTestUtil.runEventQueue();
+		runEventQueue();
+	}
+
+	@Override
+	public void simulateKeystrokeInFindInputField(char character) {
+		final Event event= new Event();
+		event.type= SWT.KeyDown;
+		event.character= character;
+		find.getDisplay().post(event);
+		runEventQueue();
 	}
 
 	@Override

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
@@ -169,23 +169,26 @@ class DialogAccess implements IFindReplaceUIAccess {
 	}
 
 	@Override
-	public void simulateEnterInFindInputField(boolean shiftPressed) {
-		simulateKeyPressInFindInputField(SWT.CR, shiftPressed);
-	}
-
-	@Override
-	public void simulateKeyPressInFindInputField(int keyCode, boolean shiftPressed) {
+	public void simulateKeyboardInteractionInFindInputField(int keyCode, boolean shiftPressed) {
 		final Event event= new Event();
-		event.type= SWT.Traverse;
 		event.detail= SWT.TRAVERSE_RETURN;
-		event.character= (char) keyCode;
+		event.type= SWT.KeyDown;
 		if (shiftPressed) {
 			event.stateMask= SWT.SHIFT;
 		}
+		event.keyCode= keyCode;
 		findCombo.traverse(SWT.TRAVERSE_RETURN, event);
 		runEventQueue();
 	}
 
+	@Override
+	public void simulateKeystrokeInFindInputField(char character) {
+		final Event event= new Event();
+		event.type= SWT.KeyDown;
+		event.character= character;
+		findCombo.getDisplay().post(event);
+		runEventQueue();
+	}
 
 	@Override
 	public String getReplaceText() {

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
@@ -63,7 +63,7 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 
 		dialog.findCombo.setFocus();
 		dialog.setFindText("line");
-		dialog.simulateEnterInFindInputField(false);
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		ensureHasFocusOnGTK();
 
 		assertTrue(dialog.getFindCombo().isFocusControl());
@@ -71,11 +71,11 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		Button wrapCheckBox= dialog.getButtonForSearchOption(SearchOptions.WRAP);
 		Button globalRadioButton= dialog.getButtonForSearchOption(SearchOptions.GLOBAL);
 		wrapCheckBox.setFocus();
-		dialog.simulateEnterInFindInputField(false);
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		assertTrue(wrapCheckBox.isFocusControl());
 
 		globalRadioButton.setFocus();
-		dialog.simulateEnterInFindInputField(false);
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		assertTrue(globalRadioButton.isFocusControl());
 	}
 
@@ -124,22 +124,22 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		ensureHasFocusOnGTK();
 		IFindReplaceTarget target= dialog.getTarget();
 
-		dialog.simulateEnterInFindInputField(false);
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(4, (target.getSelection()).y);
 
-		dialog.simulateEnterInFindInputField(false);
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		assertEquals(5, (target.getSelection()).x);
 		assertEquals(4, (target.getSelection()).y);
 
-		dialog.simulateEnterInFindInputField(true);
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, true);
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(4, (target.getSelection()).y);
 
 		// This part only makes sense for the FindReplaceDialog since not every UI might have stored
 		// the search direction as a state
 		dialog.unselect(SearchOptions.FORWARD);
-		dialog.simulateEnterInFindInputField(true);
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, true);
 		assertEquals(5, (target.getSelection()).x);
 	}
 
@@ -211,7 +211,7 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		dialog.select(SearchOptions.WRAP);
 		IFindReplaceTarget target= dialog.getTarget();
 
-		dialog.simulateEnterInFindInputField(false);
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(3, (target.getSelection()).y);
 
@@ -219,7 +219,7 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		dialog.assertDisabled(SearchOptions.WHOLE_WORD);
 		dialog.assertSelected(SearchOptions.WHOLE_WORD);
 
-		dialog.simulateEnterInFindInputField(false);
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		assertThat(target.getSelectionText(), is(dialog.getFindText()));
 
 		assertEquals(0, (target.getSelection()).x);


### PR DESCRIPTION
When the FindReplaceOverlay is opened, the search input field is initialized with the string currently selected in the target editor and this string is selected in the search input field. In consequence, starting to type after opening the dialog replaces the search string. When there is no selection in the target editor, the current search string is kept, but it is not selected. So starting to type will insert further text before the current search string instead of replacing it. This is inconsistent with the existing FindReplaceDialog.

This change improves the behavior to always select the search string when the input field receives focus. According test cases are added.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2012