### PR TITLE
Display quick search dialog result in SourceViewer with line numbers. Fixes #2010

### DIFF
--- a/bundles/org.eclipse.text.quicksearch/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.text.quicksearch/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.text.quicksearch;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.100.qualifier
 Bundle-Activator: org.eclipse.text.quicksearch.internal.ui.QuickSearchActivator
 Require-Bundle: org.eclipse.ui;bundle-version="[3.113.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.13.0,4.0.0)",


### PR DESCRIPTION
## What it does
Adds line numbers (vertical ruler) when presenting content that contains searched term in Quick Search dialog. For this, simple StyledText widget that was used to present content was replaced with SourceViewer widget. It's configured with same colors like generic text editor.

- also adds standard current line highlighting based on caret position (*)
- also always highlights (with 'current line highlight' background color) the line that contains selected match regardless of caret position - to help telling apart target match / line amongst multiple matches on other lines possibly present around target match (*)
- also scrolls horizontally, if necessary, to reveal 1st match of the searched term in the target line
- reacts to individual color preferences changes even if opened

(* current line highlighting must be enabled in preferences)


## How to test
Open Quick Search dialog (default: CTRL + SHIFT + ALT + L) and confirm bottom area presenting parts of files where match was found behaves like it used to - displays match vertically centered, keeps it centered on resizing the dialog or area, displays match 'context' (lines before & after match within source file).

## Known bugs
Changing theme (light <-> dark) while Quick Search dialog is open does not change all the colors used inside it (namely occurrences highlighting). Closing and reopening the dialog fixes the colors.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
