### PR TITLE
Find/replace overlay: fix skipping search history entry #2094

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
@@ -112,7 +112,7 @@ public class HistoryTextWrapper extends Composite {
 		offset += navigationOffset;
 		offset = offset % history.size();
 
-		if (offset + navigationOffset < 0) {
+		if (offset < 0) {
 			offset = history.size() - 1;
 		}
 


### PR DESCRIPTION
When navigating through the search history in the FindReplaceOverlay via pressing the down arrow, the first entry in the list is always skipped. This is caused by a faulty overflow calculation, which is corrected by this change.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2094