### PR TITLE
Rename Generic Text Editor into Generic Code Editor

### DIFF
--- a/bundles/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.ui.genericeditor;singleton:=true
-Bundle-Version: 1.3.400.qualifier
+Bundle-Version: 1.3.500.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ui.workbench.texteditor;bundle-version="3.10.0",

--- a/bundles/org.eclipse.ui.genericeditor/plugin.properties
+++ b/bundles/org.eclipse.ui.genericeditor/plugin.properties
@@ -14,7 +14,7 @@
 #                                 - Bug 521382 default highlighter
 #     Simon Scholz <simon.scholz@vogella.com> - Bug 527830
 ###############################################################################
-genericEditor_name=Generic Text Editor
+genericEditor_name=Generic Code Editor
 ExtPoint.reconciliers=Reconciliers
 ExtPoint.presentationReconciliers=Presentation Reconciliers
 ExtPoint.hoverProviders= Hover Providers
@@ -31,12 +31,12 @@ context_description=When editing in the Generic Code Editor
 findReferencesCommand_name=Find References
 findReferencesCommand_description=Find other code items referencing the current selected item.
 Bundle-Vendor=Eclipse.org
-Bundle-Name=Generic and Extensible Text Editor
+Bundle-Name=Generic and Extensible Code Editor
 command.toggle.highlight.label = Toggle Mark Occurences
 command.toggle.highlight.name = Toggle Highlight
 menu.source.label = Source
 gotoMatchingBracketCommand_name =  Go to Matching Bracket
 gotoMatchingBracketCommand_description = Moves the cursor to the matching bracket
-systemEditorOrGenericEditorStrategy=System Editor; if none: Advanced Text Editor
-genericEditorStrategy=Advanced Text Editor
-PreferencePages.GenericTextEditors=Generic Text Editors
+systemEditorOrGenericEditorStrategy=System Editor; if none: Generic Code Editor
+genericEditorStrategy=Generic Code Editor
+PreferencePages.GenericTextEditors=Generic Code Editor


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.ui/issues/1532 and https://github.com/eclipse-platform/eclipse.platform.ui/issues/1385