### PR TITLE
Remove dispose call for Colors in StickyScrollingHandler

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandler.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandler.java
@@ -122,9 +122,7 @@ public class StickyScrollingHandler implements IViewportListener {
 		int stickyScrollingMaxCount= store.getInt(EDITOR_STICKY_SCROLLING_MAXIMUM_COUNT);
 
 		Color lineNumberColor= new Color(PreferenceConverter.getColor(store, EDITOR_LINE_NUMBER_RULER_COLOR));
-		sourceViewer.getTextWidget().addDisposeListener(e -> lineNumberColor.dispose());
 		Color stickyLineHoverColor= new Color(PreferenceConverter.getColor(store, EDITOR_CURRENT_LINE_COLOR));
-		sourceViewer.getTextWidget().addDisposeListener(e -> stickyLineHoverColor.dispose());
 		Color stickyLineBackgroundColor= sourceViewer.getTextWidget().getBackground();
 		boolean showLineNumbers= store.getBoolean(EDITOR_LINE_NUMBER_RULER);
 		Color stickyLineSeparatorColor= null;


### PR DESCRIPTION
According to the Javadoc on Colors:

 * Colors do not need to be disposed, however to maintain compatibility
 * with older code, disposing a Color is not an error.