### PR TITLE
Find/replace dialog: properly update search string #2322

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -139,12 +139,12 @@ class FindReplaceDialog extends Dialog {
 
 		@Override
 		public void modifyText(ModifyEvent e) {
+			modificationHandler.run();
 			// XXX: Workaround for Combo bug on Linux (see bug 404202 and bug 410603)
 			if (fIgnoreNextEvent) {
 				fIgnoreNextEvent = false;
 				return;
 			}
-			modificationHandler.run();
 			evaluateFindReplaceStatus();
 
 			updateButtonState(!findReplaceLogic.isActive(SearchOptions.INCREMENTAL));


### PR DESCRIPTION
The find/replace dialog does currently not properly update its search string. When changing the search string and pressing return to execute a search, the previous search string is taken. The reason is an existing workaround for event handling of Combos in GTK.

This change ensures that the search and replace input strings are properly updated upon every text modification in the according widgets.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2322