### PR TITLE
Do not suspend JobManager during startup by default

### DIFF
--- a/bundles/org.eclipse.ui.ide.application/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide.application/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide.application;singleton:=true
-Bundle-Version: 1.5.600.qualifier
+Bundle-Version: 1.5.700.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui.ide;bundle-version="[3.21.0,4.0.0)",

--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
@@ -134,6 +134,13 @@ public class IDEApplication implements IApplication, IExecutableExtension {
 	public static final String PLUGIN_ID = "org.eclipse.ui.ide.application"; //$NON-NLS-1$
 
 	/**
+	 * Suspending JobManager can be forced by specify VM property:
+	 * {@code -Dorg.eclipse.ui.suspendJobManagerDuringStart=true}
+	 */
+	static final boolean SUSPEND_JOBMANAGER_DURING_START = Boolean
+			.getBoolean("org.eclipse.ui.suspendJobManagerDuringStart"); //$NON-NLS-1$
+
+	/**
 	 * Creates a new IDE application.
 	 */
 	public IDEApplication() {
@@ -146,7 +153,9 @@ public class IDEApplication implements IApplication, IExecutableExtension {
 		// is done to reduce resource contention during startup.
 		// The job manager will be resumed by the
 		// IDEWorkbenchAdvisor.postStartup method.
-		Job.getJobManager().suspend();
+		if (SUSPEND_JOBMANAGER_DURING_START) {
+			Job.getJobManager().suspend();
+		}
 
 		Display display = createDisplay();
 		// processor must be created before we start event loop

--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
@@ -286,7 +286,9 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 		} finally {
 			// Resume the job manager to allow background jobs to run.
 			// The job manager was suspended by the IDEApplication.start method.
-			Job.getJobManager().resume();
+			if (IDEApplication.SUSPEND_JOBMANAGER_DURING_START) {
+				Job.getJobManager().resume();
+			}
 		}
 	}
 


### PR DESCRIPTION
Because of possible deadlock when Javaeditor from JDT calls PDE calls OOMPH calls P2 to download new target platform waiting for a Job that is not executed because JobManager is suspendend

https://github.com/eclipse-pde/eclipse.pde/issues/1481

Was already suggested in
https://bugs.eclipse.org/bugs/show_bug.cgi?id=514090

Old behavior can be used by setting VM property
`-Dorg.eclipse.ui.suspendJobManagerDuringStart=true`