### PR TITLE
Fix: Statusline not cleared after job completion if sub-tasks are used

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/StatusLine.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/StatusLine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -81,6 +81,9 @@ import org.eclipse.swt.widgets.ToolItem;
 
 	/** name of the task */
 	protected volatile String fTaskName;
+
+	/** name of the task without sub-tasks */
+	protected volatile String fBaseTaskName;
 
 	/** is the task is cancled */
 	protected volatile boolean fIsCanceled;
@@ -580,6 +583,7 @@ import org.eclipse.swt.widgets.ToolItem;
 		boolean changed = !Objects.equals(fTaskName, s);
 		if (changed) {
 			fTaskName = s;
+			fBaseTaskName = s;
 			updateMessageLabel();
 		}
 	}
@@ -650,9 +654,13 @@ import org.eclipse.swt.widgets.ToolItem;
 		if (fTaskName == null || fTaskName.isEmpty()) {
 			text = newName;
 		} else {
-			text = JFaceResources.format("Set_SubTask", fTaskName, newName);//$NON-NLS-1$
+			text = JFaceResources.format("Set_SubTask", fBaseTaskName, newName);//$NON-NLS-1$
 		}
-		setMessage(text);
+		boolean changed = !Objects.equals(fTaskName, text);
+		if (changed) {
+			fTaskName = text;
+			updateMessageLabel();
+		}
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchWindowTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchWindowTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2013 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,11 +14,15 @@
 package org.eclipse.ui.tests.api;
 
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.jface.action.StatusLineManager;
+import org.eclipse.swt.custom.CLabel;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbenchActionConstants;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.WorkbenchException;
+import org.eclipse.ui.internal.WorkbenchWindow;
 import org.eclipse.ui.tests.harness.util.ArrayUtil;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
 import org.eclipse.ui.tests.harness.util.UITestCase;
@@ -196,5 +200,34 @@ public class IWorkbenchWindowTest extends UITestCase {
 		for (String id : ids) {
 			assertEquals(fWin.isApplicationMenu(id), false);
 		}
+	}
+
+	@Test
+	public void testRunJobInStatusLine() throws Throwable {
+		fWin.run(false, false, monitor -> {
+			monitor.beginTask("Task", 1);
+			assertStatusText("Task");
+		});
+		assertStatusText("");
+	}
+
+	@Test
+	public void testRunJobInStatusLineWithSubtasks() throws Throwable{
+		fWin.run(false, false, monitor -> {
+			monitor.beginTask("Task", 1);
+			assertStatusText("Task");
+			monitor.subTask("SubTask");
+			assertStatusText("Task: SubTask");
+			monitor.subTask("OtherSubTask");
+			assertStatusText("Task: OtherSubTask");
+		});
+		assertStatusText("");
+	}
+
+	private void assertStatusText(String text) {
+		StatusLineManager statusManager = ((WorkbenchWindow) fWin).getStatusLineManager();
+		Composite statusLine = (Composite) statusManager.getControl();
+		CLabel statusLabel = (CLabel) statusLine.getChildren()[0];
+		assertEquals("Status line was not updated.", text, statusLabel.getText());
 	}
 }


### PR DESCRIPTION
Similar to `setTaskName()`, the string created when calling `subTask()` must also be stored in the `fTaskName`, rather than in `fMessageText` field. Otherwise the label of the status line is not cleared after calling done() on the progress monitor.

Because the text of the sub-task is calculated using the value of `fTaskName`, the original name of the task needs to be stored in a separate field to avoid the name of the previous sub-task to be contained in the next sub-task.

Closes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2762