### PR TITLE
Increase left margins in F&R overlay

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -616,7 +616,7 @@ public class FindReplaceOverlay {
 	private void createSearchContainer() {
 		searchContainer = new FixedColorComposite(contentGroup, SWT.NONE, widgetBackgroundColor);
 		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(searchContainer);
-		GridLayoutFactory.fillDefaults().numColumns(3).extendedMargins(4, 4, 3, 5).equalWidth(false)
+		GridLayoutFactory.fillDefaults().numColumns(3).extendedMargins(7, 4, 3, 5).equalWidth(false)
 				.applyTo(searchContainer);
 
 		createSearchBar();
@@ -627,7 +627,7 @@ public class FindReplaceOverlay {
 	private void createReplaceContainer() {
 		replaceContainer = new FixedColorComposite(contentGroup, SWT.NONE, widgetBackgroundColor);
 		GridDataFactory.fillDefaults().grab(true, true).align(GridData.FILL, GridData.FILL).applyTo(replaceContainer);
-		GridLayoutFactory.fillDefaults().margins(0, 0).numColumns(2).extendedMargins(4, 4, 3, 5).equalWidth(false)
+		GridLayoutFactory.fillDefaults().margins(0, 0).numColumns(2).extendedMargins(7, 4, 3, 5).equalWidth(false)
 				.applyTo(replaceContainer);
 
 		createReplaceBar();


### PR DESCRIPTION
Allow for the error icon to appear completely when necessary e.g. when searching for an invalid regular expression.

### Before this PR
The error icon is cut on the left:

![image](https://github.com/user-attachments/assets/89253c79-a015-4378-ba8a-7a91517cff26)

### After this PR

![image](https://github.com/user-attachments/assets/8af9cdc5-3c28-4298-b5cc-b569f87fa442)
