### PR TITLE
Find/replace logic: proper replace for case-insensitive matches

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -568,7 +568,10 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 			Pattern pattern = Pattern.compile(findString, patternFlags);
 			return pattern.matcher(selectedString).find();
 		} else {
-			return getCurrentSelection().equals(findString);
+			if (isAvailableAndActive(SearchOptions.CASE_SENSITIVE)) {
+				return getCurrentSelection().equals(findString);
+			}
+			return getCurrentSelection().equalsIgnoreCase(findString);
 		}
 	}
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -348,25 +348,71 @@ public class FindReplaceLogicTest {
 	}
 
 	@Test
-	public void testPerformReplaceAndFind() {
+	public void testPerformReplaceAndFind_caseInsensitive() {
 		TextViewer textViewer= setupTextViewer("Hello<replace>World<replace>!");
 		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
 		findReplaceLogic.activate(SearchOptions.FORWARD);
-		setFindAndReplaceString(findReplaceLogic, "<replace>", " ");
+		setFindAndReplaceString(findReplaceLogic, "<Replace>", " ");
 
 		boolean status= findReplaceLogic.performReplaceAndFind();
-		assertThat(status, is(true));
+		assertTrue("replace should have been performed", status);
 		assertThat(textViewer.getDocument().get(), equalTo("Hello World<replace>!"));
 		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo("<replace>"));
 		expectStatusEmpty(findReplaceLogic);
 
+		setFindAndReplaceString(findReplaceLogic, "<replace>", " ");
 		status= findReplaceLogic.performReplaceAndFind();
-		assertThat(status, is(true));
+		assertTrue("replace should have been performed", status);
 		assertThat(textViewer.getDocument().get(), equalTo("Hello World !"));
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 
 		status= findReplaceLogic.performReplaceAndFind();
-		assertEquals("Status wasn't correctly returned", false, status);
+		assertFalse("replace should not have been performed", status);
+		assertEquals("Text shouldn't have been changed", "Hello World !", textViewer.getDocument().get());
+		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
+	}
+
+	@Test
+	public void testPerformReplaceAndFind_caseSensitive() {
+		TextViewer textViewer= setupTextViewer("Hello<Replace>World<replace>!");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.activate(SearchOptions.FORWARD);
+		findReplaceLogic.activate(SearchOptions.CASE_SENSITIVE);
+		setFindAndReplaceString(findReplaceLogic, "<replace>", " ");
+
+		boolean status= findReplaceLogic.performReplaceAndFind();
+		assertTrue("replace should have been performed", status);
+		assertThat(textViewer.getDocument().get(), equalTo("Hello<Replace>World !"));
+		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo(" "));
+
+		status= findReplaceLogic.performReplaceAndFind();
+		assertFalse("replace should not have been performed", status);
+		assertThat(textViewer.getDocument().get(), equalTo("Hello<Replace>World !"));
+		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo(" "));
+	}
+
+	@Test
+	public void testPerformReplaceAndFind_caseSensitiveAndIncremental() {
+		TextViewer textViewer= setupTextViewer("Hello<replace>World<replace>!");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.activate(SearchOptions.FORWARD);
+		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+		setFindAndReplaceString(findReplaceLogic, "<Replace>", " ");
+
+		boolean status= findReplaceLogic.performReplaceAndFind();
+		assertTrue("replace should have been performed", status);
+		assertThat(textViewer.getDocument().get(), equalTo("Hello World<replace>!"));
+		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo("<replace>"));
+		expectStatusEmpty(findReplaceLogic);
+
+		setFindAndReplaceString(findReplaceLogic, "<replace>", " ");
+		status= findReplaceLogic.performReplaceAndFind();
+		assertTrue("replace should have been performed", status);
+		assertThat(textViewer.getDocument().get(), equalTo("Hello World !"));
+		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
+
+		status= findReplaceLogic.performReplaceAndFind();
+		assertFalse("replace should not have been performed", status);
 		assertEquals("Text shouldn't have been changed", "Hello World !", textViewer.getDocument().get());
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 	}


### PR DESCRIPTION
When using find/replace (via overlay or dialog) in incremental mode, if the currently found element is only a case-insensitive match with the current search string, a replace operation will perform an unnecessary additional search and thus replace the next matching element. The reason is a comparison for whether the currently found string exactly matches the search string, not ignoring the casing.

This change adapts the behavior to properly consider case-sensitivity when performing replace operations. It also adds according regression tests.

Existing behavior shown here:
![findreplace_replace_caseinsensitive](https://github.com/user-attachments/assets/02169831-7fc7-46e4-92ae-d79e6a59810f)
