### PR TITLE
Fix for background color of some views like Types, Console etc

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
@@ -151,12 +151,16 @@ CTabFolder Canvas {
 .View StyledText[style~='SWT.READ_ONLY'],
 .View Link,
 .View FormText,
-.View Hyperlink
+.View Hyperlink,
+.View Canvas,
+.View FigureCanvas,
+.View Table
 {
 	background-color: #f8f8f8;
 }
 
 .View ToolItem,
+.View PageBook StyledText,
 .View Button{
 	background-color: inherit;
 }

--- a/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
@@ -101,8 +101,7 @@ CTabFolder Canvas {
   background-color: rgb(255, 255, 255);
 }
 
-/* Below changes were added to enhance the appearance of Light theme with ref to other IDEs like VS Code,IntelliJ etc. */  
-  
+ 
 .MTrimBar#org-eclipse-ui-trim-status {
 	background-color: '#f8f8f8';
 
@@ -124,12 +123,15 @@ CTabFolder Canvas {
 .View Link,
 .View FormText,
 .View Hyperlink,
-.View AtcProblemsViewWelcomePage StyledText
+.View Canvas,
+.View FigureCanvas,
+.View Table
 {
 	background-color: #f8f8f8;
 }
 
 .View ToolItem,
+.View PageBook StyledText,
 .View Button{
 	background-color: inherit;
 }
@@ -140,12 +142,9 @@ CTabFolder Canvas {
 
 .View Composite PrependingAsteriskFilteredTree,
 .View PrependingAsteriskFilteredTree Text,
-.View LoggingViewFilteredTree,
-.View LoggingViewFilteredTree Text,
 .View Group Text,
 .View Group Combo,
 .View Composite Text,
-.View OSLPackageSetTableComposite Label,
 .View Button[style~='SWT.PUSH']{
 	background-color: #ffffff;
 }
@@ -218,8 +217,7 @@ Composite.MArea{
 .MPart Form Label,
 .MPart Form Text,
 .MPart Form Button,
-.MPart Form Sash,
-.MPart Form AdtFormToolkit-AdtHyperLink
+.MPart Form Sash
 {
 	background-color: '#FFFFFF';
 }
@@ -229,8 +227,7 @@ Composite.MArea{
 .MPartStack.active .MPart Form Label,
 .MPartStack.active .MPart Form Text,
 .MPartStack.active .MPart Form Button,
-.MPartStack.active .MPart Form Sash,
-.MPartStack.active .MPart Form AdtFormToolkit-AdtHyperLink
+.MPartStack.active .MPart Form Sash
 {
 	background-color: '#FFFFFF';
 }

--- a/bundles/org.eclipse.ui.themes/css/e4_default_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_win.css
@@ -103,8 +103,6 @@ CTabFolder Canvas {
 	background-color: #ffffff;
 }
 
-/* Below changes were added to enhance the appearance of Light theme with ref to other IDEs like VS Code,IntelliJ etc. */
-
 .MTrimBar#org-eclipse-ui-main-toolbar {
 	background-color: '#f8f8f8';
 }
@@ -128,12 +126,16 @@ CTabFolder Canvas {
 .View StyledText[style~='SWT.READ_ONLY'],
 .View Link,
 .View FormText,
-.View Hyperlink
+.View Hyperlink,
+.View Canvas,
+.View FigureCanvas,
+.View Table
 {
 	background-color: #f8f8f8;
 }
 
 .View ToolItem,
+.View PageBook StyledText,
 .View Button{
 	background-color: inherit;
 }


### PR DESCRIPTION
Implementing fix for background color change to some of the views like Console View, Types View etc.
Background color of these views was white, with this change it has been changed to grey(#f8f8f8) to harmonize with other views.
Refer  https://github.com/eclipse-platform/eclipse.platform.ui/issues/2114#issue-2418424128 -  "Types" view does not have a grey background. Fix has been provided in Mac, Win and Linux.

![image](https://github.com/user-attachments/assets/0fde3457-9b25-4a52-99da-5282f8f9bf1d)

![image](https://github.com/user-attachments/assets/428e75f0-a774-4d3a-b53b-09852a6735ca)
