### PR TITLE
Mark unused methods  for removal in WorkbenchWindowAdvisor

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/application/WorkbenchWindowAdvisor.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/application/WorkbenchWindowAdvisor.java
@@ -272,7 +272,7 @@ public class WorkbenchWindowAdvisor {
 	 * @deprecated This method is no longer used. Applications now define workbench
 	 *             window contents in their application model.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2024-12")
 	public void createWindowContents(Shell shell) {
 		((WorkbenchWindowConfigurer) getWindowConfigurer()).createDefaultContents(shell);
 	}
@@ -291,7 +291,7 @@ public class WorkbenchWindowAdvisor {
 	 * @deprecated This method is no longer used. Applications now define workbench
 	 *             window contents in their application model.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2024-12")
 	public Control createEmptyWindowContents(Composite parent) {
 		return null;
 	}

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchWindowConfigurerTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchWindowConfigurerTest.java
@@ -294,15 +294,15 @@ public class WorkbenchWindowConfigurerTest {
 							}};
 					}
 
+					@SuppressWarnings("removal")
 					@Override
-					@SuppressWarnings("deprecation")
 					public Control createEmptyWindowContents(Composite parent) {
 						ensureThread();
 						return super.createEmptyWindowContents(parent);
 					}
 
+					@SuppressWarnings("removal")
 					@Override
-					@SuppressWarnings("deprecation")
 					public void createWindowContents(Shell shell) {
 						ensureThread();
 						super.createWindowContents(shell);


### PR DESCRIPTION
These methods are not used since the 3.x migration, time to mark them for deletion.