### PR TITLE
Perform incremental search by calling performSearch by default instead

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -325,24 +325,12 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	}
 
 	@Override
-	public boolean performSearch(String searchString) {
-		return performSearch(shouldInitIncrementalBaseLocation(), searchString);
-	}
-
-	/**
-	 * Locates the user's findString in the text of the target.
-	 *
-	 * @param mustInitIncrementalBaseLocation <code>true</code> if base location
-	 *                                        must be initialized
-	 * @param findString                      the String to search for
-	 * @return Whether the string was found in the target
-	 */
-	private boolean performSearch(boolean mustInitIncrementalBaseLocation, String findString) {
-		if (mustInitIncrementalBaseLocation) {
-			resetIncrementalBaseLocation();
-		}
+	public boolean performSearch(String findString) {
 		resetStatus();
 
+		if (isActive(SearchOptions.INCREMENTAL) && !isIncrementalSearchAvailable()) {
+			return false; // Do nothing if search options are not compatible
+		}
 		boolean somethingFound = false;
 
 		if (findString != null && !findString.isEmpty()) {
@@ -650,26 +638,6 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	 */
 	private void statusLineMessage(String message) {
 		statusLineMessage(false, message);
-	}
-
-	@Override
-	public void performIncrementalSearch(String searchString) {
-		resetStatus();
-
-		if (isActive(SearchOptions.INCREMENTAL) && isIncrementalSearchAvailable()) {
-			if (searchString.equals("") && target != null) { //$NON-NLS-1$
-				// empty selection at base location
-				int offset = incrementalBaseLocation.x;
-
-				if (isActive(SearchOptions.FORWARD)) {
-					offset = offset + incrementalBaseLocation.y;
-				}
-
-				findAndSelect(offset, ""); //$NON-NLS-1$
-			} else {
-				performSearch(false, searchString);
-			}
-		}
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/IFindReplaceLogic.java
@@ -71,21 +71,6 @@ public interface IFindReplaceLogic {
 	public boolean isIncrementalSearchAvailable();
 
 	/**
-	 * Updates the search result after the Text was Modified. Used in combination
-	 * with <code>setIncrementalSearch(true)</code>. This method specifically allows
-	 * for "search-as-you-type"
-	 *
-	 * "Search-as-you-type" is not compatible with RegEx-search. This will
-	 * initialize the base-location for search (if not initialized already) but will
-	 * not update it, meaning that incrementally searching the same string twice in
-	 * a row will always yield the same result, unless the Base location was
-	 * modified (eg., by performing "find next")
-	 *
-	 * @param searchString the String that is to be searched
-	 */
-	public void performIncrementalSearch(String searchString);
-
-	/**
 	 * Replaces all occurrences of the user's findString with the replace string.
 	 * Indicate to the user the number of replacements that occur.
 	 *
@@ -102,7 +87,11 @@ public interface IFindReplaceLogic {
 	public void performSelectAll(String findString);
 
 	/**
-	 * Locates the user's findString in the target
+	 * Locates the user's findString in the target. If incremental search is
+	 * activated, the search will be performed starting from an incremental search
+	 * position, which can be reset using {@link #resetIncrementalBaseLocation()}.
+	 * If incremental search is activated and RegEx search is activated, nothing
+	 * happens.
 	 *
 	 * @param searchString the String to search for
 	 * @return Whether the string was found in the target

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -632,7 +632,7 @@ public class FindReplaceOverlay extends Dialog {
 		if (findReplaceLogic.getTarget() instanceof IFindReplaceTargetExtension targetExtension) {
 			targetExtension.setSelection(targetExtension.getLineSelection().x, 0);
 		}
-		findReplaceLogic.performIncrementalSearch(getFindString());
+		findReplaceLogic.performSearch(getFindString());
 		evaluateFindReplaceStatus();
 	}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -142,7 +142,9 @@ class FindReplaceDialog extends Dialog {
 				return;
 			}
 
-			findReplaceLogic.performIncrementalSearch(getFindString());
+			if (findReplaceLogic.isActive(SearchOptions.INCREMENTAL)) {
+				findReplaceLogic.performSearch(getFindString());
+			}
 			evaluateFindReplaceStatus();
 
 			updateButtonState(!findReplaceLogic.isActive(SearchOptions.INCREMENTAL));
@@ -292,9 +294,12 @@ class FindReplaceDialog extends Dialog {
 						setupFindReplaceLogic();
 						boolean eventRequiresInverseSearchDirection = (e.stateMask & SWT.MODIFIER_MASK) == SWT.SHIFT;
 						boolean forwardSearchActivated = findReplaceLogic.isActive(SearchOptions.FORWARD);
+						boolean incrementalSearchActivated = findReplaceLogic.isActive(SearchOptions.INCREMENTAL);
 						activateInFindReplaceLogicIf(SearchOptions.FORWARD,
 								eventRequiresInverseSearchDirection != forwardSearchActivated);
+						findReplaceLogic.deactivate(SearchOptions.INCREMENTAL);
 						boolean somethingFound = findReplaceLogic.performSearch(getFindString());
+						activateInFindReplaceLogicIf(SearchOptions.INCREMENTAL, incrementalSearchActivated);
 						activateInFindReplaceLogicIf(SearchOptions.FORWARD, forwardSearchActivated);
 
 						writeSelection();

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -667,12 +667,32 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.activate(SearchOptions.FORWARD);
 		findReplaceLogic.activate(SearchOptions.WRAP);
 		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
-		findReplaceLogic.performIncrementalSearch("test");
+		findReplaceLogic.performSearch("test");
 		assertThat(textViewer.getSelectedRange(), is(new Point(0, 4)));
 		textViewer.setSelectedRange(5, 0);
 		findReplaceLogic.resetIncrementalBaseLocation();
-		findReplaceLogic.performIncrementalSearch("test");
+		findReplaceLogic.performSearch("test");
 		assertThat(textViewer.getSelectedRange(), is(new Point(5, 4)));
+	}
+
+	@Test
+	public void testPerformIncrementalSearch() {
+		TextViewer textViewer= setupTextViewer("Test Test Test Test");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+		findReplaceLogic.activate(SearchOptions.FORWARD);
+
+		findReplaceLogic.performSearch("Test");
+		assertThat(findReplaceLogic.getTarget().getSelection().x, is(0));
+		assertThat(findReplaceLogic.getTarget().getSelection().y, is(4));
+
+		findReplaceLogic.performSearch("Test"); // incremental search is idempotent
+		assertThat(findReplaceLogic.getTarget().getSelection().x, is(0));
+		assertThat(findReplaceLogic.getTarget().getSelection().y, is(4));
+
+		findReplaceLogic.performSearch(""); // this clears the incremental search, but the "old search" still remains active
+		assertThat(findReplaceLogic.getTarget().getSelection().x, is(0));
+		assertThat(findReplaceLogic.getTarget().getSelection().y, is(4));
 	}
 
 	private void expectStatusEmpty(IFindReplaceLogic findReplaceLogic) {


### PR DESCRIPTION
The method performIncrementalSearch broke it's contract by only
performing incremental search when incremental search was enabled (even
though it didn't specify that as precondition). Now, performSearch with
the right search option is used to perform incremental search.

fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2105