### PR TITLE
[Light Theme]Fix for regression caused by defining colors for re-use

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
@@ -190,7 +190,7 @@ CTabFolder Canvas {
 }
 
 .MPartStack{
-	swt-selected-tab-highlight: #a0a0a0;
+	swt-selected-tab-highlight: #8a8a8a;
 	swt-selected-highlight-top: false;
 }
 

--- a/bundles/org.eclipse.ui.themes/css/e4_default_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_win.css
@@ -165,7 +165,7 @@ CTabFolder Canvas {
 }
 
 .MPartStack{
-	swt-selected-tab-highlight: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
+	swt-selected-tab-highlight: #8a8a8a;
 	swt-selected-highlight-top: false;
 }
 


### PR DESCRIPTION
PR #2455 leads to regression in the behavior of highlight of selected tabs in inactive stack. This caused only in windows and Linux and has been fixed with this change.