### PR TITLE
[tests] log a TestException instead of RuntimeException

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/ClientEditor.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/ClientEditor.java
@@ -18,6 +18,7 @@ import jakarta.inject.Inject;
 import org.eclipse.e4.ui.di.Focus;
 import org.eclipse.e4.ui.di.Persist;
 import org.eclipse.e4.ui.model.application.ui.MDirtyable;
+import org.eclipse.e4.ui.tests.model.test.util.TestException;
 
 public class ClientEditor {
 
@@ -43,7 +44,7 @@ public class ClientEditor {
 	void doSave() {
 		saveCalled = true;
 		if (throwException) {
-			throw new RuntimeException();
+			throw new TestException();
 		}
 
 		dirtyable.setDirty(false);

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/EPartServiceTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/EPartServiceTest.java
@@ -43,6 +43,7 @@ import org.eclipse.e4.ui.model.application.ui.basic.MPartStack;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindowElement;
 import org.eclipse.e4.ui.services.IServiceConstants;
+import org.eclipse.e4.ui.tests.model.test.util.TestException;
 import org.eclipse.e4.ui.tests.workbench.TargetedView;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
@@ -10103,27 +10104,27 @@ public class EPartServiceTest extends UITest {
 
 		@Override
 		public void partActivated(MPart part) {
-			throw new RuntimeException();
+			throw new TestException();
 		}
 
 		@Override
 		public void partBroughtToTop(MPart part) {
-			throw new RuntimeException();
+			throw new TestException();
 		}
 
 		@Override
 		public void partDeactivated(MPart part) {
-			throw new RuntimeException();
+			throw new TestException();
 		}
 
 		@Override
 		public void partHidden(MPart part) {
-			throw new RuntimeException();
+			throw new TestException();
 		}
 
 		@Override
 		public void partVisible(MPart part) {
-			throw new RuntimeException();
+			throw new TestException();
 		}
 
 	}

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/model/test/util/TestException.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/model/test/util/TestException.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Joerg Kubitz and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Joerg Kubitz - initial API and implementation
+ ******************************************************************************/
+
+package org.eclipse.e4.ui.tests.model.test.util;
+
+public class TestException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public TestException() {
+		super("Intentional TestException. Ignore me in the logfile.");
+	}
+
+}

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/SampleView.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/SampleView.java
@@ -22,6 +22,7 @@ import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.di.PersistState;
 import org.eclipse.e4.ui.services.IServiceConstants;
+import org.eclipse.e4.ui.tests.model.test.util.TestException;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.LabelProvider;
@@ -57,7 +58,7 @@ public class SampleView {
 
 		parent.addDisposeListener(e -> {
 			if (errorOnWidgetDisposal) {
-				throw new RuntimeException();
+				throw new TestException();
 			}
 		});
 
@@ -154,7 +155,7 @@ public class SampleView {
 		nullParentContext = context.getParent() == null;
 
 		if (errorOnPreDestroy) {
-			throw new RuntimeException();
+			throw new TestException();
 		}
 	}
 


### PR DESCRIPTION
nightly logfile is flooded with intentional RuntimeException that are hard to distinguish from unintentional exceptions.