### PR TITLE
Find/replace overlay: improve first-time notification layout

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayFirstTimePopup.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayFirstTimePopup.java
@@ -104,7 +104,7 @@ public class FindReplaceOverlayFirstTimePopup {
 
 		messageBody
 				.setText(FindReplaceMessages.FindReplaceOverlayFirstTimePopup_FindReplaceOverlayFirstTimePopup_message);
-		messageBody.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false, 1, 1));
+		messageBody.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 		messageBody.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
 			disableUseOverlayPreference();
 			composite.getShell().close();


### PR DESCRIPTION
The notification pop-up on first usage of the find/replace overlay has a white bar at the bottom. This is because the contents widgets does not fill the whole composite of the pop-up, which, in turn, has a minimum size.

This change <s>adds a line break to the notification text to improve readability and</s> makes the contents use the complete vertical space of the pop-up.

The issue was reported here: https://github.com/eclipse-platform/eclipse.platform.ui/pull/1192#issuecomment-2285830201

## How it looks

Before:
![image](https://github.com/user-attachments/assets/2d512577-d6c9-4969-830d-ac573af7dd37)

After:
![image](https://github.com/user-attachments/assets/4de3f1cd-050e-4ae4-8b6d-4c0164416f0b)

@jukzi thank you for reporting the issue. What do you think about the fix? I see some opportunities for improving the design of the notification pop-up in general (such as some padding for all the text within the popup), but that's independent from this use case.