### PR TITLE
String intern org.eclipse.e4.ui.css.swt.dom.WidgetElement.swtStyles

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/SWTStyleHelpers.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/SWTStyleHelpers.java
@@ -756,7 +756,7 @@ public class SWTStyleHelpers {
 			}
 		} catch (Exception e) {
 		}
-		return swtStyles.length() == 0 ? "" : swtStyles.toString();
+		return swtStyles.length() == 0 ? "" : swtStyles.toString().intern();
 	}
 
 	/**


### PR DESCRIPTION
To avoid needless duplicate strings in heap (only few styles are actually used).
![image](https://github.com/user-attachments/assets/79b3824a-a6d0-4a56-8031-17fdc57e0b1a)
