### PR TITLE
FindReplaceOverlay: update position and size while not visible #2478

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -204,7 +204,7 @@ public class FindReplaceOverlay {
 			.controlResizedAdapter(__ -> asyncExecIfOpen(FindReplaceOverlay.this::updatePlacementAndVisibility));
 
 	private void asyncExecIfOpen(Runnable operation) {
-		if (!containerControl.isDisposed() && containerControl.isVisible()) {
+		if (!containerControl.isDisposed()) {
 			containerControl.getDisplay().asyncExec(() -> {
 				if (containerControl != null || containerControl.isDisposed()) {
 					operation.run();


### PR DESCRIPTION
When changing position and/or size of the editor of a FindReplaceOverlay while it is hidden, e.g., because another editor in the same editor stack is active, the position and size of the overlay is not updated accordingly. Thus, when making the editor of that overlay active again, its position relative to the editor and size is still the same as before another editor was set active, i.e., it is usually wrong.

With this change, the size and position of an overlay is always updated upon resize operations of the target editor, even if the editor is not visible.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2478

![findreplace_update_position_when_hidden_fixed](https://github.com/user-attachments/assets/f648c155-ba03-437c-8509-25d0ddf499de)
