### PR TITLE
Improve and add assertions for random failing HoverTest #926 #1808

### DIFF
--- a/tests/org.eclipse.ui.genericeditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.genericeditor.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.genericeditor.tests;singleton:=true
-Bundle-Version: 1.3.500.qualifier
+Bundle-Version: 1.3.600.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.genericeditor.tests,


### PR DESCRIPTION
This contributes to fixing the randomly failing HoverTests:
- Removes unnecessary focus enforcing: The code checks for the text editor having focus and afterwards uses different methods to force focus to the widget's shell again. This is unnecessary and is only prone to introduce further problems.
- Introduces further assertions: in order to better locate the cause of the failing tests, assertions are added for the conditions, on which the execution waits, to be actually fulfilled.

Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/926

Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/1808