### PR TITLE
Refresh ImageBasedFrame on ZoomChange of control

### DIFF
--- a/bundles/org.eclipse.e4.ui.widgets/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.widgets/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.e4.ui.widgets
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.e4.ui.widgets;x-friends:="org.eclipse.e4.ui.workbench.swt,org.eclipse.e4.ui.workbench.addons.swt"
 Require-Bundle: org.eclipse.swt;bundle-version="[3.6.0,4.0.0)"

--- a/bundles/org.eclipse.e4.ui.widgets/src/org/eclipse/e4/ui/widgets/ImageBasedFrame.java
+++ b/bundles/org.eclipse.e4.ui.widgets/src/org/eclipse/e4/ui/widgets/ImageBasedFrame.java
@@ -66,6 +66,10 @@ public class ImageBasedFrame extends Canvas {
 			ImageBasedFrame frame = (ImageBasedFrame) event.widget;
 			frame.setCursor(null);
 		});
+		toWrap.addListener(SWT.ZoomChanged, event -> {
+			toWrap.pack(true);
+			setFramedControlLocation();
+		});
 
 		addMouseMoveListener(e -> {
 			// Compute the display location for the handle


### PR DESCRIPTION
This commit adds a listener for the ZoomChanged event to the wrapped control of an ImageBasedFrame. If the listener is notified of this event this means, that the size and position of the wrapped control could be changed due to the zoom change. Therefor, the control is packed and repositioned. 

## How to test
The event is currently thrown for wrapped controls only in win32 with "swt.autoScale.updateOnRuntime"-flag set to true. For the other OS the event will not be thrown for this control in any case to my knowledge.

@HeikoKlare Can you have a look at my change and test it?

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/131