### PR TITLE
Find/replace tests: remove reflective logic access

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
@@ -119,7 +119,6 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		dialog.assertEnabled(SearchOptions.REGEX);
 		dialog.assertEnabled(SearchOptions.WHOLE_WORD);
 
-		dialog.getFindReplaceLogic().updateTarget(fTextViewer.getFindReplaceTarget(), false);
 		dialog.select(SearchOptions.WHOLE_WORD);
 		dialog.select(SearchOptions.REGEX);
 		dialog.assertEnabled(SearchOptions.REGEX);
@@ -161,7 +160,7 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		dialog.select(SearchOptions.INCREMENTAL);
 		dialog.setFindText("line");
 		ensureHasFocusOnGTK();
-		IFindReplaceTarget target= dialog.getTarget();
+		IFindReplaceTarget target= getFindReplaceTarget();
 
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(4, (target.getSelection()).y);
@@ -190,7 +189,7 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		dialog.select(SearchOptions.INCREMENTAL);
 
 		dialog.setFindText("lin");
-		IFindReplaceTarget target= dialog.getTarget();
+		IFindReplaceTarget target= getFindReplaceTarget();
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(dialog.getFindText().length(), (target.getSelection()).y);
 
@@ -206,7 +205,7 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		dialog.select(SearchOptions.WHOLE_WORD);
 		dialog.select(SearchOptions.WRAP);
 		dialog.setFindText("two");
-		IFindReplaceTarget target= dialog.getTarget();
+		IFindReplaceTarget target= getFindReplaceTarget();
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(3, (target.getSelection()).y);
 
@@ -227,7 +226,7 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 		dialog.select(SearchOptions.REGEX);
 		dialog.setFindText("(a|bc)");
 
-		IFindReplaceTarget target= dialog.getTarget();
+		IFindReplaceTarget target= getFindReplaceTarget();
 		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(1, (target.getSelection()).y);
@@ -372,6 +371,10 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 
 	protected TextViewer getTextViewer() {
 		return fTextViewer;
+	}
+
+	protected final IFindReplaceTarget getFindReplaceTarget() {
+		return fTextViewer.getFindReplaceTarget();
 	}
 
 }

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/IFindReplaceUIAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/IFindReplaceUIAccess.java
@@ -12,14 +12,10 @@ package org.eclipse.ui.internal.findandreplace;
 
 import org.eclipse.swt.widgets.Widget;
 
-import org.eclipse.jface.text.IFindReplaceTarget;
-
 /**
  * Wraps UI access for different find/replace UIs
  */
 public interface IFindReplaceUIAccess {
-
-	IFindReplaceTarget getTarget();
 
 	void closeAndRestore();
 
@@ -46,8 +42,6 @@ public interface IFindReplaceUIAccess {
 	boolean hasFocus();
 
 	Widget getButtonForSearchOption(SearchOptions option);
-
-	IFindReplaceLogic getFindReplaceLogic();
 
 	void performReplaceAll();
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
@@ -46,7 +46,7 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		Accessor actionAccessor= new Accessor(getFindReplaceAction(), FindReplaceAction.class);
 		actionAccessor.invoke("showOverlayInEditor", null);
 		Accessor overlayAccessor= new Accessor(actionAccessor.get("overlay"), "org.eclipse.ui.internal.findandreplace.overlay.FindReplaceOverlay", getClass().getClassLoader());
-		return new OverlayAccess(overlayAccessor);
+		return new OverlayAccess(getFindReplaceTarget(), overlayAccessor);
 	}
 
 	@Test
@@ -55,7 +55,7 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		OverlayAccess dialog= getDialog();
 
 		dialog.setFindText("line");
-		IFindReplaceTarget target= dialog.getTarget();
+		IFindReplaceTarget target= getFindReplaceTarget();
 
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(4, (target.getSelection()).y);
@@ -89,14 +89,14 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 	public void testIncrementalSearchUpdatesAfterChangingOptions() {
 		initializeTextViewerWithFindReplaceUI("alinee\naLinee\nline\nline");
 		OverlayAccess dialog= getDialog();
-		IFindReplaceTarget target= dialog.getTarget();
+		IFindReplaceTarget target= getFindReplaceTarget();
 		dialog.setFindText("Line");
-		assertThat(dialog.getTarget().getSelectionText(), is("line"));
-		assertEquals(new Point(1,4), dialog.getTarget().getSelection());
+		assertThat(target.getSelectionText(), is("line"));
+		assertEquals(new Point(1, 4), target.getSelection());
 
 		dialog.select(SearchOptions.CASE_SENSITIVE);
-		assertThat(dialog.getTarget().getSelectionText(), is("Line"));
-		assertEquals(new Point(8,4), dialog.getTarget().getSelection());
+		assertThat(target.getSelectionText(), is("Line"));
+		assertEquals(new Point(8, 4), target.getSelection());
 
 		dialog.unselect(SearchOptions.CASE_SENSITIVE);
 		assertEquals(1, (target.getSelection()).x);
@@ -110,7 +110,7 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		dialog.unselect(SearchOptions.WHOLE_WORD);
 		assertEquals(1, (target.getSelection()).x);
 		assertEquals(4, (target.getSelection()).y);
-		assertThat(dialog.getTarget().getSelectionText(), is("line"));
+		assertThat(target.getSelectionText(), is("line"));
 	}
 
 	@Test
@@ -153,18 +153,19 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 	@Test
 	public void testSearchBackwardsWithRegEx() {
 		initializeTextViewerWithFindReplaceUI("text text text");
+		IFindReplaceTarget target= getFindReplaceTarget();
 
 		OverlayAccess dialog= getDialog();
 		dialog.select(SearchOptions.REGEX);
 		dialog.setFindText("text"); // with RegEx enabled, there is no incremental search!
 		dialog.pressSearch(true);
-		assertThat(dialog.getTarget().getSelection().y, is(4));
+		assertThat(target.getSelection().y, is(4));
 		dialog.pressSearch(true);
-		assertThat(dialog.getTarget().getSelection().x, is("text ".length()));
+		assertThat(target.getSelection().x, is("text ".length()));
 		dialog.pressSearch(true);
-		assertThat(dialog.getTarget().getSelection().x, is("text text ".length()));
+		assertThat(target.getSelection().x, is("text text ".length()));
 		dialog.pressSearch(false);
-		assertThat(dialog.getTarget().getSelection().x, is("text ".length()));
+		assertThat(target.getSelection().x, is("text ".length()));
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
@@ -15,7 +15,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -34,14 +33,12 @@ import org.eclipse.text.tests.Accessor;
 import org.eclipse.jface.text.IFindReplaceTarget;
 import org.eclipse.jface.text.IFindReplaceTargetExtension;
 
-import org.eclipse.ui.internal.findandreplace.FindReplaceLogic;
-import org.eclipse.ui.internal.findandreplace.IFindReplaceLogic;
 import org.eclipse.ui.internal.findandreplace.IFindReplaceUIAccess;
 import org.eclipse.ui.internal.findandreplace.SearchOptions;
 
 class DialogAccess implements IFindReplaceUIAccess {
 
-	FindReplaceLogic findReplaceLogic;
+	private final IFindReplaceTarget findReplaceTarget;
 
 	Combo findCombo;
 
@@ -77,9 +74,9 @@ class DialogAccess implements IFindReplaceUIAccess {
 
 	Accessor dialogAccessor;
 
-	DialogAccess(Accessor findReplaceDialogAccessor) {
+	DialogAccess(IFindReplaceTarget findReplaceTarget, Accessor findReplaceDialogAccessor) {
+		this.findReplaceTarget= findReplaceTarget;
 		dialogAccessor= findReplaceDialogAccessor;
-		findReplaceLogic= (FindReplaceLogic) findReplaceDialogAccessor.get("findReplaceLogic");
 		findCombo= (Combo) findReplaceDialogAccessor.get("fFindField");
 		replaceCombo= (Combo) findReplaceDialogAccessor.get("fReplaceField");
 		forwardRadioButton= (Button) findReplaceDialogAccessor.get("fForwardRadioButton");
@@ -200,11 +197,6 @@ class DialogAccess implements IFindReplaceUIAccess {
 	}
 
 	@Override
-	public IFindReplaceTarget getTarget() {
-		return findReplaceLogic.getTarget();
-	}
-
-	@Override
 	public String getFindText() {
 		return findCombo.getText();
 	}
@@ -217,11 +209,6 @@ class DialogAccess implements IFindReplaceUIAccess {
 
 	public Combo getFindCombo() {
 		return findCombo;
-	}
-
-	@Override
-	public IFindReplaceLogic getFindReplaceLogic() {
-		return findReplaceLogic;
 	}
 
 	@Override
@@ -241,20 +228,11 @@ class DialogAccess implements IFindReplaceUIAccess {
 
 	@Override
 	public void assertInitialConfiguration() {
-		assertTrue(findReplaceLogic.isActive(SearchOptions.FORWARD));
-		assertFalse(findReplaceLogic.isActive(SearchOptions.CASE_SENSITIVE));
-		assertTrue(findReplaceLogic.isActive(SearchOptions.WRAP));
-		assertFalse(findReplaceLogic.isActive(SearchOptions.INCREMENTAL));
-		assertFalse(findReplaceLogic.isActive(SearchOptions.REGEX));
-		assertFalse(findReplaceLogic.isActive(SearchOptions.WHOLE_WORD));
-
 		assertSelected(SearchOptions.FORWARD);
-		if (!doesTextViewerHaveMultiLineSelection(findReplaceLogic.getTarget())) {
+		if (!doesTextViewerHaveMultiLineSelection(findReplaceTarget)) {
 			assertSelected(SearchOptions.GLOBAL);
-			assertTrue(findReplaceLogic.isActive(SearchOptions.GLOBAL));
 		} else {
 			assertUnselected(SearchOptions.GLOBAL);
-			assertFalse(findReplaceLogic.isActive(SearchOptions.GLOBAL));
 		}
 		assertSelected(SearchOptions.WRAP);
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
@@ -51,7 +51,7 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		Accessor fFindReplaceDialogStubAccessor= new Accessor(fFindReplaceDialogStub, "org.eclipse.ui.texteditor.FindReplaceAction$FindReplaceDialogStub", getClass().getClassLoader());
 
 		Accessor dialogAccessor= new Accessor(fFindReplaceDialogStubAccessor.invoke("getDialog", null), "org.eclipse.ui.texteditor.FindReplaceDialog", getClass().getClassLoader());
-		return new DialogAccess(dialogAccessor);
+		return new DialogAccess(getFindReplaceTarget(), dialogAccessor);
 	}
 
 	@Test
@@ -122,7 +122,7 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 
 		dialog.setFindText("line");
 		ensureHasFocusOnGTK();
-		IFindReplaceTarget target= dialog.getTarget();
+		IFindReplaceTarget target= getFindReplaceTarget();
 
 		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		assertEquals(0, (target.getSelection()).x);
@@ -152,7 +152,7 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 
 		assertThat(dialog.getFindText(), is("text"));
 
-		IFindReplaceTarget target= dialog.getTarget();
+		IFindReplaceTarget target= getFindReplaceTarget();
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(4, (target.getSelection()).y);
 
@@ -209,7 +209,7 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		dialog.setFindText("two");
 		dialog.select(SearchOptions.WHOLE_WORD);
 		dialog.select(SearchOptions.WRAP);
-		IFindReplaceTarget target= dialog.getTarget();
+		IFindReplaceTarget target= getFindReplaceTarget();
 
 		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		assertEquals(0, (target.getSelection()).x);


### PR DESCRIPTION
The IFindReplaceUIAccess currently provides access to the IFindReplaceTarget, to which the UI is attached. The implementations for the dialog and overlay employ reflection to access the target within the UI implementation. It is, however, not necessary to access this information via the find/replace UI since the tests set up the target anyway and thus have access to it.

This change removes the according methods from the IFindReplaceUIAccess and the reflective access from its implementations.