### PR TITLE
Find/Replace: keep overlay visible in all kinds of editors #2075

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -280,18 +280,16 @@ public class FindReplaceOverlay extends Dialog {
 
 	private boolean isPartCurrentlyDisplayedInPartSash() {
 		IWorkbenchPage activePage = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
-
-		// Check if the targetPart is currently displayed on the active page
-		boolean isPartDisplayed = false;
-
-		if (activePage != null) {
-			IWorkbenchPart activePart = activePage.getActivePart();
-			if (activePart != null && activePart == targetPart) {
-				isPartDisplayed = true;
-			}
+		if (activePage == null) {
+			return false;
 		}
-
-		return isPartDisplayed;
+		IWorkbenchPart activePart = activePage.getActivePart();
+		if (activePart == null) {
+			return false;
+		}
+		IFindReplaceTarget activePartFindReplaceTarget = activePart.getAdapter(IFindReplaceTarget.class);
+		IFindReplaceTarget targetPartFindReplaceTarget = targetPart.getAdapter(IFindReplaceTarget.class);
+		return activePartFindReplaceTarget == targetPartFindReplaceTarget;
 	}
 
 	/**


### PR DESCRIPTION
The FindReplaceOverlay is sometimes hidden unintendedly when switching focus to the underlying editor, which is not a standard text / source code editor, such as a Manifest editor. The reason is a faulty identification of whether the target part is displayed.

This change corrects the visibility determination of the overlay by comparing the FindReplaceTargets of active and target part instead of comparing the part itself.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2075