### PR TITLE
Updated bundles with comparator errors

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.css.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.css.swt;singleton:=true
-Bundle-Version: 0.15.400.qualifier
+Bundle-Version: 0.15.500.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.css.swt/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.e4.ui.css.swt/forceQualifierUpdate.txt
@@ -5,3 +5,4 @@ Bug 514690 - Build failure on I20170403-2000 and I20170404-0245
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/bundles/org.eclipse.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.text
-Bundle-Version: 3.14.200.qualifier
+Bundle-Version: 3.14.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.text/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.text/forceQualifierUpdate.txt
@@ -5,3 +5,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/11
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/bundles/org.eclipse.ui.workbench.texteditor/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench.texteditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench.texteditor; singleton:=true
-Bundle-Version: 3.19.0.qualifier
+Bundle-Version: 3.19.100.qualifier
 Bundle-Activator: org.eclipse.ui.internal.texteditor.TextEditorPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.workbench.texteditor/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.workbench.texteditor/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/11
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.134.0.qualifier
+Bundle-Version: 3.134.100.qualifier
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.workbench/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.ui.workbench/forceQualifierUpdate.txt
@@ -16,3 +16,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/11
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1750
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse UI Tests
 Bundle-SymbolicName: org.eclipse.ui.tests; singleton:=true
-Bundle-Version: 3.15.1800.qualifier
+Bundle-Version: 3.15.1900.qualifier
 Eclipse-BundleShape: dir
 Bundle-Activator: org.eclipse.ui.tests.TestPlugin
 Bundle-Vendor: Eclipse.org

--- a/tests/org.eclipse.ui.tests/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ui.tests/forceQualifierUpdate.txt
@@ -14,3 +14,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/16
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595


### PR DESCRIPTION
Changes to ecj are for handling of switch on String.

See: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595