### PR TITLE
Create static variant of ImageDescriptor.imageDescriptorFromURI()

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.35.200.qualifier
+Bundle-Version: 3.36.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -205,6 +205,32 @@ public abstract class ImageDescriptor extends DeviceResourceDescriptor<Image> {
 	}
 
 	/**
+	 * Convenient method to create an ImageDescriptor from an URI.
+	 *
+	 * Delegates to {@link ImageDescriptor#createFromURL(URL)}. <em>Important</em>
+	 * This method should only be used when it's guaranteed that the given
+	 * {@link URI} is also a valid {@link URL}, in order to avoid the
+	 * {@link MalformedURLException} thrown by {@link URI#toURL()}.
+	 *
+	 * If the URI is {@code null} or not a valid {@link URL}, then an image from
+	 * {@link #getMissingImageDescriptor()} will be returned.
+	 *
+	 * @param uriIconPath The URI of the image file.
+	 * @return a new image descriptor
+	 *
+	 * @since 3.36
+	 */
+	public static ImageDescriptor createFromURI(URI uriIconPath) {
+		try {
+			return ImageDescriptor.createFromURL(uriIconPath != null ? uriIconPath.toURL() : null);
+		} catch (MalformedURLException e) {
+			// return the missing image placeholder to indicate
+			// the incorrect call without interfering with the user flow
+			return getMissingImageDescriptor();
+		}
+	}
+
+	/**
 	 * Convenient method to create an ImageDescriptor from an URI
 	 *
 	 * Delegates to ImageDescriptor createFromURL
@@ -213,15 +239,11 @@ public abstract class ImageDescriptor extends DeviceResourceDescriptor<Image> {
 	 * @return a new image descriptor
 	 *
 	 * @since 3.19
+	 * @deprecated Use {@link #createFromURI(URI)} instead.
 	 */
+	@Deprecated(since = "3.36", forRemoval = true)
 	public ImageDescriptor imageDescriptorFromURI(URI uriIconPath) {
-		try {
-			return ImageDescriptor.createFromURL(new URL(uriIconPath.toString()));
-		} catch (MalformedURLException | NullPointerException e) {
-			// return the missing image placeholder to indicate
-			// the incorrect call without interfering with the user flow
-			return getMissingImageDescriptor();
-		}
+		return createFromURI(uriIconPath);
 	}
 
 	@Override


### PR DESCRIPTION
This method is intended to be used as a wrapper for createFromURL() to avoid having to deal with the checked MalformedURLException. However, this method is effectively unusable, as it requires the user to already have an instance of the ImageDescriptor they want to created.

Instead, create a new, static createFromURI() method, mark the old method as deprecated and internally delegate to the new method.

The old method was created as a response to Bug 559656 [1], in order to match the signature of IResourceUtilities. But because the latter is accessed via an OSGi service, it doesn't need to be static. Which is something that doesn't really work for image descriptors.

[1] https://bugs.eclipse.org/bugs/show_bug.cgi?id=559656