### PR TITLE
What happens if we define TestSuite by package?

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/UiTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/UiTestSuite.java
@@ -17,99 +17,13 @@
  *******************************************************************************/
 package org.eclipse.ui.tests;
 
-import org.eclipse.ui.internal.ide.ChooseWorkspaceDialogTests;
-import org.eclipse.ui.internal.ide.DirectoryProposalContentAssistTestSuite;
-import org.eclipse.ui.tests.activities.ActivitiesTestSuite;
-import org.eclipse.ui.tests.adaptable.AdaptableTestSuite;
-import org.eclipse.ui.tests.api.ApiTestSuite;
-import org.eclipse.ui.tests.api.StartupTest;
-import org.eclipse.ui.tests.commands.CommandsTestSuite;
-import org.eclipse.ui.tests.concurrency.ConcurrencyTestSuite;
-import org.eclipse.ui.tests.contexts.ContextsTestSuite;
-import org.eclipse.ui.tests.databinding.WorkbenchDatabindingTest;
-import org.eclipse.ui.tests.datatransfer.DataTransferTestSuite;
-import org.eclipse.ui.tests.decorators.DecoratorsTestSuite;
-import org.eclipse.ui.tests.dialogs.FilteredResourcesSelectionDialogTestSuite;
-import org.eclipse.ui.tests.dialogs.UIAutomatedSuite;
-import org.eclipse.ui.tests.dnd.DragTestSuite;
-import org.eclipse.ui.tests.dynamicplugins.DynamicPluginsTestSuite;
-import org.eclipse.ui.tests.encoding.EncodingTestSuite;
-import org.eclipse.ui.tests.fieldassist.FieldAssistTestSuite;
-import org.eclipse.ui.tests.filteredtree.FilteredTreeTests;
-import org.eclipse.ui.tests.filteredtree.PatternFilterTest;
-import org.eclipse.ui.tests.filteredtree.TextMatcherTest;
-import org.eclipse.ui.tests.internal.InternalTestSuite;
-import org.eclipse.ui.tests.intro.IntroTestSuite;
-import org.eclipse.ui.tests.keys.KeysTestSuite;
-import org.eclipse.ui.tests.leaks.LeaksTestSuite;
-import org.eclipse.ui.tests.menus.MenusTestSuite;
-import org.eclipse.ui.tests.multieditor.MultiEditorTestSuite;
-import org.eclipse.ui.tests.multipageeditor.MultiPageEditorTestSuite;
-import org.eclipse.ui.tests.navigator.NavigatorTestSuite;
-import org.eclipse.ui.tests.operations.OperationsTestSuite;
-import org.eclipse.ui.tests.preferences.PreferencesTestSuite;
-import org.eclipse.ui.tests.preferences.ViewerItemsLimitTest;
-import org.eclipse.ui.tests.progress.ProgressTestSuite;
-import org.eclipse.ui.tests.propertysheet.PropertySheetTestSuite;
-import org.eclipse.ui.tests.quickaccess.QuickAccessTestSuite;
-import org.eclipse.ui.tests.releng.PluginActivationTests;
-import org.eclipse.ui.tests.services.ServicesTestSuite;
-import org.eclipse.ui.tests.statushandlers.StatusHandlingTestSuite;
-import org.eclipse.ui.tests.stress.OpenCloseTest;
-import org.eclipse.ui.tests.systeminplaceeditor.OpenSystemInPlaceEditorTest;
-import org.eclipse.ui.tests.themes.ThemesTestSuite;
-import org.eclipse.ui.tests.zoom.ZoomTestSuite;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Test all areas of the UI.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-	StartupTest.class,
-	UIAutomatedSuite.class,
-	ApiTestSuite.class,
-	NavigatorTestSuite.class,
-	DecoratorsTestSuite.class,
-	DataTransferTestSuite.class,
-	PreferencesTestSuite.class,
-	KeysTestSuite.class,
-	ActivitiesTestSuite.class,
-	ThemesTestSuite.class,
-	EncodingTestSuite.class,
-	OperationsTestSuite.class,
-	FieldAssistTestSuite.class,
-	ServicesTestSuite.class,
-	PluginActivationTests.class,
-	ProgressTestSuite.class,
-	PropertySheetTestSuite.class,
-	AdaptableTestSuite.class,
-	MultiPageEditorTestSuite.class,
-	CommandsTestSuite.class,
-	ContextsTestSuite.class,
-	ConcurrencyTestSuite.class,
-	FilteredTreeTests.class,
-	PatternFilterTest.class,
-	TextMatcherTest.class,
-	StatusHandlingTestSuite.class,
-	MenusTestSuite.class,
-	QuickAccessTestSuite.class,
-	FilteredResourcesSelectionDialogTestSuite.class,
-	DirectoryProposalContentAssistTestSuite.class,
-	InternalTestSuite.class,
-	LeaksTestSuite.class,
-	StyledStringHighlighterTest.class,
-	ZoomTestSuite.class,
-	DynamicPluginsTestSuite.class,
-	DragTestSuite.class,
-	IntroTestSuite.class,
-	MultiEditorTestSuite.class,
-	OpenSystemInPlaceEditorTest.class,
-	WorkbenchDatabindingTest.class,
-	ChooseWorkspaceDialogTests.class,
-	ViewerItemsLimitTest.class,
-	OpenCloseTest.class
-})
+@Suite
+@SelectPackages({ "org.eclipse.ui.tests", "org.eclipse.ui.internal.ide" })
 public class UiTestSuite {
 }

--- a/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -43,7 +43,8 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="3.14.0",
  org.eclipse.jdt.ui,
  org.eclipse.ui.navigator;bundle-version="3.12.100",
  org.eclipse.search,
- org.eclipse.emf.ecore
+ org.eclipse.emf.ecore,
+ junit-platform-suite-api
 Import-Package: jakarta.annotation,
  jakarta.inject,
  org.osgi.service.event


### PR DESCRIPTION
```
Suite [org.eclipse.ui.tests.UiTestSuite] did not discover any tests
org.junit.platform.suite.engine.NoTestsDiscoveredException: Suite [org.eclipse.ui.tests.UiTestSuite] did not discover any tests
	at org.junit.platform.suite.engine.SuiteTestDescriptor.computeTestExecutionResult(SuiteTestDescriptor.java:156)
	at org.junit.platform.suite.engine.SuiteTestDescriptor.execute(SuiteTestDescriptor.java:151)
	at org.junit.platform.suite.engine.SuiteTestEngine.lambda$execute$0(SuiteTestEngine.java:73)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at org.junit.platform.suite.engine.SuiteTestEngine.execute(SuiteTestEngine.java:73)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:147)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:127)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:90)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:55)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:102)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:56)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:184)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:148)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:122)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.apache.maven.surefire.api.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:137)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:148)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:88)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:140)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication$1.run(AbstractUITestApplication.java:42)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable.lambda$1(E4Testable.java:127)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:132)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4164)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3780)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1151)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1042)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:639)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:546)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:152)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:34)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:129)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:44)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:208)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:143)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:109)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:439)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:271)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:668)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:605)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1481)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1454)
Oct 11, 2024 3:33:23 PM org.junit.platform.commons.util.ClasspathScanner findClassesForUri
WARNING: Error scanning files for URI bundleresource://42.fwk1789873665/org/eclipse/ui/tests/
java.nio.file.FileSystemNotFoundException: Provider "bundleresource" not installed
	at java.base/java.nio.file.Path.of(Path.java:213)
	at java.base/java.nio.file.Paths.get(Paths.java:98)
	at org.junit.platform.commons.util.CloseablePath.create(CloseablePath.java:58)
	at org.junit.platform.commons.util.ClasspathScanner.findClassesForUri(ClasspathScanner.java:108)
	at org.junit.platform.commons.util.ClasspathScanner.lambda$findClassesForUris$0(ClasspathScanner.java:100)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at org.junit.platform.commons.util.ClasspathScanner.findClassesForUris(ClasspathScanner.java:103)
	at org.junit.platform.commons.util.ClasspathScanner.scanForClassesInPackage(ClasspathScanner.java:83)
	at org.junit.platform.commons.util.ReflectionUtils.findAllClassesInPackage(ReflectionUtils.java:1020)
	at org.junit.platform.commons.util.ReflectionUtils.findAllClassesInPackage(ReflectionUtils.java:1013)
	at org.junit.platform.commons.support.ReflectionSupport.findAllClassesInPackage(ReflectionSupport.java:138)
	at org.junit.platform.engine.support.discovery.ClassContainerSelectorResolver.resolve(ClassContainerSelectorResolver.java:53)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolution.lambda$resolve$2(EngineDiscoveryRequestResolution.java:159)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1685)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:150)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:647)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolution.resolve(EngineDiscoveryRequestResolution.java:189)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolution.resolve(EngineDiscoveryRequestResolution.java:126)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolution.resolveCompletely(EngineDiscoveryRequestResolution.java:92)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolution.run(EngineDiscoveryRequestResolution.java:83)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolver.resolve(EngineDiscoveryRequestResolver.java:113)
	at org.junit.jupiter.engine.discovery.DiscoverySelectorResolver.resolveSelectors(DiscoverySelectorResolver.java:46)
	at org.junit.jupiter.engine.JupiterTestEngine.discover(JupiterTestEngine.java:69)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverEngineRoot(EngineDiscoveryOrchestrator.java:152)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverSafely(EngineDiscoveryOrchestrator.java:132)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discover(EngineDiscoveryOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discover(EngineDiscoveryOrchestrator.java:97)
	at org.junit.platform.suite.engine.SuiteLauncher.discover(SuiteLauncher.java:57)
	at org.junit.platform.suite.engine.SuiteTestDescriptor.discover(SuiteTestDescriptor.java:120)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at org.junit.platform.suite.engine.DiscoverySelectorResolver.discoverSuites(DiscoverySelectorResolver.java:36)
	at org.junit.platform.suite.engine.DiscoverySelectorResolver.resolveSelectors(DiscoverySelectorResolver.java:42)
	at org.junit.platform.suite.engine.SuiteTestEngine.discover(SuiteTestEngine.java:58)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverEngineRoot(EngineDiscoveryOrchestrator.java:152)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverSafely(EngineDiscoveryOrchestrator.java:132)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discover(EngineDiscoveryOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discover(EngineDiscoveryOrchestrator.java:78)
	at org.junit.platform.launcher.core.DefaultLauncher.discover(DefaultLauncher.java:110)
	at org.junit.platform.launcher.core.DefaultLauncher.discover(DefaultLauncher.java:78)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.discover(DefaultLauncherSession.java:81)
	at org.apache.maven.surefire.junitplatform.LazyLauncher.discover(LazyLauncher.java:50)
	at org.apache.maven.surefire.junitplatform.TestPlanScannerFilter.accept(TestPlanScannerFilter.java:52)
	at org.apache.maven.surefire.api.util.DefaultScanResult.applyFilter(DefaultScanResult.java:87)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.scanClasspath(JUnitPlatformProvider.java:142)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:122)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.apache.maven.surefire.api.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:137)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:148)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:88)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:140)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication$1.run(AbstractUITestApplication.java:42)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable.lambda$1(E4Testable.java:127)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:132)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4164)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3780)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1151)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1042)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:639)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:546)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:152)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:34)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:129)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:44)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:208)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:143)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:109)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:439)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:271)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:668)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:605)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1481)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1454)

```