### PR TITLE
Find/replace overlay: properly react to preference changes #2158

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -1027,6 +1027,9 @@ public class FindReplaceOverlay extends Dialog {
 
 	public void setPositionToTop(boolean shouldPositionOverlayOnTop) {
 		positionAtTop = shouldPositionOverlayOnTop;
+		if (overlayOpen) {
+			updatePlacementAndVisibility();
+		}
 	}
 
 	private void removeSearchScope() {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceAction.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceAction.java
@@ -421,13 +421,14 @@ public class FindReplaceAction extends ResourceAction implements IUpdate {
 				shellToUse = fShell;
 			}
 			overlay = new FindReplaceOverlay(shellToUse, fWorkbenchPart, fTarget);
-			hookDialogPreferenceListener();
 
 			FindReplaceOverlayFirstTimePopup.displayPopupIfNotAlreadyShown(shellToUse);
 		}
 
-		overlay.setPositionToTop(shouldPositionOverlayOnTop());
 		overlay.open();
+		overlay.setPositionToTop(shouldPositionOverlayOnTop());
+
+		hookDialogPreferenceListener();
 		overlay.getShell().addDisposeListener(__ -> removeDialogPreferenceListener());
 	}
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
@@ -16,8 +16,12 @@ package org.eclipse.ui.internal.findandreplace.overlay;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
+
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 
 import org.eclipse.text.tests.Accessor;
 
@@ -30,6 +34,10 @@ import org.eclipse.ui.internal.findandreplace.SearchOptions;
 import org.eclipse.ui.texteditor.FindReplaceAction;
 
 public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
+
+	private static final String INSTANCE_SCOPE_NODE_NAME= "org.eclipse.ui.editors"; //$NON-NLS-1$
+
+	private static final String USE_FIND_REPLACE_OVERLAY= "useFindReplaceOverlay"; //$NON-NLS-1$
 
 	@Override
 	public OverlayAccess openUIFromTextViewer(TextViewer viewer) {
@@ -152,6 +160,20 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		assertThat(dialog.getTarget().getSelection().x, is("text text ".length()));
 		dialog.pressSearch(false);
 		assertThat(dialog.getTarget().getSelection().x, is("text ".length()));
+	}
+
+	@Test
+	public void testDisableOverlayViaPreference() {
+		initializeTextViewerWithFindReplaceUI("");
+		IEclipsePreferences preferences= InstanceScope.INSTANCE.getNode(INSTANCE_SCOPE_NODE_NAME);
+		boolean useOverlayPreference= preferences.getBoolean(USE_FIND_REPLACE_OVERLAY, true);
+		try {
+			preferences.putBoolean(USE_FIND_REPLACE_OVERLAY, false);
+			assertNull("dialog should be closed after changing preference", getDialog().getActiveShell());
+		} finally {
+			preferences.putBoolean(USE_FIND_REPLACE_OVERLAY, useOverlayPreference);
+			reopenFindReplaceUIForTextViewer();
+		}
 	}
 
 }


### PR DESCRIPTION
The FindReplaceOverlay does not currently not properly react to preference changes:
- It does not always process a changed preference when opened
- The position is not updated immediately but only when refreshing the position due to some other change (like a repaint event)

With this change:
- The preference listener is always added when opening the overlay, not only when creating it
- The overlay updates its position when the positioning at top/bottom is changed

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2158