### PR TITLE
[StickyScrolling] Move text and style calculation to StickyLine

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/DefaultStickyLinesProvider.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/DefaultStickyLinesProvider.java
@@ -33,9 +33,9 @@ public class DefaultStickyLinesProvider implements IStickyLinesProvider {
 	private StickyLinesProperties fProperties;
 
 	@Override
-	public List<StickyLine> getStickyLines(StyledText textWidget, int lineNumber, StickyLinesProperties properties) {
+	public List<IStickyLine> getStickyLines(StyledText textWidget, int lineNumber, StickyLinesProperties properties) {
 		this.fProperties= properties;
-		LinkedList<StickyLine> stickyLines= new LinkedList<>();
+		LinkedList<IStickyLine> stickyLines= new LinkedList<>();
 
 		try {
 			int startIndetation= getStartIndentation(lineNumber, textWidget);
@@ -50,7 +50,7 @@ public class DefaultStickyLinesProvider implements IStickyLinesProvider {
 
 				if (indentation < previousIndetation) {
 					previousIndetation= indentation;
-					stickyLines.addFirst(new StickyLine(line, i));
+					stickyLines.addFirst(new StickyLine(i, textWidget));
 				}
 			}
 		} catch (IllegalArgumentException e) {

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/IStickyLine.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/IStickyLine.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2024 SAP SE.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     SAP SE - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.internal.texteditor.stickyscroll;
+
+import org.eclipse.swt.custom.StyleRange;
+
+/**
+ * Representation of a sticky line.
+ */
+public interface IStickyLine {
+
+	/**
+	 * Returns the line number of the sticky line.
+	 * 
+	 * @return the line number of the sticky line
+	 */
+	int getLineNumber();
+
+	/**
+	 * Returns the text of the sticky line.
+	 * 
+	 * @return the text of the sticky line
+	 */
+	String getText();
+
+	/**
+	 * Returns the style ranges of the sticky line.
+	 * 
+	 * @return the style ranges of the sticky line
+	 */
+	StyleRange[] getStyleRanges();
+
+}

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/IStickyLinesProvider.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/IStickyLinesProvider.java
@@ -37,7 +37,7 @@ public interface IStickyLinesProvider {
 	 * @param properties Properties for additional information
 	 * @return The list of sticky lines to show
 	 */
-	public List<StickyLine> getStickyLines(StyledText textWidget, int lineNumber, StickyLinesProperties properties);
+	public List<IStickyLine> getStickyLines(StyledText textWidget, int lineNumber, StickyLinesProperties properties);
 
 	/**
 	 * Additional properties and access in order to calculate the sticky lines.

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyLine.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyLine.java
@@ -13,13 +13,47 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.texteditor.stickyscroll;
 
+import org.eclipse.swt.custom.StyleRange;
+import org.eclipse.swt.custom.StyledText;
+
 /**
- * 
- * A record representing a sticky line containing the text to display, and line number. It serves as
- * an abstraction to represent sticky line for sticky scrolling.
- * 
- * @param text the text of the corresponding sticky line
- * @param lineNumber the specific line number of the sticky line
+ * Default implementation of {@link IStickyLine}. Information about the text and style ranges are
+ * calculated from the given text widget.
  */
-public record StickyLine(String text, int lineNumber) {
+public class StickyLine implements IStickyLine {
+
+	private int lineNumber;
+
+	private String text;
+
+	private StyledText textWidget;
+
+	public StickyLine(int lineNumber, StyledText textWidget) {
+		this.lineNumber= lineNumber;
+		this.textWidget= textWidget;
+	}
+
+	@Override
+	public int getLineNumber() {
+		return this.lineNumber;
+	}
+
+	@Override
+	public String getText() {
+		if (text == null) {
+			text= textWidget.getLine(lineNumber);
+		}
+		return text;
+	}
+
+	@Override
+	public StyleRange[] getStyleRanges() {
+		int offsetAtLine= textWidget.getOffsetAtLine(lineNumber);
+		StyleRange[] styleRanges= textWidget.getStyleRanges(offsetAtLine, getText().length());
+		for (StyleRange styleRange : styleRanges) {
+			styleRange.start= styleRange.start - offsetAtLine;
+		}
+		return styleRanges;
+	}
+
 }

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -14,8 +14,6 @@
 package org.eclipse.ui.internal.texteditor.stickyscroll;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.StringJoiner;
@@ -65,7 +63,7 @@ import org.eclipse.ui.internal.texteditor.LineNumberColumn;
 /**
  * This class builds a control that is rendered on top of the given source viewer. The controls
  * shows the sticky lines that are set via {@link #setStickyLines(List)} on top of the source
- * viewer. The {@link StickyLine#lineNumber()} is linked to to corresponding line number in the
+ * viewer. The {@link StickyLine#getLineNumber()} is linked to to corresponding line number in the
  * given source viewer, with index starting at 0.
  * 
  * As part of its responsibilities, the class handles layout arrangement and styling of the sticky
@@ -87,7 +85,7 @@ public class StickyScrollingControl {
 
 	private static final String DISABLE_CSS= "org.eclipse.e4.ui.css.disabled"; //$NON-NLS-1$
 
-	private List<StickyLine> stickyLines;
+	private List<IStickyLine> stickyLines;
 
 	private ISourceViewer sourceViewer;
 
@@ -135,7 +133,7 @@ public class StickyScrollingControl {
 	 * 
 	 * @param stickyLines The sticky lines to show
 	 */
-	public void setStickyLines(List<StickyLine> stickyLines) {
+	public void setStickyLines(List<IStickyLine> stickyLines) {
 		if (!stickyLines.equals(this.stickyLines)) {
 			this.stickyLines= stickyLines;
 			updateStickyScrollingControls();
@@ -206,9 +204,9 @@ public class StickyScrollingControl {
 		StringJoiner stickyLineTextJoiner= new StringJoiner(System.lineSeparator());
 		StringJoiner stickyLineNumberJoiner= new StringJoiner(System.lineSeparator());
 		for (int i= 0; i < getNumberStickyLines(); i++) {
-			StickyLine stickyLine= stickyLines.get(i);
-			stickyLineTextJoiner.add(stickyLine.text());
-			int lineNumber= getSourceViewerLineNumber(stickyLine.lineNumber());
+			IStickyLine stickyLine= stickyLines.get(i);
+			stickyLineTextJoiner.add(stickyLine.getText());
+			int lineNumber= getSourceViewerLineNumber(stickyLine.getLineNumber());
 			stickyLineNumberJoiner.add(fillLineNumberWithLeadingSpaces(lineNumber + 1));
 		}
 
@@ -244,14 +242,20 @@ public class StickyScrollingControl {
 			return;
 		}
 
-		List<StyleRange> stickyLinesStyleRanges= new ArrayList<>();
-		int stickyLineTextOffset= 0;
-		for (int i= 0; i < getNumberStickyLines(); i++) {
-			StickyLine stickyLine= stickyLines.get(i);
-			stickyLinesStyleRanges.addAll(getStickyLineStyleRanges(stickyLine, stickyLineTextOffset));
-			stickyLineTextOffset+= stickyLine.text().length() + System.lineSeparator().length();
+		int stickyLineOffset= 0;
+		List<StyleRange> styleRanges= new ArrayList<>();
+		for (IStickyLine stickyLine : stickyLines) {
+			StyleRange[] ranges= stickyLine.getStyleRanges();
+			if (ranges != null) {
+				for (StyleRange styleRange : ranges) {
+					styleRange.start+= stickyLineOffset;
+					styleRanges.add(styleRange);
+				}
+			}
+
+			stickyLineOffset+= stickyLine.getText().length() + System.lineSeparator().length();
 		}
-		stickyLineText.setStyleRanges(stickyLinesStyleRanges.toArray(StyleRange[]::new));
+		stickyLineText.setStyleRanges(styleRanges.toArray(StyleRange[]::new));
 
 		stickyLineNumber.setFont(textWidget.getFont());
 		stickyLineNumber.setStyleRange(new StyleRange(0, stickyLineNumber.getText().length(), settings.lineNumberColor(), null));
@@ -261,22 +265,6 @@ public class StickyScrollingControl {
 		stickyLineText.setForeground(textWidget.getForeground());
 		stickyLineText.setLineSpacing(textWidget.getLineSpacing());
 		stickyLineText.setLeftMargin(textWidget.getLeftMargin());
-	}
-
-	private List<StyleRange> getStickyLineStyleRanges(StickyLine stickyLine, int stickyLineTextOffset) {
-		int lineNumber= stickyLine.lineNumber();
-		try {
-			StyledText textWidget= sourceViewer.getTextWidget();
-			int offsetAtLine= textWidget.getOffsetAtLine(lineNumber);
-			StyleRange[] styleRanges= textWidget.getStyleRanges(offsetAtLine, stickyLine.text().length());
-			for (StyleRange styleRange : styleRanges) {
-				styleRange.start= styleRange.start - offsetAtLine + stickyLineTextOffset;
-			}
-			return Arrays.asList(styleRanges);
-		} catch (IllegalArgumentException e) {
-			//Styling could not be copied, skip!
-			return Collections.emptyList();
-		}
 	}
 
 	private void layoutStickyLines() {
@@ -365,12 +353,12 @@ public class StickyScrollingControl {
 
 	private void navigateToClickedLine(MouseEvent event) {
 		int clickedStickyLineIndex= stickyLineText.getLineIndex(event.y);
-		StickyLine clickedStickyLine= stickyLines.get(clickedStickyLineIndex);
+		IStickyLine clickedStickyLine= stickyLines.get(clickedStickyLineIndex);
 
 		try {
-			int offset= sourceViewer.getDocument().getLineOffset(clickedStickyLine.lineNumber());
+			int offset= sourceViewer.getDocument().getLineOffset(clickedStickyLine.getLineNumber());
 			sourceViewer.setSelectedRange(offset, 0);
-			ensureSourceViewerLineVisible(clickedStickyLine.lineNumber());
+			ensureSourceViewerLineVisible(clickedStickyLine.getLineNumber());
 		} catch (BadLocationException e) {
 			//Do not navigate
 		}

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandler.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandler.java
@@ -153,7 +153,7 @@ public class StickyScrollingHandler implements IViewportListener {
 	}
 
 	private void calculateAndShowStickyLines() {
-		List<StickyLine> stickyLines= Collections.emptyList();
+		List<IStickyLine> stickyLines= Collections.emptyList();
 
 		StyledText textWidget= sourceViewer.getTextWidget();
 		int startLine= textWidget.getTopIndex();
@@ -171,19 +171,19 @@ public class StickyScrollingHandler implements IViewportListener {
 		stickyScrollingControl.setStickyLines(stickyLines);
 	}
 
-	private List<StickyLine> adaptStickyLinesToVisibleArea(List<StickyLine> stickyLines, int startLine) {
+	private List<IStickyLine> adaptStickyLinesToVisibleArea(List<IStickyLine> stickyLines, int startLine) {
 		if (stickyLines.isEmpty()) {
 			return stickyLines;
 		}
 
-		LinkedList<StickyLine> adaptedStickyLines= new LinkedList<>(stickyLines);
+		LinkedList<IStickyLine> adaptedStickyLines= new LinkedList<>(stickyLines);
 
 		int firstVisibleLine= startLine + adaptedStickyLines.size();
 		StyledText textWidget= sourceViewer.getTextWidget();
 		int maximumLines= textWidget.getLineCount();
 
 		for (int i= startLine + 1; i <= firstVisibleLine && i < maximumLines; i++) {
-			List<StickyLine> stickyLinesInLineI= stickyLinesProvider.getStickyLines(textWidget, i, stickyLinesProperties);
+			List<IStickyLine> stickyLinesInLineI= stickyLinesProvider.getStickyLines(textWidget, i, stickyLinesProperties);
 
 			if (stickyLinesInLineI.size() > adaptedStickyLines.size()) {
 				adaptedStickyLines= new LinkedList<>(stickyLinesInLineI);

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/DefaultStickyLinesProviderTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/DefaultStickyLinesProviderTest.java
@@ -16,7 +16,7 @@ package org.eclipse.ui.internal.texteditor.stickyscroll;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
@@ -51,7 +51,7 @@ public class DefaultStickyLinesProviderTest {
 
 	@Test
 	public void testEmptySourceCode() {
-		List<StickyLine> stickyLines = stickyLinesProvider.getStickyLines(textWidget, 0, stickyLinesProperties);
+		List<IStickyLine> stickyLines = stickyLinesProvider.getStickyLines(textWidget, 0, stickyLinesProperties);
 
 		assertThat(stickyLines, is(empty()));
 	}
@@ -63,9 +63,10 @@ public class DefaultStickyLinesProviderTest {
 				 line 2<""";
 		setText(text);
 
-		List<StickyLine> stickyLines = stickyLinesProvider.getStickyLines(textWidget, 1, stickyLinesProperties);
+		List<IStickyLine> stickyLines = stickyLinesProvider.getStickyLines(textWidget, 1, stickyLinesProperties);
 
-		assertThat(stickyLines, contains(new StickyLine("line 1", 0)));
+		assertEquals(1, stickyLines.size());
+		assertEquals(0, stickyLines.get(0).getLineNumber());
 	}
 
 	@Test
@@ -77,9 +78,10 @@ public class DefaultStickyLinesProviderTest {
 				  line 4""";
 		setText(text);
 
-		List<StickyLine> stickyLines = stickyLinesProvider.getStickyLines(textWidget, 1, stickyLinesProperties);
+		List<IStickyLine> stickyLines = stickyLinesProvider.getStickyLines(textWidget, 1, stickyLinesProperties);
 
-		assertThat(stickyLines, contains(new StickyLine("line 1", 0)));
+		assertEquals(1, stickyLines.size());
+		assertEquals(0, stickyLines.get(0).getLineNumber());
 	}
 
 	@Test
@@ -91,9 +93,10 @@ public class DefaultStickyLinesProviderTest {
 				 line 4<""";
 		setText(text);
 
-		List<StickyLine> stickyLines = stickyLinesProvider.getStickyLines(textWidget, 3, stickyLinesProperties);
+		List<IStickyLine> stickyLines = stickyLinesProvider.getStickyLines(textWidget, 3, stickyLinesProperties);
 
-		assertThat(stickyLines, contains(new StickyLine("line 3", 2)));
+		assertEquals(1, stickyLines.size());
+		assertEquals(2, stickyLines.get(0).getLineNumber());
 	}
 
 	@Test
@@ -106,9 +109,11 @@ public class DefaultStickyLinesProviderTest {
 				  line 3<""";
 		setText(text);
 
-		List<StickyLine> stickyLines = stickyLinesProvider.getStickyLines(textWidget, 4, stickyLinesProperties);
+		List<IStickyLine> stickyLines = stickyLinesProvider.getStickyLines(textWidget, 4, stickyLinesProperties);
 
-		assertThat(stickyLines, contains(new StickyLine("line 1", 0), new StickyLine(" line 2", 2)));
+		assertEquals(2, stickyLines.size());
+		assertEquals(0, stickyLines.get(0).getLineNumber());
+		assertEquals(2, stickyLines.get(1).getLineNumber());
 	}
 
 	@Test
@@ -120,9 +125,11 @@ public class DefaultStickyLinesProviderTest {
 				\t\tline 3<""";
 		setText(text);
 
-		List<StickyLine> stickyLines = stickyLinesProvider.getStickyLines(textWidget, 2, stickyLinesProperties);
+		List<IStickyLine> stickyLines = stickyLinesProvider.getStickyLines(textWidget, 2, stickyLinesProperties);
 
-		assertThat(stickyLines, contains(new StickyLine("line 1", 0), new StickyLine("\tline 2", 1)));
+		assertEquals(2, stickyLines.size());
+		assertEquals(0, stickyLines.get(0).getLineNumber());
+		assertEquals(1, stickyLines.get(1).getLineNumber());
 	}
 
 	@Test
@@ -136,9 +143,11 @@ public class DefaultStickyLinesProviderTest {
 		textWidget.setText(text);
 		textWidget.setTopIndex(3);
 
-		List<StickyLine> stickyLines = stickyLinesProvider.getStickyLines(textWidget, 3, stickyLinesProperties);
+		List<IStickyLine> stickyLines = stickyLinesProvider.getStickyLines(textWidget, 3, stickyLinesProperties);
 
-		assertThat(stickyLines, contains(new StickyLine("line 1", 0), new StickyLine(" line 2", 2)));
+		assertEquals(2, stickyLines.size());
+		assertEquals(0, stickyLines.get(0).getLineNumber());
+		assertEquals(2, stickyLines.get(1).getLineNumber());
 	}
 
 	@Test
@@ -151,9 +160,11 @@ public class DefaultStickyLinesProviderTest {
 				line 4""";
 		setText(text);
 
-		List<StickyLine> stickyLines = stickyLinesProvider.getStickyLines(textWidget, 3, stickyLinesProperties);
+		List<IStickyLine> stickyLines = stickyLinesProvider.getStickyLines(textWidget, 3, stickyLinesProperties);
 
-		assertThat(stickyLines, contains(new StickyLine("line 1", 0), new StickyLine(" line 2", 1)));
+		assertEquals(2, stickyLines.size());
+		assertEquals(0, stickyLines.get(0).getLineNumber());
+		assertEquals(1, stickyLines.get(1).getLineNumber());
 	}
 
 	/**

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyLineTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyLineTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2024 SAP SE.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     SAP SE - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.internal.texteditor.stickyscroll;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyleRange;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.widgets.Shell;
+
+public class StickyLineTest {
+
+	private Shell shell;
+	private StyledText textWidget;
+	private Color color;
+
+	@Before
+	public void setUp() {
+		shell = new Shell();
+		textWidget = new StyledText(shell, SWT.NONE);
+		color = new Color(0, 0, 0);
+	}
+
+	@After
+	public void tearDown() {
+		shell.dispose();
+		color.dispose();
+	}
+
+	@Test
+	public void testGetLineNumber() {
+		StickyLine stickyLine = new StickyLine(1, textWidget);
+
+		assertEquals(1, stickyLine.getLineNumber());
+	}
+
+	@Test
+	public void testGetText() {
+		textWidget.setText("line1\nline2\nline3");
+		StickyLine stickyLine = new StickyLine(1, textWidget);
+
+		assertEquals("line2", stickyLine.getText());
+	}
+
+	@Test
+	public void testGetStyleRanges() {
+		textWidget.setText("line1\nline2\nline3");
+
+		// line1
+		textWidget.setStyleRange(new StyleRange(2, 1, color, null));
+
+		// line2
+		textWidget.setStyleRange(new StyleRange(6, 1, color, null));
+		textWidget.setStyleRange(new StyleRange(8, 2, color, null));
+
+		// line3
+		textWidget.setStyleRange(new StyleRange(15, 1, color, null));
+
+		StickyLine stickyLine = new StickyLine(1, textWidget);
+		StyleRange[] styleRanges = stickyLine.getStyleRanges();
+
+		assertEquals(2, styleRanges.length);
+		assertEquals(0, styleRanges[0].start);
+		assertEquals(1, styleRanges[0].length);
+		assertEquals(2, styleRanges[1].start);
+		assertEquals(2, styleRanges[1].length);
+	}
+
+}

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
@@ -90,7 +90,7 @@ public class StickyScrollingControlTest {
 
 	@Test
 	public void testShowStickyLineTexts() {
-		List<StickyLine> stickyLines = List.of(new StickyLine("line 10", 9), new StickyLine("line 20", 19));
+		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 10", 9), new StickyLineStub("line 20", 19));
 		stickyScrollingControl.setStickyLines(stickyLines);
 
 		StyledText stickyLineNumber = getStickyLineNumber();
@@ -114,7 +114,7 @@ public class StickyScrollingControlTest {
 
 		stickyScrollingControl = new StickyScrollingControl(sourceViewer, ruler, settings, null);
 
-		List<StickyLine> stickyLines = List.of(new StickyLine("line 10", 9), new StickyLine("line 20", 19));
+		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 10", 9), new StickyLineStub("line 20", 19));
 		stickyScrollingControl.setStickyLines(stickyLines);
 
 		StyledText stickyLineNumber = getStickyLineNumber();
@@ -127,7 +127,7 @@ public class StickyScrollingControlTest {
 
 	@Test
 	public void testCorrectColorsApplied() {
-		List<StickyLine> stickyLines = List.of(new StickyLine("line 10", 9), new StickyLine("line 20", 19));
+		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 10", 9), new StickyLineStub("line 20", 19));
 		stickyScrollingControl.setStickyLines(stickyLines);
 
 		StyledText stickyLineNumber = getStickyLineNumber();
@@ -143,7 +143,7 @@ public class StickyScrollingControlTest {
 
 	@Test
 	public void testLimitStickyLinesCount() {
-		List<StickyLine> stickyLines = List.of(new StickyLine("line 10", 9), new StickyLine("line 20", 19));
+		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 10", 9), new StickyLineStub("line 20", 19));
 		stickyScrollingControl.setStickyLines(stickyLines);
 
 		settings = new StickyScrollingControlSettings(1, lineNumberColor, hoverColor, backgroundColor, separatorColor,
@@ -160,15 +160,26 @@ public class StickyScrollingControlTest {
 
 	@Test
 	public void testCopyStyleRanges() {
-		sourceViewer.setInput(new Document("line 1"));
-		sourceViewer.getTextWidget().setStyleRange(new StyleRange(0, 6, lineNumberColor, backgroundColor));
-
-		List<StickyLine> stickyLines = List.of(new StickyLine("line 1", 0));
+		StyleRange styleRangeLine1 = new StyleRange(0, 1, lineNumberColor, backgroundColor);
+		StyleRange styleRangeLine2 = new StyleRange(0, 2, hoverColor, separatorColor);
+		List<IStickyLine> stickyLines = List.of(//
+				new StickyLineStub("line 1", 0, new StyleRange[] { styleRangeLine1 }),
+				new StickyLineStub("line 2", 0, new StyleRange[] { styleRangeLine2 }));
 		stickyScrollingControl.setStickyLines(stickyLines);
 
 		StyledText stickyLineText = getStickyLineText();
-		assertEquals(lineNumberColor, stickyLineText.getStyleRangeAtOffset(0).foreground);
-		assertEquals(backgroundColor, stickyLineText.getStyleRangeAtOffset(0).background);
+
+		StyleRange[] styleRanges = stickyLineText.getStyleRanges();
+		assertEquals(2, styleRanges.length);
+		assertEquals(0, styleRanges[0].start);
+		assertEquals(1, styleRanges[0].length);
+		assertEquals(lineNumberColor, styleRanges[0].foreground);
+		assertEquals(backgroundColor, styleRanges[0].background);
+		int startRangeLine2 = stickyLines.get(0).getText().length() + System.lineSeparator().length();
+		assertEquals(startRangeLine2, styleRanges[1].start);
+		assertEquals(2, styleRanges[1].length);
+		assertEquals(hoverColor, styleRanges[1].foreground);
+		assertEquals(separatorColor, styleRanges[1].background);
 	}
 
 	@Test
@@ -185,7 +196,7 @@ public class StickyScrollingControlTest {
 	@Test
 	public void testWithoutLineNumber() {
 		when(ruler.getWidth()).thenReturn(20);
-		List<StickyLine> stickyLines = List.of(new StickyLine("line 10", 9), new StickyLine("line 20", 19));
+		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 10", 9), new StickyLineStub("line 20", 19));
 		stickyScrollingControl.setStickyLines(stickyLines);
 
 		StyledText stickyLineNumber = getStickyLineNumber();
@@ -206,7 +217,7 @@ public class StickyScrollingControlTest {
 		sourceViewer.getTextWidget().setFont(font);
 		sourceViewer.getTextWidget().setForeground(hoverColor);
 
-		List<StickyLine> stickyLines = List.of(new StickyLine("line 1", 0));
+		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 1", 0));
 		stickyScrollingControl.setStickyLines(stickyLines);
 
 		StyledText stickyLineNumber = getStickyLineNumber();
@@ -223,7 +234,7 @@ public class StickyScrollingControlTest {
 	public void testLayoutStickyLinesCanvasOnResize() {
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
 
-		List<StickyLine> stickyLines = List.of(new StickyLine("line 1", 0));
+		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 1", 0));
 		stickyScrollingControl.setStickyLines(stickyLines);
 
 		Canvas stickyControlCanvas = getStickyControlCanvas(shell);
@@ -252,7 +263,7 @@ public class StickyScrollingControlTest {
 		sourceViewer.setInput(new Document(text));
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
 
-		List<StickyLine> stickyLines = List.of(new StickyLine("line 2", 1));
+		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 2", 1));
 		stickyScrollingControl.setStickyLines(stickyLines);
 
 		Canvas stickyControlCanvas = getStickyControlCanvas(shell);
@@ -300,9 +311,9 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void limitStickyLinesToTextWidgetHeight() {
+	public void testLimitStickyLinesToTextWidgetHeight() {
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
-		List<StickyLine> stickyLines = List.of(new StickyLine("line 2", 1));
+		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 2", 1));
 		stickyScrollingControl.setStickyLines(stickyLines);
 
 		StyledText stickyLineText = getStickyLineText();
@@ -469,4 +480,35 @@ public class StickyScrollingControlTest {
 
 	}
 
+	private class StickyLineStub implements IStickyLine {
+
+		private final String text;
+		private final int lineNumber;
+		private StyleRange[] styleRanges;
+
+		public StickyLineStub(String text, int lineNumber) {
+			this(text, lineNumber, null);
+		}
+
+		public StickyLineStub(String text, int lineNumber, StyleRange[] styleRanges) {
+			this.text = text;
+			this.lineNumber = lineNumber;
+			this.styleRanges = styleRanges;
+		}
+
+		@Override
+		public int getLineNumber() {
+			return lineNumber;
+		}
+
+		@Override
+		public String getText() {
+			return text;
+		}
+
+		@Override
+		public StyleRange[] getStyleRanges() {
+			return styleRanges;
+		}
+	}
 }

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandlerTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandlerTest.java
@@ -37,6 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Canvas;
@@ -97,7 +98,7 @@ public class StickyScrollingHandlerTest {
 	@Test
 	public void testShowStickyLines() {
 		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
-				.thenReturn(List.of(new StickyLine("line 10", 9)));
+				.thenReturn(List.of(new StickyLineStub("line 10", 9)));
 
 		stickyScrollingHandler.viewportChanged(100);
 
@@ -134,7 +135,7 @@ public class StickyScrollingHandlerTest {
 	@Test
 	public void testPreferencesLoaded() {
 		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
-				.thenReturn(List.of(new StickyLine("line 10", 9)));
+				.thenReturn(List.of(new StickyLineStub("line 10", 9)));
 
 		stickyScrollingHandler.viewportChanged(100);
 
@@ -145,9 +146,9 @@ public class StickyScrollingHandlerTest {
 	@Test
 	public void testPreferencesUpdated() {
 		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
-				.thenReturn(List.of(new StickyLine("line 10", 9), new StickyLine("line 20", 19)));
+				.thenReturn(List.of(new StickyLineStub("line 10", 9), new StickyLineStub("line 20", 19)));
 		when(linesProvider.getStickyLines(textWidget, 2, stickyLinesProperties))
-				.thenReturn(List.of(new StickyLine("line 10", 9), new StickyLine("line 20", 19)));
+				.thenReturn(List.of(new StickyLineStub("line 10", 9), new StickyLineStub("line 20", 19)));
 
 		stickyScrollingHandler.viewportChanged(100);
 
@@ -165,13 +166,13 @@ public class StickyScrollingHandlerTest {
 	@Test
 	public void testThrottledExecution() throws InterruptedException {
 		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
-				.thenReturn(List.of(new StickyLine("line 10", 9)));
+				.thenReturn(List.of(new StickyLineStub("line 10", 9)));
 		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
-				.thenReturn(List.of(new StickyLine("line 10", 9)));
+				.thenReturn(List.of(new StickyLineStub("line 10", 9)));
 		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
-				.thenReturn(List.of(new StickyLine("line 10", 9)));
+				.thenReturn(List.of(new StickyLineStub("line 10", 9)));
 		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
-				.thenReturn(List.of(new StickyLine("line 10", 9)));
+				.thenReturn(List.of(new StickyLineStub("line 10", 9)));
 
 		stickyScrollingHandler.viewportChanged(100);
 		Thread.sleep(10);
@@ -192,9 +193,9 @@ public class StickyScrollingHandlerTest {
 	@Test
 	public void testRemoveStickyLines() {
 		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
-				.thenReturn(List.of(new StickyLine("line 1", 0), new StickyLine("line 2", 1)));
+				.thenReturn(List.of(new StickyLineStub("line 1", 0), new StickyLineStub("line 2", 1)));
 		when(linesProvider.getStickyLines(textWidget, 2, stickyLinesProperties))
-				.thenReturn(List.of(new StickyLine("line 3", 2)));
+				.thenReturn(List.of(new StickyLineStub("line 3", 2)));
 
 		stickyScrollingHandler.viewportChanged(100);
 
@@ -206,9 +207,9 @@ public class StickyScrollingHandlerTest {
 	@Test
 	public void testLineUnderStickyLine() {
 		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
-				.thenReturn(List.of(new StickyLine("line 1", 0)));
+				.thenReturn(List.of(new StickyLineStub("line 1", 0)));
 		when(linesProvider.getStickyLines(textWidget, 2, stickyLinesProperties))
-				.thenReturn(List.of(new StickyLine("line 1", 0), new StickyLine("line 2", 1)));
+				.thenReturn(List.of(new StickyLineStub("line 1", 0), new StickyLineStub("line 2", 1)));
 
 		stickyScrollingHandler.viewportChanged(100);
 
@@ -267,6 +268,32 @@ public class StickyScrollingHandlerTest {
 		joiner.add(String.valueOf(color.getGreen()));
 		joiner.add(String.valueOf(color.getBlue()));
 		return joiner.toString();
+	}
+
+	private class StickyLineStub implements IStickyLine {
+
+		private final String text;
+		private final int lineNumber;
+
+		public StickyLineStub(String text, int lineNumber) {
+			this.text = text;
+			this.lineNumber = lineNumber;
+		}
+
+		@Override
+		public int getLineNumber() {
+			return lineNumber;
+		}
+
+		@Override
+		public String getText() {
+			return text;
+		}
+
+		@Override
+		public StyleRange[] getStyleRanges() {
+			return null;
+		}
 	}
 
 }


### PR DESCRIPTION
Move the text and style calculation to the StickyLine itself in order to enable the sticky line provider to overwrite the default behavior. This is needed to apply custom texts or custom styles for the sticky lines.

Preparation for #2398