### PR TITLE
Fix IllegalArgumentException when styling the sticky lines

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -242,20 +242,20 @@ public class StickyScrollingControl {
 			return;
 		}
 
-		int stickyLineOffset= 0;
-		List<StyleRange> styleRanges= new ArrayList<>();
-		for (IStickyLine stickyLine : stickyLines) {
+		List<StyleRange> stickyLinesStyleRanges= new ArrayList<>();
+		int stickyLineTextOffset= 0;
+		for (int i= 0; i < getNumberStickyLines(); i++) {
+			IStickyLine stickyLine= stickyLines.get(i);
 			StyleRange[] ranges= stickyLine.getStyleRanges();
 			if (ranges != null) {
 				for (StyleRange styleRange : ranges) {
-					styleRange.start+= stickyLineOffset;
-					styleRanges.add(styleRange);
+					styleRange.start+= stickyLineTextOffset;
+					stickyLinesStyleRanges.add(styleRange);
 				}
 			}
-
-			stickyLineOffset+= stickyLine.getText().length() + System.lineSeparator().length();
+			stickyLineTextOffset+= stickyLine.getText().length() + System.lineSeparator().length();
 		}
-		stickyLineText.setStyleRanges(styleRanges.toArray(StyleRange[]::new));
+		stickyLineText.setStyleRanges(stickyLinesStyleRanges.toArray(StyleRange[]::new));
 
 		stickyLineNumber.setFont(textWidget.getFont());
 		stickyLineNumber.setStyleRange(new StyleRange(0, stickyLineNumber.getText().length(), settings.lineNumberColor(), null));

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
@@ -183,6 +183,29 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
+	public void testCopyStyleRangesWithLimitedStickyLines() {
+		settings = new StickyScrollingControlSettings(1, lineNumberColor, hoverColor, backgroundColor, separatorColor,
+				true);
+		stickyScrollingControl.applySettings(settings);
+
+		StyleRange styleRangeLine1 = new StyleRange(0, 1, lineNumberColor, backgroundColor);
+		StyleRange styleRangeLine2 = new StyleRange(0, 2, hoverColor, separatorColor);
+		List<IStickyLine> stickyLines = List.of(//
+				new StickyLineStub("line 1", 0, new StyleRange[] { styleRangeLine1 }),
+				new StickyLineStub("line 2", 0, new StyleRange[] { styleRangeLine2 }));
+		stickyScrollingControl.setStickyLines(stickyLines);
+
+		StyledText stickyLineText = getStickyLineText();
+
+		StyleRange[] styleRanges = stickyLineText.getStyleRanges();
+		assertEquals(1, styleRanges.length);
+		assertEquals(0, styleRanges[0].start);
+		assertEquals(1, styleRanges[0].length);
+		assertEquals(lineNumberColor, styleRanges[0].foreground);
+		assertEquals(backgroundColor, styleRanges[0].background);
+	}
+
+	@Test
 	public void testWithoutVerticalRuler() {
 		sourceViewer = new SourceViewer(shell, null, SWT.None);
 		settings = new StickyScrollingControlSettings(5, lineNumberColor, hoverColor, backgroundColor, separatorColor,


### PR DESCRIPTION
When the sticky lines are limited by the settings, the not visible sticky lines should not be styled.

Fixes #2496