### PR TITLE
[FindNextAction] synchronize search history with FindReplaceOverlay

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/HistoryStore.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/HistoryStore.java
@@ -28,7 +28,6 @@ import org.eclipse.jface.dialogs.IDialogSettings;
 public class HistoryStore {
 	private IDialogSettings settingsManager;
 	private int historySize;
-	private List<String> history;
 	private String sectionName;
 
 	/**
@@ -38,56 +37,58 @@ public class HistoryStore {
 	 * @param historySize     how many entries to keep in the history
 	 */
 	public HistoryStore(IDialogSettings settingsManager, String sectionName, int historySize) {
+		if (sectionName == null) {
+			throw new IllegalStateException("No section loaded"); //$NON-NLS-1$
+		}
+
 		this.settingsManager = settingsManager;
 		this.historySize = historySize;
-		loadSection(sectionName);
+		this.sectionName = sectionName;
 	}
 
 	public Iterable<String> get() {
-		return history;
+		return getHistory();
 	}
 
 	public String get(int index) {
-		return history.get(index);
+		return getHistory().get(index);
 	}
 
 
 	public void add(String historyItem) {
-		if (sectionName == null) {
-			throw new IllegalStateException("No section loaded"); //$NON-NLS-1$
-		}
+		List<String> history = getHistory();
 		if (historyItem != null && !historyItem.isEmpty()) {
 			history.add(0, historyItem);
 		}
-
-		writeHistory();
+		write(history);
 	}
 
 	public void remove(String historyItem) {
+		List<String> history = getHistory();
 		int indexInHistory = history.indexOf(historyItem);
 		if (indexInHistory >= 0) {
 			history.remove(indexInHistory);
 		}
+		write(history);
 	}
 
 	public boolean isEmpty() {
-		return history.isEmpty();
+		return getHistory().isEmpty();
 	}
 
-	private void loadSection(String newSectionName) {
-		this.sectionName = newSectionName;
-		history = new ArrayList<>();
-
-		String[] newHistoryEntries = settingsManager.getArray(newSectionName);
-		if (newHistoryEntries != null) {
-			history.addAll(Arrays.asList(newHistoryEntries));
+	private List<String> getHistory() {
+		String[] historyEntries = settingsManager.getArray(sectionName);
+		List<String> result = new ArrayList<>();
+		if (historyEntries != null) {
+			result.addAll(Arrays.asList(historyEntries));
 		}
+		return result;
 	}
 
 	/**
 	 * Writes the given history into the given dialog store.
 	 */
-	private void writeHistory() {
+	private void write(List<String> history) {
 		int itemCount = history.size();
 		Set<String> distinctItems = new HashSet<>(itemCount);
 		for (int i = 0; i < itemCount; i++) {
@@ -110,10 +111,10 @@ public class HistoryStore {
 	}
 
 	public int indexOf(String entry) {
-		return history.indexOf(entry);
+		return getHistory().indexOf(entry);
 	}
 
 	public int size() {
-		return history.size();
+		return getHistory().size();
 	}
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -71,6 +71,7 @@ import org.eclipse.ui.internal.findandreplace.status.IFindReplaceStatus;
 import org.eclipse.ui.internal.texteditor.TextEditorPlugin;
 
 import org.eclipse.ui.texteditor.AbstractTextEditor;
+import org.eclipse.ui.texteditor.FindReplaceAction;
 import org.eclipse.ui.texteditor.IAbstractTextEditorHelpContextIds;
 import org.eclipse.ui.texteditor.ITextEditorActionDefinitionIds;
 import org.eclipse.ui.texteditor.StatusTextEditor;
@@ -228,10 +229,13 @@ public class FindReplaceOverlay {
 	 *
 	 * @return the dialog settings to be used
 	 */
-	private static IDialogSettings getDialogSettings() {
+	private IDialogSettings getDialogSettings() {
 		IDialogSettings settings = PlatformUI
-				.getDialogSettingsProvider(FrameworkUtil.getBundle(FindReplaceOverlay.class)).getDialogSettings();
-		return settings;
+				.getDialogSettingsProvider(FrameworkUtil.getBundle(FindReplaceAction.class)).getDialogSettings();
+		IDialogSettings dialogSettings = settings.getSection(FindReplaceAction.class.getClass().getName());
+		if (dialogSettings == null)
+			dialogSettings = settings.addNewSection(FindReplaceAction.class.getClass().getName());
+		return dialogSettings;
 	}
 
 	public void close() {
@@ -542,8 +546,7 @@ public class FindReplaceOverlay {
 		searchBarContainer = new Composite(searchContainer, SWT.NONE);
 		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(searchBarContainer);
 		GridLayoutFactory.fillDefaults().numColumns(1).applyTo(searchBarContainer);
-
-		HistoryStore searchHistory = new HistoryStore(getDialogSettings(), "searchhistory", //$NON-NLS-1$
+		HistoryStore searchHistory = new HistoryStore(getDialogSettings(), "findhistory", //$NON-NLS-1$
 				HISTORY_SIZE);
 		searchBar = new HistoryTextWrapper(searchHistory, searchBarContainer, SWT.SINGLE);
 		searchBarDecoration = new ControlDecoration(searchBar, SWT.BOTTOM | SWT.LEFT);

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindNextAction.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindNextAction.java
@@ -340,14 +340,13 @@ public class FindNextAction extends ResourceAction implements IUpdate {
 	 * @return the dialog settings to be used
 	 */
 	private IDialogSettings getDialogSettings() {
-		IDialogSettings settings = PlatformUI.getDialogSettingsProvider(FrameworkUtil.getBundle(FindNextAction.class))
-				.getDialogSettings();
-		fDialogSettings= settings.getSection(FindReplaceDialog.class.getName());
+		IDialogSettings settings = PlatformUI
+				.getDialogSettingsProvider(FrameworkUtil.getBundle(FindReplaceAction.class)).getDialogSettings();
+		fDialogSettings = settings.getSection(FindReplaceAction.class.getClass().getName());
 		if (fDialogSettings == null)
-			fDialogSettings= settings.addNewSection(FindReplaceDialog.class.getName());
+			fDialogSettings = settings.addNewSection(FindReplaceAction.class.getClass().getName());
 		return fDialogSettings;
 	}
-
 	/**
 	 * Initializes itself from the dialog settings with the same state
 	 * as at the previous invocation.

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -318,7 +318,7 @@ class FindReplaceDialog extends Dialog {
 
 						writeSelection();
 						updateButtonState(!somethingFound);
-						
+
 						updateFindHistory();
 						evaluateFindReplaceStatus();
 					}
@@ -1278,10 +1278,10 @@ class FindReplaceDialog extends Dialog {
 	 */
 	private IDialogSettings getDialogSettings() {
 		IDialogSettings settings = PlatformUI
-				.getDialogSettingsProvider(FrameworkUtil.getBundle(FindReplaceDialog.class)).getDialogSettings();
-		fDialogSettings = settings.getSection(getClass().getName());
+				.getDialogSettingsProvider(FrameworkUtil.getBundle(FindReplaceAction.class)).getDialogSettings();
+		fDialogSettings = settings.getSection(FindReplaceAction.class.getClass().getName());
 		if (fDialogSettings == null)
-			fDialogSettings = settings.addNewSection(getClass().getName());
+			fDialogSettings = settings.addNewSection(FindReplaceAction.class.getClass().getName());
 		return fDialogSettings;
 	}
 


### PR DESCRIPTION
synchronize search history with the FindReplaceOverlay and FindReplaceDialog.

![37](https://github.com/user-attachments/assets/f9b2bfbe-5f4f-4e00-b3e0-6ad4f8cf0111)

This fix is not as extensive as a prior attempt (https://github.com/eclipse-platform/eclipse.platform.ui/pull/2308) and thus does not require as much testing. Since this is a high-priority issue, we want this to be fixed ASAP.

1) search histories and options are now stored at a centralized place - in the options for the FindReplaceAction class.
2) the name of the search history settings section is now unified
3) the search history component of the Find/Replace Overlay now updates it's history on the fly to accomodate.
