### PR TITLE
search: fail fast for binary file types without opening the file #2180

### DIFF
--- a/bundles/org.eclipse.search.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.search.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search.core;singleton:=true
-Bundle-Version: 3.16.300.qualifier
+Bundle-Version: 3.16.400.qualifier
 Bundle-Activator: org.eclipse.search.internal.core.SearchCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.ui/issues/2180

assumes that files are binary if they have a IContentType that is not text