### PR TITLE
[ui.tests] log a TestException instead of RuntimeException

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/BadElementFactory.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/BadElementFactory.java
@@ -72,7 +72,7 @@ public class BadElementFactory implements IElementFactory {
 		public void saveState(IMemento memento) {
 			if (shouldSaveFail) {
 				saveAttemptedWhileShouldFail = true;
-				throw new RuntimeException();
+				throw new TestException();
 			}
 
 		}
@@ -83,7 +83,7 @@ public class BadElementFactory implements IElementFactory {
 	public IAdaptable createElement(IMemento memento) {
 		if (shouldFailOnCreateElement) {
 			elementCreationAttemptedWhileShouldFail = true;
-			throw new RuntimeException();
+			throw new TestException();
 		}
 		return new BadElementInstance();
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetManagerTest.java
@@ -419,7 +419,7 @@ public class IWorkingSetManagerTest extends UITestCase {
 		final boolean[] result = new boolean[1];
 		// add a bogus listener that dies unexpectedly
 		IPropertyChangeListener badListener = event -> {
-			throw new RuntimeException();
+			throw new TestException();
 
 		};
 		IPropertyChangeListener goodListener = event -> result[0] = true;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/TestException.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/TestException.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Joerg Kubitz and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Joerg Kubitz - initial API and implementation
+ ******************************************************************************/
+
+package org.eclipse.ui.tests.api;
+
+public class TestException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public TestException() {
+		super("Intentional TestException. Ignore me in the logfile.");
+	}
+
+}


### PR DESCRIPTION
Nightly org.eclipse.ui.tests.UiTestSuite.txt contains intentional RuntimeException that are hard to distinguish from unintentional exceptions.