### PR TITLE
Correct bundle version after changes in MultiPageEditorPart

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IWorkbenchPreferenceConstants.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/IWorkbenchPreferenceConstants.java
@@ -634,7 +634,7 @@ public interface IWorkbenchPreferenceConstants {
 	 * The default value for this preference is: {@link SWT#BOTTOM}
 	 * </p>
 	 *
-	 * @since 3.133
+	 * @since 3.134
 	 */
 	String ALIGN_MULTI_PAGE_EDITOR_TABS = "ALIGN_MULTI_PAGE_EDITOR_TABS"; //$NON-NLS-1$
 
@@ -726,7 +726,7 @@ public interface IWorkbenchPreferenceConstants {
 	 * runtime. It only effects Windows.
 	 * </p>
 	 *
-	 * @since 3.133
+	 * @since 3.134
 	 */
 	String RESCALING_AT_RUNTIME = "RESCALING_AT_RUNTIME"; //$NON-NLS-1$
 }

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/part/MultiPageEditorPart.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/part/MultiPageEditorPart.java
@@ -172,7 +172,7 @@ public abstract class MultiPageEditorPart extends EditorPart implements IPageCha
 	 *
 	 * @param event the {@link PropertyChangeEvent} triggered by a change in the
 	 *              preference store
-	 * @since 3.133
+	 * @since 3.134
 	 */
 	protected boolean isUpdateRequired(PropertyChangeEvent event) {
 		if (event.getProperty().equals(IWorkbenchPreferenceConstants.ALIGN_MULTI_PAGE_EDITOR_TABS)) {
@@ -327,14 +327,14 @@ public abstract class MultiPageEditorPart extends EditorPart implements IPageCha
 	 * @return {@code SWT.TOP} if the user prefers tabs to be aligned on top,
 	 *         {@code SWT.BOTTOM} if the user prefers tabs to be aligned on the
 	 *         bottom.
-	 * @since 3.133
+	 * @since 3.134
 	 */
 	protected int getTabStyle() {
 		return getAPIPreferenceStore().getInt(IWorkbenchPreferenceConstants.ALIGN_MULTI_PAGE_EDITOR_TABS);
 	}
 
 	/**
-	 * @since 3.133
+	 * @since 3.134
 	 */
 	protected IPreferenceStore getAPIPreferenceStore() {
 		return PrefUtil.getAPIPreferenceStore();
@@ -1288,7 +1288,7 @@ public abstract class MultiPageEditorPart extends EditorPart implements IPageCha
 	 * on the user preference.
 	 * </p>
 	 *
-	 * @since 3.133
+	 * @since 3.134
 	 */
 	protected void updateContainer() {
 		Composite container = getContainer();

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.133.100.qualifier
+Bundle-Version: 3.134.0.qualifier
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName


### PR DESCRIPTION
Recent API changes to MultiPageEditorPart and IWorkbenchPreferenceConstants have been introduced after 3.133 has already been released. Thus, the micro version bump made since then is insufficient. This change corrects the version but and the according since tags to 3.134.

Fixes API errors introduced by https://github.com/eclipse-platform/eclipse.platform.ui/pull/2224 and https://github.com/eclipse-platform/eclipse.platform.ui/pull/2461:
![image](https://github.com/user-attachments/assets/f69454b8-7f43-4842-8357-5d0878b11964)