### PR TITLE
Removing ADT specific changes related to breadcrumbs

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4-dark_linux.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_linux.css
@@ -88,16 +88,6 @@ CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
     swt-selected-highlight-top: false;
 }
 
-#DebugBreadcrumbItemComposite,
-#DebugBreadcrumbItemDropDownToolBar,
-#DebugBreadcrumbItemDetailComposite,
-#DebugBreadcrumbItemDetailImageComposite,
-#DebugBreadcrumbItemDetailImageLabel,
-#DebugBreadcrumbItemDetailTextComposite,
-#DebugBreadcrumbItemDetailTextLabel {
-	background-color: '#1E1F22';
-}
-
 .MPart Form Composite,
 .MPart Form Composite Tree,
 .MPartStack.active .MPart Form Composite Tree

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
@@ -95,16 +95,6 @@ CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
     swt-selected-highlight-top: false;
 }
 
-#DebugBreadcrumbItemComposite,
-#DebugBreadcrumbItemDropDownToolBar,
-#DebugBreadcrumbItemDetailComposite,
-#DebugBreadcrumbItemDetailImageComposite,
-#DebugBreadcrumbItemDetailImageLabel,
-#DebugBreadcrumbItemDetailTextComposite,
-#DebugBreadcrumbItemDetailTextLabel {
-	background-color: '#1E1F22';
-}
-
 .MPart Form Composite,
 .MPart Form Composite Tree,
 .MPartStack.active .MPart Form Composite Tree

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
@@ -177,16 +177,6 @@ CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
     swt-selected-highlight-top: false;
 }
 
-#DebugBreadcrumbItemComposite,
-#DebugBreadcrumbItemDropDownToolBar,
-#DebugBreadcrumbItemDetailComposite,
-#DebugBreadcrumbItemDetailImageComposite,
-#DebugBreadcrumbItemDetailImageLabel,
-#DebugBreadcrumbItemDetailTextComposite,
-#DebugBreadcrumbItemDetailTextLabel {
-	background-color: '#1E1F22';
-}
-
 .MPart Form Composite,
 .MPart Form Composite Tree,
 .MPartStack.active .MPart Form Composite Tree

--- a/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
@@ -227,16 +227,6 @@ CTabFolder Canvas {
 	background-color: #ffffff;
 }
 
-#DebugBreadcrumbItemComposite,
-#DebugBreadcrumbItemDropDownToolBar,
-#DebugBreadcrumbItemDetailComposite,
-#DebugBreadcrumbItemDetailImageComposite,
-#DebugBreadcrumbItemDetailImageLabel,
-#DebugBreadcrumbItemDetailTextComposite,
-#DebugBreadcrumbItemDetailTextLabel {
-	background-color: '#FFFFFF';
-}
-
 Composite.MPartSashContainer{
 	background-color: #f8f8f8;
 }

--- a/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
@@ -197,16 +197,6 @@ CTabFolder Canvas {
 	background-color: #ffffff;
 }
 
-#DebugBreadcrumbItemComposite,
-#DebugBreadcrumbItemDropDownToolBar,
-#DebugBreadcrumbItemDetailComposite,
-#DebugBreadcrumbItemDetailImageComposite,
-#DebugBreadcrumbItemDetailImageLabel,
-#DebugBreadcrumbItemDetailTextComposite,
-#DebugBreadcrumbItemDetailTextLabel {
-	background-color: '#FFFFFF';
-}
-
 Composite.MPartSashContainer{
 	background-color: #f8f8f8;
 }

--- a/bundles/org.eclipse.ui.themes/css/e4_default_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_win.css
@@ -202,16 +202,6 @@ CTabFolder Canvas {
 	background-color: #ffffff;
 }
 
-#DebugBreadcrumbItemComposite,
-#DebugBreadcrumbItemDropDownToolBar,
-#DebugBreadcrumbItemDetailComposite,
-#DebugBreadcrumbItemDetailImageComposite,
-#DebugBreadcrumbItemDetailImageLabel,
-#DebugBreadcrumbItemDetailTextComposite,
-#DebugBreadcrumbItemDetailTextLabel {
-	background-color: '#FFFFFF';
-}
-
 Composite.MPartSashContainer{
 	background-color: #f8f8f8;
 }


### PR DESCRIPTION
While addressing an issue related to inconsistent background color for breadcrumbs in java editor, which is reported here - https://github.com/eclipse-platform/eclipse.platform.ui/issues/2114#issuecomment-2241561690. Realized that piece of code was specific to ADT. Hence reverting the code.