### PR TITLE
Don't run the automatic URL scheme registration in Development Mode

### DIFF
--- a/bundles/org.eclipse.ui.ide.application/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide.application/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide.application;singleton:=true
-Bundle-Version: 1.5.500.qualifier
+Bundle-Version: 1.5.600.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui.ide;bundle-version="[3.21.0,4.0.0)",

--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
@@ -226,7 +226,9 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 			jfaceComparatorIsSet = true;
 		}
 
-		new AutoRegisterSchemeHandlersJob().schedule();
+		if (!Platform.inDevelopmentMode()) {
+			new AutoRegisterSchemeHandlersJob().schedule();
+		}
 	}
 
 	protected void initResourceTracking() {


### PR DESCRIPTION
If the IDE is running in "Development Mode" it doesn't make sense to run this registration job.

Contributes to:
https://github.com/eclipse-platform/eclipse.platform.ui/issues/2245