### PR TITLE
Reverting the bg color for StyledText, Button, Table controls

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
@@ -154,8 +154,7 @@ CTabFolder Canvas {
 .View FormText,
 .View Hyperlink,
 .View Canvas,
-.View FigureCanvas,
-.View Table
+.View FigureCanvas
 {
 	background-color: #f8f8f8;
 }
@@ -168,13 +167,16 @@ CTabFolder Canvas {
 	background-color:#f8f8f8;
 }
 
-.View PageBook StyledText,
-.View Button{
+.View Button[style~='SWT.CHECK']{
 	background-color: inherit;
 }
 
-.View Section ToolItem{
-	background-color: #EAEAEA;
+.View Toolbar ToolItem{
+	background-color: #eaeaea;
+}
+
+.View TabbedPropertyList{
+	swt-tabBackground-color: #ffffff;
 }
 
 .View Composite PrependingAsteriskFilteredTree,

--- a/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
@@ -124,8 +124,7 @@ CTabFolder Canvas {
 .View FormText,
 .View Hyperlink,
 .View Canvas,
-.View FigureCanvas,
-.View Table
+.View FigureCanvas
 {
 	background-color: #f8f8f8;
 }
@@ -138,13 +137,16 @@ CTabFolder Canvas {
 	background-color:#f8f8f8;
 }
 
-.View PageBook StyledText,
-.View Button{
+.View Button[style~='SWT.CHECK']{
 	background-color: inherit;
 }
 
-.View Section ToolItem{
-	background-color: #EAEAEA;
+.View Toolbar ToolItem{
+	background-color: #eaeaea;
+}
+
+.View TabbedPropertyList{
+	swt-tabBackground-color: #ffffff;
 }
 
 .View Composite PrependingAsteriskFilteredTree,

--- a/bundles/org.eclipse.ui.themes/css/e4_default_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_win.css
@@ -129,8 +129,7 @@ CTabFolder Canvas {
 .View FormText,
 .View Hyperlink,
 .View Canvas,
-.View FigureCanvas,
-.View Table
+.View FigureCanvas
 {
 	background-color: #f8f8f8;
 }
@@ -143,13 +142,16 @@ CTabFolder Canvas {
 	background-color:#f8f8f8;
 }
 
-.View PageBook StyledText,
-.View Button{
+.View Button[style~='SWT.CHECK']{
 	background-color: inherit;
 }
 
 .View Toolbar ToolItem{
 	background-color: #eaeaea;
+}
+
+.View TabbedPropertyList{
+	swt-tabBackground-color: #ffffff;
 }
 
 .View Composite PrependingAsteriskFilteredTree,


### PR DESCRIPTION
Reverting the changes done to bg colors of controls like StyledText, Button, Table in views.
Selected tab in TabbedPropertyList had grey background in view, even that has been changed to white with this change.
Issue  https://github.com/eclipse-platform/eclipse.platform.ui/issues/2173 has been addressed with this change.
Please again test and provide feedback if there are still some issues.

Below are the screenshots

Before:
![image](https://github.com/user-attachments/assets/05b1416f-0b0b-4b3e-9861-67c7f7e094e6)

After:
![image](https://github.com/user-attachments/assets/f4d97722-ba73-4615-811c-1b231866fb67)


