### PR TITLE
[Sticky Scrolling] Don't scroll on caret movement to the end of editor

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -507,7 +507,8 @@ public class StickyScrollingControl {
 
 		@Override
 		public void caretMoved(CaretEvent event) {
-			if (event.caretOffset == 0) {
+			int offsetEndPosition = sourceViewer.getTextWidget().getText().length();
+			if (event.caretOffset == 0 || event.caretOffset == offsetEndPosition) {
 				return;
 			}
 			Display.getDefault().asyncExec(() -> {


### PR DESCRIPTION
When the caret is moved to the end of the editor, the sticky scrolling does not need to adapt the visible source lines. This is for example done at the select all command (STRG+A). 
Without sticky scrolling enable, the complete source code gets selected and the caret is moved to the end without scrolling. When sticky scrolling is enabled, the editor should behave in the same way.

### Testing
1. Open a editor and enable sticky scrolling
2. Select all via STRG+A, the editor should not scroll down to the end of the file