### PR TITLE
Use LTK Refactoring when copying (duplicating) a Project.

### DIFF
--- a/bundles/org.eclipse.ltk.ui.refactoring/plugin.properties
+++ b/bundles/org.eclipse.ltk.ui.refactoring/plugin.properties
@@ -29,3 +29,7 @@ renameResource.description=Rename the selected resource and notify LTK participa
 renameResource.commandParameter.newName=Selected resource's new name.
 
 contentMergeViewers.refactoring.label=Refactoring Compare
+
+copyProject.name=Copy Project
+copyProject.commandParameter.newName=The name of the new project.
+copyProject.commandParameter.newLocation=The location of the new project.

--- a/bundles/org.eclipse.ltk.ui.refactoring/plugin.xml
+++ b/bundles/org.eclipse.ltk.ui.refactoring/plugin.xml
@@ -136,7 +136,7 @@
             categoryId="org.eclipse.ltk.ui.category.refactoring"
             defaultHandler="org.eclipse.ltk.internal.ui.refactoring.actions.CopyProjectHandler"
             id="org.eclipse.ltk.ui.refactoring.commands.copyProject"
-            name="Copy Project LTK">
+            name="%copyProject.name">
          <commandParameter
                id="org.eclipse.ltk.ui.refactoring.commands.copyProject.newName.parameter.key"
                name="%copyProject.commandParameter.newName"


### PR DESCRIPTION
Added missing plugin.properties