### PR TITLE
Fix CascadingTheme.keySet signature

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/themes/CascadingTheme.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/themes/CascadingTheme.java
@@ -102,7 +102,7 @@ public class CascadingTheme extends EventManager implements ITheme {
 	}
 
 	@Override
-	public Set keySet() {
+	public Set<String> keySet() {
 		return currentTheme.keySet();
 	}
 


### PR DESCRIPTION
There is no point in using raw Set as underlying data is not raw.