### PR TITLE
Find/replace: improve message when no search results were found #1993

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceMessages.properties
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceMessages.properties
@@ -13,7 +13,7 @@
 ############################################################################
 
 # FindReplace_Status_noMatch_label=String not found
-FindReplace_Status_noMatchWithValue_label=String {0} not found
+FindReplace_Status_noMatchWithValue_label=No search results for: {0}
 FindReplace_Status_replacement_label=1 match replaced
 FindReplace_Status_replacements_label={0} matches replaced
 FindReplace_Status_selection_label=1 match selected


### PR DESCRIPTION
When a search in an editor does not yield any results, a status message with the content "String xyz is not found" with "xyz" being the search string. It is currently hard to understand which part of the message the actual search string is and maybe users do not even know the term "string".

With this change, the message for a search of "xyz" not yielding any results is changed to: "No search results for: xyz" This makes clear what the search string is without requiring to quote it.

Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/1993

### Screenshots

Status message before the change:
![image](https://github.com/user-attachments/assets/e7229065-908b-4f20-9145-05e3881d3016)

Status message after the change:
![image](https://github.com/user-attachments/assets/e03c6dbc-1dad-42a8-917d-a8aebc0515c0)
