### PR TITLE
[Sticky Scrolling] Fix line number layout in sticky scrolling control

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -326,6 +326,7 @@ public class StickyScrollingControl {
 			((GridData) stickyLineNumber.getLayoutData()).widthHint= lineNumberBounds.width;
 			stickyLineNumber.setRightMargin(verticalRuler.getWidth() - lineNumberBounds.x - lineNumberBounds.width);
 		}
+		stickyLinesCanvas.layout();
 	}
 
 	private LineNumberColumn getLineNumberColumn(IVerticalRuler ruler) {
@@ -507,7 +508,7 @@ public class StickyScrollingControl {
 
 		@Override
 		public void caretMoved(CaretEvent event) {
-			int offsetEndPosition = sourceViewer.getTextWidget().getText().length();
+			int offsetEndPosition= sourceViewer.getTextWidget().getText().length();
 			if (event.caretOffset == 0 || event.caretOffset == offsetEndPosition) {
 				return;
 			}


### PR DESCRIPTION
In some cases the line number layout was to small so that the line numbers was not displayed correct.

Before:
<img width="389" alt="Bildschirmfoto 2024-07-15 um 13 44 32" src="https://github.com/user-attachments/assets/20e16a2b-c5fb-459e-8c72-5808a698812e">

After:
<img width="450" alt="Bildschirmfoto 2024-07-15 um 13 45 39" src="https://github.com/user-attachments/assets/ec726cd6-cfc5-42b1-a3a4-113f34fa8fea">

### Testing
I did not find out when the issue exactly occurred. For me I was able to reproduce the error by:

1. Open a plugin.xml in text editor
2. Scroll down until a sticky line is visible
