### PR TITLE
AbstractTextEditor: resolve "Potential null pointer access"

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AbstractTextEditor.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AbstractTextEditor.java
@@ -6998,7 +6998,8 @@ public abstract class AbstractTextEditor extends EditorPart implements ITextEdit
 					if (currentDistance < 0)
 						currentDistance= endOfDocument + currentDistance;
 
-					if (currentDistance < distance || currentDistance == distance && p.length < nextAnnotationPosition.length) {
+					if (nextAnnotationPosition == null || currentDistance < distance
+							|| currentDistance == distance && p.length < nextAnnotationPosition.length) {
 						distance= currentDistance;
 						nextAnnotation= a;
 						nextAnnotationPosition= p;
@@ -7008,7 +7009,8 @@ public abstract class AbstractTextEditor extends EditorPart implements ITextEdit
 					if (currentDistance < 0)
 						currentDistance= endOfDocument + currentDistance;
 
-					if (currentDistance < distance || currentDistance == distance && p.length < nextAnnotationPosition.length) {
+					if (nextAnnotationPosition == null || currentDistance < distance
+							|| currentDistance == distance && p.length < nextAnnotationPosition.length) {
 						distance= currentDistance;
 						nextAnnotation= a;
 						nextAnnotationPosition= p;


### PR DESCRIPTION
"The variable nextAnnotationPosition may be null at this location"

The code assumed "distance=Integer.MAX_VALUE" will cause short circuit "currentDistance < distance" while theoretically equality could happen with currentDistance=Integer.MAX_VALUE.