### PR TITLE
Cleanup css files

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4-dark_linux.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_linux.css
@@ -21,17 +21,17 @@
 @import url("platform:/plugin/org.eclipse.ui.themes/css/dark/e4-dark-drag-styling.css");
 
 CTabFolder Canvas {
-    background-color: #2F2F2F;
-    color: #CCC;
+	background-color: #2F2F2F;
+	color: #CCC;
 }
 
 CTabFolder Scale {
-    background-color: inherit;
+	background-color: inherit;
 }
 
 .MPartStack.active CTabFolder Canvas {
-    background-color: #262626;
-    color: #CCC;
+	background-color: #262626;
+	color: #CCC;
 }
 
 
@@ -43,5 +43,5 @@ ImageBasedFrame,
 #org-eclipse-ui-StatusLine CLabel,
 #org-eclipse-ui-ProgressBar,
 #org-eclipse-ui-ProgressBar Canvas {
-     color:'#org-eclipse-ui-workbench-DARK_FOREGROUND'; 
+	color:'#org-eclipse-ui-workbench-DARK_FOREGROUND'; 
 }

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
@@ -20,8 +20,8 @@
 @import url("platform:/plugin/org.eclipse.ui.themes/css/dark/e4-dark-drag-styling.css");
 
 .MPartStack.active CTabFolder Canvas {
-    background-color: #262626;
-    color: #CCC;
+	background-color: #262626;
+	color: #CCC;
 }
 
 
@@ -33,7 +33,7 @@ ImageBasedFrame,
 #org-eclipse-ui-StatusLine CLabel,
 #org-eclipse-ui-ProgressBar,
 #org-eclipse-ui-ProgressBar Canvas {
-     color:'#org-eclipse-ui-workbench-DARK_FOREGROUND'; 
+	color:'#org-eclipse-ui-workbench-DARK_FOREGROUND'; 
 }
 
 /* ###################### Global Styles ########################## */
@@ -41,15 +41,15 @@ ImageBasedFrame,
 /* Use unset to set the foreground/background color to null */
 
 Table[swt-lines-visible=true] {
-    background-color: unset;
+	background-color: unset;
 }
 
 Tree[swt-lines-visible=true] {
-    background-color: unset;
+	background-color: unset;
 }
 
 Button  {
-    background-color: unset;
-    color: unset;
+	background-color: unset;
+	color: unset;
 }
 

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_mac1013.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_mac1013.css
@@ -20,13 +20,13 @@
 @import url("platform:/plugin/org.eclipse.ui.themes/css/dark/e4-dark-drag-styling.css");
 
 CTabFolder Canvas {
-    background-color: #2F2F2F;
-    color: #CCC;
+	background-color: #2F2F2F;
+	color: #CCC;
 }
 
 .MPartStack.active CTabFolder Canvas {
-    background-color: #262626;
-    color: #CCC;
+	background-color: #262626;
+	color: #CCC;
 }
 
 /* #################### Bottom Status Bar ######################## */
@@ -37,44 +37,42 @@ ImageBasedFrame,
 #org-eclipse-ui-StatusLine CLabel,
 #org-eclipse-ui-ProgressBar,
 #org-eclipse-ui-ProgressBar Canvas {
-     color:'#org-eclipse-ui-workbench-DARK_FOREGROUND'; 
+	color:'#org-eclipse-ui-workbench-DARK_FOREGROUND'; 
 }
 
 
 /* ###################### Global Styles ########################## */
 
 TabFolder {
-    /* background-color is not applied to the whole button,
-       but text color is changed, so it appear light on light */
-    background-color: '#org-eclipse-ui-workbench-DARK_BACKGROUND'; 
-    color: #222;
+	/* background-color is not applied to the whole button, but text color is changed, so it appear light on light */
+	background-color: '#org-eclipse-ui-workbench-DARK_BACKGROUND'; 
+	color: #222;
 }
 
 Button {
-    /* background-color is not applied to the whole button,
-       but text color is changed, so it appear light on light */
-    background-color: #2F2F2F;
-    color: #CCCCCC;
+	/* background-color is not applied to the whole button, but text color is changed, so it appear light on light */
+	background-color: #2F2F2F;
+	color: #CCCCCC;
 }
 Button[style~='SWT.CHECK'] {
-    /* currently, Button object isn't consistent (eg. also a checkbox is seen as Button) */
-    /* so, css rules applied to Button have to be overridden for non-Button matches */
-    background-color: '#org-eclipse-ui-workbench-DARK_BACKGROUND'; 
-    color: #ddd;
+	/* currently, Button object isn't consistent (eg. also a checkbox is seen as Button) */
+	/* so, css rules applied to Button have to be overridden for non-Button matches */
+	background-color: '#org-eclipse-ui-workbench-DARK_BACKGROUND'; 
+	color: #ddd;
 }
 Button[style~='SWT.RADIO'] {
-    /* currently, Button object isn't consistent (eg. also a checkbox is seen as Button) */
-    /* so, css rules applied to Button have to be overridden for non-Button matches */
-    background-color: '#org-eclipse-ui-workbench-DARK_BACKGROUND'; 
-    color: #ddd;
+	/* currently, Button object isn't consistent (eg. also a checkbox is seen as Button) */
+	/* so, css rules applied to Button have to be overridden for non-Button matches */
+	background-color: '#org-eclipse-ui-workbench-DARK_BACKGROUND'; 
+	color: #ddd;
 }
 
 Combo {
-    background-color: #949DA5; 
-    color: #222;  /* background of drop-drown list is hard-coded to white */
+	background-color: #949DA5; 
+	color: #222;  /* background of drop-drown list is hard-coded to white */
 }
 Combo:selected {
-    background-color: #41464A;
-    color: #FFF;
+	background-color: #41464A;
+	color: #FFF;
 }
 

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
@@ -23,22 +23,22 @@
 @import url("platform:/plugin/org.eclipse.ui.themes/css/dark/e4-dark-drag-styling.css");
 
 CTabFolder Canvas {
-    background-color: #2F2F2F;
-    color: #CCC;
+	background-color: #2F2F2F;
+	color: #CCC;
 }
 
 CTabFolder Scale {
-    background-color: inherit;
+	background-color: inherit;
 }
 
 .MPartStack.active CTabFolder Canvas {
-    background-color: #262626;
-    color: #CCC;
+	background-color: #262626;
+	color: #CCC;
 }
 
 .MPartStack.active Table {
-    background-color: #2F2F2F;
-    color: #CCC;
+	background-color: #2F2F2F;
+	color: #CCC;
 }
 
 Tree, Table {
@@ -53,7 +53,7 @@ ImageBasedFrame,
 #org-eclipse-ui-StatusLine CLabel,
 #org-eclipse-ui-ProgressBar,
 #org-eclipse-ui-ProgressBar Canvas {
-     color:'#org-eclipse-ui-workbench-DARK_FOREGROUND'; 
+	color:'#org-eclipse-ui-workbench-DARK_FOREGROUND'; 
 }
 
 
@@ -102,8 +102,8 @@ ImageBasedFrame,
 .MPartStack.active .MPart Form ListEditorComposite,
 .MPartStack.active .MPart Form Text[style~='SWT.READ_ONLY'],
 .MPartStack.active .MPart Form DependenciesComposite > SashForm > Section > * { /* Section > DependenciesComposite$... */ 
-    background-color: #4f5355;
-    color: #f4f7f7;
+	background-color: #4f5355;
+	color: #f4f7f7;
 }
 #org-eclipse-help-ui-HelpView Form,
 #org-eclipse-help-ui-HelpView Form Sash,
@@ -114,8 +114,8 @@ ImageBasedFrame,
 #org-eclipse-help-ui-HelpView Form Group,
 #org-eclipse-help-ui-HelpView Form ScrolledPageBook,
 #org-eclipse-help-ui-HelpView Form Text[style~='SWT.READ_ONLY'] {
-    background-color: #2F2F2F;
-    color: #CCCCCC;
+	background-color: #2F2F2F;
+	color: #CCCCCC;
 }
 .MPartStack.active #org-eclipse-help-ui-HelpView Form,
 .MPartStack.active #org-eclipse-help-ui-HelpView Form Sash,
@@ -126,12 +126,12 @@ ImageBasedFrame,
 .MPartStack.active #org-eclipse-help-ui-HelpView Form Group,
 .MPartStack.active #org-eclipse-help-ui-HelpView Form ScrolledPageBook,
 .MPartStack.active #org-eclipse-help-ui-HelpView Form Text[style~='SWT.READ_ONLY'] {
-    background-color: #262626;
-    color: #BBBBBB;
+	background-color: #262626;
+	color: #BBBBBB;
 }
 .MPart Form Section Tree,
 .MPartStack.active .MPart Form Section Tree {
-    background-color: #313538;
-    color: #DDDDDD;
+	background-color: #313538;
+	color: #DDDDDD;
 }
 

--- a/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
@@ -93,13 +93,13 @@ CTabFolder.MArea {
 }
 
 CTabFolder {
-  swt-selected-tabs-background: rgb(255, 255, 255);
+	swt-selected-tabs-background: rgb(255, 255, 255);
 }
 
 CTabFolder CTabItem:selected {
-  background-color: rgb(230, 230, 230);
+	background-color: rgb(230, 230, 230);
 }
 
 CTabFolder Canvas {
-  background-color: rgb(255, 255, 255);
+	background-color: rgb(255, 255, 255);
 }

--- a/bundles/org.eclipse.ui.themes/css/e4_preview_gtk.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_gtk.css
@@ -126,11 +126,11 @@ CTabFolder Canvas {
 }
 
 .MTrimBar#org-eclipse-ui-main-toolbar {
-	background-color: '#f8f8f8';
+	background-color: #f8f8f8;
 }
 
 .MTrimBar#org-eclipse-ui-trim-status {
-	background-color: '#f8f8f8';
+	background-color: #f8f8f8;
 }
 
 .View Composite,
@@ -197,14 +197,14 @@ CTabFolder Canvas {
 
 /* text color and background color of unselected tabs in editor*/
 #org-eclipse-ui-editorss CTabItem{
-	color: '#000000';
-	background-color: '#f8f8f8';
+	color: #000000;
+	background-color: #f8f8f8;
 }
 
 /*text color and background color of selected tab in editor */
 #org-eclipse-ui-editorss CTabItem:selected{
-	color: '#000000';
-	background-color: '#FFFFFF';
+	color: #000000;
+	background-color: #FFFFFF;
 }
 
 #org-eclipse-ui-editorss CTabFolder{
@@ -218,7 +218,7 @@ CTabFolder Canvas {
 }
 
 #org-eclipse-ui-editorss CTabFolder.active {
-	swt-selected-tab-highlight: '#2160bb';
+	swt-selected-tab-highlight: #2160bb;
 	swt-selected-highlight-top: true;
 }
 

--- a/bundles/org.eclipse.ui.themes/css/e4_preview_gtk.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_gtk.css
@@ -89,11 +89,11 @@ ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_TEXT_COLOR {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_TEXT_COLOR {
-   color: #000000;
+	color: #000000;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
-   color: #000000;
+	color: #000000;
 }
 
 .MTrimmedWindow {
@@ -187,12 +187,12 @@ CTabFolder Canvas {
 
 .MPartStack{
 	swt-selected-tab-highlight: #A0A0A0;
-    swt-selected-highlight-top: false;
+	swt-selected-highlight-top: false;
 }
 
 .MPartStack.active {
-    swt-selected-tab-highlight: #2160bb;
-    swt-selected-highlight-top: false;
+	swt-selected-tab-highlight: #2160bb;
+	swt-selected-highlight-top: false;
 }
 
 /* text color and background color of unselected tabs in editor*/
@@ -218,8 +218,8 @@ CTabFolder Canvas {
 }
 
 #org-eclipse-ui-editorss CTabFolder.active {
-    swt-selected-tab-highlight: '#2160bb';
-    swt-selected-highlight-top: true;
+	swt-selected-tab-highlight: '#2160bb';
+	swt-selected-highlight-top: true;
 }
 
 #org-eclipse-e4-ui-compatibility-editor Composite{

--- a/bundles/org.eclipse.ui.themes/css/e4_preview_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_mac.css
@@ -83,15 +83,15 @@ ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
 }
 
 .MTrimmedWindow {
-	background-color: '#f8f8f8';
+	background-color: #f8f8f8;
 }
 
 .MTrimBar {
-	background-color: '#f8f8f8';
+	background-color: #f8f8f8;
 }
 
 .MTrimBar#org-eclipse-ui-main-toolbar {
-	background-color: '#f8f8f8';
+	background-color: #f8f8f8;
 }
 
 CTabFolder Canvas {
@@ -100,7 +100,7 @@ CTabFolder Canvas {
 
  
 .MTrimBar#org-eclipse-ui-trim-status {
-	background-color: '#f8f8f8';
+	background-color: #f8f8f8;
 }
 
 .View Composite,
@@ -167,14 +167,14 @@ CTabFolder Canvas {
 
 /* text color of unselected tabs in editor*/
 #org-eclipse-ui-editorss CTabItem{
-	color: '#000000';
-	background-color: '#f8f8f8';
+	color: #000000;
+	background-color: #f8f8f8;
 }
 
 /*text color and background color of selected tab in editor */
 #org-eclipse-ui-editorss CTabItem:selected{
-	color: '#000000';
-	background-color: '#FFFFFF';
+	color: #000000;
+	background-color: #FFFFFF;
 }
 
 #org-eclipse-ui-editorss CTabFolder{
@@ -188,7 +188,7 @@ CTabFolder Canvas {
 }
 
 #org-eclipse-ui-editorss CTabFolder.active {
-	swt-selected-tab-highlight: '#5983c5';
+	swt-selected-tab-highlight: #5983c5;
 	swt-selected-highlight-top: true;
 }
 

--- a/bundles/org.eclipse.ui.themes/css/e4_preview_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_mac.css
@@ -75,11 +75,11 @@ ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_TEXT_COLOR {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_TEXT_COLOR {
-   color: #000000;
+	color: #000000;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
-   color: #000000;
+	color: #000000;
 }
 
 .MTrimmedWindow {
@@ -95,7 +95,7 @@ ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
 }
 
 CTabFolder Canvas {
-  background-color: rgb(255, 255, 255);
+	background-color: rgb(255, 255, 255);
 }
 
  
@@ -161,8 +161,8 @@ CTabFolder Canvas {
 }
 
 .MPartStack.active {
-    swt-selected-tab-highlight: #5983c5;
-    swt-selected-highlight-top: false;
+	swt-selected-tab-highlight: #5983c5;
+	swt-selected-highlight-top: false;
 }
 
 /* text color of unselected tabs in editor*/
@@ -188,8 +188,8 @@ CTabFolder Canvas {
 }
 
 #org-eclipse-ui-editorss CTabFolder.active {
-    swt-selected-tab-highlight: '#5983c5';
-    swt-selected-highlight-top: true;
+	swt-selected-tab-highlight: '#5983c5';
+	swt-selected-highlight-top: true;
 }
 
 #org-eclipse-e4-ui-compatibility-editor Composite{

--- a/bundles/org.eclipse.ui.themes/css/e4_preview_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_win.css
@@ -75,11 +75,11 @@ ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_TEXT_COLOR {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_TEXT_COLOR {
-   color: #000000;
+	color: #000000;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
-   color: #000000;
+	color: #000000;
 }
 
 .MPartStack {
@@ -165,8 +165,8 @@ CTabFolder Canvas {
 }
 
 .MPartStack.active {
-    swt-selected-tab-highlight: #2160bb;
-    swt-selected-highlight-top: false;
+	swt-selected-tab-highlight: #2160bb;
+	swt-selected-highlight-top: false;
 }
 
 /* text color and background color of unselected tabs in editor*/
@@ -192,8 +192,8 @@ CTabFolder Canvas {
 }
 
 #org-eclipse-ui-editorss CTabFolder.active {
-    swt-selected-tab-highlight: '#2160bb';
-    swt-selected-highlight-top: true;
+	swt-selected-tab-highlight: '#2160bb';
+	swt-selected-highlight-top: true;
 }
 
 #org-eclipse-e4-ui-compatibility-editor Composite{

--- a/bundles/org.eclipse.ui.themes/css/e4_preview_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_win.css
@@ -100,11 +100,11 @@ CTabFolder Canvas {
 }
 
 .MTrimBar#org-eclipse-ui-main-toolbar {
-	background-color: '#f8f8f8';
+	background-color: #f8f8f8;
 }
 
 .MTrimBar#org-eclipse-ui-trim-status {
-	background-color: '#f8f8f8';
+	background-color: #f8f8f8;
 }
 
 .View Composite,
@@ -171,14 +171,14 @@ CTabFolder Canvas {
 
 /* text color and background color of unselected tabs in editor*/
 #org-eclipse-ui-editorss CTabItem{
-	color: '#000000';
-	background-color: '#f8f8f8';
+	color: #000000;
+	background-color: #f8f8f8;
 }
 
 /*text color and background color of selected tab in editor */
 #org-eclipse-ui-editorss CTabItem:selected{
-	color: '#000000';
-	background-color: '#FFFFFF';
+	color: #000000;
+	background-color: #FFFFFF;
 }
 
 #org-eclipse-ui-editorss CTabFolder{
@@ -192,7 +192,7 @@ CTabFolder Canvas {
 }
 
 #org-eclipse-ui-editorss CTabFolder.active {
-	swt-selected-tab-highlight: '#2160bb';
+	swt-selected-tab-highlight: #2160bb;
 	swt-selected-highlight-top: true;
 }
 

--- a/bundles/org.eclipse.ui.themes/css/high-contrast.css
+++ b/bundles/org.eclipse.ui.themes/css/high-contrast.css
@@ -11,11 +11,11 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
- 
- @import url("platform:/plugin/org.eclipse.ui.themes/css/e4_classic.css");
+
+@import url("platform:/plugin/org.eclipse.ui.themes/css/e4_classic.css");
 
 CTabItem:selected {
- 	color: '#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR';
+	color: '#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR';
 }
 
 .MPartStack.active > CTabItem:selected {
@@ -24,5 +24,5 @@ CTabItem:selected {
 
 .MPart Composite
 {
-    background-color: #000000;
+	background-color: #000000;
 }

--- a/bundles/org.eclipse.ui.themes/css/light/e4-light_globalstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/light/e4-light_globalstyle.css
@@ -35,10 +35,10 @@ Form {
 
 Section {
 	background-color: #ffffff;
-  	color: #505050;
-  	background-color-titlebar: #eaeaea;
-  	background-color-gradient-titlebar: #eaeaea;
-  	border-color-titlebar: #ffffff;
+	color: #505050;
+	background-color-titlebar: #eaeaea;
+	background-color-gradient-titlebar: #eaeaea;
+	border-color-titlebar: #ffffff;
 }
 
 TabbedPropertyTitle > CLabel{

--- a/bundles/org.eclipse.ui.themes/css/light/e4-light_ide_colorextensions.css
+++ b/bundles/org.eclipse.ui.themes/css/light/e4-light_ide_colorextensions.css
@@ -126,13 +126,13 @@ ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_TEXT_COLOR {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_TEXT_COLOR {
-    color: '#COLOR_WIDGET_FOREGROUND';
-    category: '#org-eclipse-ui-presentation-default';
-    label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_TAB_TEXT_COLOR');
+	color: '#COLOR_WIDGET_FOREGROUND';
+	category: '#org-eclipse-ui-presentation-default';
+	label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_TAB_TEXT_COLOR');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
-    color: '#COLOR_WIDGET_FOREGROUND';
-    category: '#org-eclipse-ui-presentation-default';
-    label: url('platform:/plugin/org.eclipse.ui.themes?message=INACTIVE_TAB_TEXT_COLOR');
+	color: '#COLOR_WIDGET_FOREGROUND';
+	category: '#org-eclipse-ui-presentation-default';
+	label: url('platform:/plugin/org.eclipse.ui.themes?message=INACTIVE_TAB_TEXT_COLOR');
 }

--- a/bundles/org.eclipse.ui.themes/css/light/e4-light_tabstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/light/e4-light_tabstyle.css
@@ -56,12 +56,12 @@ CTabFolder.MArea {
 }
 
 CTabFolder {
-    swt-selected-tab-highlight: none;
+	swt-selected-tab-highlight: none;
 }
 
 CTabFolder.active {
-    swt-selected-tab-highlight: rgb(103,145,230);
-    swt-selected-highlight-top: false;
+	swt-selected-tab-highlight: rgb(103,145,230);
+	swt-selected-highlight-top: false;
 }
 
 .MPartStack.active.noFocus > CTabItem:selected {

--- a/bundles/org.eclipse.ui.themes/css/light/e4-light_tabstyle_preview.css
+++ b/bundles/org.eclipse.ui.themes/css/light/e4-light_tabstyle_preview.css
@@ -58,8 +58,8 @@ CTabFolder {
 }
 
 CTabFolder.active {
-    swt-selected-tab-highlight: rgb(103,145,230);
-    swt-selected-highlight-top: false;
+	swt-selected-tab-highlight: rgb(103,145,230);
+	swt-selected-highlight-top: false;
 }
 
 .MPartStack.active.noFocus > CTabItem:selected {


### PR DESCRIPTION
- We should not mix tabs and spaces as they make it harder to read code reviews
- color valus don't need to be put into single quotes like `color: '#ffffff'` but should be `color: #ffffff`. By doing this the Generic Code Editor in Eclipse does correctly show the color inline with a code mining in the editor.