### PR TITLE
Find/replace overlay: avoid exception in target without scrollbars #2147

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -42,6 +42,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.ScrollBar;
 import org.eclipse.swt.widgets.Scrollable;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
@@ -899,8 +900,14 @@ public class FindReplaceOverlay extends Dialog {
 		int width = localControlBounds.width;
 		int height = localControlBounds.height;
 		if (control instanceof Scrollable scrollable) {
-			width -= scrollable.getVerticalBar().getSize().x;
-			height -= scrollable.getHorizontalBar().getSize().y;
+			ScrollBar verticalBar = scrollable.getVerticalBar();
+			ScrollBar horizontalBar = scrollable.getHorizontalBar();
+			if (verticalBar != null) {
+				width -= verticalBar.getSize().x;
+			}
+			if (horizontalBar != null) {
+				height -= horizontalBar.getSize().y;
+			}
 		}
 		if (control instanceof StyledText styledText) {
 			width -= styledText.getRightMargin();


### PR DESCRIPTION
The FindReplaceOverlay currently expects a target control that is an instance of Scrollable to provide a horizontal and vertical scrollbar. This is invalid, as per API the according getter methods do not necessarily return scrollbars. In consequence, exceptions occur that lead to an improperly positioned overlay, as the update callback for the position and size aborts.

This change ensures that scrollbars of the target control are only considered when available.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2147

## How to test
With the current implementation, opening the overlay in editors without a horizontal scrollbar will result in an exception and a misplaced overlay. An example is the Markdown editor provided by Mylyn (see #2147). Without the fix, it looks like this:
![image](https://github.com/user-attachments/assets/393601b9-8866-470e-94aa-5ff5b78306af)
```
java.lang.NullPointerException: Cannot invoke "org.eclipse.swt.widgets.ScrollBar.getSize()" because the return value of "org.eclipse.swt.widgets.Scrollable.getHorizontalBar()" is null
	at org.eclipse.ui.internal.findandreplace.overlay.FindReplaceOverlay.calculateAbsoluteControlBounds(FindReplaceOverlay.java:903)
	at org.eclipse.ui.internal.findandreplace.overlay.FindReplaceOverlay.updatePlacementAndVisibility(FindReplaceOverlay.java:877)
```

With the fix, it properly looks like this:
![image](https://github.com/user-attachments/assets/f38a66fa-9887-452e-bcaf-cba63e6999e6)
