### PR TITLE
Light (Preview) theme - change in the behavior of highlights for selected tabs

### DIFF
--- a/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.themes;singleton:=true
-Bundle-Version: 1.2.2500.qualifier
+Bundle-Version: 1.2.2600.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.e4.ui.css.swt.theme

--- a/bundles/org.eclipse.ui.themes/css/e4_preview_gtk.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_gtk.css
@@ -186,7 +186,7 @@ CTabFolder Canvas {
 }
 
 .MPartStack{
-	swt-selected-tab-highlight: #2160bb;
+	swt-selected-tab-highlight: #A0A0A0;
     swt-selected-highlight-top: false;
 }
 
@@ -209,7 +209,7 @@ CTabFolder Canvas {
 
 #org-eclipse-ui-editorss CTabFolder{
 	swt-selected-tab-fill : '#ffffff';
-	swt-selected-tab-highlight: '#2160bb';
+	swt-selected-tab-highlight: '#A0A0A0';
     swt-selected-highlight-top: true;	
 	swt-tab-outline:#e5e5e5; 
 	swt-tab-outer-keyline: #e5e5e5;

--- a/bundles/org.eclipse.ui.themes/css/e4_preview_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_mac.css
@@ -156,7 +156,7 @@ CTabFolder Canvas {
 }
 
 .MPartStack{
-	swt-selected-tab-highlight: #5983c5;
+	swt-selected-tab-highlight: #A0A0A0;
     swt-selected-highlight-top: false;
 }
 
@@ -179,7 +179,7 @@ CTabFolder Canvas {
 
 #org-eclipse-ui-editorss CTabFolder{
 	swt-selected-tab-fill : '#ffffff';
-	swt-selected-tab-highlight: '#5983c5';
+	swt-selected-tab-highlight: '#A0A0A0';
     swt-selected-highlight-top: true;	
 	swt-tab-outline:#eaeaea; 
 	swt-tab-outer-keyline: #eaeaea;

--- a/bundles/org.eclipse.ui.themes/css/e4_preview_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_win.css
@@ -160,7 +160,7 @@ CTabFolder Canvas {
 }
 
 .MPartStack{
-	swt-selected-tab-highlight: #2160bb;
+	swt-selected-tab-highlight: #A0A0A0;
     swt-selected-highlight-top: false;
 }
 
@@ -183,7 +183,7 @@ CTabFolder Canvas {
 
 #org-eclipse-ui-editorss CTabFolder{
 	swt-selected-tab-fill : '#ffffff';
-	swt-selected-tab-highlight: '#2160bb';
+	swt-selected-tab-highlight: '#A0A0A0';
     swt-selected-highlight-top: true;	
 	swt-tab-outline:#e5e5e5; 
 	swt-tab-outer-keyline: #e5e5e5;


### PR DESCRIPTION
All selected tabs in Light (Preview) theme had blue highlight(underline) irrespective of stack being active or inactive. At any point in time only one tab could be active and it has to be blue. This change has been done by making blue highlight only for the active selected tab and rest of the selected tabs which are inactive will have grey highlight.
Please find the below screen shots:

Before:
![image](https://github.com/user-attachments/assets/a3f491f9-5027-40da-a19d-256c13debfd2)

![image](https://github.com/user-attachments/assets/9679aef3-9d37-4abc-8520-d9b5b0cd820a)

After :
![image](https://github.com/user-attachments/assets/24d33d89-7d20-48e0-a1e3-45ad85c0ff79)

![image](https://github.com/user-attachments/assets/48993c26-51e3-48cc-bed2-cc56b155533e)



