### PR TITLE
Find/Replace Overlay: adapt to target theming

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -466,11 +466,17 @@ public class FindReplaceOverlay extends Dialog {
 	 * grab it's color and then immediately dispose of that bar.
 	 */
 	private void retrieveBackgroundColor() {
-		Text textBarForRetrievingTheRightColor = new Text(container, SWT.SINGLE | SWT.SEARCH);
-		container.layout();
-		backgroundToUse = textBarForRetrievingTheRightColor.getBackground();
-		normalTextForegroundColor = textBarForRetrievingTheRightColor.getForeground();
-		textBarForRetrievingTheRightColor.dispose();
+		if (targetPart instanceof StatusTextEditor textEditor) {
+			Control targetWidget = textEditor.getAdapter(ITextViewer.class).getTextWidget();
+			backgroundToUse = targetWidget.getBackground();
+			normalTextForegroundColor = targetWidget.getForeground();
+		} else {
+			Text textBarForRetrievingTheRightColor = new Text(container, SWT.SINGLE | SWT.SEARCH);
+			container.layout();
+			backgroundToUse = textBarForRetrievingTheRightColor.getBackground();
+			normalTextForegroundColor = textBarForRetrievingTheRightColor.getForeground();
+			textBarForRetrievingTheRightColor.dispose();
+		}
 	}
 
 


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/501b2f0d-1e19-495d-8a70-36fb265fe735)

The find/replace overlay now gets it's colors from the targetted view if the target is a text editor.

fixes #2118

Before:
![grafik](https://github.com/user-attachments/assets/5a959c60-9bf9-4352-bd50-05130e3c22af)

Light theme: 
![grafik](https://github.com/user-attachments/assets/3b2bd7d0-aca1-4b9e-9cca-cc12e5f02a84)
