### PR TITLE
Error Log: do not pop up on info/warning/freeze by default #2218

### DIFF
--- a/bundles/org.eclipse.ui.monitoring/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.monitoring/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: %Bundle-Name
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-SymbolicName: org.eclipse.ui.monitoring;singleton:=true
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 1.3.300.qualifier
+Bundle-Version: 1.3.400.qualifier
 Export-Package: org.eclipse.ui.internal.monitoring;x-internal:=true,
  org.eclipse.ui.internal.monitoring.preferences;x-internal:=true,
  org.eclipse.ui.monitoring;x-internal:=true

--- a/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/preferences/MonitoringPreferenceInitializer.java
+++ b/bundles/org.eclipse.ui.monitoring/src/org/eclipse/ui/internal/monitoring/preferences/MonitoringPreferenceInitializer.java
@@ -30,7 +30,7 @@ public class MonitoringPreferenceInitializer extends AbstractPreferenceInitializ
 
 		store.setDefault(PreferenceConstants.MONITORING_ENABLED, false);
 		store.setDefault(PreferenceConstants.LONG_EVENT_WARNING_THRESHOLD_MILLIS, 500); // 0.5 sec
-		store.setDefault(PreferenceConstants.LONG_EVENT_ERROR_THRESHOLD_MILLIS, 1000); // 2 sec
+		store.setDefault(PreferenceConstants.LONG_EVENT_ERROR_THRESHOLD_MILLIS, 100_000); // 100 sec
 		store.setDefault(PreferenceConstants.MAX_STACK_SAMPLES, 3);
 		store.setDefault(PreferenceConstants.DEADLOCK_REPORTING_THRESHOLD_MILLIS,
 				5 * 60 * 1000); // 5 min

--- a/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.ui.views.log;singleton:=true
-Bundle-Version: 1.4.500.qualifier
+Bundle-Version: 1.4.600.qualifier
 Bundle-Activator: org.eclipse.ui.internal.views.log.Activator
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogView.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogView.java
@@ -1762,9 +1762,10 @@ public class LogView extends ViewPart implements LogListener {
 		fMemento.putInteger(P_COLUMN_1, getColumnWidthPreference(instancePrefs, defaultPrefs, P_COLUMN_1, 300));
 		fMemento.putInteger(P_COLUMN_2, getColumnWidthPreference(instancePrefs, defaultPrefs, P_COLUMN_2, 150));
 		fMemento.putInteger(P_COLUMN_3, getColumnWidthPreference(instancePrefs, defaultPrefs, P_COLUMN_3, 150));
-		fMemento.putBoolean(P_ACTIVATE, instancePrefs.getBoolean(P_ACTIVATE, defaultPrefs.getBoolean(P_ACTIVATE, true)));
+		fMemento.putBoolean(P_ACTIVATE,
+				instancePrefs.getBoolean(P_ACTIVATE, defaultPrefs.getBoolean(P_ACTIVATE, false)));
 		fMemento.putBoolean(P_ACTIVATE_WARN,
-				instancePrefs.getBoolean(P_ACTIVATE_WARN, defaultPrefs.getBoolean(P_ACTIVATE_WARN, true)));
+				instancePrefs.getBoolean(P_ACTIVATE_WARN, defaultPrefs.getBoolean(P_ACTIVATE_WARN, false)));
 		fMemento.putBoolean(P_ACTIVATE_ERRROR,
 				instancePrefs.getBoolean(P_ACTIVATE_ERRROR, defaultPrefs.getBoolean(P_ACTIVATE_ERRROR, true)));
 		fMemento.putInteger(P_ORDER_VALUE, instancePrefs.getInt(P_ORDER_VALUE, defaultPrefs.getInt(P_ORDER_VALUE, DESCENDING)));


### PR DESCRIPTION
As it is counterproductive to pop up error log when something took too long.

https://github.com/eclipse-platform/eclipse.platform.ui/issues/2218
![image](https://github.com/user-attachments/assets/5b719c66-ce0b-4e62-b23d-2d21baa90fef)
![image](https://github.com/user-attachments/assets/4ca2df0b-2cc9-45a6-a779-6a2a831e0cdc)
