### PR TITLE
code minings drawn more consistently always via drawAsLeftOf1stCharacter

### DIFF
--- a/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.text
-Bundle-Version: 3.25.300.qualifier
+Bundle-Version: 3.26.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineContentAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineContentAnnotation.java
@@ -61,6 +61,8 @@ public class CodeMiningLineContentAnnotation extends LineContentAnnotation imple
 	 */
 	private IProgressMonitor fMonitor;
 
+	private final boolean afterPosition;
+
 	/**
 	 * Code mining annotation constructor.
 	 *
@@ -72,6 +74,21 @@ public class CodeMiningLineContentAnnotation extends LineContentAnnotation imple
 		fResolvedMinings= null;
 		fMinings= new ArrayList<>();
 		fBounds= new ArrayList<>();
+		afterPosition= false;
+	}
+
+	/**
+	 * Code mining annotation constructor.
+	 *
+	 * @param position the position
+	 * @param viewer the viewer
+	 */
+	public CodeMiningLineContentAnnotation(Position position, ISourceViewer viewer, boolean afterPosition) {
+		super(position, viewer);
+		fResolvedMinings= null;
+		fMinings= new ArrayList<>();
+		fBounds= new ArrayList<>();
+		this.afterPosition= afterPosition;
 	}
 
 	@Override
@@ -182,5 +199,9 @@ public class CodeMiningLineContentAnnotation extends LineContentAnnotation imple
 	@Override
 	public boolean isInVisibleLines() {
 		return super.isInVisibleLines();
+	}
+
+	public final boolean isAfterPosition() {
+		return afterPosition;
 	}
 }

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningManager.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningManager.java
@@ -42,6 +42,7 @@ import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.codemining.ICodeMining;
 import org.eclipse.jface.text.codemining.ICodeMiningProvider;
+import org.eclipse.jface.text.codemining.LineContentCodeMining;
 import org.eclipse.jface.text.codemining.LineHeaderCodeMining;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.text.source.inlined.AbstractInlinedAnnotation;
@@ -251,12 +252,17 @@ public class CodeMiningManager implements Runnable {
 
 			Position pos= new Position(g.getKey().offset, g.getKey().length);
 			List<ICodeMining> minings= g.getValue();
-			boolean inLineHeader= !minings.isEmpty() ? (minings.get(0) instanceof LineHeaderCodeMining) : true;
+			ICodeMining first= minings.get(0);
+			boolean inLineHeader= !minings.isEmpty() ? (first instanceof LineHeaderCodeMining) : true;
 			// Try to find existing annotation
 			AbstractInlinedAnnotation ann= fInlinedAnnotationSupport.findExistingAnnotation(pos);
 			if (ann == null) {
 				// The annotation doesn't exists, create it.
-				ann= inLineHeader ? new CodeMiningLineHeaderAnnotation(pos, viewer) : new CodeMiningLineContentAnnotation(pos, viewer);
+				boolean afterPosition= false;
+				if (first instanceof LineContentCodeMining m) {
+					afterPosition= m.isAfterPosition();
+				}
+				ann= inLineHeader ? new CodeMiningLineHeaderAnnotation(pos, viewer) : new CodeMiningLineContentAnnotation(pos, viewer, afterPosition);
 			} else if (ann instanceof ICodeMiningAnnotation && ((ICodeMiningAnnotation) ann).isInVisibleLines()) {
 				// annotation is in visible lines
 				annotationsToRedraw.add((ICodeMiningAnnotation) ann);

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/codemining/LineContentCodeMining.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/codemining/LineContentCodeMining.java
@@ -26,6 +26,8 @@ import org.eclipse.jface.text.Position;
  */
 public abstract class LineContentCodeMining extends AbstractCodeMining {
 
+	private final boolean afterPosition;
+
 	/**
 	 * CodeMining constructor to locate the code mining in a given position.
 	 *
@@ -40,11 +42,51 @@ public abstract class LineContentCodeMining extends AbstractCodeMining {
 	 * CodeMining constructor to locate the code mining in a given position.
 	 *
 	 * @param position the position where the mining must be drawn.
+	 * @param afterPosition if true code mining is treated as suffix code mining where cursor and
+	 *            selection is not including the mining
+	 * @param provider the owner codemining provider which creates this mining.
+	 *
+	 * @since 3.26
+	 */
+	public LineContentCodeMining(Position position, boolean afterPosition, ICodeMiningProvider provider) {
+		this(position, afterPosition, provider, null);
+	}
+
+	/**
+	 * CodeMining constructor to locate the code mining in a given position.
+	 *
+	 * @param position the position where the mining must be drawn.
 	 * @param provider the owner codemining provider which creates this mining.
 	 * @param action the action to execute when mining is clicked and null otherwise.
 	 */
 	public LineContentCodeMining(Position position, ICodeMiningProvider provider, Consumer<MouseEvent> action) {
+		this(position, false, provider, action);
+	}
+
+	/**
+	 * CodeMining constructor to locate the code mining in a given position.
+	 *
+	 * @param position the position where the mining must be drawn.
+	 * @param provider the owner codemining provider which creates this mining.
+	 * @param action the action to execute when mining is clicked and null otherwise.
+	 * @param afterPosition if true code mining is treated as suffix code mining where cursor and
+	 *            selection is not including the mining
+	 *
+	 * @since 3.26
+	 */
+	public LineContentCodeMining(Position position, boolean afterPosition, ICodeMiningProvider provider, Consumer<MouseEvent> action) {
 		super(position, provider, action);
+		this.afterPosition= afterPosition;
+	}
+
+	/**
+	 * indicates if code mining should be rendered after given position; cursor and selection does
+	 * not include the code mining if set to true.
+	 *
+	 * @since 3.26
+	 */
+	public boolean isAfterPosition() {
+		return afterPosition;
 	}
 
 }

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationSupport.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationSupport.java
@@ -42,6 +42,8 @@ import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.core.runtime.Assert;
 
+import org.eclipse.jface.internal.text.codemining.CodeMiningLineContentAnnotation;
+
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
@@ -107,7 +109,7 @@ public class InlinedAnnotationSupport {
 					.forEachRemaining(annotation -> {
 						if (annotation instanceof LineContentAnnotation) {
 							LineContentAnnotation ann= (LineContentAnnotation) annotation;
-							StyleRange style= ann.updateStyle(null, fFontMetrics, fViewer);
+							StyleRange style= ann.updateStyle(null, fFontMetrics, fViewer, isAfterPosition(ann));
 							if (style != null) {
 								if (fViewer instanceof ITextViewerExtension5 projectionViewer) {
 									IRegion annotationRegion= projectionViewer.widgetRange2ModelRange(new Region(style.start, style.length));
@@ -118,6 +120,13 @@ public class InlinedAnnotationSupport {
 							}
 						}
 					});
+		}
+
+		private static boolean isAfterPosition(LineContentAnnotation annotation) {
+			if (annotation instanceof CodeMiningLineContentAnnotation a) {
+				return a.isAfterPosition();
+			}
+			return false;
 		}
 	}
 

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineContentAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineContentAnnotation.java
@@ -117,13 +117,16 @@ public class LineContentAnnotation extends AbstractInlinedAnnotation {
 	 * @return the style to apply with GlyphMetrics width only if needed. It uses widget position,
 	 *         not model position.
 	 */
-	StyleRange updateStyle(StyleRange style, FontMetrics fontMetrics, ITextViewer viewer) {
+	StyleRange updateStyle(StyleRange style, FontMetrics fontMetrics, ITextViewer viewer, boolean afterPosition) {
 		Position widgetPosition= computeWidgetPosition(viewer);
 		if (widgetPosition == null) {
 			return null;
 		}
 		StyledText textWidget = viewer.getTextWidget();
-		boolean usePreviousChar= drawRightToPreviousChar(widgetPosition.getOffset(), textWidget);
+		boolean usePreviousChar= false;
+		if (!afterPosition) {
+			usePreviousChar= drawRightToPreviousChar(widgetPosition.getOffset(), textWidget);
+		}
 		if (width == 0 || getRedrawnCharacterWidth() == 0) {
 			return null;
 		}

--- a/examples/org.eclipse.jface.text.examples/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.jface.text.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: CodeMinig Examples
 Bundle-SymbolicName: org.eclipse.jface.text.examples
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: Eclipse.org
 Require-Bundle: org.eclipse.jface.text,

--- a/examples/org.eclipse.jface.text.examples/src/org/eclipse/jface/text/examples/codemining/CodeMiningDemo.java
+++ b/examples/org.eclipse.jface.text.examples/src/org/eclipse/jface/text/examples/codemining/CodeMiningDemo.java
@@ -16,10 +16,12 @@ package org.eclipse.jface.text.examples.codemining;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextViewerExtension2;
+import org.eclipse.jface.text.WhitespaceCharacterPainter;
 import org.eclipse.jface.text.codemining.ICodeMiningProvider;
 import org.eclipse.jface.text.reconciler.DirtyRegion;
 import org.eclipse.jface.text.reconciler.IReconcilingStrategy;
@@ -42,6 +44,8 @@ import org.eclipse.swt.widgets.Text;
  */
 public class CodeMiningDemo {
 
+	private static boolean showWhitespaces = false;
+
 	public static void main(String[] args) throws Exception {
 
 		Display display = new Display();
@@ -54,7 +58,13 @@ public class CodeMiningDemo {
 		endOfLineText.setText(endOfLineString.get());
 		GridDataFactory.fillDefaults().grab(true, false).applyTo(endOfLineText);
 
-		ISourceViewer sourceViewer = new SourceViewer(shell, null, SWT.V_SCROLL | SWT.BORDER);
+		SourceViewer sourceViewer = new SourceViewer(shell, null, SWT.V_SCROLL | SWT.BORDER);
+		sourceViewer.getTextWidget().setFont(JFaceResources.getTextFont());
+		if (showWhitespaces) {
+			WhitespaceCharacterPainter whitespaceCharPainter = new WhitespaceCharacterPainter(sourceViewer, true, true,
+					true, true, true, true, true, true, true, true, true, 100);
+			sourceViewer.addPainter(whitespaceCharPainter);
+		}
 		sourceViewer.setDocument(
 				new Document("// Type class & new keyword and see references CodeMining\n"
 						+ "// Name class with a number N to emulate Nms before resolving the references CodeMining\n"
@@ -71,7 +81,8 @@ public class CodeMiningDemo {
 						+ "new 5\n" //
 						+ "new 5\n" //
 						+ "multiline \n" //
-						+ "multiline \n\n"),
+						+ "multiline \n\n" //
+						+ "suffix \n"),
 				new AnnotationModel());
 		GridDataFactory.fillDefaults().grab(true, true).applyTo(sourceViewer.getTextWidget());
 		// Add AnnotationPainter (required by CodeMining)
@@ -83,7 +94,8 @@ public class CodeMiningDemo {
 				new ToEchoWithHeaderAndInlineCodeMiningProvider("echo"), //
 				new MultilineCodeMiningProvider(), //
 				new EmptyLineCodeMiningProvider(), //
-				new EchoAtEndOfLineCodeMiningProvider(endOfLineString) });
+				new EchoAtEndOfLineCodeMiningProvider(endOfLineString), //
+				new LineContentCodeMiningAfterPositionProvider() });
 		// Execute codemining in a reconciler
 		MonoReconciler reconciler = new MonoReconciler(new IReconcilingStrategy() {
 

--- a/examples/org.eclipse.jface.text.examples/src/org/eclipse/jface/text/examples/codemining/LineContentCodeMiningAfterPositionProvider.java
+++ b/examples/org.eclipse.jface.text.examples/src/org/eclipse/jface/text/examples/codemining/LineContentCodeMiningAfterPositionProvider.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ *  Copyright (c) 2024, SAP SE
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jface.text.examples.codemining;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.codemining.AbstractCodeMiningProvider;
+import org.eclipse.jface.text.codemining.ICodeMining;
+import org.eclipse.jface.text.codemining.LineContentCodeMining;
+
+public class LineContentCodeMiningAfterPositionProvider extends AbstractCodeMiningProvider {
+
+	public LineContentCodeMiningAfterPositionProvider() {
+	}
+
+	@Override
+	public CompletableFuture<List<? extends ICodeMining>> provideCodeMinings(ITextViewer viewer,
+			IProgressMonitor monitor) {
+		String suffix = "suffix";
+		int index = 0;
+		List<ICodeMining> res = new ArrayList<>();
+		while ((index = viewer.getDocument().get().indexOf(suffix, index)) != -1) {
+			index += suffix.length();
+			res.add(new LineContentCodeMining(new Position(index, 1), true, this) {
+				@Override
+				public String getLabel() {
+					return suffix;
+				}
+
+				@Override
+				public boolean isResolved() {
+					return true;
+				}
+			});
+		}
+		return CompletableFuture.completedFuture(res);
+	}
+}
+

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/source/inlined/AnnotationOnTabTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/source/inlined/AnnotationOnTabTest.java
@@ -74,7 +74,7 @@ public class AnnotationOnTabTest {
 		// add annotations
 		int annotationIndex = sourceViewer.getDocument().get().indexOf("annotated");
 		LineContentAnnotation annotation= new LineContentAnnotation(new Position(annotationIndex, 1), sourceViewer);
-		annotation.setText("a"); // single char, so overall annoation is 3 chars, less than default 4 chars
+		annotation.setText("a"); // single char, so overall annotation is 3 chars, less than default 4 chars
 		support.updateAnnotations(Collections.singleton(annotation));
 		fParent.open();
 		Assert.assertTrue(new DisplayHelper() {
@@ -87,6 +87,7 @@ public class AnnotationOnTabTest {
 		int referenceIndex = textWidget.getText().indexOf("reference");
 		Rectangle referenceBounds = textWidget.getTextBounds(referenceIndex, referenceIndex);
 		Rectangle annotatedCharactedBounds = textWidget.getTextBounds(annotationIndex, annotationIndex);
-		Assert.assertTrue("Annotation didn't shift target character to the right, it most likely replaced the tab instead of expanding it", referenceBounds.x < annotatedCharactedBounds.x);
+		Assert.assertTrue("Annotation didn't shift target character to the right, it most likely replaced the tab instead of expanding it",
+				referenceBounds.x + referenceBounds.width < annotatedCharactedBounds.x + annotatedCharactedBounds.width);
 	}
 }


### PR DESCRIPTION
this improves the selection behavior for the scenario where the selection end offset contains a LineContentAnnotation. Selection is no longer extended with the code mining.

The selection behavior before this change always included the code mining text which is located at the end selection offset. The following screenshot shows the behavior. By including the last character "o" of "echo" in the selection, the selection is extended with the code mining text next to the "o" character.
![code_mining_draw_right_to_the_previous_character](https://github.com/user-attachments/assets/ca310b43-aa15-43ef-adf5-50ef65b67ab6)

This is no longer the case with this change. The code mining text is no longer added to the selection when "echo" is selected.
![code_mining_draw_at_current_character](https://github.com/user-attachments/assets/78fcee62-1c0d-4d58-9425-fbfd5ca1eebe)

Is the current behavior of drawing the code mining texts intended? Is this behavior needed for a feature (which I am not aware of)?

Let me try to explain why I request this change.
In the ABAP Development Tools in Eclipse we use the code minings to show inline keyword completions while the user is typing a keyword. If a matching keyword is available, it is shown as code mining and user can take over the text by pressing the tab key. Here a screencast showing the scenario when the user is typing the keyword "definition". 

https://github.com/user-attachments/assets/8770b291-08e6-4cd2-ba83-bf1a67d6c93c

It works quite well. Users don't like the way how the cursor always jumps to the end of the code mining showing the rest of the keyword "definition". The cursor jumps to the end of the code mining because method drawAsRightOfPreviousCharacter is used to render the code mining. 

The cursor does not jump to the end of the code mining with this pull request by using method drawAsLeftOf1stCharacter to render the code mining.

https://github.com/user-attachments/assets/111a41bf-1c9d-4c46-9e89-17965c05a1d4

The question now is if we would break any existing functionality regarding rendering of code minings by always using method drawAsLeftOf1stCharacter?
An alternative approach would be to provide an API with which the user can decide how to draw the code mining. What would be your preferred solution? Could you please give any guidance?

Thanks a lot,
Tobias
