### PR TITLE
Find/replace overlay: react to target relocation instead of paint events

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -28,7 +28,6 @@ import org.eclipse.swt.events.ControlListener;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.KeyListener;
-import org.eclipse.swt.events.PaintListener;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.events.ShellAdapter;
 import org.eclipse.swt.events.ShellEvent;
@@ -42,6 +41,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.ScrollBar;
 import org.eclipse.swt.widgets.Scrollable;
 import org.eclipse.swt.widgets.Shell;
@@ -204,7 +204,7 @@ public class FindReplaceOverlay extends Dialog {
 		}
 	};
 
-	private PaintListener widgetMovementListener = __ -> asyncExecIfOpen(
+	private Listener targetRelocationListener = __ -> asyncExecIfOpen(
 			FindReplaceOverlay.this::updatePlacementAndVisibility);
 
 	private void asyncExecIfOpen(Runnable operation) {
@@ -423,7 +423,8 @@ public class FindReplaceOverlay extends Dialog {
 			Control targetWidget = textEditor.getAdapter(ITextViewer.class).getTextWidget();
 			if (targetWidget != null) {
 				targetWidget.getShell().removeControlListener(shellMovementListener);
-				targetWidget.removePaintListener(widgetMovementListener);
+				targetWidget.removeListener(SWT.Move, targetRelocationListener);
+				targetWidget.removeListener(SWT.Resize, targetRelocationListener);
 				targetWidget.removeKeyListener(closeOnTargetEscapeListener);
 				targetPart.getSite().getPage().removePartListener(targetPartVisibilityHandler);
 			}
@@ -436,7 +437,8 @@ public class FindReplaceOverlay extends Dialog {
 			Control targetWidget = textEditor.getAdapter(ITextViewer.class).getTextWidget();
 
 			targetWidget.getShell().addControlListener(shellMovementListener);
-			targetWidget.addPaintListener(widgetMovementListener);
+			targetWidget.addListener(SWT.Move, targetRelocationListener);
+			targetWidget.addListener(SWT.Resize, targetRelocationListener);
 			targetWidget.addKeyListener(closeOnTargetEscapeListener);
 			targetPart.getSite().getPage().addPartListener(targetPartVisibilityHandler);
 		}


### PR DESCRIPTION
The FindReplaceOverlay currently registers a paint listener to the target in order to reposition itself upon move or resize events of the parent (paint events subsume resize and move events). This has two drawbacks:
1. The update is performed too often, as paint events happen more often than move or resize events.
2. Due to limitations in Wayland, repositioning the overlay does not work there. A combination of processed repaint events and failing position updates even leads to the shell contents moving out of the shell.

This change replaces the repaint listener with a move and resize listener. In consequence, less (unnecessary) updates of the overlay's position and size are executed and on Wayland at least the shell contents do not move out of the window anymore.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/1447

### Behavior on Wayland
This change does _not_ resolve the location problem of the overlay when using Wayland. That issue is not specific for the overlay but affect all shells/dialogs. It only works towards its contents not vanishing, thus improving usability of the overlay, even though its location is wrong.

Before change:
![Peek 2024-09-07 11-08](https://github.com/user-attachments/assets/bbad288f-e25f-42ac-aa8e-15ba674750df)

After change:
![Peek 2024-09-07 11-13](https://github.com/user-attachments/assets/1ef8f03e-cee9-43a9-b1c3-a68b494cf860)
