### PR TITLE
Add static method to the interface of ISharedImages to get the instance

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/ISharedImages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/ISharedImages.java
@@ -18,6 +18,7 @@ import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.ui.internal.WorkbenchPlugin;
 
 /**
  * A registry for common images used by the workbench which may be useful to
@@ -855,4 +856,12 @@ public interface ISharedImages {
 	 * @return the image descriptor, or <code>null</code> if not found
 	 */
 	ImageDescriptor getImageDescriptor(String symbolicName);
+
+	/**
+	 * @since 3.135
+	 * @return the default {@link ISharedImages} instance
+	 */
+	static ISharedImages get() {
+		return WorkbenchPlugin.getDefault().getSharedImages();
+	}
 }

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/actions/NewWizardAction.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/actions/NewWizardAction.java
@@ -99,11 +99,11 @@ public class NewWizardAction extends Action implements ActionFactory.IWorkbenchA
 		this.workbenchWindow = window;
 		tracker = new PerspectiveTracker(window, this);
 		// @issues should be IDE-specific images
-		ISharedImages images = PlatformUI.getWorkbench().getSharedImages();
+		ISharedImages images = window.getWorkbench().getSharedImages();
 		setImageDescriptor(images.getImageDescriptor(ISharedImages.IMG_TOOL_NEW_WIZARD));
 		setDisabledImageDescriptor(images.getImageDescriptor(ISharedImages.IMG_TOOL_NEW_WIZARD_DISABLED));
 		setToolTipText(WorkbenchMessages.NewWizardAction_toolTip);
-		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IWorkbenchHelpContextIds.NEW_ACTION);
+		window.getWorkbench().getHelpSystem().setHelp(this, IWorkbenchHelpContextIds.NEW_ACTION);
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPartReference.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPartReference.java
@@ -329,7 +329,7 @@ public abstract class WorkbenchPartReference implements IWorkbenchPartReference,
 	@Override
 	public final Image getTitleImage() {
 		if (isDisposed()) {
-			return PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_DEF_VIEW);
+			return ISharedImages.get().getImage(ISharedImages.IMG_DEF_VIEW);
 		}
 
 		WorkbenchWindow wbw = (WorkbenchWindow) PlatformUI.getWorkbench().getActiveWorkbenchWindow();
@@ -341,7 +341,7 @@ public abstract class WorkbenchPartReference implements IWorkbenchPartReference,
 			}
 		}
 
-		return PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_DEF_VIEW);
+		return wbw.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_DEF_VIEW);
 	}
 
 	/* package */ void fireVisibilityChange() {

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/about/ProductInfoPage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/about/ProductInfoPage.java
@@ -93,7 +93,7 @@ public abstract class ProductInfoPage extends InstallationPage implements IShell
 		MenuItem copyItem = new MenuItem(menu, SWT.NONE);
 		copyItem.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> handler.copySelection(table)));
 		copyItem.setText(JFaceResources.getString("copy")); //$NON-NLS-1$
-		copyItem.setImage(PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_TOOL_COPY));
+		copyItem.setImage(ISharedImages.get().getImage(ISharedImages.IMG_TOOL_COPY));
 
 		table.setMenu(menu);
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/WorkbenchWizardElement.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/WorkbenchWizardElement.java
@@ -24,6 +24,7 @@ import org.eclipse.jface.resource.ResourceLocator;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.ui.IPluginContribution;
+import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.IWorkbenchWizard;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.SelectionEnabler;
@@ -169,7 +170,7 @@ public class WorkbenchWizardElement extends WorkbenchAdapter
 			}
 			imageDescriptor = ResourceLocator
 					.imageDescriptorFromBundle(configurationElement.getNamespaceIdentifier(), iconName)
-					.orElse(PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(iconName));
+					.orElse(ISharedImages.get().getImageDescriptor(iconName));
 		}
 		return imageDescriptor;
 	}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/operations/RedoActionHandler.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/operations/RedoActionHandler.java
@@ -21,7 +21,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.IWorkbenchCommandConstants;
 import org.eclipse.ui.IWorkbenchPartSite;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.WorkbenchMessages;
 
 /**
@@ -44,9 +43,9 @@ public final class RedoActionHandler extends OperationHistoryActionHandler {
 	 */
 	public RedoActionHandler(IWorkbenchPartSite site, IUndoContext context) {
 		super(site, context);
-		setImageDescriptor(PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(ISharedImages.IMG_TOOL_REDO));
+		setImageDescriptor(ISharedImages.get().getImageDescriptor(ISharedImages.IMG_TOOL_REDO));
 		setDisabledImageDescriptor(
-				PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(ISharedImages.IMG_TOOL_REDO_DISABLED));
+				ISharedImages.get().getImageDescriptor(ISharedImages.IMG_TOOL_REDO_DISABLED));
 		setActionDefinitionId(IWorkbenchCommandConstants.EDIT_REDO);
 	}
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/operations/UndoActionHandler.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/operations/UndoActionHandler.java
@@ -21,7 +21,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.IWorkbenchCommandConstants;
 import org.eclipse.ui.IWorkbenchPartSite;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.WorkbenchMessages;
 
 /**
@@ -44,9 +43,9 @@ public final class UndoActionHandler extends OperationHistoryActionHandler {
 	 */
 	public UndoActionHandler(IWorkbenchPartSite site, IUndoContext context) {
 		super(site, context);
-		setImageDescriptor(PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(ISharedImages.IMG_TOOL_UNDO));
+		setImageDescriptor(ISharedImages.get().getImageDescriptor(ISharedImages.IMG_TOOL_UNDO));
 		setDisabledImageDescriptor(
-				PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(ISharedImages.IMG_TOOL_UNDO_DISABLED));
+				ISharedImages.get().getImageDescriptor(ISharedImages.IMG_TOOL_UNDO_DISABLED));
 		setActionDefinitionId(IWorkbenchCommandConstants.EDIT_UNDO);
 	}
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/part/DrillDownAdapter.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/part/DrillDownAdapter.java
@@ -24,7 +24,6 @@ import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.ui.ISharedImages;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.WorkbenchImages;
 import org.eclipse.ui.internal.WorkbenchMessages;
 
@@ -166,7 +165,7 @@ public class DrillDownAdapter implements ISelectionChangedListener {
 		homeAction.setImageDescriptor(WorkbenchImages.getImageDescriptor(ISharedImages.IMG_ETOOL_HOME_NAV));
 
 		// Back.
-		ISharedImages images = PlatformUI.getWorkbench().getSharedImages();
+		ISharedImages images = ISharedImages.get();
 		backAction = new Action(WorkbenchMessages.GoBack_text) {
 			@Override
 			public void run() {

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/part/IntroPart.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/part/IntroPart.java
@@ -32,7 +32,6 @@ import org.eclipse.ui.IMemento;
 import org.eclipse.ui.IPropertyListener;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.intro.IntroMessages;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
 import org.eclipse.ui.intro.IIntroPart;
@@ -151,7 +150,7 @@ public abstract class IntroPart extends EventManager implements IIntroPart, IExe
 	 * @return the default image
 	 */
 	protected Image getDefaultImage() {
-		return PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_DEF_VIEW);
+		return ISharedImages.get().getImage(ISharedImages.IMG_DEF_VIEW);
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/part/WorkbenchPart.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/part/WorkbenchPart.java
@@ -43,7 +43,6 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchPart3;
 import org.eclipse.ui.IWorkbenchPartConstants;
 import org.eclipse.ui.IWorkbenchPartSite;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.PartSite;
 import org.eclipse.ui.internal.WorkbenchMessages;
 import org.eclipse.ui.internal.WorkbenchPlugin;
@@ -168,7 +167,7 @@ public abstract class WorkbenchPart extends EventManager
 	 * @return the default image
 	 */
 	protected Image getDefaultImage() {
-		return PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_DEF_VIEW);
+		return ISharedImages.get().getImage(ISharedImages.IMG_DEF_VIEW);
 	}
 
 	@Override
@@ -233,7 +232,7 @@ public abstract class WorkbenchPart extends EventManager
 		}
 		imageDescriptor = ResourceLocator.imageDescriptorFromBundle(configElement.getContributor().getName(), strIcon);
 		if (!imageDescriptor.isPresent()) {
-			ImageDescriptor shared = PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(strIcon);
+			ImageDescriptor shared = ISharedImages.get().getImageDescriptor(strIcon);
 			imageDescriptor = Optional.ofNullable(shared);
 		}
 		imageDescriptor.ifPresent(d -> titleImage = JFaceResources.getResources().createImageWithDefault(d));


### PR DESCRIPTION
Currently one needs to first obtain the PaltformUI Workbench and then call getSharedImages on this instance. As this actually maps down to WorkBenchPlugin that do not require a running workbench this limits the usage of such code only wanting to share images.

This adds a new ISharedImages.get() that directly calls the code the IWorkbench implementation would call and replace static calls to the workbench with this one.

See for example:
- https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1952