### PR TITLE
Help not shown in "Import preferences" dialog #2759

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/IWorkbenchHelpContextIds.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/IWorkbenchHelpContextIds.java
@@ -249,5 +249,10 @@ public interface IWorkbenchHelpContextIds {
 	String WORKING_SET_EDIT_WIZARD = PREFIX + "working_set_edit_wizard_context"; //$NON-NLS-1$
 
 	String CAPABILITY_PREFERENCE_PAGE = PREFIX + "capabilities_preference_page_context"; //$NON-NLS-1$
+
 	String TOGGLE_COOLBAR_ACTION = PREFIX + "toggle_coolbar_action"; //$NON-NLS-1$
+
+	String PREFERENCES_IMPORT_WIZARD_PAGE = PREFIX + "preferences_import_wizard_page"; //$NON-NLS-1$
+
+	String PREFERENCES_EXPORT_WIZARD_PAGE = PREFIX + "preferences_export_wizard_page"; //$NON-NLS-1$
 }

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/wizards/preferences/WizardPreferencesExportPage1.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/wizards/preferences/WizardPreferencesExportPage1.java
@@ -59,7 +59,7 @@ public class WizardPreferencesExportPage1 extends WizardPreferencesPage {
 	@Override
 	public void createControl(Composite composite) {
 		super.createControl(composite);
-		PlatformUI.setHelp(composite, IWorkbenchHelpContextIds.PREFERENCES_IMPORT_WIZARD_PAGE);
+		PlatformUI.setHelp(composite, IWorkbenchHelpContextIds.PREFERENCES_EXPORT_WIZARD_PAGE);
 	}
 
 	protected String getOutputSuffix() {

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/wizards/preferences/WizardPreferencesExportPage1.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/wizards/preferences/WizardPreferencesExportPage1.java
@@ -25,6 +25,8 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.IWorkbenchHelpContextIds;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.preferences.PreferenceTransferElement;
 
@@ -52,6 +54,12 @@ public class WizardPreferencesExportPage1 extends WizardPreferencesPage {
 	 */
 	public WizardPreferencesExportPage1() {
 		this(PREFERENCESEXPORTPAGE1);
+	}
+
+	@Override
+	public void createControl(Composite composite) {
+		super.createControl(composite);
+		PlatformUI.setHelp(composite, IWorkbenchHelpContextIds.PREFERENCES_IMPORT_WIZARD_PAGE);
 	}
 
 	protected String getOutputSuffix() {

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/wizards/preferences/WizardPreferencesImportPage1.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/wizards/preferences/WizardPreferencesImportPage1.java
@@ -25,6 +25,8 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.IWorkbenchHelpContextIds;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.preferences.PreferenceTransferElement;
 
@@ -50,6 +52,12 @@ public class WizardPreferencesImportPage1 extends WizardPreferencesPage {
 	 */
 	public WizardPreferencesImportPage1() {
 		this("preferencesImportPage1");//$NON-NLS-1$
+	}
+
+	@Override
+	public void createControl(Composite composite) {
+		super.createControl(composite);
+		PlatformUI.setHelp(composite, IWorkbenchHelpContextIds.PREFERENCES_IMPORT_WIZARD_PAGE);
 	}
 
 	@Override


### PR DESCRIPTION
- Add preferences import and export help contexts to IWorkbenchHelpContextIds.java
- Register missing help contexts for WizardPreferencesExportPage1.java and WizardPreferencesImportPage1.java to the help system.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2759