### PR TITLE
FindNextAction: synchronize History with FindReplaceOverlay and Dialog

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/HistoryStore.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/HistoryStore.java
@@ -26,6 +26,9 @@ import org.eclipse.jface.dialogs.IDialogSettings;
  * the nodes using the DialogSettings mechanism.
  */
 public class HistoryStore {
+	public static final String SEARCH_HISTORY_KEY = "searchhistory"; //$NON-NLS-1$
+	public static final String REPLACE_HISTORY_KEY = "replacehistory"; //$NON-NLS-1$
+
 	private IDialogSettings settingsManager;
 	private int historySize;
 	private List<String> history;
@@ -44,10 +47,12 @@ public class HistoryStore {
 	}
 
 	public Iterable<String> get() {
+		loadSection(sectionName);
 		return history;
 	}
 
 	public String get(int index) {
+		loadSection(sectionName);
 		return history.get(index);
 	}
 
@@ -68,9 +73,17 @@ public class HistoryStore {
 		if (indexInHistory >= 0) {
 			history.remove(indexInHistory);
 		}
+
+		writeHistory();
+	}
+
+	public void addOrPushToTop(String historyItem) {
+		remove(historyItem);
+		add(historyItem);
 	}
 
 	public boolean isEmpty() {
+		loadSection(sectionName);
 		return history.isEmpty();
 	}
 
@@ -110,10 +123,12 @@ public class HistoryStore {
 	}
 
 	public int indexOf(String entry) {
+		loadSection(sectionName);
 		return history.indexOf(entry);
 	}
 
 	public int size() {
+		loadSection(sectionName);
 		return history.size();
 	}
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -628,7 +628,7 @@ public class FindReplaceOverlay extends Dialog {
 	}
 
 	private void createSearchBar() {
-		HistoryStore searchHistory = new HistoryStore(getDialogSettings(), "searchhistory", //$NON-NLS-1$
+		HistoryStore searchHistory = new HistoryStore(getDialogSettings(), HistoryStore.SEARCH_HISTORY_KEY,
 				HISTORY_SIZE);
 		searchBar = new HistoryTextWrapper(searchHistory, searchBarContainer, SWT.SINGLE);
 		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(searchBar);
@@ -663,7 +663,8 @@ public class FindReplaceOverlay extends Dialog {
 	}
 
 	private void createReplaceBar() {
-		HistoryStore replaceHistory = new HistoryStore(getDialogSettings(), "replacehistory", HISTORY_SIZE); //$NON-NLS-1$
+		HistoryStore replaceHistory = new HistoryStore(getDialogSettings(), HistoryStore.REPLACE_HISTORY_KEY,
+				HISTORY_SIZE);
 		replaceBar = new HistoryTextWrapper(replaceHistory, replaceBarContainer, SWT.SINGLE);
 		GridDataFactory.fillDefaults().grab(true, false).align(SWT.FILL, SWT.END).applyTo(replaceBar);
 		replaceBar.setMessage(FindReplaceMessages.FindReplaceOverlay_replaceBar_message);

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
@@ -123,8 +123,7 @@ public class HistoryTextWrapper extends Composite {
 
 	public void storeHistory() {
 		String string = textBar.getText();
-		history.remove(string); // ensure findString is now on the newest index of the history
-		history.add(string);
+		history.addOrPushToTop(string);
 	}
 
 	private static boolean okayToUse(final Widget widget) {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -1246,8 +1246,8 @@ class FindReplaceDialog extends Dialog {
 	 * Sets up the required managers for search history
 	 */
 	private void setupSearchHistory() {
-		findHistory = new HistoryStore(getDialogSettings(), "findhistory", HISTORY_SIZE); //$NON-NLS-1$
-		replaceHistory = new HistoryStore(getDialogSettings(), "replacehistory", HISTORY_SIZE); //$NON-NLS-1$
+		findHistory = new HistoryStore(getDialogSettings(), HistoryStore.SEARCH_HISTORY_KEY, HISTORY_SIZE); // $NON-NLS-1$
+		replaceHistory = new HistoryStore(getDialogSettings(), HistoryStore.REPLACE_HISTORY_KEY, HISTORY_SIZE); // $NON-NLS-1$
 	}
 
 	/**


### PR DESCRIPTION
The history of the FindNextAction is now synchronized with the search history of either the FindReplaceOverlay or of the FindReplaceDialog (whichever is active currently).

fixes #2285

caveat: 15 entries of search history are lost after this PR