### PR TITLE
Change to font colors in selected/unselected tabs in views and editor

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
@@ -91,14 +91,6 @@ ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_TEXT_COLOR {
 	color: #3b3b3b;
 }
 
-ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_TEXT_COLOR {
-   color: #3b3b3b;
-}
-
-ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
-   color: #3b3b3b;
-}
-
 .MTrimmedWindow {
 	background-color: #F6F5F4;
 }
@@ -198,15 +190,19 @@ CTabFolder Canvas {
     swt-selected-highlight-top: false;
 }
 
+CTabItem{
+	background-color: #3b3b3b;
+}
+
 /* text color and background color of unselected tabs in editor*/
 #org-eclipse-ui-editorss CTabItem{
-	color: '#6A6A6A';
+	color: '#3b3b3b';
 	background-color: '#f8f8f8';
 }
 
 /*text color and background color of selected tab in editor */
 #org-eclipse-ui-editorss CTabItem:selected{
-	color: '#3b3b3b';
+	color: '#org-eclipse-ui-workbench-ACTIVE_TAB_TEXT_COLOR';
 	background-color: '#FFFFFF';
 }
 

--- a/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
@@ -74,15 +74,7 @@ ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_BG_END {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_TEXT_COLOR {
-	color: #404040;
-}
-
-ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_TEXT_COLOR {
-   color: #404040;
-}
-
-ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
-   color: #404040;
+	color: #3b3b3b;
 }
 
 .MTrimmedWindow {
@@ -168,15 +160,19 @@ CTabFolder Canvas {
     swt-selected-highlight-top: false;
 }
 
-/* text color of unselected tabs in editor*/
+CTabItem {
+	color: #3b3b3b;
+}
+
+/* text color and background color of unselected tabs in editor*/
 #org-eclipse-ui-editorss CTabItem{
-	color: '#6A6A6A';
+	color: '#3b3b3b';
 	background-color: '#f8f8f8';
 }
 
 /*text color and background color of selected tab in editor */
 #org-eclipse-ui-editorss CTabItem:selected{
-	color: '#3b3b3b';
+	color: '#org-eclipse-ui-workbench-ACTIVE_TAB_TEXT_COLOR';
 	background-color: '#FFFFFF';
 }
 

--- a/bundles/org.eclipse.ui.themes/css/e4_default_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_win.css
@@ -78,14 +78,6 @@ ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_TEXT_COLOR {
 	color: #3b3b3b;
 }
 
-ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_TEXT_COLOR {
-   color: #3b3b3b;
-}
-
-ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
-   color: #3b3b3b;
-}
-
 .MPartStack {
 	swt-simple: true;
 }
@@ -173,15 +165,19 @@ CTabFolder Canvas {
     swt-selected-highlight-top: false;
 }
 
+CTabItem {
+	color: #3b3b3b;
+}
+
 /* text color and background color of unselected tabs in editor*/
 #org-eclipse-ui-editorss CTabItem{
-	color: '#6A6A6A';
+	color: #3b3b3b;
 	background-color: '#f8f8f8';
 }
 
 /*text color and background color of selected tab in editor */
 #org-eclipse-ui-editorss CTabItem:selected{
-	color: '#3b3b3b';
+	color: '#org-eclipse-ui-workbench-ACTIVE_TAB_TEXT_COLOR';
 	background-color: '#FFFFFF';
 }
 


### PR DESCRIPTION
Change to the existing light theme https://github.com/eclipse-platform/eclipse.platform.ui/issues/2114 also involved the change to the font colors of selected and unselected tabs in views and editors. This led to an issue from a user https://github.com/eclipse-platform/eclipse.platform.ui/issues/2182.

Selected tab in Views and Editor now has #00000 color code 
Unselected tabs in Views and Editor now have #3b3b3b color code 
This change has been done to improve the contrast between font color and background color of tabs.
Please let us know your views.

Screenshots can be found here.

Before:
![image](https://github.com/user-attachments/assets/e76c3cfa-491c-4e69-9425-a73701272960)


After: 
![image](https://github.com/user-attachments/assets/d99e18b3-8a4f-48bf-bde5-bdd9672c9003)
