### PR TITLE
Only prompt for restart on zoom change when not rescaling at runtime

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchWindow.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchWindow.java
@@ -934,25 +934,31 @@ public class WorkbenchWindow implements IWorkbenchWindow {
 
 			getShell().setData(this);
 			trackShellActivation();
-			/**
-			 * When SWT zoom changes for primary monitor, prompt user to restart Eclipse to
-			 * apply the changes.
-			 */
-			getShell().addListener(SWT.ZoomChanged, event -> {
-				if (getShell().getDisplay().getPrimaryMonitor().equals(getShell().getMonitor())) {
-					int dialogResponse = MessageDialog.open(MessageDialog.QUESTION, getShell(),
-							WorkbenchMessages.Workbench_zoomChangedTitle,
-							WorkbenchMessages.Workbench_zoomChangedMessage, SWT.NONE,
-							WorkbenchMessages.Workbench_RestartButton, WorkbenchMessages.Workbench_DontRestartButton);
-					if (event.doit && dialogResponse == 0) {
-						getWorkbenchImpl().restart(true);
-					}
-				}
-			});
-
+			addZoomChangeListenerToPromptForRestart();
 		} finally {
 			HandlerServiceImpl.pop();
 		}
+	}
+
+	private void addZoomChangeListenerToPromptForRestart() {
+		getShell().addListener(SWT.ZoomChanged, event -> {
+			/**
+			 * Prompt for restart when an SWT zoom change for the primary monitor occurs,
+			 * only when rescaling at runtime is not activated.
+			 */
+			if (getShell().getDisplay().isRescalingAtRuntime()) {
+				return;
+			}
+			if (getShell().getDisplay().getPrimaryMonitor().equals(getShell().getMonitor())) {
+				int dialogResponse = MessageDialog.open(MessageDialog.QUESTION, getShell(),
+						WorkbenchMessages.Workbench_zoomChangedTitle, WorkbenchMessages.Workbench_zoomChangedMessage,
+						SWT.NONE, WorkbenchMessages.Workbench_RestartButton,
+						WorkbenchMessages.Workbench_DontRestartButton);
+				if (event.doit && dialogResponse == 0) {
+					getWorkbenchImpl().restart(true);
+				}
+			}
+		});
 	}
 
 	@PreDestroy


### PR DESCRIPTION
When the zoom of the primary monitor changes, the workbench asks for a restart to adapt the workbench windows to the changed zoom. With the runtime rescaling functionality recently introduced to SWT, this behavior is only desired if that rescaling functionality is not activated. This change adapts the functionality for showing the restart prompt to only come up if the rescaling functionality is deactivated.

<s>⚠️ Requires recent SWT API changes, thus CI runs will only succeed after the next I-Build.</s>