### PR TITLE
Improve performance for large selection

### DIFF
--- a/bundles/org.eclipse.ui.navigator/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.navigator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.navigator; singleton:=true
-Bundle-Version: 3.12.500.qualifier
+Bundle-Version: 3.12.600.qualifier
 Bundle-Activator: org.eclipse.ui.internal.navigator.NavigatorPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/actions/CommonActionProviderDescriptor.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/actions/CommonActionProviderDescriptor.java
@@ -236,6 +236,7 @@ public class CommonActionProviderDescriptor implements
 				context.setAllowPluginActivation(true);
 				if (NavigatorPlugin.safeEvaluate(enablement, context) != EvaluationResult.TRUE) {
 					isEnabled = false;
+					break;
 				}
 			}
 			if (!isEnabled) {


### PR DESCRIPTION
In a custom RCP application I noticed that selecting a huge amount of files (by holding Shift-Scroll down for some seconds) gets slower with the growing size of the selection.

We should short-circuit the evaluation the moment the overall result is known to be false.