### PR TITLE
Remove redundant flag check from ThemeEngine

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt.theme/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.css.swt.theme;singleton:=true
-Bundle-Version: 0.14.400.qualifier
+Bundle-Version: 0.14.500.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/ThemeEngine.java
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/ThemeEngine.java
@@ -588,13 +588,11 @@ public class ThemeEngine implements IThemeEngine {
 			prefThemeId = "org.eclipse.e4.ui.css.theme.e4_classic"; //$NON-NLS-1$
 		}
 
-		boolean flag = true;
 		if (prefThemeId != null) {
 			for (ITheme t : getThemes()) {
 				if (prefThemeId.equals(t.getId())) {
 					setTheme(t, false);
-					flag = false;
-					break;
+					return;
 				}
 			}
 		}
@@ -608,7 +606,7 @@ public class ThemeEngine implements IThemeEngine {
 		boolean disableOSDarkThemeInherit = "true".equalsIgnoreCase(System.getProperty(DISABLE_OS_DARK_THEME_INHERIT));
 		boolean overrideWithDarkTheme = Display.isSystemDarkTheme() && hasDarkTheme && !disableOSDarkThemeInherit;
 		String themeToRestore = overrideWithDarkTheme ? E4_DARK_THEME_ID : alternateTheme;
-		if (themeToRestore != null && flag) {
+		if (themeToRestore != null) {
 			setTheme(themeToRestore, false);
 		}
 	}


### PR DESCRIPTION
If the boolean "flag" is set to false the last conditional check will never be true so return early. The theme will have been set anyway.