### PR TITLE
WhitespaceCharaterPainter takes code minings at whitespaces into account

### DIFF
--- a/tests/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
@@ -26,3 +26,6 @@ Require-Bundle:
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.jface.text.tests
+Import-Package: org.mockito,
+ org.mockito.invocation,
+ org.mockito.stubbing

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/JFaceTextTestSuite.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/JFaceTextTestSuite.java
@@ -80,7 +80,8 @@ import org.eclipse.jface.text.tests.templates.persistence.TemplatePersistenceDat
 		DefaultTextDoubleClickStrategyTest.class,
 		MultiSelectionTest.class,
 		FindReplaceDocumentAdapterContentProposalProviderTest.class,
-		ProjectionViewerTest.class
+		ProjectionViewerTest.class,
+		TestWhitespaceCharacterPainter.class
 })
 public class JFaceTextTestSuite {
 	// see @SuiteClasses

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/TestWhitespaceCharacterPainter.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/TestWhitespaceCharacterPainter.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2024 SAP SE
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package org.eclipse.jface.text.tests;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyleRange;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.events.PaintEvent;
+import org.eclipse.swt.graphics.FontMetrics;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.GlyphMetrics;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Shell;
+
+import org.eclipse.jface.resource.JFaceResources;
+
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.WhitespaceCharacterPainter;
+import org.eclipse.jface.text.source.SourceViewer;
+
+public class TestWhitespaceCharacterPainter {
+
+	private Shell shell;
+
+	@Before
+	public void before() {
+		shell= new Shell();
+		shell.setSize(500, 200);
+		shell.setLayout(new FillLayout());
+	}
+
+	@After
+	public void after() {
+		shell.dispose();
+	}
+
+	@Test
+	public void glyphMetricsTakenIntoAccount() throws Exception {
+		SourceViewer sourceViewer= new SourceViewer(shell, null, SWT.V_SCROLL | SWT.BORDER);
+		sourceViewer.setDocument(new Document("first  \nsecond  \nthird  \n"));
+		StyledText textWidget= sourceViewer.getTextWidget();
+		textWidget.setFont(JFaceResources.getTextFont());
+		WhitespaceCharacterPainter whitespaceCharPainter= new WhitespaceCharacterPainter(sourceViewer, true, true, true, true, true, true, true,
+				true, true, true, true, 100);
+		sourceViewer.addPainter(whitespaceCharPainter);
+		textWidget.setStyleRange(createStyleRangeWithMetrics(6));
+		textWidget.setStyleRange(createStyleRangeWithMetrics(15));
+		Event e= new Event();
+		e.widget= textWidget;
+		PaintEvent ev= new PaintEvent(e);
+
+		ev.gc= mock(GC.class);
+		when(ev.gc.getClipping()).thenReturn(new Rectangle(0, 0, 100, 100));
+		when(ev.gc.stringExtent(anyString())).thenAnswer(new Answer<Point>() {
+			@Override
+			public Point answer(InvocationOnMock invocation) throws Throwable {
+				GC gc= new GC(shell);
+				gc.setFont(JFaceResources.getTextFont());
+				Point result= gc.stringExtent(invocation.getArgument(0));
+				gc.dispose();
+				return result;
+			}
+		});
+		when(ev.gc.getFontMetrics()).thenAnswer(new Answer<FontMetrics>() {
+			@Override
+			public FontMetrics answer(InvocationOnMock invocation) throws Throwable {
+				GC gc= new GC(shell);
+				gc.setFont(JFaceResources.getTextFont());
+				FontMetrics metrics= gc.getFontMetrics();
+				gc.dispose();
+				return metrics;
+			}
+		});
+		ev.x= 0;
+		ev.y= 0;
+		ev.width= 100;
+		ev.height= 100;
+		whitespaceCharPainter.paintControl(ev);
+		verify(ev.gc, times(5)).drawString(anyString(), anyInt(), anyInt(), anyBoolean());
+	}
+
+	private StyleRange createStyleRangeWithMetrics(int start) {
+		StyleRange sr= new StyleRange();
+		sr.start= start;
+		sr.metrics= new GlyphMetrics(20, 20, 20);
+		return sr;
+	}
+}


### PR DESCRIPTION
The listed code snippet below shows up a current problem in rendering of the invisible whitespaces in the Eclipse TextViewer if a code mining is rendered at a whitespace. 
By executing the snippet below, you can see that the linefeed character `¶` is drawn on top of the code mining with label `code_mining`. Here a screenshot:

![line_feed_character_rendered_on_top_of_code_mining](https://github.com/user-attachments/assets/95614bb9-8641-45ea-81bc-39c6c5c1568a)

This rendering problem will be fixed with the given pull request. Here a screenshot of the test application with the changes of the pull request:

![line_feed_character_rendered_after_code_mining](https://github.com/user-attachments/assets/acc1405e-fb9a-428e-ae69-4590c9fcdc75)

Problem is making the `spaceCharsAreSameWidth` optimization in class `org.eclipse.jface.text.WhitespaceCharacterPainter` which tries to render a sequence of whitespaces with one `GC#drawString` call. Problem now is if a code mining is rendered in the middle of this whitespace sequence. The call now needs to be split into two separate `GC#drawString` calls, one before and one after the code mining. 

Could you please review and merge the request?

Thanks a lot,
Tobias

```
package org.eclipse.jface.text.tests;

import java.util.ArrayList;
import java.util.List;
import java.util.concurrent.CompletableFuture;

import org.eclipse.swt.SWT;
import org.eclipse.swt.layout.GridLayout;
import org.eclipse.swt.widgets.Display;
import org.eclipse.swt.widgets.Shell;

import org.eclipse.core.runtime.IProgressMonitor;

import org.eclipse.jface.layout.GridDataFactory;
import org.eclipse.jface.resource.JFaceResources;

import org.eclipse.jface.text.Document;
import org.eclipse.jface.text.IDocument;
import org.eclipse.jface.text.IRegion;
import org.eclipse.jface.text.ITextViewer;
import org.eclipse.jface.text.ITextViewerExtension2;
import org.eclipse.jface.text.Position;
import org.eclipse.jface.text.WhitespaceCharacterPainter;
import org.eclipse.jface.text.codemining.AbstractCodeMiningProvider;
import org.eclipse.jface.text.codemining.ICodeMining;
import org.eclipse.jface.text.codemining.ICodeMiningProvider;
import org.eclipse.jface.text.codemining.LineContentCodeMining;
import org.eclipse.jface.text.reconciler.DirtyRegion;
import org.eclipse.jface.text.reconciler.IReconcilingStrategy;
import org.eclipse.jface.text.reconciler.MonoReconciler;
import org.eclipse.jface.text.source.Annotation;
import org.eclipse.jface.text.source.AnnotationModel;
import org.eclipse.jface.text.source.AnnotationPainter;
import org.eclipse.jface.text.source.IAnnotationAccess;
import org.eclipse.jface.text.source.ISourceViewer;
import org.eclipse.jface.text.source.ISourceViewerExtension5;
import org.eclipse.jface.text.source.SourceViewer;

public class Snippet {
	public static void main(String[] args) {
		final Display display= new Display();
		Shell shell= new Shell(display);
		shell.setLayout(new GridLayout());

		SourceViewer sourceViewer= new SourceViewer(shell, null, SWT.V_SCROLL | SWT.BORDER);
		sourceViewer.getTextWidget().setFont(JFaceResources.getTextFont());
		WhitespaceCharacterPainter whitespaceCharPainter= new WhitespaceCharacterPainter(sourceViewer, true, true, true, true, true, true, true,
				true, true, true, true, 100);
		sourceViewer.addPainter(whitespaceCharPainter);
		sourceViewer.setDocument(new Document("first    \nsecond"), new AnnotationModel());

		GridDataFactory.fillDefaults().grab(true, true).applyTo(sourceViewer.getTextWidget());
		addAnnotationPainter(sourceViewer);
		((ISourceViewerExtension5) sourceViewer).setCodeMiningProviders(new ICodeMiningProvider[] {
				createMiningProvider() });
		MonoReconciler reconciler= new MonoReconciler(new IReconcilingStrategy() {

			@Override
			public void setDocument(IDocument document) {
				((ISourceViewerExtension5) sourceViewer).updateCodeMinings();
			}

			@Override
			public void reconcile(DirtyRegion dirtyRegion, IRegion subRegion) {
			}

			@Override
			public void reconcile(IRegion partition) {
				((ISourceViewerExtension5) sourceViewer).updateCodeMinings();
			}
		}, false);
		reconciler.install(sourceViewer);
		shell.open();
		while (!shell.isDisposed()) {
			if (!display.readAndDispatch())
				display.sleep();
		}
		display.dispose();
	}

	private static ICodeMiningProvider createMiningProvider() {
		return new AbstractCodeMiningProvider() {

			@Override
			public CompletableFuture<List<? extends ICodeMining>> provideCodeMinings(ITextViewer viewer, IProgressMonitor monitor) {
				List<ICodeMining> res= new ArrayList<>();
				res.add(new LineContentCodeMining(new Position("first    ".length(), 1), this) {
					@Override
					public String getLabel() {
						return "code_mining";
					}

					@Override
					public boolean isResolved() {
						return true;
					}
				});
				return CompletableFuture.completedFuture(res);
			}
		};
	}

	private static void addAnnotationPainter(ISourceViewer viewer) {
		IAnnotationAccess annotationAccess= new IAnnotationAccess() {
			@SuppressWarnings("deprecation")
			@Override
			public Object getType(Annotation annotation) {
				return annotation.getType();
			}

			@SuppressWarnings("deprecation")
			@Override
			public boolean isMultiLine(Annotation annotation) {
				return true;
			}

			@SuppressWarnings("deprecation")
			@Override
			public boolean isTemporary(Annotation annotation) {
				return true;
			}
		};
		AnnotationPainter painter= new AnnotationPainter(viewer, annotationAccess);
		((ITextViewerExtension2) viewer).addPainter(painter);
		// Register this annotation painter as CodeMining annotation painter.
		((ISourceViewerExtension5) viewer).setCodeMiningAnnotationPainter(painter);
	}
}
```