### PR TITLE
Add eclipse.appName System Property for setting the Display's AppName

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
@@ -747,9 +747,8 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 	 * @return the display
 	 */
 	public static Display createDisplay() {
-		// setup the application name used by SWT to lookup resources on some
-		// platforms
-		String applicationName = WorkbenchPlugin.getDefault().getAppName();
+		// setup the application name used by SWT to lookup resources on some platforms
+		String applicationName = System.getProperty("eclipse.appName", WorkbenchPlugin.getDefault().getAppName()); //$NON-NLS-1$
 		if (applicationName != null) {
 			Display.setAppName(applicationName);
 		}


### PR DESCRIPTION
The eclipse.appName sytem property allows users to specify on the command line the appName to be used for a specific Eclipse instance. The appName Display property is used by window managers and desktop environments for identification and grouping. This is helpful to distinguish Eclipse instances (e.g., JDT vs CDT) as per default these all are using the same identifier.

https://github.com/eclipse-packaging/packages/issues/253