### PR TITLE
CloseAllHandlerTest stabilisation

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/e4/CloseAllHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/e4/CloseAllHandlerTest.java
@@ -114,7 +114,7 @@ public class CloseAllHandlerTest {
 		boolean canExecute = handlerService.canExecute(parameterizedCommand);
 		assertFalse(canExecute);
 
-		// scenario 2: open a compatibility layer editor
+		// scenario 1: open a compatibility layer editor
 		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 		assertNotNull("Active workbench window not found.", window);
 
@@ -141,7 +141,7 @@ public class CloseAllHandlerTest {
 		canExecute = handlerService.canExecute(parameterizedCommand);
 		assertFalse(canExecute);
 
-		// scenario 1: e4 part descriptor contribution
+		// scenario 2: e4 part descriptor contribution
 		MPartDescriptor partDescriptor = createDummyPartDescriptor();
 		application.getDescriptors().add(partDescriptor);
 


### PR DESCRIPTION
An attempt at resolving a race condition/sporadic test failure in the CloseAllHandlerTest by reordering some testing scenarios, and making use of PlatformUI.getWorkbench().getActiveWorkbenchWindow() to get/init the active workbench window.