### PR TITLE
Find/replace overlay: improve expressiveness of IFindReplaceUIAccess

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
@@ -81,7 +81,7 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 	protected final void ensureHasFocusOnGTK() {
 		if (Util.isGtk()) {
 			runEventQueue();
-			if (dialog.getActiveShell() == null) {
+			if (!dialog.hasFocus()) {
 				String screenshotPath= ScreenshotTest.takeScreenshot(FindReplaceUITest.class, testName.getMethodName(), System.out);
 				fail("this test does not work on GTK unless the runtime workbench has focus. Screenshot: " + screenshotPath);
 			}

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/IFindReplaceUIAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/IFindReplaceUIAccess.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.findandreplace;
 
-import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Widget;
 
 import org.eclipse.jface.text.IFindReplaceTarget;
@@ -25,6 +24,8 @@ public interface IFindReplaceUIAccess {
 	void closeAndRestore();
 
 	void close();
+
+	boolean isShown();
 
 	void unselect(SearchOptions option);
 
@@ -42,7 +43,7 @@ public interface IFindReplaceUIAccess {
 
 	void setReplaceText(String text);
 
-	Shell getActiveShell();
+	boolean hasFocus();
 
 	Widget getButtonForSearchOption(SearchOptions option);
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
@@ -16,7 +16,7 @@ package org.eclipse.ui.internal.findandreplace.overlay;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
 
@@ -174,7 +174,7 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		boolean useOverlayPreference= preferences.getBoolean(USE_FIND_REPLACE_OVERLAY, true);
 		try {
 			preferences.putBoolean(USE_FIND_REPLACE_OVERLAY, false);
-			assertNull("dialog should be closed after changing preference", getDialog().getActiveShell());
+			assertFalse("dialog should be closed after changing preference", getDialog().isShown());
 		} finally {
 			preferences.putBoolean(USE_FIND_REPLACE_OVERLAY, useOverlayPreference);
 			reopenFindReplaceUIForTextViewer();

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.ToolItem;
@@ -321,8 +322,16 @@ class OverlayAccess implements IFindReplaceUIAccess {
 	}
 
 	@Override
-	public Shell getActiveShell() {
-		return shellRetriever.get();
+	public boolean isShown() {
+		return shellRetriever.get() != null && shellRetriever.get().isVisible();
+	}
+
+	@Override
+	public boolean hasFocus() {
+		Shell overlayShell= shellRetriever.get();
+		Control focusControl= overlayShell.getDisplay().getFocusControl();
+		Shell focusControlShell= focusControl != null ? focusControl.getShell() : null;
+		return focusControlShell == overlayShell;
 	}
 
 }

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
@@ -165,8 +165,8 @@ class DialogAccess implements IFindReplaceUIAccess {
 	}
 
 	@Override
-	public Shell getActiveShell() {
-		return shellRetriever.get();
+	public boolean hasFocus() {
+		return shellRetriever.get() != null;
 	}
 
 	@Override
@@ -314,6 +314,11 @@ class DialogAccess implements IFindReplaceUIAccess {
 		return Arrays.stream(SearchOptions.values())
 				.filter(option -> getButtonForSearchOption(option).getSelection())
 				.collect(Collectors.toSet());
+	}
+
+	@Override
+	public boolean isShown() {
+		return shellRetriever.get() != null;
 	}
 
 }


### PR DESCRIPTION
Improves the design/expressiveness of the IFindReplaceUIAccess to reduce dependency on implementation details (like using shells as the container for the dialog and the overlay).

Extracted from #2254, as it's an independent improvement of the test design.