### PR TITLE
Resolve problem markers "Unlikely argument type for equals()"

### DIFF
--- a/bundles/org.eclipse.ui.forms/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.forms/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.ui.forms;singleton:=true
-Bundle-Version: 3.13.300.qualifier
+Bundle-Version: 3.13.400.qualifier
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.forms,

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/Paragraph.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/Paragraph.java
@@ -162,7 +162,7 @@ public class Paragraph {
 				computeRowHeights(gc, width, loc, lineHeight, resourceTable);
 			for (ParagraphSegment segment : segments) {
 				boolean doSelect = false;
-				if (selectedLink != null && segment.equals(selectedLink))
+				if (selectedLink instanceof ParagraphSegment sl && segment.equals(sl))
 					doSelect = true;
 				segment.layout(gc, width, loc, resourceTable, doSelect);
 			}
@@ -182,7 +182,7 @@ public class Paragraph {
 			if (!segment.intersects(repaintRegion))
 				continue;
 			boolean doSelect = false;
-			if (selectedLink != null && segment.equals(selectedLink))
+			if (selectedLink instanceof ParagraphSegment sl && segment.equals(sl))
 				doSelect = true;
 			segment.paint(gc, false, resourceTable, doSelect, selData, repaintRegion);
 		}

--- a/bundles/org.eclipse.ui.views.properties.tabbed/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views.properties.tabbed/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.views.properties.tabbed;singleton:=true
-Bundle-Version: 3.10.300.qualifier
+Bundle-Version: 3.10.400.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.internal.views.properties.tabbed;x-internal:=true,

--- a/bundles/org.eclipse.ui.views.properties.tabbed/src/org/eclipse/ui/views/properties/tabbed/TabbedPropertySheetPage.java
+++ b/bundles/org.eclipse.ui.views.properties.tabbed/src/org/eclipse/ui/views/properties/tabbed/TabbedPropertySheetPage.java
@@ -315,8 +315,8 @@ public class TabbedPropertySheetPage
 		 * The properties view has been activated and the current page is this
 		 * instance of TabbedPropertySheetPage
 		 */
-		boolean thisActivated = part instanceof PropertySheet
-			&& ((PropertySheet) part).getCurrentPage() == this;
+		boolean thisActivated = part instanceof PropertySheet propertySheet
+			&& propertySheet.getCurrentPage() == this;
 
 		/*
 		 * When the active part changes and the part does not provide a
@@ -325,16 +325,15 @@ public class TabbedPropertySheetPage
 		 * of these events since we want to send aboutToBeHidden() and
 		 * aboutToBeShown() when the property sheet is hidden or shown.
 		 */
-		if (!thisActivated && !part.equals(contributor)
+		if (!thisActivated && !(part instanceof ITabbedPropertySheetPageContributor p && p.equals(contributor))
 				&& !part.getSite().getId().equals(contributor.getContributorId())) {
 			/*
 			 * Is the part is a IContributedContentsView for the contributor,
 			 * for example, outline view.
 			 */
 			IContributedContentsView view = Adapters.adapt(part, IContributedContentsView.class);
-			if (view == null
-				|| (view.getContributingPart() != null && !view
-					.getContributingPart().equals(contributor))) {
+			if (!(view.getContributingPart() instanceof ITabbedPropertySheetPageContributor cp
+					&& cp.equals(contributor))) {
 				if (activePropertySheet) {
 					if (currentTab != null) {
 						currentTab.aboutToBeHidden();


### PR DESCRIPTION
trick the compiler to ignore false positives:
* IHyperlinkSegment is related to ParagraphSegment
* ITabbedPropertySheetPageContributor is related to IWorkbenchPart

as they have common implementations.