### PR TITLE
IWorkbenchPageTest: delete project after shutdown

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPageTest.java
@@ -169,11 +169,11 @@ public class IWorkbenchPageTest extends UITestCase {
 	@Override
 	protected void doTearDown() throws Exception {
 		Platform.removeLogListener(openAndHideListener);
+		super.doTearDown();
 		if (proj != null) {
 			FileUtil.deleteProject(proj);
 			proj = null;
 		}
-		super.doTearDown();
 	}
 
 	/**


### PR DESCRIPTION
To avoid error messages about missing file after testOpenEditors3()