### PR TITLE
LineNumberRulerColumn consider LineSpacing for word wrapping

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/LineNumberRulerColumn.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/LineNumberRulerColumn.java
@@ -852,6 +852,7 @@ public class LineNumberRulerColumn implements IVerticalRulerColumn {
 
 				// use height of text bounding because bounds.width changes on word wrap
 				y+= fCachedTextWidget.getTextBounds(offsetAtLine, offsetEnd).height;
+				y+= fCachedTextWidget.getLineSpacing();
 			}
 		}
 	}


### PR DESCRIPTION
The LineNumberRulerColumn should consider the text widget's LineSpacing when word wrapping is enabled.

Before the fix:
![image](https://github.com/user-attachments/assets/2f02b0bf-58e3-4c39-b618-b91ece21ddbf)

After the fix:
![image](https://github.com/user-attachments/assets/d866cca2-9148-407d-8302-891566c1b80c)

Fixes #2668