### PR TITLE
Remove include of org.apache.xmlgraphics from org.eclipse.e4.rcp feature

### DIFF
--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -77,10 +77,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.apache.xmlgraphics"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.e4.core.di.extensions"
          version="0.0.0"/>
 


### PR DESCRIPTION
- This is to avoid needing to touch the feature when this 3rd party dependency is updated in the target platform.