### PR TITLE
EclipseCommandURIHandler: Fix decoding of query parameters.

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.swt;singleton:=true
-Bundle-Version: 0.17.400.qualifier
+Bundle-Version: 0.17.500.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/handlers/EclipseCommandURIHandler.java
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/handlers/EclipseCommandURIHandler.java
@@ -10,6 +10,8 @@
 package org.eclipse.e4.ui.internal.workbench.swt.handlers;
 
 import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -44,14 +46,15 @@ public class EclipseCommandURIHandler implements IUriSchemeHandler {
 		ECommandService commandService = context.get(ECommandService.class);
 		EHandlerService eHandlerService = context.get(EHandlerService.class);
 		Command command = commandService.getCommand(commandId);
-		String query = uri.getQuery();
+		String query = uri.getRawQuery();
 		if (query == null) {
 			query = ""; //$NON-NLS-1$
 		}
 		Map<String, String> uriParams = Arrays.stream(query.split("&")) //$NON-NLS-1$
 				.filter(s -> !s.isEmpty()) //
 				.map(param -> param.split("=")) //$NON-NLS-1$
-				.collect(Collectors.toMap(segments -> segments[0], segements -> segements[1]));
+				.collect(Collectors.toMap(segments -> URLDecoder.decode(segments[0], StandardCharsets.UTF_8),
+						segments -> URLDecoder.decode(segments[1], StandardCharsets.UTF_8)));
 		ParameterizedCommand parametrizedCommand = ParameterizedCommand.generateCommand(command, uriParams);
 		// a confirmation dialog is required as invoking arbitrary commands from
 		// external applications is an unsecure operation


### PR DESCRIPTION
`URI#getQuery()` URL-decodes the full query string, destroying semantics. The, the result is split on `&` and `=`.

Instead, we first need to use `URI#getRawQuery(),` then split on `&` and `=`, and only then do the URL-decoding of the individual parts.

Fixes: #2166