### PR TITLE
Improve workspace lock error dialog.

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
@@ -1147,6 +1147,12 @@ public class IDEWorkbenchMessages extends NLS {
 	public static String WorkbenchPreference_maxSimultaneousBuilds;
 	public static String WorkbenchPreference_maxSimultaneousBuildIntervalError;
 
+	public static String IDEApplication_Ws_Lock_Owner_User;
+	public static String IDEApplication_Ws_Lock_Owner_Host;
+	public static String IDEApplication_Ws_Lock_Owner_Disp;
+	public static String IDEApplication_Ws_Lock_Owner_P_Id;
+	public static String IDEApplication_Ws_Lock_Owner_Message;
+
 	static {
 		// load message values from bundle file
 		NLS.initializeMessages(BUNDLE_NAME, IDEWorkbenchMessages.class);

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
@@ -1150,3 +1150,9 @@ OpenDelayedUrlAction_title=Open URL
 editorAssociationOverride_error_couldNotCreate_message=The ''{0}'' extension from plug-in ''{1}'' to the ''org.eclipse.ui.ide.editorAssociationOverride'' extension point failed to load the editor association override class.
 editorAssociationOverride_error_invalidElementName_message=An extension from plug-in ''{0}'' to the ''org.eclipse.ui.ide.editorAssociationOverride'' extension point was ignored because it contains the following invalid element: ''{1}''.
 editorAssociationOverride_error_invalidExtension_message=The ''{0}'' extension from plug-in ''{1}'' to the ''org.eclipse.ui.ide.editorAssociationOverride'' extension point will be ignored because it contains invalid attributes.
+
+IDEApplication_Ws_Lock_Owner_User=User:\t\t{0}\n
+IDEApplication_Ws_Lock_Owner_Host=Host:\t\t{0}\n
+IDEApplication_Ws_Lock_Owner_Disp=Display:\t\t{0}\n
+IDEApplication_Ws_Lock_Owner_P_Id=Process ID:\t{0}\n
+IDEApplication_Ws_Lock_Owner_Message=Workspace lock is currently held by:\n{0}


### PR DESCRIPTION
Write workspace lock info like user, host, java process id, display properties onto .lock file if the lock was successful. Read the current lock data in case of lock was unsuccessful and shown it in error dialog.
If the .lock file has no info then nothing is shown. For older eclipse versions.

see https://github.com/eclipse-platform/eclipse.platform.ui/issues/2343