### PR TITLE
fix LineHeaderCodeMining redraw logic on empty lines

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/AnnotationPainter.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/AnnotationPainter.java
@@ -1413,7 +1413,12 @@ public class AnnotationPainter implements IPainter, PaintListener, IAnnotationMo
 				int paintStart= Math.max(lineOffset, p.getOffset());
 				String lineDelimiter= document.getLineDelimiter(i);
 				int delimiterLength= lineDelimiter != null ? lineDelimiter.length() : 0;
-				int paintLength= Math.min(lineOffset + document.getLineLength(i) - delimiterLength, p.getOffset() + p.getLength()) - paintStart;
+				int lineLengthWithoutDelimiter= document.getLineLength(i) - delimiterLength;
+				int paintLength= Math.min(lineOffset + lineLengthWithoutDelimiter, p.getOffset() + p.getLength()) - paintStart;
+				if (paintLength == 0 && lineDelimiter != null && lineDelimiter.length() > 0) {
+					// textWidget.redrawRange with length 0 is ignored and no redraw takes place
+					paintLength= lineDelimiter.length();
+				}
 				if (paintLength >= 0 && regionsTouchOrOverlap(paintStart, paintLength, clippingOffset, clippingLength)) {
 					// otherwise inside a line delimiter
 					IRegion widgetRange= getWidgetRange(paintStart, paintLength);

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineContentAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineContentAnnotation.java
@@ -159,7 +159,7 @@ public class LineContentAnnotation extends AbstractInlinedAnnotation {
 	}
 
 	static boolean drawRightToPreviousChar(int widgetOffset, StyledText textWidget) {
-		return widgetOffset > 0 &&
+		return widgetOffset > 0 && widgetOffset < textWidget.getCharCount() &&
 				textWidget.getLineAtOffset(widgetOffset) == textWidget.getLineAtOffset(widgetOffset - 1);
 	}
 

--- a/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,8 @@ Bundle-SymbolicName: org.eclipse.ui.editors.tests;singleton:=true
 Bundle-Version: 3.13.500.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
-Export-Package: org.eclipse.ui.editors.tests,
+Export-Package: org.eclipse.jface.text.tests.codemining,
+ org.eclipse.ui.editors.tests,
  org.eclipse.ui.internal.texteditor.stickyscroll
 Require-Bundle: 
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/tests/org.eclipse.ui.editors.tests/plugin.xml
+++ b/tests/org.eclipse.ui.editors.tests/plugin.xml
@@ -16,4 +16,10 @@
 			extensions="testfile">
 		</provider>
 	</extension>
+	<extension point="org.eclipse.ui.workbench.texteditor.codeMiningProviders">
+		<codeMiningProvider
+			class="org.eclipse.jface.text.tests.codemining.CodeMiningTestProvider"
+			id="org.eclipse.jface.text.tests.codemining.CodeMiningTestProvider">
+		</codeMiningProvider>
+	</extension>
 </plugin>

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningTest.java
@@ -1,0 +1,293 @@
+/*******************************************************************************
+ * Copyright (c) 2024 SAP
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jface.text.tests.codemining;
+
+import java.io.ByteArrayInputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.concurrent.Callable;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Display;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.resources.ResourcesPlugin;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.jface.text.source.ISourceViewerExtension5;
+
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.IDE;
+
+public class CodeMiningTest {
+	private static String PROJECT_NAME = "test_" + new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+
+	private static IProject project;
+
+	@BeforeClass
+	public static void beforeClass() throws Exception {
+		hideWelcomePage();
+		createProject(PROJECT_NAME);
+	}
+
+	@AfterClass
+	public static void afterClass() throws Exception {
+		if (project != null)
+			project.delete(true, new NullProgressMonitor());
+	}
+
+	@After
+	public void after() {
+		closeAllEditors();
+		drainEventQueue();
+		CodeMiningTestProvider.provideContentMiningAtOffset = -1;
+		CodeMiningTestProvider.provideHeaderMiningAtLine = -1;
+	}
+
+	private static void closeAllEditors() {
+		IWorkbenchWindow[] windows = PlatformUI.getWorkbench().getWorkbenchWindows();
+		for (IWorkbenchWindow window : windows) {
+			for (IWorkbenchPage page : window.getPages()) {
+				page.closeAllEditors(false);
+			}
+		}
+	}
+
+	private static void createProject(String projectName) throws Exception {
+		project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+		if (project.exists()) {
+			project.delete(true, true, new NullProgressMonitor());
+		}
+		ResourcesPlugin.getWorkspace().run(new IWorkspaceRunnable() {
+
+			@Override
+			public void run(IProgressMonitor monitor) throws CoreException {
+				project.create(monitor);
+				project.open(monitor);
+			}
+
+		}, new NullProgressMonitor());
+	}
+
+	@Test
+	public void testCodeMiningOnEmptyLine() throws Exception {
+		IFile file = project.getFile("test.txt");
+		if (file.exists()) {
+			file.delete(true, new NullProgressMonitor());
+		}
+		String source = "first line\n" + //
+				"\n" + //
+				"third line\n";
+		file.create(new ByteArrayInputStream(source.getBytes("UTF-8")), true, new NullProgressMonitor());
+		IEditorPart editor = IDE.openEditor(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), file);
+		drainEventQueue();
+		ISourceViewer viewer = (ISourceViewer) editor.getAdapter(ITextViewer.class);
+		StyledText widget = viewer.getTextWidget();
+		Assert.assertTrue("line content mining not available",
+				waitForCondition(widget.getDisplay(), 1000, new Callable<Boolean>() {
+					@Override
+					public Boolean call() throws Exception {
+						return widget.getStyleRangeAtOffset(0) != null
+								&& widget.getStyleRangeAtOffset(0).metrics != null;
+					}
+				}));
+		drainEventQueue();
+
+		CodeMiningTestProvider.provideHeaderMiningAtLine = 1;
+		((ISourceViewerExtension5) viewer).updateCodeMinings();
+
+		Assert.assertTrue("Code mining not drawn at empty line after calling updateCodeMinings",
+				waitForCondition(widget.getDisplay(), 2000, new Callable<Boolean>() {
+					@Override
+					public Boolean call() throws Exception {
+						try {
+							return existsPixelWithNonBackgroundColorAtLine(viewer, 1);
+						} catch (BadLocationException e) {
+							e.printStackTrace();
+							return false;
+						}
+					}
+				}));
+	}
+
+	@Test
+	public void testCodeMiningAtEndOfLine() throws Exception {
+		IFile file = project.getFile("test.txt");
+		if (file.exists()) {
+			file.delete(true, new NullProgressMonitor());
+		}
+		String firstPart = "first line\n" + //
+				"second line";
+		String secondPart = "\n" + //
+				"third line\n";
+		String source = firstPart + secondPart;
+		file.create(new ByteArrayInputStream(source.getBytes("UTF-8")), true, new NullProgressMonitor());
+		IEditorPart editor = IDE.openEditor(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), file);
+		drainEventQueue();
+		ISourceViewer viewer = (ISourceViewer) editor.getAdapter(ITextViewer.class);
+		StyledText widget = viewer.getTextWidget();
+		Assert.assertTrue("line content mining not available",
+				waitForCondition(widget.getDisplay(), 1000, new Callable<Boolean>() {
+					@Override
+					public Boolean call() throws Exception {
+						return widget.getStyleRangeAtOffset(0) != null
+								&& widget.getStyleRangeAtOffset(0).metrics != null;
+					}
+				}));
+		drainEventQueue();
+
+		CodeMiningTestProvider.provideContentMiningAtOffset = firstPart.length();
+		((ISourceViewerExtension5) viewer).updateCodeMinings();
+
+		Assert.assertTrue("Code mining not drawn at the end of second line after calling updateCodeMinings",
+				waitForCondition(widget.getDisplay(), 2000, new Callable<Boolean>() {
+					@Override
+					public Boolean call() throws Exception {
+						try {
+							return existsPixelWithNonBackgroundColorAtEndOfLine(viewer, 1);
+						} catch (BadLocationException e) {
+							e.printStackTrace();
+							return false;
+						}
+					}
+				}));
+	}
+
+	private void drainEventQueue() {
+		while (Display.getDefault().readAndDispatch()) {
+		}
+	}
+
+	private static void hideWelcomePage() {
+		IWorkbenchPage ap = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+		ap.hideView(ap.findViewReference("org.eclipse.ui.internal.introview"));
+	}
+
+	private static boolean existsPixelWithNonBackgroundColorAtLine(ITextViewer viewer, int line)
+			throws BadLocationException {
+		StyledText widget = viewer.getTextWidget();
+		IDocument document = viewer.getDocument();
+		String delim = document.getLineDelimiter(line);
+		int delimLen = 0;
+		if (delim != null) {
+			delimLen = delim.length();
+		}
+		int lineLength = document.getLineLength(line) - delimLen;
+		if (lineLength < 0) {
+			lineLength = 0;
+		}
+		int verticalScroolBarWidth = viewer.getTextWidget().getVerticalBar().getThumbBounds().width;
+		Rectangle lineBounds = widget.getTextBounds(document.getLineOffset(line),
+				document.getLineOffset(line) + lineLength);
+		Image image = new Image(widget.getDisplay(), widget.getSize().x, widget.getSize().y);
+		try {
+			GC gc = new GC(widget);
+			gc.copyArea(image, 0, 0);
+			gc.dispose();
+			ImageData imageData = image.getImageData();
+			for (int x = lineBounds.x + 1; x < image.getBounds().width - verticalScroolBarWidth
+					&& x < imageData.width - verticalScroolBarWidth; x++) {
+				for (int y = lineBounds.y; y < lineBounds.y + lineBounds.height; y++) {
+					if (!imageData.palette.getRGB(imageData.getPixel(x, y)).equals(widget.getBackground().getRGB())) {
+						return true;
+					}
+				}
+			}
+		} finally {
+			image.dispose();
+		}
+		return false;
+	}
+
+	private static boolean existsPixelWithNonBackgroundColorAtEndOfLine(ITextViewer viewer, int line)
+			throws BadLocationException {
+		StyledText widget = viewer.getTextWidget();
+		IDocument document = viewer.getDocument();
+		int verticalScroolBarWidth = viewer.getTextWidget().getVerticalBar().getThumbBounds().width;
+		int lineOffset = document.getLineOffset(line);
+		String lineStr = document.get(lineOffset,
+				document.getLineLength(line) - document.getLineDelimiter(line).length());
+		Rectangle lineBounds = widget.getTextBounds(lineOffset, lineOffset);
+		Image image = new Image(widget.getDisplay(), widget.getSize().x, widget.getSize().y);
+		try {
+			GC gc = new GC(widget);
+			gc.copyArea(image, 0, 0);
+			Point textExtent = gc.textExtent(lineStr);
+			lineBounds.x += textExtent.x;
+			gc.dispose();
+			ImageData imageData = image.getImageData();
+			for (int x = lineBounds.x + 1; x < image.getBounds().width - verticalScroolBarWidth
+					&& x < imageData.width - verticalScroolBarWidth; x++) {
+				for (int y = lineBounds.y; y < lineBounds.y + lineBounds.height; y++) {
+					if (!imageData.palette.getRGB(imageData.getPixel(x, y)).equals(widget.getBackground().getRGB())) {
+						return true;
+					}
+				}
+			}
+		} finally {
+			image.dispose();
+		}
+		return false;
+	}
+
+	private final boolean waitForCondition(Display display, long timeout, Callable<Boolean> condition)
+			throws Exception {
+		// if the condition already holds, succeed
+		if (condition.call()) {
+			return true;
+		}
+		if (timeout < 0) {
+			return false;
+		}
+		drainEventQueue();
+		if (condition.call()) {
+			return true;
+		}
+		if (timeout == 0) {
+			return false;
+		}
+		// repeatedly sleep until condition becomes true or timeout elapses
+		long start = System.currentTimeMillis();
+		long diff = timeout;
+		Boolean cond = false;
+		do {
+			if (display.sleep()) {
+				drainEventQueue();
+			}
+			cond = condition.call();
+			diff = System.currentTimeMillis() - start;
+		} while (!cond && diff < timeout);
+		return cond;
+	}
+}

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningTestProvider.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningTestProvider.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2024 SAP
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jface.text.tests.codemining;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.codemining.AbstractCodeMining;
+import org.eclipse.jface.text.codemining.AbstractCodeMiningProvider;
+import org.eclipse.jface.text.codemining.ICodeMining;
+import org.eclipse.jface.text.codemining.ICodeMiningProvider;
+import org.eclipse.jface.text.codemining.LineContentCodeMining;
+import org.eclipse.jface.text.codemining.LineHeaderCodeMining;
+
+public class CodeMiningTestProvider extends AbstractCodeMiningProvider {
+	public static int provideHeaderMiningAtLine = -1;
+	public static int provideContentMiningAtOffset = -1;
+
+	@Override
+	public CompletableFuture<List<? extends ICodeMining>> provideCodeMinings(ITextViewer viewer,
+			IProgressMonitor monitor) {
+		try {
+			List<ICodeMining> minings = new ArrayList<>();
+			// used as indication when the code minings are finished with
+			// drawing - widget.getStyleRangeAtOffset(0).metrics
+			minings.add(new StaticContentLineCodeMining(new Position(1, 1), "mining", this));
+			if (provideHeaderMiningAtLine >= 0) {
+				minings.add(new LineHeaderCodeMining(provideHeaderMiningAtLine, viewer.getDocument(), this) {
+					@Override
+					public String getLabel() {
+						return "line header mining";
+					}
+				});
+			}
+			if (provideContentMiningAtOffset >= 0) {
+				minings.add(new AbstractCodeMining(new Position(provideContentMiningAtOffset, 1), this, null) {
+					@Override
+					public String getLabel() {
+						return "Content mining";
+					}
+				});
+			}
+			return CompletableFuture.completedFuture(minings);
+		} catch (BadLocationException e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	private static final class StaticContentLineCodeMining extends LineContentCodeMining {
+
+		public StaticContentLineCodeMining(Position position, String message, ICodeMiningProvider provider) {
+			super(position, provider);
+			setLabel(message);
+		}
+
+		public StaticContentLineCodeMining(int i, char c, ICodeMiningProvider repeatLettersCodeMiningProvider) {
+			super(new Position(i, 1), repeatLettersCodeMiningProvider);
+			setLabel(Character.toString(c));
+		}
+
+		@Override
+		public boolean isResolved() {
+			return true;
+		}
+	}
+}

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/EditorsTestSuite.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/EditorsTestSuite.java
@@ -19,6 +19,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import org.eclipse.jface.text.tests.codemining.CodeMiningTest;
+
 import org.eclipse.ui.internal.texteditor.stickyscroll.StickyLinesProviderTest;
 import org.eclipse.ui.internal.texteditor.stickyscroll.StickyScrollingControlTest;
 import org.eclipse.ui.internal.texteditor.stickyscroll.StickyScrollingHandlerTest;
@@ -48,6 +50,8 @@ import org.eclipse.ui.internal.texteditor.stickyscroll.StickyScrollingHandlerTes
 		StickyScrollingControlTest.class,
 		StickyScrollingHandlerTest.class,
 		StickyLinesProviderTest.class,
+
+		CodeMiningTest.class,
 })
 public class EditorsTestSuite {
 	// see @SuiteClasses


### PR DESCRIPTION
LineHeaderCodeMinings on empty lines were not drawn after calling ISourceViewerExtension5#updateCodeMinings.
Reason: InlinedAnnotationDrawingStrategy#draw triggered call StyledText#redrawRange with length = 0 which is ignored by SWT and no redraw event was triggered



CodeMiningPdeTest is documenting the problem scenario. It opens a plain text editor and the registered provider org.eclipse.jface.text.tests.codemining.CodeMiningTestProvider wants to contribute code minings. 
The StaticContentLineCodeMining at line 1, column 1 with label 'mining' will be immediately rendered when the text editor is opened. It is used as indication in the unit test to verify that the text editor is opened and the code minings are all loaded and rendered properly.

![pde_test_1](https://github.com/user-attachments/assets/1140238d-cefa-4271-b54b-55b2be7c7dfa)

Afterwards the global variable ```CodeMiningTestProvider.provideLineHeaderMining= true;``` is set which lets the provider also return a LineHeaderCodeMining at the second line. The second line has no text and is empty (there is only one \n character).
The unit test is then calling```((ISourceViewerExtension5) viewer).updateCodeMinings();``` with the goal to make the additional LineHeaderCodeMining visible.

![pde_test_2](https://github.com/user-attachments/assets/59bd8d08-d0bb-4428-ba14-c65ab8af034d)

This was not working before and this pull request will fix the scenario.

I hope you can follow the explanation and understand how this pull request wants to fix this scenario.
The redrawRange call in org.eclipse.jface.text.source.inlined.InlinedAnnotationDrawingStrategy did not trigger a repaint event when length has value 0. The pull request sets the length value to the line delimiter length (value 1 in in the unit test)
```
textWidget.redrawRange(offset, length, true);
```

One question to the PDE test. Is it ok to add an additional PDE test in org.eclipse.jface.text.tests? I needed to add a dependency to the plugins org.eclipse.core.resources and org.eclipse.ui.ide so that the text editor could be opened in the unit test. Is that ok? 