### PR TITLE
Fix NPE if IWorkbenchPart cannot be adapted to IContributedContentsView

### DIFF
--- a/bundles/org.eclipse.ui.views.properties.tabbed/src/org/eclipse/ui/views/properties/tabbed/TabbedPropertySheetPage.java
+++ b/bundles/org.eclipse.ui.views.properties.tabbed/src/org/eclipse/ui/views/properties/tabbed/TabbedPropertySheetPage.java
@@ -332,8 +332,8 @@ public class TabbedPropertySheetPage
 			 * for example, outline view.
 			 */
 			IContributedContentsView view = Adapters.adapt(part, IContributedContentsView.class);
-			if (!(view.getContributingPart() instanceof ITabbedPropertySheetPageContributor cp
-					&& cp.equals(contributor))) {
+			if (view == null || (!(view.getContributingPart() instanceof ITabbedPropertySheetPageContributor cp
+					&& cp.equals(contributor)))) {
 				if (activePropertySheet) {
 					if (currentTab != null) {
 						currentTab.aboutToBeHidden();


### PR DESCRIPTION
When debugging a Maven build in Eclipse my error log is currently flooded with the error below and I can hardly do anything because the error log is pooping up constantly:
```
java.lang.NullPointerException: Cannot invoke "org.eclipse.ui.part.IContributedContentsView.getContributingPart()" because "view" is null
	at org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetPage.handlePartActivated(TabbedPropertySheetPage.java:335)
	at org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetPage$1.partActivated(TabbedPropertySheetPage.java:121)
	at org.eclipse.ui.internal.PartService$1.run(PartService.java:85)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.ui.internal.PartService.partActivated(PartService.java:82)
	at org.eclipse.ui.internal.WorkbenchWindow$WWinPartService.partActivated(WorkbenchWindow.java:3157)
	at org.eclipse.ui.internal.WorkbenchPage$2.run(WorkbenchPage.java:4887)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.ui.internal.WorkbenchPage.firePartActivated(WorkbenchPage.java:4884)
	at org.eclipse.ui.internal.WorkbenchPage$E4PartListener.partActivated(WorkbenchPage.java:215)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl$2.run(PartServiceImpl.java:250)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.firePartActivated(PartServiceImpl.java:247)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.activate(PartServiceImpl.java:780)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.activate(PartServiceImpl.java:686)
	at org.eclipse.e4.ui.internal.workbench.swt.AbstractPartRenderer.activate(AbstractPartRenderer.java:95)
	at org.eclipse.e4.ui.workbench.renderers.swt.ContributedPartRenderer.lambda$0(ContributedPartRenderer.java:63)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4326)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1174)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1198)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1183)
	at org.eclipse.swt.widgets.Shell.setActiveControl(Shell.java:1533)
	at org.eclipse.swt.widgets.Shell.WM_MOUSEACTIVATE(Shell.java:2467)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4771)
	at org.eclipse.swt.widgets.Canvas.windowProc(Canvas.java:342)
	at org.eclipse.swt.widgets.Decorations.windowProc(Decorations.java:1482)
	at org.eclipse.swt.widgets.Shell.windowProc(Shell.java:2311)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5091)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4828)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5091)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4828)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5091)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4828)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5091)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4828)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5091)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4828)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5091)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4828)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5091)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4828)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5091)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4828)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5091)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4828)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5091)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Scrollable.callWindowProc(Scrollable.java:91)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4828)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5091)
	at org.eclipse.swt.internal.win32.OS.DefWindowProc(Native Method)
	at org.eclipse.swt.widgets.Tree.callWindowProc(Tree.java:1483)
	at org.eclipse.swt.widgets.Tree.windowProc(Tree.java:6051)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5091)
	at org.eclipse.swt.internal.win32.OS.CallWindowProc(Native Method)
	at org.eclipse.swt.widgets.Tree.callWindowProc(Tree.java:1575)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:4828)
	at org.eclipse.swt.widgets.Tree.windowProc(Tree.java:6150)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5091)
	at org.eclipse.swt.internal.win32.OS.PeekMessage(Native Method)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3707)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1151)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1042)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:639)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:546)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:152)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:208)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:143)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:109)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:439)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:271)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:668)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:605)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1481)
```

It looks like this is is regression from Regression from https://github.com/eclipse-platform/eclipse.platform.ui/pull/2228, where the `view==null` case was removed.