### PR TITLE
Remove faulty since tag at FindReplaceOverlay

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -74,9 +74,6 @@ import org.eclipse.ui.internal.findandreplace.status.IFindReplaceStatus;
 import org.eclipse.ui.texteditor.IAbstractTextEditorHelpContextIds;
 import org.eclipse.ui.texteditor.StatusTextEditor;
 
-/**
- * @since 3.17
- */
 public class FindReplaceOverlay extends Dialog {
 	private final class KeyboardShortcuts {
 		private static final List<KeyStroke> SEARCH_FORWARD = List.of( //


### PR DESCRIPTION
The FindReplaceOverlay is not part of API and was introduced in current version (3.18.0) but has a since tag for 3.17. This change removes the obsolete and incorrect tag.