### PR TITLE
Height reduction of highlight

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
@@ -621,10 +621,12 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 			if (onBottom) {
 				highlightOnTop = !highlightOnTop;
 			}
-			int verticalOffset = highlightOnTop ? 0 : bounds.height - 2;
+			int highlightHeight = 2;
+			int verticalOffset = highlightOnTop ? 0 : bounds.height - (highlightHeight - 1);
 			int horizontalOffset = itemIndex == 0 || cornerSize == SQUARE_CORNER ? 0 : 1;
 			int widthAdjustment = cornerSize == SQUARE_CORNER ? 0 : 1;
-			gc.fillRectangle(bounds.x + horizontalOffset, bounds.y + verticalOffset, bounds.width - widthAdjustment, 3);
+			gc.fillRectangle(bounds.x + horizontalOffset, bounds.y + verticalOffset, bounds.width - widthAdjustment,
+					highlightHeight);
 		}
 
 		if (backgroundPattern != null) {


### PR DESCRIPTION
Reduced the thickness of the blue line (highlight) for selected tabs.
For the full details of the change including screenshots see issue: https://github.com/eclipse-platform/eclipse.platform.ui/issues/2114

![image](https://github.com/user-attachments/assets/76aed069-1af7-4d0d-b7c8-a56c3e261b4d)

![image](https://github.com/user-attachments/assets/fce20e4d-958f-45fd-90db-a30c78dc2655)

See the highlight for the selected Properties tab