### PR TITLE
Fix StickyScrollingHandlerTest.testThrottledExecution on Mac

### DIFF
--- a/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.editors.tests;singleton:=true
-Bundle-Version: 3.13.500.qualifier
+Bundle-Version: 3.13.600.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface.text.tests.codemining,

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandlerTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandlerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.StringJoiner;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -73,6 +74,11 @@ public class StickyScrollingHandlerTest {
 		linesProvider = mock(StickyLinesProvider.class);
 
 		stickyScrollingHandler = new StickyScrollingHandler(sourceViewer, ruler, store, linesProvider);
+	}
+
+	@After
+	public void teardown() {
+		shell.dispose();
 	}
 
 	@Test
@@ -129,13 +135,19 @@ public class StickyScrollingHandlerTest {
 	@Test
 	public void testThrottledExecution() throws InterruptedException {
 		when(linesProvider.get(100, sourceViewer)).thenReturn(List.of(new StickyLine("line 10", 9)));
+		when(linesProvider.get(200, sourceViewer)).thenReturn(List.of(new StickyLine("line 10", 9)));
+		when(linesProvider.get(300, sourceViewer)).thenReturn(List.of(new StickyLine("line 10", 9)));
+		when(linesProvider.get(400, sourceViewer)).thenReturn(List.of(new StickyLine("line 10", 9)));
 
 		stickyScrollingHandler.viewportChanged(100);
+		Thread.sleep(10);
 		stickyScrollingHandler.viewportChanged(200);
+		Thread.sleep(10);
 		stickyScrollingHandler.viewportChanged(300);
+		Thread.sleep(10);
 		stickyScrollingHandler.viewportChanged(400);
 
-		waitInUi(200);
+		waitInUi(300);
 
 		// Call to lines provider should be throttled
 		verify(linesProvider, times(1)).get(100, sourceViewer);


### PR DESCRIPTION
The unit test StickyScrollingHandlerTest.testThrottledExecution was failing in the I build on MacOS. With this change, the test should run again.

Fixes #2190