### PR TITLE
[test] TestLabelProvider: reduce font not disposed warnings

### DIFF
--- a/tests/org.eclipse.ui.tests.navigator/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.navigator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundlename
 Bundle-SymbolicName: org.eclipse.ui.tests.navigator;singleton:=true
-Bundle-Version: 3.7.500.qualifier
+Bundle-Version: 3.7.600.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/NavigatorTestBase.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/NavigatorTestBase.java
@@ -402,7 +402,7 @@ public class NavigatorTestBase {
 			}
 			assertEquals(tlp.backgroundColor, rootItem.getBackground(0));
 			assertEquals(TestLabelProvider.toForegroundColor(tlp.backgroundColor), rootItem.getForeground(0));
-			assertEquals(tlp.font, rootItem.getFont(0));
+			assertEquals(TestLabelProvider.font, rootItem.getFont(0));
 			assertEquals(tlp.image, rootItem.getImage(0));
 			if (all) {
 				checkItems(rootItem.getItems(), tlp, all, text);

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProvider.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProvider.java
@@ -42,7 +42,7 @@ public abstract class TestLabelProvider extends LabelProvider implements
 
 	public Image image;
 
-	public Font font;
+	public static final Font font = new Font(Display.getDefault(), new FontData());
 
 	private Font boldFont;
 
@@ -170,9 +170,8 @@ public abstract class TestLabelProvider extends LabelProvider implements
 			_runnable.run();
 		boldFont.dispose();
 		boldFont = null;
-
-//		font.dispose();
-//		font = null;
+		// font can not disposed here because the TestLabelProviders are used by its
+		// static instances
 	}
 
 }

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProviderBlank.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProviderBlank.java
@@ -15,7 +15,6 @@
 package org.eclipse.ui.tests.navigator.extension;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
@@ -32,7 +31,6 @@ public class TestLabelProviderBlank extends TestStyledLabelProvider {
 	protected void initSubclass() {
 		backgroundColor = Display.getCurrent().getSystemColor(SWT.COLOR_RED);
 		backgroundColorName = "Red";
-		font = new Font(Display.getDefault(), boldFontData);
 		image = PlatformUI.getWorkbench().getSharedImages().getImage(
 				ISharedImages.IMG_OBJ_ADD);
 		instance = this;

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProviderBlue.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProviderBlue.java
@@ -15,7 +15,6 @@
 package org.eclipse.ui.tests.navigator.extension;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
@@ -32,7 +31,6 @@ public class TestLabelProviderBlue extends TestStyledLabelProvider {
 		backgroundColor = Display.getCurrent().getSystemColor(
 				SWT.COLOR_BLUE);
 		backgroundColorName = "Blue";
-		font = new Font(Display.getDefault(), boldFontData);
 		image = PlatformUI.getWorkbench().getSharedImages().getImage(
 				ISharedImages.IMG_ETOOL_SAVE_EDIT);
 		instance = this;

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProviderCyan.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProviderCyan.java
@@ -15,7 +15,6 @@
 package org.eclipse.ui.tests.navigator.extension;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
@@ -32,7 +31,6 @@ public class TestLabelProviderCyan extends TestStyledLabelProvider {
 		backgroundColor = Display.getCurrent().getSystemColor(
 				SWT.COLOR_CYAN);
 		backgroundColorName = "Cyan";
-		font = new Font(Display.getDefault(), boldFontData);
 		image = PlatformUI.getWorkbench().getSharedImages().getImage(
 				ISharedImages.IMG_DEF_VIEW);
 		instance = this;

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProviderPlainGreen.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProviderPlainGreen.java
@@ -15,7 +15,6 @@
 package org.eclipse.ui.tests.navigator.extension;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
@@ -31,7 +30,6 @@ public class TestLabelProviderPlainGreen extends TestLabelProvider {
 		backgroundColor = Display.getCurrent().getSystemColor(
 				SWT.COLOR_GREEN);
 		backgroundColorName = "Green";
-		font = new Font(Display.getDefault(), boldFontData);
 		image = PlatformUI.getWorkbench().getSharedImages().getImage(
 				ISharedImages.IMG_ELCL_COLLAPSEALL);
 		instance = this;

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProviderPlainRed.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProviderPlainRed.java
@@ -15,7 +15,6 @@
 package org.eclipse.ui.tests.navigator.extension;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
@@ -31,7 +30,6 @@ public class TestLabelProviderPlainRed extends TestLabelProvider {
 		backgroundColor = Display.getCurrent().getSystemColor(
 				SWT.COLOR_RED);
 		backgroundColorName = "Red";
-		font = new Font(Display.getDefault(), boldFontData);
 		image = PlatformUI.getWorkbench().getSharedImages().getImage(
 				ISharedImages.IMG_ELCL_REMOVE);
 		instance = this;

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProviderStyledGreen.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProviderStyledGreen.java
@@ -15,7 +15,6 @@
 package org.eclipse.ui.tests.navigator.extension;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
@@ -31,7 +30,6 @@ public class TestLabelProviderStyledGreen extends TestStyledLabelProvider {
 		backgroundColor = Display.getCurrent().getSystemColor(
 				SWT.COLOR_GREEN);
 		backgroundColorName = "Green";
-		font = new Font(Display.getDefault(), boldFontData);
 		image = PlatformUI.getWorkbench().getSharedImages().getImage(
 				ISharedImages.IMG_ELCL_COLLAPSEALL);
 		instance = this;

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProviderStyledRed.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProviderStyledRed.java
@@ -15,7 +15,6 @@
 package org.eclipse.ui.tests.navigator.extension;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
@@ -31,7 +30,6 @@ public class TestLabelProviderStyledRed extends TestStyledLabelProvider {
 		backgroundColor = Display.getCurrent().getSystemColor(
 				SWT.COLOR_RED);
 		backgroundColorName = "Red";
-		font = new Font(Display.getDefault(), boldFontData);
 		image = PlatformUI.getWorkbench().getSharedImages().getImage(
 				ISharedImages.IMG_ELCL_REMOVE);
 		instance = this;


### PR DESCRIPTION
to a single "SWT Resource was not properly disposed" during LabelProviderTest

(and fixed the font to be not bold)