### PR TITLE
Replace button in find dialog gets enabled with regular expressions

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -1361,7 +1361,7 @@ class FindReplaceDialog extends Dialog {
 	private void decorate() {
 		if (fIsRegExCheckBox.getSelection()) {
 			regexOk = SearchDecoration.validateRegex(fFindField.getText(), fFindFieldDecoration);
-			updateButtonState(regexOk);
+			updateButtonState(!regexOk);
 
 		} else {
 			fFindFieldDecoration.hide();
@@ -1406,6 +1406,7 @@ class FindReplaceDialog extends Dialog {
 		fReplaceSelectionButton.setData(ID_DATA_KEY, "replaceOne");
 		fReplaceFindButton.setData(ID_DATA_KEY, "replaceFindOne");
 		fReplaceAllButton.setData(ID_DATA_KEY, "replaceAll");
+		fFindNextButton.setData(ID_DATA_KEY, "findNext");
 	}
 
 }

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
@@ -71,6 +71,8 @@ class DialogAccess implements IFindReplaceUIAccess {
 
 	private final Button replaceAllButton;
 
+	private final Button findNextButton;
+
 	DialogAccess(IFindReplaceTarget findReplaceTarget, Dialog findReplaceDialog) {
 		this.findReplaceTarget= findReplaceTarget;
 		this.findReplaceDialog= findReplaceDialog;
@@ -89,6 +91,7 @@ class DialogAccess implements IFindReplaceUIAccess {
 		replaceButton= widgetExtractor.findButton("replaceOne");
 		replaceFindButton= widgetExtractor.findButton("replaceFindOne");
 		replaceAllButton= widgetExtractor.findButton("replaceAll");
+		findNextButton= widgetExtractor.findButton("findNext");
 	}
 
 	void restoreInitialConfiguration() {
@@ -205,6 +208,10 @@ class DialogAccess implements IFindReplaceUIAccess {
 		return findCombo.getText().substring(selection.x, selection.y);
 	}
 
+	public Button getReplaceButton() {
+		return replaceButton;
+	}
+
 	public Combo getFindCombo() {
 		return findCombo;
 	}
@@ -217,6 +224,10 @@ class DialogAccess implements IFindReplaceUIAccess {
 	@Override
 	public void performReplace() {
 		replaceButton.notifyListeners(SWT.Selection, null);
+	}
+
+	public void performFindNext() {
+		findNextButton.notifyListeners(SWT.Selection, null);
 	}
 
 	@Override

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
@@ -222,4 +222,17 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		assertEquals(2, (target.getSelection()).y);
 	}
 
+	@Test
+	public void testReplaceButtonEnabledWithRegexSearched() {
+		initializeTextViewerWithFindReplaceUI("one two three");
+
+		DialogAccess dialog= getDialog();
+		dialog.setFindText("two");
+		dialog.select(SearchOptions.REGEX);
+		dialog.setReplaceText("two2");
+		dialog.performFindNext();
+
+		assertTrue(dialog.getReplaceButton().isEnabled());
+	}
+
 }


### PR DESCRIPTION
"Replace" button in find dialog did not get enabled when "Regular expressions" checkbox was set.

This pull request is fixing the issue so that replace functionality is again possible together with regular expressions.
![find_dialog](https://github.com/user-attachments/assets/4d78463d-07da-455a-af23-42b7e6b018d2)
