### PR TITLE
Cleanups in unstable tests in I-builds

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/.classpath
+++ b/tests/org.eclipse.e4.ui.tests/.classpath
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
@@ -29,7 +29,8 @@ Require-Bundle: org.eclipse.emf.ecore.xmi;bundle-version="2.4.0",
  org.eclipse.e4.ui.css.swt;bundle-version="0.11.0",
  org.mockito.mockito-core;bundle-version="2.13.0",
  org.eclipse.e4.ui.css.core;bundle-version="0.10.100",
- org.eclipse.test;bundle-version="3.6.200"
+ org.eclipse.test;bundle-version="3.6.200",
+ org.eclipse.ui.tests.harness
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.e4.ui.tests.model.test,
  org.eclipse.e4.ui.tests.model.test.impl,

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MWindowTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MWindowTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2023 IBM Corporation and others.
+ * Copyright (c) 2009, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -50,6 +50,7 @@ import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.Widget;
+import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -365,12 +366,9 @@ public class MWindowTest {
 		// the shell's width should have been updated
 		window.setHeight(300);
 
-		while (shell.getDisplay().readAndDispatch()) {
-			// spin the event loop
-		}
-
+		// Give time for change to propagate
+		DisplayHelper.waitForCondition(shell.getDisplay(), 10000, () -> (300 == shell.getBounds().height));
 		assertEquals(shell.getBounds().height, window.getHeight());
-		assertEquals(300, shell.getBounds().height);
 	}
 
 	@Test

--- a/tests/org.eclipse.search.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.search.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search.tests;singleton:=true
-Bundle-Version: 3.11.500.qualifier
+Bundle-Version: 3.11.600.qualifier
 Bundle-Activator: org.eclipse.search.tests.SearchTestPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/AnnotationManagerTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/AnnotationManagerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -159,7 +159,6 @@ public class AnnotationManagerTest {
 				IFile file = (IFile) f;
 				ITextEditor editor= (ITextEditor)SearchTestPlugin.openTextEditor(SearchPlugin.getActivePage(), file);
 				IAnnotationModel annotationModel= editor.getDocumentProvider().getAnnotationModel(editor.getEditorInput());
-				int annotationCount= 0;
 				IDocument document= editor.getDocumentProvider().getDocument(editor.getEditorInput());
 				for (Iterator<Annotation> annotations= annotationModel.getAnnotationIterator(); annotations.hasNext();) {
 					Annotation annotation= annotations.next();
@@ -169,7 +168,6 @@ public class AnnotationManagerTest {
 						assertTrue(text.equalsIgnoreCase(fQuery2.getSearchString()));
 					}
 				}
-				assertEquals(0, annotationCount);
 			}
 		} finally {
 			SearchPlugin.getActivePage().closeAllEditors(false);
@@ -188,7 +186,6 @@ public class AnnotationManagerTest {
 				IFile file = (IFile) f;
 				ITextEditor editor= (ITextEditor)SearchTestPlugin.openTextEditor(SearchPlugin.getActivePage(), file);
 				IAnnotationModel annotationModel= editor.getDocumentProvider().getAnnotationModel(editor.getEditorInput());
-				int annotationCount= 0;
 				IDocument document= editor.getDocumentProvider().getDocument(editor.getEditorInput());
 				for (Iterator<Annotation> annotations= annotationModel.getAnnotationIterator(); annotations.hasNext();) {
 					Annotation annotation= annotations.next();
@@ -198,7 +195,6 @@ public class AnnotationManagerTest {
 						assertTrue(text.equalsIgnoreCase(fQuery1.getSearchString()));
 					}
 				}
-				assertEquals(0, annotationCount);
 			}
 		} finally {
 			SearchPlugin.getActivePage().closeAllEditors(false);


### PR DESCRIPTION
Use DisplayHelper to delay checks so listener changes can propagate. Remove unused variables.