### PR TITLE
Reduce freeze times on updating search results on resource changes

### DIFF
--- a/bundles/org.eclipse.search/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search; singleton:=true
-Bundle-Version: 3.16.400.qualifier
+Bundle-Version: 3.17.0.qualifier
 Bundle-Activator: org.eclipse.search.internal.ui.SearchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.search/newsearch/org/eclipse/search/ui/text/AbstractTextSearchResult.java
+++ b/bundles/org.eclipse.search/newsearch/org/eclipse/search/ui/text/AbstractTextSearchResult.java
@@ -21,6 +21,7 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -306,6 +307,19 @@ public abstract class AbstractTextSearchResult implements ISearchResult {
 			count += element.size();
 		}
 		return count;
+	}
+
+	/**
+	 * @return {@code true} if the result is not empty
+	 * @since 3.17
+	 */
+	public boolean hasMatches() {
+		for (Entry<Object, Set<Match>> entry : fElementsToMatches.entrySet()) {
+			if (!entry.getValue().isEmpty()) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
If the search view shows ~100000 matches, deleting resources that are shown in the search view freezes Eclipse for many minutes. With this change the freeze is only about 30 seconds.

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/2279

To test, perform steps from https://github.com/eclipse-platform/eclipse.platform.ui/issues/2279 and after search results view shows matches, delete generated files in Package Explorer.