### PR TITLE
Follow-Up Feature: Icon-Enablement with Rasterization of SVGs

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/URLImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/URLImageDescriptor.java
@@ -139,6 +139,9 @@ class URLImageDescriptor extends ImageDescriptor implements IAdaptable {
 	private static ImageData getImageData(String url, int zoom) {
 		URL tempURL = getURL(url);
 		if (tempURL != null) {
+//			if (tempURL.toString().endsWith(".svg")) { //$NON-NLS-1$
+//				return getImageData(tempURL, zoom);
+//			}
 			if (zoom == 100) {
 				return getImageData(tempURL);
 			}
@@ -176,6 +179,23 @@ class URLImageDescriptor extends ImageDescriptor implements IAdaptable {
 		}
 		return result;
 	}
+
+//	private static ImageData getImageData(URL url, int zoom) {
+//		ImageData result = null;
+//		try (InputStream in = getStream(url)) {
+//			if (in != null) {
+//				result = new ImageData(in, zoom);
+//			}
+//		} catch (SWTException e) {
+//			if (e.code != SWT.ERROR_INVALID_IMAGE) {
+//				throw e;
+//				// fall through otherwise
+//			}
+//		} catch (IOException e) {
+//			Policy.getLog().log(new Status(IStatus.ERROR, Policy.JFACE, e.getLocalizedMessage(), e));
+//		}
+//		return result;
+//	}
 
 	/**
 	 * Returns a stream on the image contents. Returns null if a stream could

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/URLImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/URLImageDescriptor.java
@@ -95,7 +95,23 @@ class URLImageDescriptor extends ImageDescriptor implements IAdaptable {
 		public ImageData getImageData(int zoom) {
 			return URLImageDescriptor.getImageData(url, zoom);
 		}
+//
+//		@Override
+//		public ImageData getCustomizedImageData(int zoom, int flag) {
+//			return URLImageDescriptor.getCustomizedImageData(url, zoom, flag);
+//		}
 
+//		@Override
+//		public boolean supportsRasterizationFlag(int flag) {
+//			boolean supportsFlag = flag == SWT.IMAGE_DISABLE || flag == SWT.IMAGE_GRAY || flag == SWT.IMAGE_COPY;
+//			URL tempURL = getURL(url);
+//			if (tempURL != null) {
+//				if (tempURL.toString().endsWith(".svg") && supportsFlag) { //$NON-NLS-1$
+//					return true;
+//				}
+//			}
+//			return false;
+//		}
 	}
 
 	private static long cumulativeTime;
@@ -180,11 +196,11 @@ class URLImageDescriptor extends ImageDescriptor implements IAdaptable {
 		return result;
 	}
 
-//	private static ImageData getImageData(URL url, int zoom) {
+//	private static ImageData getImageData(URL url, int zoom, int flag) {
 //		ImageData result = null;
 //		try (InputStream in = getStream(url)) {
 //			if (in != null) {
-//				result = new ImageData(in, zoom);
+//				result = new ImageData(in, zoom, flag);
 //			}
 //		} catch (SWTException e) {
 //			if (e.code != SWT.ERROR_INVALID_IMAGE) {
@@ -195,6 +211,11 @@ class URLImageDescriptor extends ImageDescriptor implements IAdaptable {
 //			Policy.getLog().log(new Status(IStatus.ERROR, Policy.JFACE, e.getLocalizedMessage(), e));
 //		}
 //		return result;
+//	}
+//
+//	private static ImageData getCustomizedImageData(String url, int zoom, int flag) {
+//		URL tempURL = getURL(url);
+//		return getImageData(tempURL, zoom, flag);
 //	}
 
 	/**

--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -295,6 +295,10 @@
          version="0.0.0"/>
 
    <plugin
+         id="org.eclipse.swt.svg"
+         version="0.0.0"/>
+
+   <plugin
          id="org.eclipse.jface"
          version="0.0.0"/>
 


### PR DESCRIPTION
Please see this [Draft](https://github.com/eclipse-platform/eclipse.platform.swt/pull/1647) for a detailed description.

The new functionality of this draft can be found in the commit 05e7d58e54589408278712f47c4b1711689c4164. The other commit is the functionality from the [PR](https://github.com/eclipse-platform/eclipse.platform.ui/pull/2593) that this draft is based on.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1438.