### PR TITLE
Added dynamic tab alignment support in MultiPageEditorPart

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/IDEEditorsPreferencePage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/IDEEditorsPreferencePage.java
@@ -62,6 +62,7 @@ public class IDEEditorsPreferencePage extends EditorsPreferencePage {
 		createUseIPersistablePref(composite);
 		createPromptWhenStillOpenPref(composite);
 		createEditorReuseGroup(composite);
+		createAlignMultiPageEditorTabsOnTop(composite);
 
 		applyDialogFont(composite);
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/IDEEditorsPreferencePage.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/IDEEditorsPreferencePage.java
@@ -62,7 +62,7 @@ public class IDEEditorsPreferencePage extends EditorsPreferencePage {
 		createUseIPersistablePref(composite);
 		createPromptWhenStillOpenPref(composite);
 		createEditorReuseGroup(composite);
-		createAlignMultiPageEditorTabsOnTop(composite);
+		createAlignMultiPageEditorTabs(composite);
 
 		applyDialogFont(composite);
 

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IWorkbenchPreferenceConstants.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IWorkbenchPreferenceConstants.java
@@ -625,19 +625,18 @@ public interface IWorkbenchPreferenceConstants {
 	String DISABLE_OPEN_EDITOR_IN_PLACE = "DISABLE_OPEN_EDITOR_IN_PLACE"; //$NON-NLS-1$
 
 	/**
-	 * Workbench preference id for whether the tabs in the multi-page editor is
-	 * displayed on top. Note that tabs will be shown in the top only if this
-	 * preference is <code>true</code>.
+	 * Workbench preference id for the position of the tabs in the multi-page
+	 * editor.
 	 *
-	 * Boolean-valued: <code>true</code> show the tabs on the top, and
-	 * <code>false</code> if shown at the bottom.
+	 * Integer-valued: {@link SWT#TOP} for tabs on the top, and {@link SWT#BOTTOM}
+	 * for tabs at the bottom.
 	 * <p>
-	 * The default value for this preference is: <code>false</code>
+	 * The default value for this preference is: {@link SWT#BOTTOM}
 	 * </p>
 	 *
 	 * @since 3.133
 	 */
-	String ALIGN_MULTI_PAGE_EDITOR_TABS_ON_TOP = "ALIGN_MULTI_PAGE_EDITOR_TABS_ON_TOP"; //$NON-NLS-1$
+	String ALIGN_MULTI_PAGE_EDITOR_TABS = "ALIGN_MULTI_PAGE_EDITOR_TABS"; //$NON-NLS-1$
 
 	/**
 	 * Workbench preference id for indicating the size of the list of most recently

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IWorkbenchPreferenceConstants.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IWorkbenchPreferenceConstants.java
@@ -625,6 +625,21 @@ public interface IWorkbenchPreferenceConstants {
 	String DISABLE_OPEN_EDITOR_IN_PLACE = "DISABLE_OPEN_EDITOR_IN_PLACE"; //$NON-NLS-1$
 
 	/**
+	 * Workbench preference id for whether the tabs in the multi-page editor is
+	 * displayed on top. Note that tabs will be shown in the top only if this
+	 * preference is <code>true</code>.
+	 *
+	 * Boolean-valued: <code>true</code> show the tabs on the top, and
+	 * <code>false</code> if shown at the bottom.
+	 * <p>
+	 * The default value for this preference is: <code>false</code>
+	 * </p>
+	 *
+	 * @since 3.133
+	 */
+	String ALIGN_MULTI_PAGE_EDITOR_TABS_ON_TOP = "ALIGN_MULTI_PAGE_EDITOR_TABS_ON_TOP"; //$NON-NLS-1$
+
+	/**
 	 * Workbench preference id for indicating the size of the list of most recently
 	 * used working sets.
 	 * <p>

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchMessages.java
@@ -452,6 +452,7 @@ public class WorkbenchMessages extends NLS {
 	public static String WorkbenchPreference_stickyCycleButton;
 	public static String WorkbenchPreference_RunInBackgroundButton;
 	public static String WorkbenchPreference_RunInBackgroundToolTip;
+	public static String WorkbenchPreference_AlignMultiPageEditorTabsOnTopButton;
 
 	// --- Appearance ---
 	public static String ViewsPreferencePage_Theme;

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchMessages.java
@@ -452,7 +452,9 @@ public class WorkbenchMessages extends NLS {
 	public static String WorkbenchPreference_stickyCycleButton;
 	public static String WorkbenchPreference_RunInBackgroundButton;
 	public static String WorkbenchPreference_RunInBackgroundToolTip;
-	public static String WorkbenchPreference_AlignMultiPageEditorTabsOnTopButton;
+	public static String WorkbenchPreference_AlignMultiPageEditorTabs;
+	public static String WorkbenchPreference_AlignMultiPageEditorTabs_Top;
+	public static String WorkbenchPreference_AlignMultiPageEditorTabs_Bottom;
 
 	// --- Appearance ---
 	public static String ViewsPreferencePage_Theme;

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchPreferenceInitializer.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchPreferenceInitializer.java
@@ -102,6 +102,7 @@ public class WorkbenchPreferenceInitializer extends AbstractPreferenceInitialize
 		// Heap status preferences is stored in different node
 		IEclipsePreferences heapNode = context.getNode("org.eclipse.ui"); //$NON-NLS-1$
 		heapNode.putBoolean(IWorkbenchPreferenceConstants.SHOW_MEMORY_MONITOR, false);
+		heapNode.putInt(IWorkbenchPreferenceConstants.ALIGN_MULTI_PAGE_EDITOR_TABS, SWT.BOTTOM);
 		node.putInt(IHeapStatusConstants.PREF_UPDATE_INTERVAL, 500);
 		node.putBoolean(IHeapStatusConstants.PREF_SHOW_MAX, false);
 		node.putBoolean(IPreferenceConstants.OVERRIDE_PRESENTATION, false);

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/EditorsPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/EditorsPreferencePage.java
@@ -18,8 +18,10 @@ package org.eclipse.ui.internal.dialogs;
 
 import static org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter;
 
+import org.eclipse.jface.action.Action;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.IntegerFieldEditor;
@@ -74,7 +76,7 @@ public class EditorsPreferencePage extends PreferencePage implements IWorkbenchP
 
 	private Button allowInplaceEditor;
 
-	private Button alignMultiPageEditorTabsOnTop;
+	private ComboFieldEditor multiPageEditorTabPositionComboField;
 
 	@Override
 	protected Control createContents(Composite parent) {
@@ -134,13 +136,21 @@ public class EditorsPreferencePage extends PreferencePage implements IWorkbenchP
 		setButtonLayoutData(promptWhenStillOpenEditor);
 	}
 
-	protected void createAlignMultiPageEditorTabsOnTop(Composite composite) {
-		alignMultiPageEditorTabsOnTop = new Button(composite, SWT.CHECK);
-		alignMultiPageEditorTabsOnTop
-				.setText(WorkbenchMessages.WorkbenchPreference_AlignMultiPageEditorTabsOnTopButton);
-		alignMultiPageEditorTabsOnTop.setSelection(
-				getAPIPreferenceStore().getBoolean(IWorkbenchPreferenceConstants.ALIGN_MULTI_PAGE_EDITOR_TABS_ON_TOP));
-		setButtonLayoutData(alignMultiPageEditorTabsOnTop);
+	protected void createAlignMultiPageEditorTabs(Composite parent) {
+		Composite comboComposite = new Composite(parent, SWT.NONE);
+		comboComposite.setLayout(GridLayoutFactory.fillDefaults().numColumns(2).create());
+		comboComposite.setLayoutData(GridDataFactory.fillDefaults().create());
+		String name = IWorkbenchPreferenceConstants.ALIGN_MULTI_PAGE_EDITOR_TABS;
+		String label = WorkbenchMessages.WorkbenchPreference_AlignMultiPageEditorTabs;
+		String[][] namesAndValues = {
+				{ Action.removeMnemonics(WorkbenchMessages.WorkbenchPreference_AlignMultiPageEditorTabs_Top),
+						String.valueOf(SWT.TOP) },
+				{ Action.removeMnemonics(WorkbenchMessages.WorkbenchPreference_AlignMultiPageEditorTabs_Bottom),
+						String.valueOf(SWT.BOTTOM) } };
+		multiPageEditorTabPositionComboField = new ComboFieldEditor(name, label, namesAndValues, comboComposite);
+		multiPageEditorTabPositionComboField.setPreferenceStore(getAPIPreferenceStore());
+		multiPageEditorTabPositionComboField.setPage(this);
+		multiPageEditorTabPositionComboField.load();
 	}
 
 	protected Composite createComposite(Composite parent) {
@@ -163,8 +173,6 @@ public class EditorsPreferencePage extends PreferencePage implements IWorkbenchP
 		IPreferenceStore store = getPreferenceStore();
 		allowInplaceEditor.setSelection(
 				!getAPIPreferenceStore().getDefaultBoolean(IWorkbenchPreferenceConstants.DISABLE_OPEN_EDITOR_IN_PLACE));
-		alignMultiPageEditorTabsOnTop.setSelection(getAPIPreferenceStore()
-				.getDefaultBoolean(IWorkbenchPreferenceConstants.ALIGN_MULTI_PAGE_EDITOR_TABS_ON_TOP));
 		useIPersistableEditor.setSelection(store.getDefaultBoolean(IPreferenceConstants.USE_IPERSISTABLE_EDITORS));
 		promptWhenStillOpenEditor.setSelection(getAPIPreferenceStore()
 				.getDefaultBoolean(IWorkbenchPreferenceConstants.PROMPT_WHEN_SAVEABLE_STILL_OPEN));
@@ -173,13 +181,13 @@ public class EditorsPreferencePage extends PreferencePage implements IWorkbenchP
 		reuseEditorsThreshold.getLabelControl(editorReuseThresholdGroup).setEnabled(reuseEditors.getSelection());
 		reuseEditorsThreshold.getTextControl(editorReuseThresholdGroup).setEnabled(reuseEditors.getSelection());
 		recentFilesEditor.loadDefault();
+		multiPageEditorTabPositionComboField.loadDefault();
 	}
 
 	@Override
 	public boolean performOk() {
 		IPreferenceStore store = getPreferenceStore();
-		getAPIPreferenceStore().setValue(IWorkbenchPreferenceConstants.ALIGN_MULTI_PAGE_EDITOR_TABS_ON_TOP,
-				alignMultiPageEditorTabsOnTop.getSelection());
+		multiPageEditorTabPositionComboField.store();
 		getAPIPreferenceStore().setValue(IWorkbenchPreferenceConstants.DISABLE_OPEN_EDITOR_IN_PLACE,
 				!allowInplaceEditor.getSelection());
 		store.setValue(IPreferenceConstants.USE_IPERSISTABLE_EDITORS, useIPersistableEditor.getSelection());

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/EditorsPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/dialogs/EditorsPreferencePage.java
@@ -74,6 +74,8 @@ public class EditorsPreferencePage extends PreferencePage implements IWorkbenchP
 
 	private Button allowInplaceEditor;
 
+	private Button alignMultiPageEditorTabsOnTop;
+
 	@Override
 	protected Control createContents(Composite parent) {
 		Composite composite = createComposite(parent);
@@ -132,6 +134,15 @@ public class EditorsPreferencePage extends PreferencePage implements IWorkbenchP
 		setButtonLayoutData(promptWhenStillOpenEditor);
 	}
 
+	protected void createAlignMultiPageEditorTabsOnTop(Composite composite) {
+		alignMultiPageEditorTabsOnTop = new Button(composite, SWT.CHECK);
+		alignMultiPageEditorTabsOnTop
+				.setText(WorkbenchMessages.WorkbenchPreference_AlignMultiPageEditorTabsOnTopButton);
+		alignMultiPageEditorTabsOnTop.setSelection(
+				getAPIPreferenceStore().getBoolean(IWorkbenchPreferenceConstants.ALIGN_MULTI_PAGE_EDITOR_TABS_ON_TOP));
+		setButtonLayoutData(alignMultiPageEditorTabsOnTop);
+	}
+
 	protected Composite createComposite(Composite parent) {
 		Composite composite = new Composite(parent, SWT.NULL);
 		GridLayout layout = new GridLayout();
@@ -152,6 +163,8 @@ public class EditorsPreferencePage extends PreferencePage implements IWorkbenchP
 		IPreferenceStore store = getPreferenceStore();
 		allowInplaceEditor.setSelection(
 				!getAPIPreferenceStore().getDefaultBoolean(IWorkbenchPreferenceConstants.DISABLE_OPEN_EDITOR_IN_PLACE));
+		alignMultiPageEditorTabsOnTop.setSelection(getAPIPreferenceStore()
+				.getDefaultBoolean(IWorkbenchPreferenceConstants.ALIGN_MULTI_PAGE_EDITOR_TABS_ON_TOP));
 		useIPersistableEditor.setSelection(store.getDefaultBoolean(IPreferenceConstants.USE_IPERSISTABLE_EDITORS));
 		promptWhenStillOpenEditor.setSelection(getAPIPreferenceStore()
 				.getDefaultBoolean(IWorkbenchPreferenceConstants.PROMPT_WHEN_SAVEABLE_STILL_OPEN));
@@ -165,6 +178,8 @@ public class EditorsPreferencePage extends PreferencePage implements IWorkbenchP
 	@Override
 	public boolean performOk() {
 		IPreferenceStore store = getPreferenceStore();
+		getAPIPreferenceStore().setValue(IWorkbenchPreferenceConstants.ALIGN_MULTI_PAGE_EDITOR_TABS_ON_TOP,
+				alignMultiPageEditorTabsOnTop.getSelection());
 		getAPIPreferenceStore().setValue(IWorkbenchPreferenceConstants.DISABLE_OPEN_EDITOR_IN_PLACE,
 				!allowInplaceEditor.getSelection());
 		store.setValue(IPreferenceConstants.USE_IPERSISTABLE_EDITORS, useIPersistableEditor.getSelection());

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
@@ -419,7 +419,9 @@ WorkbenchPreference_RunInBackgroundButton=Always r&un in background
 WorkbenchPreference_RunInBackgroundToolTip=Run long operations in the background where possible
 WorkbenchPreference_HeapStatusButton = Sho&w heap status
 WorkbenchPreference_HeapStatusButtonToolTip = Show the heap status area on the bottom of the window
-WorkbenchPreference_AlignMultiPageEditorTabsOnTopButton= &Align multi-page editor tabs on top
+WorkbenchPreference_AlignMultiPageEditorTabs= &Align multi-page editor tabs:
+WorkbenchPreference_AlignMultiPageEditorTabs_Top= &Top
+WorkbenchPreference_AlignMultiPageEditorTabs_Bottom= &Bottom
 
 
 # --- Appearance ---

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
@@ -419,6 +419,7 @@ WorkbenchPreference_RunInBackgroundButton=Always r&un in background
 WorkbenchPreference_RunInBackgroundToolTip=Run long operations in the background where possible
 WorkbenchPreference_HeapStatusButton = Sho&w heap status
 WorkbenchPreference_HeapStatusButtonToolTip = Show the heap status area on the bottom of the window
+WorkbenchPreference_AlignMultiPageEditorTabsOnTopButton= &Align multi-page editor tabs on top
 
 
 # --- Appearance ---
@@ -493,7 +494,7 @@ OpenPerspectiveDialogAction_tooltip=Open Perspective
 
 #---- General Preferences----
 PreferencePage_noDescription = (No description available)
-PreferencePageParameterValues_pageLabelSeparator = \ >\ 
+PreferencePageParameterValues_pageLabelSeparator = \ >\
 ThemingEnabled = E&nable theming
 ThemeChangeWarningText = Restart for the theme changes to take full effect
 ThemeChangeWarningTitle = Theme Changed

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/part/MultiPageEditorPart.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/part/MultiPageEditorPart.java
@@ -1280,7 +1280,17 @@ public abstract class MultiPageEditorPart extends EditorPart implements IPageCha
 		}
 	}
 
-	private void updateContainer() {
+	/**
+	 * Updates the tab position of the container in the multi-page editor.
+	 *
+	 * <p>
+	 * This method retrieves the current container and sets the tab position based
+	 * on the user preference.
+	 * </p>
+	 *
+	 * @since 3.133
+	 */
+	protected void updateContainer() {
 		Composite container = getContainer();
 		if (container instanceof CTabFolder tabFolder) {
 			tabFolder.setTabPosition(getTabStyle());

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/part/MultiPageEditorPart.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/part/MultiPageEditorPart.java
@@ -161,24 +161,24 @@ public abstract class MultiPageEditorPart extends EditorPart implements IPageCha
 	protected MultiPageEditorPart() {
 		super();
 		getAPIPreferenceStore().addPropertyChangeListener(event -> {
-			handlePropertyChange(event);
+			if (isUpdateRequired(event)) {
+				updateContainer();
+			}
 		});
 	}
 
 	/**
-	 * Handles property change events related to editor preferences.
-	 *
-	 * <p>
-	 * This method is invoked when a property change occurs in the preference store.
-	 * </p>
+	 * Determines whether an update is required based on a property change event.
 	 *
 	 * @param event the {@link PropertyChangeEvent} triggered by a change in the
 	 *              preference store
+	 * @since 3.133
 	 */
-	private void handlePropertyChange(PropertyChangeEvent event) {
-		if (event.getProperty().equals(IWorkbenchPreferenceConstants.ALIGN_MULTI_PAGE_EDITOR_TABS_ON_TOP)) {
-			updateContainer();
+	protected boolean isUpdateRequired(PropertyChangeEvent event) {
+		if (event.getProperty().equals(IWorkbenchPreferenceConstants.ALIGN_MULTI_PAGE_EDITOR_TABS)) {
+			return true;
 		}
+		return false;
 	}
 
 	/**
@@ -290,7 +290,7 @@ public abstract class MultiPageEditorPart extends EditorPart implements IPageCha
 		// use SWT.FLAT style so that an extra 1 pixel border is not reserved
 		// inside the folder
 		parent.setLayout(new FillLayout());
-		final CTabFolder newContainer = new CTabFolder(parent, getPreferredTabStyle());
+		final CTabFolder newContainer = new CTabFolder(parent, getTabStyle() | SWT.FLAT);
 		newContainer.addSelectionListener(widgetSelectedAdapter(e -> {
 			int newPageIndex = newContainer.indexOf((CTabItem) e.item);
 			pageChange(newPageIndex);
@@ -318,7 +318,7 @@ public abstract class MultiPageEditorPart extends EditorPart implements IPageCha
 	}
 
 	/**
-	 * Determines the preferred tab style based on user preferences.
+	 * Determines the tab style based on user preferences.
 	 * <p>
 	 * This method retrieves the user preference for aligning multi-page editor tabs
 	 * on top or bottom, and returns the corresponding SWT style constant.
@@ -327,12 +327,10 @@ public abstract class MultiPageEditorPart extends EditorPart implements IPageCha
 	 * @return {@code SWT.TOP} if the user prefers tabs to be aligned on top,
 	 *         {@code SWT.BOTTOM} if the user prefers tabs to be aligned on the
 	 *         bottom.
+	 * @since 3.133
 	 */
-	private int getPreferredTabStyle() {
-		boolean alignTabsOnTop = getAPIPreferenceStore()
-				.getBoolean(IWorkbenchPreferenceConstants.ALIGN_MULTI_PAGE_EDITOR_TABS_ON_TOP);
-		int style = alignTabsOnTop ? SWT.TOP : SWT.BOTTOM;
-		return style;
+	protected int getTabStyle() {
+		return getAPIPreferenceStore().getInt(IWorkbenchPreferenceConstants.ALIGN_MULTI_PAGE_EDITOR_TABS);
 	}
 
 	/**
@@ -1285,7 +1283,7 @@ public abstract class MultiPageEditorPart extends EditorPart implements IPageCha
 	private void updateContainer() {
 		Composite container = getContainer();
 		if (container instanceof CTabFolder tabFolder) {
-			tabFolder.setTabPosition(getPreferredTabStyle());
+			tabFolder.setTabPosition(getTabStyle());
 			tabFolder.requestLayout();
 		}
 	}


### PR DESCRIPTION
Issue: #2223 

This pull request introduces a new feature in Eclipse that allows users to configure the alignment of tabs in multi-page editors. The tabs, which are currently fixed at the bottom, can now be dynamically positioned on the top or bottom, based on user preference. 

Key Changes:
- Added a new preference for multi-page editor tab alignment.
- Added a preference change listener to MultiPageEditorPart.
- Updated tab style based on the user's preference.

New preference: 
![New preference selected](https://github.com/user-attachments/assets/4ca0fbf9-fa2e-4d54-8349-cd949e5ad41c)

Tabs on top of the screen:
![Expected look](https://github.com/user-attachments/assets/7ccbcbd6-a42a-4804-be22-7128eee1cc88)
