### PR TITLE
Light (Preview) Font color change for text in tabs

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4_preview_gtk.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_gtk.css
@@ -85,15 +85,15 @@ ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_BG_END {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_TEXT_COLOR {
-	color: #3b3b3b;
+	color: #000000;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_TEXT_COLOR {
-   color: #3b3b3b;
+   color: #000000;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
-   color: #3b3b3b;
+   color: #000000;
 }
 
 .MTrimmedWindow {
@@ -197,13 +197,13 @@ CTabFolder Canvas {
 
 /* text color and background color of unselected tabs in editor*/
 #org-eclipse-ui-editorss CTabItem{
-	color: '#6A6A6A';
+	color: '#000000';
 	background-color: '#f8f8f8';
 }
 
 /*text color and background color of selected tab in editor */
 #org-eclipse-ui-editorss CTabItem:selected{
-	color: '#3b3b3b';
+	color: '#000000';
 	background-color: '#FFFFFF';
 }
 

--- a/bundles/org.eclipse.ui.themes/css/e4_preview_gtk.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_gtk.css
@@ -208,13 +208,13 @@ CTabFolder Canvas {
 }
 
 #org-eclipse-ui-editorss CTabFolder{
-	swt-selected-tab-fill : '#ffffff';
-	swt-selected-tab-highlight: '#A0A0A0';
-    swt-selected-highlight-top: true;	
+	swt-selected-tab-fill : #ffffff;
+	swt-selected-tab-highlight: #8a8a8a;
+	swt-selected-highlight-top: true;	
 	swt-tab-outline:#e5e5e5; 
 	swt-tab-outer-keyline: #e5e5e5;
 	swt-draw-custom-tab-content-background: true;
-	swt-unselected-hot-tab-color-background:'#FFFFFF';
+	swt-unselected-hot-tab-color-background:#ffffff;
 }
 
 #org-eclipse-ui-editorss CTabFolder.active {

--- a/bundles/org.eclipse.ui.themes/css/e4_preview_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_mac.css
@@ -71,15 +71,15 @@ ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_BG_END {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_TEXT_COLOR {
-	color: #404040;
+	color: #000000;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_TEXT_COLOR {
-   color: #404040;
+   color: #000000;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
-   color: #404040;
+   color: #000000;
 }
 
 .MTrimmedWindow {
@@ -167,13 +167,13 @@ CTabFolder Canvas {
 
 /* text color of unselected tabs in editor*/
 #org-eclipse-ui-editorss CTabItem{
-	color: '#6A6A6A';
+	color: '#000000';
 	background-color: '#f8f8f8';
 }
 
 /*text color and background color of selected tab in editor */
 #org-eclipse-ui-editorss CTabItem:selected{
-	color: '#3b3b3b';
+	color: '#000000';
 	background-color: '#FFFFFF';
 }
 

--- a/bundles/org.eclipse.ui.themes/css/e4_preview_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_mac.css
@@ -156,8 +156,8 @@ CTabFolder Canvas {
 }
 
 .MPartStack{
-	swt-selected-tab-highlight: #A0A0A0;
-    swt-selected-highlight-top: false;
+	swt-selected-tab-highlight: #8a8a8a;
+	swt-selected-highlight-top: false;
 }
 
 .MPartStack.active {
@@ -178,13 +178,13 @@ CTabFolder Canvas {
 }
 
 #org-eclipse-ui-editorss CTabFolder{
-	swt-selected-tab-fill : '#ffffff';
-	swt-selected-tab-highlight: '#A0A0A0';
-    swt-selected-highlight-top: true;	
+	swt-selected-tab-fill : #ffffff;
+	swt-selected-tab-highlight: #8a8a8a;
+	swt-selected-highlight-top: true;	
 	swt-tab-outline:#eaeaea; 
 	swt-tab-outer-keyline: #eaeaea;
 	swt-draw-custom-tab-content-background: true;
-	swt-unselected-hot-tab-color-background:'#FFFFFF';
+	swt-unselected-hot-tab-color-background:#ffffff;
 }
 
 #org-eclipse-ui-editorss CTabFolder.active {

--- a/bundles/org.eclipse.ui.themes/css/e4_preview_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_win.css
@@ -160,8 +160,8 @@ CTabFolder Canvas {
 }
 
 .MPartStack{
-	swt-selected-tab-highlight: #A0A0A0;
-    swt-selected-highlight-top: false;
+	swt-selected-tab-highlight: #8a8a8a;
+	swt-selected-highlight-top: false;
 }
 
 .MPartStack.active {
@@ -182,13 +182,13 @@ CTabFolder Canvas {
 }
 
 #org-eclipse-ui-editorss CTabFolder{
-	swt-selected-tab-fill : '#ffffff';
-	swt-selected-tab-highlight: '#A0A0A0';
-    swt-selected-highlight-top: true;	
+	swt-selected-tab-fill : #ffffff;
+	swt-selected-tab-highlight: #8a8a8a;
+	swt-selected-highlight-top: true;	
 	swt-tab-outline:#e5e5e5; 
 	swt-tab-outer-keyline: #e5e5e5;
 	swt-draw-custom-tab-content-background: true;
-	swt-unselected-hot-tab-color-background:'#FFFFFF';
+	swt-unselected-hot-tab-color-background:#ffffff;
 }
 
 #org-eclipse-ui-editorss CTabFolder.active {

--- a/bundles/org.eclipse.ui.themes/css/e4_preview_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_win.css
@@ -71,15 +71,15 @@ ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_BG_END {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_TEXT_COLOR {
-	color: #3b3b3b;
+	color: #000000;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_TEXT_COLOR {
-   color: #3b3b3b;
+   color: #000000;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
-   color: #3b3b3b;
+   color: #000000;
 }
 
 .MPartStack {
@@ -171,13 +171,13 @@ CTabFolder Canvas {
 
 /* text color and background color of unselected tabs in editor*/
 #org-eclipse-ui-editorss CTabItem{
-	color: '#6A6A6A';
+	color: '#000000';
 	background-color: '#f8f8f8';
 }
 
 /*text color and background color of selected tab in editor */
 #org-eclipse-ui-editorss CTabItem:selected{
-	color: '#3b3b3b';
+	color: '#000000';
 	background-color: '#FFFFFF';
 }
 


### PR DESCRIPTION
Font color of all tabs selected or unselected are set to black  #000000 with this change to have a better contrast.

Before :
![image](https://github.com/user-attachments/assets/f919a906-17cc-4453-8357-35752d446cbf)

After:
![image](https://github.com/user-attachments/assets/f835c75e-4c25-4e57-a981-0a5871095da7)
