### PR TITLE
Convert o.e.ui.tests to plain JUnit (part 2)

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/activities/ImagesTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/activities/ImagesTest.java
@@ -29,13 +29,10 @@ import org.eclipse.ui.internal.WorkbenchImages;
 import org.eclipse.ui.tests.harness.util.ImageTests;
 import org.junit.After;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * @since 3.1
  */
-@RunWith(JUnit4.class)
 public class ImagesTest {
 
 	private Image defaultImage;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/activities/MenusTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/activities/MenusTest.java
@@ -14,6 +14,11 @@
 
 package org.eclipse.ui.tests.activities;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Collections;
 import java.util.Set;
 
@@ -25,16 +30,12 @@ import org.eclipse.ui.menus.IContributionRoot;
 import org.eclipse.ui.menus.IMenuService;
 import org.eclipse.ui.services.IServiceLocator;
 import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-/**
- * @since 3.3
- */
-@RunWith(JUnit4.class)
-public class MenusTest extends UITestCase {
+public class MenusTest {
 
 	private TestFactory factory;
 	private IWorkbenchWindow window;
@@ -81,22 +82,17 @@ public class MenusTest extends UITestCase {
 		}
 	}
 
-	public MenusTest() {
-		super(MenusTest.class.getSimpleName());
-	}
-
-	@Override
-	protected void doSetUp() throws Exception {
-		super.doSetUp();
-		window = openTestWindow();
+	@Before
+	public void doSetUp() throws Exception {
+		window = UITestCase.openTestWindow();
 		enabledActivities = window.getWorkbench().getActivitySupport()
 				.getActivityManager().getEnabledActivityIds();
 		service = window.getService(IMenuService.class);
 		assertNotNull(service);
 	}
 
-	@Override
-	protected void doTearDown() throws Exception {
+	@After
+	public void doTearDown() throws Exception {
 		window.getWorkbench().getActivitySupport().setEnabledActivityIds(
 				enabledActivities);
 		assertEquals(enabledActivities, window.getWorkbench()
@@ -105,7 +101,6 @@ public class MenusTest extends UITestCase {
 		if (factory != null) {
 			service.removeContributionFactory(factory);
 		}
-		super.doTearDown();
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/activities/StaticTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/activities/StaticTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.activities;
 
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -26,18 +28,14 @@ import org.eclipse.ui.activities.IIdentifier;
 import org.eclipse.ui.activities.NotDefinedException;
 import org.eclipse.ui.internal.activities.ActivityRequirementBinding;
 import org.eclipse.ui.internal.activities.CategoryActivityBinding;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  *
  * The static test reads activity definitions from the plugin.xml (in
  * org.eclipse.ui.tests) file and valides its content.
  */
-@RunWith(JUnit4.class)
-public class StaticTest extends UITestCase {
+public class StaticTest {
 	private final IActivityManager activityManager;
 
 	private List<String> categoryIds;
@@ -47,7 +45,6 @@ public class StaticTest extends UITestCase {
 	private List<Object> patternActivityIds;
 
 	public StaticTest() {
-		super(StaticTest.class.getSimpleName());
 		activityManager = PlatformUI.getWorkbench().getActivitySupport()
 				.getActivityManager();
 		populateIds();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/MarkerImageProviderTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/MarkerImageProviderTest.java
@@ -13,40 +13,32 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.adaptable;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.model.IWorkbenchAdapter;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * Tests the markerImageProviders extension point.
  */
-@RunWith(JUnit4.class)
-public class MarkerImageProviderTest extends UITestCase {
-
-	public MarkerImageProviderTest() {
-		super(MarkerImageProviderTest.class.getSimpleName());
-	}
+public class MarkerImageProviderTest {
 
 	/**
 	 * Tests the static form of the extension, where just a file path is given.
+	 *
+	 * @throws CoreException
 	 */
 	@Test
-	public void testStatic() {
+	public void testStatic() throws CoreException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
-		IMarker marker = null;
-		try {
-			marker = workspace.getRoot().createMarker(
+		IMarker marker = workspace.getRoot().createMarker(
 					"org.eclipse.ui.tests.testmarker"); //$NON-NLS-1$
-		} catch (CoreException e) {
-			fail(e.getMessage());
-		}
 		IWorkbenchAdapter adapter = marker.getAdapter(IWorkbenchAdapter.class);
 		ImageDescriptor imageDesc = adapter.getImageDescriptor(marker);
 		assertNotNull(imageDesc);
@@ -54,18 +46,16 @@ public class MarkerImageProviderTest extends UITestCase {
 	}
 
 	/**
-	 * Tests the dynamic form of the extension, where an IMarkerImageProvider class is given.
+	 * Tests the dynamic form of the extension, where an IMarkerImageProvider class
+	 * is given.
+	 *
+	 * @throws CoreException
 	 */
 	@Test
-	public void testDynamic() {
+	public void testDynamic() throws CoreException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
-		IMarker marker = null;
-		try {
-			marker = workspace.getRoot().createMarker(
+		IMarker marker = workspace.getRoot().createMarker(
 					"org.eclipse.ui.tests.testmarker2"); //$NON-NLS-1$
-		} catch (CoreException e) {
-			fail(e.getMessage());
-		}
 		IWorkbenchAdapter adapter = marker.getAdapter(IWorkbenchAdapter.class);
 		ImageDescriptor imageDesc = adapter.getImageDescriptor(marker);
 		assertNotNull(imageDesc);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/EditorIconTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/EditorIconTest.java
@@ -14,17 +14,18 @@
 
 package org.eclipse.ui.tests.api;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import java.net.URL;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ResourceLocator;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.tests.harness.util.ImageTests;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * Tests to ensure that various icon scenarios work. These are tested on editors
@@ -33,12 +34,7 @@ import org.junit.runners.JUnit4;
  *
  * @since 3.0
  */
-@RunWith(JUnit4.class)
-public class EditorIconTest extends UITestCase {
-
-	public EditorIconTest() {
-		super(EditorIconTest.class.getSimpleName());
-	}
+public class EditorIconTest {
 
 	@Test
 	public void testDependantBundleIcon() {
@@ -46,7 +42,7 @@ public class EditorIconTest extends UITestCase {
 		Image i2 = null;
 
 		try {
-			i1 = fWorkbench.getEditorRegistry().getDefaultEditor(
+			i1 = PlatformUI.getWorkbench().getEditorRegistry().getDefaultEditor(
 					"foo.icontest1").getImageDescriptor().createImage();
 			i2 = ResourceLocator.imageDescriptorFromBundle("org.eclipse.ui", "icons/full/obj16/font.png")
 					.orElseThrow(AssertionError::new).createImage();
@@ -67,7 +63,8 @@ public class EditorIconTest extends UITestCase {
 		Image i1 = null;
 		Image i2 = null;
 		try {
-			i1 = fWorkbench.getEditorRegistry().getDefaultEditor(
+			i1 = PlatformUI.getWorkbench().getEditorRegistry()
+					.getDefaultEditor(
 					"foo.icontest2").getImageDescriptor().createImage();
 			i2 = ResourceLocator.imageDescriptorFromBundle(
 					"org.eclipse.jdt.ui", "icons/full/obj16/class_obj.png") // layer breaker!
@@ -90,7 +87,7 @@ public class EditorIconTest extends UITestCase {
 		Image i2 = null;
 
 		try {
-			i1 = fWorkbench.getEditorRegistry().getDefaultEditor(
+			i1 = PlatformUI.getWorkbench().getEditorRegistry().getDefaultEditor(
 					"foo.icontest3").getImageDescriptor().createImage();
 			i2 = ResourceLocator.imageDescriptorFromBundle("org.eclipse.ui", "icons/full/obj16/file_obj.png")
 					.orElseThrow(AssertionError::new).createImage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/StartupTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/StartupTest.java
@@ -13,21 +13,15 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.tests.TestPlugin;
-import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-@RunWith(JUnit4.class)
-public class StartupTest extends UITestCase {
-
-	/**
-	 * Construct an instance.
-	 */
-	public StartupTest() {
-		super(StartupTest.class.getSimpleName());
-	}
+public class StartupTest {
 
 	@Test
 	public void testStartup() {
@@ -36,9 +30,13 @@ public class StartupTest extends UITestCase {
 		assertTrue("Startup - completed before tests", StartupClass.getEarlyStartupCompleted());
 	}
 
-	@Override
-	protected void doTearDown() throws Exception {
-		super.doTearDown();
+	@Before
+	public void doSetUp() {
+		PlatformUI.getWorkbench();
+	}
+
+	@After
+	public void doTearDown() throws Exception {
 		// NOTE:  tearDown will run after each test.  Therefore, we
 		// only want one test in this suite (or the values set when
 		// this plugin started up will be lost).

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/ActionDelegateProxyTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/ActionDelegateProxyTest.java
@@ -41,13 +41,7 @@ import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-/**
- * @since 3.3
- */
-@RunWith(JUnit4.class)
 @Ignore("broke during e4 transition and still need adjustments")
 public class ActionDelegateProxyTest {
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandEnablementTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandEnablementTest.java
@@ -74,13 +74,10 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * @since 3.3
  */
-@RunWith(JUnit4.class)
 @Ignore("broke during e4 transition and still need adjustments")
 public class CommandEnablementTest {
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/HelpContextIdTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/HelpContextIdTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.commands;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.ExecutionEvent;
@@ -23,20 +25,17 @@ import org.eclipse.core.expressions.Expression;
 import org.eclipse.core.expressions.ExpressionInfo;
 import org.eclipse.core.expressions.IEvaluationContext;
 import org.eclipse.ui.ISources;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.handlers.IHandlerService;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * Tests the new help context identifier support on commands and handlers.
  *
  * @since 3.2
  */
-@RunWith(JUnit4.class)
-public final class HelpContextIdTest extends UITestCase {
+public final class HelpContextIdTest {
 
 	private static final String COMMAND_HELP_ID = "org.eclipse.ui.tests.commandHelp";
 
@@ -45,13 +44,6 @@ public final class HelpContextIdTest extends UITestCase {
 	private static final String HANDLER_HELP_ID = "org.eclipse.ui.tests.handlerHelp";
 
 	private static final String NEW_HELP_ID = "new_help_id";
-
-	/**
-	 * Constructs a new instance of <code>HelpContextIdTest</code>
-	 */
-	public HelpContextIdTest() {
-		super(HelpContextIdTest.class.getSimpleName());
-	}
 
 	/**
 	 * Tests the reading of the help context identifier of the registry, as well
@@ -63,9 +55,9 @@ public final class HelpContextIdTest extends UITestCase {
 	 */
 	@Test
 	public final void testHelpContextId() throws NotDefinedException {
-		final ICommandService commandService = fWorkbench
+		final ICommandService commandService = PlatformUI.getWorkbench()
 				.getService(ICommandService.class);
-		final IHandlerService handlerService = fWorkbench
+		final IHandlerService handlerService = PlatformUI.getWorkbench()
 				.getService(IHandlerService.class);
 		String helpContextId = null;
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/RadioStateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/RadioStateTest.java
@@ -32,14 +32,7 @@ import org.eclipse.ui.menus.UIElement;
 import org.eclipse.ui.services.IServiceLocator;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-/**
- * @since 3.5
- * @author Prakash G.R.
- */
-@RunWith(JUnit4.class)
 public class RadioStateTest {
 
 	private final IWorkbench fWorkbench = PlatformUI.getWorkbench();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/StateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/StateTest.java
@@ -38,15 +38,12 @@ import org.eclipse.ui.tests.TestPlugin;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * Tests various aspects of command state.
  *
  * @since 3.2
  */
-@RunWith(JUnit4.class)
 public class StateTest {
 
 	private static final String TEXT_HELLO = "hello";

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/TransferRuleTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/TransferRuleTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.concurrency;
 
+import static org.junit.Assert.fail;
+
 import java.lang.reflect.InvocationTargetException;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -22,18 +24,14 @@ import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.operation.IThreadListener;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * Tests IJobManger#transferRule in conjunction with ModalContext.run.
  * This also exercises the IThreadListener API to allow the runnable to transfer
  * and obtain the rule owned by the calling thread.
  */
-@RunWith(JUnit4.class)
-public class TransferRuleTest extends UITestCase {
+public class TransferRuleTest {
 	static class TestRule implements ISchedulingRule {
 		@Override
 		public boolean contains(ISchedulingRule rule) {
@@ -88,12 +86,8 @@ public class TransferRuleTest extends UITestCase {
 		}
 	}
 
-	public TransferRuleTest() {
-		super(TransferRuleTest.class.getSimpleName());
-	}
-
 	@Test
-	public void testModalContextTransfer() {
+	public void testModalContextTransfer() throws InvocationTargetException, InterruptedException {
 		ISchedulingRule rule = new TestRule();
 		TestRunnable runnable = new TestRunnable(rule);
 		try {
@@ -101,12 +95,6 @@ public class TransferRuleTest extends UITestCase {
 			Job.getJobManager().beginRule(rule, null);
 			//now execute the runnable using ModalContext - the rule should transfer correctly
 			new ProgressMonitorDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell()).run(true, true, runnable);
-		} catch (InvocationTargetException e) {
-			e.printStackTrace();
-			fail("1.0");
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-			fail("1.1");
 		} finally {
 			//must release the rule when finished
 			Job.getJobManager().endRule(rule);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/contexts/ExtensionTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/contexts/ExtensionTestCase.java
@@ -13,14 +13,15 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.contexts;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.contexts.IContext;
 import org.eclipse.ui.contexts.IContextManager;
 import org.eclipse.ui.contexts.IWorkbenchContextSupport;
 import org.eclipse.ui.contexts.NotDefinedException;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * The test case for reading in elements from the extension point. This verifies
@@ -30,16 +31,7 @@ import org.junit.runners.JUnit4;
  *
  * @since 3.0
  */
-@RunWith(JUnit4.class)
-public class ExtensionTestCase extends UITestCase {
-
-	/**
-	 * Constructs a new instance of <code>ExtensionTestCase</code> with the
-	 * given name.
-	 */
-	public ExtensionTestCase() {
-		super(ExtensionTestCase.class.getSimpleName());
-	}
+public class ExtensionTestCase {
 
 	/**
 	 * Tests that the "org.eclipse.ui.acceleratorScopes" extension point can be
@@ -51,7 +43,7 @@ public class ExtensionTestCase extends UITestCase {
 	 */
 	@Test
 	public final void testAcceleratorScopes() throws NotDefinedException {
-		final IWorkbenchContextSupport contextSupport = fWorkbench
+		final IWorkbenchContextSupport contextSupport = PlatformUI.getWorkbench()
 				.getContextSupport();
 		final IContextManager contextManager = contextSupport
 				.getContextManager();
@@ -90,7 +82,7 @@ public class ExtensionTestCase extends UITestCase {
 	 */
 	@Test
 	public final void testCommandsScopes() throws NotDefinedException {
-		final IWorkbenchContextSupport contextSupport = fWorkbench
+		final IWorkbenchContextSupport contextSupport = PlatformUI.getWorkbench()
 				.getContextSupport();
 		final IContextManager contextManager = contextSupport
 				.getContextManager();
@@ -128,7 +120,7 @@ public class ExtensionTestCase extends UITestCase {
 	 */
 	@Test
 	public final void testContexts() throws NotDefinedException {
-		final IWorkbenchContextSupport contextSupport = fWorkbench
+		final IWorkbenchContextSupport contextSupport = PlatformUI.getWorkbench()
 				.getContextSupport();
 		final IContextManager contextManager = contextSupport
 				.getContextManager();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/contexts/PartContextTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/contexts/PartContextTest.java
@@ -14,6 +14,12 @@
 
 package org.eclipse.ui.tests.contexts;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+import static org.eclipse.ui.tests.harness.util.UITestCase.openTestWindow;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Collection;
 
 import org.eclipse.core.resources.IFile;
@@ -28,8 +34,6 @@ import org.eclipse.ui.tests.api.MockViewPart;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * Test that the contexts activated through their local services are only in
@@ -37,17 +41,12 @@ import org.junit.runners.JUnit4;
  *
  * @since 3.2
  */
-@RunWith(JUnit4.class)
-public class PartContextTest extends UITestCase {
+public class PartContextTest {
 	public static final String PAGE_VIEW_ID = "org.eclipse.ui.tests.contexts.MockPageView";
 
 	private static final String TEXT_EDITOR_ID = "org.eclipse.ui.DefaultTextEditor";
 
 	public static final String WINDOW_CONTEXT_ID = "org.eclipse.ui.tests.contexts.WorkbenchWindow";
-
-	public PartContextTest() {
-		super(PartContextTest.class.getSimpleName());
-	}
 
 	@Test
 	public void testBasicContextActivation() throws Exception {
@@ -106,7 +105,7 @@ public class PartContextTest extends UITestCase {
 		checkActiveContext(globalService, WINDOW_CONTEXT_ID, false);
 
 		IWorkbenchWindow window = openTestWindow();
-		assertTrue(forceActive(window.getShell()));
+		assertTrue(UITestCase.forceActive(window.getShell()));
 
 		IContextService localService = window
 				.getService(IContextService.class);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ZipSlipTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ZipSlipTests.java
@@ -25,21 +25,13 @@ import java.util.zip.ZipFile;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.ui.internal.wizards.datatransfer.ZipLeveledStructureProvider;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.eclipse.ui.wizards.datatransfer.ZipFileStructureProvider;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
-@RunWith(JUnit4.class)
-public class ZipSlipTests extends UITestCase {
-
-	public ZipSlipTests() {
-		super(ZipSlipTests.class.getName());
-	}
+public class ZipSlipTests {
 
 	public static final String ZIPSLIP_FILE = "data/zipSlip.zip"; //$NON-NLS-1$
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/filteredtree/FilteredTreeTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/filteredtree/FilteredTreeTests.java
@@ -28,13 +28,10 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.dialogs.FilteredTree;
 import org.eclipse.ui.dialogs.PatternFilter;
-import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.After;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-@RunWith(JUnit4.class)
-public class FilteredTreeTests extends UITestCase {
+public class FilteredTreeTests {
 	private FilteredTree fTreeViewer;
 	private TestElement fRootElement;
 	// create an 8000-item Tree
@@ -74,10 +71,6 @@ public class FilteredTreeTests extends UITestCase {
 
 		protected abstract FilteredTree doCreateFilteredTree(Composite comp, int style);
 
-	}
-
-	public FilteredTreeTests() {
-		super(FilteredTreeTests.class.getSimpleName());
 	}
 
 	@Test
@@ -203,9 +196,8 @@ public class FilteredTreeTests extends UITestCase {
 		fTreeViewer.getViewer().setInput(fRootElement);
 	}
 
-	@Override
-	protected void doTearDown() throws Exception {
-		super.doTearDown();
+	@After
+	public void doTearDown() throws Exception {
 		fTreeViewer = null;
 		fRootElement = null;
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/ide/api/FileEditorInputTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/ide/api/FileEditorInputTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.ide.api;
 
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IStorage;
@@ -24,22 +26,14 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IPersistableElement;
 import org.eclipse.ui.part.FileEditorInput;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * Tests [I]FileEditorInput API.
  *
  * @since 3.1
  */
-@RunWith(JUnit4.class)
-public class FileEditorInputTest extends UITestCase {
-
-	public FileEditorInputTest() {
-		super(FileEditorInputTest.class.getSimpleName());
-	}
+public class FileEditorInputTest {
 
 	/**
 	 * Regression test for bug 72337 - [IDE] FileEditorInput .equals() not implemented against interface

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/ide/api/IDETest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/ide/api/IDETest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.ide.api;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 
 import org.eclipse.core.runtime.content.IContentType;
@@ -21,22 +24,16 @@ import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.ide.IEditorAssociationOverride;
 import org.eclipse.ui.internal.registry.EditorDescriptor;
-import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * Tests the <code>IDE</code> API and behaviour.
  *
  * @since 3.5
  */
-@RunWith(JUnit4.class)
-public class IDETest extends UITestCase {
-
-	public IDETest() {
-		super(IDETest.class.getSimpleName());
-	}
+public class IDETest {
 
 	static EditorDescriptor descriptor1 = EditorDescriptor.createForProgram("echo");
 	static EditorDescriptor descriptor2 = EditorDescriptor.createForProgram("ps");
@@ -73,16 +70,14 @@ public class IDETest extends UITestCase {
 		}
 	}
 
-	@Override
-	protected void doSetUp() throws Exception {
-		super.doSetUp();
+	@Before
+	public void doSetUp() throws Exception {
 		TestOverride.returnNullEntries = true;
 	}
 
-	@Override
-	protected void doTearDown() throws Exception {
+	@After
+	public void doTearDown() throws Exception {
 		TestOverride.returnNullEntries = false;
-		super.doTearDown();
 	}
 
 	public static class TestOverride implements IEditorAssociationOverride {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/ide/api/IDETest2.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/ide/api/IDETest2.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.ide.api;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -23,31 +25,23 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.tests.harness.FileSystemHelper;
 import org.eclipse.ui.IEditorDescriptor;
 import org.eclipse.ui.ide.IDE;
-import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.After;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * More tests for the <code>IDE</code> API and behaviour.
  */
-@RunWith(JUnit4.class)
-public class IDETest2 extends UITestCase {
+public class IDETest2 {
 	private final Set<IFileStore> storesToDelete = new HashSet<>();
 
-	@Override
-	protected void doTearDown() throws Exception {
+	@After
+	public void doTearDown() throws Exception {
 		storesToDelete.forEach(file -> {
 			try {
 				file.delete(EFS.NONE, null);
 			} catch (CoreException e) {
 			}
 		});
-		super.doTearDown();
-	}
-
-	public IDETest2() {
-		super(IDETest2.class.getSimpleName());
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/largefile/LargeFileLimitsPreferenceHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/largefile/LargeFileLimitsPreferenceHandlerTest.java
@@ -14,7 +14,14 @@
 
 package org.eclipse.ui.tests.largefile;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
@@ -44,7 +51,6 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorRegistry;
 import org.eclipse.ui.IPathEditorInput;
 import org.eclipse.ui.IWorkbenchPage;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.eclipse.ui.internal.LargeFileLimitsPreferenceHandler;
 import org.eclipse.ui.internal.LargeFileLimitsPreferenceHandler.FileLimit;
@@ -52,17 +58,16 @@ import org.eclipse.ui.internal.LargeFileLimitsPreferenceHandler.LargeFileEditorS
 import org.eclipse.ui.internal.LargeFileLimitsPreferenceHandler.PromptForEditor;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * Tests for the large file associations preference added for bug 577289.
  *
  * @since 3.5
  */
-@RunWith(JUnit4.class)
-public class LargeFileLimitsPreferenceHandlerTest extends UITestCase {
+public class LargeFileLimitsPreferenceHandlerTest {
 
 	public static final String TEST_EDITOR_ID1 = "org.eclipse.ui.tests.largefile.testeditor1";
 	public static final String TEST_EDITOR_ID2 = "org.eclipse.ui.tests.largefile.testeditor2";
@@ -81,13 +86,11 @@ public class LargeFileLimitsPreferenceHandlerTest extends UITestCase {
 	private TestLogListener logListener;
 
 	public LargeFileLimitsPreferenceHandlerTest() {
-		super(LargeFileLimitsPreferenceHandlerTest.class.getSimpleName());
 		monitor = new NullProgressMonitor();
 	}
 
-	@Override
-	protected void doSetUp() throws Exception {
-		super.doSetUp();
+	@Before
+	public void doSetUp() throws Exception {
 		createTestFile();
 		testPromptForEditor = new TestPromptForEditor();
 		preferenceHandler = new LargeFileLimitsPreferenceHandler(testPromptForEditor);
@@ -109,18 +112,14 @@ public class LargeFileLimitsPreferenceHandlerTest extends UITestCase {
 		temporaryFile.create(new ByteArrayInputStream(content.getBytes()), force, monitor);
 	}
 
-	@Override
-	protected void doTearDown() throws Exception {
-		try {
-			Platform.removeLogListener(logListener);
-			setDefaultPreferences();
-			preferenceHandler.dispose();
-			deleteTestFile();
-			boolean save = false;
-			closeAllEditors(save);
-		} finally {
-			super.doTearDown();
-		}
+	@After
+	public void doTearDown() throws Exception {
+		Platform.removeLogListener(logListener);
+		setDefaultPreferences();
+		preferenceHandler.dispose();
+		deleteTestFile();
+		boolean save = false;
+		closeAllEditors(save);
 	}
 
 	private void deleteTestFile() throws CoreException {
@@ -462,7 +461,7 @@ public class LargeFileLimitsPreferenceHandlerTest extends UITestCase {
 	}
 
 	private static void waitForJobs() {
-		waitForJobs(250, 2_000);
+		UITestCase.waitForJobs(250, 2_000);
 	}
 
 	private static void setDefaultPreferences() {
@@ -483,7 +482,7 @@ public class LargeFileLimitsPreferenceHandlerTest extends UITestCase {
 	}
 
 	private static void closeAllEditors(boolean save) {
-		PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().closeAllEditors(save);
+		getWorkbench().getActiveWorkbenchWindow().getActivePage().closeAllEditors(save);
 	}
 
 	private static class TestLogListener implements ILogListener {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/operations/MultiThreadedOperationsTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/operations/MultiThreadedOperationsTests.java
@@ -18,10 +18,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
@@ -32,12 +29,7 @@ import junit.framework.TestSuite;
  *
  * @since 3.1
  */
-@RunWith(JUnit4.class)
-public class MultiThreadedOperationsTests extends UITestCase {
-
-	public MultiThreadedOperationsTests() {
-		super(MultiThreadedOperationsTests.class.getSimpleName());
-	}
+public class MultiThreadedOperationsTests {
 
 	@Test
 	public void testOperationsAPIinThreads() {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/operations/WorkbenchOperationHistoryTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/operations/WorkbenchOperationHistoryTests.java
@@ -14,37 +14,34 @@
 
 package org.eclipse.ui.tests.operations;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.core.commands.operations.IOperationHistory;
 import org.eclipse.core.commands.operations.IUndoContext;
 import org.eclipse.core.commands.operations.IUndoableOperation;
 import org.eclipse.core.commands.operations.ObjectUndoContext;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * Tests the Operations Framework API.
  *
  * @since 3.1
  */
-@RunWith(JUnit4.class)
-public class WorkbenchOperationHistoryTests extends UITestCase {
+public class WorkbenchOperationHistoryTests {
 	IUndoContext context, contextA, contextB;
 
 	IOperationHistory history;
 
 	IUndoableOperation op1, op2, op3, op4, op5, op6;
 
-	public WorkbenchOperationHistoryTests() {
-		super(WorkbenchOperationHistoryTests.class.getSimpleName());
-	}
 
-	@Override
-	protected void doSetUp() throws Exception {
-		super.doSetUp();
+	@Before
+	public void doSetUp() throws Exception {
 		history = PlatformUI.getWorkbench().getOperationSupport().getOperationHistory();
 		context = PlatformUI.getWorkbench().getOperationSupport().getUndoContext();
 		contextA = new ObjectUndoContext("A");
@@ -72,10 +69,9 @@ public class WorkbenchOperationHistoryTests extends UITestCase {
 
 	}
 
-	@Override
-	protected void doTearDown() throws Exception {
+	@After
+	public void doTearDown() throws Exception {
 		history.dispose(IOperationHistory.GLOBAL_UNDO_CONTEXT, true, true, true);
-		super.doTearDown();
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/operations/WorkspaceOperationsTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/operations/WorkspaceOperationsTests.java
@@ -16,6 +16,13 @@
 
 package org.eclipse.ui.tests.operations;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -64,10 +71,9 @@ import org.eclipse.ui.ide.undo.MoveProjectOperation;
 import org.eclipse.ui.ide.undo.MoveResourcesOperation;
 import org.eclipse.ui.ide.undo.UpdateMarkersOperation;
 import org.eclipse.ui.internal.operations.AdvancedValidationUserApprover;
-import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * Tests the undo of various workspace operations. Uses the following workspace
@@ -88,8 +94,7 @@ import org.junit.runners.JUnit4;
  *
  * @since 3.3
  */
-@RunWith(JUnit4.class)
-public class WorkspaceOperationsTests extends UITestCase {
+public class WorkspaceOperationsTests {
 
 	IProject testProject, targetProject;
 
@@ -353,13 +358,8 @@ public class WorkspaceOperationsTests extends UITestCase {
 		}
 	}
 
-	public WorkspaceOperationsTests() {
-		super(WorkspaceOperationsTests.class.getSimpleName());
-	}
-
-	@Override
-	protected void doSetUp() throws Exception {
-		super.doSetUp();
+	@Before
+	public void doSetUp() throws Exception {
 		// Suppress validation UI
 		AdvancedValidationUserApprover.AUTOMATED_MODE = true;
 		// Project
@@ -421,8 +421,8 @@ public class WorkspaceOperationsTests extends UITestCase {
 
 	}
 
-	@Override
-	protected void doTearDown() throws Exception {
+	@After
+	public void doTearDown() throws Exception {
 		testProject = (IProject) getWorkspaceRoot().findMember(
 				TEST_PROJECT_NAME);
 		if (testProject != null) {
@@ -459,8 +459,6 @@ public class WorkspaceOperationsTests extends UITestCase {
 		testLinkedFile = null;
 		testFileInSubFolder = null;
 		testFileInProject = null;
-
-		super.doTearDown();
 	}
 
 	private IWorkspace getWorkspace() {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/FontPreferenceTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/FontPreferenceTestCase.java
@@ -13,6 +13,11 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.preferences;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -28,19 +33,15 @@ import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
-import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * The FontPreferenceTestCase tests adding fonts to
  * the preference store and what occurs if the values
  * are bogus
  */
-
-@RunWith(JUnit4.class)
-public class FontPreferenceTestCase extends UITestCase {
+public class FontPreferenceTestCase {
 
 	public String BAD_FONT_DEFINITION = "BadFont-regular-10";
 
@@ -50,16 +51,8 @@ public class FontPreferenceTestCase extends UITestCase {
 
 	private IPreferenceStore preferenceStore;
 
-	/**
-	 * Constructor for FontPreferenceTestCase.
-	 */
-	public FontPreferenceTestCase() {
-		super(FontPreferenceTestCase.class.getSimpleName());
-	}
-
-	@Override
-	protected void doSetUp() throws Exception {
-		super.doSetUp();
+	@Before
+	public void doSetUp() throws Exception {
 		AbstractUIPlugin plugin = WorkbenchPlugin.getDefault();
 		preferenceStore = plugin.getPreferenceStore();
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ListenerRemovalTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ListenerRemovalTestCase.java
@@ -14,20 +14,19 @@
 
 package org.eclipse.ui.tests.preferences;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.ui.tests.TestPlugin;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * @since 3.3
  */
-@RunWith(JUnit4.class)
-public class ListenerRemovalTestCase extends UITestCase {
+public class ListenerRemovalTestCase {
 
 	static class TestPropertyListener implements IPropertyChangeListener {
 		boolean listened = false;
@@ -40,10 +39,6 @@ public class ListenerRemovalTestCase extends UITestCase {
 		public void propertyChange(PropertyChangeEvent event) {
 			listened = true;
 		}
-	}
-
-	public ListenerRemovalTestCase() {
-		super(ListenerRemovalTestCase.class.getSimpleName());
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ScopedPreferenceStoreTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ScopedPreferenceStoreTestCase.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.preferences;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
@@ -20,22 +24,14 @@ import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-@RunWith(JUnit4.class)
-public class ScopedPreferenceStoreTestCase extends UITestCase {
+public class ScopedPreferenceStoreTestCase {
 
 	final String DEFAULT_DEFAULT_STRING = "";
 
-	public ScopedPreferenceStoreTestCase() {
-		super(ScopedPreferenceStoreTestCase.class.getSimpleName());
-	}
-
 	@Test
-	public void testNeedsSaving() {
+	public void testNeedsSaving() throws IOException {
 		IScopeContext context = InstanceScope.INSTANCE;
 		String qualifier = "org.eclipse.ui.tests.preferences";
 		ScopedPreferenceStore store = new ScopedPreferenceStore(context,
@@ -55,11 +51,7 @@ public class ScopedPreferenceStoreTestCase extends UITestCase {
 		assertEquals("1.2", value, store.getString(key));
 
 		// flush
-		try {
-			store.save();
-		} catch (IOException e) {
-			fail("2.99", e);
-		}
+		store.save();
 
 		// do the test
 		assertFalse("3.0", store.needsSaving());

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/WorkingCopyPreferencesTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/WorkingCopyPreferencesTestCase.java
@@ -13,27 +13,22 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.preferences;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.ui.preferences.WorkingCopyManager;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.osgi.service.prefs.BackingStoreException;
 
-@RunWith(JUnit4.class)
-public class WorkingCopyPreferencesTestCase extends UITestCase {
-
-	public WorkingCopyPreferencesTestCase() {
-		super(WorkingCopyPreferencesTestCase.class.getSimpleName());
-	}
+public class WorkingCopyPreferencesTestCase {
 
 	/*
 	 * See bug 94926 - WorkingCopyPreferences.remove(key) not working
 	 */
 	@Test
-	public void testRemoveKey() {
+	public void testRemoveKey() throws BackingStoreException {
 
 		// set the value in the real node
 		String key = "key";
@@ -48,18 +43,14 @@ public class WorkingCopyPreferencesTestCase extends UITestCase {
 		prefs.remove(key);
 
 		// apply the changes
-		try {
-			manager.applyChanges();
-		} catch (BackingStoreException e) {
-			fail("2.99", e);
-		}
+		manager.applyChanges();
 
 		// see if our change was applied
 		assertNull("3.0", eNode.get(key, null));
 	}
 
 	@Test
-	public void testRemoveNode() {
+	public void testRemoveNode() throws BackingStoreException {
 		// set the value in the real node
 		String key = "key";
 		String value = "value";
@@ -72,17 +63,9 @@ public class WorkingCopyPreferencesTestCase extends UITestCase {
 		IEclipsePreferences prefs = manager.getWorkingCopy(eNode);
 
 		// remove the node
-		try {
-			prefs.removeNode();
-		} catch (BackingStoreException e) {
-			fail("2.99", e);
-		}
+		prefs.removeNode();
 
 		// apply the changes
-		try {
-			manager.applyChanges();
-		} catch (BackingStoreException e) {
-			fail("3.99", e);
-		}
+		manager.applyChanges();
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessProvidersTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessProvidersTest.java
@@ -29,13 +29,10 @@ import org.eclipse.ui.internal.quickaccess.providers.ActionProvider;
 import org.eclipse.ui.internal.quickaccess.providers.CommandProvider;
 import org.eclipse.ui.quickaccess.QuickAccessElement;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * Tests the quick access providers.
  */
-@RunWith(JUnit4.class)
 public class QuickAccessProvidersTest {
 	private static final String ACTIVITY_ID = "org.eclipse.ui.tests.activitySupportTest.issue1832";
 	private final String COMMAND_ID = "org.eclipse.ui.tests.activitySupportTest.commands.issue1832";

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/stress/OpenCloseTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/stress/OpenCloseTest.java
@@ -43,13 +43,10 @@ import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * Test opening and closing of items.
  */
-@RunWith(JUnit4.class)
 public class OpenCloseTest {
 	private static final String ORG_ECLIPSE_JDT_UI_JAVA_PERSPECTIVE = "org.eclipse.jdt.ui.JavaPerspective";
 


### PR DESCRIPTION
Reduce inheritance, simplify setup/teardown, improve assertions, etc.