### PR TITLE
Remove reflective access from find/replace tests #2060

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -104,6 +104,8 @@ public class FindReplaceOverlay extends Dialog {
 				KeyStroke.getInstance(SWT.MOD1, 'R'), KeyStroke.getInstance(SWT.MOD1, 'r'));
 	}
 
+	public static final String ID_DATA_KEY = "org.eclipse.ui.internal.findreplace.overlay.FindReplaceOverlay.id"; //$NON-NLS-1$
+
 	private static final String REPLACE_BAR_OPEN_DIALOG_SETTING = "replaceBarOpen"; //$NON-NLS-1$
 	private static final double WORST_CASE_RATIO_EDITOR_TO_OVERLAY = 0.95;
 	private static final double BIG_WIDTH_RATIO_EDITOR_TO_OVERLAY = 0.7;
@@ -130,9 +132,9 @@ public class FindReplaceOverlay extends Dialog {
 	private ToolItem wholeWordSearchButton;
 	private ToolItem caseSensitiveSearchButton;
 	private ToolItem regexSearchButton;
-	private ToolItem searchUpButton;
-	private ToolItem searchDownButton;
-	private ToolItem searchAllButton;
+	private ToolItem searchBackwardButton;
+	private ToolItem searchForwardButton;
+	private ToolItem selectAllButton;
 	private AccessibleToolBar closeTools;
 	private ToolItem closeButton;
 
@@ -370,6 +372,7 @@ public class FindReplaceOverlay extends Dialog {
 		}
 		overlayOpen = true;
 		applyOverlayColors(backgroundToUse, true);
+		assignIDs();
 		updateFromTargetSelection();
 		searchBar.forceFocus();
 
@@ -391,6 +394,25 @@ public class FindReplaceOverlay extends Dialog {
 		}
 	}
 
+	@SuppressWarnings("nls")
+	private void assignIDs() {
+		replaceToggle.setData(ID_DATA_KEY, "replaceToggle");
+		searchBar.setData(ID_DATA_KEY, "searchInput");
+		searchBackwardButton.setData(ID_DATA_KEY, "searchBackward");
+		searchForwardButton.setData(ID_DATA_KEY, "searchForward");
+		selectAllButton.setData(ID_DATA_KEY, "selectAll");
+		searchInSelectionButton.setData(ID_DATA_KEY, "searchInSelection");
+		wholeWordSearchButton.setData(ID_DATA_KEY, "wholeWordSearch");
+		regexSearchButton.setData(ID_DATA_KEY, "regExSearch");
+		caseSensitiveSearchButton.setData(ID_DATA_KEY, "caseSensitiveSearch");
+
+		if (replaceBarOpen) {
+			replaceBar.setData(ID_DATA_KEY, "replaceInput");
+			replaceButton.setData(ID_DATA_KEY, "replaceOne");
+			replaceAllButton.setData(ID_DATA_KEY, "replaceAll");
+		}
+	}
+
 	private void applyOverlayColors(Color color, boolean tryToColorReplaceBar) {
 		closeTools.setBackground(color);
 		closeButton.setBackground(color);
@@ -400,9 +422,9 @@ public class FindReplaceOverlay extends Dialog {
 		wholeWordSearchButton.setBackground(color);
 		regexSearchButton.setBackground(color);
 		caseSensitiveSearchButton.setBackground(color);
-		searchAllButton.setBackground(color);
-		searchUpButton.setBackground(color);
-		searchDownButton.setBackground(color);
+		selectAllButton.setBackground(color);
+		searchBackwardButton.setBackground(color);
+		searchForwardButton.setBackground(color);
 
 		searchBarContainer.setBackground(color);
 		searchBar.setBackground(color);
@@ -511,20 +533,20 @@ public class FindReplaceOverlay extends Dialog {
 
 		searchTools.createToolItem(SWT.SEPARATOR);
 
-		searchUpButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.PUSH)
+		searchBackwardButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.PUSH)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_FIND_PREV))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_upSearchButton_toolTip)
 				.withOperation(() -> performSearch(false))
 				.withShortcuts(KeyboardShortcuts.SEARCH_BACKWARD).build();
 
-		searchDownButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.PUSH)
+		searchForwardButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.PUSH)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_FIND_NEXT))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_downSearchButton_toolTip)
 				.withOperation(() -> performSearch(true))
 				.withShortcuts(KeyboardShortcuts.SEARCH_FORWARD).build();
-		searchDownButton.setSelection(true); // by default, search down
+		searchForwardButton.setSelection(true); // by default, search down
 
-		searchAllButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.PUSH)
+		selectAllButton = new AccessibleToolItemBuilder(searchTools).withStyleBits(SWT.PUSH)
 				.withImage(FindReplaceOverlayImages.get(FindReplaceOverlayImages.KEY_SEARCH_ALL))
 				.withToolTipText(FindReplaceMessages.FindReplaceOverlay_searchAllButton_toolTip)
 				.withOperation(this::performSelectAll).withShortcuts(KeyboardShortcuts.SEARCH_ALL).build();
@@ -759,6 +781,7 @@ public class FindReplaceOverlay extends Dialog {
 
 		updatePlacementAndVisibility();
 		applyOverlayColors(backgroundToUse, true);
+		assignIDs();
 		replaceBar.forceFocus();
 	}
 

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -79,6 +79,8 @@ import org.eclipse.ui.internal.texteditor.SWTUtil;
  */
 class FindReplaceDialog extends Dialog {
 
+	public static final String ID_DATA_KEY = "org.eclipse.ui.texteditor.FindReplaceDialog.id"; //$NON-NLS-1$
+
 	private static final int CLOSE_BUTTON_ID = 101;
 	private IFindReplaceLogic findReplaceLogic;
 
@@ -275,6 +277,7 @@ class FindReplaceDialog extends Dialog {
 		shell.setText(FindReplaceMessages.FindReplace_Dialog_Title);
 
 		updateButtonState();
+		assignIDs();
 	}
 
 	/**
@@ -1353,4 +1356,23 @@ class FindReplaceDialog extends Dialog {
 			return null;
 		return target.getSelectionText();
 	}
+
+	@SuppressWarnings("nls")
+	private void assignIDs() {
+		fFindField.setData(ID_DATA_KEY, "searchInput");
+		fReplaceField.setData(ID_DATA_KEY, "replaceInput");
+		fForwardRadioButton.setData(ID_DATA_KEY, "searchForward");
+		fGlobalRadioButton.setData(ID_DATA_KEY, "globalSearch");
+		fSelectedRangeRadioButton.setData(ID_DATA_KEY, "searchInSelection");
+		fCaseCheckBox.setData(ID_DATA_KEY, "caseSensitiveSearch");
+		fWrapCheckBox.setData(ID_DATA_KEY, "wrappedSearch");
+		fWholeWordCheckBox.setData(ID_DATA_KEY, "wholeWordSearch");
+		fIncrementalCheckBox.setData(ID_DATA_KEY, "incrementalSearch");
+		fIsRegExCheckBox.setData(ID_DATA_KEY, "regExSearch");
+
+		fReplaceSelectionButton.setData(ID_DATA_KEY, "replaceOne");
+		fReplaceFindButton.setData(ID_DATA_KEY, "replaceFindOne");
+		fReplaceAllButton.setData(ID_DATA_KEY, "replaceAll");
+	}
+
 }

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/WidgetExtractor.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/WidgetExtractor.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Vector Informatik GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.internal.findandreplace;
+
+import static org.junit.Assert.assertFalse;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Combo;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.ToolBar;
+import org.eclipse.swt.widgets.ToolItem;
+import org.eclipse.swt.widgets.Widget;
+
+import org.eclipse.ui.internal.findandreplace.overlay.HistoryTextWrapper;
+
+public final class WidgetExtractor {
+
+	private final Composite rootContainer;
+
+	private final String idDataKey;
+
+	public WidgetExtractor(String idDataKey, Composite container) {
+		this.idDataKey= idDataKey;
+		this.rootContainer= container;
+	}
+
+	public HistoryTextWrapper findHistoryTextWrapper(String id) {
+		return findWidget(rootContainer, HistoryTextWrapper.class, id);
+	}
+
+	public Combo findCombo(String id) {
+		return findWidget(rootContainer, Combo.class, id);
+	}
+
+	public Button findButton(String id) {
+		return findWidget(rootContainer, Button.class, id);
+	}
+
+	public ToolItem findToolItem(String id) {
+		return findWidget(rootContainer, ToolItem.class, id);
+	}
+
+	private <T extends Widget> T findWidget(Composite container, Class<T> type, String id) {
+		List<T> widgets= findWidgets(container, type, id);
+		assertFalse("more than one matching widget found for id '" + id + "':" + widgets, widgets.size() > 1);
+		return widgets.isEmpty() ? null : widgets.get(0);
+	}
+
+	private <T extends Widget> List<T> findWidgets(Composite container, Class<T> type, String id) {
+		List<Widget> children= new ArrayList<>();
+		children.addAll(List.of(container.getChildren()));
+		if (container instanceof ToolBar toolbar) {
+			children.addAll(List.of(toolbar.getItems()));
+		}
+		List<T> result= new ArrayList<>();
+		for (Widget child : children) {
+			if (type.isInstance(child)) {
+				if (id.equals(child.getData(idDataKey))) {
+					result.add(type.cast(child));
+				}
+			}
+			if (child instanceof Composite compositeChild) {
+				result.addAll(findWidgets(compositeChild, type, id));
+			}
+		}
+		return result;
+	}
+
+}

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
@@ -45,8 +45,8 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 	public OverlayAccess openUIFromTextViewer(TextViewer viewer) {
 		Accessor actionAccessor= new Accessor(getFindReplaceAction(), FindReplaceAction.class);
 		actionAccessor.invoke("showOverlayInEditor", null);
-		Accessor overlayAccessor= new Accessor(actionAccessor.get("overlay"), "org.eclipse.ui.internal.findandreplace.overlay.FindReplaceOverlay", getClass().getClassLoader());
-		return new OverlayAccess(getFindReplaceTarget(), overlayAccessor);
+		FindReplaceOverlay overlay= (FindReplaceOverlay) actionAccessor.get("overlay");
+		return new OverlayAccess(getFindReplaceTarget(), overlay);
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.eclipse.swt.SWT;
@@ -31,13 +30,12 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.ToolItem;
 
-import org.eclipse.text.tests.Accessor;
-
 import org.eclipse.jface.text.IFindReplaceTarget;
 import org.eclipse.jface.text.IFindReplaceTargetExtension;
 
 import org.eclipse.ui.internal.findandreplace.IFindReplaceUIAccess;
 import org.eclipse.ui.internal.findandreplace.SearchOptions;
+import org.eclipse.ui.internal.findandreplace.WidgetExtractor;
 
 class OverlayAccess implements IFindReplaceUIAccess {
 	private final IFindReplaceTarget findReplaceTarget;
@@ -64,28 +62,33 @@ class OverlayAccess implements IFindReplaceUIAccess {
 
 	private ToolItem replaceAllButton;
 
-	private final Runnable closeOperation;
+	private final FindReplaceOverlay overlay;
 
-	private final Accessor dialogAccessor;
+	private final Shell shell;
 
-	private final Supplier<Shell> shellRetriever;
-
-	OverlayAccess(IFindReplaceTarget findReplaceTarget, Accessor findReplaceOverlayAccessor) {
+	OverlayAccess(IFindReplaceTarget findReplaceTarget, FindReplaceOverlay findReplaceOverlay) {
 		this.findReplaceTarget= findReplaceTarget;
-		dialogAccessor= findReplaceOverlayAccessor;
-		find= (HistoryTextWrapper) findReplaceOverlayAccessor.get("searchBar");
-		replace= (HistoryTextWrapper) findReplaceOverlayAccessor.get("replaceBar");
-		caseSensitive= (ToolItem) findReplaceOverlayAccessor.get("caseSensitiveSearchButton");
-		wholeWord= (ToolItem) findReplaceOverlayAccessor.get("wholeWordSearchButton");
-		regEx= (ToolItem) findReplaceOverlayAccessor.get("regexSearchButton");
-		searchForward= (ToolItem) findReplaceOverlayAccessor.get("searchDownButton");
-		searchBackward= (ToolItem) findReplaceOverlayAccessor.get("searchUpButton");
-		closeOperation= () -> findReplaceOverlayAccessor.invoke("close", null);
-		openReplaceDialog= (Button) findReplaceOverlayAccessor.get("replaceToggle");
-		replaceButton= (ToolItem) findReplaceOverlayAccessor.get("replaceButton");
-		replaceAllButton= (ToolItem) findReplaceOverlayAccessor.get("replaceAllButton");
-		inSelection= (ToolItem) findReplaceOverlayAccessor.get("searchInSelectionButton");
-		shellRetriever= () -> ((Shell) findReplaceOverlayAccessor.invoke("getShell", null));
+		overlay= findReplaceOverlay;
+		shell= overlay.getShell();
+		WidgetExtractor widgetExtractor= new WidgetExtractor(FindReplaceOverlay.ID_DATA_KEY, shell);
+		find= widgetExtractor.findHistoryTextWrapper("searchInput");
+		caseSensitive= widgetExtractor.findToolItem("caseSensitiveSearch");
+		wholeWord= widgetExtractor.findToolItem("wholeWordSearch");
+		regEx= widgetExtractor.findToolItem("regExSearch");
+		inSelection= widgetExtractor.findToolItem("searchInSelection");
+		searchForward= widgetExtractor.findToolItem("searchForward");
+		searchBackward= widgetExtractor.findToolItem("searchBackward");
+		openReplaceDialog= widgetExtractor.findButton("replaceToggle");
+		extractReplaceWidgets();
+	}
+
+	private void extractReplaceWidgets() {
+		if (!isReplaceDialogOpen() && Objects.nonNull(openReplaceDialog)) {
+			WidgetExtractor widgetExtractor= new WidgetExtractor(FindReplaceOverlay.ID_DATA_KEY, shell);
+			replace= widgetExtractor.findHistoryTextWrapper("replaceInput");
+			replaceButton= widgetExtractor.findToolItem("replaceOne");
+			replaceAllButton= widgetExtractor.findToolItem("replaceAll");
+		}
 	}
 
 	private void restoreInitialConfiguration() {
@@ -100,12 +103,12 @@ class OverlayAccess implements IFindReplaceUIAccess {
 	public void closeAndRestore() {
 		restoreInitialConfiguration();
 		assertInitialConfiguration();
-		closeOperation.run();
+		overlay.close();
 	}
 
 	@Override
 	public void close() {
-		closeOperation.run();
+		overlay.close();
 	}
 
 	@Override
@@ -234,15 +237,13 @@ class OverlayAccess implements IFindReplaceUIAccess {
 	}
 
 	public boolean isReplaceDialogOpen() {
-		return dialogAccessor.getBoolean("replaceBarOpen");
+		return replace != null;
 	}
 
 	public void openReplaceDialog() {
 		if (!isReplaceDialogOpen() && Objects.nonNull(openReplaceDialog)) {
 			openReplaceDialog.notifyListeners(SWT.Selection, null);
-			replace= (HistoryTextWrapper) dialogAccessor.get("replaceBar");
-			replaceButton= (ToolItem) dialogAccessor.get("replaceButton");
-			replaceAllButton= (ToolItem) dialogAccessor.get("replaceAllButton");
+			extractReplaceWidgets();
 		}
 	}
 
@@ -309,15 +310,14 @@ class OverlayAccess implements IFindReplaceUIAccess {
 
 	@Override
 	public boolean isShown() {
-		return shellRetriever.get() != null && shellRetriever.get().isVisible();
+		return !shell.isDisposed() && shell.isVisible();
 	}
 
 	@Override
 	public boolean hasFocus() {
-		Shell overlayShell= shellRetriever.get();
-		Control focusControl= overlayShell.getDisplay().getFocusControl();
+		Control focusControl= shell.getDisplay().getFocusControl();
 		Shell focusControlShell= focusControl != null ? focusControl.getShell() : null;
-		return focusControlShell == overlayShell;
+		return focusControlShell == shell;
 	}
 
 }

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
@@ -18,81 +18,77 @@ import static org.junit.Assert.assertFalse;
 
 import java.util.Arrays;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
 
-import org.eclipse.text.tests.Accessor;
+import org.eclipse.jface.dialogs.Dialog;
 
 import org.eclipse.jface.text.IFindReplaceTarget;
 import org.eclipse.jface.text.IFindReplaceTargetExtension;
 
 import org.eclipse.ui.internal.findandreplace.IFindReplaceUIAccess;
 import org.eclipse.ui.internal.findandreplace.SearchOptions;
+import org.eclipse.ui.internal.findandreplace.WidgetExtractor;
 
 class DialogAccess implements IFindReplaceUIAccess {
 
+	private static final String DATA_ID = "org.eclipse.ui.texteditor.FindReplaceDialog.id";
+
 	private final IFindReplaceTarget findReplaceTarget;
 
-	Combo findCombo;
+	private final Dialog findReplaceDialog;
 
-	Combo replaceCombo;
+	private final Combo findCombo;
 
-	Button forwardRadioButton;
+	private final Combo replaceCombo;
 
-	Button globalRadioButton;
+	private final Button forwardRadioButton;
 
-	Button searchInRangeRadioButton;
+	private final Button globalRadioButton;
 
-	Button caseCheckBox;
+	private final Button searchInRangeRadioButton;
 
-	Button wrapCheckBox;
+	private final Button caseCheckBox;
 
-	Button wholeWordCheckBox;
+	private final Button wrapCheckBox;
 
-	Button incrementalCheckBox;
+	private final Button wholeWordCheckBox;
 
-	Button regExCheckBox;
+	private final Button incrementalCheckBox;
 
-	Button findButton;
+	private final Button regExCheckBox;
 
-	Button replaceButton;
+	private final Button replaceButton;
 
-	Button replaceFindButton;
+	private final Button replaceFindButton;
 
-	Button replaceAllButton;
+	private final Button replaceAllButton;
 
-	private Supplier<Shell> shellRetriever;
-
-	private Runnable closeOperation;
-
-	Accessor dialogAccessor;
-
-	DialogAccess(IFindReplaceTarget findReplaceTarget, Accessor findReplaceDialogAccessor) {
+	DialogAccess(IFindReplaceTarget findReplaceTarget, Dialog findReplaceDialog) {
 		this.findReplaceTarget= findReplaceTarget;
-		dialogAccessor= findReplaceDialogAccessor;
-		findCombo= (Combo) findReplaceDialogAccessor.get("fFindField");
-		replaceCombo= (Combo) findReplaceDialogAccessor.get("fReplaceField");
-		forwardRadioButton= (Button) findReplaceDialogAccessor.get("fForwardRadioButton");
-		globalRadioButton= (Button) findReplaceDialogAccessor.get("fGlobalRadioButton");
-		searchInRangeRadioButton= (Button) findReplaceDialogAccessor.get("fSelectedRangeRadioButton");
-		caseCheckBox= (Button) findReplaceDialogAccessor.get("fCaseCheckBox");
-		wrapCheckBox= (Button) findReplaceDialogAccessor.get("fWrapCheckBox");
-		wholeWordCheckBox= (Button) findReplaceDialogAccessor.get("fWholeWordCheckBox");
-		incrementalCheckBox= (Button) findReplaceDialogAccessor.get("fIncrementalCheckBox");
-		regExCheckBox= (Button) findReplaceDialogAccessor.get("fIsRegExCheckBox");
-		shellRetriever= () -> ((Shell) findReplaceDialogAccessor.get("fActiveShell"));
-		closeOperation= () -> findReplaceDialogAccessor.invoke("close", null);
-		findButton= (Button) findReplaceDialogAccessor.get("fFindNextButton");
-		replaceButton= (Button) findReplaceDialogAccessor.get("fReplaceSelectionButton");
-		replaceFindButton= (Button) findReplaceDialogAccessor.get("fReplaceFindButton");
-		replaceAllButton= (Button) findReplaceDialogAccessor.get("fReplaceAllButton");
+		this.findReplaceDialog= findReplaceDialog;
+		WidgetExtractor widgetExtractor= new WidgetExtractor(DATA_ID, findReplaceDialog.getShell());
+		findCombo= widgetExtractor.findCombo("searchInput");
+		replaceCombo= widgetExtractor.findCombo("replaceInput");
+		forwardRadioButton= widgetExtractor.findButton("searchForward");
+		globalRadioButton= widgetExtractor.findButton("globalSearch");
+		searchInRangeRadioButton= widgetExtractor.findButton("searchInSelection");
+		caseCheckBox= widgetExtractor.findButton("caseSensitiveSearch");
+		wrapCheckBox= widgetExtractor.findButton("wrappedSearch");
+		wholeWordCheckBox= widgetExtractor.findButton("wholeWordSearch");
+		incrementalCheckBox= widgetExtractor.findButton("incrementalSearch");
+		regExCheckBox= widgetExtractor.findButton("regExSearch");
+
+		replaceButton= widgetExtractor.findButton("replaceOne");
+		replaceFindButton= widgetExtractor.findButton("replaceFindOne");
+		replaceAllButton= widgetExtractor.findButton("replaceAll");
 	}
 
 	void restoreInitialConfiguration() {
@@ -153,17 +149,19 @@ class DialogAccess implements IFindReplaceUIAccess {
 	public void closeAndRestore() {
 		restoreInitialConfiguration();
 		assertInitialConfiguration();
-		closeOperation.run();
+		findReplaceDialog.close();
 	}
 
 	@Override
 	public void close() {
-		closeOperation.run();
+		findReplaceDialog.close();
 	}
 
 	@Override
 	public boolean hasFocus() {
-		return shellRetriever.get() != null;
+		Control focusControl= findReplaceDialog.getShell().getDisplay().getFocusControl();
+		Shell focusControlShell= focusControl != null ? focusControl.getShell() : null;
+		return focusControlShell == findReplaceDialog.getShell();
 	}
 
 	@Override
@@ -296,7 +294,7 @@ class DialogAccess implements IFindReplaceUIAccess {
 
 	@Override
 	public boolean isShown() {
-		return shellRetriever.get() != null;
+		return findReplaceDialog.getShell().isVisible();
 	}
 
 }

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
@@ -28,6 +28,7 @@ import org.eclipse.swt.widgets.Event;
 
 import org.eclipse.text.tests.Accessor;
 
+import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.util.Util;
 
 import org.eclipse.jface.text.IFindReplaceTarget;
@@ -50,8 +51,8 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		}
 		Accessor fFindReplaceDialogStubAccessor= new Accessor(fFindReplaceDialogStub, "org.eclipse.ui.texteditor.FindReplaceAction$FindReplaceDialogStub", getClass().getClassLoader());
 
-		Accessor dialogAccessor= new Accessor(fFindReplaceDialogStubAccessor.invoke("getDialog", null), "org.eclipse.ui.texteditor.FindReplaceDialog", getClass().getClassLoader());
-		return new DialogAccess(getFindReplaceTarget(), dialogAccessor);
+		Dialog dialog= (Dialog) fFindReplaceDialogStubAccessor.invoke("getDialog", null);
+		return new DialogAccess(getFindReplaceTarget(), dialog);
 	}
 
 	@Test
@@ -61,7 +62,7 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		initializeTextViewerWithFindReplaceUI("line\nline\nline");
 		DialogAccess dialog= getDialog();
 
-		dialog.findCombo.setFocus();
+		dialog.getFindCombo().setFocus();
 		dialog.setFindText("line");
 		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		ensureHasFocusOnGTK();


### PR DESCRIPTION
The tests for the FindReplaceDialog and FindReplaceOverlay currently use reflection to access specific UI elements. This ties the test implementations to implementation details of the production classes (i.e., specific hidden field to be present) and particularly requires the production code to contain (hidden) fields even if they would not be required just to provide according tests.

This change replaces the reflective access (at the code level) with widget extraction functionality based on unique information about the widget to be searched for. This may also be considered reflective (at the configuration level), but at least it gets rid of requiring the code to contain specific fields just in order to write tests that need to extract them.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2060

This is also a preparation for:
- #2254