### PR TITLE
Replace keystroke simulation in FindReplaceOverlayTest/-DialogTest #2088

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
@@ -156,6 +156,10 @@ public class HistoryTextWrapper extends Composite {
 		textBar.setSelection(i, j);
 	}
 
+	public String getSelectionText() {
+		return textBar.getSelectionText();
+	}
+
 	@Override
 	public boolean isFocusControl() {
 		return textBar.isFocusControl();

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
@@ -306,23 +306,24 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 	@Test
 	public void testSearchTextSelectedWhenOpeningDialog() {
 		openTextViewer("test");
+
 		fTextViewer.setSelection(new TextSelection(0, 4));
 		initializeFindReplaceUIForTextViewer();
-		assertEquals("test", dialog.getFindText());
 
-		dialog.simulateKeystrokeInFindInputField('w');
-		assertEquals("w", dialog.getFindText());
+		assertEquals("test", dialog.getFindText());
+		assertEquals(dialog.getSelectedFindText(), dialog.getFindText());
 	}
 
 	@Test
 	public void testSearchTextSelectedWhenSwitchingFocusToDialog() {
 		openTextViewer("");
 		initializeFindReplaceUIForTextViewer();
-		dialog.setFindText("text");
-		reopenFindReplaceUIForTextViewer();
 
-		dialog.simulateKeystrokeInFindInputField('w');
-		assertEquals("w", dialog.getFindText());
+		dialog.setFindText("text");
+		initializeFindReplaceUIForTextViewer();
+
+		assertEquals("text", dialog.getFindText());
+		assertEquals(dialog.getSelectedFindText(), dialog.getFindText());
 	}
 
 	private void assertScopeActivationOnTextInput(String input) {

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/IFindReplaceUIAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/IFindReplaceUIAccess.java
@@ -32,9 +32,9 @@ public interface IFindReplaceUIAccess {
 
 	void simulateKeyboardInteractionInFindInputField(int keyCode, boolean shiftPressed);
 
-	void simulateKeystrokeInFindInputField(char character);
-
 	String getFindText();
+
+	String getSelectedFindText();
 
 	String getReplaceText();
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
@@ -153,17 +153,13 @@ class OverlayAccess implements IFindReplaceUIAccess {
 	}
 
 	@Override
-	public void simulateKeystrokeInFindInputField(char character) {
-		final Event event= new Event();
-		event.type= SWT.KeyDown;
-		event.character= character;
-		find.getDisplay().post(event);
-		runEventQueue();
+	public String getFindText() {
+		return find.getText();
 	}
 
 	@Override
-	public String getFindText() {
-		return find.getText();
+	public String getSelectedFindText() {
+		return find.getSelectionText();
 	}
 
 	@Override

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Event;
@@ -182,15 +183,6 @@ class DialogAccess implements IFindReplaceUIAccess {
 	}
 
 	@Override
-	public void simulateKeystrokeInFindInputField(char character) {
-		final Event event= new Event();
-		event.type= SWT.KeyDown;
-		event.character= character;
-		findCombo.getDisplay().post(event);
-		runEventQueue();
-	}
-
-	@Override
 	public String getReplaceText() {
 		return replaceCombo.getText();
 	}
@@ -214,6 +206,12 @@ class DialogAccess implements IFindReplaceUIAccess {
 	@Override
 	public String getFindText() {
 		return findCombo.getText();
+	}
+
+	@Override
+	public String getSelectedFindText() {
+		Point selection = findCombo.getSelection();
+		return findCombo.getText().substring(selection.x, selection.y);
 	}
 
 	public Combo getFindCombo() {


### PR DESCRIPTION
The test cases testSearchTextSelectedWhenOpeningDialog and testSearchTextSelectedWhenSwitchingFocusToDialog used in FindReplaceOverlayTest and FindReplaceDialogTest currently simulate keyboard inputs to validate that the text in the find input fields is selected in specific situations. This pushes keyboard events to the main event loop, which (1) requires the Window to have focus during test execution and (2) currently even fails in I-Builds on Windows.

This change replaces the test concept by validating the selection in the search input field instead of validating the behavior upon keyboard inputs. This makes the test independent from the main event loop and should thus improve its stability.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2088