### PR TITLE
org.eclipse.search.core requires org.eclipse.core.resources 3.21.100

### DIFF
--- a/bundles/org.eclipse.search.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.search.core/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Export-Package: org.eclipse.search.core.text,
  org.eclipse.search.internal.core.text;x-friends:="org.eclipse.search,org.eclipse.search.tests"
 Require-Bundle: 
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
- org.eclipse.core.resources;bundle-version="[3.14.0,4.0.0)",
+ org.eclipse.core.resources;bundle-version="[3.21.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.3.0,2.0.0)",
  org.eclipse.core.filebuffers;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ltk.core.refactoring;bundle-version="[3.5.0,4.0.0)",


### PR DESCRIPTION
`org.eclipse.search.internal.core.text.FileCharSequenceProvider.toShortString(...)` requires the method `byte[] org.eclipse.core.resources.IFile.readNBytes(int)` which was introduced in org.eclipse.core.resources 3.21.100.

The increasing of the lower bound of that requirement was missed in https://github.com/eclipse-platform/eclipse.platform/commit/906371db294e0d090180248d673d0c84f7b2d2b9.

Fixes https://github.com/eclipse-m2e/m2e-core/issues/1886