### PR TITLE
Find/replace overlay: improve focus/tab order #2161

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolBar.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/AccessibleToolBar.java
@@ -74,4 +74,9 @@ class AccessibleToolBar extends Composite {
 		}
 	}
 
+	Control getFirstControl() {
+		Control[] children = getChildren();
+		return children.length == 0 ? null : getChildren()[0];
+	}
+
 }

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
@@ -207,4 +207,8 @@ public class HistoryTextWrapper extends Composite {
 		return textBar;
 	}
 
+	AccessibleToolBar getDropDownTool() {
+		return tools;
+	}
+
 }


### PR DESCRIPTION
The FindReplaceOverlay currently uses the default focus order. When tabbing through the widgets, this means that when starting from the find input field you have to tab over all the search options before coming to the replace input field. Since the most often used navigation is between the two input fields for find and replace, they should come after each other in the focus order.

This change adapts the focus order of the involved elements:
- Tab between find and replace input field
- Tab between replace input field and the tools (starting from the search tools)
- Tab between search/close and replace search tools (instead of coming from search/close tools to the replace input field)

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2161

### Proposed Tab Order
![image](https://github.com/user-attachments/assets/426b241e-89a3-4ca1-bc54-bae0e6fb74c1)

### Behavior
Existing tab order:
![findreplace_taborder_existing](https://github.com/user-attachments/assets/76c13401-f3a0-4a14-9cb2-bb313184c2bf)

Proposed tab order:
![findreplace_taborder_new](https://github.com/user-attachments/assets/d202c608-7bd2-41c9-9700-ecb23b076d6d)
