### PR TITLE
Bugfix for Hover which is visible above other application windows. #2534

### DIFF
--- a/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.text
-Bundle-Version: 3.26.0.qualifier
+Bundle-Version: 3.26.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/html/BrowserInformationControl.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/html/BrowserInformationControl.java
@@ -332,8 +332,6 @@ public class BrowserInformationControl extends AbstractInformationControl implem
 	@Override
 	public void setVisible(boolean visible) {
 		Shell shell= getShell();
-		if (shell.isVisible() == visible)
-			return;
 
 		if (!visible) {
 			super.setVisible(false);
@@ -342,6 +340,8 @@ public class BrowserInformationControl extends AbstractInformationControl implem
 			return;
 		}
 
+		if (shell.isVisible() == visible)
+			return;
 		/*
 		 * The Browser widget flickers when made visible while it is not completely loaded.
 		 * The fix is to delay the call to setVisible until either loading is completed

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/AbstractInformationControl.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/AbstractInformationControl.java
@@ -505,7 +505,7 @@ public abstract class AbstractInformationControl implements IInformationControl,
 
 	@Override
 	public void setVisible(boolean visible) {
-		if (fShell.isVisible() == visible)
+		if (visible && fShell.isVisible() == visible)
 			return;
 
 		fShell.setVisible(visible);


### PR DESCRIPTION
This patch is fixing the problem, where the HoverManagers listeners are deregistered but the hover is still visibile on top. This happens when the hover was sticky and after that eclipse was minimized and put back on foreground after it. In that case the listeners are already deregistered and there is no chance to react at all. So for this case the visibility has to be set explicitly when the close is going to stop.