### PR TITLE
Find/replace overlay: focus target editor when closing #2101

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -332,6 +332,9 @@ public class FindReplaceOverlay extends Dialog {
 		if (!overlayOpen) {
 			return true;
 		}
+		if (targetPart != null) {
+			targetPart.setFocus();
+		}
 		storeOverlaySettings();
 
 		findReplaceLogic.activate(SearchOptions.GLOBAL);


### PR DESCRIPTION
When closing a find/replace overlay, focus is moved to the widget that last had focus before the overlay received focus. This changes the behavior to focus the target part when starting to close the overlay.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2101