### PR TITLE
Bug 567104 - Export Error if a File should be overriden

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/FileSystemExporter.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/FileSystemExporter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -84,7 +84,7 @@ public class FileSystemExporter {
 		if (sourceLocation != null) {
 			// local file, preserve attributes
 			Files.copy(sourceLocation.toFile().toPath(), destinationPath.toFile().toPath(),
-					StandardCopyOption.COPY_ATTRIBUTES, LinkOption.NOFOLLOW_LINKS);
+					StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES, LinkOption.NOFOLLOW_LINKS);
 		} else {
 			// virtual file system, transfer stream
 			try (InputStream is = new BufferedInputStream(file.getContents(false))) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ExportFileSystemOperationTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ExportFileSystemOperationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2017 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -217,6 +217,9 @@ public class ExportFileSystemOperationTest extends UITestCase implements
 		operation.setCreateLeadupStructure(false);
 		openTestWindow().run(true, true, operation);
 
+		// overwrite successful?
+		IStatus status = operation.getStatus();
+		assertTrue(status.toString(), status.isOK());
 		// +1 for .settings
 		verifyFolders(directoryNames.length + 1);
 	}


### PR DESCRIPTION
The change done in 9c6c5519dfb245b2b1c9bf5b3686cf9c324bd67e introduces a regression due to which it is no longer possible to export a file to the file system, if the file already exists.

When copying a file using the Files API, one needs to explicitly set the REPLACE_EXISTING flag, in order to overwrite the target file, otherwise a FileAreadyExistsException is thrown.

Note: The "writeFile" method is only called when the user explicitly chose to overwrite the existing file. It is therefore safe to always set this flag.