### PR TITLE
Find/replace overlay: avoid disposed exception on closing

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
@@ -99,7 +99,9 @@ public class HistoryTextWrapper extends Composite {
 	}
 
 	private void enableDropDown() {
-		dropDown.setEnabled(true);
+		if (!dropDown.isDisposed()) {
+			dropDown.setEnabled(true);
+		}
 	}
 
 	private void navigateInHistory(int navigationOffset) {


### PR DESCRIPTION
When closing a find/replace overlay while a history drop-down menu is open, an exception can occur because the state of a disposed widget is updated. This change ensures that only when the widget is not disposed, its state is changed.