### PR TITLE
Correct contract of Window#getShell()

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.35.0.qualifier
+Bundle-Version: 3.35.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/window/Window.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/window/Window.java
@@ -655,8 +655,8 @@ public abstract class Window implements IShellProvider {
 	/**
 	 * Returns this window's shell.
 	 *
-	 * @return this window's shell, or <code>null</code> if this window's
-	 *         shell has not been created yet
+	 * @return this window's shell, or <code>null</code> if this window's shell has
+	 *         not been created yet or if this window has been closed
 	 */
 	@Override
 	public Shell getShell() {


### PR DESCRIPTION
Currently, Window#getShell() only states to return null if the shell has not been created yet. It will, however, also return null if the Window has been closed. The contract of Window#close() only states that the shell will be disposed, but not that #getShell() will return null afterwards as well. This change improves the explicit contract with this information. It has been part of the implicit contract anyway, since it is the behavior ever since the class and method exist.