### PR TITLE
Expanding trees below now possible on linux

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.35.100.qualifier
+Bundle-Version: 3.35.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
@@ -1857,9 +1857,6 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 			}
 			createChildren(widget, false);
 			// XXX for performance widget should be expanded after expanding children:
-			if (widget instanceof Item it) {
-				setExpanded(it, true);
-			}
 			if (level == ALL_LEVELS || level > 1) {
 				Item[] children = getChildren(widget);
 				if (children != null) {
@@ -1872,7 +1869,9 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 					}
 				}
 			}
-			// XXX expanding here fails on linux
+			if (widget instanceof Item it) {
+				setExpanded(it, true);
+			}
 		}
 	}
 

--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.e4.rcp"
       label="%featureName"
-      version="4.34.0.qualifier"
+      version="4.34.100.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
This pull request is linked to [eclipse-jdt/eclipse.jdt.ui#1811](https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1811). The changes introduced in that pull request make it possible to expand trees after the for loop on Linux, which was not previously possible.

It is crucial to review both pull requests together. Do not merge this pull request before [eclipse-jdt/eclipse.jdt.ui#1811](https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1811), as doing so would prevent tree expansion from working correctly on Linux.