### PR TITLE
TextSearchVisitor: don't check for binary files if not required

### DIFF
--- a/bundles/org.eclipse.search.core/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
+++ b/bundles/org.eclipse.search.core/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
@@ -206,7 +206,7 @@ public class TextSearchVisitor {
 				} else {
 					try {
 						charsequence = fileCharSequenceProvider.newCharSequence(file);
-						if (hasBinaryContent(charsequence, file) && !fCollector.reportBinaryFile(file)) {
+						if (!fCollector.reportBinaryFile(file) && hasBinaryContent(charsequence, file)) {
 							return Status.OK_STATUS;
 						}
 						occurences = locateMatches(file, charsequence, matcher, monitor);


### PR DESCRIPTION
If a workspace search is allowed to search in binary files, we should not perform a (possibly expensive) check for whether a file is binary - we are going to search through it regardless of the result of that query.

As discussed in
https://github.com/eclipse-platform/eclipse.platform.ui/issues/2180

Note: the performance increase is not yet optimal - we still load the file to ram, the difference is that now, we don't scan through the file for zero-bytes. A "good" solution would recognize file extensions and not load those files to begin with.