### PR TITLE
Use SubMonintor in FileBufferOperationAction

### DIFF
--- a/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.editors; singleton:=true
-Bundle-Version: 3.19.0.qualifier
+Bundle-Version: 3.19.100.qualifier
 Bundle-Activator: org.eclipse.ui.internal.editors.text.EditorsPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/editors/text/FileBufferOperationAction.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/editors/text/FileBufferOperationAction.java
@@ -198,20 +198,15 @@ public class FileBufferOperationAction extends Action implements IWorkbenchWindo
 	}
 
 	protected final IPath[] generateLocations(IFile[] files, IProgressMonitor progressMonitor) {
-		progressMonitor.beginTask(TextEditorMessages.FileBufferOperationAction_collectionFiles_label, files.length);
-		try {
-			Set<IPath> locations= new HashSet<>();
-			for (IFile file : files) {
-				IPath fullPath = file.getFullPath();
-				if (isAcceptableLocation(fullPath))
-					locations.add(fullPath);
-				progressMonitor.worked(1);
-			}
-			return locations.toArray(new IPath[locations.size()]);
-
-		} finally {
-			progressMonitor.done();
+		SubMonitor subMonitor= SubMonitor.convert(progressMonitor, TextEditorMessages.FileBufferOperationAction_collectionFiles_label, files.length);
+		Set<IPath> locations= new HashSet<>();
+		for (IFile file : files) {
+			IPath fullPath= file.getFullPath();
+			if (isAcceptableLocation(fullPath))
+				locations.add(fullPath);
+			subMonitor.worked(1);
 		}
+		return locations.toArray(new IPath[locations.size()]);
 	}
 
 	/**


### PR DESCRIPTION
done() call not necessary here and convert can also show the label and set the number of work unit.

See https://www.eclipse.org/articles/Article-Progress-Monitors/article.html