### PR TITLE
[MAC] - Light(Preview) theme - Fix for missing alternate row colors for Tree 

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4_preview_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_preview_mac.css
@@ -103,7 +103,6 @@ CTabFolder Canvas {
 }
 
 .View Composite,
-.View Composite Tree,
 .View Composite Label,
 .View ToolBar,
 .View Group,
@@ -143,6 +142,11 @@ CTabFolder Canvas {
 
 .View TabbedPropertyList{
 	swt-tabBackground-color: #ffffff;
+}
+
+
+.View Composite Tree[swt-lines-visible=false]{
+	background-color: #f8f8f8;
 }
 
 .View Composite PrependingAsteriskFilteredTree,


### PR DESCRIPTION
Tree Viewers had alternate row colors if they had coloumns, in Light Theme. This was missing in Light(Preview) theme. This has been fixed with this change by making swt-lines-visible (Tree Property) to true.
Please refer #2395 