### PR TITLE
PreferencePageParameterValues_pageLabelSeparator add trailing space

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
@@ -493,7 +493,7 @@ OpenPerspectiveDialogAction_tooltip=Open Perspective
 
 #---- General Preferences----
 PreferencePage_noDescription = (No description available)
-PreferencePageParameterValues_pageLabelSeparator = \ >\
+PreferencePageParameterValues_pageLabelSeparator = \ >\ 
 ThemingEnabled = E&nable theming
 ThemeChangeWarningText = Restart for the theme changes to take full effect
 ThemeChangeWarningTitle = Theme Changed


### PR DESCRIPTION
- This property is supposed to have a training space which was specified by `\ ` but the space as removed which then continues the property value onto the next line which is not the desired effect and results in the ThemingEnabled property being missing.