### PR TITLE
Restore ability to filter views by category

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.swt;singleton:=true
-Bundle-Version: 0.17.600.qualifier
+Bundle-Version: 0.17.700.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/workbench/swt/internal/copy/ViewPatternFilter.java
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/workbench/swt/internal/copy/ViewPatternFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2019 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.workbench.swt.internal.copy;
 
+import java.util.stream.Stream;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.dialogs.filteredtree.PatternFilter;
 import org.eclipse.e4.ui.model.LocalizationHelper;
@@ -42,20 +43,8 @@ public class ViewPatternFilter extends PatternFilter {
 
 	@Override
 	protected boolean isLeafMatch(Viewer viewer, Object element) {
-		if (element instanceof String) {
-			return false;
-		}
-
-		String text = null;
-		if (element instanceof MPartDescriptor) {
-			MPartDescriptor desc = (MPartDescriptor) element;
-			text = LocalizationHelper.getLocalized(desc.getLabel(), desc,
-					context);
-			if (wordMatches(text)) {
-				return true;
-			}
-		}
-
-		return false;
+		return element instanceof MPartDescriptor desc && Stream.of(desc.getLabel(), desc.getCategory()) //
+				.map(text -> LocalizationHelper.getLocalized(text, desc, context)) //
+				.anyMatch(this::wordMatches);
 	}
 }

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewPatternFilter.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewPatternFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2014 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.dialogs;
 
+import java.util.stream.Stream;
 import org.eclipse.e4.ui.model.LocalizationHelper;
 import org.eclipse.e4.ui.model.application.descriptor.basic.MPartDescriptor;
 import org.eclipse.jface.viewers.Viewer;
@@ -34,19 +35,8 @@ public class ViewPatternFilter extends PatternFilter {
 
 	@Override
 	protected boolean isLeafMatch(Viewer viewer, Object element) {
-		if (element instanceof String) {
-			return false;
-		}
-
-		String text = null;
-		if (element instanceof MPartDescriptor) {
-			MPartDescriptor desc = (MPartDescriptor) element;
-			text = LocalizationHelper.getLocalized(desc.getLabel(), desc);
-			if (wordMatches(text)) {
-				return true;
-			}
-		}
-
-		return false;
+		return element instanceof MPartDescriptor desc && Stream.of(desc.getLabel(), desc.getCategory()) //
+				.map(text -> LocalizationHelper.getLocalized(text, desc)) //
+				.anyMatch(this::wordMatches);
 	}
 }


### PR DESCRIPTION
The ability to sort by categories was previously possible, but broke as part of 7275893613e8050290cac3c970e14f9889b87b73. This seems to be unintentional, given that the linked bug [1] is about exposing the FilteredTree and likely a result of streamlining the implementation.

[1] - https://bugs.eclipse.org/bugs/show_bug.cgi?id=74795

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2576
