### PR TITLE
Remove done() call on SubMonitor in Refactoring

### DIFF
--- a/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/Refactoring.java
+++ b/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/Refactoring.java
@@ -162,7 +162,6 @@ public abstract class Refactoring extends PlatformObject {
 		if (!result.hasFatalError()) {
 			result.merge(checkFinalConditions(subMon.split(refactoringTickProvider.getCheckFinalConditionsTicks())));
 		}
-		subMon.done();
 		return result;
 	}
 


### PR DESCRIPTION
done() call not necessary here

See https://www.eclipse.org/articles/Article-Progress-Monitors/article.html