### PR TITLE
Remove special flattening-behavior for Wizard content providers

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/WizardContentProvider.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/WizardContentProvider.java
@@ -46,11 +46,6 @@ public class WizardContentProvider implements ITreeContentProvider {
 				handleChild(childWizard, list);
 			}
 
-			// flatten lists with only one category
-			if (list.size() == 1 && list.get(0) instanceof WizardCollectionElement) {
-				return getChildren(list.get(0));
-			}
-
 			return list.toArray();
 		} else if (parentElement instanceof AdaptableList) {
 			AdaptableList aList = (AdaptableList) parentElement;
@@ -58,10 +53,6 @@ public class WizardContentProvider implements ITreeContentProvider {
 			ArrayList list = new ArrayList(children.length);
 			for (Object element : children) {
 				handleChild(element, list);
-			}
-			// if there is only one category, return it's children directly (flatten list)
-			if (list.size() == 1 && list.get(0) instanceof WizardCollectionElement) {
-				return getChildren(list.get(0));
 			}
 
 			return list.toArray();


### PR DESCRIPTION
This removes the feature from the "New" and "Import/Export" wizards, where container for wizard elements would be flattened, if it only contains a single, other container.

There are two reasons for this change:
- it is not consistent with the other viewers, that always show the complete tree path (e.g. the preference dialog).
- it doesn't work properly, as it is still possible to produce the undesirable behavior in the "New" wizard (for e.g. Java/JUnit/...)

See https://github.com/eclipse-platform/eclipse.platform.ui/pull/2602 for context.