### PR TITLE
ImportExistingArchiveProjectFilterTest: skip jdt #2432

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingArchiveProjectFilterTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingArchiveProjectFilterTest.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -154,7 +155,7 @@ public class ImportExistingArchiveProjectFilterTest extends UITestCase {
 		if (element instanceof IFolder) {
 			IFolder folder = (IFolder) element;
 			assertFalse(folder.getName().equalsIgnoreCase("res"));
-		} else {
+		} else if (element instanceof IResource) { // to expensive to walk other contributions like whole JRE from JDT
 			Object[] children = contentProvider.getChildren(element);
 			for (Object child : children) {
 				processElementAndChildren(child, contentProvider);


### PR DESCRIPTION
When running locally and jdt plugins are available the test walked the whole contributed JDT items in the project explorer, which took much time and Heap memory

https://github.com/eclipse-platform/eclipse.platform.ui/issues/2432