### PR TITLE
PerspectiveSwitcher.ignoreEvent: fix NPE

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/e4/ui/workbench/addons/perspectiveswitcher/PerspectiveSwitcher.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/e4/ui/workbench/addons/perspectiveswitcher/PerspectiveSwitcher.java
@@ -334,7 +334,7 @@ public class PerspectiveSwitcher {
 	 * @return true if the event is relevant, false if it can be ignored
 	 */
 	private boolean ignoreEvent(Object changedObj) {
-		if (perspSwitcherToolControl == null || perspSwitcherToolbar.isDisposed()) {
+		if (perspSwitcherToolControl == null || perspSwitcherToolbar == null || perspSwitcherToolbar.isDisposed()) {
 			return true;
 		}
 


### PR DESCRIPTION
perspSwitcherToolbar is null before createWidget() called