### PR TITLE
[Light Theme]Fix for bg colors of entries in Progress View

### DIFF
--- a/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.themes;singleton:=true
-Bundle-Version: 1.2.2800.qualifier
+Bundle-Version: 1.2.2900.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.e4.ui.css.swt.theme

--- a/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_gtk.css
@@ -241,3 +241,8 @@ Composite.MArea{
 .MPart CTabFolder{
 	swt-outer-keyline-color: #ffffff;
 }
+
+ProgressInfoItem,
+ProgressInfoItem > *{
+	background-color:'#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
+}

--- a/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_mac.css
@@ -214,3 +214,8 @@ Composite.MArea{
 .MPart CTabFolder{
 	swt-outer-keyline-color: #ffffff;
 }
+
+ProgressInfoItem,
+ProgressInfoItem > *{
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
+}

--- a/bundles/org.eclipse.ui.themes/css/e4_default_win.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_win.css
@@ -216,3 +216,8 @@ Composite.MArea{
 .MPart CTabFolder{
 	swt-outer-keyline-color: #ffffff;
 }
+
+ProgressInfoItem,
+ProgressInfoItem > *{
+	background-color: '#org-eclipse-ui-workbench-SECONDARY_BACKGROUND';
+}


### PR DESCRIPTION
Fix for issue [#2313](https://github.com/eclipse-platform/eclipse.platform.ui/issues/2313)
Issue has been fixed in all three platforms Win, Mac and Linux.
