### PR TITLE
EXPERIMENT: display the Find/Replace overlay as partstack

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench.texteditor/META-INF/MANIFEST.MF
@@ -33,6 +33,9 @@ Require-Bundle:
  org.eclipse.jface.text;bundle-version="[3.19.0,4.0.0)",
  org.eclipse.swt;bundle-version="[3.107.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.5.0,4.0.0)",
- org.eclipse.jface.notifications
+ org.eclipse.jface.notifications,
+ org.eclipse.e4.ui.model.workbench,
+ org.eclipse.e4.core.contexts,
+ org.eclipse.e4.ui.workbench
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.ui.workbench.texteditor

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceAction.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceAction.java
@@ -16,8 +16,11 @@ package org.eclipse.ui.texteditor;
 
 import java.util.ResourceBundle;
 
+import org.eclipse.e4.ui.model.application.ui.basic.MPartStack;
+
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.core.runtime.Assert;
@@ -411,6 +414,8 @@ public class FindReplaceAction extends ResourceAction implements IUpdate {
 		dialog.open();
 	}
 
+	MPartStack pipStack = null;
+	Composite pipComp = null;
 	private void showOverlayInEditor() {
 		if (overlay == null) {
 			Shell shellToUse = null;
@@ -429,7 +434,7 @@ public class FindReplaceAction extends ResourceAction implements IUpdate {
 		overlay.setPositionToTop(shouldPositionOverlayOnTop());
 
 		hookDialogPreferenceListener();
-		overlay.getShell().addDisposeListener(__ -> removeDialogPreferenceListener());
+//		overlay.getShell().addDisposeListener(__ -> removeDialogPreferenceListener());
 	}
 
 	@Override


### PR DESCRIPTION
Experiment with display the Find/Replace Overlay as a Part in a Partstack instead of an overlay shell.

Caveats:
- the part has the annoying tendency to stick to the side instead of allowing to be "positionned to the top all the time"
- keypresses are still interpreted as keypresses targeted towards the Editor behind (ie. pressing Ctrl+Backspace delets a full word in the editor not in the overlay)

First time opening the overlay (something is wrong...)
![grafik](https://github.com/user-attachments/assets/1da9ce85-33a8-4c47-8fc7-26f1929cb384)

Second time pressing Cltr+F
![grafik](https://github.com/user-attachments/assets/213cf559-86f5-4a51-85a0-89d0728fc528)

Adapted from https://github.com/eclipse-platform/eclipse.platform.ui/issues/2093

I do not believe that this solution can bring improvement to #2099