### PR TITLE
Bugfix for #2453: NPE in BarContentAssistProcessor.

### DIFF
--- a/tests/org.eclipse.ui.genericeditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.genericeditor.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.genericeditor.tests;singleton:=true
-Bundle-Version: 1.3.500.qualifier
+Bundle-Version: 1.3.600.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.genericeditor.tests,

--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/contributions/BarContentAssistProcessor.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/contributions/BarContentAssistProcessor.java
@@ -42,11 +42,15 @@ public class BarContentAssistProcessor implements IContentAssistProcessor {
 
 	@Override
 	public ICompletionProposal[] computeCompletionProposals(ITextViewer viewer, int offset) {
-		for (int offsetInProposal = Math.min(this.completeString.length(), viewer.getDocument().getLength()); offsetInProposal > 0; offsetInProposal--) {
+		final IDocument doc= viewer.getDocument();
+		if (doc == null) {
+			return new ICompletionProposal[0];
+		}
+		for (int offsetInProposal = Math.min(this.completeString.length(), doc.getLength()); offsetInProposal > 0; offsetInProposal--) {
 			String maybeMatchingString = this.completeString.substring(0, offsetInProposal);
 			try {
 				int lastIndex = offset - offsetInProposal + this.completeString.length();
-				if (offset >= offsetInProposal && viewer.getDocument().get(offset - offsetInProposal, maybeMatchingString.length()).equals(maybeMatchingString)) {
+				if (offset >= offsetInProposal && doc.get(offset - offsetInProposal, maybeMatchingString.length()).equals(maybeMatchingString)) {
 					CompletionProposal proposal = new CompletionProposal(this.completeString.substring(offsetInProposal), offset, 0, lastIndex);
 					return new ICompletionProposal[] { proposal };
 				}
@@ -98,13 +102,13 @@ public class BarContentAssistProcessor implements IContentAssistProcessor {
 		return new IContextInformationValidator() {
 			private ITextViewer viewer;
 			private int offset;
-			
+
 			@Override
 			public void install(IContextInformation info, ITextViewer infoViewer, int documentOffset) {
 				this.viewer= infoViewer;
 				this.offset= documentOffset;
 			}
-			
+
 			@Override
 			public boolean isContextInformationValid(int offsetToTest) {
 				try {
@@ -123,5 +127,4 @@ public class BarContentAssistProcessor implements IContentAssistProcessor {
 	public String getErrorMessage() {
 		return null;
 	}
-
 }


### PR DESCRIPTION
This bugfix simply adds a check for NULL which was missing. In case of NULL a default value is returned. Fxes #2453 