### PR TITLE
Update lower bound to org.eclipse.core.runtime due to new API

### DIFF
--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -94,7 +94,7 @@ Export-Package: org.eclipse.e4.ui.workbench.addons.perspectiveswitcher;x-interna
  org.eclipse.ui.themes,
  org.eclipse.ui.views,
  org.eclipse.ui.wizards
-Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.33.0,4.0.0)",
  org.eclipse.help;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.jface;bundle-version="[3.31.0,4.0.0)",
  org.eclipse.jface.databinding;bundle-version="[1.3.0,2.0.0)",


### PR DESCRIPTION
The new StringMatcher API used with
db41fb4a1a8edb434df83d273c22fa7bc572ed4d is only available starting with version 3.33.0 of org.eclipse.core.runtime.

See https://github.com/eclipse-platform/eclipse.platform/pull/1673