### PR TITLE
FindReplaceOverlay: use search-as-you-type in regex mode #1911

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -132,12 +132,11 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	@Override
 	public boolean isAvailable(SearchOptions searchOption) {
 		switch (searchOption) {
-		case INCREMENTAL:
-			return !isAvailableAndActive(SearchOptions.REGEX);
 		case REGEX:
 			return isTargetSupportingRegEx;
 		case WHOLE_WORD:
 			return !isAvailableAndActive(SearchOptions.REGEX) && isWord(findString);
+		case INCREMENTAL:
 		case CASE_SENSITIVE:
 		case FORWARD:
 		case GLOBAL:

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -589,6 +589,7 @@ class FindReplaceDialog extends Dialog {
 					return;
 				}
 				findReplaceLogic.activate(SearchOptions.GLOBAL);
+				updateFindString();
 			}
 
 			@Override
@@ -608,6 +609,7 @@ class FindReplaceDialog extends Dialog {
 					return;
 				}
 				findReplaceLogic.deactivate(SearchOptions.GLOBAL);
+				updateFindString();
 			}
 
 			@Override
@@ -650,11 +652,7 @@ class FindReplaceDialog extends Dialog {
 				ITextEditorActionDefinitionIds.CONTENT_ASSIST_PROPOSALS, new char[0], true);
 		setGridData(fFindField, SWT.FILL, true, SWT.CENTER, false);
 		addDecorationMargin(fFindField);
-		fFindModifyListener = new InputModifyListener(() -> {
-			if (okToUse(fFindField)) {
-				findReplaceLogic.setFindString(fFindField.getText());
-			}
-		});
+		fFindModifyListener = new InputModifyListener(this::updateFindString);
 		fFindField.addModifyListener(fFindModifyListener);
 
 		fReplaceLabel = new Label(panel, SWT.LEFT);
@@ -678,6 +676,12 @@ class FindReplaceDialog extends Dialog {
 		fReplaceField.addModifyListener(listener);
 
 		return panel;
+	}
+
+	private void updateFindString() {
+		if (okToUse(fFindField)) {
+			findReplaceLogic.setFindString(fFindField.getText());
+		}
 	}
 
 	/**
@@ -708,6 +712,7 @@ class FindReplaceDialog extends Dialog {
 			public void widgetSelected(SelectionEvent e) {
 				setupFindReplaceLogic();
 				storeSettings();
+				updateFindString();
 			}
 
 			@Override
@@ -745,6 +750,7 @@ class FindReplaceDialog extends Dialog {
 			public void widgetSelected(SelectionEvent e) {
 				setupFindReplaceLogic();
 				storeSettings();
+				updateFindString();
 			}
 
 			@Override
@@ -770,7 +776,7 @@ class FindReplaceDialog extends Dialog {
 				storeSettings();
 				updateButtonState();
 				setContentAssistsEnablement(newState);
-				fIncrementalCheckBox.setEnabled(findReplaceLogic.isAvailable(SearchOptions.INCREMENTAL));
+				updateFindString();
 			}
 		});
 		storeButtonWithMnemonicInMap(fIsRegExCheckBox);
@@ -779,9 +785,9 @@ class FindReplaceDialog extends Dialog {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				updateButtonState();
+				updateFindString();
 			}
 		});
-		fIncrementalCheckBox.setEnabled(findReplaceLogic.isAvailable(SearchOptions.INCREMENTAL));
 		return panel;
 	}
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
@@ -212,17 +212,25 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 	@Test
 	public void testRegExSearch() {
 		initializeTextViewerWithFindReplaceUI("abc");
-		dialog.select(SearchOptions.REGEX);
+		dialog.select(SearchOptions.INCREMENTAL);
 		dialog.setFindText("(a|bc)");
+		dialog.select(SearchOptions.REGEX);
 
 		IFindReplaceTarget target= getFindReplaceTarget();
-		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(1, (target.getSelection()).y);
 
 		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
 		assertEquals(1, (target.getSelection()).x);
 		assertEquals(2, (target.getSelection()).y);
+
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
+		assertEquals(0, (target.getSelection()).x);
+		assertEquals(1, (target.getSelection()).y);
+
+		dialog.setFindText("b|c");
+		assertEquals(1, (target.getSelection()).x);
+		assertEquals(1, (target.getSelection()).y);
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
@@ -160,8 +160,7 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 
 		OverlayAccess dialog= getDialog();
 		dialog.select(SearchOptions.REGEX);
-		dialog.setFindText("text"); // with RegEx enabled, there is no incremental search!
-		dialog.pressSearch(true);
+		dialog.setFindText("text");
 		assertThat(target.getSelection().y, is(4));
 		dialog.pressSearch(true);
 		assertThat(target.getSelection().x, is("text ".length()));

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
@@ -163,18 +163,6 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		assertEquals(4, (target.getSelection()).y);
 	}
 
-	@Test
-	public void testIncrementalSearchOnlyEnabledWhenAllowed() {
-		initializeTextViewerWithFindReplaceUI("text text text");
-		DialogAccess dialog= getDialog();
-
-		dialog.select(SearchOptions.INCREMENTAL);
-		dialog.select(SearchOptions.REGEX);
-
-		dialog.assertSelected(SearchOptions.INCREMENTAL);
-		dialog.assertDisabled(SearchOptions.INCREMENTAL);
-	}
-
 	/*
 	 * Test for https://github.com/eclipse-platform/eclipse.platform.ui/pull/1805#pullrequestreview-1993772378
 	 */
@@ -191,15 +179,6 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		dialog= getDialog();
 		dialog.assertSelected(SearchOptions.INCREMENTAL);
 		dialog.assertEnabled(SearchOptions.INCREMENTAL);
-
-		dialog.select(SearchOptions.REGEX);
-		dialog.assertSelected(SearchOptions.INCREMENTAL);
-		dialog.assertDisabled(SearchOptions.INCREMENTAL);
-
-		reopenFindReplaceUIForTextViewer();
-		dialog= getDialog();
-		dialog.assertSelected(SearchOptions.INCREMENTAL);
-		dialog.assertDisabled(SearchOptions.INCREMENTAL);
 	}
 
 	@Test
@@ -225,4 +204,22 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		assertEquals(0, (target.getSelection()).x);
 		assertEquals(dialog.getFindText().length(), (target.getSelection()).y);
 	}
+
+	@Test
+	public void testRegExSearch_nonIncremental() {
+		initializeTextViewerWithFindReplaceUI("abc");
+		DialogAccess dialog= getDialog();
+		dialog.setFindText("(a|bc)");
+		dialog.select(SearchOptions.REGEX);
+
+		IFindReplaceTarget target= getFindReplaceTarget();
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
+		assertEquals(0, (target.getSelection()).x);
+		assertEquals(1, (target.getSelection()).y);
+
+		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
+		assertEquals(1, (target.getSelection()).x);
+		assertEquals(2, (target.getSelection()).y);
+	}
+
 }


### PR DESCRIPTION
Currently, the FindReplaceLogic disables the incremental mode (i.e., search-as-you-type) in case the regex search option is activated. This makes the FindReplaceOverlay, which uses search-as-you-type in all other situations, behave non-intuitively when the regex option is activated.

In order to achieve consistent, user-expectable behavior of the find and replace functionality and because of lacking arguments against using search-as-you-type in regex mode, this change makes the regex search mode independent from the incremental mode of the FindReplaceLogic. In consequence, the FindReplaceOverlay always uses search-as-you-type, no matter which search options are activated.
In addition, explicit test code for that exceptional behavior is removed or adapted.

Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/2066

Contributes to https://github.com/eclipse-platform/eclipse.platform.ui/issues/2646

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1911

Note that this also aligns the behavior with similar functionality in other tools (like VS code).