### PR TITLE
Revert "Use SubMonintor in TextChange"

### DIFF
--- a/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/TextChange.java
+++ b/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/TextChange.java
@@ -247,6 +247,7 @@ public abstract class TextChange extends TextEditBasedChange {
 			throw Changes.asCoreException(e);
 		} finally {
 			releaseDocument(document, subMon.newChild(1));
+			subMon.done();
 		}
 	}
 
@@ -310,6 +311,7 @@ public abstract class TextChange extends TextEditBasedChange {
 		} finally {
 			releaseDocument(result, subMon.newChild(1));
 		}
+		subMon.done();
 		return result;
 	}
 


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.ui#2573

see https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1833