### PR TITLE
Remove o.e.jdt.ui dependency from navigator tests

### DIFF
--- a/tests/org.eclipse.ui.tests.navigator/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.navigator/META-INF/MANIFEST.MF
@@ -14,7 +14,6 @@ Require-Bundle: org.eclipse.core.resources,
  org.eclipse.ui.navigator.resources,
  org.eclipse.ui.tests.harness,
  org.eclipse.ui.editors,
- org.eclipse.jdt.ui,
  org.eclipse.ui.genericeditor
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/PipelineTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/PipelineTest.java
@@ -40,13 +40,12 @@ public class PipelineTest extends NavigatorTestBase {
 	@Test
 	public void testNavigatorResourceJava() throws Exception {
 
+		String[] exts = { COMMON_NAVIGATOR_RESOURCE_EXT, COMMON_NAVIGATOR_JAVA_EXT };
 		assertEquals(
 				"There should be no visible extensions for the pipeline viewer.",
 				0, _contentService.getVisibleExtensionIds().length);
 
-		_contentService.bindExtensions(new String[] {
-				COMMON_NAVIGATOR_RESOURCE_EXT, COMMON_NAVIGATOR_JAVA_EXT },
-				false);
+		_contentService.bindExtensions(exts, false);
 
 		// Note this test will fail showing only one if the JDT stuff
 		// is not included in the executing bundles (which it normally is)
@@ -54,9 +53,7 @@ public class PipelineTest extends NavigatorTestBase {
 				"There should be two visible extensions for the pipeline viewer.",
 				2, _contentService.getVisibleExtensionIds().length);
 
-		_contentService.getActivationService().activateExtensions(
-				new String[] { COMMON_NAVIGATOR_RESOURCE_EXT,
-						COMMON_NAVIGATOR_JAVA_EXT }, true);
+		_contentService.getActivationService().activateExtensions(exts, true);
 
 		refreshViewer();
 
@@ -100,8 +97,7 @@ public class PipelineTest extends NavigatorTestBase {
 
 		boolean found = false;
 		for (int i = 0; i < rootItems.length && !found; i++) {
-			if (rootItems[i].getData() instanceof IProject) {
-				IProject newProjectFromTree = (IProject) rootItems[i].getData();
+			if (rootItems[i].getData() instanceof IProject newProjectFromTree) {
 				if (newProject.equals(newProjectFromTree))
 					found = true;
 			}
@@ -112,12 +108,9 @@ public class PipelineTest extends NavigatorTestBase {
 	// Make sure problems in bad extension points are reported well
 	@Test
 	public void testInterceptAddThrow() throws Exception {
-		_contentService.bindExtensions(new String[] {
-				COMMON_NAVIGATOR_RESOURCE_EXT, TEST_CONTENT_RESOURCE_OVERRIDE},
-				false);
-		_contentService.getActivationService().activateExtensions(
-				new String[] { COMMON_NAVIGATOR_RESOURCE_EXT,
-						TEST_CONTENT_RESOURCE_OVERRIDE }, true);
+		String[] exts = { COMMON_NAVIGATOR_RESOURCE_EXT, TEST_CONTENT_RESOURCE_OVERRIDE };
+		_contentService.bindExtensions(exts, false);
+		_contentService.getActivationService().activateExtensions(exts, true);
 
 		refreshViewer();
 
@@ -137,12 +130,9 @@ public class PipelineTest extends NavigatorTestBase {
 
 	private void testHasNoChildrenOverride(boolean hasChildren) throws Exception {
 		TestContentProviderNoChildren._hasChildrenTrue = hasChildren;
-		_contentService.bindExtensions(new String[] {
-				COMMON_NAVIGATOR_RESOURCE_EXT, TEST_CONTENT_NO_CHILDREN},
-				false);
-		_contentService.getActivationService().activateExtensions(
-				new String[] { COMMON_NAVIGATOR_RESOURCE_EXT,
-						TEST_CONTENT_NO_CHILDREN }, true);
+		String[] exts = { COMMON_NAVIGATOR_RESOURCE_EXT, TEST_CONTENT_NO_CHILDREN };
+		_contentService.bindExtensions(exts, false);
+		_contentService.getActivationService().activateExtensions(exts, true);
 
 		refreshViewer();
 

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/jst/JstPipelineTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/jst/JstPipelineTest.java
@@ -58,17 +58,15 @@ public class JstPipelineTest extends NavigatorTestBase {
 	 */
 	@Test
 	public void testJstPipeline() throws Exception {
-
-		_contentService.bindExtensions(
-				new String[] { COMMON_NAVIGATOR_RESOURCE_EXT, COMMON_NAVIGATOR_JAVA_EXT, TEST_CONTENT_JST }, false);
+		String[] exts = { COMMON_NAVIGATOR_RESOURCE_EXT, COMMON_NAVIGATOR_JAVA_EXT, TEST_CONTENT_JST };
+		_contentService.bindExtensions(exts, false);
 
 		// Note this test will fail showing only one if the JDT stuff
 		// is not included in the executing bundles (which it normally is)
 		assertEquals("There should be 3 visible extensions for the pipeline viewer.", 3,
 				_contentService.getVisibleExtensionIds().length);
 
-		_contentService.getActivationService().activateExtensions(
-				new String[] { COMMON_NAVIGATOR_RESOURCE_EXT, COMMON_NAVIGATOR_JAVA_EXT, TEST_CONTENT_JST }, true);
+		_contentService.getActivationService().activateExtensions(exts, true);
 
 		refreshViewer();
 


### PR DESCRIPTION
Reduces cyclic dependencies between git repositories.