### PR TITLE
[Light Theme]Breadcrumb issue fix

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
@@ -226,8 +226,10 @@ CTabFolder Canvas {
 	swt-selected-highlight-top: true;
 }
 
-#org-eclipse-e4-ui-compatibility-editor Composite{
-	background-color: #ffffff;
+#org-eclipse-e4-ui-compatibility-editor Composite,
+#org-eclipse-e4-ui-compatibility-editor Composite>*
+{
+	background-color:#ffffff;
 }
 
 Composite.MPartSashContainer{

--- a/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
@@ -199,8 +199,10 @@ CTabFolder Canvas {
 	swt-selected-highlight-top: true;
 }
 
-#org-eclipse-e4-ui-compatibility-editor Composite{
-	background-color: #ffffff;
+#org-eclipse-e4-ui-compatibility-editor Composite,
+#org-eclipse-e4-ui-compatibility-editor Composite>*
+{
+	background-color:#ffffff;
 }
 
 Composite.MPartSashContainer{

--- a/bundles/org.eclipse.ui.themes/css/e4_default_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_win.css
@@ -201,8 +201,10 @@ CTabFolder Canvas {
 	swt-selected-highlight-top: true;
 }
 
-#org-eclipse-e4-ui-compatibility-editor Composite{
-	background-color: #ffffff;
+#org-eclipse-e4-ui-compatibility-editor Composite,
+#org-eclipse-e4-ui-compatibility-editor Composite>*
+{
+	background-color:#ffffff;
 }
 
 Composite.MPartSashContainer{


### PR DESCRIPTION
The breadcrumb in the source code editor had a grey background. With the new light theme changes, the background color of the breadcrumbs has also been changed to white.

Before:
![Screenshot 2025-01-03 115958](https://github.com/user-attachments/assets/a5eab14c-a252-417b-b4ac-8302617cafac)


After:
![Screenshot 2025-01-03 120351](https://github.com/user-attachments/assets/bb297316-d672-4328-bb49-57fa300925cc)
