### PR TITLE
fix calculation of multiline heigth on windows with consolas size 9

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineHeaderAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineHeaderAnnotation.java
@@ -77,24 +77,61 @@ public class CodeMiningLineHeaderAnnotation extends LineHeaderAnnotation impleme
 
 	@Override
 	public int getHeight() {
-		return hasAtLeastOneResolvedMiningNotEmpty() ? getMultilineHeight() : 0;
+		return hasAtLeastOneResolvedMiningNotEmpty() ? getMultilineHeight(null) : 0;
 	}
 
-	private int getMultilineHeight() {
+	public int getHeight(GC gc) {
+		return hasAtLeastOneResolvedMiningNotEmpty() ? getMultilineHeight(gc) : 0;
+	}
+
+	private int getMultilineHeight(GC gc) {
 		int numLinesOfAllMinings= 0;
-		for (ICodeMining mining : fMinings) {
+		StyledText styledText= super.getTextWidget();
+		boolean ignoreFirstLine= false;
+		int sumLineHeight= 0;
+		for (int i= 0; i < fMinings.size(); i++) {
+			ICodeMining mining= fMinings.get(i);
 			String label= mining.getLabel();
 			if (label == null) {
 				continue;
 			}
-			int numLines= label.split("\\r?\\n|\\r").length; //$NON-NLS-1$
-			if (numLines > 1) {
-				numLinesOfAllMinings= numLines - 1;
+			String[] splitted= label.split("\\r?\\n|\\r"); //$NON-NLS-1$
+			int numLines= splitted.length;
+			if (ignoreFirstLine) {
+				numLines--;
 			}
+			numLinesOfAllMinings+= numLines;
+			if (gc != null) {
+				sumLineHeight= calculateLineHeight(gc, styledText, ignoreFirstLine, sumLineHeight, i, splitted);
+			}
+			ignoreFirstLine= true;
 		}
-		numLinesOfAllMinings++;
-		StyledText styledText= super.getTextWidget();
-		return numLinesOfAllMinings * (styledText.getLineHeight() + styledText.getLineSpacing());
+		if (gc != null) {
+			return sumLineHeight;
+		} else {
+			int lineHeight= styledText.getLineHeight();
+			int result= numLinesOfAllMinings * (lineHeight + styledText.getLineSpacing());
+			return result;
+		}
+	}
+
+	private int calculateLineHeight(GC gc, StyledText styledText, boolean ignoreFirstLine, int sumLineHeight, int miningIndex, String[] splitted) {
+		for (int j= 0; j < splitted.length; j++) {
+			String line= splitted[j];
+			if (j == 0 && ignoreFirstLine) {
+				continue;
+			}
+			if (j == splitted.length - 1 && miningIndex + 1 < fMinings.size()) { // last line, take first line from next mining
+				String nextLabel= fMinings.get(miningIndex + 1).getLabel();
+				if (nextLabel != null) {
+					String firstFromNext= nextLabel.split("\\r?\\n|\\r")[0]; //$NON-NLS-1$
+					line+= firstFromNext;
+				}
+			}
+			Point ext= gc.textExtent(line);
+			sumLineHeight+= ext.y + styledText.getLineSpacing();
+		}
+		return sumLineHeight;
 	}
 
 	/**

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationDrawingStrategy.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationDrawingStrategy.java
@@ -25,6 +25,7 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 
 import org.eclipse.jface.internal.text.codemining.CodeMiningLineContentAnnotation;
+import org.eclipse.jface.internal.text.codemining.CodeMiningLineHeaderAnnotation;
 
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.source.Annotation;
@@ -161,7 +162,12 @@ class InlinedAnnotationDrawingStrategy implements IDrawingStrategy {
 		}
 		if (gc != null) {
 			// Setting vertical indent first, before computing bounds
-			int height= annotation.getHeight();
+			int height;
+			if (annotation instanceof CodeMiningLineHeaderAnnotation cmlha) {
+				height= cmlha.getHeight(gc);
+			} else {
+				height= annotation.getHeight();
+			}
 			if (height != 0) {
 				if (height != textWidget.getLineVerticalIndent(line)) {
 					if (annotation.oldLine != -1 && annotation.oldLine < textWidget.getLineCount()) {

--- a/examples/org.eclipse.jface.text.examples/src/org/eclipse/jface/text/examples/codemining/EmptyLineCodeMiningProvider.java
+++ b/examples/org.eclipse.jface.text.examples/src/org/eclipse/jface/text/examples/codemining/EmptyLineCodeMiningProvider.java
@@ -35,7 +35,7 @@ public class EmptyLineCodeMiningProvider extends AbstractCodeMiningProvider {
 					emptyLineHeaders.add(new LineHeaderCodeMining(line, document, this) {
 						@Override
 						public String getLabel() {
-							return "Next line is empty";
+							return "Next line is \nempty";
 						}
 					});
 				}


### PR DESCRIPTION

Before:
![multiline_codemining1](https://github.com/user-attachments/assets/9a5590dd-4bb4-4004-bfaf-2e62ddf36707)

After with the changes of this pull request:
![multiline_codemining2](https://github.com/user-attachments/assets/91ce0e4c-c105-4659-8a97-4d1e4507cc11)
