### PR TITLE
Find/replace overlay: properly show message for no search results #1993

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -63,7 +63,6 @@ import org.eclipse.jface.window.Window;
 import org.eclipse.jface.text.FindReplaceDocumentAdapter;
 import org.eclipse.jface.text.FindReplaceDocumentAdapterContentProposalProvider;
 import org.eclipse.jface.text.IFindReplaceTarget;
-import org.eclipse.jface.text.IFindReplaceTargetExtension;
 import org.eclipse.jface.text.ITextViewer;
 
 import org.eclipse.ui.IPartListener2;
@@ -630,10 +629,7 @@ public class FindReplaceOverlay extends Dialog {
 			wholeWordSearchButton.setEnabled(findReplaceLogic.isWholeWordSearchAvailable(getFindString()));
 
 			showUserFeedback(normalTextForegroundColor, true);
-			// don't perform incremental search if we are already on the word.
-			if (!getFindString().equals(findReplaceLogic.getTarget().getSelectionText())) {
-				updateIncrementalSearch();
-			}
+			updateIncrementalSearch();
 		});
 		searchBar.addFocusListener(new FocusListener() {
 
@@ -653,11 +649,6 @@ public class FindReplaceOverlay extends Dialog {
 	}
 
 	private void updateIncrementalSearch() {
-		// clear the current incrementally searched selection to avoid having an old
-		// selection left when incrementally searching for an invalid string
-		if (findReplaceLogic.getTarget() instanceof IFindReplaceTargetExtension targetExtension) {
-			targetExtension.setSelection(targetExtension.getLineSelection().x, 0);
-		}
 		findReplaceLogic.performSearch(getFindString());
 		evaluateFindReplaceStatus();
 	}


### PR DESCRIPTION
The status message when a search does not yield any results is currently shown for some milliseconds when using search-as-you-type within the find/replace overlay. The reason for this are selection updates in the editor performed before starting an incremental search, which are then processed by JDT removing the status message immediately after it has been defined. These selection updates are unnecessary, probably since resetting the incremental base position has been streamlined.

This change removes obsolete logic for setting selections and comparing current search results in the editor when performing incremental search. It simplifies the implementation and ensures that status messages are properly shown when the search does not yield any result.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1993

### How it looks

Before the change:
![find_replace_status_before](https://github.com/user-attachments/assets/3332dd39-b302-401e-b989-85a4c1ddd2e6)

After the change:
![find_replace_status_after](https://github.com/user-attachments/assets/7f0145bb-4ef8-4a9d-9759-10b56db4b221)
