### PR TITLE
fix InlinedAnnotationSupport#isInVisibleLines

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationSupport.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationSupport.java
@@ -163,7 +163,9 @@ public class InlinedAnnotationSupport {
 
 		@Override
 		public void documentChanged(DocumentEvent event) {
-			// Do nothing
+			if (endOffset != null && event != null && event.fDocument != null && event.fDocument.getLength() > endOffset) {
+				endOffset= null;
+			}
 		}
 
 		@Override

--- a/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.editors.tests;singleton:=true
-Bundle-Version: 3.13.600.qualifier
+Bundle-Version: 3.13.700.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface.text.tests.codemining,

--- a/tests/org.eclipse.ui.editors.tests/plugin.xml
+++ b/tests/org.eclipse.ui.editors.tests/plugin.xml
@@ -22,4 +22,14 @@
 			id="org.eclipse.jface.text.tests.codemining.CodeMiningTestProvider">
 		</codeMiningProvider>
 	</extension>
+ <extension
+       point="org.eclipse.ui.editors">
+    <editor
+          class="org.eclipse.jface.text.tests.codemining.TextProjectionTextEditor"
+          default="false"
+          extensions="testprojectionviewer"
+          id="org.eclipse.jface.text.tests.codemining.TestProjectionTextEditor"
+          name="TestProjectionTextEditor">
+    </editor>
+ </extension>
 </plugin>

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningTestProvider.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningTestProvider.java
@@ -29,7 +29,7 @@ import org.eclipse.jface.text.codemining.LineHeaderCodeMining;
 public class CodeMiningTestProvider extends AbstractCodeMiningProvider {
 	public static int provideHeaderMiningAtLine = -1;
 	public static int provideContentMiningAtOffset = -1;
-
+	public static String lineHeaderMiningText;
 	@Override
 	public CompletableFuture<List<? extends ICodeMining>> provideCodeMinings(ITextViewer viewer,
 			IProgressMonitor monitor) {
@@ -42,6 +42,9 @@ public class CodeMiningTestProvider extends AbstractCodeMiningProvider {
 				minings.add(new LineHeaderCodeMining(provideHeaderMiningAtLine, viewer.getDocument(), this) {
 					@Override
 					public String getLabel() {
+						if (lineHeaderMiningText != null) {
+							return lineHeaderMiningText;
+						}
 						return "line header mining";
 					}
 				});

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/jface/text/tests/codemining/TextProjectionTextEditor.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/jface/text/tests/codemining/TextProjectionTextEditor.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2024 SAP
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jface.text.tests.codemining;
+
+import org.eclipse.swt.widgets.Composite;
+
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.jface.text.source.IVerticalRuler;
+import org.eclipse.jface.text.source.projection.ProjectionSupport;
+import org.eclipse.jface.text.source.projection.ProjectionViewer;
+
+import org.eclipse.ui.texteditor.AbstractDecoratedTextEditor;
+
+public class TextProjectionTextEditor extends AbstractDecoratedTextEditor {
+
+	@Override
+	protected ISourceViewer createSourceViewer(Composite parent, IVerticalRuler ruler, int styles) {
+		fAnnotationAccess = getAnnotationAccess();
+		fOverviewRuler = createOverviewRuler(getSharedColors());
+		ISourceViewer viewer = new ProjectionViewer(parent, ruler, getOverviewRuler(), isOverviewRulerVisible(),
+				styles);
+		getSourceViewerDecorationSupport(viewer);
+		return viewer;
+	}
+
+	@Override
+	public void createPartControl(Composite parent) {
+		super.createPartControl(parent);
+		var projectionViewer = (ProjectionViewer) getSourceViewer();
+		var projectionSupport = new ProjectionSupport(projectionViewer, getAnnotationAccess(), getSharedColors());
+		projectionSupport.install();
+		projectionViewer.enableProjection();
+	}
+}


### PR DESCRIPTION
isInVisibleLines uses a cached endOffset variable which is not correctly invalidated when ProjectionSupport is enabled.

cached endOffset variable is only reset in callback documentAboutToBeChanged but not in documentChanged which is not sufficient.

Scenario:
1. document.replace(...) is called
2. documentAboutToBeChanged is called and endOffset is set to null
3. source viewer repaint event is triggered (between documentAboutToBeChanged and documentChanged) and code minings are drawn, isInVisibleLines is called with the old not yet updated document and endOffset is set. The repaint event is only triggered in this timeslot when ProjectionSupport is installed on the SourceViewer.
4. documentChanged called; now document is up to date but endOffset cache contains outdated value of the old document
5. code minings at end of document are no longer rendered because isInVisibleLines returns false (which is not correct)