### PR TITLE
Load marker content generator details from marker content generator extensions (fix for #2193)

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/ProblemKeyMarkerField.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/ProblemKeyMarkerField.java
@@ -1,0 +1,16 @@
+package org.eclipse.ui.tests.markers;
+
+import org.eclipse.ui.views.markers.MarkerField;
+import org.eclipse.ui.views.markers.MarkerItem;
+
+public class ProblemKeyMarkerField extends MarkerField {
+
+	@Override
+	public String getValue(MarkerItem item) {
+		if (item == null) {
+			return "";
+		}
+		return item.getAttributeValue("problemKey", "");
+	}
+
+}

--- a/tests/org.eclipse.ui.tests/plugin.xml
+++ b/tests/org.eclipse.ui.tests/plugin.xml
@@ -3461,7 +3461,58 @@
        </markerContentGenerator>
         <markerContentGenerator
              id="org.eclipse.ui.tests.customScopeContentGenerator">
-       </markerContentGenerator>       
+       </markerContentGenerator>
+        <markerField
+              class="org.eclipse.ui.tests.markers.ProblemKeyMarkerField"
+              id="org.eclipse.ui.tests.markerField.problemKey"
+              name="Problem Key">
+        </markerField>
+        <markerField
+              class="org.eclipse.ui.tests.markers.ProblemKeyMarkerField"
+              id="org.eclipse.ui.tests.markerField.problemKeyV2"
+              name="Problem Key V2">
+        </markerField>
+        <markerContentGenerator
+              id="org.eclipse.ui.tests.additionalProblemMarkerContentGenerator"
+              name="Additional Problem Marker Content Generator">
+           <markerFieldReference
+                 visible="true"
+                 id="org.eclipse.ui.tests.markerField.problemKey">
+           </markerFieldReference>
+           <markerTypeReference
+                 id="org.eclipse.ui.tests.markers.static.analysis.problem">
+           </markerTypeReference>
+           <markerTypeReference
+                 id="org.eclipse.ui.tests.markers.artificial.problem">
+           </markerTypeReference>
+        </markerContentGenerator>
+        <markerContentGeneratorExtension
+              generatorId="org.eclipse.ui.ide.problemsGenerator"
+              id="org.eclipse.ui.tests.additionalProblemMarkerContentGenerator">
+           <markerGrouping
+                 id="org.eclipse.ui.tests.test.extended"
+                 label="Extended Problem Category">
+           </markerGrouping>
+        </markerContentGeneratorExtension>
+        <markerContentGeneratorExtension
+              generatorId="org.eclipse.ui.ide.allMarkersGenerator"
+              id="org.eclipse.ui.tests.additionalProblemMarkerContentGenerator">
+        </markerContentGeneratorExtension>
+        <markerContentGenerator
+              id="org.eclipse.ui.tests.additionalProblemMarkerContentGenerator2"
+              name="Additional Problem Marker Content Generator 2">
+           <markerFieldReference
+                 visible="false"
+                 id="org.eclipse.ui.tests.markerField.problemKeyV2">
+           </markerFieldReference>
+           <markerTypeReference
+                 id="org.eclipse.ui.tests.markers.static.analysis.problem">
+           </markerTypeReference>
+        </markerContentGenerator>
+        <markerContentGeneratorExtension
+              generatorId="org.eclipse.ui.tests.additionalProblemMarkerContentGenerator"
+              id="org.eclipse.ui.tests.additionalProblemMarkerContentGenerator2">
+        </markerContentGeneratorExtension>
    </extension>
    <extension
          id="categoryTestMarker"
@@ -4887,6 +4938,25 @@
          activityId="org.eclipse.ui.tests.activitySupportTest.issue1832"
          categoryId="org.eclipse.ui.tests.issue1832">
      </categoryActivityBinding>
+ </extension>
+ <extension
+       id="markers.static.analysis.problem"
+       name="Static Analysis Test Problem"
+       point="org.eclipse.core.resources.markers">
+    <super
+          type="org.eclipse.core.resources.problemmarker">
+    </super>
+    <persistent
+          value="true">
+    </persistent>
+    <attribute
+          name="problemKey">
+    </attribute>
+ </extension>
+ <extension
+       id="markers.artificial.problem"
+       name="Artificial Test Problem"
+       point="org.eclipse.core.resources.markers">
  </extension>
 
 </plugin>


### PR DESCRIPTION
This patch fixes issue #2193. The implementation and tests ensure loading of marker content generator extensions, including new marker fields,  marker types, and groups provided via marker content generator extensions.

This way, it is now possible to extends, e.g. the Problems View and the Markers View with new columns. For example, you could add a column with a URL to a vulnerability issue's detailed description (e.g. [CWE-200](https://cwe.mitre.org/data/definitions/200.html)) or in my case to an issue's description found by clang-tidy in a C++ program, like e.g. https://clang.llvm.org/extra/clang-tidy/checks/readability/magic-numbers.html.

![gh2193_new_column](https://github.com/user-attachments/assets/24b23eb5-3ded-4acc-a47d-07d099c96ed6)

Fixes:  #2193