### PR TITLE
Always update incremental search base location, even if RegEx is enabled

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -138,7 +138,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 
 	@Override
 	public void resetIncrementalBaseLocation() {
-		if (target != null && isActive(SearchOptions.INCREMENTAL) && !isRegExSearchAvailableAndActive()) {
+		if (target != null && shouldInitIncrementalBaseLocation()) {
 			incrementalBaseLocation = target.getSelection();
 		} else {
 			incrementalBaseLocation = new Point(0, 0);
@@ -146,7 +146,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	}
 
 	public boolean shouldInitIncrementalBaseLocation() {
-		return isActive(SearchOptions.INCREMENTAL) && !isActive(SearchOptions.REGEX);
+		return isActive(SearchOptions.INCREMENTAL);
 	}
 
 	/**

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -695,6 +695,33 @@ public class FindReplaceLogicTest {
 		assertThat(findReplaceLogic.getTarget().getSelection().y, is(4));
 	}
 
+	@Test
+	public void testIncrementBaseLocationWithRegEx() {
+		TextViewer textViewer= setupTextViewer("Test Test Test Test Test");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+		findReplaceLogic.activate(SearchOptions.FORWARD);
+
+		findReplaceLogic.performSearch("Test");
+		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(0, 4)));
+
+		findReplaceLogic.activate(SearchOptions.REGEX);
+		findReplaceLogic.deactivate(SearchOptions.INCREMENTAL);
+		findReplaceLogic.performSearch("Test");
+		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(5, 4)));
+		findReplaceLogic.deactivate(SearchOptions.INCREMENTAL);
+		findReplaceLogic.performSearch("Test");
+		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(10, 4)));
+		findReplaceLogic.deactivate(SearchOptions.REGEX);
+
+		findReplaceLogic.performSearch("Test");
+		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(15, 4)));
+		findReplaceLogic.performSearch("Test");
+		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(15, 4)));
+	}
+
 	private void expectStatusEmpty(IFindReplaceLogic findReplaceLogic) {
 		assertThat(findReplaceLogic.getStatus(), instanceOf(NoStatus.class));
 	}


### PR DESCRIPTION
Update the incremental Base location even if RegEx is enabled and
incremental search is disabled. Once RegEx is disabled, the incremental
base location is thus still valid.

fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1915