### PR TITLE
Modify the 'Close Editor' handler and enabled when evaluation to supp…

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/PartTaggedAsEditorPropertyTester.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/PartTaggedAsEditorPropertyTester.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2007, 2015 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ ******************************************************************************/
+
+package org.eclipse.ui.internal;
+
+import java.util.List;
+import org.eclipse.core.expressions.PropertyTester;
+
+/**
+ * <p>
+ * Tests whether the object under test represents an MPart instance which is
+ * tagged as being one which represents an Editor (rather than a View).
+ * </p>
+ *
+ * <p>
+ * This test is performed via a query of the tags associated with the MPart, and
+ * checking whether this collection contains the
+ * {@link org.eclipse.ui.internal.Workbench#EDITOR_TAG} identifier.
+ * </p>
+ *
+ */
+public class PartTaggedAsEditorPropertyTester extends PropertyTester {
+
+	@Override
+	public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
+		if (receiver instanceof E4PartWrapper) {
+			E4PartWrapper partWrapper = (E4PartWrapper) receiver;
+			if (partWrapper.wrappedPart != null) {
+				List<String> partTags = partWrapper.wrappedPart.getTags();
+				return partTags == null || partTags.isEmpty() ? false
+						: partTags.stream().anyMatch(tag -> Workbench.EDITOR_TAG.equals(tag));
+			}
+		}
+		return false;
+	}
+}

--- a/bundles/org.eclipse.ui/plugin.xml
+++ b/bundles/org.eclipse.ui/plugin.xml
@@ -2149,6 +2149,13 @@
               properties="isPerspectiveOpen"
               type="org.eclipse.ui.IWorkbenchWindow">
         </propertyTester>
+        <propertyTester
+              class="org.eclipse.ui.internal.PartTaggedAsEditorPropertyTester"
+              id="org.eclipse.ui.isPartTaggedAsEditor"
+              namespace="org.eclipse.ui"
+              properties="isPartTaggedAsEditor"
+              type="org.eclipse.ui.IWorkbenchPart">
+        </propertyTester>
      </extension>
    <extension
          point="org.eclipse.core.expressions.definitions">
@@ -2207,11 +2214,11 @@
             class="org.eclipse.ui.internal.CloseEditorHandler"
             commandId="org.eclipse.ui.file.close">
          <enabledWhen>
-            <with
-                  variable="activeEditor">
-               <instanceof
-                     value="org.eclipse.ui.IEditorPart">
-               </instanceof>
+            <with variable="activePart">
+				<or>
+					<instanceof value="org.eclipse.ui.IEditorPart" />
+					<test property="org.eclipse.ui.isPartTaggedAsEditor" />
+				</or>
             </with>
          </enabledWhen>
       </handler>


### PR DESCRIPTION
Modify the 'Close Editor' handler and '_enabledWhen_' evaluation to add support for both compatibility-layer editor parts, _and_ new Parts contributions which represent an Editor and are contributed via eg. a PartDescriptors in a Model Fragment addition.

Associated with Issue#2176 (https://github.com/eclipse-platform/eclipse.platform.ui/issues/2176).