### PR TITLE
IAbstractTextEditorHelpContextIds.FIND_REPLACE_OVERLAY is @since 3.18

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench.texteditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench.texteditor; singleton:=true
-Bundle-Version: 3.17.500.qualifier
+Bundle-Version: 3.18.0.qualifier
 Bundle-Activator: org.eclipse.ui.internal.texteditor.TextEditorPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/IAbstractTextEditorHelpContextIds.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/IAbstractTextEditorHelpContextIds.java
@@ -296,7 +296,7 @@ public interface IAbstractTextEditorHelpContextIds {
 	 * find/replace dialog.
 	 * <code>"org.eclipse.ui.find_replace_overlay_context"</code>
 	 *
-	 * @since 3.17
+	 * @since 3.18
 	 */
 	String FIND_REPLACE_OVERLAY = PREFIX + "find_replace_overlay_context"; //$NON-NLS-1$
 


### PR DESCRIPTION
- New API requires a new minor version