### PR TITLE
WorkingSetActionProvider: fix "Widget is disposed"

### DIFF
--- a/bundles/org.eclipse.ui.navigator.resources/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.navigator.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.navigator.resources; singleton:=true
-Bundle-Version: 3.9.400.qualifier
+Bundle-Version: 3.9.500.qualifier
 Bundle-Activator: org.eclipse.ui.internal.navigator.resources.plugin.WorkbenchNavigatorPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/WorkingSetActionProvider.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/WorkingSetActionProvider.java
@@ -329,6 +329,9 @@ public class WorkingSetActionProvider extends CommonActionProvider {
 
 		// Need to run this async to avoid being reentered when processing a selection change
 		viewer.getControl().getShell().getDisplay().asyncExec(() -> {
+			if (viewer.getControl().isDisposed()) {
+				return;
+			}
 			boolean showWorkingSets = true;
 			if (aMemento != null) {
 				Integer showWorkingSetsInt = aMemento


### PR DESCRIPTION
as logged during LabelProviderTest

asyncExec can happen when viewer is already disposed