### PR TITLE
[win] Adding experimental preference to enable update on runtime behavior

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IWorkbenchPreferenceConstants.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IWorkbenchPreferenceConstants.java
@@ -705,4 +705,14 @@ public interface IWorkbenchPreferenceConstants {
 	 * @since 3.130
 	 */
 	String LARGE_VIEW_LIMIT = "largeViewLimit"; //$NON-NLS-1$
+
+	/**
+	 * <p>
+	 * <strong>EXPERIMENTAL</strong>. Whether the UI adapts to DPI changes at
+	 * runtime. It only effects Windows.
+	 * </p>
+	 *
+	 * @since 3.133
+	 */
+	String RESCALING_AT_RUNTIME = "RESCALING_AT_RUNTIME"; //$NON-NLS-1$
 }

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/Workbench.java
@@ -584,7 +584,7 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 				int orientation = store.getInt(IPreferenceConstants.LAYOUT_DIRECTION);
 				Window.setDefaultOrientation(orientation);
 			}
-
+			setRescaleAtRuntimePropertyFromPreference(display);
 			if (obj instanceof E4Application) {
 				E4Application e4app = (E4Application) obj;
 				E4Workbench e4Workbench = e4app.createE4Workbench(getApplicationContext(), display);
@@ -676,6 +676,15 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 			}
 		});
 		return returnCode[0];
+	}
+
+	private static void setRescaleAtRuntimePropertyFromPreference(final Display display) {
+		boolean rescaleAtRuntime = PrefUtil.getAPIPreferenceStore()
+				.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME);
+		if (rescaleAtRuntime) {
+			display.setRescalingAtRuntime(rescaleAtRuntime);
+			System.setProperty("org.eclipse.swt.browser.DefaultType", "edge"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
 	}
 
 	private static void setSearchContribution(MApplication app, boolean enabled) {

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/WorkbenchMessages.java
@@ -34,6 +34,16 @@ public class WorkbenchMessages extends NLS {
 
 	public static String ThemingEnabled;
 
+	public static String HiDpiSettingsGroupTitle;
+
+	public static String RescaleAtRuntimeEnabled;
+
+	public static String RescaleAtRuntimeDisclaimer;
+
+	public static String RescaleAtRuntimeSettingChangeWarningTitle;
+
+	public static String RescaleAtRuntimeSettingChangeWarningText;
+
 	public static String ThemeChangeWarningText;
 
 	public static String ThemeChangeWarningTitle;

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
@@ -497,6 +497,11 @@ PreferencePageParameterValues_pageLabelSeparator = \ >\
 ThemingEnabled = E&nable theming
 ThemeChangeWarningText = Restart for the theme changes to take full effect
 ThemeChangeWarningTitle = Theme Changed
+RescaleAtRuntimeSettingChangeWarningTitle = DPI Setting Changed
+RescaleAtRuntimeSettingChangeWarningText = Restart for the DPI setting changes to take effect
+HiDpiSettingsGroupTitle = HiDPI settings
+RescaleAtRuntimeEnabled = Monitor-specific UI &scaling
+RescaleAtRuntimeDisclaimer = EXPERIMENTAL! Activating this option will dynamically scale all windows according to the monitor they are currently in. It will also set the default browser to Edge in order to provide the appropriate scaling of content displayed in a browser. This feature is still in development and therefore considered experimental.
 # --- Workbench -----
 WorkbenchPreference_openMode=Open mode
 WorkbenchPreference_doubleClick=D&ouble click


### PR DESCRIPTION
In the UI Preferences -> General -> Appearance, there is a new HiDPI setting that could be checked to enable the monitor-specific scaling of the UI. This check will also enable Edge browser by default. This is an experimental feature to test the multi-monitor HiDPI support before it is actually released and set by default. For now, this preference is disabled by default.

**Note: This preference check is only available in Windows** 

![image](https://github.com/user-attachments/assets/a1288374-5aeb-436f-9c8e-7557863f12e2)

When changing the preference, the dialog will appear to prompt the restart. 

![image](https://github.com/user-attachments/assets/8580a8fd-73f8-42c1-b79f-22ed031fe04c)
