### PR TITLE
[Dark Theme] Visual refresh for eclipse

### DIFF
--- a/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.themes;singleton:=true
-Bundle-Version: 1.2.2600.qualifier
+Bundle-Version: 1.2.2700.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.e4.ui.css.swt.theme

--- a/bundles/org.eclipse.ui.themes/css/dark/e4-dark_ide_colorextensions.css
+++ b/bundles/org.eclipse.ui.themes/css/dark/e4-dark_ide_colorextensions.css
@@ -50,7 +50,8 @@ ThemesExtension { color-definition:
 }
 
 ColorDefinition#org-eclipse-ui-workbench-DARK_BACKGROUND {
-	color: #515658;
+	/* color: #515658; */
+	color: #48484c;
 	category: '#org-eclipse-ui-presentation-default';
 	label: url('platform:/plugin/org.eclipse.ui.themes?message=DARK_BACKGROUND');
 }
@@ -122,31 +123,31 @@ ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_SELECTED_TEXT_COLOR {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_UNSELECTED_TABS_COLOR_START {
-	color: #494A4D;
+	color: #49484C;
 	category: '#org-eclipse-ui-presentation-default';
 	label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_UNSELECTED_TABS_COLOR_START');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_UNSELECTED_TABS_COLOR_END {
-	color: #404043;
+	color: #48484C;
 	category: '#org-eclipse-ui-presentation-default';
 	label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_UNSELECTED_TABS_COLOR_END');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_BG_START {
-    color: #2B2C2D;
+    color: #48484C;
     category: '#org-eclipse-ui-presentation-default';
     label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_TAB_BG_START');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_BG_END {
-    color: #292929;
+    color: #48484C;
     category: '#org-eclipse-ui-presentation-default';
     label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_TAB_BG_END');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_OUTER_KEYLINE_COLOR {
-	color: #4B4C4F;
+	color: #646464;
 	category: '#org-eclipse-ui-presentation-default';
 	label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_TAB_OUTER_KEYLINE_COLOR');
 }
@@ -158,25 +159,25 @@ ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_INNER_KEYLINE_COLOR {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_OUTLINE_COLOR {
-	color: #4B4C4F;
+	color:#646464;
 	category: '#org-eclipse-ui-presentation-default';
 	label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_TAB_OUTLINE_COLOR');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_TEXT_COLOR {
-    color: #DDDDDD;
+    color: #BBBBBB;
     category: '#org-eclipse-ui-presentation-default';
     label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_TAB_TEXT_COLOR');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_UNSELECTED_TEXT_COLOR {
-    color: #DDDDDD;
+    color: #BBBBBB;
     category: '#org-eclipse-ui-presentation-default';
     label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_TAB_UNSELECTED_TEXT_COLOR');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_SELECTED_TEXT_COLOR {
-    color: #f7f8f8;
+    color: #FFFFFF;
     category: '#org-eclipse-ui-presentation-default';
     label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_TAB_SELECTED_TEXT_COLOR');
 }
@@ -194,13 +195,13 @@ ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_BG_END {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_TEXT_COLOR {
-    color: #CCCCCC;
+    color: #FFFFFF;
     category: '#org-eclipse-ui-presentation-default';
     label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_NOFOCUS_TAB_TEXT_COLOR');
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_SELECTED_TEXT_COLOR {
-    color: #CCCCCC;
+    color: #FFFFFF;
     category: '#org-eclipse-ui-presentation-default';
     label: url('platform:/plugin/org.eclipse.ui.themes?message=ACTIVE_NOFOCUS_TAB_SELECTED_TEXT_COLOR');
 }

--- a/bundles/org.eclipse.ui.themes/css/dark/e4-dark_preferencestyle.css
+++ b/bundles/org.eclipse.ui.themes/css/dark/e4-dark_preferencestyle.css
@@ -22,7 +22,7 @@ IEclipsePreferences#org-eclipse-ui-editors:org-eclipse-ui-themes { /* pseudo att
 		'AbstractTextEditor.Color.Background.SystemDefault=false'
 		'AbstractTextEditor.Color.SelectionForeground.SystemDefault=false'
 		'AbstractTextEditor.Color.SelectionBackground.SystemDefault=false'
-		'AbstractTextEditor.Color.Background=47,47,47'
+		'AbstractTextEditor.Color.Background=30,31,34'
 		'AbstractTextEditor.Color.Foreground.SystemDefault=false'
 		'AbstractTextEditor.Color.SelectionBackground=33,66,131'
 		'AbstractTextEditor.Color.SelectionForeground=147,161,161'

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_linux.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_linux.css
@@ -45,3 +45,51 @@ ImageBasedFrame,
 #org-eclipse-ui-ProgressBar Canvas {
 	color:'#org-eclipse-ui-workbench-DARK_FOREGROUND'; 
 }
+
+/* Inactive view tabs  */
+.MPartStack{
+	swt-selected-tab-highlight: #a6a6a6;
+    swt-selected-highlight-top: false;
+    swt-draw-custom-tab-content-background: true;
+	swt-unselected-hot-tab-color-background: #161616;
+}
+
+.MPartStack.active {
+    swt-selected-tab-highlight: #2b79d7;
+    swt-selected-highlight-top: false;
+}
+
+/*text color of selected tab in editor */
+#org-eclipse-ui-editorss CTabItem:selected{
+	color: '#FFFFFF';
+}
+
+#org-eclipse-ui-editorss CTabFolder{
+ 	swt-selected-tab-fill : '#1E1F22';
+swt-selected-tab-highlight: '#a6a6a6';
+    swt-selected-highlight-top: true;
+    swt-draw-custom-tab-content-background: true;
+	swt-unselected-hot-tab-color-background:#161616;		
+}
+
+#org-eclipse-ui-editorss CTabFolder.active {
+    swt-selected-tab-highlight: '#2b79d7';
+    swt-selected-highlight-top: true;
+}
+
+CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
+    /* Set the styles for the bottom inner tabs (Bug 430051): */
+    swt-tab-renderer: url('bundleclass://org.eclipse.e4.ui.workbench.renderers.swt/org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering');
+    swt-selected-tab-fill: #1E1F22;
+    swt-unselected-tabs-color: #48484c;
+    swt-unselected-hot-tab-color-background: #2f2f2f;
+    swt-selected-tab-highlight: #2b79d7;
+    swt-selected-highlight-top: false;
+}
+
+.MPart Form Composite,
+.MPart Form Composite Tree,
+.MPartStack.active .MPart Form Composite Tree
+{
+	background-color: #1E1F22;
+}

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
@@ -53,3 +53,51 @@ Button  {
 	color: unset;
 }
 
+/* Inactive view tabs  */
+.MPartStack{
+	swt-selected-tab-highlight: #a6a6a6;
+    swt-selected-highlight-top: false;
+    swt-draw-custom-tab-content-background: true;
+	swt-unselected-hot-tab-color-background: #161616;
+}
+
+.MPartStack.active {
+    swt-selected-tab-highlight: #2b79d7;
+    swt-selected-highlight-top: false;
+}
+
+/*text color of selected tab in editor */
+#org-eclipse-ui-editorss CTabItem:selected{
+	color: '#FFFFFF';
+}
+
+#org-eclipse-ui-editorss CTabFolder{
+ 	swt-selected-tab-fill : '#1E1F22';
+	swt-selected-tab-highlight: '#a6a6a6';
+    swt-selected-highlight-top: true;
+    swt-draw-custom-tab-content-background: true;
+	swt-unselected-hot-tab-color-background:#161616;	
+}
+
+#org-eclipse-ui-editorss CTabFolder.active {
+    swt-selected-tab-highlight: '#2b79d7';
+    swt-selected-highlight-top: true;
+}
+
+CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
+    /* Set the styles for the bottom inner tabs (Bug 430051): */
+    swt-tab-renderer: url('bundleclass://org.eclipse.e4.ui.workbench.renderers.swt/org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering');
+    swt-selected-tab-fill: #1E1F22;
+    swt-unselected-tabs-color: #48484c;
+    swt-unselected-hot-tab-color-background: #2f2f2f;
+    swt-selected-tab-highlight: #2b79d7;
+    swt-selected-highlight-top: false;
+}
+
+.MPart Form Composite,
+.MPart Form Composite Tree,
+.MPartStack.active .MPart Form Composite Tree
+{
+	background-color: #1E1F22;
+}
+

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
@@ -135,3 +135,50 @@ ImageBasedFrame,
 	color: #DDDDDD;
 }
 
+/* Inactive view tabs  */
+.MPartStack{
+	swt-selected-tab-highlight: #a6a6a6;
+    swt-selected-highlight-top: false;
+    swt-draw-custom-tab-content-background: true;
+	swt-unselected-hot-tab-color-background: #161616;
+}
+
+.MPartStack.active {
+    swt-selected-tab-highlight: #2b79d7;
+    swt-selected-highlight-top: false;
+}
+
+/*text color of selected tab in editor */
+#org-eclipse-ui-editorss CTabItem:selected{
+	color: '#FFFFFF';
+}
+
+#org-eclipse-ui-editorss CTabFolder{
+ 	swt-selected-tab-fill : '#1E1F22';
+	swt-selected-tab-highlight: '#a6a6a6';
+    swt-selected-highlight-top: true;
+    swt-draw-custom-tab-content-background: true;
+	swt-unselected-hot-tab-color-background:#161616;	
+}
+
+#org-eclipse-ui-editorss CTabFolder.active {
+    swt-selected-tab-highlight: '#2b79d7';
+    swt-selected-highlight-top: true;
+}
+
+CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
+    /* Set the styles for the bottom inner tabs (Bug 430051): */
+    swt-tab-renderer: url('bundleclass://org.eclipse.e4.ui.workbench.renderers.swt/org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering');
+    swt-selected-tab-fill: #1E1F22;
+    swt-unselected-tabs-color: #48484c;
+    swt-unselected-hot-tab-color-background: #2f2f2f;
+    swt-selected-tab-highlight: #2b79d7;
+    swt-selected-highlight-top: false;
+}
+
+.MPart Form Composite,
+.MPart Form Composite Tree,
+.MPartStack.active .MPart Form Composite Tree
+{
+	background-color: #1E1F22;
+}


### PR DESCRIPTION
This change includes improvement to the existing dark theme. This has been adopted in all three platform Win, Mac and Linux.
Refer issue: https://github.com/eclipse-platform/eclipse.platform.ui/issues/2114

Changes include:
- Background color of editor
- Highlight(underline) of selected tabs in active and inactive parts
- Outline for selected tabs
- Background color of selected and unselected tabs
- Background color of Toolbar

Before:
![image](https://github.com/user-attachments/assets/f687f223-dc53-46c1-a7d2-bfa3b5f9389f)


After:
![image](https://github.com/user-attachments/assets/597e203f-9705-4269-b9b8-3c5d9a78f8f4)

