### PR TITLE
Fix- Background color for gutter line in editor

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
@@ -111,3 +111,7 @@ CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
 {
 	background-color: #1E1F22;
 }
+
+#org-eclipse-e4-ui-compatibility-editor Composite{
+	background-color: #1e1f22;
+}

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
@@ -193,3 +193,7 @@ CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
 {
 	background-color: #1E1F22;
 }
+
+#org-eclipse-e4-ui-compatibility-editor Composite{
+	background-color: #1e1f22;
+}


### PR DESCRIPTION
Implementing fix for gutter line background change in dark theme for Win and Mac.
Ref 4th issue reported in https://github.com/eclipse-platform/eclipse.platform.ui/issues/2114#issue-2418424128

![image](https://github.com/user-attachments/assets/334d903c-ae16-4e8f-b911-8e44dfd58305)

![image](https://github.com/user-attachments/assets/f99239be-dd78-4629-8bd1-ba987420a5e6)





Was able to fix only this part (strip next to vertical scroll bar) of the editor. Unable to change the gutter line background. It works when I change via CSS spy but not via css file. Any suggestions on this ?