### PR TITLE
Find/replace: fix search operation during replace in RegEx mode #2203

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -326,9 +326,13 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 
 	@Override
 	public boolean performSearch(String findString) {
+		return performSearch(findString, true);
+	}
+
+	private boolean performSearch(String findString, boolean validateSearchOptions) {
 		resetStatus();
 
-		if (isActive(SearchOptions.INCREMENTAL) && !isIncrementalSearchAvailable()) {
+		if (validateSearchOptions && (isActive(SearchOptions.INCREMENTAL) && !isIncrementalSearchAvailable())) {
 			return false; // Do nothing if search options are not compatible
 		}
 		boolean somethingFound = false;
@@ -543,7 +547,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	public boolean performReplaceAndFind(String findString, String replaceString) {
 		resetStatus();
 		if (performSelectAndReplace(findString, replaceString)) {
-			performSearch(findString);
+			performSearch(findString, false);
 			return true;
 		}
 		return false;
@@ -553,7 +557,7 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	public boolean performSelectAndReplace(String findString, String replaceString) {
 		resetStatus();
 		if (!isFindStringSelected(findString)) {
-			performSearch(findString);
+			performSearch(findString, false);
 		}
 		if (getStatus().wasSuccessful()) {
 			return replaceSelection(replaceString);

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -351,6 +351,21 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.activate(SearchOptions.FORWARD);
 		findReplaceLogic.activate(SearchOptions.REGEX);
 
+		executeReplaceAndFindRegExTest(textViewer, findReplaceLogic);
+	}
+
+	@Test
+	public void testPerformReplaceAndFindRegEx_incrementalActive() {
+		TextViewer textViewer= setupTextViewer("Hello<replace>World<replace>!<r>!");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.activate(SearchOptions.FORWARD);
+		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+		findReplaceLogic.activate(SearchOptions.REGEX);
+
+		executeReplaceAndFindRegExTest(textViewer, findReplaceLogic);
+	}
+
+	private void executeReplaceAndFindRegExTest(TextViewer textViewer, IFindReplaceLogic findReplaceLogic) {
 		boolean status= findReplaceLogic.performReplaceAndFind("<(\\w*)>", " ");
 		assertTrue(status);
 		assertThat(textViewer.getDocument().get(), equalTo("Hello World<replace>!<r>!"));
@@ -372,6 +387,22 @@ public class FindReplaceLogicTest {
 		assertEquals("Status wasn't correctly returned", false, status);
 		assertEquals("Text shouldn't have been changed", "Hello World ! !", textViewer.getDocument().get());
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
+	}
+
+	@Test
+	public void testPerformSearchAndReplaceRegEx_incrementalActive() {
+		TextViewer textViewer= setupTextViewer("some text");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.activate(SearchOptions.FORWARD);
+		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+		findReplaceLogic.activate(SearchOptions.REGEX);
+
+		findReplaceLogic.performSearch("text");
+		textViewer.setSelectedRange(0, 0);
+
+		findReplaceLogic.performSelectAndReplace("text", "");
+
+		assertEquals("some ", textViewer.getDocument().get());
 	}
 
 	@Test


### PR DESCRIPTION
When performing a search operation in the FindReplaceLogic, it currently always validates compatibility of the search options. In particular, having incremental search and regex search enabled at the same time will result in search operations not being performed. This results in problems when performing replace operations that also include search operations, as the search operation will not be executed then.

With this change, the search operations performed while doing a replace will not validate the search operations but always perform the requested search instead.

ℹ️  I consider this an intermediate solution for the upcoming 2024-09 release. It is a rather local change only affecting the replace behavior when incremental and regex search mode are enabled (as that's the only case in which the existing guard applied). The root cause is, in my opinion, a design flaw, as the FindReplaceLogic is (1) used to reflect all current search option, (2) at the same time disallows specific operations when options are conflicting while (3) consumers rely on applying these operations even though options are conflicting. This results in consumers switching options before performing some operations (such as disabling incremental mode when performing an explicit search). Improving this will probably be a bit more invasive than the current change and is only about design, not about functionality. Thus, from a risk assessment perspective, it should be done after 2024-09. I will do this in follow-up work.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2203