### PR TITLE
[Sticky Scrolling] Don't scroll if caret offset is not in the text range

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -508,15 +508,15 @@ public class StickyScrollingControl {
 
 		@Override
 		public void caretMoved(CaretEvent event) {
-			int offsetEndPosition= sourceViewer.getTextWidget().getText().length();
+			int offsetEndPosition= sourceViewer.getTextWidget().getCharCount();
 			if (event.caretOffset == 0 || event.caretOffset == offsetEndPosition) {
 				return;
 			}
 			Display.getDefault().asyncExec(() -> {
-				if (!enableCaretListener) {
+				StyledText textWidget= sourceViewer.getTextWidget();
+				if (!enableCaretListener || event.caretOffset > textWidget.getCharCount()) {
 					return;
 				}
-				StyledText textWidget= sourceViewer.getTextWidget();
 				int line= textWidget.getLineAtOffset(event.caretOffset);
 				if (sourceViewer instanceof ITextViewerExtension5 extension) {
 					line= extension.widgetLine2ModelLine(line);

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
@@ -268,7 +268,7 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testListenForCarretAfterKeyDown() {
+	public void testListenForCaretAfterKeyDown() {
 		// set height to 10 so that scrolling is needed
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 10);
 		String text = """
@@ -315,7 +315,7 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testDontMoveCaretAtDocumentEnd() {
+	public void testDontScrollOnCaretAtDocumentEnd() {
 		// set height to 10 so that scrolling is needed
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 10);
 		String text = """
@@ -333,6 +333,32 @@ public class StickyScrollingControlTest {
 
 		sourceViewer.getTextWidget().notifyListeners(SWT.KeyDown, new Event());
 		sourceViewer.getTextWidget().setCaretOffset(62);
+
+		drainDisplayEventQueue();
+		assertEquals(0, sourceViewer.getTextWidget().getTopPixel());
+	}
+
+	@Test
+	public void testDontScrollOnCaretWhenDocumentChangedBeforeExecution() {
+		// set height to 10 so that scrolling is needed
+		sourceViewer.getTextWidget().setBounds(0, 0, 200, 10);
+		String text = """
+				line 1
+				line 2
+				line 3
+				line 4
+				line 5
+				line 6
+				line 7
+				line 8
+				line 9""";
+		sourceViewer.setInput(new Document(text));
+		assertEquals(0, sourceViewer.getTextWidget().getTopPixel());
+		sourceViewer.getTextWidget().notifyListeners(SWT.KeyDown, new Event());
+		sourceViewer.getTextWidget().setCaretOffset(62);
+
+		// change document before event queue is drained
+		sourceViewer.setInput(new Document("line"));
 
 		drainDisplayEventQueue();
 		assertEquals(0, sourceViewer.getTextWidget().getTopPixel());


### PR DESCRIPTION
The scrolling based on caret movement is done in a asynchronous task to keep the impact on the UI thread as low as possible. If the source viewer document is changed between caret movement and execution of the scrolling, it can happen that the offset is not in the text range any longer. In this case, scrolling is not done.

Fixes #2127