### PR TITLE
Find/replace overlay: store search in history when leaving overlay #2291

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -227,6 +227,7 @@ public class FindReplaceOverlay extends Dialog {
 		@Override
 		public void shellDeactivated(ShellEvent e) {
 			removeSearchScope();
+			searchBar.storeHistory();
 		}
 	};
 


### PR DESCRIPTION
The find/replace overlay only stores a search input in the history when an explicit search operation (forward/backward/all search) is performed. In case only an incremental search (via search-as-you-type) is performed, this input will not be added to the history. In some cases, no explicit search is executed but the final result of a search-as-you-type input is sufficient for the user. Since this final result, after they finished typing, also represented a relevant search input, it should be added to the history.

This change addresses the issue by adding a search input to the history also when the overlay is left, i.e., the focus is moved to somewhere else, such as the target editor or some other view.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2291