### PR TITLE
Revert "Project Explorer: auto-expand long paths of single elements"

### DIFF
--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/navigator/resources/ProjectExplorer.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/navigator/resources/ProjectExplorer.java
@@ -28,7 +28,6 @@ import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.SafeRunner;
-import org.eclipse.jface.viewers.AbstractTreeViewer;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -84,14 +83,6 @@ import org.eclipse.ui.views.WorkbenchViewerSetup;
  */
 @SuppressWarnings("restriction")
 public final class ProjectExplorer extends CommonNavigator implements ISecondarySaveableSource {
-
-	/**
-	 * Number of levels to automatically expand when an element only has a single
-	 * child.
-	 *
-	 * @see AbstractTreeViewer#setAutoExpandOnSingleChildLevels(int)
-	 */
-	private static final int AUTO_EXPAND_ON_SINGLE_CHILD_LEVEL_COUNT = 10;
 
 	/**
 	 * Provides a constant for the standard instance of the Common Navigator.
@@ -173,7 +164,6 @@ public final class ProjectExplorer extends CommonNavigator implements ISecondary
 		if (this.userFilters.stream().anyMatch(UserFilter::isEnabled)) {
 			getCommonViewer().refresh();
 		}
-		getCommonViewer().setAutoExpandOnSingleChildLevels(AUTO_EXPAND_ON_SINGLE_CHILD_LEVEL_COUNT);
 	}
 
 	@Override


### PR DESCRIPTION
This reverts commit 3f00c8b2d69ac6f06a803c046a61a9a104ba5790.

The recursive auto-expansion of elements without siblings in the project explorer led to unintended behavior for non-folder/non-package elements, which are not expected to be expanded even if they do not have siblings (such as a class within a Java file). Until a better, context-solution is found, this reverts the enablement of the auto-expansion functionality in the project explorer.

Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/1063

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2002