### PR TITLE
Get rid of ArrayUtil.equals(Object[], Object[])

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/ArrayUtil.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/ArrayUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2014 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -71,21 +71,4 @@ public class ArrayUtil {
 		return false;
 	}
 
-	/**
-	 * Returns whether two arrays are equal.  They must
-	 * have the same size and the same contents.
-	 *
-	 * @param one the first array
-	 * @param two the second array
-	 * @return <code>true</code> if the array are equal,
-	 * 		<code>false</code> otherwise.
-	 */
-	public static boolean equals(Object[] one, Object[] two) {
-		if (one.length != two.length)
-			return false;
-		for (int i = 0; i < one.length; i++)
-			if (one[i] != two[i])
-				return false;
-		return true;
-	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IAggregateWorkingSetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IAggregateWorkingSetTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -34,7 +34,6 @@ import org.eclipse.ui.internal.AbstractWorkingSet;
 import org.eclipse.ui.internal.AbstractWorkingSetManager;
 import org.eclipse.ui.internal.AggregateWorkingSet;
 import org.eclipse.ui.internal.IWorkbenchConstants;
-import org.eclipse.ui.tests.harness.util.ArrayUtil;
 import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -128,9 +127,7 @@ public class IAggregateWorkingSetTest extends UITestCase {
 		//</possible client code>
 
 		//unexpected
-		assertTrue(ArrayUtil.equals(
-				new IAdaptable[] {},
-				fWorkingSet.getElements()));
+		assertArrayEquals(new IAdaptable[] {}, fWorkingSet.getElements());
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorRegistryTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorRegistryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -123,7 +123,7 @@ public class IEditorRegistryTest {
 			assertEquals(editors[0].getId(), map[1]);
 			editors2 = fReg.getEditors(FileUtil.createFile(map[0], proj)
 					.getName());
-			assertEquals(ArrayUtil.equals(editors, editors2), true);
+			assertArrayEquals(editors, editors2);
 		}
 
 		// there is no matching editor

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetManagerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,10 @@
  *     Tomasz Zarna <tomasz.zarna@tasktop.com> - Bug 37183
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.util.Arrays;
 
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -161,22 +165,19 @@ public class IWorkingSetManagerTest extends UITestCase {
 	public void testAddRecentWorkingSet() throws Throwable {
 		fWorkingSetManager.addRecentWorkingSet(fWorkingSet);
 		fWorkingSetManager.addWorkingSet(fWorkingSet);
-		assertTrue(ArrayUtil.equals(new IWorkingSet[] { fWorkingSet },
-				fWorkingSetManager.getRecentWorkingSets()));
+		assertArrayEquals(new IWorkingSet[] { fWorkingSet }, fWorkingSetManager.getRecentWorkingSets());
 
 		IWorkingSet workingSet2 = fWorkingSetManager.createWorkingSet(
 				WORKING_SET_NAME_2, new IAdaptable[] { fWorkspace.getRoot() });
 		fWorkingSetManager.addRecentWorkingSet(workingSet2);
 		fWorkingSetManager.addWorkingSet(workingSet2);
-		assertTrue(ArrayUtil.equals(new IWorkingSet[] { workingSet2,
-				fWorkingSet }, fWorkingSetManager.getRecentWorkingSets()));
+		assertArrayEquals(new IWorkingSet[] { workingSet2, fWorkingSet }, fWorkingSetManager.getRecentWorkingSets());
 	}
 
 	@Test
 	public void testAddWorkingSet() throws Throwable {
 		fWorkingSetManager.addWorkingSet(fWorkingSet);
-		assertTrue(ArrayUtil.equals(new IWorkingSet[] { fWorkingSet },
-				fWorkingSetManager.getWorkingSets()));
+		assertArrayEquals(new IWorkingSet[] { fWorkingSet }, fWorkingSetManager.getWorkingSets());
 
 		boolean exceptionThrown = false;
 		try {
@@ -185,8 +186,7 @@ public class IWorkingSetManagerTest extends UITestCase {
 			exceptionThrown = true;
 		}
 		assertTrue(exceptionThrown);
-		assertTrue(ArrayUtil.equals(new IWorkingSet[] { fWorkingSet },
-				fWorkingSetManager.getWorkingSets()));
+		assertArrayEquals(new IWorkingSet[] { fWorkingSet }, fWorkingSetManager.getWorkingSets());
 	}
 
 	@Test
@@ -194,14 +194,12 @@ public class IWorkingSetManagerTest extends UITestCase {
 		IWorkingSet workingSet2 = fWorkingSetManager.createWorkingSet(
 				WORKING_SET_NAME_2, new IAdaptable[] { fWorkspace.getRoot() });
 		assertEquals(WORKING_SET_NAME_2, workingSet2.getName());
-		assertTrue(ArrayUtil.equals(new IAdaptable[] { fWorkspace.getRoot() },
-				workingSet2.getElements()));
+		assertArrayEquals(new IAdaptable[] { fWorkspace.getRoot() }, workingSet2.getElements());
 
 		workingSet2 = fWorkingSetManager.createWorkingSet("",
 				new IAdaptable[] {});
 		assertEquals("", workingSet2.getName());
-		assertTrue(ArrayUtil.equals(new IAdaptable[] {}, workingSet2
-				.getElements()));
+		assertArrayEquals(new IAdaptable[] {}, workingSet2.getElements());
 	}
 
 	@Test
@@ -213,8 +211,7 @@ public class IWorkingSetManagerTest extends UITestCase {
 		IWorkingSet restoredWorkingSet2 = fWorkingSetManager
 				.createWorkingSet(memento);
 		assertEquals(WORKING_SET_NAME_2, restoredWorkingSet2.getName());
-		assertTrue(ArrayUtil.equals(new IAdaptable[] { fWorkspace.getRoot() },
-				restoredWorkingSet2.getElements()));
+		assertArrayEquals(new IAdaptable[] { fWorkspace.getRoot() }, restoredWorkingSet2.getElements());
 	}
 
 	@Test
@@ -232,19 +229,16 @@ public class IWorkingSetManagerTest extends UITestCase {
 
 		fWorkingSetManager.addRecentWorkingSet(fWorkingSet);
 		fWorkingSetManager.addWorkingSet(fWorkingSet);
-		assertTrue(ArrayUtil.equals(new IWorkingSet[] { fWorkingSet },
-				fWorkingSetManager.getRecentWorkingSets()));
+		assertArrayEquals(new IWorkingSet[] { fWorkingSet }, fWorkingSetManager.getRecentWorkingSets());
 
 		IWorkingSet workingSet2 = fWorkingSetManager.createWorkingSet(
 				WORKING_SET_NAME_2, new IAdaptable[] { fWorkspace.getRoot() });
 		fWorkingSetManager.addRecentWorkingSet(workingSet2);
 		fWorkingSetManager.addWorkingSet(workingSet2);
-		assertTrue(ArrayUtil.equals(new IWorkingSet[] { workingSet2,
-				fWorkingSet }, fWorkingSetManager.getRecentWorkingSets()));
+		assertArrayEquals(new IWorkingSet[] { workingSet2, fWorkingSet }, fWorkingSetManager.getRecentWorkingSets());
 
 		fWorkingSetManager.removeWorkingSet(workingSet2);
-		assertTrue(ArrayUtil.equals(new IWorkingSet[] { fWorkingSet },
-				fWorkingSetManager.getRecentWorkingSets()));
+		assertArrayEquals(new IWorkingSet[] { fWorkingSet }, fWorkingSetManager.getRecentWorkingSets());
 	}
 
 	@Test
@@ -261,12 +255,12 @@ public class IWorkingSetManagerTest extends UITestCase {
 				fWorkingSetManager.addWorkingSet(workingSet);
 				workingSets[9 - i] = workingSet;
 			}
-			assertTrue(ArrayUtil.equals(workingSets, fWorkingSetManager.getRecentWorkingSets()));
+			assertArrayEquals(workingSets, fWorkingSetManager.getRecentWorkingSets());
 
 			fWorkingSetManager.setRecentWorkingSetsLength(7);
 			IWorkingSet[] workingSets7 = new IWorkingSet[7];
 			System.arraycopy(workingSets, 0, workingSets7, 0, 7);
-			assertTrue(ArrayUtil.equals(workingSets7, fWorkingSetManager.getRecentWorkingSets()));
+			assertArrayEquals(workingSets7, fWorkingSetManager.getRecentWorkingSets());
 
 			fWorkingSetManager.setRecentWorkingSetsLength(9);
 			IWorkingSet[] workingSets9 = new IWorkingSet[9];
@@ -280,7 +274,7 @@ public class IWorkingSetManagerTest extends UITestCase {
 				workingSets9[8 - i] = workingSet;
 			}
 
-			assertTrue(ArrayUtil.equals(workingSets9, fWorkingSetManager.getRecentWorkingSets()));
+			assertArrayEquals(workingSets9, fWorkingSetManager.getRecentWorkingSets());
 		} finally {
 			if (oldMRULength > 0) {
 				fWorkingSetManager.setRecentWorkingSetsLength(oldMRULength);
@@ -302,20 +296,17 @@ public class IWorkingSetManagerTest extends UITestCase {
 
 	@Test
 	public void testGetWorkingSets() throws Throwable {
-		assertTrue(ArrayUtil.equals(new IWorkingSet[] {}, fWorkingSetManager
-				.getWorkingSets()));
+		assertArrayEquals(new IWorkingSet[] {}, fWorkingSetManager.getWorkingSets());
 
 		fWorkingSetManager.addWorkingSet(fWorkingSet);
-		assertTrue(ArrayUtil.equals(new IWorkingSet[] { fWorkingSet },
-				fWorkingSetManager.getWorkingSets()));
+		assertArrayEquals(new IWorkingSet[] { fWorkingSet }, fWorkingSetManager.getWorkingSets());
 
 		try {
 			fWorkingSetManager.addWorkingSet(fWorkingSet);
 			fail("Added the same set twice");
 		} catch (RuntimeException exception) {
 		}
-		assertTrue(ArrayUtil.equals(new IWorkingSet[] { fWorkingSet },
-				fWorkingSetManager.getWorkingSets()));
+		assertArrayEquals(new IWorkingSet[] { fWorkingSet }, fWorkingSetManager.getWorkingSets());
 
 		IWorkingSet workingSet2 = fWorkingSetManager.createWorkingSet(
 				WORKING_SET_NAME_2, new IAdaptable[] { fWorkspace.getRoot() });
@@ -369,16 +360,14 @@ public class IWorkingSetManagerTest extends UITestCase {
 	@Test
 	public void testRemoveWorkingSet() throws Throwable {
 		fWorkingSetManager.removeWorkingSet(fWorkingSet);
-		assertTrue(ArrayUtil.equals(new IWorkingSet[] {}, fWorkingSetManager
-				.getWorkingSets()));
+		assertArrayEquals(new IWorkingSet[] {}, fWorkingSetManager.getWorkingSets());
 
 		fWorkingSetManager.addWorkingSet(fWorkingSet);
 		IWorkingSet workingSet2 = fWorkingSetManager.createWorkingSet(
 				WORKING_SET_NAME_2, new IAdaptable[] { fWorkspace.getRoot() });
 		fWorkingSetManager.addWorkingSet(workingSet2);
 		fWorkingSetManager.removeWorkingSet(fWorkingSet);
-		assertTrue(ArrayUtil.equals(new IWorkingSet[] { workingSet2 },
-				fWorkingSetManager.getWorkingSets()));
+		assertArrayEquals(new IWorkingSet[] { workingSet2 }, fWorkingSetManager.getWorkingSets());
 	}
 
 	@Test
@@ -391,9 +380,7 @@ public class IWorkingSetManagerTest extends UITestCase {
 		String origName=fWorkingSet.getName();
 
 		/* check that workingSetManager contains "fWorkingSet"*/
-		assertTrue(ArrayUtil.equals(
-				new IWorkingSet[] {  fWorkingSet },
-				workingSetManager.getWorkingSets()));
+		assertArrayEquals(new IWorkingSet[] { fWorkingSet }, workingSetManager.getWorkingSets());
 
 		fWorkingSet.setName(" ");
 		assertEquals(" ", fWorkingSet.getName());
@@ -402,7 +389,7 @@ public class IWorkingSetManagerTest extends UITestCase {
 		workingSetManager.removeWorkingSet(fWorkingSet);
 
 		/* check that "fWorkingSet" was removed  after rename*/
-		if(!ArrayUtil.equals(new IWorkingSet[] {},
+		if (!Arrays.equals(new IWorkingSet[] {},
 				workingSetManager.getWorkingSets())){
 			/*Test Failure, report after restoring state*/
 			fWorkingSet.setName(origName);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.junit.Assert.assertArrayEquals;
+
+import java.util.Arrays;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
@@ -24,7 +28,6 @@ import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.IWorkingSetManager;
 import org.eclipse.ui.XMLMemento;
 import org.eclipse.ui.internal.WorkingSet;
-import org.eclipse.ui.tests.harness.util.ArrayUtil;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.eclipse.ui.tests.menus.ObjectContributionClasses.IA;
@@ -101,7 +104,7 @@ public class IWorkingSetTest extends UITestCase {
 		IFile f1 = FileUtil.createFile("f1.txt", p1);
 		IAdaptable[] elements = new IAdaptable[] { f1, p1 };
 		fWorkingSet.setElements(elements);
-		assertTrue(ArrayUtil.equals(elements, fWorkingSet.getElements()));
+		assertArrayEquals(elements, fWorkingSet.getElements());
 
 		fWorkingSet.setElements(new IAdaptable[] { f1 });
 		assertEquals(f1, fWorkingSet.getElements()[0]);
@@ -160,17 +163,16 @@ public class IWorkingSetTest extends UITestCase {
 		/*
 		 * check that initially workingSetManager contains "fWorkingSet"
 		 */
-		assertTrue(ArrayUtil.equals(new IWorkingSet[] { fWorkingSet },
-				workingSetManager.getWorkingSets()));
+		assertArrayEquals(new IWorkingSet[] { fWorkingSet }, workingSetManager.getWorkingSets());
 
 		IWorkingSet wSet = workingSetManager.createWorkingSet(
 				WORKING_SET_NAME_2, new IAdaptable[] {});
 		workingSetManager.addWorkingSet(wSet);
 
 		/* check that workingSetManager contains "fWorkingSet" and wSet */
-		assertTrue(ArrayUtil.equals(new IWorkingSet[] { fWorkingSet, wSet },
+		assertTrue(Arrays.equals(new IWorkingSet[] { fWorkingSet, wSet },
 				workingSetManager.getWorkingSets())
-				|| ArrayUtil.equals(new IWorkingSet[] { wSet, fWorkingSet },
+				|| Arrays.equals(new IWorkingSet[] { wSet, fWorkingSet },
 						workingSetManager.getWorkingSets()));
 
 		String sameName = fWorkingSet.getName();
@@ -198,8 +200,7 @@ public class IWorkingSetTest extends UITestCase {
 		/*
 		 * check that initially workingSetManager contains "fWorkingSet"
 		 */
-		assertTrue(ArrayUtil.equals(new IWorkingSet[] { fWorkingSet },
-				workingSetManager.getWorkingSets()));
+		assertArrayEquals(new IWorkingSet[] { fWorkingSet }, workingSetManager.getWorkingSets());
 
 		String sameName = fWorkingSet.getName();
 		IWorkingSet wSet = workingSetManager.createWorkingSet(sameName,


### PR DESCRIPTION
Use JUnit's assertArrayEquals or JVM's Arrays.equals instead.