### PR TITLE
FindReplaceOverlay: avoid exception while closing workbench window #2666

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlay.java
@@ -172,7 +172,7 @@ public class FindReplaceOverlay {
 		 * boolean)
 		 */
 		private void setTextEditorActionsActivated(boolean state) {
-			if (!(targetPart instanceof AbstractTextEditor)) {
+			if (!(targetPart instanceof AbstractTextEditor) || targetPart.getSite().getWorkbenchWindow().isClosing()) {
 				return;
 			}
 			if (targetPart.getSite() instanceof MultiPageEditorSite multiEditorSite) {


### PR DESCRIPTION
When closing a workbench window while a find/replace overlay is open and one of the input fields (find/replace) has focus, an exception is thrown. This is caused by the FindReplaceOverlay trying to reactive shortcuts of the underlying editor while the input field is losing focus, but the handler service to perform the activation in is already disposed.

Since there is no direct way of determining the underlying handler service from the overlay to identify whether it is already disposed, this change makes the overlay simply check for the workbench window currently being closed. This is reasonable as the reactivation of handlers is unnecessary if the underlying window is closed anyway.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/pull/2666