### PR TITLE
Workbench restart is unavailable if --launcher.noRestart is used

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/E4Workbench.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/E4Workbench.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.UUID;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.e4.core.commands.ExpressionContext;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.EclipseContextFactory;
@@ -201,6 +202,12 @@ public class E4Workbench implements IWorkbench {
 
 	@Override
 	public boolean restart() {
+		if (!canRestart()) {
+			String message = "The workbench cannot be restarted. This application was started with the '--launcher.noRestart' argument. Instead of restarting, shut down and start again manually."; //$NON-NLS-1$
+			ILog.get().error(message);
+			return false;
+		}
+
 		this.restart = true;
 		return close();
 	}
@@ -210,6 +217,22 @@ public class E4Workbench implements IWorkbench {
 	 */
 	public boolean isRestart() {
 		return restart;
+	}
+
+	/**
+	 * Returns whether the workbench can be {@link #restart() restarted}.
+	 *
+	 * <p>
+	 * It can not be restarted if the <code>--launcher.noRestart</code> argument is
+	 * given.
+	 * </p>
+	 *
+	 * @return <code>true</code> if the workbench can be restarted.
+	 */
+	public static boolean canRestart() {
+		String commands = System.getProperty("eclipse.commands", ""); //$NON-NLS-1$ //$NON-NLS-2$
+		String NO_RESTART_ARGUMENT = "--launcher.noRestart"; //$NON-NLS-1$
+		return commands.lines().map(String::strip).noneMatch(NO_RESTART_ARGUMENT::equals);
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/Workbench.java
@@ -1404,6 +1404,11 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 	 */
 	/* package */
 	boolean close(int returnCode, final boolean force) {
+		if (returnCode == PlatformUI.RETURN_RESTART && !E4Workbench.canRestart()) {
+			informNoRestart();
+			return false;
+		}
+
 		this.returnCode = returnCode;
 		final boolean[] ret = new boolean[1];
 		BusyIndicator.showWhile(null, () -> ret[0] = busyClose(force));
@@ -2555,11 +2560,21 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 
 	@Override
 	public boolean restart() {
+		if (!E4Workbench.canRestart()) {
+			informNoRestart();
+			return false;
+		}
+
 		return close(PlatformUI.RETURN_RESTART, false);
 	}
 
 	@Override
 	public boolean restart(boolean useCurrrentWorkspace) {
+		if (!E4Workbench.canRestart()) {
+			informNoRestart();
+			return false;
+		}
+
 		if (Platform.inDevelopmentMode()) {
 			// In development mode, command line parameters cannot be changed and restart
 			// will always be EXIT_RESTART. Also see setRestartArguments method
@@ -2581,6 +2596,18 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 			}
 		}
 		return close(PlatformUI.RETURN_RESTART, false);
+	}
+
+	/**
+	 * Inform the user that the workbench can't be restarted. If the workbench UI is
+	 * not available, this method does nothing.
+	 */
+	private void informNoRestart() {
+		final Display display = getDisplay();
+		if (display != null && !display.isDisposed()) {
+			MessageDialog.openError(null, WorkbenchMessages.Workbench_CantRestart_Title,
+					WorkbenchMessages.Workbench_CantRestart_Message);
+		}
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchMessages.java
@@ -586,6 +586,9 @@ public class WorkbenchMessages extends NLS {
 	public static String Workbench_NeedsClose_Title;
 	public static String Workbench_NeedsClose_Message;
 
+	public static String Workbench_CantRestart_Title;
+	public static String Workbench_CantRestart_Message;
+
 	public static String ErrorPreferencePage_errorMessage;
 
 	public static String ListSelection_title;

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/RestartWorkbenchHandler.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/handlers/RestartWorkbenchHandler.java
@@ -16,12 +16,17 @@ package org.eclipse.ui.internal.handlers;
 
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.e4.ui.internal.workbench.E4Workbench;
 import org.eclipse.ui.PlatformUI;
 
 /**
  * Provide a Handler for the Restart Workbench command.
  */
 public class RestartWorkbenchHandler extends AbstractHandler {
+
+	public RestartWorkbenchHandler() {
+		setBaseEnabled(E4Workbench.canRestart());
+	}
 
 	@Override
 	public Object execute(ExecutionEvent event) {

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
@@ -554,6 +554,12 @@ InstallationDialog_ShellTitle={0} Installation Details
 Workbench_NeedsClose_Title = Restart Needed
 Workbench_NeedsClose_Message = A required plug-in is no longer available and the Workbench needs to be restarted. You will be prompted to save if there is any unsaved work.
 
+Workbench_CantRestart_Title = Restart unavailable
+Workbench_CantRestart_Message = The workbench cannot be restarted.\n\
+This application was started with the '--launcher.noRestart' argument.\n\
+\n\
+Instead of restarting, shut down and start again manually.
+
 ErrorPreferencePage_errorMessage = An error has occurred when creating this preference page.
 
 ListSelection_title = Selection Needed


### PR DESCRIPTION
This new argument just got added. See https://github.com/eclipse-equinox/equinox/pull/595. Here we make sure the workbench understands it.

Should be rare that people actually use the option and start the IDE, as it is not meant for that. This PR detects it and informs the user restart is not available, as documented (see https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2195).

I haven't tested it. Not sure how to build a new IDE with Equinox I-build and this PR both included.