### PR TITLE
#2323 'Restore Defaults' uses different value when USE_MARKER_LIMITS pref is false.

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/FiltersConfigurationDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/FiltersConfigurationDialog.java
@@ -707,7 +707,7 @@ public class FiltersConfigurationDialog extends TrayDialog {
 
 		IPreferenceStore preferenceStore = IDEWorkbenchPlugin.getDefault().getPreferenceStore();
 		boolean useMarkerLimits = preferenceStore.getBoolean(IDEInternalPreferences.USE_MARKER_LIMITS);
-		int markerLimits = useMarkerLimits ? preferenceStore.getInt(IDEInternalPreferences.MARKER_LIMITS_VALUE) : 1000;
+		int markerLimits = preferenceStore.getInt(IDEInternalPreferences.MARKER_LIMITS_VALUE);
 
 		limitButton.setSelection(useMarkerLimits);
 		updateLimitTextEnablement();


### PR DESCRIPTION
Proposed fix for issue #2323 is to use 100 as the default value on first launch and also on pressing the 'Restore Defaults' button.