### PR TITLE
Avoid "null" in "Show In" menu when there is no key binding

### DIFF
--- a/bundles/org.eclipse.ui.navigator.resources/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.navigator.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.navigator.resources; singleton:=true
-Bundle-Version: 3.9.500.qualifier
+Bundle-Version: 3.9.600.qualifier
 Bundle-Activator: org.eclipse.ui.internal.navigator.resources.plugin.WorkbenchNavigatorPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/ShowInActionProvider.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/ShowInActionProvider.java
@@ -45,6 +45,6 @@ public class ShowInActionProvider extends CommonActionProvider {
 				? bindingService
 						.getBestActiveBindingFormattedFor(IWorkbenchCommandConstants.NAVIGATE_SHOW_IN_QUICK_MENU)
 				: ""; //$NON-NLS-1$
-		return WorkbenchNavigatorMessages.ShowInActionProvider_showInAction_label + (keyBinding != null ? '\t' + keyBinding : ""); //$NON-NLS-2$
+		return WorkbenchNavigatorMessages.ShowInActionProvider_showInAction_label + (keyBinding != null ? "\t" + keyBinding : ""); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 }

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/ShowInActionProvider.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/ShowInActionProvider.java
@@ -45,6 +45,6 @@ public class ShowInActionProvider extends CommonActionProvider {
 				? bindingService
 						.getBestActiveBindingFormattedFor(IWorkbenchCommandConstants.NAVIGATE_SHOW_IN_QUICK_MENU)
 				: ""; //$NON-NLS-1$
-		return WorkbenchNavigatorMessages.ShowInActionProvider_showInAction_label + '\t' + keyBinding;
+		return WorkbenchNavigatorMessages.ShowInActionProvider_showInAction_label + (keyBinding != null ? '\t' + keyBinding : ""); //$NON-NLS-2$
 	}
 }


### PR DESCRIPTION
When the "Show In" command has no key binding (we disable it for our reasons in our product), there is a `null` label in the menu:

![image](https://github.com/user-attachments/assets/2b168068-e55e-46c3-9090-30ffeb3507c4)

The proposed change fixes this issue.