### PR TITLE
Border for selected tab in views - Win and Mac

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
@@ -38,7 +38,7 @@ ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_OUTER_KEYLINE_COLOR {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_OUTLINE_COLOR {
-	color: #f8f8f8;
+	color: #EAEAEA;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_BG_START {
@@ -54,7 +54,7 @@ ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_OUTER_KEYLINE_COLOR {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_OUTLINE_COLOR {
-	color: #f8f8f8;
+	color: #EAEAEA;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_BG_START {

--- a/bundles/org.eclipse.ui.themes/css/e4_default_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_win.css
@@ -31,7 +31,7 @@ ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_OUTER_KEYLINE_COLOR {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_OUTLINE_COLOR {
-	color: #f8f8f8;
+	color: #E5E5E5;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_UNSELECTED_TABS_COLOR_START {
@@ -47,7 +47,7 @@ ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_OUTER_KEYLINE_COLOR {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_OUTLINE_COLOR {
-	color: #f8f8f8;
+	color: #E5E5E5;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_BG_START {


### PR DESCRIPTION
Missing border for selected tab in views. This is mostly visible when only one tab is selected per stack. This change also fixes issues reported w.r.t to the horizontal separator between view header and content. Also, vertical separation between tabs.
Changes are done for Mac and Win. For linux it is part of PR  - https://github.com/eclipse-platform/eclipse.platform.ui/pull/2137

Find the before and after image in windows
![image](https://github.com/user-attachments/assets/42940929-9104-4179-9312-3903bc4f1982)

![image](https://github.com/user-attachments/assets/9f72bebe-2c3a-4638-80e2-e30018a5cd22)
