### PR TITLE
Adapt double buffering use cases for multi-zoom

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/AnnotationRulerColumn.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/AnnotationRulerColumn.java
@@ -266,6 +266,13 @@ public class AnnotationRulerColumn implements IVerticalRulerColumn, IVerticalRul
 			fCachedTextWidget= null;
 		});
 
+		fCanvas.addListener(SWT.ZoomChanged, e -> {
+			if (fBuffer != null) {
+				fBuffer.dispose();
+				fBuffer= null;
+			}
+		});
+
 		fMouseListener= new MouseListener() {
 			@Override
 			public void mouseUp(MouseEvent event) {
@@ -517,24 +524,28 @@ public class AnnotationRulerColumn implements IVerticalRulerColumn, IVerticalRul
 				fBuffer= null;
 			}
 		}
-		if (fBuffer == null)
-			fBuffer= new Image(fCanvas.getDisplay(), size.x, size.y);
-
-		GC gc= new GC(fBuffer);
-		gc.setFont(fCachedTextWidget.getFont());
-		try {
-			gc.setBackground(fCanvas.getBackground());
-			gc.fillRectangle(0, 0, size.x, size.y);
-
-			if (fCachedTextViewer instanceof ITextViewerExtension5)
-				doPaint1(gc);
-			else
-				doPaint(gc);
-		} finally {
-			gc.dispose();
+		if (fBuffer == null) {
+			fBuffer= new Image(fCanvas.getDisplay(), this::doPaint, size.x, size.y);
+		} else {
+			GC gc= new GC(fBuffer);
+			try {
+				doPaint(gc, size.x, size.y);
+			} finally {
+				gc.dispose();
+			}
 		}
-
 		dest.drawImage(fBuffer, 0, 0);
+	}
+
+	private void doPaint(GC gc, int width, int height) {
+		gc.setFont(fCachedTextWidget.getFont());
+		gc.setBackground(fCanvas.getBackground());
+		gc.fillRectangle(0, 0, width, height);
+
+		if (fCachedTextViewer instanceof ITextViewerExtension5)
+			doPaint1(gc);
+		else
+			doPaint(gc);
 	}
 
 	/**

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/ChangeRulerColumn.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/ChangeRulerColumn.java
@@ -199,6 +199,13 @@ public final class ChangeRulerColumn implements IChangeRulerColumn, IRevisionRul
 			fCachedTextWidget= null;
 		});
 
+		fCanvas.addListener(SWT.ZoomChanged, e -> {
+			if (fBuffer != null) {
+				fBuffer.dispose();
+				fBuffer= null;
+			}
+		});
+
 		fCanvas.addMouseListener(fMouseHandler);
 		fCanvas.addMouseMoveListener(fMouseHandler);
 
@@ -249,19 +256,15 @@ public final class ChangeRulerColumn implements IChangeRulerColumn, IRevisionRul
 				fBuffer= null;
 			}
 		}
-		if (fBuffer == null)
-			fBuffer= new Image(fCanvas.getDisplay(), size.x, size.y);
-
-		GC gc= new GC(fBuffer);
-		gc.setFont(fCanvas.getFont());
-
-		try {
-			gc.setBackground(getBackground());
-			gc.fillRectangle(0, 0, size.x, size.y);
-
-			doPaint(gc);
-		} finally {
-			gc.dispose();
+		if (fBuffer == null) {
+			fBuffer= new Image(fCanvas.getDisplay(), this::doPaint, size.x, size.y);
+		} else {
+			GC gc= new GC(fBuffer);
+			try {
+				doPaint(gc, size.x, size.y);
+			} finally {
+				gc.dispose();
+			}
 		}
 
 		dest.drawImage(fBuffer, 0, 0);
@@ -289,6 +292,14 @@ public final class ChangeRulerColumn implements IChangeRulerColumn, IRevisionRul
 	 */
 	protected final boolean isViewerCompletelyShown() {
 		return JFaceTextUtil.isShowingEntireContents(fCachedTextWidget);
+	}
+
+	private void doPaint(GC gc, int width, int height) {
+		gc.setFont(fCanvas.getFont());
+		gc.setBackground(getBackground());
+		gc.fillRectangle(0, 0, width, height);
+
+		doPaint(gc);
 	}
 
 	/**

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/LineNumberRulerColumn.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/LineNumberRulerColumn.java
@@ -34,6 +34,7 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontMetrics;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Canvas;
@@ -616,7 +617,13 @@ public class LineNumberRulerColumn implements IVerticalRulerColumn {
 			fCachedTextWidget= null;
 		});
 
-		fCanvas.addListener(SWT.ZoomChanged, e -> computeIndentations());
+		fCanvas.addListener(SWT.ZoomChanged, e -> {
+			computeIndentations();
+			if (fBuffer != null) {
+				fBuffer.dispose();
+				fBuffer= null;
+			}
+		});
 
 		fMouseHandler= new MouseHandler();
 		fCanvas.addMouseListener(fMouseHandler);
@@ -679,10 +686,28 @@ public class LineNumberRulerColumn implements IVerticalRulerColumn {
 			return;
 		}
 
-		boolean bufferStillValid = fBuffer != null;
 		if (fBuffer == null) {
-			fBuffer= new Image(fCanvas.getDisplay(), size.x, size.y);
+			fBuffer= newFullBufferImage(size);
+		} else {
+			doPaint(visibleLines, size);
 		}
+		dest.drawImage(fBuffer, 0, 0);
+	}
+
+	private Image newFullBufferImage(Point size) {
+		ImageGcDrawer imageGcDrawer= (gc, imageWidth, imageHeight) -> {
+			ILineRange lines= JFaceTextUtil.getVisibleModelLines(fCachedTextViewer);
+			if (lines == null) {
+				return;
+			}
+			// We redraw everything; paint directly into the buffer
+			initializeGC(gc, 0, 0, imageWidth, imageHeight);
+			doPaint(gc, lines);
+		};
+		return new Image(fCanvas.getDisplay(), imageGcDrawer, size.x, size.y);
+	}
+
+	private void doPaint(ILineRange visibleLines, Point size) {
 		GC bufferGC= new GC(fBuffer);
 		Image newBuffer= null;
 		try {
@@ -696,7 +721,7 @@ public class LineNumberRulerColumn implements IVerticalRulerColumn {
 			int bottomWidgetLine= JFaceTextUtil.modelLineToWidgetLine(fCachedTextViewer, bottomModelLine);
 			boolean atEnd= bottomWidgetLine + 1 >= fCachedTextWidget.getLineCount();
 			int height= size.y;
-			if (dy != 0 && !atEnd && bufferStillValid && fLastTopPixel >= 0 && numberOfLines > 1 && numberOfLines == fLastNumberOfLines) {
+			if (dy != 0 && !atEnd && fLastTopPixel >= 0 && numberOfLines > 1 && numberOfLines == fLastNumberOfLines) {
 				int bottomPixel= fCachedTextWidget.getLinePixel(bottomWidgetLine + 1);
 				if (dy > 0 && bottomPixel < size.y) {
 					// Can occur on GTK with static scrollbars; see bug 551320.
@@ -745,16 +770,7 @@ public class LineNumberRulerColumn implements IVerticalRulerColumn {
 			fLastBottomModelLine= bottomModelLine;
 			fLastHeight= height;
 			if (dy != 0) {
-				// Some rulers may paint outside the line region. Let them paint in a new image,
-				// the copy the wanted bits.
-				newBuffer= new Image(fCanvas.getDisplay(), size.x, size.y);
-				GC localGC= new GC(newBuffer);
-				try {
-					initializeGC(localGC, 0, bufferY, size.x, bufferH);
-					doPaint(localGC, visibleLines);
-				} finally {
-					localGC.dispose();
-				}
+				newBuffer= newBufferImage(size, bufferY, bufferH, visibleLines);
 				bufferGC.drawImage(newBuffer, 0, bufferY, size.x, bufferH, 0, bufferY, size.x, bufferH);
 				if (dy > 0 && bufferY + bufferH < size.y) {
 					// Scrolled down in the text, but didn't use the full height of the Canvas: clear
@@ -774,7 +790,16 @@ public class LineNumberRulerColumn implements IVerticalRulerColumn {
 				newBuffer.dispose();
 			}
 		}
-		dest.drawImage(fBuffer, 0, 0);
+	}
+
+	private Image newBufferImage(Point size, int bufferY, int bufferH, final ILineRange visibleLines) {
+		ImageGcDrawer imageGcDrawer= (localGC, imageWidth, imageHeight) -> {
+			// Some rulers may paint outside the line region. Let them paint in a new image,
+			// the copy the wanted bits.
+			initializeGC(localGC, 0, bufferY, imageWidth, bufferH);
+			doPaint(localGC, visibleLines);
+		};
+		return new Image(fCanvas.getDisplay(), imageGcDrawer, size.x, size.y);
 	}
 
 	private void initializeGC(GC gc, int x, int y, int width, int height) {

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/OverviewRuler.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/OverviewRuler.java
@@ -597,6 +597,13 @@ public class OverviewRuler implements IOverviewRulerExtension, IOverviewRuler {
 			fTextViewer= null;
 		});
 
+		fCanvas.addListener(SWT.ZoomChanged, e -> {
+			if (fBuffer != null) {
+				fBuffer.dispose();
+				fBuffer= null;
+			}
+		});
+
 		fCanvas.addMouseListener(new MouseAdapter() {
 			@Override
 			public void mouseDown(MouseEvent event) {
@@ -676,23 +683,27 @@ public class OverviewRuler implements IOverviewRulerExtension, IOverviewRuler {
 				fBuffer= null;
 			}
 		}
-		if (fBuffer == null)
-			fBuffer= new Image(fCanvas.getDisplay(), size.x, size.y);
-
-		GC gc= new GC(fBuffer);
-		try {
-			gc.setBackground(fCanvas.getBackground());
-			gc.fillRectangle(0, 0, size.x, size.y);
-
-			cacheAnnotations();
-
-			doPaint(gc);
-
-		} finally {
-			gc.dispose();
+		if (fBuffer == null) {
+			fBuffer= new Image(fCanvas.getDisplay(), this::doPaint, size.x, size.y);
+		} else {
+			GC gc= new GC(fBuffer);
+			try {
+				doPaint(gc, size.x, size.y);
+			} finally {
+				gc.dispose();
+			}
 		}
 
 		dest.drawImage(fBuffer, 0, 0);
+	}
+
+	private void doPaint(GC gc, int width, int height) {
+		gc.setBackground(fCanvas.getBackground());
+		gc.fillRectangle(0, 0, width, height);
+
+		cacheAnnotations();
+
+		doPaint(gc);
 	}
 
 	private void cacheAnnotations() {

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/VerticalRuler.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/VerticalRuler.java
@@ -159,6 +159,13 @@ public final class VerticalRuler implements IVerticalRuler, IVerticalRulerExtens
 			fTextViewer= null;
 		});
 
+		fCanvas.addListener(SWT.ZoomChanged, e -> {
+			if (fBuffer != null) {
+				fBuffer.dispose();
+				fBuffer= null;
+			}
+		});
+
 		fCanvas.addMouseListener(new MouseListener() {
 			@Override
 			public void mouseUp(MouseEvent event) {
@@ -223,25 +230,29 @@ public final class VerticalRuler implements IVerticalRuler, IVerticalRulerExtens
 				fBuffer= null;
 			}
 		}
-		if (fBuffer == null)
-			fBuffer= new Image(fCanvas.getDisplay(), size.x, size.y);
 
-		GC gc= new GC(fBuffer);
-		gc.setFont(fTextViewer.getTextWidget().getFont());
-		try {
-			gc.setBackground(fCanvas.getBackground());
-			gc.fillRectangle(0, 0, size.x, size.y);
-
-			if (fTextViewer instanceof ITextViewerExtension5)
-				doPaint1(gc);
-			else
-				doPaint(gc);
-
-		} finally {
-			gc.dispose();
+		if (fBuffer == null) {
+			fBuffer= new Image(fCanvas.getDisplay(), this::doPaint, size.x, size.y);
+		} else {
+			GC gc= new GC(fBuffer);
+			try {
+				doPaint(gc, size.x, size.y);
+			} finally {
+				gc.dispose();
+			}
 		}
-
 		dest.drawImage(fBuffer, 0, 0);
+	}
+
+	private void doPaint(GC gc, int width, int height) {
+		gc.setFont(fTextViewer.getTextWidget().getFont());
+		gc.setBackground(fCanvas.getBackground());
+		gc.fillRectangle(0, 0, width, height);
+
+		if (fTextViewer instanceof ITextViewerExtension5)
+			doPaint1(gc);
+		else
+			doPaint(gc);
 	}
 
 	/**


### PR DESCRIPTION
This PR replaces three use cases where GC together with Images where used to draw double buffered images. With new multi-zoom-setting in Windows this leads to multiple issues like:
- destructive scaling, e.g. up- or downscaling of the pixel data
- fragments, when buffer image and second buffer image use different zoom 

The changes utilize the newly added ImageGcDrawer to provide a dynamic callback to draw on a correctly initialized GC on demand.

Most important changes are:
- cleanup of the buffer image on zoom change
- Always do a full draw when a new variant is requested

### How to test

1. You need to use the branch from https://github.com/eclipse-platform/eclipse.platform.swt/pull/1734 for SWT. 
2. Either make sure you have the the experimental monitor specific flag enabled or use `
-Dswt.autoScale.updateOnRuntime=true
-Dswt.autoScale=quarter` as additional VM arguments

1. Have at least two monitors with different zoom (e.g. one with 100, one with 150), detach a view and move it to the second monitor. Then you should be able to create fragments or other glitches in the text editors e.g. by just resizing it -> resizing always retriggers a full re-creation.

#### Example for OverviewRuler and LineNumberRulerColumn
If you have a monitor setup with 200% and 100%, have both (main view and detached view) on 200%, move one to the 100% monitor and resize the view remaining on 200%. You will see:
Before it blurry scales the 100% variant of the image and blurry scales the line number
![Screenshot 2025-01-20 110042](https://github.com/user-attachments/assets/e516855d-144f-4e53-b295-8a0efb71433c)
After it correctly fetches the 200% variant of the image and the line numbers are redrawn sharply
![Screenshot 2025-01-20 105208](https://github.com/user-attachments/assets/0cd44a02-2404-4051-9f6b-590ab15d5766)

#### Example for not refreshed line numbers
Use the same setup as above: 200% and 100% monitor, have both (main view and detached view) on 200%, move one to the 100% monitor and resize the view remaining on 200%. You should see the line number not correctly refreshed on scrolling though a file anymore

**Important**: As it is quite visible I want to mention, that the DefaultRangeIndicator will still looks glitchy like 
![image](https://github.com/user-attachments/assets/82ba04b0-e6dd-461f-b871-e0b4250578e7)
in some scenarios. This is an additional issue related to ImageData and the destructive scaling of ImageData and will be fixed in a separate PR. This is a pre-existing issue, but the monitor aware scaling makes it way more obvious.