### PR TITLE
Find/replace: allow changing whole word option when input is empty #2162

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -128,7 +128,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	 * @return <code>true</code> if the given string is a word
 	 */
 	private static boolean isWord(String str) {
-		return str != null && !str.isEmpty() && str.chars().allMatch(Character::isJavaIdentifierPart);
+		return str != null && str.chars().allMatch(Character::isJavaIdentifierPart);
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -551,7 +551,7 @@ public class FindReplaceOverlay extends Dialog {
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_regexSearchButton_toolTip)
 				.withOperation(() -> {
 					activateInFindReplacerIf(SearchOptions.REGEX, regexSearchButton.getSelection());
-					wholeWordSearchButton.setEnabled(!findReplaceLogic.isActive(SearchOptions.REGEX));
+					wholeWordSearchButton.setEnabled(findReplaceLogic.isWholeWordSearchAvailable(getFindString()));
 					updateIncrementalSearch();
 					updateContentAssistAvailability();
 				}).withShortcuts(KeyboardShortcuts.OPTION_REGEX).build();

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
@@ -268,7 +268,6 @@ class DialogAccess implements IFindReplaceUIAccess {
 
 		String findString= getFindText();
 		if (getEnabledOptions().contains(SearchOptions.WHOLE_WORD)) {
-			assertFalse(findString.isEmpty());
 			assertFalse(findString.contains(" "));
 		}
 	}


### PR DESCRIPTION
The find/replace dialog and overlay do not allow to change the "whole word" search option when the input field is empty. There is, however, no reason for disabling the option when the input field is empty. With this change, the "whole word" option can also be activated and deactivated when the find input is empty. In addition, the enablement behavior of the option in the find/replace overlay is unified.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2162

### How it look

Without this change, the "whole word" option cannot be enabled/disabled when the find input field is empty. Here is how it looks for the dialog (overlay affected in the same way):
![image](https://github.com/user-attachments/assets/b84321bf-693f-4df9-9128-aff410985f9b)

And here is how it looks with the change for the dialog:
![image](https://github.com/user-attachments/assets/7fc01fe7-eb04-4250-8e27-421439955a09)

