### PR TITLE
Activate monitor-specific scaling before Display instantiation

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
@@ -588,7 +588,6 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 				int orientation = store.getInt(IPreferenceConstants.LAYOUT_DIRECTION);
 				Window.setDefaultOrientation(orientation);
 			}
-			setRescaleAtRuntimePropertyFromPreference();
 			if (obj instanceof E4Application) {
 				E4Application e4app = (E4Application) obj;
 				E4Workbench e4Workbench = e4app.createE4Workbench(getApplicationContext(), display);
@@ -684,9 +683,9 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 
 	private static void setRescaleAtRuntimePropertyFromPreference() {
 		if (System.getProperty(SWT_RESCALE_AT_RUNTIME_PROPERTY) != null) {
-			WorkbenchPlugin.log(StatusUtil.newStatus(IStatus.WARNING, SWT_RESCALE_AT_RUNTIME_PROPERTY
-					+ " is configured (e.g., via the INI), but the according preference should be preferred instead.", //$NON-NLS-1$
-					new RuntimeException()));
+			WorkbenchPlugin.log(Status.warning(SWT_RESCALE_AT_RUNTIME_PROPERTY
+					+ " is configured (e.g., via the INI), but the according preference should be preferred instead." //$NON-NLS-1$
+			));
 		} else {
 			boolean rescaleAtRuntime = PrefUtil.getAPIPreferenceStore()
 					.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME);
@@ -757,6 +756,8 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 		if (applicationName != null) {
 			Display.setAppName(applicationName);
 		}
+
+		setRescaleAtRuntimePropertyFromPreference();
 
 		// create the display
 		Display newDisplay = Display.getCurrent();

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
@@ -504,7 +504,7 @@ RescaleAtRuntimeSettingChangeWarningTitle = DPI Setting Changed
 RescaleAtRuntimeSettingChangeWarningText = Restart for the DPI setting changes to take effect
 HiDpiSettingsGroupTitle = HiDPI settings
 RescaleAtRuntimeEnabled = Monitor-specific UI &scaling
-RescaleAtRuntimeDisclaimer = EXPERIMENTAL! Activating this option will dynamically scale all windows according to the monitor they are currently in. It will also set the default browser to Edge in order to provide the appropriate scaling of content displayed in a browser. This feature is still in development and therefore considered experimental.
+RescaleAtRuntimeDisclaimer = EXPERIMENTAL! Activating this option will dynamically scale all windows according to the monitor they are currently in. It is still in development and therefore considered experimental.
 # --- Workbench -----
 WorkbenchPreference_openMode=Open mode
 WorkbenchPreference_doubleClick=D&ouble click


### PR DESCRIPTION
Monitor-specific scaling needs to be activated before the display that is supposed to run in that mode is created. Currently, the scaling is activated in the Workbench based on an according preference after the Display has already been created.

This change moves the evaluation of the experimental preference and the according initialization of monitor-specific scaling to before the Display is created inside the Workbench.
In addition, the disclaimer is cleaned up from the statement about Edge, which is now already been enabled by default.