### PR TITLE
Fix build path error for missing org.eclipse.emf.ecore.impl.EFactoryImpl

### DIFF
--- a/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -42,7 +42,8 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="3.14.0",
  org.eclipse.ui.views.log;bundle-version="1.2.1300",
  org.eclipse.jdt.ui,
  org.eclipse.ui.navigator;bundle-version="3.12.100",
- org.eclipse.search
+ org.eclipse.search,
+ org.eclipse.emf.ecore
 Import-Package: jakarta.annotation,
  jakarta.inject,
  org.osgi.service.event


### PR DESCRIPTION
https://github.com/eclipse-emf/org.eclipse.emf/issues/41