### PR TITLE
make "Text editor code mining color" configurable in preferences

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/AnnotationPainter.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/AnnotationPainter.java
@@ -445,6 +445,12 @@ public class AnnotationPainter implements IPainter, PaintListener, IAnnotationMo
 	private ReusableRegion fReusableRegion= new ReusableRegion();
 
 	/**
+	 * Color used to draw inline annotations.
+	 * @since 3.26
+	 */
+	private Color fInlineAnnotationColor;
+
+	/**
 	 * Creates a new annotation painter for the given source viewer and with the
 	 * given annotation access. The painter is not initialized, i.e. no
 	 * annotation types are configured to be painted.
@@ -1646,5 +1652,19 @@ public class AnnotationPainter implements IPainter, PaintListener, IAnnotationMo
 
 	@Override
 	public void setPositionManager(IPaintPositionManager manager) {
+	}
+
+	/**
+	 * @since 3.26
+	 */
+	public void setInlineAnnotationColor(Color color) {
+		fInlineAnnotationColor= color;
+	}
+
+	/**
+	 * @since 3.26
+	 */
+	public Color getInlineAnnotationColor() {
+		return fInlineAnnotationColor;
 	}
 }

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationSupport.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationSupport.java
@@ -366,7 +366,11 @@ public class InlinedAnnotationSupport {
 		visibleLines= new VisibleLines();
 		text.addMouseListener(fMouseTracker);
 		text.addMouseMoveListener(fMouseTracker);
-		setColor(text.getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY));
+		Color c= painter.getInlineAnnotationColor();
+		if (c == null) {
+			c= text.getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY);
+		}
+		setColor(c);
 		GC gc= new GC(viewer.getTextWidget());
 		gc.setFont(viewer.getTextWidget().getFont());
 		fFontMetrics= gc.getFontMetrics();

--- a/bundles/org.eclipse.ui.editors/build.properties
+++ b/bundles/org.eclipse.ui.editors/build.properties
@@ -16,7 +16,8 @@ bin.includes = .,\
                plugin.properties,\
                about.html,\
                icons/,\
-               META-INF/
+               META-INF/,\
+               css/
 
 src.includes = about.html,\
                schema/

--- a/bundles/org.eclipse.ui.editors/css/e4-dark_preferencestyle.css
+++ b/bundles/org.eclipse.ui.editors/css/e4-dark_preferencestyle.css
@@ -1,0 +1,5 @@
+
+IEclipsePreferences#org-eclipse-ui-workbench:org-eclipse-ui-editors { 
+	preferences:
+		'org.eclipse.ui.editors.inlineAnnotationColor=155,155,155'
+}

--- a/bundles/org.eclipse.ui.editors/plugin.properties
+++ b/bundles/org.eclipse.ui.editors/plugin.properties
@@ -151,3 +151,7 @@ HyperlinkDetectorsPreferencePage= Hyperlinking
 
 #--- Unused label ---
 dummy=
+
+#--- color definition for code mining annotations
+TEXT_EDITOR_CODE_MINING_COLOR= Text editor code mining color
+TEXT_EDITOR_CODE_MINING_COLOR_DESCRIPTION= The default color used for text editor code mining annotations.

--- a/bundles/org.eclipse.ui.editors/plugin.xml
+++ b/bundles/org.eclipse.ui.editors/plugin.xml
@@ -1178,9 +1178,6 @@
          <themeid
                refid="org.eclipse.e4.ui.css.theme.e4_dark">
          </themeid>
-         <themeid
-               refid="com.sap.adt.tools.core.ui.darkthemepoc">
-         </themeid>
       </stylesheet>
    </extension>
 </plugin>

--- a/bundles/org.eclipse.ui.editors/plugin.xml
+++ b/bundles/org.eclipse.ui.editors/plugin.xml
@@ -1119,6 +1119,16 @@
             label="test"
             value="232,232,232">
       </colorDefinition>
+      <colorDefinition
+            categoryId="org.eclipse.ui.workbenchMisc"
+            id="org.eclipse.ui.editors.inlineAnnotationColor"
+            isEditable="true"
+            label="%TEXT_EDITOR_CODE_MINING_COLOR"
+            value="128,128,128">
+        <description>
+            %TEXT_EDITOR_CODE_MINING_COLOR_DESCRIPTION
+         </description>
+      </colorDefinition>
 
       <theme
 		  id="org.eclipse.ui.ide.systemDefault">
@@ -1160,5 +1170,17 @@
             class="org.eclipse.ui.internal.editors.text.codemining.annotation.AnnotationCodeMiningProvider"
             id="org.eclipse.ui.internal.editors.annotationCodeMiningProvider">
       </codeMiningProvider>
+   </extension>
+   <extension
+         point="org.eclipse.e4.ui.css.swt.theme">
+      <stylesheet
+            uri="css/e4-dark_preferencestyle.css">
+         <themeid
+               refid="org.eclipse.e4.ui.css.theme.e4_dark">
+         </themeid>
+         <themeid
+               refid="com.sap.adt.tools.core.ui.darkthemepoc">
+         </themeid>
+      </stylesheet>
    </extension>
 </plugin>

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/texteditor/AbstractDecoratedTextEditor.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/texteditor/AbstractDecoratedTextEditor.java
@@ -197,6 +197,10 @@ public abstract class AbstractDecoratedTextEditor extends StatusTextEditor {
 	 */
 	private final static String CURRENT_LINE_COLOR= AbstractDecoratedTextEditorPreferenceConstants.EDITOR_CURRENT_LINE_COLOR;
 	/**
+	 * Preference key for inline annotation color
+	 */
+	private final static String INLINE_ANNOTATION_COLOR= AbstractDecoratedTextEditorPreferenceConstants.EDITOR_INLINE_ANNOTATION_COLOR;
+	/**
 	 * Preference key for showing print margin ruler.
 	 */
 	private final static String PRINT_MARGIN= AbstractDecoratedTextEditorPreferenceConstants.EDITOR_PRINT_MARGIN;
@@ -456,6 +460,7 @@ public abstract class AbstractDecoratedTextEditor extends StatusTextEditor {
 
 		support.setCursorLinePainterPreferenceKeys(CURRENT_LINE, CURRENT_LINE_COLOR);
 		support.setMarginPainterPreferenceKeys(PRINT_MARGIN, PRINT_MARGIN_COLOR, PRINT_MARGIN_COLUMN);
+		support.setInlineAnnotationColorPreferenceKey(INLINE_ANNOTATION_COLOR);
 	}
 
 	/*

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/texteditor/AbstractDecoratedTextEditorPreferenceConstants.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/texteditor/AbstractDecoratedTextEditorPreferenceConstants.java
@@ -72,10 +72,17 @@ public class AbstractDecoratedTextEditorPreferenceConstants {
 	public final static String EDITOR_CURRENT_LINE_COLOR= "currentLineColor"; //$NON-NLS-1$
 
 	/**
+	 * A named preference that holds the color used to render the text editor inline annotation
+	 * 
+	 * @since 3.18
+	 */
+	public final static String EDITOR_INLINE_ANNOTATION_COLOR= "org.eclipse.ui.editors.inlineAnnotationColor"; //$NON-NLS-1$
+
+	/**
 	 * A named preference that holds the number of spaces used per tab in the text editor.
 	 * <p>
-	 * Value is of type <code>int</code>: positive int value specifying the number of
-	 * spaces per tab.
+	 * Value is of type <code>int</code>: positive int value specifying the number of spaces per
+	 * tab.
 	 * </p>
 	 */
 	public final static String EDITOR_TAB_WIDTH= "tabWidth"; //$NON-NLS-1$


### PR DESCRIPTION
introduce a new entry in preference page "General"->"Appearance"->"Colors and Fonts" so that code mining color can be configured by the end user

Introduce a slightly brighter default color for code minings in the dark theme.

What do you think? Does it make sense to allow users to configure the code mining color? Currently SWT.COLOR_DARK_GRAY is used in all themes wich might be a problem in the dark theme.