### PR TITLE
Increase InternalDialog width hint from 50 characters to 70 characters

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/statushandlers/InternalDialog.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/statushandlers/InternalDialog.java
@@ -239,7 +239,7 @@ public class InternalDialog extends TrayDialog {
 		titleImageLabel.setLayoutData(layoutData);
 
 		GridData messageData = new GridData(SWT.FILL, SWT.FILL, true, true);
-		messageData.widthHint = convertWidthInCharsToPixels(50);
+		messageData.widthHint = convertWidthInCharsToPixels(70);
 		mainMessageLabel = new Label(titleArea, SWT.WRAP);
 		mainMessageLabel.setLayoutData(messageData);
 		// main message set up early, to address bug 222391
@@ -602,7 +602,7 @@ public class InternalDialog extends TrayDialog {
 		// label that wraps
 		singleStatusLabel = new Label(singleStatusParent, SWT.WRAP);
 		GridData labelLayoutData = new GridData(SWT.FILL, SWT.FILL, true, true);
-		labelLayoutData.widthHint = convertWidthInCharsToPixels(50);
+		labelLayoutData.widthHint = convertWidthInCharsToPixels(70);
 		singleStatusLabel.setLayoutData(labelLayoutData);
 		// main message set up early, to address bug 222391
 		singleStatusLabel.setText(getLabelProviderWrapper().getColumnText(getCurrentStatusAdapter(), 0));


### PR DESCRIPTION
At 50 characters, the dialog almost never is able to display a message without wrapping:

![image](https://github.com/user-attachments/assets/44374a22-1967-4b35-8c9c-622821ac80ef)

Even at 70 characters it's still small but at least there is a better chance that the text will fit:

![image](https://github.com/user-attachments/assets/ca98a402-017b-489b-8ea1-5b4c1f6d09b8)