### PR TITLE
[Dark Theme]Fix for background color of gutter line in editor

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4-dark_linux.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_linux.css
@@ -118,3 +118,9 @@ ImageBasedFrame,
 {
 	background-color: #1E1F22;
 }
+
+#org-eclipse-e4-ui-compatibility-editor Canvas,
+#org-eclipse-e4-ui-compatibility-editor Canvas > *
+{
+	background-color: #1E1F22;
+}

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_mac.css
@@ -104,3 +104,9 @@ Button  {
 {
 	background-color: #1E1F22;
 }
+
+#org-eclipse-e4-ui-compatibility-editor Canvas,
+#org-eclipse-e4-ui-compatibility-editor Canvas > *
+{
+	background-color: #1E1F22;
+}

--- a/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4-dark_win.css
@@ -186,3 +186,9 @@ ImageBasedFrame,
 {
 	background-color: #1E1F22;
 }
+
+#org-eclipse-e4-ui-compatibility-editor Canvas,
+#org-eclipse-e4-ui-compatibility-editor Canvas > *
+{
+	background-color: #1E1F22;
+}


### PR DESCRIPTION
Implementing fix for gutter line background change in dark theme for Win, Mac and Linux.
Ref 4th issue reported in https://github.com/eclipse-platform/eclipse.platform.ui/issues/2114#issue-2418424128

Will update before and after images soon.
