### PR TITLE
ToolItemUpdater: fix possible Integer overflow

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.renderers.swt;singleton:=true
-Bundle-Version: 0.16.600.qualifier
+Bundle-Version: 0.16.700.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/ToolItemUpdater.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/ToolItemUpdater.java
@@ -55,7 +55,7 @@ public class ToolItemUpdater implements Runnable {
 					if (timestampOfEarliestQueuedUpdate == 0) {
 						timestampOfEarliestQueuedUpdate = System.nanoTime();
 					}
-					if (System.nanoTime() - timestampOfEarliestQueuedUpdate > DELAY * 1_000_000) {
+					if (System.nanoTime() - timestampOfEarliestQueuedUpdate > DELAY * 1_000_000L) {
 						// runnable was not called within the last DELAY milliseconds, do it now.
 						// For scenario: a plugin is forcing that updateContributionItems is called
 						// again and again in less than given DELAY frequency. TimerExec would then


### PR DESCRIPTION
Both DELAY and 1_000_000 are Integers. Multiplied they could exceed max integer. Currently the DELAY is small enough to not overflow, but changing the constant would silently overflow.