### PR TITLE
Fix for 'Git Staging' view background

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
@@ -143,6 +143,7 @@ CTabFolder Canvas {
 .View Group,
 .View Group Label,
 .View Section,
+.View BusyIndicator,
 .View Text[style~='SWT.READ_ONLY'],
 .View SashForm,
 .View OleFrame,
@@ -159,7 +160,14 @@ CTabFolder Canvas {
 	background-color: #f8f8f8;
 }
 
-.View ToolItem,
+.View TitleRegion{
+	background-color:#f8f8f8;
+}
+
+.MPartStack.active .View TitleRegion{
+	background-color:#f8f8f8;
+}
+
 .View PageBook StyledText,
 .View Button{
 	background-color: inherit;
@@ -239,24 +247,4 @@ Composite.MArea{
 
 .MPart CTabFolder{
 	swt-outer-keyline-color: #ffffff;
-}
-
-.MPart Form Composite,
-.MPart Form Section,
-.MPart Form Label,
-.MPart Form Text,
-.MPart Form Button,
-.MPart Form Sash
-{
-	background-color: '#FFFFFF';
-}
-
-.MPartStack.active .MPart Form Composite,
-.MPartStack.active .MPart Form Section,
-.MPartStack.active .MPart Form Label,
-.MPartStack.active .MPart Form Text,
-.MPartStack.active .MPart Form Button,
-.MPartStack.active .MPart Form Sash
-{
-	background-color: '#FFFFFF';
 }

--- a/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
@@ -104,7 +104,6 @@ CTabFolder Canvas {
  
 .MTrimBar#org-eclipse-ui-trim-status {
 	background-color: '#f8f8f8';
-
 }
 
 .View Composite,
@@ -114,6 +113,7 @@ CTabFolder Canvas {
 .View Group,
 .View Group Label,
 .View Section,
+.View BusyIndicator,
 .View Text[style~='SWT.READ_ONLY'],
 .View SashForm,
 .View OleFrame,
@@ -130,7 +130,14 @@ CTabFolder Canvas {
 	background-color: #f8f8f8;
 }
 
-.View ToolItem,
+.View TitleRegion{
+	background-color:#f8f8f8;
+}
+
+.MPartStack.active .View TitleRegion{
+	background-color:#f8f8f8;
+}
+
 .View PageBook StyledText,
 .View Button{
 	background-color: inherit;
@@ -210,24 +217,4 @@ Composite.MArea{
 
 .MPart CTabFolder{
 	swt-outer-keyline-color: #ffffff;
-}
-
-.MPart Form Composite,
-.MPart Form Section,
-.MPart Form Label,
-.MPart Form Text,
-.MPart Form Button,
-.MPart Form Sash
-{
-	background-color: '#FFFFFF';
-}
-
-.MPartStack.active .MPart Form Composite,
-.MPartStack.active .MPart Form Section,
-.MPartStack.active .MPart Form Label,
-.MPartStack.active .MPart Form Text,
-.MPartStack.active .MPart Form Button,
-.MPartStack.active .MPart Form Sash
-{
-	background-color: '#FFFFFF';
 }

--- a/bundles/org.eclipse.ui.themes/css/e4_default_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_win.css
@@ -118,6 +118,7 @@ CTabFolder Canvas {
 .View Group,
 .View Group Label,
 .View Section,
+.View BusyIndicator,
 .View Text[style~='SWT.READ_ONLY'],
 .View SashForm,
 .View OleFrame,
@@ -134,14 +135,21 @@ CTabFolder Canvas {
 	background-color: #f8f8f8;
 }
 
-.View ToolItem,
+.View TitleRegion{
+	background-color:#f8f8f8;
+}
+
+.MPartStack.active .View TitleRegion{
+	background-color:#f8f8f8;
+}
+
 .View PageBook StyledText,
 .View Button{
 	background-color: inherit;
 }
 
-.View Section ToolItem{
-	background-color: #EAEAEA;
+.View Toolbar ToolItem{
+	background-color: #eaeaea;
 }
 
 .View Composite PrependingAsteriskFilteredTree,
@@ -214,24 +222,4 @@ Composite.MArea{
 
 .MPart CTabFolder{
 	swt-outer-keyline-color: #ffffff;
-}
-
-.MPart Form Composite,
-.MPart Form Section,
-.MPart Form Label,
-.MPart Form Text,
-.MPart Form Button,
-.MPart Form Sash
-{
-	background-color: '#FFFFFF';
-}
-
-.MPartStack.active .MPart Form Composite,
-.MPartStack.active .MPart Form Section,
-.MPartStack.active .MPart Form Label,
-.MPartStack.active .MPart Form Text,
-.MPartStack.active .MPart Form Button,
-.MPartStack.active .MPart Form Sash
-{
-	background-color: '#FFFFFF';
 }


### PR DESCRIPTION
There was inconsistency in the background colors for sections and toolItems in the Git Staging view after introducing the enhancements to the light theme https://github.com/eclipse-platform/eclipse.platform.ui/issues/2114#issuecomment-2241561690. It has been fixed with this change in Win, Mac and Linux.  Section and ToolItem now has same grey as background color.

![image](https://github.com/user-attachments/assets/52ecabc4-9f64-4b56-883f-ae5ccae1ad77)

![image](https://github.com/user-attachments/assets/83b8649b-b4a1-480b-be0c-9ac2b2ba084c)
