### PR TITLE
AbstractDocument fix concurrency issues (BadPositionCategoryException)

### DIFF
--- a/bundles/org.eclipse.core.filebuffers/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.filebuffers/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.filebuffers; singleton:=true
-Bundle-Version: 3.8.300.qualifier
+Bundle-Version: 3.8.400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.core.filebuffers/src/org/eclipse/core/internal/filebuffers/SynchronizableDocument.java
+++ b/bundles/org.eclipse.core.filebuffers/src/org/eclipse/core/internal/filebuffers/SynchronizableDocument.java
@@ -13,10 +13,14 @@
  *******************************************************************************/
 package org.eclipse.core.internal.filebuffers;
 
+import java.util.List;
+import java.util.Map;
+
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.BadPartitioningException;
 import org.eclipse.jface.text.BadPositionCategoryException;
 import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.DocumentRewriteSession;
 import org.eclipse.jface.text.DocumentRewriteSessionType;
 import org.eclipse.jface.text.IDocumentExtension4;
@@ -37,6 +41,97 @@ import org.eclipse.jface.text.Position;
 public class SynchronizableDocument extends Document implements ISynchronizable {
 
 	private Object fLockObject;
+
+	@Override
+	protected void updateDocumentStructures(DocumentEvent event) {
+		Object lockObject= getLockObject();
+		if (lockObject == null) {
+			super.updateDocumentStructures(event);
+			return;
+		}
+		synchronized (lockObject) {
+			super.updateDocumentStructures(event);
+		}
+	}
+
+	@Override
+	public void removePositionCategory(String category) throws BadPositionCategoryException {
+		Object lockObject= getLockObject();
+		if (lockObject == null) {
+			super.removePositionCategory(category);
+			return;
+		}
+		synchronized (lockObject) {
+			super.removePositionCategory(category);
+		}
+	}
+
+	@Override
+	public String[] getPositionCategories() {
+		Object lockObject= getLockObject();
+		if (lockObject == null) {
+			return super.getPositionCategories();
+		}
+		synchronized (lockObject) {
+			return super.getPositionCategories();
+		}
+	}
+
+	@Override
+	protected Map<String, List<Position>> getDocumentManagedPositions() {
+		Object lockObject= getLockObject();
+		if (lockObject == null) {
+			return super.getDocumentManagedPositions();
+		}
+		synchronized (lockObject) {
+			return super.getDocumentManagedPositions();
+		}
+	}
+
+	@Override
+	public boolean containsPositionCategory(String category) {
+		Object lockObject= getLockObject();
+		if (lockObject == null) {
+			return super.containsPositionCategory(category);
+		}
+		synchronized (lockObject) {
+			return super.containsPositionCategory(category);
+		}
+	}
+
+	@Override
+	public boolean containsPosition(String category, int offset, int length) {
+		Object lockObject= getLockObject();
+		if (lockObject == null) {
+			return super.containsPosition(category, offset, length);
+		}
+		synchronized (lockObject) {
+			return super.containsPosition(category, offset, length);
+		}
+	}
+
+	@Override
+	public int computeIndexInCategory(String category, int offset) throws BadLocationException, BadPositionCategoryException {
+		Object lockObject= getLockObject();
+		if (lockObject == null) {
+			return super.computeIndexInCategory(category, offset);
+		}
+		synchronized (lockObject) {
+			return super.computeIndexInCategory(category, offset);
+		}
+	}
+
+	@Override
+	public void addPositionCategory(String category) {
+		Object lockObject= getLockObject();
+		if (lockObject == null) {
+			super.addPositionCategory(category);
+			return;
+		}
+		synchronized (lockObject) {
+			super.addPositionCategory(category);
+		}
+	}
 
 	@Override
 	public synchronized void setLockObject(Object lockObject) {

--- a/bundles/org.eclipse.text/src/org/eclipse/jface/text/AbstractDocument.java
+++ b/bundles/org.eclipse.text/src/org/eclipse/jface/text/AbstractDocument.java
@@ -345,12 +345,12 @@ public abstract class AbstractDocument implements IDocument, IDocumentExtension,
 
 		List<Position> list= fPositions.get(category);
 		if (list == null)
-			throw new BadPositionCategoryException();
+			throw new BadPositionCategoryException(category);
 		list.add(computeIndexInPositionList(list, position.offset), position);
 
 		List<Position> endPositions= fEndPositions.get(category);
 		if (endPositions == null)
-			throw new BadPositionCategoryException();
+			throw new BadPositionCategoryException(category);
 		endPositions.add(computeIndexInPositionList(endPositions, position.offset + position.length - 1, false), position);
 	}
 
@@ -514,7 +514,7 @@ public abstract class AbstractDocument implements IDocument, IDocumentExtension,
 
 		List<Position> c= fPositions.get(category);
 		if (c == null)
-			throw new BadPositionCategoryException();
+			throw new BadPositionCategoryException(category);
 
 		return computeIndexInPositionList(c, offset);
 	}
@@ -925,7 +925,7 @@ public abstract class AbstractDocument implements IDocument, IDocumentExtension,
 
 		List<Position> c= fPositions.get(category);
 		if (c == null)
-			throw new BadPositionCategoryException();
+			throw new BadPositionCategoryException(category);
 
 		Position[] positions= new Position[c.size()];
 		c.toArray(positions);
@@ -980,12 +980,12 @@ public abstract class AbstractDocument implements IDocument, IDocumentExtension,
 
 		List<Position> c= fPositions.get(category);
 		if (c == null)
-			throw new BadPositionCategoryException();
+			throw new BadPositionCategoryException(category);
 		removeFromPositionsList(c, position, true);
 
 		List<Position> endPositions= fEndPositions.get(category);
 		if (endPositions == null)
-			throw new BadPositionCategoryException();
+			throw new BadPositionCategoryException(category);
 		removeFromPositionsList(endPositions, position, false);
 	}
 
@@ -1043,7 +1043,7 @@ public abstract class AbstractDocument implements IDocument, IDocumentExtension,
 			return;
 
 		if ( !containsPositionCategory(category))
-			throw new BadPositionCategoryException();
+			throw new BadPositionCategoryException(category);
 
 		fPositions.remove(category);
 		fEndPositions.remove(category);
@@ -1674,7 +1674,7 @@ public abstract class AbstractDocument implements IDocument, IDocumentExtension,
 	private List<Position> getEndingPositions(String category, int offset, int length) throws BadPositionCategoryException {
 		List<Position> positions= fEndPositions.get(category);
 		if (positions == null)
-			throw new BadPositionCategoryException();
+			throw new BadPositionCategoryException(category);
 
 		int indexStart= computeIndexInPositionList(positions, offset, false);
 		int indexEnd= computeIndexInPositionList(positions, offset + length, false);


### PR DESCRIPTION
By synchronized access to members used from different thread

https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1067