### PR TITLE
Adding hover indicator for unselected tabs

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
@@ -56,8 +56,8 @@ Button  {
 /* Inactive view tabs  */
 .MPartStack {
 	swt-draw-custom-tab-content-background: true;
-	swt-unselected-hot-tab-color-background: #48484c;
-}
+	swt-unselected-hot-tab-color-background: #161616;
+} 
 
 CTabFolder{
 	swt-selected-tab-highlight: #2b79d7;

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
@@ -138,7 +138,7 @@ ImageBasedFrame,
 /* Inactive view tabs  */
 .MPartStack {
 	swt-draw-custom-tab-content-background: true;
-	swt-unselected-hot-tab-color-background: #48484c;
+	swt-unselected-hot-tab-color-background: #161616;
 }
 
 CTabFolder{

--- a/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
@@ -178,6 +178,8 @@ CTabFolder Canvas {
     swt-selected-highlight-top: true;	
 	swt-tab-outline:#eaeaea; 
 	swt-tab-outer-keyline: #eaeaea;
+	swt-draw-custom-tab-content-background: true;
+	swt-unselected-hot-tab-color-background:'#FFFFFF';
 }
 
 #org-eclipse-ui-editorss CTabFolder.active {

--- a/bundles/org.eclipse.ui.themes/css/e4_default_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_win.css
@@ -179,6 +179,8 @@ CTabFolder Canvas {
     swt-selected-highlight-top: true;	
 	swt-tab-outline:#e5e5e5; 
 	swt-tab-outer-keyline: #e5e5e5;
+	swt-draw-custom-tab-content-background: true;
+	swt-unselected-hot-tab-color-background:'#FFFFFF';
 }
 
 #org-eclipse-ui-editorss CTabFolder.active {

--- a/bundles/org.eclipse.ui.themes/css/light/e4-light_tabstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/light/e4-light_tabstyle.css
@@ -30,7 +30,7 @@
 	padding: 0px;
 	color: '#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR';
 	swt-draw-custom-tab-content-background: true;
-	swt-unselected-hot-tab-color-background:'#org-eclipse-ui-workbench-ACTIVE_TAB_BG_START';
+	swt-unselected-hot-tab-color-background:#EAEAEA;
 }
 
 .MPartStack.active {


### PR DESCRIPTION
Hover indicators are included in both Dark and Light theme for unselected tabs in views and editors.
Light theme,
Editor tab's hover color is set to white 
View tab's hover color is set to darker grey

Dark Theme,
Both Editor and View tab's hover color is set to darker black

Please find the details of this issue reported in https://github.com/eclipse-platform/eclipse.platform.ui/issues/2114
