### PR TITLE
Use SubMonintor in CheckConditionsContext

### DIFF
--- a/bundles/org.eclipse.ltk.core.refactoring/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ltk.core.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.ltk.core.refactoring
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ltk.core.refactoring; singleton:=true
-Bundle-Version: 3.15.100.qualifier
+Bundle-Version: 3.15.200.qualifier
 Bundle-Activator: org.eclipse.ltk.internal.core.refactoring.RefactoringCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/participants/CheckConditionsContext.java
+++ b/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/participants/CheckConditionsContext.java
@@ -22,8 +22,6 @@ import java.util.Map;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 
@@ -102,9 +100,7 @@ public class CheckConditionsContext {
 	 * @throws CoreException if an error occurs during condition checking
 	 */
 	public RefactoringStatus check(IProgressMonitor pm) throws CoreException {
-		if (pm == null) {
-			pm= new NullProgressMonitor();
-		}
+
 		RefactoringStatus result= new RefactoringStatus();
 		mergeResourceOperationAndValidateEdit();
 		List<IConditionChecker> values= new ArrayList<>(fCheckers.values());
@@ -120,14 +116,11 @@ public class CheckConditionsContext {
 			}
 			return 0;
 		});
+
 		SubMonitor sm= SubMonitor.convert(pm, "", values.size()); //$NON-NLS-1$
 		for (IConditionChecker checker : values) {
 			result.merge(checker.check(sm.split(1)));
-			if (pm.isCanceled()) {
-				throw new OperationCanceledException();
-			}
 		}
-		pm.done();
 		return result;
 	}
 


### PR DESCRIPTION
done() call not necessary here and convert can also handle null.  Also split will also check for cancellation so the additional cancellation check is not necessary.

See https://www.eclipse.org/articles/Article-Progress-Monitors/article.html