### PR TITLE
Replace o.e.test.performance dep with o.e.test

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.ui.tests;singleton:=true
-Bundle-Version: 0.15.500.qualifier
+Bundle-Version: 0.15.600.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.emf.ecore.xmi;bundle-version="2.4.0",

--- a/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
@@ -29,7 +29,7 @@ Require-Bundle: org.eclipse.emf.ecore.xmi;bundle-version="2.4.0",
  org.eclipse.e4.ui.css.swt;bundle-version="0.11.0",
  org.mockito.mockito-core;bundle-version="2.13.0",
  org.eclipse.e4.ui.css.core;bundle-version="0.10.100",
- org.eclipse.test.performance;bundle-version="3.13.0"
+ org.eclipse.test;bundle-version="3.6.200"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.e4.ui.tests.model.test,
  org.eclipse.e4.ui.tests.model.test.impl,

--- a/tests/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jface.text.tests
-Bundle-Version: 3.13.600.qualifier
+Bundle-Version: 3.13.700.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/tests/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Require-Bundle:
  org.eclipse.text.tests;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.ui.workbench.texteditor,
- org.eclipse.test.performance;bundle-version="3.13.0"
+ org.eclipse.test;bundle-version="3.6.200"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.jface.text.tests


### PR DESCRIPTION
The only reason to depend on o.e.test.performance bundle in these was the use of Screenshots class which should have not lived in performance test ever.