### PR TITLE
[StickyScrolling] Show sticky lines if opened via search

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -440,7 +440,7 @@ public class StickyScrollingControl {
 			int lastStickyLineNumber = stickyLines.get(stickyLines.size() - 1).getLineNumber();
 			return lastStickyLineNumber > textWidget.getLineCount();
 		}
-		return true;
+		return false;
 	}
 
 	private void limitVisibleStickyLinesToTextWidgetHeight(StyledText textWidget) {


### PR DESCRIPTION
Sticky lines should be shown when the file is opened via search view.

Fixes #2678