### PR TITLE
Find/Replace Logic: Allow reset of Incremental Base Position

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -67,7 +67,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 		case FORWARD:
 		case INCREMENTAL:
 			if (shouldInitIncrementalBaseLocation()) {
-				initIncrementalBaseLocation();
+				resetIncrementalBaseLocation();
 			}
 			break;
 		// $CASES-OMITTED$
@@ -87,7 +87,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 		}
 
 		if (searchOption == SearchOptions.FORWARD && shouldInitIncrementalBaseLocation()) {
-			initIncrementalBaseLocation();
+			resetIncrementalBaseLocation();
 		}
 	}
 
@@ -136,12 +136,8 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 		return isActive(SearchOptions.REGEX) && isTargetSupportingRegEx;
 	}
 
-
-	/**
-	 * Initializes the anchor used as starting point for incremental searching.
-	 *
-	 */
-	private void initIncrementalBaseLocation() {
+	@Override
+	public void resetIncrementalBaseLocation() {
 		if (target != null && isActive(SearchOptions.INCREMENTAL) && !isRegExSearchAvailableAndActive()) {
 			incrementalBaseLocation = target.getSelection();
 		} else {
@@ -159,7 +155,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	 */
 	private void initializeSearchScope() {
 		if (shouldInitIncrementalBaseLocation()) {
-			initIncrementalBaseLocation();
+			resetIncrementalBaseLocation();
 		}
 
 		if (target == null || !(target instanceof IFindReplaceTargetExtension)) {
@@ -343,7 +339,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	 */
 	private boolean performSearch(boolean mustInitIncrementalBaseLocation, String findString) {
 		if (mustInitIncrementalBaseLocation) {
-			initIncrementalBaseLocation();
+			resetIncrementalBaseLocation();
 		}
 		resetStatus();
 
@@ -604,7 +600,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 			}
 		}
 
-		initIncrementalBaseLocation();
+		resetIncrementalBaseLocation();
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
@@ -174,4 +174,26 @@ public interface IFindReplaceLogic {
 	 */
 	public boolean isWholeWordSearchAvailable(String findString);
 
+	/**
+	 * Initializes the anchor used as the starting point for incremental searching.
+	 * Subsequent incremental searches will start from the first letter of the
+	 * currently selected range in the FindReplaceTarget.
+	 *
+	 * <p>
+	 * The "current selection" refers to the range of text that is currently
+	 * highlighted or selected within the FindReplaceTarget. This selection can be
+	 * either a single position (if no range is selected) or a range of text.
+	 *
+	 * <p>
+	 * When handling range selections:
+	 * <ul>
+	 * <li>Forward search operations will use the beginning of the selection as the
+	 * starting point.</li>
+	 * <li>Backward search operations will use the end of the selection as the
+	 * starting point.</li>
+	 * </ul>
+	 * </p>
+	 */
+	void resetIncrementalBaseLocation();
+
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -614,11 +614,7 @@ public class FindReplaceOverlay extends Dialog {
 
 			@Override
 			public void focusGained(FocusEvent e) {
-				// we want to update the base-location of where we start incremental search
-				// to the currently selected position in the target
-				// when coming back into the dialog
-				findReplaceLogic.deactivate(SearchOptions.INCREMENTAL);
-				findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+				findReplaceLogic.resetIncrementalBaseLocation();
 			}
 
 			@Override

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -658,6 +658,23 @@ public class FindReplaceLogicTest {
 		assertThat(findReplaceLogic.getTarget().getSelection().y, is(4));
 	}
 
+	@Test
+	public void testResetIncrementalBaseLocation() {
+		String setupString= "test\ntest\ntest";
+		TextViewer textViewer= setupTextViewer(setupString);
+		textViewer.setSelectedRange(0, 0);
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.activate(SearchOptions.FORWARD);
+		findReplaceLogic.activate(SearchOptions.WRAP);
+		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+		findReplaceLogic.performIncrementalSearch("test");
+		assertThat(textViewer.getSelectedRange(), is(new Point(0, 4)));
+		textViewer.setSelectedRange(5, 0);
+		findReplaceLogic.resetIncrementalBaseLocation();
+		findReplaceLogic.performIncrementalSearch("test");
+		assertThat(textViewer.getSelectedRange(), is(new Point(5, 4)));
+	}
+
 	private void expectStatusEmpty(IFindReplaceLogic findReplaceLogic) {
 		assertThat(findReplaceLogic.getStatus(), instanceOf(NoStatus.class));
 	}


### PR DESCRIPTION
Allow the client to reset the base position for incremental search without enabling/disabling the Incremental search.

fixes #1913