### PR TITLE
improve RegistrationMacOsX performance #2245

### DIFF
--- a/bundles/org.eclipse.urischeme/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.urischeme/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.urischeme;singleton:=true
-Bundle-Version: 1.3.400.qualifier
+Bundle-Version: 1.3.500.qualifier
 Automatic-Module-Name: org.eclipse.urischeme
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.8.0,4.0.0)",

--- a/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/internal/registration/RegistrationMacOsX.java
+++ b/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/internal/registration/RegistrationMacOsX.java
@@ -35,7 +35,7 @@ public class RegistrationMacOsX implements IOperatingSystemRegistration {
 	private IFileProvider fileProvider;
 	private IProcessExecutor processExecutor;
 
-	private String lsRegisterOutput = null;
+	private String[] lsRegisterOutput = null;
 
 	public RegistrationMacOsX() {
 		this(new FileProvider(), new ProcessExecutor());
@@ -75,17 +75,15 @@ public class RegistrationMacOsX implements IOperatingSystemRegistration {
 		return returnList;
 	}
 
-	private String getLsRegisterOutput() throws Exception {
+	private String[] getLsRegisterOutput() throws Exception {
 		if (this.lsRegisterOutput != null) {
 			return this.lsRegisterOutput;
 		}
-		this.lsRegisterOutput = processExecutor.execute(LSREGISTER, DUMP);
+		this.lsRegisterOutput = processExecutor.execute(LSREGISTER, DUMP).split("-".repeat(80) + "\n"); //$NON-NLS-1$//$NON-NLS-2$
 		return this.lsRegisterOutput;
 	}
 
-	private String determineHandlerLocation(String lsRegisterDump, String scheme) {
-
-		String[] lsRegisterEntries = lsRegisterDump.split("-{80}\n"); //$NON-NLS-1$
+	private String determineHandlerLocation(String[] lsRegisterEntries, String scheme) {
 		String keyOfFirstLine;
 		String keyOfSchemeList;
 


### PR DESCRIPTION
Pattern matching with String.split("-{80}\n") is quiet expensive especially if the string contains more then 80 dashes in a row.

https://github.com/eclipse-platform/eclipse.platform.ui/issues/2245