### PR TITLE
StickyScrolling: Exceptions while opening Java editors from Search view

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -407,6 +407,9 @@ public class StickyScrollingControl {
 		controlListener= new ControlListener() {
 			@Override
 			public void controlResized(ControlEvent e) {
+				if (areStickyLinesOutDated(textWidget)) {
+					return;
+				}
 				limitVisibleStickyLinesToTextWidgetHeight(textWidget);
 				layoutStickyLines();
 				if (stickyScrollingHandler != null) {
@@ -420,6 +423,24 @@ public class StickyScrollingControl {
 			}
 		};
 		textWidget.addControlListener(controlListener);
+	}
+
+	/**
+	 * Checks if the sticky lines are out dated. Specifically, it verifies that the
+	 * line number of the last sticky line does not exceed the total line count of
+	 * the source viewer.
+	 * 
+	 * This situation can occur, for example, when an editor is opened via the
+	 * search view and "reuse editor" is enabled. In such cases, the text in the
+	 * source viewer is replaced, but the out dated sticky lines associated with the
+	 * previous source code remain in the first call.
+	 */
+	private boolean areStickyLinesOutDated(StyledText textWidget) {
+		if (stickyLines.size() > 0) {
+			int lastStickyLineNumber = stickyLines.get(stickyLines.size() - 1).getLineNumber();
+			return lastStickyLineNumber > textWidget.getLineCount();
+		}
+		return true;
 	}
 
 	private void limitVisibleStickyLinesToTextWidgetHeight(StyledText textWidget) {

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
@@ -253,6 +253,25 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
+	public void testDontLayoutOutDatedStickyLinesOnResize() {
+		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
+
+		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 10", 10));
+		stickyScrollingControl.setStickyLines(stickyLines);
+
+		Canvas stickyControlCanvas = getStickyControlCanvas(shell);
+		Rectangle boundsBeforeResize = stickyControlCanvas.getBounds();
+
+		sourceViewer.getTextWidget().setBounds(0, 0, 150, 200);
+
+		stickyControlCanvas = getStickyControlCanvas(shell);
+		Rectangle boundsAfterResize = stickyControlCanvas.getBounds();
+
+		// No IllegalArgumentException: Index out of bounds
+		assertEquals(boundsAfterResize, boundsBeforeResize);
+	}
+
+	@Test
 	public void testNavigateToStickyLine() {
 		String text = """
 				line 1


### PR DESCRIPTION
The search view with "reuse editor" enabled sets new source code in the existing editor and causes a resize. In this call, it can happen that the sticky line number exceeds the amount of line in the new source code. In general this is not a problem since the sticky lines will be recalculated afterwards, but to avoid IllegalArgumentException it is checked for this case.

Fixes #2678