### PR TITLE
Improve 'Replace All' performance.

### DIFF
--- a/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionAnnotationModel.java
+++ b/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionAnnotationModel.java
@@ -149,7 +149,7 @@ public class ProjectionAnnotationModel extends AnnotationModel {
 
 		boolean expanding= false;
 
-		Iterator<Annotation> iterator= getAnnotationIterator();
+		Iterator<Annotation> iterator= getAnnotationIterator(offset, length, true, true);
 		while (iterator.hasNext()) {
 			ProjectionAnnotation annotation= (ProjectionAnnotation) iterator.next();
 			if (annotation.isCollapsed()) {


### PR DESCRIPTION
For Large Java file 'Replace All' takes long time and freezes the UI. One of the reason is Projection Model tries to iterate over all the Projection Annotations to expand/collapse status.
We can improve this situation by using Region specific iterator. This returns annotations which are enclosed by given offset. This improves the performance by 25% at least.

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/2257