### PR TITLE
Find/replace overlay: improve operation and shortcut association

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolBar.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolBar.java
@@ -20,8 +20,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.ToolBar;
-import org.eclipse.swt.widgets.ToolItem;
+import org.eclipse.swt.widgets.Control;
 
 import org.eclipse.jface.layout.GridLayoutFactory;
 
@@ -35,11 +34,14 @@ import org.eclipse.jface.layout.GridLayoutFactory;
  */
 class AccessibleToolBar extends Composite {
 
-	private List<ToolBar> toolBars = new ArrayList<>();
+	private final List<AccessibleToolItem> accessibleToolItems = new ArrayList<>();
+
+	private final GridLayout layout;
 
 	public AccessibleToolBar(Composite parent) {
 		super(parent, SWT.NONE);
-		GridLayoutFactory.fillDefaults().numColumns(0).spacing(0, 0).margins(0, 0).applyTo(this);
+		this.layout = GridLayoutFactory.fillDefaults().numColumns(0).spacing(0, 0).margins(0, 0).create();
+		this.setLayout(layout);
 	}
 
 	/**
@@ -49,33 +51,26 @@ class AccessibleToolBar extends Composite {
 	 * @param styleBits the StyleBits to apply to the created ToolItem
 	 * @return a newly created ToolItem
 	 */
-	public ToolItem createToolItem(int styleBits) {
-		ToolBar parent = new ToolBar(this, SWT.FLAT | SWT.HORIZONTAL);
-		ToolItem toolItem = new ToolItem(parent, styleBits);
-
-		addToolItemTraverseListener(parent, toolItem);
-
-		((GridLayout) getLayout()).numColumns++;
-
-		toolBars.add(parent);
+	public AccessibleToolItem createToolItem(int styleBits) {
+		AccessibleToolItem toolItem = new AccessibleToolItem(this, styleBits);
+		accessibleToolItems.add(toolItem);
+		layout.numColumns++;
 		return toolItem;
-	}
-
-	private void addToolItemTraverseListener(ToolBar parent, ToolItem result) {
-		parent.addTraverseListener(e -> {
-			if (e.keyCode == SWT.CR || e.keyCode == SWT.KEYPAD_CR) {
-				result.setSelection(!result.getSelection());
-				e.doit = false;
-			}
-		});
 	}
 
 	@Override
 	public void setBackground(Color color) {
 		super.setBackground(color);
-		for (ToolBar bar : toolBars) { // some ToolItems (like SWT.SEPARATOR) don't easily inherit the color from the
-										// parent control.
-			bar.setBackground(color);
+		// some ToolItems (like SWT.SEPARATOR) don't easily inherit the color from the
+		// parent control
+		for (AccessibleToolItem item : accessibleToolItems) {
+			item.setBackground(color);
+		}
+	}
+
+	void registerActionShortcutsAtControl(Control control) {
+		for (AccessibleToolItem item : accessibleToolItems) {
+			item.registerActionShortcutsAtControl(control);
 		}
 	}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItem.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItem.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ui.internal.findandreplace.overlay;
+
+import java.util.List;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.ToolBar;
+import org.eclipse.swt.widgets.ToolItem;
+
+import org.eclipse.jface.bindings.keys.KeyStroke;
+
+class AccessibleToolItem {
+	private final ToolItem toolItem;
+
+	private FindReplaceOverlayAction action = new FindReplaceOverlayAction(null);
+
+	AccessibleToolItem(Composite parent, int styleBits) {
+		ToolBar toolbar = new ToolBar(parent, SWT.FLAT | SWT.HORIZONTAL);
+		toolItem = new ToolItem(toolbar, styleBits);
+		addToolItemTraverseListener(toolbar);
+	}
+
+	private void addToolItemTraverseListener(ToolBar parent) {
+		parent.addTraverseListener(e -> {
+			if (e.keyCode == SWT.CR || e.keyCode == SWT.KEYPAD_CR) {
+				action.execute();
+				e.doit = false;
+			}
+		});
+	}
+
+	ToolItem getToolItem() {
+		return toolItem;
+	}
+
+	void setBackground(Color color) {
+		toolItem.getParent().setBackground(color);
+	}
+
+	void setImage(Image image) {
+		toolItem.setImage(image);
+	}
+
+	void setToolTipText(String text) {
+		toolItem.setToolTipText(action.addShortcutHintToTooltipText(text));
+	}
+
+	void setOperation(Runnable operation, List<KeyStroke> shortcuts) {
+		boolean isCheckbox = (toolItem.getStyle() & SWT.CHECK) != 0;
+		if (isCheckbox) {
+			action = new FindReplaceOverlayAction(() -> {
+				toolItem.setSelection(!toolItem.getSelection());
+				operation.run();
+			});
+		} else {
+			action = new FindReplaceOverlayAction(operation);
+		}
+		action.addShortcuts(shortcuts);
+		setToolTipText(toolItem.getToolTipText());
+		toolItem.addSelectionListener(SelectionListener.widgetSelectedAdapter(__ -> operation.run()));
+	}
+
+	void registerActionShortcutsAtControl(Control control) {
+		FindReplaceShortcutUtil.registerActionShortcutsAtControl(action, control);
+	}
+
+}

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItemBuilder.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItemBuilder.java
@@ -13,12 +13,15 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.findandreplace.overlay;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.ToolItem;
+
+import org.eclipse.jface.bindings.keys.KeyStroke;
 
 /**
  * Builder for ToolItems for {@link AccessibleToolBar}.
@@ -28,7 +31,8 @@ class AccessibleToolItemBuilder {
 	private int styleBits = SWT.NONE;
 	private Image image;
 	private String toolTipText;
-	private SelectionListener selectionListener;
+	private List<KeyStroke> shortcuts = Collections.emptyList();
+	private Runnable operation;
 
 	public AccessibleToolItemBuilder(AccessibleToolBar accessibleToolBar) {
 		this.accessibleToolBar = Objects.requireNonNull(accessibleToolBar);
@@ -49,26 +53,28 @@ class AccessibleToolItemBuilder {
 		return this;
 	}
 
-	public AccessibleToolItemBuilder withSelectionListener(SelectionListener newSelectionListener) {
-		this.selectionListener = newSelectionListener;
+	public AccessibleToolItemBuilder withShortcuts(List<KeyStroke> newShortcuts) {
+		this.shortcuts = newShortcuts;
+		return this;
+	}
+
+	public AccessibleToolItemBuilder withOperation(Runnable newOperation) {
+		this.operation = newOperation;
 		return this;
 	}
 
 	public ToolItem build() {
-		ToolItem toolItem = accessibleToolBar.createToolItem(styleBits);
-
+		AccessibleToolItem accessibleToolItem = accessibleToolBar.createToolItem(styleBits);
 		if (image != null) {
-			toolItem.setImage(image);
+			accessibleToolItem.setImage(image);
 		}
-
 		if (toolTipText != null) {
-			toolItem.setToolTipText(toolTipText);
+			accessibleToolItem.setToolTipText(toolTipText);
+		}
+		if (operation != null) {
+			accessibleToolItem.setOperation(operation, shortcuts);
 		}
 
-		if (selectionListener != null) {
-			toolItem.addSelectionListener(selectionListener);
-		}
-
-		return toolItem;
+		return accessibleToolItem.getToolItem();
 	}
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayAction.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayAction.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ui.internal.findandreplace.overlay;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jface.bindings.keys.KeyStroke;
+
+class FindReplaceOverlayAction {
+	private final Runnable operation;
+
+	private final List<KeyStroke> shortcuts = new ArrayList<>();
+
+	FindReplaceOverlayAction(Runnable operation) {
+		this.operation = operation;
+	}
+
+	void addShortcuts(List<KeyStroke> shortcutsToAdd) {
+		this.shortcuts.addAll(shortcutsToAdd);
+	}
+
+	void execute() {
+		operation.run();
+	}
+
+	boolean executeIfMatching(KeyStroke keystroke) {
+		if (shortcuts.stream().anyMatch(keystroke::equals)) {
+			execute();
+			return true;
+		}
+		return false;
+	}
+
+	String addShortcutHintToTooltipText(String originalTooltipText) {
+		if (shortcuts.isEmpty()) {
+			return originalTooltipText;
+		}
+		return originalTooltipText + " (" + shortcuts.get(0).format() + ")"; //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+}

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceShortcutUtil.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceShortcutUtil.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ui.internal.findandreplace.overlay;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.events.KeyListener;
+import org.eclipse.swt.widgets.Control;
+
+import org.eclipse.jface.bindings.keys.KeyStroke;
+
+public final class FindReplaceShortcutUtil {
+	private FindReplaceShortcutUtil() {
+	}
+
+	static void registerActionShortcutsAtControl(FindReplaceOverlayAction action, Control control) {
+		control.addKeyListener(KeyListener.keyPressedAdapter(event -> {
+			KeyStroke actualStroke = extractKeyStroke(event);
+			if (action.executeIfMatching(actualStroke)) {
+				event.doit = false;
+			}
+		}));
+	}
+
+	static private KeyStroke extractKeyStroke(KeyEvent e) {
+		char character = e.character;
+		boolean ctrlDown = (e.stateMask & SWT.CTRL) != 0;
+		if (ctrlDown && e.character != e.keyCode && e.character < 0x20 && (e.keyCode & SWT.KEYCODE_BIT) == 0) {
+			character += 0x40;
+		}
+		KeyStroke actualStroke = KeyStroke.getInstance(e.stateMask & (SWT.MOD1 | SWT.SHIFT),
+				character == 0 ? e.keyCode : character);
+		return actualStroke;
+	}
+}

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
@@ -19,7 +19,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.events.ModifyListener;
-import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
@@ -61,7 +60,7 @@ public class HistoryTextWrapper extends Composite {
 		dropDown = new AccessibleToolItemBuilder(tools).withStyleBits(SWT.PUSH)
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_searchHistory_toolTip)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_OPEN_HISTORY))
-				.withSelectionListener(SelectionListener.widgetSelectedAdapter(e -> createHistoryMenuDropdown()))
+				.withOperation(this::createHistoryMenuDropdown)
 				.build();
 
 		listenForKeyboardHistoryNavigation();


### PR DESCRIPTION
In the FindReplaceOverlay, the assignment of actions to buttons and checkboxes as well as their shortcuts, and the correlation of shortcuts with buttons is not supported by proper OO design by needs to be done manually. This leads to higher code complexity in the FindReplaceOverlay and makes it prone to error when doing changes in that class.

This change extracts the actions assigned to buttons into a separate class that combines these actions with associated shortcuts. They are then automatically registered for the buttons they are assigned to.