### PR TITLE
Find/replace overlay: asynchronously update on editor movement #2138

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -195,18 +195,23 @@ public class FindReplaceOverlay extends Dialog {
 	private ControlListener shellMovementListener = new ControlListener() {
 		@Override
 		public void controlMoved(ControlEvent e) {
-			if (getShell() != null) {
-				getShell().getDisplay().asyncExec(() -> updatePlacementAndVisibility());
-			}
+			asyncUpdatePlacementAndVisibility();
 		}
 
 		@Override
 		public void controlResized(ControlEvent e) {
-			if (getShell() != null) {
-				getShell().getDisplay().asyncExec(() -> updatePlacementAndVisibility());
-			}
+			asyncUpdatePlacementAndVisibility();
 		}
 	};
+
+	private PaintListener widgetMovementListener = __ -> asyncUpdatePlacementAndVisibility();
+
+	private void asyncUpdatePlacementAndVisibility() {
+		Shell shell = getShell();
+		if (shell != null) {
+			shell.getDisplay().asyncExec(this::updatePlacementAndVisibility);
+		}
+	}
 
 	private ShellAdapter overlayDeactivationListener = new ShellAdapter() {
 		@Override
@@ -219,8 +224,6 @@ public class FindReplaceOverlay extends Dialog {
 			removeSearchScope();
 		}
 	};
-
-	private PaintListener widgetMovementListener = __ -> updatePlacementAndVisibility();
 
 	private static class TargetPartVisibilityHandler implements IPartListener2, IPageChangedListener {
 		private final IWorkbenchPart targetPart;
@@ -926,11 +929,16 @@ public class FindReplaceOverlay extends Dialog {
 	}
 
 	private void updateVisibility(Rectangle targetControlBounds, Rectangle overlayBounds) {
+		boolean shallBeVisible = true;
 		if (positionAtTop) {
-			getShell().setVisible(
-					overlayBounds.y + overlayBounds.height <= targetControlBounds.y + targetControlBounds.height);
+			shallBeVisible = overlayBounds.y + overlayBounds.height <= targetControlBounds.y
+					+ targetControlBounds.height;
 		} else {
-			getShell().setVisible(overlayBounds.y >= targetControlBounds.y);
+			shallBeVisible = overlayBounds.y >= targetControlBounds.y;
+		}
+		Shell shell = getShell();
+		if (shallBeVisible != shell.isVisible()) {
+			shell.setVisible(shallBeVisible);
 		}
 	}
 


### PR DESCRIPTION
The update of the find/replace overlay placement and size while a repaint for its target editor is being processed (e.g., in order to handle minimizing/maximizing the target editor) is currently executed just-in-time. Other updates, reacting to movements and resizes of the shell, are processed asynchronously. The just-in-time execution leads to deadlocks on GTK.

With this change, all update operations for the size and position of the overlay are performed via asynchronous executions scheduled via the Display.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2138