### PR TITLE
Find/replace overlay: avoid attempt to set focus while disposing overlay

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
@@ -192,7 +192,10 @@ public class HistoryTextWrapper extends Composite {
 
 	@Override
 	public boolean forceFocus() {
-		return textBar.forceFocus();
+		if (!textBar.isDisposed()) {
+			return textBar.forceFocus();
+		}
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
When closing a find/replace overlay, the SWT dispose operations try to set focus to some remaining widget. The HistoryTextWrapper tries to pass this operation to the contained Text widget without validating it for already being disposed (which is the case when closing the overlay), thus potentially leading to exception.

This change ensures that before trying to set focus on the Text widget of a HistoryTextWrapper that widget is validated for not being disposed.

Avoids exceptions like this (found when executing the FindReplaceOverlayTests on Linux):
```
org.eclipse.swt.SWTException: Widget is disposed
	at org.eclipse.swt.SWT.error(SWT.java:4922)
	at org.eclipse.swt.SWT.error(SWT.java:4837)
	at org.eclipse.swt.SWT.error(SWT.java:4808)
	at org.eclipse.swt.widgets.Widget.error(Widget.java:597)
	at org.eclipse.swt.widgets.Widget.checkWidget(Widget.java:512)
	at org.eclipse.swt.widgets.Control.forceFocus(Control.java:2891)
	at org.eclipse.ui.internal.findandreplace.overlay.HistoryTextWrapper.forceFocus(HistoryTextWrapper.java:195)
	at org.eclipse.swt.widgets.Control.setFocus(Control.java:5475)
	at org.eclipse.swt.widgets.Composite.setFocus(Composite.java:1674)
	at org.eclipse.swt.widgets.Control.fixFocus(Control.java:321)
	at org.eclipse.swt.widgets.Control.releaseWidget(Control.java:4776)
	at org.eclipse.swt.widgets.Composite.releaseWidget(Composite.java:1577)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:1413)
	at org.eclipse.swt.widgets.Control.release(Control.java:4753)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:1560)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:1401)
	at org.eclipse.swt.widgets.Control.release(Control.java:4753)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:1560)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:1401)
	at org.eclipse.swt.widgets.Control.release(Control.java:4753)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:1560)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:1401)
	at org.eclipse.swt.widgets.Control.release(Control.java:4753)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:1560)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:1401)
	at org.eclipse.swt.widgets.Control.release(Control.java:4753)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:1560)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:1401)
	at org.eclipse.swt.widgets.Control.release(Control.java:4753)
	at org.eclipse.swt.widgets.Widget.dispose(Widget.java:575)
	at org.eclipse.ui.internal.findandreplace.overlay.FindReplaceOverlay.close(FindReplaceOverlay.java:358)
```