### PR TITLE
[StickyScrolling] Use source viewer to calculate the sticky lines

### DIFF
--- a/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.editors; singleton:=true
-Bundle-Version: 3.19.0.qualifier
+Bundle-Version: 3.19.100.qualifier
 Bundle-Activator: org.eclipse.ui.internal.editors.text.EditorsPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/IStickyLinesProvider.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/IStickyLinesProvider.java
@@ -15,12 +15,10 @@ package org.eclipse.ui.internal.texteditor.stickyscroll;
 
 import java.util.List;
 
-import org.eclipse.swt.custom.StyledText;
-
 import org.eclipse.jface.text.source.ISourceViewer;
 
 /**
- * A sticky lines provider calculates the sticky lines for a given text widget. The sticky lines
+ * A sticky lines provider calculates the sticky lines for a given source viewer. The sticky lines
  * will be displayed in the top area of the editor.
  * 
  * TODO move to public package and add since 3.19
@@ -28,24 +26,24 @@ import org.eclipse.jface.text.source.ISourceViewer;
 public interface IStickyLinesProvider {
 
 	/**
-	 * Calculate the sticky lines for the source code of the given textWidget. Specific properties,
-	 * such as the <code>tabWidht</code> and the source viewer, can be retrieved from the
+	 * Calculate the sticky lines for the source code of the given sourceViewer. Specific
+	 * properties, such as the <code>tabWidht</code>, can be retrieved from the
 	 * <code>properties</code>.
 	 * 
-	 * @param textWidget The text widget containing the source code
+	 * @param sourceViewer The source viewer containing the source code and gives access to the text
+	 *            widget
 	 * @param lineNumber The line number to calculate the sticky lines for
 	 * @param properties Properties for additional information
 	 * @return The list of sticky lines to show
 	 */
-	public List<IStickyLine> getStickyLines(StyledText textWidget, int lineNumber, StickyLinesProperties properties);
+	public List<IStickyLine> getStickyLines(ISourceViewer sourceViewer, int lineNumber, StickyLinesProperties properties);
 
 	/**
 	 * Additional properties and access in order to calculate the sticky lines.
 	 * 
 	 * @param tabWith The with of a tab
-	 * @param sourceViewer The sourceViewer to access additional information
 	 */
-	record StickyLinesProperties(int tabWith, ISourceViewer sourceViewer) {
+	record StickyLinesProperties(int tabWith) {
 	}
 
 }

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -206,7 +206,7 @@ public class StickyScrollingControl {
 		for (int i= 0; i < getNumberStickyLines(); i++) {
 			IStickyLine stickyLine= stickyLines.get(i);
 			stickyLineTextJoiner.add(stickyLine.getText());
-			int lineNumber= getSourceViewerLineNumber(stickyLine.getLineNumber());
+			int lineNumber= stickyLine.getLineNumber();
 			stickyLineNumberJoiner.add(fillLineNumberWithLeadingSpaces(lineNumber + 1));
 		}
 
@@ -220,13 +220,6 @@ public class StickyScrollingControl {
 			styleStickyLines();
 			layoutStickyLines();
 		}
-	}
-
-	private int getSourceViewerLineNumber(int i) {
-		if (sourceViewer instanceof ITextViewerExtension5 extension) {
-			return extension.widgetLine2ModelLine(i);
-		}
-		return i;
 	}
 
 	private String fillLineNumberWithLeadingSpaces(int lineNumber) {
@@ -399,6 +392,8 @@ public class StickyScrollingControl {
 	 * resized/moved.<br>
 	 */
 	private void addSourceViewerListeners() {
+		StyledText textWidget= sourceViewer.getTextWidget();
+
 		if (sourceViewer instanceof ITextViewerExtension4 extension) {
 			textPresentationListener= e -> {
 				Job.create("Update sticky lines styling", (ICoreRunnable) monitor -> { //$NON-NLS-1$
@@ -411,13 +406,12 @@ public class StickyScrollingControl {
 		}
 
 		caretListener= new StickyScollingCaretListener();
-		sourceViewer.getTextWidget().addCaretListener(caretListener);
-		sourceViewer.getTextWidget().addKeyListener(caretListener);
+		textWidget.addCaretListener(caretListener);
+		textWidget.addKeyListener(caretListener);
 
 		controlListener= new ControlListener() {
 			@Override
 			public void controlResized(ControlEvent e) {
-				StyledText textWidget= sourceViewer.getTextWidget();
 				limitVisibleStickyLinesToTextWidgetHeight(textWidget);
 				layoutStickyLines();
 				if (stickyScrollingHandler != null) {
@@ -430,7 +424,7 @@ public class StickyScrollingControl {
 				layoutStickyLines();
 			}
 		};
-		sourceViewer.getTextWidget().addControlListener(controlListener);
+		textWidget.addControlListener(controlListener);
 	}
 
 	private void limitVisibleStickyLinesToTextWidgetHeight(StyledText textWidget) {

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandler.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandler.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
 
@@ -140,7 +139,7 @@ public class StickyScrollingHandler implements IViewportListener {
 
 	private StickyLinesProperties loadStickyLinesProperties(IPreferenceStore store) {
 		int tabWidth= store.getInt(EDITOR_TAB_WIDTH);
-		return new StickyLinesProperties(tabWidth, sourceViewer);
+		return new StickyLinesProperties(tabWidth);
 	}
 
 	@Override
@@ -155,11 +154,10 @@ public class StickyScrollingHandler implements IViewportListener {
 	private void calculateAndShowStickyLines() {
 		List<IStickyLine> stickyLines= Collections.emptyList();
 
-		StyledText textWidget= sourceViewer.getTextWidget();
-		int startLine= textWidget.getTopIndex();
+		int startLine= sourceViewer.getTopIndex();
 
 		if (startLine > 0) {
-			stickyLines= stickyLinesProvider.getStickyLines(textWidget, startLine, stickyLinesProperties);
+			stickyLines= stickyLinesProvider.getStickyLines(sourceViewer, sourceViewer.getTopIndex(), stickyLinesProperties);
 		}
 
 		if (stickyLines == null) {
@@ -179,11 +177,10 @@ public class StickyScrollingHandler implements IViewportListener {
 		LinkedList<IStickyLine> adaptedStickyLines= new LinkedList<>(stickyLines);
 
 		int firstVisibleLine= startLine + adaptedStickyLines.size();
-		StyledText textWidget= sourceViewer.getTextWidget();
-		int maximumLines= textWidget.getLineCount();
+		int numberOfLines= sourceViewer.getDocument().getNumberOfLines();
 
-		for (int i= startLine + 1; i <= firstVisibleLine && i < maximumLines; i++) {
-			List<IStickyLine> stickyLinesInLineI= stickyLinesProvider.getStickyLines(textWidget, i, stickyLinesProperties);
+		for (int i= startLine + 1; i <= firstVisibleLine && i < numberOfLines; i++) {
+			List<IStickyLine> stickyLinesInLineI= stickyLinesProvider.getStickyLines(sourceViewer, i, stickyLinesProperties);
 
 			if (stickyLinesInLineI.size() > adaptedStickyLines.size()) {
 				adaptedStickyLines= new LinkedList<>(stickyLinesInLineI);

--- a/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.editors.tests;singleton:=true
-Bundle-Version: 3.13.600.qualifier
+Bundle-Version: 3.13.700.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface.text.tests.codemining,

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
@@ -43,8 +43,6 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.jface.text.Document;
-import org.eclipse.jface.text.IRegion;
-import org.eclipse.jface.text.ITextViewerExtension5;
 import org.eclipse.jface.text.source.IVerticalRuler;
 import org.eclipse.jface.text.source.SourceViewer;
 
@@ -95,30 +93,6 @@ public class StickyScrollingControlTest {
 
 		StyledText stickyLineNumber = getStickyLineNumber();
 		String expLineNumber = "10" + System.lineSeparator() + "20";
-		assertEquals(expLineNumber, stickyLineNumber.getText());
-		StyledText stickyLineText = getStickyLineText();
-		String expStickyLineText = "line 10" + System.lineSeparator() + "line 20";
-		assertEquals(expStickyLineText, stickyLineText.getText());
-	}
-
-	@Test
-	public void testShowStickyLineTextsWithSourceViewerMapping() {
-		shell.dispose();
-		shell = new Shell(Display.getDefault());
-		shell.setSize(200, 200);
-		shell.setLayout(new FillLayout());
-
-		sourceViewer = new SourceViewerLineMapping(shell, ruler, SWT.V_SCROLL | SWT.H_SCROLL);
-		sourceViewer.setDocument(new Document());
-		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
-
-		stickyScrollingControl = new StickyScrollingControl(sourceViewer, ruler, settings, null);
-
-		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 10", 9), new StickyLineStub("line 20", 19));
-		stickyScrollingControl.setStickyLines(stickyLines);
-
-		StyledText stickyLineNumber = getStickyLineNumber();
-		String expLineNumber = "52" + System.lineSeparator() + "62";
 		assertEquals(expLineNumber, stickyLineNumber.getText());
 		StyledText stickyLineText = getStickyLineText();
 		String expStickyLineText = "line 10" + System.lineSeparator() + "line 20";
@@ -478,29 +452,6 @@ public class StickyScrollingControlTest {
 	private void drainDisplayEventQueue() {
 		while (Display.getDefault().readAndDispatch()) {
 		}
-	}
-
-	private class SourceViewerLineMapping extends SourceViewer implements ITextViewerExtension5 {
-
-		public SourceViewerLineMapping(Composite parent, IVerticalRuler ruler, int styles) {
-			super(parent, ruler, styles);
-		}
-
-		@Override
-		public IRegion[] getCoveredModelRanges(IRegion modelRange) {
-			return null;
-		}
-
-		@Override
-		public boolean exposeModelRange(IRegion modelRange) {
-			return false;
-		}
-
-		@Override
-		public int widgetLine2ModelLine(int widgetLine) {
-			return widgetLine + 42;
-		}
-
 	}
 
 	private class StickyLineStub implements IStickyLine {

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandlerTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandlerTest.java
@@ -87,7 +87,7 @@ public class StickyScrollingHandlerTest {
 		linesProvider = mock(IStickyLinesProvider.class);
 
 		stickyScrollingHandler = new StickyScrollingHandler(sourceViewer, ruler, store, linesProvider);
-		stickyLinesProperties = new StickyLinesProperties(4, sourceViewer);
+		stickyLinesProperties = new StickyLinesProperties(4);
 	}
 
 	@After
@@ -97,7 +97,7 @@ public class StickyScrollingHandlerTest {
 
 	@Test
 	public void testShowStickyLines() {
-		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
+		when(linesProvider.getStickyLines(sourceViewer, 1, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 10", 9)));
 
 		stickyScrollingHandler.viewportChanged(100);
@@ -134,7 +134,7 @@ public class StickyScrollingHandlerTest {
 
 	@Test
 	public void testPreferencesLoaded() {
-		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
+		when(linesProvider.getStickyLines(sourceViewer, 1, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 10", 9)));
 
 		stickyScrollingHandler.viewportChanged(100);
@@ -145,9 +145,9 @@ public class StickyScrollingHandlerTest {
 
 	@Test
 	public void testPreferencesUpdated() {
-		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
+		when(linesProvider.getStickyLines(sourceViewer, 1, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 10", 9), new StickyLineStub("line 20", 19)));
-		when(linesProvider.getStickyLines(textWidget, 2, stickyLinesProperties))
+		when(linesProvider.getStickyLines(sourceViewer, 2, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 10", 9), new StickyLineStub("line 20", 19)));
 
 		stickyScrollingHandler.viewportChanged(100);
@@ -165,13 +165,13 @@ public class StickyScrollingHandlerTest {
 
 	@Test
 	public void testThrottledExecution() throws InterruptedException {
-		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
+		when(linesProvider.getStickyLines(sourceViewer, 1, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 10", 9)));
-		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
+		when(linesProvider.getStickyLines(sourceViewer, 1, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 10", 9)));
-		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
+		when(linesProvider.getStickyLines(sourceViewer, 1, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 10", 9)));
-		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
+		when(linesProvider.getStickyLines(sourceViewer, 1, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 10", 9)));
 
 		stickyScrollingHandler.viewportChanged(100);
@@ -186,15 +186,15 @@ public class StickyScrollingHandlerTest {
 
 		// Call to lines provider should be throttled, at least one and at most
 		// 3 calls expected
-		verify(linesProvider, atMost(3)).getStickyLines(textWidget, 1, stickyLinesProperties);
-		verify(linesProvider, atLeastOnce()).getStickyLines(textWidget, 1, stickyLinesProperties);
+		verify(linesProvider, atMost(3)).getStickyLines(sourceViewer, 1, stickyLinesProperties);
+		verify(linesProvider, atLeastOnce()).getStickyLines(sourceViewer, 1, stickyLinesProperties);
 	}
 
 	@Test
 	public void testRemoveStickyLines() {
-		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
+		when(linesProvider.getStickyLines(sourceViewer, 1, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 1", 0), new StickyLineStub("line 2", 1)));
-		when(linesProvider.getStickyLines(textWidget, 2, stickyLinesProperties))
+		when(linesProvider.getStickyLines(sourceViewer, 2, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 3", 2)));
 
 		stickyScrollingHandler.viewportChanged(100);
@@ -206,9 +206,9 @@ public class StickyScrollingHandlerTest {
 
 	@Test
 	public void testLineUnderStickyLine() {
-		when(linesProvider.getStickyLines(textWidget, 1, stickyLinesProperties))
+		when(linesProvider.getStickyLines(sourceViewer, 1, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 1", 0)));
-		when(linesProvider.getStickyLines(textWidget, 2, stickyLinesProperties))
+		when(linesProvider.getStickyLines(sourceViewer, 2, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 1", 0), new StickyLineStub("line 2", 1)));
 
 		stickyScrollingHandler.viewportChanged(100);


### PR DESCRIPTION
Use the source viewer instead of the text widget to calculate the sticky lines. The source viewer is the standard instance for source code operations in JDT and other editors.

Preparation for #2398