### PR TITLE
Create Color Definition for Reuse

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
@@ -19,73 +19,73 @@
 @import url("platform:/plugin/org.eclipse.ui.themes/css/e4_basestyle.css");
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_UNSELECTED_TABS_COLOR_START {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_UNSELECTED_TABS_COLOR_END {
-	color: #F8F8F8;
+	color: #F8F8F8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_OUTER_KEYLINE_COLOR {
-	color: #E5E5E5;
+	color: #e5e5e5;
 }
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_INNER_KEYLINE_COLOR {
-	color: #f8f8f8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_OUTLINE_COLOR {
-	color: #E5E5E5;
+	color: #e5e5e5;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_UNSELECTED_TABS_COLOR_START {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_UNSELECTED_TABS_COLOR_END {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_OUTER_KEYLINE_COLOR {
-	color: #E5E5E5;
+	color: #e5e5e5;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_INNER_KEYLINE_COLOR {
-	color: #f8f8f8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_OUTLINE_COLOR {
-	color: #E5E5E5;
+	color: #e5e5e5;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_BG_START {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_BG_END {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_BG_START{
-	color: #f8f8f8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_BG_END {
-	color: #f8f8f8;
+	color: #f8f8f8;  /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_NOFOCUS_TAB_BG_START {
-	color: #f8f8f8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_NOFOCUS_TAB_BG_END {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_BG_START {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_BG_END {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_TEXT_COLOR {
@@ -101,15 +101,15 @@ ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
 }
 
 .MTrimmedWindow {
-	background-color: #F6F5F4;
+	background-color: #f6f5f4;
 }
 
 .MTrimBar {
-	background-color: #F6F5F4;
+	background-color: #f6f5f4;
 }
 
 .MTrimBar#org-eclipse-ui-main-toolbar  {
-	background-color: COLOR-WIDGET-BACKGROUND #F6F5F4 100%;
+	background-color: COLOR-WIDGET-BACKGROUND #f6f5f4 100%;
 }
 
 .MPartStack {
@@ -117,24 +117,24 @@ ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
 }
 
 CTabFolder.MArea {
-	background-color: #f8f8f8;
-	swt-selected-tab-fill: #f8f8f8;
-	swt-unselected-tabs-color: #f8f8f8;
-	swt-outer-keyline-color: #f8f8f8;
-	swt-inner-keyline-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
+	swt-selected-tab-fill: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
+	swt-unselected-tabs-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
+	swt-outer-keyline-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
+	swt-inner-keyline-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 	swt-tab-outline: #ffffff;
 }
 
 CTabFolder Canvas {
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .MTrimBar#org-eclipse-ui-main-toolbar {
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .MTrimBar#org-eclipse-ui-trim-status {
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .View Composite,
@@ -157,15 +157,15 @@ CTabFolder Canvas {
 .View Canvas,
 .View FigureCanvas
 {
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .View TitleRegion{
-	background-color:#f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .MPartStack.active .View TitleRegion{
-	background-color:#f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .View Button[style~='SWT.CHECK']{
@@ -190,7 +190,7 @@ CTabFolder Canvas {
 }
 
 .MPartStack{
-	swt-selected-tab-highlight: #A0A0A0;
+	swt-selected-tab-highlight: #a0a0a0;
 	swt-selected-highlight-top: false;
 }
 
@@ -208,7 +208,7 @@ CTabFolder Canvas {
 /*text color and background color of selected tab in editor */
 #org-eclipse-ui-editorss CTabItem:selected{
 	color: #000000;
-	background-color: #FFFFFF;
+	background-color: #ffffff;
 }
 
 #org-eclipse-ui-editorss CTabFolder{
@@ -231,7 +231,7 @@ CTabFolder Canvas {
 }
 
 Composite.MPartSashContainer{
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 Composite.MArea{

--- a/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
@@ -19,59 +19,59 @@
 @import url("platform:/plugin/org.eclipse.ui.themes/css/e4_basestyle.css");
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_UNSELECTED_TABS_COLOR_START {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_UNSELECTED_TABS_COLOR_END {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_UNSELECTED_TABS_COLOR_START {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_UNSELECTED_TABS_COLOR_END {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_OUTER_KEYLINE_COLOR {
-	color: #EAEAEA;
+	color: #eaeaea;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_OUTLINE_COLOR {
-	color: #EAEAEA;
+	color: #eaeaea;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_BG_START {
-	color: #f8f8f8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_BG_END {
-	color: #f8f8f8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_OUTER_KEYLINE_COLOR {
-	color: #EAEAEA;
+	color: #eaeaea;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_OUTLINE_COLOR {
-	color: #EAEAEA;
+	color: #eaeaea;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_BG_START {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_BG_END {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_BG_START {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_BG_END {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_TEXT_COLOR {
@@ -87,23 +87,23 @@ ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
 }
 
 .MTrimmedWindow {
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .MTrimBar {
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .MTrimBar#org-eclipse-ui-main-toolbar {
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 CTabFolder Canvas {
-	  background-color: #f8f8f8;
+	  background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
  
 .MTrimBar#org-eclipse-ui-trim-status {
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .View Composite,
@@ -125,15 +125,15 @@ CTabFolder Canvas {
 .View Canvas,
 .View FigureCanvas
 {
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .View TitleRegion{
-	background-color:#f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .MPartStack.active .View TitleRegion{
-	background-color:#f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .View Button[style~='SWT.CHECK']{
@@ -150,7 +150,7 @@ CTabFolder Canvas {
 
 
 .View Composite Tree[swt-lines-visible=false]{
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .View Composite PrependingAsteriskFilteredTree,
@@ -175,13 +175,13 @@ CTabFolder Canvas {
 /* text color of unselected tabs in editor*/
 #org-eclipse-ui-editorss CTabItem{
 	color: #000000;
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 /*text color and background color of selected tab in editor */
 #org-eclipse-ui-editorss CTabItem:selected{
 	color: #000000;
-	background-color: #FFFFFF;
+	background-color: #ffffff;
 }
 
 #org-eclipse-ui-editorss CTabFolder{
@@ -204,7 +204,7 @@ CTabFolder Canvas {
 }
 
 Composite.MPartSashContainer{
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 Composite.MArea{

--- a/bundles/org.eclipse.ui.themes/css/e4_default_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_win.css
@@ -20,59 +20,59 @@
 @import url("platform:/plugin/org.eclipse.ui.themes/css/e4_basestyle.css");
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_UNSELECTED_TABS_COLOR_START {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_UNSELECTED_TABS_COLOR_END {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_OUTER_KEYLINE_COLOR {
-	color: #E5E5E5;
+	color: #e5e5e5;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_OUTLINE_COLOR {
-	color: #E5E5E5;
+	color: #e5e5e5;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_UNSELECTED_TABS_COLOR_START {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_UNSELECTED_TABS_COLOR_END {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_OUTER_KEYLINE_COLOR {
-	color: #E5E5E5;
+	color: #e5e5e5;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_OUTLINE_COLOR {
-	color: #E5E5E5;
+	color: #e5e5e5;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_BG_START {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_BG_END {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_BG_START{
-	color: #f8f8f8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_BG_END {
-	color: #f8f8f8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_BG_START {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_BG_END {
-	color: #F8F8F8;
+	color: #f8f8f8; /* same as '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND' cannot use it directly*/
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_TEXT_COLOR {
@@ -92,24 +92,24 @@ ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR {
 }
 
 CTabFolder.MArea {
-	background-color: #f8f8f8;
-	swt-selected-tab-fill: #f8f8f8;
-	swt-unselected-tabs-color: #f8f8f8;
-	swt-outer-keyline-color: #f8f8f8;
-	swt-inner-keyline-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
+	swt-selected-tab-fill: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
+	swt-unselected-tabs-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
+	swt-outer-keyline-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
+	swt-inner-keyline-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 	swt-tab-outline: #ffffff;
 }
 
 CTabFolder Canvas {
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .MTrimBar#org-eclipse-ui-main-toolbar {
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .MTrimBar#org-eclipse-ui-trim-status {
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .View Composite,
@@ -132,15 +132,15 @@ CTabFolder Canvas {
 .View Canvas,
 .View FigureCanvas
 {
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .View TitleRegion{
-	background-color:#f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .MPartStack.active .View TitleRegion{
-	background-color:#f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 .View Button[style~='SWT.CHECK']{
@@ -165,7 +165,7 @@ CTabFolder Canvas {
 }
 
 .MPartStack{
-	swt-selected-tab-highlight: #8a8a8a;
+	swt-selected-tab-highlight: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 	swt-selected-highlight-top: false;
 }
 
@@ -177,7 +177,7 @@ CTabFolder Canvas {
 /* text color and background color of unselected tabs in editor*/
 #org-eclipse-ui-editorss CTabItem{
 	color: #000000;
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 /*text color and background color of selected tab in editor */
@@ -206,7 +206,7 @@ CTabFolder Canvas {
 }
 
 Composite.MPartSashContainer{
-	background-color: #f8f8f8;
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 Composite.MArea{

--- a/bundles/org.eclipse.ui.themes/css/light/e4-light_ide_colorextensions.css
+++ b/bundles/org.eclipse.ui.themes/css/light/e4-light_ide_colorextensions.css
@@ -32,67 +32,75 @@ ThemesExtension { color-definition:
 	'#org-eclipse-ui-workbench-ACTIVE_TAB_INNER_KEYLINE_COLOR',
 	'#org-eclipse-ui-workbench-ACTIVE_TAB_OUTLINE_COLOR',
 	'#org-eclipse-ui-workbench-ACTIVE_TAB_TEXT_COLOR',
-	'#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR';
+	'#org-eclipse-ui-workbench-INACTIVE_TAB_TEXT_COLOR',
+	'#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_UNSELECTED_TABS_COLOR_START {
-	color: #FFFFFF;
+	color: #ffffff;
 	category: '#org-eclipse-ui-presentation-default';
 	label: url('platform:/plugin/org.eclipse.ui.themes?message=INACTIVE_UNSELECTED_TABS_COLOR_START')
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_UNSELECTED_TABS_COLOR_END {
-	color: #FFFFFF;
+	color: #ffffff;
 	category: '#org-eclipse-ui-presentation-default';
 	label: url('platform:/plugin/org.eclipse.ui.themes?message=INACTIVE_UNSELECTED_TABS_COLOR_END');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_OUTER_KEYLINE_COLOR {
-	color: #FFFFFF;
+	color: #ffffff;
 	category: '#org-eclipse-ui-presentation-default';
 	label: url('platform:/plugin/org.eclipse.ui.themes?message=INACTIVE_TAB_OUTER_KEYLINE_COLOR');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_INNER_KEYLINE_COLOR {
-	color: #FFFFFF;
+	color: #ffffff;
 	category: '#org-eclipse-ui-presentation-default';
 	label: url('platform:/plugin/org.eclipse.ui.themes?message=INACTIVE_TAB_INNER_KEYLINE_COLOR');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_OUTLINE_COLOR {
-	color: #B6BCCC;
+	color: #b6bccc;
 	category: '#org-eclipse-ui-presentation-default';
 	label: url('platform:/plugin/org.eclipse.ui.themes?message=INACTIVE_TAB_OUTLINE_COLOR');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_UNSELECTED_TABS_COLOR_START {
-	color: #FFFFFF;
+	color: #ffffff;
 	category: '#org-eclipse-ui-presentation-default';
 	label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_UNSELECTED_TABS_COLOR_START');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_UNSELECTED_TABS_COLOR_END {
-	color: #FFFFFF;
+	color: #ffffff;
 	category: '#org-eclipse-ui-presentation-default';
 	label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_UNSELECTED_TABS_COLOR_END');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_OUTER_KEYLINE_COLOR {
-	color: #CCCCCC;
+	color: #cccccc;
 	category: '#org-eclipse-ui-presentation-default';
 	label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_TAB_OUTER_KEYLINE_COLOR');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_INNER_KEYLINE_COLOR {
-	color: #FFFFFF;
+	color: #ffffff;
 	category: '#org-eclipse-ui-presentation-default';
 	label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_TAB_INNER_KEYLINE_COLOR');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_OUTLINE_COLOR {
-	color: #B6BCCC;
+	color: #b6bccc;
 	category: '#org-eclipse-ui-presentation-default';
 	label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_TAB_OUTLINE_COLOR');
+}
+
+ColorDefinition#org-eclipse-ui-workbench-SECONDARY_BACKGROUND {
+	color: #f8f8f8;
+	category: '#org-eclipse-ui-presentation-default';
+	label: url('platform:/plugin/org.eclipse.ui.themes?message=SECONDARY_BACKGROUND');
+	editable: false;
 }
 
 /* Already existing ColorDefinitions overridden for the E4 default theme */
@@ -101,15 +109,15 @@ ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_BG_START {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_BG_END {
-	color: #FFFFFF;
+	color: #ffffff;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_BG_START{
-	color: #FFFFFF;
+	color: #ffffff;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_BG_END {
-	color: #FFFFFF;
+	color: #ffffff;
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_BG_START {

--- a/bundles/org.eclipse.ui.themes/plugin.properties
+++ b/bundles/org.eclipse.ui.themes/plugin.properties
@@ -24,6 +24,7 @@ theme.high-contrast = High Contrast
 #New theme element definitions
 DARK_BACKGROUND=Dark Background Color
 DARK_FOREGROUND=Dark Foreground Color
+SECONDARY_BACKGROUND=Background color of secondary part
 INACTIVE_UNSELECTED_TABS_COLOR_START=Inactive, unselected part color begin
 INACTIVE_UNSELECTED_TABS_COLOR_START=Inactive, unselected part color begin
 INACTIVE_UNSELECTED_TABS_COLOR_END=Inactive, unselected part color end


### PR DESCRIPTION
Instead of writing the same RBG color codes over and over again in various places in the CSS files only do it once.
Define a new color and re-use that color definition at all other locations. This also adds a semantic name to the color code.

Unfortunately color definitions cannot refer to other color definitions. So at some places we still have to provides the color code. These places are marked with a comment.

~~The new defined color is now also visible in the "Colors and Fonts" preference page. I am unsure if this is something we want. If users change this this does not work 100% because of the limitation above.~~