### PR TITLE
Refresh LineNumberRulerColumn on ZoomChange of canvas

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/LineNumberRulerColumn.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/LineNumberRulerColumn.java
@@ -616,6 +616,8 @@ public class LineNumberRulerColumn implements IVerticalRulerColumn {
 			fCachedTextWidget= null;
 		});
 
+		fCanvas.addListener(SWT.ZoomChanged, e -> computeIndentations());
+
 		fMouseHandler= new MouseHandler();
 		fCanvas.addMouseListener(fMouseHandler);
 		fCanvas.addMouseMoveListener(fMouseHandler);


### PR DESCRIPTION
This PR adds a listener for the ZoomChanged event to the canvas of a LineNumberRulerColumn. If the listener is notified of this event this means, that state, that differs over different zoom values, must be recalculated. Therefore the indentation are reset, when the event occurs. Problem and solution is similar to #2141 for ImageBasedFrage

## How to test
The event is currently thrown for wrapped controls only in win32 with "swt.autoScale.updateOnRuntime"-flag set to true. For the other OS the event will not be thrown for this control in any case to my knowledge.

You need a multi zoom setup, e.g. two monitors with 200% and 100% zoom. If you e.g. open a JavaEditor with line number on the 200% monitor and move that editor over to the 100% monitor, you should see something like the following
![Screenshot 2024-10-31 141206](https://github.com/user-attachments/assets/d54df141-6f9f-405a-9f79-c2d228f2dd0a)
