### PR TITLE
[Oomph-Setup] Add eclipse.platform.ui configuration setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ For more information, refer to the [Eclipse Platform project page](https://proje
 
 Contributions are most welcome. There are many ways to contribute, from entering high quality bug reports, to contributing code or documentation changes.
 
-For a complete guide, see the https://github.com/eclipse-platform/.github/blob/main/CONTRIBUTING.md.
+For a complete guide, see the [CONTRIBUTING](https://github.com/eclipse-platform/.github/blob/main/CONTRIBUTING.md) page.
+
+[![Create Eclipse Development Environment for Eclipse Platform UI](https://download.eclipse.org/oomph/www/setups/svg/Eclipse_Platform_UI.svg)](
+https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/releng/org.eclipse.ui.releng/platformUIConfiguration.setup&show=true
+"Click to open Eclipse-Installer Auto Launch or drag into your running installer")
 
 
 ## Test Dependencies
@@ -27,10 +31,10 @@ Please install them by installing "Eclipse Test Framework" from the [current rel
 
 ## How to Build on the Command Line
 
-You need Maven 3.8.x installed. After this you can run the build via the following command:
+You need Maven 3.9.x installed. After this you can run the build via the following command:
 
 ```
-mvn clean verify -Pbuild-individual-bundles
+mvn clean verify
 ```
 
 

--- a/releng/org.eclipse.ui.releng/.project
+++ b/releng/org.eclipse.ui.releng/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.eclipse.ui.releng</name>
+	<name>org.eclipse.platform.ui.setup</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/releng/org.eclipse.ui.releng/platformUIConfiguration.setup
+++ b/releng/org.eclipse.ui.releng/platformUIConfiguration.setup
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<setup:Configuration
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
+    label="Eclipse Platform UI">
+  <annotation
+      source="http://www.eclipse.org/oomph/setup/BrandingInfo">
+    <detail
+        key="imageURI">
+      <value>https://www.eclipse.org/downloads/images/committers.png</value>
+    </detail>
+    <detail
+        key="badgeLabel">
+      <value>Eclipse Platform UI</value>
+    </detail>
+  </annotation>
+  <installation
+      name="eclipse.platform.ui.installation"
+      label="Eclipse Platform UI Installation">
+    <setupTask
+        xsi:type="setup:VariableTask"
+        name="installation.id.default"
+        value="eclipse-platform-ui"/>
+    <productVersion
+        href="index:/org.eclipse.setup#//@productCatalogs[name='org.eclipse.applications']/@products[name='eclipse.platform.sdk']/@versions[name='latest']"/>
+    <description>The Eclipse Platform UI installation provides the latest tools needed to work with the project's source code.</description>
+  </installation>
+  <workspace
+      name="eclipse.platform.ui.workspace"
+      label="Eclipse Platform UI Workspace">
+    <setupTask
+        xsi:type="setup:VariableTask"
+        name="workspace.id.default"
+        value="eclipse-platform-ui-ws"/>
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="User Preferences">
+      <annotation
+          source="http://www.eclipse.org/oomph/setup/UserPreferences">
+        <detail
+            key="/instance/org.eclipse.oomph.setup.ui/showToolBarContributions">
+          <value>record</value>
+        </detail>
+      </annotation>
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.oomph.setup.ui">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.oomph.setup.ui/showToolBarContributions"
+            value="true"/>
+      </setupTask>
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.ui.ide">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.ui.ide/WORKSPACE_NAME"
+            value="Eclipse Platform UI"/>
+      </setupTask>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:VariableTask"
+        name="eclipse.git.authentication.style"
+        defaultValue="anonymous"/>
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='platform']/@projects[name='ui']/@streams[name='master']"/>
+    <description>The Eclipse Platform UI workspace provides all the source code of the project.</description>
+  </workspace>
+  <description>
+    &lt;p>
+    The &lt;code>Eclipse Platform UI&lt;/code> configuration provisions a dedicated development environment for the complete set of projects that comprise the Eclipse Platform UI,
+    i.e. the projects that are contained in the &lt;a href=&quot;https://github.com/eclipse-platform/eclipse.platform.ui&quot;>eclipse.platform.ui&lt;/a> repository.
+    &lt;/p>
+    &lt;p>
+    The installation is based on the latest successful integration build of the &lt;code>Eclipse Platform SDK&lt;/code>,
+    the PDE target platform, like the installation, is also based on the latest integration build,
+    and the API baseline is based on the most recent release.
+    &lt;p>
+    &lt;/p>
+    Please &lt;a href=&quot;https://wiki.eclipse.org/Eclipse_Platform_SDK_Provisioning&quot;>read the tutorial instructions&lt;/a> for more details.
+    &lt;/p>
+  </description>
+</setup:Configuration>

--- a/releng/org.eclipse.ui.releng/platformUi.setup
+++ b/releng/org.eclipse.ui.releng/platformUi.setup
@@ -13,6 +13,11 @@
     xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Git.ecore http://www.eclipse.org/oomph/predicates/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/targlets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/SetupTarglets.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/SetupWorkingSets.ecore http://www.eclipse.org/oomph/workingsets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/WorkingSets.ecore"
     name="ui"
     label="UI">
+  <annotation
+      source="http://www.eclipse.org/oomph/setup/ConfigurationReference">
+    <reference
+        href="platformUIConfiguration.setup#/"/>
+  </annotation>
   <setupTask
       xsi:type="setup:EclipseIniTask"
       option="-Doomph.redirection.platform.ui"


### PR DESCRIPTION
Additionally add a styled and drag&drop-able Oomph Configuration button.

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2430