### PR TITLE
Revert "Activate monitor-specific scaling before Display instantiation"

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
@@ -588,6 +588,7 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 				int orientation = store.getInt(IPreferenceConstants.LAYOUT_DIRECTION);
 				Window.setDefaultOrientation(orientation);
 			}
+			setRescaleAtRuntimePropertyFromPreference();
 			if (obj instanceof E4Application) {
 				E4Application e4app = (E4Application) obj;
 				E4Workbench e4Workbench = e4app.createE4Workbench(getApplicationContext(), display);
@@ -756,8 +757,6 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 		if (applicationName != null) {
 			Display.setAppName(applicationName);
 		}
-
-		setRescaleAtRuntimePropertyFromPreference();
 
 		// create the display
 		Display newDisplay = Display.getCurrent();


### PR DESCRIPTION
This partially reverts commit 3587081. It introduced a regression as preferences cannot be read that early during startup. Moving that preference evaluation call is reverted.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2712