### PR TITLE
Mark DefaultPartitioner for removal

### DIFF
--- a/bundles/org.eclipse.text/src/org/eclipse/jface/text/IDocumentPartitioner.java
+++ b/bundles/org.eclipse.text/src/org/eclipse/jface/text/IDocumentPartitioner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2005 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -40,7 +40,7 @@ package org.eclipse.jface.text;
  * </ul>
  * <p>
  * Clients may implement this interface and its extension interfaces or use the standard
- * implementation <code>DefaultPartitioner</code>.
+ * implementation <code>FastPartitioner</code>.
  * </p>
  *
  * @see org.eclipse.jface.text.IDocumentPartitionerExtension

--- a/bundles/org.eclipse.text/src/org/eclipse/jface/text/rules/DefaultPartitioner.java
+++ b/bundles/org.eclipse.text/src/org/eclipse/jface/text/rules/DefaultPartitioner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2007 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -37,8 +37,6 @@ import org.eclipse.jface.text.TextUtilities;
 import org.eclipse.jface.text.TypedPosition;
 import org.eclipse.jface.text.TypedRegion;
 
-
-
 /**
  * A standard implementation of a document partitioner. It uses a partition
  * token scanner to scan the document and to determine the document's
@@ -53,7 +51,7 @@ import org.eclipse.jface.text.TypedRegion;
  * @since 3.14
  * @deprecated As of 3.1, replaced by {@link org.eclipse.jface.text.rules.FastPartitioner} instead
  */
-@Deprecated
+@Deprecated(forRemoval= true, since="2025-03")
 public class DefaultPartitioner implements IDocumentPartitioner, IDocumentPartitionerExtension, IDocumentPartitionerExtension2, IDocumentPartitionerExtension3 {
 
 	/**

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/JFaceTextTestSuite.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/JFaceTextTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -26,9 +26,8 @@ import org.eclipse.jface.text.tests.contentassist.FilteringAsyncContentAssistTes
 import org.eclipse.jface.text.tests.contentassist.IncrementalAsyncContentAssistTests;
 import org.eclipse.jface.text.tests.reconciler.AbstractReconcilerTest;
 import org.eclipse.jface.text.tests.reconciler.FastAbstractReconcilerTest;
-import org.eclipse.jface.text.tests.rules.DefaultPartitionerTest;
-import org.eclipse.jface.text.tests.rules.DefaultPartitionerZeroLengthTest;
 import org.eclipse.jface.text.tests.rules.FastPartitionerTest;
+import org.eclipse.jface.text.tests.rules.FastPartitionerZeroLengthTest;
 import org.eclipse.jface.text.tests.rules.ScannerColumnTest;
 import org.eclipse.jface.text.tests.rules.WordRuleTest;
 import org.eclipse.jface.text.tests.source.AnnotationRulerColumnTest;
@@ -64,8 +63,7 @@ import org.eclipse.jface.text.tests.templates.persistence.TemplatePersistenceDat
 		AbstractReconcilerTest.class,
 		FastAbstractReconcilerTest.class,
 
-		DefaultPartitionerTest.class,
-		DefaultPartitionerZeroLengthTest.class,
+		FastPartitionerZeroLengthTest.class,
 		FastPartitionerTest.class,
 		ScannerColumnTest.class,
 		WordRuleTest.class,

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/rules/DefaultPartitionerTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/rules/DefaultPartitionerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2008 IBM Corporation and others.
+ * Copyright (c) 2005,2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,7 @@ import org.eclipse.jface.text.IDocumentPartitioner;
 import org.eclipse.jface.text.rules.DefaultPartitioner;
 import org.eclipse.jface.text.rules.IPartitionTokenScanner;
 
+@Deprecated
 public class DefaultPartitionerTest extends FastPartitionerTest {
 	@Override
 	protected IDocumentPartitioner createPartitioner(IPartitionTokenScanner scanner) {

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/rules/FastPartitionerZeroLengthTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/rules/FastPartitionerZeroLengthTest.java
@@ -34,7 +34,7 @@ import org.eclipse.jface.text.rules.Token;
 /**
  * @since 3.0
  */
-public class DefaultPartitionerZeroLengthTest {
+public class FastPartitionerZeroLengthTest {
 
 	private static final String COMMENT= "comment";
 	private static final String DEFAULT= IDocument.DEFAULT_CONTENT_TYPE;


### PR DESCRIPTION
FastPartitioner is the replacement since Eclipse 3.1. Organized tests:
* mark DefaultPartitionerTest as deprecated
* renamed DefaultPartitionerZeroLengthTest to match the fact that it uses FastPartitioner