### PR TITLE
TestRunLogUtil: add stacktrace to stdout

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/TestRunLogUtil.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/TestRunLogUtil.java
@@ -41,6 +41,12 @@ public final class TestRunLogUtil {
 		}
 
 		@Override
+		protected void failed(Throwable e, Description description) {
+			System.out.println(description.getMethodName() + " failed:");
+			e.printStackTrace(System.out);
+		}
+
+		@Override
 		protected void finished(Description description) {
 			System.out.println(formatTestFinishedMessage(description.getMethodName()));
 		}


### PR DESCRIPTION
Otherwise it's hard to tell which test failed when/first if errors are collected in other logfiles only.