### PR TITLE
[Win] Activate monitor-specific scaling before Display instantiation

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
@@ -81,6 +81,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.dynamichelpers.IExtensionTracker;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.preferences.ConfigurationScope;
 import org.eclipse.e4.core.contexts.ContextFunction;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
@@ -687,8 +688,8 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 					+ " is configured (e.g., via the INI), but the according preference should be preferred instead." //$NON-NLS-1$
 			));
 		} else {
-			boolean rescaleAtRuntime = PrefUtil.getAPIPreferenceStore()
-					.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME);
+			boolean rescaleAtRuntime = ConfigurationScope.INSTANCE.getNode(WorkbenchPlugin.PI_WORKBENCH)
+					.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME, false);
 			System.setProperty(SWT_RESCALE_AT_RUNTIME_PROPERTY, Boolean.toString(rescaleAtRuntime));
 		}
 	}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
@@ -39,6 +39,7 @@ import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.core.runtime.RegistryFactory;
+import org.eclipse.core.runtime.preferences.ConfigurationScope;
 import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -218,8 +219,8 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 		infoLabel.setLayoutData(GridDataFactory.defaultsFor(infoLabel).create());
 		createLabel(group, ""); //$NON-NLS-1$
 
-		boolean initialStateRescaleAtRuntime = PrefUtil.getAPIPreferenceStore()
-				.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME);
+		boolean initialStateRescaleAtRuntime = ConfigurationScope.INSTANCE.getNode(WorkbenchPlugin.PI_WORKBENCH)
+				.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME, false);
 		rescaleAtRuntime = createCheckButton(group, WorkbenchMessages.RescaleAtRuntimeEnabled, initialStateRescaleAtRuntime);
 	}
 
@@ -373,10 +374,17 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 
 		boolean isRescaleAtRuntimeChanged = false;
 		if (rescaleAtRuntime != null) {
-			boolean initialStateRescaleAtRuntime = PrefUtil.getAPIPreferenceStore()
-					.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME);
+			IEclipsePreferences configurationScopeNode = ConfigurationScope.INSTANCE
+					.getNode(WorkbenchPlugin.PI_WORKBENCH);
+			boolean initialStateRescaleAtRuntime = configurationScopeNode
+					.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME, false);
 			isRescaleAtRuntimeChanged = initialStateRescaleAtRuntime != rescaleAtRuntime.getSelection();
-			apiStore.setValue(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME, rescaleAtRuntime.getSelection());
+			configurationScopeNode.putBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME,
+					rescaleAtRuntime.getSelection());
+			try {
+				configurationScopeNode.flush();
+			} catch (BackingStoreException e) {
+			}
 		}
 
 		prefs.putBoolean(CTabRendering.USE_ROUND_TABS, useRoundTabs.getSelection());


### PR DESCRIPTION
Monitor-specific scaling needs to be activated before the display that is supposed to run in that mode is created. Currently, the scaling is activated in the Workbench based on an according preference after the Display has already been created.

This change moves the evaluation of the experimental preference and the according initialization of monitor-specific scaling to before the Display is created inside the Workbench. Since the preference is now accessed at a point in time where no workspace may already be available, the preference was moved to the ConfigurationScope so that it is stored independent from the actual workspace.

The drawback with this approach is that for an Eclipse application started from a workspace, where the configuration area will usually be cleared before every application start, the preference will be reset on every restart. Thus, for that scenario, the system property would currently have to be set explicitly via the VM arguments.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2712

Closes https://github.com/eclipse-platform/eclipse.platform.ui/pull/2713