### PR TITLE
deprecate DefaultUndoManager for removal

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/DefaultUndoManager.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/DefaultUndoManager.java
@@ -72,7 +72,7 @@ import org.eclipse.jface.dialogs.MessageDialog;
  * @deprecated As of 3.2, replaced by {@link TextViewerUndoManager}
  * @noextend This class is not intended to be subclassed by clients.
  */
-@Deprecated
+@Deprecated(forRemoval= true, since= "2025-03")
 public class DefaultUndoManager implements IUndoManager, IUndoManagerExtension {
 
 	/**

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/DefaultUndoManagerTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/DefaultUndoManagerTest.java
@@ -23,6 +23,7 @@ import org.eclipse.jface.text.IUndoManager;
  */
 public class DefaultUndoManagerTest extends AbstractUndoManagerTest {
 
+	@SuppressWarnings("removal")
 	@Override
 	protected IUndoManager createUndoManager(int maxUndoLevel) {
 		return new DefaultUndoManager(maxUndoLevel);


### PR DESCRIPTION
only referenced in org.eclipse.jdt.ui.tests.leaks.UndoManagerLeakTest
see https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1936