### PR TITLE
[Windows] Add warning about activating "Monitor-specific UI scaling" in preferences dialog

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchMessages.java
@@ -76,6 +76,8 @@ public class WorkbenchMessages extends NLS {
 
 	public static String StatusUtil_errorOccurred;
 
+	public static String EdgeBrowserDisclaimer;
+
 	// ==============================================================================
 	// Workbench Actions
 	// ==============================================================================

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
@@ -20,6 +20,7 @@
 package org.eclipse.ui.internal.dialogs;
 
 import static org.eclipse.jface.viewers.LabelProvider.createTextProvider;
+import static org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter;
 import static org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants.ATT_COLOR_AND_FONT_ID;
 import static org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants.ATT_OS_VERSION;
 import static org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants.ATT_THEME_ASSOCIATION;
@@ -71,12 +72,14 @@ import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.program.Program;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferenceConstants;
 import org.eclipse.ui.IWorkbenchPreferencePage;
@@ -213,9 +216,12 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 		group.setFont(parent.getFont());
 		GridLayout layout = new GridLayout(1, false);
 		group.setLayout(layout);
-		Label infoLabel = new Label(group, SWT.WRAP);
-		infoLabel.setText(WorkbenchMessages.RescaleAtRuntimeDisclaimer);
+		Link infoLabel = new Link(group, SWT.WRAP);
+		infoLabel.setText(WorkbenchMessages.RescaleAtRuntimeDisclaimer + System.lineSeparator() + System.lineSeparator()
+				+ WorkbenchMessages.EdgeBrowserDisclaimer);
 		infoLabel.setLayoutData(GridDataFactory.defaultsFor(infoLabel).create());
+		infoLabel.addSelectionListener(widgetSelectedAdapter(c -> Program.launch(c.text)));
+
 		createLabel(group, ""); //$NON-NLS-1$
 
 		boolean initialStateRescaleAtRuntime = PrefUtil.getAPIPreferenceStore()

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
@@ -505,6 +505,8 @@ RescaleAtRuntimeSettingChangeWarningText = Restart for the DPI setting changes t
 HiDpiSettingsGroupTitle = HiDPI settings
 RescaleAtRuntimeEnabled = Monitor-specific UI &scaling
 RescaleAtRuntimeDisclaimer = EXPERIMENTAL! Activating this option will dynamically scale all windows according to the monitor they are currently in. It will also set the default browser to Edge in order to provide the appropriate scaling of content displayed in a browser. This feature is still in development and therefore considered experimental.
+EdgeBrowserDisclaimer = Note that the usage of Edge may currently lead to flickering when resizing a browser window (see <a href="https://github.com/eclipse-platform/eclipse.platform.swt/issues/1122">this issue</a> for more details).
+
 # --- Workbench -----
 WorkbenchPreference_openMode=Open mode
 WorkbenchPreference_doubleClick=D&ouble click


### PR DESCRIPTION
### [**Windows only!**]

Since the flickering issue (https://github.com/eclipse-platform/eclipse.platform.swt/issues/1122) is still open and activating this option also sets **Edge** as the browser of choice, the user should be warned.

This is the new warning:

![image](https://github.com/user-attachments/assets/d1591bf4-cc94-44ff-a360-bf303fda3177)
