### PR TITLE
Fix failing StackRendererTest Test

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRendererTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRendererTest.java
@@ -49,14 +49,12 @@ import org.eclipse.e4.ui.services.internal.events.EventBroker;
 import org.eclipse.e4.ui.tests.rules.WorkbenchContextRule;
 import org.eclipse.e4.ui.workbench.UIEvents;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Widget;
 import org.junit.Before;
@@ -539,8 +537,6 @@ public class StackRendererTest {
 		MPart part1 = ems.createModelElement(MPart.class);
 		partStack.getChildren().add(part1);
 		partStack.setSelectedElement(part1);
-
-		tabFolder.notifyListeners(SWT.Paint, new Event());
 
 		expected = new Rectangle(StackRenderer.ONBOARDING_SPACING, StackRenderer.ONBOARDING_TOP_SPACING, 0, 0);
 		assertEquals(expected, outerOnboardingComposite.getBounds());


### PR DESCRIPTION
GC of the event must not be null.

Fixes: https://github.com/eclipse-platform/eclipse.platform.swt/issues/1515