### PR TITLE
[e4] Improve User Experience for saving a single part

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/internal/workbench/renderers/swt/SWTRenderersMessages.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/internal/workbench/renderers/swt/SWTRenderersMessages.java
@@ -24,6 +24,10 @@ public class SWTRenderersMessages extends NLS {
 
 	public static String choosePartsToSaveTitle;
 	public static String choosePartsToSave;
+	public static String choosePartsToSave_Button_Save;
+	public static String choosePartsToSave_Button_Cancel;
+	public static String choosePartsToSave_Button_Dont_Save;
+	public static String saveSingleChangesQuestionTitle;
 
 	public static String menuClose;
 	public static String menuCloseOthers;

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/internal/workbench/renderers/swt/messages.properties
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/internal/workbench/renderers/swt/messages.properties
@@ -16,6 +16,10 @@
 
 choosePartsToSaveTitle=Save Parts
 choosePartsToSave=Select the parts to save:
+choosePartsToSave_Button_Save=&Save
+choosePartsToSave_Button_Cancel=Cancel
+choosePartsToSave_Button_Dont_Save=Do&n't Save
+saveSingleChangesQuestionTitle=Save ''{0}''?
 menuClose = &Close
 menuCloseOthers = Close &Others
 menuCloseAll = Close &All


### PR DESCRIPTION
Currently when a single part is saved this gives a very bad user experience as the user has to choose from a (single element) checkbox list with option [OK] and [CANCEL], but to *not* save the part one has to uncheck that part and then press [OK].

![grafik](https://github.com/user-attachments/assets/b41785a7-b10b-45e1-a792-3b98f7fcf632)


This now enhances the case of single element to asking the user with a simple dialog and the choice to [SAVE] / [DON'T SAVE] / [CANCEL] how it is done for the IDE with the e3 editors.

![grafik](https://github.com/user-attachments/assets/3621d3ff-af62-4b4a-8430-2c40a1105ff7)


**Please note:** One won't notice that in an Eclipse IDE itself because in this case a different implementation is used (that already has this behavior) if a compatibility part is shown and almost all Editors in Eclipse are such compatibility parts.