### PR TITLE
Add ViewerComparator methods in INavigatorSorterService

### DIFF
--- a/bundles/org.eclipse.ui.navigator/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.navigator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.navigator; singleton:=true
-Bundle-Version: 3.12.600.qualifier
+Bundle-Version: 3.13.0.qualifier
 Bundle-Activator: org.eclipse.ui.internal.navigator.NavigatorPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/sorters/CommonSorterDescriptor.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/sorters/CommonSorterDescriptor.java
@@ -90,17 +90,16 @@ public class CommonSorterDescriptor implements INavigatorContentExtPtConstants {
 
 	/**
 	 *
-	 * @return An instance of the ViewerSorter defined by the extension. Callers
-	 *         of this method are responsible for managing the instantiated
-	 *         filter.
+	 * @return An instance of the ViewerComparator defined by the extension. Callers
+	 *         of this method are responsible for managing the instantiated filter.
 	 */
-	public ViewerSorter createSorter() {
-		final ViewerSorter[] sorter = new ViewerSorter[1];
+	public ViewerComparator createComparator() {
+		final ViewerComparator[] sorter = new ViewerComparator[1];
 
 		SafeRunner.run(new NavigatorSafeRunnable(element) {
 			@Override
 			public void run() throws Exception {
-				sorter[0] = createSorterInstance();
+				sorter[0] = createComparatorInstance();
 			}
 		});
 		if (sorter[0] != null)
@@ -108,13 +107,10 @@ public class CommonSorterDescriptor implements INavigatorContentExtPtConstants {
 		return SkeletonViewerSorter.INSTANCE;
 	}
 
-	private ViewerSorter createSorterInstance() throws CoreException {
+	private ViewerComparator createComparatorInstance() throws CoreException {
 		Object contributed = element.createExecutableExtension(ATT_CLASS);
-		if (contributed instanceof ViewerSorter) {
-			return (ViewerSorter) contributed;
-		}
-		if (contributed instanceof ViewerComparator) {
-			return new WrappedViewerComparator((ViewerComparator) contributed);
+		if (contributed instanceof ViewerComparator comparator) {
+			return comparator;
 		}
 		throw new ClassCastException("Class contributed by " + element.getNamespaceIdentifier() + //$NON-NLS-1$
 				" to " + INavigatorContentExtPtConstants.TAG_NAVIGATOR_CONTENT + //$NON-NLS-1$

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/sorters/CommonSorterDescriptorManager.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/sorters/CommonSorterDescriptorManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2015 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -40,7 +40,7 @@ public class CommonSorterDescriptorManager {
 
 	private static final CommonSorterDescriptor[] NO_SORTER_DESCRIPTORS = new CommonSorterDescriptor[0];
 
-	private final Map<INavigatorContentDescriptor, Set> sortersMap = new HashMap<>();
+	private final Map<INavigatorContentDescriptor, Set<CommonSorterDescriptor>> sortersMap = new HashMap<>();
 
 	/**
 	 *

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/navigator/CommonNavigator.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/navigator/CommonNavigator.java
@@ -192,7 +192,7 @@ public class CommonNavigator extends ViewPart implements ISetSelectionTarget, IS
 				commonViewer.addFilter(visibleFilter);
 			}
 
-			commonViewer.setSorter(new CommonViewerSorter());
+			commonViewer.setComparator(new CommonViewerSorter());
 
 			/*
 			 * make sure input is set after sorters and filters to avoid unnecessary

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/navigator/CommonViewer.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/navigator/CommonViewer.java
@@ -25,6 +25,7 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.LabelProviderChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.jface.viewers.ViewerSorter;
 import org.eclipse.swt.dnd.DND;
 import org.eclipse.swt.events.DisposeEvent;
@@ -263,16 +264,32 @@ public class CommonViewer extends TreeViewer {
 	 * Sets this viewer's sorter and triggers refiltering and resorting of this
 	 * viewer's element. Passing <code>null</code> turns sorting off.
 	 *
-	 * @param sorter
-	 *            a viewer sorter, or <code>null</code> if none
+	 * @param sorter a viewer sorter, or <code>null</code> if none
+	 * @deprecated Use {@link #setComparator(ViewerComparator)} instead.
 	 */
 	@Override
+	@Deprecated(forRemoval = true, since = "2025-03")
 	public void setSorter(ViewerSorter sorter) {
 		if (sorter != null && sorter instanceof CommonViewerSorter commonSorter) {
 			commonSorter.setContentService(contentService);
 		}
 
 		super.setSorter(sorter);
+	}
+
+	/**
+	 * Sets this viewer's sorter and triggers refiltering and resorting of this
+	 * viewer's element. Passing <code>null</code> turns sorting off.
+	 *
+	 * @param comparator a viewer sorter, or <code>null</code> if none
+	 */
+	@Override
+	public void setComparator(ViewerComparator comparator) {
+		if (comparator != null && comparator instanceof CommonViewerSorter commonSorter) {
+			commonSorter.setContentService(contentService);
+		}
+
+		super.setComparator(comparator);
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/navigator/CommonViewerSorter.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/navigator/CommonViewerSorter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2015 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ import java.util.Set;
 import org.eclipse.jface.viewers.TreePath;
 import org.eclipse.jface.viewers.TreePathViewerSorter;
 import org.eclipse.jface.viewers.Viewer;
-import org.eclipse.jface.viewers.ViewerSorter;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.ui.internal.navigator.CommonNavigatorMessages;
 import org.eclipse.ui.internal.navigator.NavigatorContentService;
@@ -99,15 +99,15 @@ public final class CommonViewerSorter extends TreePathViewerSorter {
 			return -1;
 		}
 
-		ViewerSorter sorter = null;
+		ViewerComparator sorter = null;
 
 		// shortcut if contributed by same source
 		if (sourceOfLvalue == sourceOfRvalue) {
-			sorter = sorterService.findSorter(sourceOfLvalue, parent, e1, e2);
+			sorter = sorterService.findComparator(sourceOfLvalue, parent, e1, e2);
 		} else {
 			// findSorter returns the sorter specified at the source or if it has a higher priority a sortOnly sorter that is registered for the parent
-			ViewerSorter lSorter = findApplicableSorter(sourceOfLvalue, parent, e1, e2);
-			ViewerSorter rSorter = findApplicableSorter(sourceOfRvalue, parent, e1, e2);
+			ViewerComparator lSorter = findApplicableSorter(sourceOfLvalue, parent, e1, e2);
+			ViewerComparator rSorter = findApplicableSorter(sourceOfRvalue, parent, e1, e2);
 			sorter = rSorter;
 
 			if (rSorter == null || (lSorter != null && sourceOfLvalue.getSequenceNumber() < sourceOfRvalue.getSequenceNumber())) {
@@ -126,10 +126,10 @@ public final class CommonViewerSorter extends TreePathViewerSorter {
 		return categoryDelta;
 	}
 
-	private ViewerSorter findApplicableSorter(INavigatorContentDescriptor descriptor, Object parent,
+	private ViewerComparator findApplicableSorter(INavigatorContentDescriptor descriptor, Object parent,
 			Object e1,
 			Object e2) {
-		ViewerSorter sorter = sorterService.findSorter(descriptor, parent, e1, e2);
+		ViewerComparator sorter = sorterService.findComparator(descriptor, parent, e1, e2);
 		if (!descriptor.isSortOnly()) { // for compatibility
 			if (!(descriptor.isTriggerPoint(e1) && descriptor.isTriggerPoint(e2))) {
 				return null;
@@ -155,7 +155,7 @@ public final class CommonViewerSorter extends TreePathViewerSorter {
 		INavigatorContentDescriptor contentDesc = getSource(element);
 		if (parentPath.getSegmentCount() == 0)
 			return false;
-		ViewerSorter sorter = sorterService.findSorter(contentDesc, parentPath.getLastSegment(), element, null);
+		ViewerComparator sorter = sorterService.findComparator(contentDesc, parentPath.getLastSegment(), element, null);
 		if (sorter != null)
 			return sorter.isSorterProperty(element, property);
 		return false;

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/navigator/INavigatorSorterService.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/navigator/INavigatorSorterService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2015 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@ package org.eclipse.ui.navigator;
 
 import java.util.Map;
 
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.jface.viewers.ViewerSorter;
 
 /**
@@ -31,7 +32,7 @@ import org.eclipse.jface.viewers.ViewerSorter;
  * </p>
  *
  * @see INavigatorContentService#getSorterService()
- * @see ViewerSorter
+ * @see ViewerComparator
  *
  * @noimplement This interface is not intended to be implemented by clients.
  * @noextend This interface is not intended to be extended by clients.
@@ -44,46 +45,74 @@ public interface INavigatorSorterService {
 	 * associated {@link INavigatorContentService} and whose <b>parentExpression</b>
 	 * matches the given parent.
 	 *
-	 * @param aParent
-	 *            An element from the tree
+	 * @param aParent An element from the tree
 	 * @return An applicable ViewerSorter or simple {@link ViewerSorter} if no
 	 *         sorter is found.
+	 * @deprecated Use {@link #findComparatorForParent(Object)} instead
 	 */
+	@Deprecated(since = "2025-03", forRemoval = true)
 	ViewerSorter findSorterForParent(Object aParent);
+
+	/**
+	 * Return a {@link ViewerComparator} from an extension which is visible to the
+	 * associated {@link INavigatorContentService} and whose <b>parentExpression</b>
+	 * matches the given parent.
+	 *
+	 * @param aParent An element from the tree
+	 * @return An applicable ViewerComparator or simple {@link ViewerComparator} if
+	 *         no sorter is found.
+	 * @since 3.13
+	 */
+	ViewerComparator findComparatorForParent(Object aParent);
 
 	/**
 	 * Return a {@link ViewerSorter} from an extension which is visible to the
 	 * associated {@link INavigatorContentService} and whose <b>parentExpression</b>
 	 * matches the given parent.
 	 *
-	 * @param source
-	 *            The source of the element.
-	 * @param parent
-	 *            An element from the tree
-	 * @param lvalue
-	 *            An element from the tree
-	 * @param rvalue
-	 *            An element from the tree
+	 * @param source The source of the element.
+	 * @param parent An element from the tree
+	 * @param lvalue An element from the tree
+	 * @param rvalue An element from the tree
 	 * @return An applicable ViewerSorter or simple {@link ViewerSorter} if no
 	 *         sorter is found.
+	 * @deprecated Use
+	 *             {@link #findComparator(INavigatorContentDescriptor, Object, Object, Object)}
+	 *             instead.
 	 */
+	@Deprecated(since = "2025-03", forRemoval = true)
 	ViewerSorter findSorter(INavigatorContentDescriptor source, Object parent,
 			Object lvalue, Object rvalue);
+
+	/**
+	 * Return a {@link ViewerComparator} from an extension which is visible to the
+	 * associated {@link INavigatorContentService} and whose <b>parentExpression</b>
+	 * matches the given parent.
+	 *
+	 * @param source The source of the element.
+	 * @param parent An element from the tree
+	 * @param lvalue An element from the tree
+	 * @param rvalue An element from the tree
+	 * @return An applicable ViewerComparator or simple {@link ViewerComparator} if
+	 *         no sorter is found.
+	 * @since 3.13
+	 */
+	ViewerComparator findComparator(INavigatorContentDescriptor source, Object parent, Object lvalue,
+			Object rvalue);
 
 	/**
 	 * Find and return all viewer sorters associated with the given descriptor.
 	 *
 	 * <p>
-	 * The <i>commonSorter</i> element is not required to have an id, so in
-	 * some cases, an auto-generated id, using the content extension id as a
-	 * base, is generated to ensure the map is properly filled with all
-	 * available sorters. No guarantees are given as to the order or consistency
-	 * of these generated ids between invocations.
+	 * The <i>commonSorter</i> element is not required to have an id, so in some
+	 * cases, an auto-generated id, using the content extension id as a base, is
+	 * generated to ensure the map is properly filled with all available sorters. No
+	 * guarantees are given as to the order or consistency of these generated ids
+	 * between invocations.
 	 * </p>
 	 *
-	 * @param theSource
-	 *            A descriptor that identifies a particular content extension
-	 * @return A Map[String sorterDescriptorId, ViewerSorter instance] where the
+	 * @param theSource A descriptor that identifies a particular content extension
+	 * @return A Map[String sorterDescriptorId, ViewerComparator instance] where the
 	 *         key is the id defined in the extension and the value is the
 	 *         instantiated sorter.
 	 *
@@ -92,6 +121,6 @@ public interface INavigatorSorterService {
 	 * @see INavigatorContentExtension#getDescriptor()
 	 * @since 3.3
 	 */
-	public Map findAvailableSorters(INavigatorContentDescriptor theSource);
+	public Map<String, ViewerComparator> findAvailableSorters(INavigatorContentDescriptor theSource);
 
 }

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/SorterTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/SorterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Oakland Software Incorporated and others.
+ * Copyright (c) 2008, 2025 Oakland Software Incorporated and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -29,7 +29,6 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
-import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.internal.navigator.NavigatorPlugin;
 import org.eclipse.ui.internal.navigator.sorters.CommonSorterDescriptor.WrappedViewerComparator;
@@ -131,7 +130,7 @@ public class SorterTest extends NavigatorTestBase {
 
 		// Make it sort backwards so we can tell
 		TestSorterResource sorter = (TestSorterResource) _contentService
-			.getSorterService().findSorter(desc, _project, null, null);
+				.getSorterService().findComparator(desc, _project, null, null);
 		sorter._forward = false;
 
 		_contentService.bindExtensions(
@@ -258,7 +257,7 @@ public class SorterTest extends NavigatorTestBase {
 
 		// Make it sort backwards so we can tell
 		TestSorterDataAndResource sorter = (TestSorterDataAndResource) _contentService
-				.getSorterService().findSorter(desc, _project, null, null);
+				.getSorterService().findComparator(desc, _project, null, null);
 		sorter._forward = false;
 
 		_viewer.setExpandedState(_project,	true);
@@ -326,20 +325,20 @@ public class SorterTest extends NavigatorTestBase {
 
 		INavigatorContentDescriptor desc = _contentService.getContentDescriptorById(TEST_CONTENT_COMPARATOR_MODEL);
 
-		ViewerComparator sorter = _contentService.getSorterService().findSorter(desc, _project, null, null);
-		assertNotNull(sorter);
-		WrappedViewerComparator wrapper = (WrappedViewerComparator) sorter;
-		TestComparatorData original = (TestComparatorData) wrapper.getWrappedComparator();
+		TestComparatorData comparator = (TestComparatorData) _contentService.getSorterService().findComparator(desc,
+				_project, null, null);
+		assertNotNull(comparator);
+		WrappedViewerComparator wrapper = new WrappedViewerComparator(comparator);
 		Object[] dataArray = new Object[items.length];
 
 		for (int i = 0; i < items.length; i++) {
 			TreeItem treeItem = items[i];
 			Object data = treeItem.getData();
 			dataArray[i] = data;
-			assertEquals(original.category(data), wrapper.category(data));
-			assertEquals(original.isSorterProperty(data, "true"), wrapper.isSorterProperty(data, "true"));
-			assertEquals(original.isSorterProperty(data, "false"), wrapper.isSorterProperty(data, "false"));
-			assertEquals(original.compare(_viewer, data, items[0].getData()),
+			assertEquals(comparator.category(data), wrapper.category(data));
+			assertEquals(comparator.isSorterProperty(data, "true"), wrapper.isSorterProperty(data, "true"));
+			assertEquals(comparator.isSorterProperty(data, "false"), wrapper.isSorterProperty(data, "false"));
+			assertEquals(comparator.compare(_viewer, data, items[0].getData()),
 					wrapper.compare(_viewer, data, items[0].getData()));
 			assertEquals(false, wrapper.isSorterProperty(data, "false"));
 			assertEquals(true, wrapper.isSorterProperty(data, "true"));
@@ -347,8 +346,8 @@ public class SorterTest extends NavigatorTestBase {
 
 		Object[] copy1 = Arrays.copyOf(dataArray, dataArray.length);
 		Object[] copy2 = Arrays.copyOf(dataArray, dataArray.length);
-		original._forward = !original._forward;
-		original.sort(_viewer, copy1);
+		comparator._forward = !comparator._forward;
+		comparator.sort(_viewer, copy1);
 		wrapper.sort(_viewer, copy2);
 		assertArrayEquals(copy1, copy2);
 
@@ -423,7 +422,7 @@ public class SorterTest extends NavigatorTestBase {
 				.getContentDescriptorById(TEST_CONTENT_SORTER_RESOURCE);
 
 		TestSorterResource sorter = (TestSorterResource) _contentService
-				.getSorterService().findSorter(desc, _p2, null, null);
+				.getSorterService().findComparator(desc, _p2, null, null);
 		sorter._forward = false;
 
 		IStructuredSelection sel;

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestSorterData.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestSorterData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,9 +16,9 @@ package org.eclipse.ui.tests.navigator.extension;
 import java.text.Collator;
 
 import org.eclipse.jface.viewers.Viewer;
-import org.eclipse.jface.viewers.ViewerSorter;
+import org.eclipse.jface.viewers.ViewerComparator;
 
-public class TestSorterData extends ViewerSorter {
+public class TestSorterData extends ViewerComparator {
 
 	public static String _sorterProperty;
 	public static Object _sorterElement;
@@ -41,11 +41,8 @@ public class TestSorterData extends ViewerSorter {
 	@Override
 	public int compare(Viewer viewer, Object e1, Object e2) {
 
-		if(e1 instanceof TestExtensionTreeData) {
-			if(e2 instanceof TestExtensionTreeData) {
-				TestExtensionTreeData lvalue = (TestExtensionTreeData) e1;
-				TestExtensionTreeData rvalue = (TestExtensionTreeData) e2;
-
+		if (e1 instanceof TestExtensionTreeData lvalue) {
+			if (e2 instanceof TestExtensionTreeData rvalue) {
 				if (_forward)
 					return lvalue.getName().compareTo(rvalue.getName());
 				return rvalue.getName().compareTo(lvalue.getName());

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestSorterDataAndResource.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestSorterDataAndResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 Oakland Software Incorporated and others.
+ * Copyright (c) 2009, 2025 Oakland Software Incorporated and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,9 +17,9 @@ import java.text.Collator;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.jface.viewers.Viewer;
-import org.eclipse.jface.viewers.ViewerSorter;
+import org.eclipse.jface.viewers.ViewerComparator;
 
-public class TestSorterDataAndResource extends ViewerSorter {
+public class TestSorterDataAndResource extends ViewerComparator {
 
 	public boolean _forward = true;
 

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestSorterResource.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestSorterResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 Oakland Software Incorporated and others.
+ * Copyright (c) 2009, 2025 Oakland Software Incorporated and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,9 +17,9 @@ import java.text.Collator;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.jface.viewers.Viewer;
-import org.eclipse.jface.viewers.ViewerSorter;
+import org.eclipse.jface.viewers.ViewerComparator;
 
-public class TestSorterResource extends ViewerSorter {
+public class TestSorterResource extends ViewerComparator {
 
 	public static String _sorterProperty;
 	public static Object _sorterElement;


### PR DESCRIPTION
As every ViewerSorter is ViewerComparator the new default methods can be trivially added to implementors.
There are expected to be none as the interface is marked as noimplement and noextend.