### PR TITLE
Light (Preview) theme: Change to bg color of vertical bar in editor

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4_preview_gtk.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_gtk.css
@@ -122,7 +122,7 @@ CTabFolder.MArea {
 }
 
 CTabFolder Canvas {
-	background-color: #ffffff;
+	background-color: #f8f8f8;
 }
 
 .MTrimBar#org-eclipse-ui-main-toolbar {

--- a/bundles/org.eclipse.ui.themes/css/e4_preview_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_mac.css
@@ -95,9 +95,8 @@ ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
 }
 
 CTabFolder Canvas {
-	background-color: rgb(255, 255, 255);
+	  background-color: #f8f8f8;
 }
-
  
 .MTrimBar#org-eclipse-ui-trim-status {
 	background-color: #f8f8f8;

--- a/bundles/org.eclipse.ui.themes/css/e4_preview_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_win.css
@@ -96,7 +96,7 @@ CTabFolder.MArea {
 }
 
 CTabFolder Canvas {
-	background-color: #ffffff;
+	background-color: #f8f8f8;
 }
 
 .MTrimBar#org-eclipse-ui-main-toolbar {


### PR DESCRIPTION
Vertical bar next to the scroll bar in editor had white background color.
This has been reverted to grey.  Refer issue #2201 . Find screen shots below, captured in win os.

Before:
![image](https://github.com/user-attachments/assets/a652ad25-2d60-4de2-9a5a-3ad0408a5463)

After:
![image](https://github.com/user-attachments/assets/6c57b19d-cd66-4768-82a6-c96a2b374a69)

