### PR TITLE
FindReplaceLogic: incremental doesn't skip over current selection

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -504,17 +504,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 			return false;
 		}
 
-		Point r = null;
-		if (isActive(SearchOptions.INCREMENTAL)) {
-			r = incrementalBaseLocation;
-		} else {
-			r = target.getSelection();
-		}
-
-		int findReplacePosition = r.x;
-		if (isActive(SearchOptions.FORWARD)) {
-			findReplacePosition += r.y;
-		}
+		int findReplacePosition = calculateFindBeginningOffset();
 
 		int index = findIndex(findString, findReplacePosition);
 
@@ -531,6 +521,22 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 		}
 
 		return true;
+	}
+
+	private int calculateFindBeginningOffset() {
+		Point r = null;
+		if (isActive(SearchOptions.INCREMENTAL)) {
+			r = incrementalBaseLocation;
+		} else {
+			r = target.getSelection();
+		}
+
+		int findReplacePosition = r.x;
+		if (isActive(SearchOptions.FORWARD) && !isActive(SearchOptions.INCREMENTAL)
+				|| isActive(SearchOptions.INCREMENTAL) && !isActive(SearchOptions.FORWARD)) {
+			findReplacePosition += r.y;
+		}
+		return findReplacePosition;
 	}
 
 	@Override

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -717,9 +717,33 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.deactivate(SearchOptions.REGEX);
 
 		findReplaceLogic.performSearch("Test");
-		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(15, 4)));
+		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(10, 4)));
 		findReplaceLogic.performSearch("Test");
-		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(15, 4)));
+		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(10, 4)));
+	}
+
+	@Test
+	public void testIncrementalSearchNoUpdateIfAlreadyOnWord() {
+		TextViewer textViewer= setupTextViewer("hellohello");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.activate(SearchOptions.FORWARD);
+		textViewer.setSelectedRange(0, 4);
+		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+		textViewer.setSelectedRange(0, 0);
+		findReplaceLogic.performSearch("hello");
+		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(0, 5)));
+	}
+
+	@Test
+	public void testIncrementalSearchBackwardNoUpdateIfAlreadyOnWord() {
+		TextViewer textViewer= setupTextViewer("hellohello");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.deactivate(SearchOptions.FORWARD);
+		textViewer.setSelectedRange(5, 5);
+		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+		textViewer.setSelectedRange(5, 0);
+		findReplaceLogic.performSearch("hello");
+		assertThat(findReplaceLogic.getTarget().getSelection(), is(new Point(5, 5)));
 	}
 
 	private void expectStatusEmpty(IFindReplaceLogic findReplaceLogic) {


### PR DESCRIPTION
Incremental search would start incremental search immediately after the
current word. This meant that the incremental search would not go back
to the word where the incremental search initially started.

fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2107