### PR TITLE
Improved Regex handeling when searching 

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -48,6 +48,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.bindings.keys.KeyStroke;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogSettings;
+import org.eclipse.jface.fieldassist.ControlDecoration;
 import org.eclipse.jface.fieldassist.TextContentAdapter;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
@@ -61,6 +62,7 @@ import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.fieldassist.ContentAssistCommandAdapter;
+import org.eclipse.ui.internal.SearchDecoration;
 import org.eclipse.ui.internal.findandreplace.FindReplaceLogic;
 import org.eclipse.ui.internal.findandreplace.FindReplaceMessages;
 import org.eclipse.ui.internal.findandreplace.HistoryStore;
@@ -140,6 +142,7 @@ public class FindReplaceOverlay {
 	private Color overlayBackgroundColor;
 	private Color normalTextForegroundColor;
 	private boolean positionAtTop = true;
+	private ControlDecoration searchBarDecoration;
 	private ContentAssistCommandAdapter contentAssistSearchField, contentAssistReplaceField;
 
 	public FindReplaceOverlay(Shell parent, IWorkbenchPart part, IFindReplaceTarget target) {
@@ -469,6 +472,7 @@ public class FindReplaceOverlay {
 					wholeWordSearchButton.setEnabled(findReplaceLogic.isAvailable(SearchOptions.WHOLE_WORD));
 					updateIncrementalSearch();
 					updateContentAssistAvailability();
+					decorate();
 				}).withShortcuts(KeyboardShortcuts.OPTION_REGEX).build();
 		regexSearchButton.setSelection(findReplaceLogic.isActive(SearchOptions.REGEX));
 	}
@@ -542,6 +546,7 @@ public class FindReplaceOverlay {
 		HistoryStore searchHistory = new HistoryStore(getDialogSettings(), "searchhistory", //$NON-NLS-1$
 				HISTORY_SIZE);
 		searchBar = new HistoryTextWrapper(searchHistory, searchBarContainer, SWT.SINGLE);
+		searchBarDecoration = new ControlDecoration(searchBar, SWT.BOTTOM | SWT.LEFT);
 		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(searchBar);
 		searchBar.forceFocus();
 		searchBar.selectAll();
@@ -587,6 +592,9 @@ public class FindReplaceOverlay {
 		});
 		searchBar.setMessage(FindReplaceMessages.FindReplaceOverlay_searchBar_message);
 		contentAssistSearchField = createContentAssistField(searchBar, true);
+		searchBar.addModifyListener(Event -> {
+			decorate();
+		});
 	}
 
 	private void updateIncrementalSearch() {
@@ -919,6 +927,14 @@ public class FindReplaceOverlay {
 
 	private void updateContentAssistAvailability() {
 		setContentAssistsEnablement(findReplaceLogic.isAvailableAndActive(SearchOptions.REGEX));
+	}
+
+	private void decorate() {
+		if (regexSearchButton.getSelection()) {
+			SearchDecoration.validateRegex(getFindString(), searchBarDecoration);
+		} else {
+			searchBarDecoration.hide();
+		}
 	}
 
 }

--- a/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Activator: org.eclipse.ui.internal.UIPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
-Export-Package: org.eclipse.ui.internal;x-internal:=true
+Export-Package: org.eclipse.ui.internal;x-friends:="org.eclipse.ui.workbench.texteditor,org.eclipse.search"
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.swt;bundle-version="[3.126.0,4.0.0)";visibility:=reexport,
  org.eclipse.jface;bundle-version="[3.34.0,4.0.0)";visibility:=reexport,

--- a/bundles/org.eclipse.ui/src/org/eclipse/ui/internal/SearchDecoration.java
+++ b/bundles/org.eclipse.ui/src/org/eclipse/ui/internal/SearchDecoration.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Vector Informatik GmbH - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.ui.internal;
+
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.eclipse.jface.fieldassist.ControlDecoration;
+import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
+import org.eclipse.swt.graphics.Image;
+
+/**
+ * This class contains methods to validate and decorate search fields.
+ */
+public class SearchDecoration {
+
+	private SearchDecoration() {
+		// avoid instantiation
+	}
+
+	/**
+	 * Validate the given regular expression and change the control decoration
+	 * accordingly. If the expression is invalid then the decoration will show an
+	 * error icon and a message and if the expression is valid then the decoration
+	 * will be hidden.
+	 *
+	 * @param regex            The regular expression to be validated.
+	 * @param targetDecoration The control decoration that will show the result of
+	 *                         the validation.
+	 */
+	public static boolean validateRegex(String regex, ControlDecoration targetDecoration) {
+		String errorMessage = getValidationError(regex);
+		if (errorMessage.isEmpty()) {
+			targetDecoration.hide();
+			return true;
+
+		}
+
+		Image decorationImage = FieldDecorationRegistry.getDefault()
+				.getFieldDecoration(FieldDecorationRegistry.DEC_ERROR).getImage();
+		targetDecoration.setImage(decorationImage);
+		targetDecoration.setDescriptionText(errorMessage);
+		targetDecoration.show();
+		return false;
+	}
+
+	/**
+	 * Validate a regular expression.
+	 *
+	 * @return The appropriate error message if the regex is invalid or an empty
+	 *         string if the regex is valid.
+	 */
+	private static String getValidationError(String regex) {
+		try {
+			Pattern.compile(regex);
+			return ""; //$NON-NLS-1$
+		} catch (PatternSyntaxException e) {
+			String message = e.getLocalizedMessage();
+
+			// Only preserve the first line of the original error message.
+			int i = 0;
+			while (i < message.length() && "\n\r".indexOf(message.charAt(i)) == -1) { //$NON-NLS-1$
+				i++;
+			}
+
+			return message.substring(0, i);
+		}
+	}
+
+}


### PR DESCRIPTION
## What it does
This PR improves the handeling of the Regex search when searching in the new or old find/replace dialog or the Big Search (strg+h).  This is regarding #1204
## Before
![image](https://github.com/user-attachments/assets/bc23904b-7705-4731-adc0-821199660131)

## After
while typing:
![Screenshot 2024-10-09 134416](https://github.com/user-attachments/assets/6db88b2c-3086-45fb-bfb6-09ebd573c29c)
when hovering: 
![Screenshot 2024-10-09 134409](https://github.com/user-attachments/assets/d03d5865-c596-48f1-8e5c-b5eea17fd942)

Additionally to the functional changes the new class helps with reusing the code that handles the regex search. 