### PR TITLE
WhitespaceCharacterPainter: fix off-by-one error at CR and LF offsets

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/WhitespaceCharacterPainter.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/WhitespaceCharacterPainter.java
@@ -407,6 +407,7 @@ public class WhitespaceCharacterPainter implements IPainter, PaintListener {
 						if (fShowCarriageReturn) {
 							if (visibleChar.length() > 0 && cache.contains(fTextWidget, lineOffset + textOffset)) {
 								textOffset--;
+								delta--;
 								break;
 							}
 							visibleChar.append(CARRIAGE_RETURN_SIGN);
@@ -420,6 +421,7 @@ public class WhitespaceCharacterPainter implements IPainter, PaintListener {
 						if (fShowLineFeed) {
 							if (visibleChar.length() > 0 && cache.contains(fTextWidget, lineOffset + textOffset)) {
 								textOffset--;
+								delta--;
 								break;
 							}
 							visibleChar.append(LINE_FEED_SIGN);


### PR DESCRIPTION
Following screenshot shows the incorrect behavior:

![bug](https://github.com/user-attachments/assets/f4b20c71-1e4a-479d-bf4c-1c4718f67725)

And here a screenshot with the changes of this pull request:

![fixed](https://github.com/user-attachments/assets/f640dd28-ff3c-4eed-b1a7-fc18f324cce9)

The first line contains a carriage return and line feed character, the second line 5 space characters and a code mining with text "label" at the end of the line. 
The 5 space characters were drawn at the first line by mistake. 