### PR TITLE
[StickyScrolling] Move complex line adaption to central handler

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/IStickyLinesProvider.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/IStickyLinesProvider.java
@@ -20,7 +20,7 @@ import org.eclipse.swt.custom.StyledText;
 import org.eclipse.jface.text.source.ISourceViewer;
 
 /**
- * A sticky lines provider calculates the sticky lines for a given source viewer. The sticky lines
+ * A sticky lines provider calculates the sticky lines for a given text widget. The sticky lines
  * will be displayed in the top area of the editor.
  * 
  * TODO move to public package and add since 3.19
@@ -28,26 +28,24 @@ import org.eclipse.jface.text.source.ISourceViewer;
 public interface IStickyLinesProvider {
 
 	/**
-	 * Calculate the sticky lines for the source code of the given sourceViewer. Specific
-	 * properties, such as the <code>tabWidht</code> can be retrieved from the
+	 * Calculate the sticky lines for the source code of the given textWidget. Specific properties,
+	 * such as the <code>tabWidht</code> and the source viewer, can be retrieved from the
 	 * <code>properties</code>.
 	 * 
-	 * @param sourceViewer The source viewer containing the source code and information about the
-	 *            first visible line
+	 * @param textWidget The text widget containing the source code
+	 * @param lineNumber The line number to calculate the sticky lines for
+	 * @param properties Properties for additional information
 	 * @return The list of sticky lines to show
-	 * 
-	 * @see ISourceViewer#getTopIndex()
-	 * @see ISourceViewer#getTextWidget()
-	 * @see StyledText#getTopIndex()
 	 */
-	public List<StickyLine> getStickyLines(ISourceViewer sourceViewer, StickyLinesProperties properties);
+	public List<StickyLine> getStickyLines(StyledText textWidget, int lineNumber, StickyLinesProperties properties);
 
 	/**
-	 * Properties required to calculate the sticky lines.
+	 * Additional properties and access in order to calculate the sticky lines.
 	 * 
 	 * @param tabWith The with of a tab
+	 * @param sourceViewer The sourceViewer to access additional information
 	 */
-	record StickyLinesProperties(int tabWith) {
+	record StickyLinesProperties(int tabWith, ISourceViewer sourceViewer) {
 	}
 
 }

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -208,7 +208,8 @@ public class StickyScrollingControl {
 		for (int i= 0; i < getNumberStickyLines(); i++) {
 			StickyLine stickyLine= stickyLines.get(i);
 			stickyLineTextJoiner.add(stickyLine.text());
-			stickyLineNumberJoiner.add(fillLineNumberWithLeadingSpaces(stickyLine.lineNumber() + 1));
+			int lineNumber= getSourceViewerLineNumber(stickyLine.lineNumber());
+			stickyLineNumberJoiner.add(fillLineNumberWithLeadingSpaces(lineNumber + 1));
 		}
 
 		String newStickyLineText= stickyLineTextJoiner.toString();
@@ -221,6 +222,13 @@ public class StickyScrollingControl {
 			styleStickyLines();
 			layoutStickyLines();
 		}
+	}
+
+	private int getSourceViewerLineNumber(int i) {
+		if (sourceViewer instanceof ITextViewerExtension5 extension) {
+			return extension.widgetLine2ModelLine(i);
+		}
+		return i;
 	}
 
 	private String fillLineNumberWithLeadingSpaces(int lineNumber) {
@@ -257,9 +265,6 @@ public class StickyScrollingControl {
 
 	private List<StyleRange> getStickyLineStyleRanges(StickyLine stickyLine, int stickyLineTextOffset) {
 		int lineNumber= stickyLine.lineNumber();
-		if (sourceViewer instanceof ITextViewerExtension5 extension) {
-			lineNumber= extension.modelLine2WidgetLine(lineNumber);
-		}
 		try {
 			StyledText textWidget= sourceViewer.getTextWidget();
 			int offsetAtLine= textWidget.getOffsetAtLine(lineNumber);


### PR DESCRIPTION
Move the adaption of the sticky lines to the growing sticky lines control into the central handler class. This change simplifies the sticky lines provider, making implementations for specific languages more straightforward and maintainable.

Preparation for #2398