### PR TITLE
[StickyScrolling] Don't style outdated sticky lines

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -394,6 +394,9 @@ public class StickyScrollingControl {
 		if (sourceViewer instanceof ITextViewerExtension4 extension) {
 			textPresentationListener = e -> {
 				Display.getDefault().asyncExec(() -> {
+					if (textWidget.isDisposed() || areStickyLinesOutDated(textWidget)) {
+						return;
+					}
 					styleStickyLines();
 				});
 			};


### PR DESCRIPTION
The search view with "reuse editor" enabled sets new source code in the existing editor and fires a extPresentation change event. In this call, it can happen that the sticky line number exceeds the amount of line in the new source code. In general this is not a problem since the sticky lines will be recalculated afterwards, but to avoid IllegalArgumentException it is checked for this case.

Fixes #2678