### PR TITLE
Add memory reporting for UI tests and exit for E4Testable on OOM

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.harness/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Harness Plug-in
 Bundle-SymbolicName: org.eclipse.ui.tests.harness;singleton:=true
-Bundle-Version: 1.10.500.qualifier
+Bundle-Version: 1.10.600.qualifier
 Eclipse-BundleShape: dir
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
@@ -21,6 +21,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -212,6 +213,7 @@ public abstract class UITestCase extends TestCase {
 	public final void tearDown() throws Exception {
 		String name = runningTest != null ? runningTest : this.getName();
 		trace(TestRunLogUtil.formatTestFinishedMessage(name));
+
 		prefMemento.resetPreferences();
 		doTearDown();
 
@@ -227,7 +229,27 @@ public abstract class UITestCase extends TestCase {
 		fWorkbench = null;
 		assertEquals("Test leaked modal shell: [" + String.join(", ", leakedModalShellTitles) + "]", 0,
 				leakedModalShellTitles.size());
+		runGcAndPrintMemoryUse(name);
 	}
+
+	public static void runGcAndPrintMemoryUse(String testName) {
+    	System.gc();
+    	System.runFinalization();
+    	System.gc();
+    	System.runFinalization();
+    	long nax = Runtime.getRuntime().maxMemory();
+    	long total = Runtime.getRuntime().totalMemory();
+		long free = Runtime.getRuntime().freeMemory();
+		long used = total - free;
+		System.out.print("\n#################################################");
+		System.out.print("\n" + testName);
+		System.out.print("\n########### Memory usage reported by JVM ########");
+		System.out.printf(Locale.GERMAN, "%n%,16d bytes max heap", nax);
+		System.out.printf(Locale.GERMAN, "%n%,16d bytes heap allocated", total);
+		System.out.printf(Locale.GERMAN, "%n%,16d bytes free heap", free);
+    	System.out.printf(Locale.GERMAN, "%n%,16d bytes used heap", used);
+    	System.out.println("\n#################################################\n");
+    }
 
 	/**
 	 * Tears down the fixture, for example, close a network connection.

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/stress/OpenCloseTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/stress/OpenCloseTest.java
@@ -41,8 +41,12 @@ import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.intro.IIntroPart;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.tests.harness.util.FileUtil;
+import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 /**
  * Test opening and closing of items.
@@ -56,6 +60,8 @@ public class OpenCloseTest {
 	private IWorkbench workbench;
 	private IWorkbenchPage page;
 
+	@Rule
+	public TestName testName = new TestName();
 
 	@Before
 	public void setup() {
@@ -76,6 +82,10 @@ public class OpenCloseTest {
 		assertNotNull(page);
 	}
 
+	@After
+	public void teardown() {
+		UITestCase.runGcAndPrintMemoryUse(testName.getMethodName());
+	}
 
 	/**
 	 * Test the opening and closing of a file.


### PR DESCRIPTION
Maybe this could help understanding OOM errors on jenkins.

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/2432