### PR TITLE
Use DS annotations instead of handcrafted XML

### DIFF
--- a/bundles/org.eclipse.search/.project
+++ b/bundles/org.eclipse.search/.project
@@ -25,6 +25,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>

--- a/bundles/org.eclipse.search/.settings/org.eclipse.pde.ds.annotations.prefs
+++ b/bundles/org.eclipse.search/.settings/org.eclipse.pde.ds.annotations.prefs
@@ -1,0 +1,7 @@
+dsVersion=V1_4
+eclipse.preferences.version=1
+enabled=true
+generateBundleActivationPolicyLazy=true
+path=OSGI-INF
+validationErrorLevel=error
+validationErrorLevel.missingImplicitUnbindMethod=error

--- a/bundles/org.eclipse.search/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.search/META-INF/MANIFEST.MF
@@ -30,6 +30,6 @@ Require-Bundle:
  org.eclipse.ltk.core.refactoring;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ltk.ui.refactoring;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.search.core;bundle-version="[3.16.0,4.0.0)";visibility:=reexport
+Service-Component: OSGI-INF/org.eclipse.search.ui.dirtyEditorSearchParticipant.xml
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.search
-Service-Component: OSGI-INF/*.xml

--- a/bundles/org.eclipse.search/OSGI-INF/dirtyEditorService.xml
+++ b/bundles/org.eclipse.search/OSGI-INF/dirtyEditorService.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" enabled="true" immediate="false" name="org.eclipse.search.ui.dirtyEditorSearchParticipant">
-   <implementation class="org.eclipse.search.internal.ui.text.DirtyFileSearchParticipant"/>
-   <service>
-      <provide interface="org.eclipse.search.internal.core.text.DirtyFileProvider"/>
-   </service>
-   <property name="weight" type="Integer" value="100"/>
-</scr:component>

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/text/DirtyFileSearchParticipant.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/text/DirtyFileSearchParticipant.java
@@ -16,6 +16,8 @@ package org.eclipse.search.internal.ui.text;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.osgi.service.component.annotations.Component;
+
 import org.eclipse.core.resources.IFile;
 
 import org.eclipse.core.filebuffers.FileBuffers;
@@ -38,6 +40,7 @@ import org.eclipse.ui.texteditor.ITextEditor;
 
 import org.eclipse.search.internal.core.text.DirtyFileProvider;
 
+@Component(service = DirtyFileProvider.class, name = "org.eclipse.search.ui.dirtyEditorSearchParticipant", property = "weight:Integer=100")
 public class DirtyFileSearchParticipant implements DirtyFileProvider {
 
 	@Override


### PR DESCRIPTION
This also fixes a build warning due to usage of wildcard pattern for components, I don't see any reason to use a wildcard here.

Beside that, weight = 100 seems strange here as usually one would use a service ranking instead but I have leave this as-is for now.

FYI @robstryker 