### PR TITLE
Fix missing NLS for "Enable theming" #2480

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/messages.properties
@@ -496,7 +496,7 @@ OpenPerspectiveDialogAction_tooltip=Open Perspective
 
 #---- General Preferences----
 PreferencePage_noDescription = (No description available)
-PreferencePageParameterValues_pageLabelSeparator = \ >\
+PreferencePageParameterValues_pageLabelSeparator = \ >\ 
 ThemingEnabled = E&nable theming
 ThemeChangeWarningText = Restart for the theme changes to take full effect
 ThemeChangeWarningTitle = Theme Changed


### PR DESCRIPTION
The NLS for "Enable theming" is not found because of a recent change to the according messages.properties file. This change reverts the faulty change.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2480