### PR TITLE
Fix NullPointerException in LogView

### DIFF
--- a/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.ui.views.log;singleton:=true
-Bundle-Version: 1.4.600.qualifier
+Bundle-Version: 1.4.700.qualifier
 Bundle-Activator: org.eclipse.ui.internal.views.log.Activator
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogView.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogView.java
@@ -1250,8 +1250,9 @@ public class LogView extends ViewPart implements LogListener {
 
 	private void asyncRefreshAndActivate(int severity) {
 		asyncRefresh();
-		if ((fActivateViewAction.isChecked()) || (severity >= IStatus.WARNING && fActivateViewWarnAction.isChecked())
-				|| (severity >= IStatus.ERROR && fActivateViewErrorAction.isChecked())) {
+		if ((fActivateViewAction != null && fActivateViewAction.isChecked()) 
+				|| (severity >= IStatus.WARNING && fActivateViewWarnAction != null && fActivateViewWarnAction.isChecked())
+				|| (severity >= IStatus.ERROR && fActivateViewErrorAction != null && fActivateViewErrorAction.isChecked())) {
 			mutualActivate.throttledExec();
 		}
 	}


### PR DESCRIPTION
This commit addresses an occasionally occurring NullPointerException in the LogView class:
```py
LogListener.logged threw a non-fatal unchecked exception as follows:
java.lang.NullPointerException: Cannot invoke "org.eclipse.jface.action.Action.isChecked()" because "this.fActivateViewAction" is null
	at org.eclipse.ui.internal.views.log.LogView.asyncRefreshAndActivate(LogView.java:1253)
	at org.eclipse.ui.internal.views.log.LogView.pushEntry(LogView.java:1212)
	at org.eclipse.ui.internal.views.log.LogView.logged(LogView.java:1143)
	at org.eclipse.osgi.internal.log.ExtendedLogReaderServiceFactory.safeLogged(ExtendedLogReaderServiceFactory.java:108)
	at org.eclipse.osgi.internal.log.ExtendedLogReaderServiceFactory$LogTask.run(ExtendedLogReaderServiceFactory.java:56)
	at org.eclipse.osgi.internal.log.OrderedExecutor$OrderedTaskQueue$OrderedTask.run(ExtendedLogReaderServiceFactory.java:458)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```