### PR TITLE
Abort failing FindReplaceDocumentAdapter operations consistently #2657

### DIFF
--- a/tests/org.eclipse.text.tests/src/org/eclipse/text/tests/FindReplaceDocumentAdapterTest.java
+++ b/tests/org.eclipse.text.tests/src/org/eclipse/text/tests/FindReplaceDocumentAdapterTest.java
@@ -15,7 +15,12 @@
  *******************************************************************************/
 package org.eclipse.text.tests;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Locale;
@@ -288,6 +293,18 @@ public class FindReplaceDocumentAdapterTest {
 		fDocument.set("foo");
 		regexReplace("(f)oo", "$10", findReplaceDocumentAdapter);
 		assertEquals("f0", fDocument.get());
+	}
+
+	@Test
+	public void testRegexReplace_invalidRegex() throws Exception {
+		FindReplaceDocumentAdapter findReplaceDocumentAdapter = new FindReplaceDocumentAdapter(fDocument);
+
+		fDocument.set("foo");
+		assertThrows(PatternSyntaxException.class, () -> regexReplace("foo", "foo\\", findReplaceDocumentAdapter));
+		assertEquals("foo", fDocument.get());
+
+		findReplaceDocumentAdapter.replace("foo" + System.lineSeparator(), true);
+		assertEquals("foo" + System.lineSeparator(), fDocument.get());
 	}
 
 	/*

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.workbench.texteditor.tests
-Bundle-Version: 3.14.600.qualifier
+Bundle-Version: 3.14.700.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -438,6 +438,29 @@ public class FindReplaceLogicTest {
 		executeReplaceAndFindRegExTest(textViewer, findReplaceLogic);
 	}
 
+	@Test
+	public void testPerformReplaceAndFindRegEx_withInvalidEscapeInReplace() {
+		TextViewer textViewer= setupTextViewer("Hello");
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.activate(SearchOptions.FORWARD);
+		findReplaceLogic.activate(SearchOptions.REGEX);
+
+		setFindAndReplaceString(findReplaceLogic, "Hello", "Hello\\");
+		boolean status= findReplaceLogic.performReplaceAndFind();
+		assertFalse(status);
+		assertThat(textViewer.getDocument().get(), equalTo("Hello"));
+		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo("Hello"));
+		assertThat(findReplaceLogic.getStatus(), instanceOf(InvalidRegExStatus.class));
+
+		setFindAndReplaceString(findReplaceLogic, "Hello", "Hello" + System.lineSeparator());
+
+		status= findReplaceLogic.performReplaceAndFind();
+		assertTrue(status);
+		assertThat(textViewer.getDocument().get(), equalTo("Hello" + System.lineSeparator()));
+		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo("Hello" + System.lineSeparator()));
+		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
+	}
+
 	private void executeReplaceAndFindRegExTest(TextViewer textViewer, IFindReplaceLogic findReplaceLogic) {
 		setFindAndReplaceString(findReplaceLogic, "<(\\w*)>", " ");
 


### PR DESCRIPTION
The implementation of FindReplaceDocumentAdapter#findReplace(), used by its API methods #find() and #replace(), currently leaves an inconsistent state when failing because of an invalid input or state. This inconsistent state affects the last executed operation type, which the adapter stores in order to identify whether a replace operation is preceded by an according find operation. In case the #findReplace() method is called with an invalid position or to execute a replace without a preceding find, the method aborts (throwing an exception) without storing the operation to be executed as the last executed operation, i.e., it leaves the adapter as if that method was never called. In case the method is called in regular expression mode and the expression used as find or replace input is invalid, the operation aborts (throwing an exception) but still stores the operation to be executed as the last executed operation, i.e., it leaves the adapter as if that method was called successfully.

This behavior is unexpected as is handles invalid inputs inconsistently. This also becomes visible in the existing consumers, such as FindReplaceTarget#replaceSelection() used by the FindReplaceDialog and FindReplaceOvleray. They assume that in case an exception occurs while trying to perform a replace operation, a subsequent replace should succeed without an additional find operation being required. This assumption does currently not hold.

This change corrects the behavior of the FindReplaceDocumentAdapter#findReplace() method to always leave the adapter in an unmodified state when the method fails because of being called with invalid input or in an inconsistent state. In addition, regular expressions with an unfinished character escape at the end now lead to a proper exception.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2657

### How it behaves

This is how it behaves after the fix
![findreplace_replace_regex_fix](https://github.com/user-attachments/assets/160644ed-61b9-4294-8df0-e057fe4f2451)

The inconsistent error indication (input colored red) is specific to the FindReplaceOverlay and will be fixed in a follow-up PR.