### PR TITLE
Find/replace overlay: do not escape selected text when not regex #2270

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -977,7 +977,7 @@ public class FindReplaceOverlay extends Dialog {
 			findReplaceLogic.deactivate(SearchOptions.GLOBAL);
 			searchInSelectionButton.setSelection(true);
 		} else if (!selectionText.isEmpty()) {
-			if (findReplaceLogic.isAvailable(SearchOptions.REGEX)) {
+			if (findReplaceLogic.isAvailableAndActive(SearchOptions.REGEX)) {
 				selectionText = FindReplaceDocumentAdapter.escapeForRegExPattern(selectionText);
 			}
 			searchBar.setText(selectionText);

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
@@ -340,6 +340,18 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 	}
 
 	@Test
+	public void testActivateDialogSelectionActive_withoutRegExOptionActivated() {
+		openTextViewer("test text.*;");
+		initializeFindReplaceUIForTextViewer();
+
+		fTextViewer.setSelection(new TextSelection("test ".length(), "text.*".length()));
+		reopenFindReplaceUIForTextViewer();
+
+		dialog.assertUnselected(SearchOptions.REGEX);
+		assertEquals("text.*", dialog.getFindText());
+	}
+
+	@Test
 	public void testActivateDialogSelectionActive_withRegExOptionActivated() {
 		openTextViewer("test text.*;");
 		initializeFindReplaceUIForTextViewer();


### PR DESCRIPTION
When opening the find/replace overlay with a text selection in the target editor, this text is set as the find input to the overlay. When in regex mode, the string is escaped accordingly. Currently, the string is also escaped when regex mode is not activated.

With this change, the find input string is not escaped when regex mode is not activated. An according test case is added.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2270