### PR TITLE
FindReplaceOverlay: avoid inconsistent borders #2194

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -33,6 +33,7 @@ import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
@@ -695,9 +696,10 @@ public class FindReplaceOverlay {
 		if (!okayToUse(replaceToggle)) {
 			return;
 		}
-		boolean visible = enable && findReplaceLogic.getTarget().isEditable();
-		((GridData) replaceToggleTools.getLayoutData()).exclude = !visible;
-		replaceToggleTools.setVisible(visible);
+		boolean shouldBeVisible = enable && findReplaceLogic.getTarget().isEditable();
+		((GridLayout) containerControl.getLayout()).numColumns = shouldBeVisible ? 2 : 1;
+		((GridData) replaceToggleTools.getLayoutData()).exclude = !shouldBeVisible;
+		replaceToggleTools.setVisible(shouldBeVisible);
 	}
 
 	private void enableReplaceTools(boolean enable) {


### PR DESCRIPTION
When the replace toggle in the FindReplaceOverlay is not shown because the target file is read-only or because the editor is too small to show the toggle button, the right border of the overlay is larger than the others. The reason is an inconsistent layout, as the container always expects two columns of elements but when the replace toggle is hidden only one column is present.

With this change, the number of columns of the container is adapted according to whether the replace toggle is present or not.

Fixed https://github.com/eclipse-platform/eclipse.platform.ui/issues/2194

![{5D737CB6-6D92-41D8-8DCE-8CE4A3AA16BB}](https://github.com/user-attachments/assets/6b93ca36-83fb-404a-a1c1-072a056cff4b)
![{84B92C23-5C69-4728-8AD1-F1BB7FF975C4}](https://github.com/user-attachments/assets/99827f80-c554-4135-a4c8-db4c73d9f4af)
