### PR TITLE
[test] DialogCheck: reuse VerifyDialog

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.harness/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Harness Plug-in
 Bundle-SymbolicName: org.eclipse.ui.tests.harness;singleton:=true
-Bundle-Version: 1.10.400.qualifier
+Bundle-Version: 1.10.500.qualifier
 Eclipse-BundleShape: dir
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/DialogCheck.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/DialogCheck.java
@@ -104,8 +104,10 @@ public class DialogCheck {
 	public static Shell getShell() {
 		Shell shell = PlatformUI.getWorkbench()
 				.getActiveWorkbenchWindow().getShell();
-		_verifyDialog = new VerifyDialog(shell);
-		_verifyDialog.create();
+		if (_verifyDialog == null) {
+			_verifyDialog = new VerifyDialog(shell);
+			_verifyDialog.create();
+		}
 		return _verifyDialog.getShell();
 	}
 


### PR DESCRIPTION
to reduce used OS handles
try to avoid "org.eclipse.swt.SWTError: No more handles" during tests