### PR TITLE
[Dark Theme] Fix for highlight issue in sub-tabs

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/dark/e4-dark_tabstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/dark/e4-dark_tabstyle.css
@@ -40,11 +40,10 @@ CTabFolder {
 CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
     /* Set the styles for the bottom inner tabs (Bug 430051): */
     swt-tab-renderer: url('bundleclass://org.eclipse.e4.ui.workbench.renderers.swt/org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering');
-    swt-unselected-hot-tab-color-background: #161616; /* Bug 465711 */
+    swt-unselected-hot-tab-color-background: #161616;/*  Bug 465711 */
     swt-selected-tab-highlight: #316c9b;
     swt-selected-highlight-top: false;
 }
-
 
 CTabFolder.active {
     swt-selected-tab-highlight: #316c9b;

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_linux.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_linux.css
@@ -80,6 +80,21 @@ ImageBasedFrame,
     swt-selected-highlight-top: false;
 }
 
+.MPartStack CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
+    /* Set the styles for the bottom inner tabs (Bug 430051): */
+    swt-tab-renderer: url('bundleclass://org.eclipse.e4.ui.workbench.renderers.swt/org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering');
+    swt-unselected-hot-tab-color-background: #161616;/*  Bug 465711 */
+    swt-selected-tab-highlight: #a6a6a6;
+    swt-selected-highlight-top: true;
+}
+.MPartStack.active CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
+    /* Set the styles for the bottom inner tabs (Bug 430051): */
+    swt-tab-renderer: url('bundleclass://org.eclipse.e4.ui.workbench.renderers.swt/org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering');
+    swt-unselected-hot-tab-color-background: #161616;/*  Bug 465711 */
+    swt-selected-tab-highlight: #2b97d7;
+    swt-selected-highlight-top: true;
+}
+
 /*text color of selected tab in editor */
 #org-eclipse-ui-editorss CTabItem:selected{
 	color: '#FFFFFF';
@@ -87,7 +102,6 @@ ImageBasedFrame,
 
 #org-eclipse-ui-editorss CTabFolder{
  	swt-selected-tab-fill : '#1E1F22';
-swt-selected-tab-highlight: '#a6a6a6';
     swt-selected-highlight-top: true;
     swt-draw-custom-tab-content-background: true;
 	swt-unselected-hot-tab-color-background:#161616;		
@@ -96,16 +110,6 @@ swt-selected-tab-highlight: '#a6a6a6';
 #org-eclipse-ui-editorss CTabFolder.active {
     swt-selected-tab-highlight: '#2b79d7';
     swt-selected-highlight-top: true;
-}
-
-CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
-    /* Set the styles for the bottom inner tabs (Bug 430051): */
-    swt-tab-renderer: url('bundleclass://org.eclipse.e4.ui.workbench.renderers.swt/org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering');
-    swt-selected-tab-fill: #1E1F22;
-    swt-unselected-tabs-color: #48484c;
-    swt-unselected-hot-tab-color-background: #2f2f2f;
-    swt-selected-tab-highlight: #2b79d7;
-    swt-selected-highlight-top: false;
 }
 
 .Editor Form Composite,

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
@@ -66,6 +66,21 @@ Button  {
     swt-selected-highlight-top: false;
 }
 
+.MPartStack CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
+    /* Set the styles for the bottom inner tabs (Bug 430051): */
+    swt-tab-renderer: url('bundleclass://org.eclipse.e4.ui.workbench.renderers.swt/org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering');
+    swt-unselected-hot-tab-color-background: #161616;/*  Bug 465711 */
+    swt-selected-tab-highlight: #a6a6a6;
+    swt-selected-highlight-top: true;
+}
+.MPartStack.active CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
+    /* Set the styles for the bottom inner tabs (Bug 430051): */
+    swt-tab-renderer: url('bundleclass://org.eclipse.e4.ui.workbench.renderers.swt/org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering');
+    swt-unselected-hot-tab-color-background: #161616;/*  Bug 465711 */
+    swt-selected-tab-highlight: #2b97d7;
+    swt-selected-highlight-top: true;
+}
+
 /*text color of selected tab in editor */
 #org-eclipse-ui-editorss CTabItem:selected{
 	color: '#FFFFFF';
@@ -73,7 +88,6 @@ Button  {
 
 #org-eclipse-ui-editorss CTabFolder{
  	swt-selected-tab-fill : '#1E1F22';
-	swt-selected-tab-highlight: '#a6a6a6';
     swt-selected-highlight-top: true;
     swt-draw-custom-tab-content-background: true;
 	swt-unselected-hot-tab-color-background:#161616;	
@@ -84,20 +98,9 @@ Button  {
     swt-selected-highlight-top: true;
 }
 
-CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
-    /* Set the styles for the bottom inner tabs (Bug 430051): */
-    swt-tab-renderer: url('bundleclass://org.eclipse.e4.ui.workbench.renderers.swt/org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering');
-    swt-selected-tab-fill: #1E1F22;
-    swt-unselected-tabs-color: #48484c;
-    swt-unselected-hot-tab-color-background: #2f2f2f;
-    swt-selected-tab-highlight: #2b79d7;
-    swt-selected-highlight-top: false;
-}
-
 .Editor Form Composite,
 .Editor Form Composite Tree,
 .MPartStack.active .Editor Form Composite Tree
 {
 	background-color: #1E1F22;
 }
-

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
@@ -148,6 +148,21 @@ ImageBasedFrame,
     swt-selected-highlight-top: false;
 }
 
+.MPartStack CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
+    /* Set the styles for the bottom inner tabs (Bug 430051): */
+    swt-tab-renderer: url('bundleclass://org.eclipse.e4.ui.workbench.renderers.swt/org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering');
+    swt-unselected-hot-tab-color-background: #161616;/*  Bug 465711 */
+    swt-selected-tab-highlight: #a6a6a6;
+    swt-selected-highlight-top: true;
+}
+.MPartStack.active CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
+    /* Set the styles for the bottom inner tabs (Bug 430051): */
+    swt-tab-renderer: url('bundleclass://org.eclipse.e4.ui.workbench.renderers.swt/org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering');
+    swt-unselected-hot-tab-color-background: #161616;/*  Bug 465711 */
+    swt-selected-tab-highlight: #2b97d7;
+    swt-selected-highlight-top: true;
+}
+
 /*text color of selected tab in editor */
 #org-eclipse-ui-editorss CTabItem:selected{
 	color: '#FFFFFF';
@@ -155,26 +170,15 @@ ImageBasedFrame,
 
 #org-eclipse-ui-editorss CTabFolder{
  	swt-selected-tab-fill : '#1E1F22';
-	swt-selected-tab-highlight: '#a6a6a6';
     swt-selected-highlight-top: true;
     swt-draw-custom-tab-content-background: true;
-	swt-unselected-hot-tab-color-background:#161616;	
+	swt-unselected-hot-tab-color-background:#161616;
 }
 
 #org-eclipse-ui-editorss CTabFolder.active {
     swt-selected-tab-highlight: '#2b79d7';
     swt-selected-highlight-top: true;
-}
-
-CTabFolder[style~='SWT.DOWN'][style~='SWT.BOTTOM'] {
-    /* Set the styles for the bottom inner tabs (Bug 430051): */
-    swt-tab-renderer: url('bundleclass://org.eclipse.e4.ui.workbench.renderers.swt/org.eclipse.e4.ui.workbench.renderers.swt.CTabRendering');
-    swt-selected-tab-fill: #1E1F22;
-    swt-unselected-tabs-color: #48484c;
-    swt-unselected-hot-tab-color-background: #2f2f2f;
-    swt-selected-tab-highlight: #2b79d7;
-    swt-selected-highlight-top: false;
-}
+} 
 
 .Editor Form Composite,
 .Editor Form Composite Tree,


### PR DESCRIPTION
With the dark theme changes, selected sub-tabs in the editor and views were missing blue highlights. This has been fixed with this PR. The screenshots below are from Windows. The same change has been incorporated in Mac and Linux.

Before:
![Screenshot 2024-12-19 231102](https://github.com/user-attachments/assets/3fe65df1-0226-4afe-bc09-ad799d74a14e)

After:
![Screenshot 2024-12-19 225628](https://github.com/user-attachments/assets/5f9905c8-4f4c-4fd6-9414-f97ace8ae070)
