### PR TITLE
ProjectionAnnotationModel.expandAll should tolerate the empty selection

### DIFF
--- a/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionAnnotationModel.java
+++ b/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionAnnotationModel.java
@@ -147,6 +147,10 @@ public class ProjectionAnnotationModel extends AnnotationModel {
 	 */
 	protected boolean expandAll(int offset, int length, boolean fireModelChanged) {
 
+		if (offset < 0 || length < 0) {
+			return false;
+		}
+
 		boolean expanding= false;
 
 		Iterator<Annotation> iterator= getAnnotationIterator(offset, length, true, true);


### PR DESCRIPTION
- ITextSelection.emptySelection has offset and length -1 so those values need to be tolerated downstream, included in the recent-optimized ProjectionAnnotationModel.expandAll method.

https://github.com/eclipse-platform/eclipse.platform.ui/issues/2257