### PR TITLE
Complete invalid patterns when validating regex during search #2564

### DIFF
--- a/bundles/org.eclipse.ui/src/org/eclipse/ui/internal/SearchDecoration.java
+++ b/bundles/org.eclipse.ui/src/org/eclipse/ui/internal/SearchDecoration.java
@@ -83,6 +83,12 @@ public class SearchDecoration {
 		GC gc = new GC(targetControl);
 		String pattern = e.getPattern();
 
+		// This happens when the error is in the last (still unwritten) character e.g.
+		// for an "Unescaped trailing backslash"
+		if (errorIndex >= pattern.length()) {
+			pattern += " "; //$NON-NLS-1$
+		}
+
 		StringBuilder validationErrorMessage = new StringBuilder();
 
 		validationErrorMessage.append(description);


### PR DESCRIPTION
If the error is due to an unwritten character at the end of the regex (e.g. an unescaped trailing backslash) then add a whitespace to avoid IOOBE.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2654