### PR TITLE
Find/replace overlay: reassign to changed shell asynchronously #1945

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -883,11 +883,13 @@ public class FindReplaceOverlay extends Dialog {
 			return;
 		}
 		if (isInvalidTargetShell()) {
-			getShell().getDisplay().syncExec(() -> {
-				close();
-				setParentShell(targetPart.getSite().getShell());
-				open();
-				targetPart.setFocus();
+			getShell().getDisplay().asyncExec(() -> {
+				if (isInvalidTargetShell()) {
+					close();
+					setParentShell(targetPart.getSite().getShell());
+					open();
+					targetPart.setFocus();
+				}
 			});
 			return;
 		}


### PR DESCRIPTION
The synchronous execution of reassigning the FindReplaceOverlay to a shell sporadically makes the application hang on Linux. This makes the execution asynchronous and avoid repeated executions of the reassignment.

Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/1945

Follow-up to #1946 