### PR TITLE
[Dark Theme]Fix for inconsistent Git Staging view bg colors

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4-dark_linux.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_linux.css
@@ -108,9 +108,9 @@ CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
     swt-selected-highlight-top: false;
 }
 
-.MPart Form Composite,
-.MPart Form Composite Tree,
-.MPartStack.active .MPart Form Composite Tree
+.Editor Form Composite,
+.Editor Form Composite Tree,
+.MPartStack.active .Editor Form Composite Tree
 {
 	background-color: #1E1F22;
 }

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
@@ -94,9 +94,9 @@ CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
     swt-selected-highlight-top: false;
 }
 
-.MPart Form Composite,
-.MPart Form Composite Tree,
-.MPartStack.active .MPart Form Composite Tree
+.Editor Form Composite,
+.Editor Form Composite Tree,
+.MPartStack.active .Editor Form Composite Tree
 {
 	background-color: #1E1F22;
 }

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
@@ -176,9 +176,9 @@ CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
     swt-selected-highlight-top: false;
 }
 
-.MPart Form Composite,
-.MPart Form Composite Tree,
-.MPartStack.active .MPart Form Composite Tree
+.Editor Form Composite,
+.Editor Form Composite Tree,
+.MPartStack.active .Editor Form Composite Tree
 {
 	background-color: #1E1F22;
 }


### PR DESCRIPTION
After improving the existing dark theme #2548, the Git staging view had side effects regarding the background colors of the whole view and also the Unstaged Changes and Staged Changes section. This has been fixed with this change by applying those dark background changes only to the editor. This also fixes the bg color of tool items.

Before:
![image](https://github.com/user-attachments/assets/b6d95d32-c771-4a4d-92db-a66b30dfefb4)

After:
![image](https://github.com/user-attachments/assets/71a875c0-33fa-4b82-a8fb-c08c988f200e)
