### PR TITLE
Find/replace overlay: invert keyboard navigation direction for history

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
@@ -69,7 +69,7 @@ public class HistoryTextWrapper extends Composite {
 	private void listenForKeyboardHistoryNavigation() {
 		addKeyListener(KeyListener.keyPressedAdapter(e -> {
 			if (e.keyCode == SWT.ARROW_UP || e.keyCode == SWT.ARROW_DOWN) {
-				int stepDirection = e.keyCode == SWT.ARROW_UP ? 1 : -1;
+				int stepDirection = e.keyCode == SWT.ARROW_UP ? -1 : 1;
 				navigateInHistory(stepDirection);
 			}
 		}));


### PR DESCRIPTION
To navigate through the history of searches in the find/replace overlay via keyboard buttons, you currently have to press the "up" button for moving "downwards" in the history (i.e., from the most recent to the oldest search input) and "up" for the opposite direction. This is counter-intuitive, as it is the opposite direction of what you expect from the entry order in this drop-down menu of the history entries. In particular, one would usually expect to move to the most recent search input via the "down" button while you currently have to press the "up" button.

This change inverts the keyboard navigation direction for the search history.

As proposed by @HannesWell: https://github.com/eclipse-platform/eclipse.platform.ui/pull/1990#issuecomment-2253140609