### PR TITLE
Find/replace overlay: correct heights and vertical centering #1997 #2092

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolBar.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolBar.java
@@ -40,7 +40,7 @@ class AccessibleToolBar extends Composite {
 
 	public AccessibleToolBar(Composite parent) {
 		super(parent, SWT.NONE);
-		this.layout = GridLayoutFactory.fillDefaults().numColumns(0).spacing(0, 0).margins(0, 0).create();
+		this.layout = GridLayoutFactory.fillDefaults().numColumns(0).spacing(0, 0).margins(1, 1).create();
 		this.setLayout(layout);
 	}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -595,7 +595,7 @@ public class FindReplaceOverlay extends Dialog {
 		HistoryStore searchHistory = new HistoryStore(getDialogSettings(), "searchhistory", //$NON-NLS-1$
 				HISTORY_SIZE);
 		searchBar = new HistoryTextWrapper(searchHistory, searchBarContainer, SWT.SINGLE);
-		GridDataFactory.fillDefaults().grab(true, false).align(GridData.FILL, GridData.END).applyTo(searchBar);
+		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(searchBar);
 		searchBar.forceFocus();
 		searchBar.selectAll();
 		searchBar.addModifyListener(e -> {
@@ -651,18 +651,18 @@ public class FindReplaceOverlay extends Dialog {
 	private void createFindContainer() {
 		searchContainer = new Composite(contentGroup, SWT.NONE);
 		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(searchContainer);
-		GridLayoutFactory.fillDefaults().numColumns(3).extendedMargins(4, 4, 2, 8).equalWidth(false)
+		GridLayoutFactory.fillDefaults().numColumns(3).extendedMargins(4, 4, 3, 5).equalWidth(false)
 				.applyTo(searchContainer);
 		searchContainer.setBackground(getShell().getDisplay().getSystemColor(SWT.COLOR_WIDGET_LIGHT_SHADOW));
 		searchBarContainer = new Composite(searchContainer, SWT.NONE);
-		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.END).applyTo(searchBarContainer);
+		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(searchBarContainer);
 		GridLayoutFactory.fillDefaults().numColumns(1).applyTo(searchBarContainer);
 	}
 
 	private void createReplaceContainer() {
 		replaceContainer = new Composite(contentGroup, SWT.NONE);
 		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(replaceContainer);
-		GridLayoutFactory.fillDefaults().margins(0, 1).numColumns(2).extendedMargins(4, 4, 2, 8).equalWidth(false)
+		GridLayoutFactory.fillDefaults().margins(0, 1).numColumns(2).extendedMargins(4, 4, 3, 5).equalWidth(false)
 				.applyTo(replaceContainer);
 		replaceContainer.setBackground(getShell().getDisplay().getSystemColor(SWT.COLOR_WIDGET_LIGHT_SHADOW));
 		replaceBarContainer = new Composite(replaceContainer, SWT.NONE);


### PR DESCRIPTION
This adapts the defined margins in the FindReplaceOverlay, such that
1. there is no vertical cutoff of the buttons
2. the search and replace input boxes are vertically centered

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1997 Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2092

### How it looks like

#### Before:
Windows:
![image](https://github.com/user-attachments/assets/96c134eb-f6b8-4a53-ba75-0737475dcdbf)
Linux:
![image](https://github.com/user-attachments/assets/31730441-9047-49ee-8498-5cb6130f07ad)

#### After:
Windows:
![image](https://github.com/user-attachments/assets/3bc0a3be-3e59-467f-8439-a6ad25029cef)
Mac:
<img width="581" alt="image" src="https://github.com/user-attachments/assets/0665d374-1f64-4ad2-948c-4bba5c479ccd">
Linux:
![image](https://github.com/user-attachments/assets/ce872f2c-e3a0-445e-8d60-e666babfd70f)
