### PR TITLE
fix workspace considered not writable on a smb home share #2225

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
@@ -1049,7 +1049,7 @@ ChooseWorkspaceDialog_recentWorkspaces=&Recent Workspaces
 ChooseWorkspaceDialog_ResolvedAbsolutePath=Full path: {0} 
 ChooseWorkspaceDialog_TildeNonExpandedWarning=\u26A0\uFE0F '~' is not expanded, full path: {0}
 ChooseWorkspaceDialog_InvalidPathWarning=\u26A0\uFE0F The path is invalid on this system: {0}
-ChooseWorkspaceDialog_NotWriteablePathWarning=\u26A0\uFE0F The path is not writable by the current user: {0} 
+ChooseWorkspaceDialog_NotWriteablePathWarning=\u26A0\uFE0F The path may not be writable by the current user: {0} 
 ChooseWorkspaceDialog_useDefaultMessage=&Use this as the default and do not ask again
 
 ChooseWorkspaceWithSettingsDialog_SettingsGroupName=&Copy Settings


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.ui/issues/2225

java.io.File.canWrite() and java.nio.file.Files.isWritable(Path) can not be trusted on windows. they may return wrong values. see for example JDK-8282720, JDK-8148211, JDK-8154915

=> allow the user to press "Launch" even if jdk states the directory is not writable