### PR TITLE
Find/replace overlay: improve replace toggle button appearance

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItem.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolItem.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 
 import org.eclipse.jface.bindings.keys.KeyStroke;
+import org.eclipse.jface.layout.GridDataFactory;
 
 class AccessibleToolItem {
 	private final ToolItem toolItem;
@@ -30,6 +31,7 @@ class AccessibleToolItem {
 
 	AccessibleToolItem(Composite parent, int styleBits) {
 		ToolBar toolbar = new ToolBar(parent, SWT.FLAT | SWT.HORIZONTAL);
+		GridDataFactory.fillDefaults().grab(true, true).align(SWT.CENTER, SWT.CENTER).applyTo(toolbar);
 		toolItem = new ToolItem(toolbar, styleBits);
 		addToolItemTraverseListener(toolbar);
 	}

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/OverlayAccess.java
@@ -24,7 +24,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
@@ -54,7 +53,7 @@ class OverlayAccess implements IFindReplaceUIAccess {
 
 	private final ToolItem searchBackward;
 
-	private final Button openReplaceDialog;
+	private final ToolItem openReplaceDialog;
 
 	private HistoryTextWrapper replace;
 
@@ -78,7 +77,7 @@ class OverlayAccess implements IFindReplaceUIAccess {
 		inSelection= widgetExtractor.findToolItem("searchInSelection");
 		searchForward= widgetExtractor.findToolItem("searchForward");
 		searchBackward= widgetExtractor.findToolItem("searchBackward");
-		openReplaceDialog= widgetExtractor.findButton("replaceToggle");
+		openReplaceDialog= widgetExtractor.findToolItem("replaceToggle");
 		extractReplaceWidgets();
 	}
 


### PR DESCRIPTION
The button to toggle whether the replace bar in a find/replace overlay is shown currently appears to be a rather heavyweight button with a border. With this change, the button is replace with a lightweight toolbar item like used for all other buttons in the overlay. This improves the appearance as well as the implementation as the same implementation patterns can now be applied to all buttons in the overlay.

This is also a preparatory change for #2254 as with that change optmizing the appearance of the button would otherwise become difficult.

### How it looks

#### Windows
Before:
![{97308575-0F78-4232-A151-3E93115F274C}](https://github.com/user-attachments/assets/4d5a35a5-0537-4eda-b1d1-7668d4d195a5)
![{D7A666D1-B597-46C2-A220-CD829ACBA500}](https://github.com/user-attachments/assets/e02bdb96-4653-4d2c-b32c-839ed6800686)
![{FB7A0830-8AAE-4204-B2AC-BE2A9DFCCF3A}](https://github.com/user-attachments/assets/15688896-4d8e-4495-a2c0-1100f14cca2e)
![{F2B46CA7-A9FD-4D6C-B2D5-A8C8B0710BB2}](https://github.com/user-attachments/assets/900c6435-300e-473b-9cc6-a24b7d07a7e6)

After:
![{4C0AFC57-EA34-4582-A506-50D820761F7C}](https://github.com/user-attachments/assets/1b57cb95-0203-4029-91cb-106aa194e035)
![{5D4F867C-8ACA-44F8-A8E6-D317EE2D3E9D}](https://github.com/user-attachments/assets/48ba7d1c-0d43-4bf2-b883-de613002e543)
![{4DC065F8-126A-476C-A732-1677DC81A31C}](https://github.com/user-attachments/assets/0b1f3e1c-dd65-42e8-9888-28cdd2c54932)
![{FBCCA0D9-14C9-47DA-8C86-0635C544B538}](https://github.com/user-attachments/assets/84647eb9-9153-467f-bb2f-f7b9c44a9172)

#### MacOS
Before:
<img width="538" alt="image" src="https://github.com/user-attachments/assets/d6d4df4e-ad17-4bda-8b7a-6a41b95f6c7b">
<img width="533" alt="image" src="https://github.com/user-attachments/assets/c7b8a391-cf5e-4fe3-b126-834273f17cd4">
<img width="537" alt="image" src="https://github.com/user-attachments/assets/673dd2c7-76df-41bd-9ac5-a49d6590acf6">
<img width="530" alt="image" src="https://github.com/user-attachments/assets/a198310a-4c66-4ff5-bac5-787cee25b3d7">

After:
<img width="538" alt="image" src="https://github.com/user-attachments/assets/0f91191c-b3e9-4f9b-8507-c7a41968e6cc">
<img width="539" alt="image" src="https://github.com/user-attachments/assets/2d3f332b-382a-4ce9-97a8-32d8ffe1fb50">
<img width="534" alt="image" src="https://github.com/user-attachments/assets/d83f5492-9b68-4b31-93a2-624155bc9d01">
<img width="543" alt="image" src="https://github.com/user-attachments/assets/9d51cd2b-0d77-4d26-87d8-6c65ae852c2d">


#### Linux
Before:
![image](https://github.com/user-attachments/assets/2333cb21-1d34-468e-95f2-8358c9ff567e)
![image](https://github.com/user-attachments/assets/87ff03e3-c1d9-41a4-878a-a25ee6d68c5f)
![image](https://github.com/user-attachments/assets/67731af7-547a-4c4b-91b0-4e7db581511e)
![image](https://github.com/user-attachments/assets/4e1c115f-3ad1-46a6-bbed-2fcd1b681425)

After:
![image](https://github.com/user-attachments/assets/a754a41e-ebdd-4408-825d-500cd6832dfe)
![image](https://github.com/user-attachments/assets/66980fb0-726a-4fab-8f59-176d2da293c5)
![image](https://github.com/user-attachments/assets/8b2a2983-c3d1-4af6-86b0-7eeb4727ea6f)
![image](https://github.com/user-attachments/assets/c3176752-4de7-4e27-9355-e2bc33d36d3a)
