### PR TITLE
Prune useless parts of o.e.ui.tests

### DIFF
--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/RcpTestSuite.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/RcpTestSuite.java
@@ -27,6 +27,4 @@ import org.junit.platform.suite.api.Suite;
 		WorkbenchWindowConfigurerTest.class, ActionBarConfigurerTest.class, IWorkbenchPageTest.class,
 		WorkbenchSaveRestoreStateTest.class, WorkbenchListenerTest.class, WorkbenchTest.class })
 public class RcpTestSuite {
-	public RcpTestSuite() {
-	}
 }

--- a/tests/org.eclipse.ui.tests.rcp/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.rcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.tests.rcp; singleton:=true
-Bundle-Version: 3.6.400.qualifier
+Bundle-Version: 3.6.500.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,

--- a/tests/org.eclipse.ui.tests.rcp/RCP Test Suite.launch
+++ b/tests/org.eclipse.ui.tests.rcp/RCP Test Suite.launch
@@ -33,7 +33,7 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JRE for JavaSE-17"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.ui.tests.rcp.RcpTestSuite"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.ui.tests.rcp"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/autotests/XmlUtil.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/autotests/XmlUtil.java
@@ -14,8 +14,6 @@
 package org.eclipse.ui.tests.autotests;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,7 +21,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.URL;
 
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.WorkbenchException;
@@ -44,40 +41,23 @@ public class XmlUtil {
 		try {
 			return read(toRead.openStream());
 		} catch (IOException e) {
-			throw new WorkbenchException(new Status(IStatus.ERROR,
-					TestPlugin.getDefault().getBundle().getSymbolicName(),
-					IStatus.OK, null, e));
-		}
-	}
-
-	public static IMemento read(File toRead) throws WorkbenchException {
-		FileInputStream input;
-		try {
-			input = new FileInputStream(toRead);
-			return read(input);
-		} catch (FileNotFoundException e) {
-			throw new WorkbenchException(new Status(IStatus.ERROR,
-					TestPlugin.getDefault().getBundle().getSymbolicName(),
-					IStatus.OK, null, e));
+			throw new WorkbenchException(Status.error(TestPlugin.getDefault().getBundle().getSymbolicName(), e));
 		}
 	}
 
 	public static void write(File file, XMLMemento data) throws WorkbenchException {
 
-		FileOutputStream output;
 		try {
 			file.getParentFile().mkdirs();
 			file.delete();
 			file.createNewFile();
 
-			output = new FileOutputStream(file);
-			try (OutputStreamWriter writer = new OutputStreamWriter(output)) {
+			try (FileOutputStream output = new FileOutputStream(file);
+					OutputStreamWriter writer = new OutputStreamWriter(output)) {
 				data.save(writer);
 			}
 		} catch (IOException e) {
-			throw new WorkbenchException(new Status(IStatus.ERROR,
-					TestPlugin.getDefault().getBundle().getSymbolicName(),
-					IStatus.OK, e.toString(), e));
+			throw new WorkbenchException(Status.error(TestPlugin.getDefault().getBundle().getSymbolicName(), e));
 		}
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/ToggleStateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/ToggleStateTest.java
@@ -16,8 +16,8 @@
 package org.eclipse.ui.tests.commands;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.ExecutionException;
@@ -36,15 +36,12 @@ import org.eclipse.ui.services.IServiceLocator;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.junit.runners.MethodSorters;
 
 /**
  * @since 3.5
  * @author Prakash G.R.
  */
-@RunWith(JUnit4.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ToggleStateTest {
 
@@ -61,9 +58,7 @@ public class ToggleStateTest {
 	// Note: this and all other tests are numbered because they must run in a
 	// specific order.
 	// See https://bugs.eclipse.org/bugs/show_bug.cgi?id=369660
-	// The old junit3 implementation used a custom suite(). Because junit4 provides
-	// less options on test run order the tests are now numbered and run in method
-	// name order.
+	// Tests are now numbered and run in method name order.
 	@Test
 	public void test01DefaultValues() throws Exception {
 
@@ -85,16 +80,10 @@ public class ToggleStateTest {
 
 	@Test
 	public void test02ExceptionThrown() throws Exception {
-
 		Command command3 = commandService.getCommand("org.eclipse.ui.tests.toggleStateCommand3");
-		try {
-			handlerService.executeCommand(command3.getId(), null);
-			fail("Command3 doesn't have any state. An exception must be thrown from the handler, when trying to change that");
-		} catch (Exception e) {
-			if(!(e instanceof ExecutionException)) {
-				throw e;
-			}
-		}
+		assertThrows(
+				"Command3 doesn't have any state. An exception must be thrown from the handler, when trying to change that",
+				ExecutionException.class, () -> handlerService.executeCommand(command3.getId(), null));
 	}
 
 	static class MyUIElement extends UIElement{

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/Bug_262032.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/Bug_262032.java
@@ -116,7 +116,9 @@ public class Bug_262032 {
 			j.join();
 			tb1.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
 			assertEquals(Status.OK_STATUS, j.getResult());
-		} catch (InterruptedException e) {fail();}
+		} catch (InterruptedException e) {
+			fail(e.getMessage());
+		}
 	}
 
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/NestedSyncExecDeadlockTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/NestedSyncExecDeadlockTest.java
@@ -52,10 +52,6 @@ public class NestedSyncExecDeadlockTest {
 
 	private final IWorkspace workspace = ResourcesPlugin.getWorkspace();
 
-	public NestedSyncExecDeadlockTest() {
-		super();
-	}
-
 	public void doTest(final long timeToSleep) throws Exception {
 		ProgressMonitorDialog dialog = new ProgressMonitorDialog(new Shell());
 		dialog.run(true, false, new WorkspaceModifyOperation() {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/NoFreezeWhileWaitingForRuleTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/NoFreezeWhileWaitingForRuleTest.java
@@ -93,7 +93,7 @@ public class NoFreezeWhileWaitingForRuleTest {
 			blockingJob.join();
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
-			fail();
+			fail(e.getMessage());
 		}
 		assertFalse("Timeout reached, blocking occurred!", ruleMonitor.isCanceled());
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/SyncExecWhileUIThreadWaitsForLock.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/SyncExecWhileUIThreadWaitsForLock.java
@@ -141,7 +141,7 @@ public class SyncExecWhileUIThreadWaitsForLock {
 			}
 			//if we waited too long, fail the test
 			if (System.currentTimeMillis() - waitStart > 60000) {
-				assertTrue("Deadlock occurred", false);
+				fail("Deadlock occurred");
 			}
 		}
 		//if we get here, the test succeeded

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/TestBug105491.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/TestBug105491.java
@@ -74,10 +74,6 @@ public class TestBug105491 {
 
 	private final IWorkspace workspace = ResourcesPlugin.getWorkspace();
 
-	public TestBug105491() {
-		super();
-	}
-
 	/**
 	 * Performs the test
 	 */

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/TestBug108162.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/TestBug108162.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.concurrency;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -47,10 +47,6 @@ public class TestBug108162 {
 
 	private final IWorkspace workspace = ResourcesPlugin.getWorkspace();
 
-	public TestBug108162() {
-		super();
-	}
-
 	/**
 	 * Performs the test
 	 */
@@ -61,7 +57,7 @@ public class TestBug108162 {
 			try {
 				dialog.run(true, false, new LockAcquiringOperation());
 				// should not succeed
-				assertTrue("Should not get here", false);
+				fail("Should not get here");
 			} catch (InvocationTargetException | InterruptedException | IllegalStateException e) {
 				// this failure is expected because it tried to fork and block while owning a
 				// lock.

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/TestBug98621.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/TestBug98621.java
@@ -75,10 +75,6 @@ public class TestBug98621 {
 
 	private final IWorkspace workspace = ResourcesPlugin.getWorkspace();
 
-	public TestBug98621() {
-		super();
-	}
-
 	/**
 	 * Performs the test
 	 */

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingProjectsWizardTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingProjectsWizardTest.java
@@ -17,8 +17,14 @@
 package org.eclipse.ui.tests.datatransfer;
 
 import static org.eclipse.jface.dialogs.IMessageProvider.WARNING;
+import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.eclipse.ui.tests.datatransfer.ImportTestUtils.restoreWorkspaceConfiguration;
 import static org.eclipse.ui.tests.datatransfer.ImportTestUtils.setWorkspaceAutoBuild;
+import static org.eclipse.ui.tests.harness.util.UITestCase.processEvents;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -48,7 +54,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.dialogs.ImportExportWizard;
 import org.eclipse.ui.internal.wizards.datatransfer.DataTransferMessages;
@@ -56,18 +61,18 @@ import org.eclipse.ui.internal.wizards.datatransfer.WizardProjectsImportPage;
 import org.eclipse.ui.internal.wizards.datatransfer.WizardProjectsImportPage.ProjectRecord;
 import org.eclipse.ui.tests.TestPlugin;
 import org.eclipse.ui.tests.datatransfer.ImportTestUtils.TestBuilder;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.eclipse.ui.wizards.datatransfer.ExternalProjectImportWizard;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.FixMethodOrder;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.junit.runners.MethodSorters;
 
-@RunWith(JUnit4.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class ImportExistingProjectsWizardTest extends UITestCase {
+public class ImportExistingProjectsWizardTest {
 
 	private static final String DATA_PATH_PREFIX = "data/org.eclipse.datatransferArchives/";
 	private static final String WS_DATA_LOCATION = "importExistingFromDirTest";
@@ -89,17 +94,15 @@ public class ImportExistingProjectsWizardTest extends UITestCase {
 
 	private boolean originalRefreshSetting;
 
-	public ImportExistingProjectsWizardTest() {
-		super(ImportExistingProjectsWizardTest.class.getName());
-	}
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	private Shell getShell() {
-		return PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+		return getWorkbench().getActiveWorkbenchWindow().getShell();
 	}
 
-	@Override
-	protected void doSetUp() throws Exception {
-		super.doSetUp();
+	@Before
+	public void doSetUp() throws Exception {
 		originalRefreshSetting = ResourcesPlugin.getPlugin()
 				.getPluginPreferences().getBoolean(
 						ResourcesPlugin.PREF_AUTO_REFRESH);
@@ -108,8 +111,8 @@ public class ImportExistingProjectsWizardTest extends UITestCase {
 		setWorkspaceAutoBuild(true);
 	}
 
-	@Override
-	protected void doTearDown() throws Exception {
+	@After
+	public void doTearDown() throws Exception {
 		if (dialog != null) {
 			dialog.close();
 			dialog = null;
@@ -143,12 +146,11 @@ public class ImportExistingProjectsWizardTest extends UITestCase {
 		ResourcesPlugin.getPlugin().getPluginPreferences().setValue(
 				ResourcesPlugin.PREF_AUTO_REFRESH, originalRefreshSetting);
 		restoreWorkspaceConfiguration();
-		super.doTearDown();
 	}
 
 	private void waitForRefresh() {
 		try {
-			PlatformUI.getWorkbench().getProgressService().busyCursorWhile(
+			getWorkbench().getProgressService().busyCursorWhile(
 					monitor -> Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH,
 							new NullProgressMonitor()));
 		} catch (InvocationTargetException | InterruptedException e) {
@@ -159,9 +161,7 @@ public class ImportExistingProjectsWizardTest extends UITestCase {
 	// Note: this and all other tests are numbered because they must run in a
 	// specific order.
 	// See https://bugs.eclipse.org/bugs/show_bug.cgi?id=369660
-	// The old junit3 implementation used a custom suite(). Because junit4 provides
-	// less options on test run order the tests are now numbered and run in method
-	// name order.
+	// Tests are now numbered and run in method name order.
 	@Test
 	public void test01FindSingleZip() throws IOException {
 		URL archiveFile = FileLocator.toFileURL(FileLocator.find(TestPlugin.getDefault().getBundle(),

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dnd/Bug87211Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dnd/Bug87211Test.java
@@ -14,8 +14,7 @@
 
 package org.eclipse.ui.tests.dnd;
 
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import static org.junit.Assert.assertEquals;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.ui.IViewPart;
@@ -23,18 +22,17 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.WorkbenchPage;
 import org.eclipse.ui.internal.WorkbenchPlugin;
+import org.junit.Before;
+import org.junit.Test;
 
-public class Bug87211Test extends TestCase {
-	public static TestSuite suite() {
-		return new TestSuite(Bug87211Test.class);
-	}
+public class Bug87211Test {
 
 	private WorkbenchPage fPage;
 
 	private IWorkbenchWindow fWindow;
 
-	@Override
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		fWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 		fPage = (WorkbenchPage) fWindow.getActivePage();
 	}
@@ -44,6 +42,7 @@ public class Bug87211Test extends TestCase {
 	 * another view on top of it.  The views should still be in their
 	 * separate stacks.
 	 */
+	@Test
 	public void testDragStandaloneView() throws Throwable {
 		fPage.setPerspective(WorkbenchPlugin.getDefault()
 				.getPerspectiveRegistry().findPerspectiveWithId(

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multieditor/MultiEditorTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multieditor/MultiEditorTest.java
@@ -13,6 +13,15 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.multieditor;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+import static org.eclipse.ui.tests.harness.util.UITestCase.openTestWindow;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -52,20 +61,15 @@ import org.eclipse.ui.part.MultiEditor;
 import org.eclipse.ui.part.MultiEditorInput;
 import org.eclipse.ui.tests.TestPlugin;
 import org.eclipse.ui.tests.api.MockEditorPart;
-import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
-import junit.framework.TestSuite;
 
 /**
  * Test MultiEditor behaviour to highlight some of the broken functionality.
  *
  * @since 3.1
  */
-@RunWith(JUnit4.class)
-public class MultiEditorTest extends UITestCase {
+public class MultiEditorTest {
 	private static final String ACTION_TOOLTIP = "MultiEditorActionThing";
 
 	private static final String PROJECT_NAME = "TiledEditorProject";
@@ -108,18 +112,10 @@ public class MultiEditorTest extends UITestCase {
 			"updateGradient", "updateGradient", "updateGradient",
 			"widgetsDisposed", "dispose" };
 
-	public static TestSuite suite() {
-		return new TestSuite(MultiEditorTest.class);
-	}
-
 	/**
 	 * Can catch a MultiEditor unexpect Exception on init.
 	 */
 	private EditorErrorListener fErrorListener;
-
-	public MultiEditorTest() {
-		super(MultiEditorTest.class.getSimpleName());
-	}
 
 	/**
 	 * Test that the test tiled editor can be opened with a basic
@@ -532,7 +528,7 @@ public class MultiEditorTest extends UITestCase {
 			IProject testProject) throws CoreException, IOException {
 		String[] ids = new String[simpleFiles.length];
 		IEditorInput[] inputs = new IEditorInput[simpleFiles.length];
-		IEditorRegistry registry = fWorkbench.getEditorRegistry();
+		IEditorRegistry registry = getWorkbench().getEditorRegistry();
 
 		for (int f = 0; f < simpleFiles.length; ++f) {
 			IFile f1 = createFile(testProject, simpleFiles[f]);
@@ -556,10 +552,9 @@ public class MultiEditorTest extends UITestCase {
 	/**
 	 * Close any editors at the beginner of a test, so the test can be clean.
 	 */
-	@Override
-	protected void doSetUp() throws Exception {
-		super.doSetUp();
-		IWorkbenchPage page = fWorkbench.getActiveWorkbenchWindow()
+	@Before
+	public void doSetUp() throws Exception {
+		IWorkbenchPage page = getWorkbench().getActiveWorkbenchWindow()
 				.getActivePage();
 		page.closeAllEditors(false);
 


### PR DESCRIPTION
A lot of no longer needed legacy from JUnit 3.x time is simply cluttering the codebase now.