### PR TITLE
CSS: Allow Color And Font Definitions To Be Marked As Not Editable

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt/plugin.xml
+++ b/bundles/org.eclipse.e4.ui.css.swt/plugin.xml
@@ -494,6 +494,7 @@
        	 <property-name name="category"/>
          <property-name name="label"/>       
          <property-name name="description"/>
+         <property-name name="editable"/>
       </handler>
       <handler
             adapter="org.eclipse.e4.ui.css.swt.dom.definition.FontDefinitionElement"

--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/properties/definition/CSSPropertyThemeElementDefinitionHandler.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/properties/definition/CSSPropertyThemeElementDefinitionHandler.java
@@ -42,6 +42,8 @@ public class CSSPropertyThemeElementDefinitionHandler implements ICSSPropertyHan
 
 	private static final String MESSAGE_QUERY_PARAM = "message";
 
+	private static final String EDITABLE_PROP = "editable";
+
 	private Map<Long, ResourceBundle> bundleToResourceBundles = new WeakHashMap<>();
 
 	@Override
@@ -64,6 +66,10 @@ public class CSSPropertyThemeElementDefinitionHandler implements ICSSPropertyHan
 			break;
 		case DESCRIPTION_PROP:
 			definition.setDescription(getLabel(value));
+			break;
+		case EDITABLE_PROP:
+			Boolean editable = (Boolean) engine.convert(value, Boolean.class, null);
+			definition.setEditable(editable);
 			break;
 		default:
 			return false;

--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/internal/css/swt/definition/IThemeElementDefinitionOverridable.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/internal/css/swt/definition/IThemeElementDefinitionOverridable.java
@@ -27,4 +27,6 @@ public interface IThemeElementDefinitionOverridable<T> {
 	void setName(String name);
 
 	void setDescription(String description);
+
+	void setEditable(Boolean editable);
 }

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/themes/ColorDefinition.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/themes/ColorDefinition.java
@@ -155,4 +155,10 @@ public class ColorDefinition extends ThemeElementDefinition implements IPluginCo
 			appendState(State.OVERRIDDEN);
 		}
 	}
+
+	@Override
+	public void setEditable(Boolean editable) {
+		isEditable = editable;
+	}
+
 }

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/themes/FontDefinition.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/themes/FontDefinition.java
@@ -138,4 +138,10 @@ public class FontDefinition extends ThemeElementDefinition implements IHierarcha
 			appendState(State.OVERRIDDEN);
 		}
 	}
+
+	@Override
+	public void setEditable(Boolean editable) {
+		isEditable = editable;
+	}
+
 }


### PR DESCRIPTION
Color and Fonts can be defined as not editable if done via the extensions point. Provide the same possibility if they are defined via CSS.

Needed for #2455 