### PR TITLE
Undeprecate updateToolbar() in FilteredTree  and call again on refresh

### DIFF
--- a/bundles/org.eclipse.e4.ui.dialogs/src/org/eclipse/e4/ui/dialogs/filteredtree/FilteredTree.java
+++ b/bundles/org.eclipse.e4.ui.dialogs/src/org/eclipse/e4/ui/dialogs/filteredtree/FilteredTree.java
@@ -259,10 +259,15 @@ public class FilteredTree extends AbstractFilteredViewerComposite<PatternFilter>
 						int treeHeight = getViewer().getTree().getBounds().height;
 						int numVisibleItems = treeHeight / getViewer().getTree().getItemHeight();
 						long stopTime = SOFT_MAX_EXPAND_TIME + System.currentTimeMillis();
+
+						updateToolbar(true);
+
 						if (items.length > 0
 								&& recursiveExpand(items, monitor, stopTime, new int[] { numVisibleItems })) {
 							return Status.CANCEL_STATUS;
 						}
+					} else {
+						updateToolbar(false);
 					}
 				} finally {
 					// done updating the tree - set redraw back to true
@@ -310,10 +315,6 @@ public class FilteredTree extends AbstractFilteredViewerComposite<PatternFilter>
 		};
 	}
 
-	/**
-	 * @deprecated As of 4.13 not used anymore
-	 */
-	@Deprecated(since = "2025-03", forRemoval = true)
 	protected void updateToolbar(boolean visible) {
 		// nothing to do
 	}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/dialogs/FilteredTree.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/dialogs/FilteredTree.java
@@ -430,10 +430,15 @@ public class FilteredTree extends AbstractFilteredViewerComposite<PatternFilter>
 						int treeHeight = getViewer().getTree().getBounds().height;
 						int numVisibleItems = treeHeight / getViewer().getTree().getItemHeight();
 						long stopTime = SOFT_MAX_EXPAND_TIME + System.currentTimeMillis();
+
+						updateToolbar(true);
+
 						if (items.length > 0
 								&& recursiveExpand(items, monitor, stopTime, new int[] { numVisibleItems })) {
 							return Status.CANCEL_STATUS;
 						}
+					} else {
+						updateToolbar(false);
 					}
 				} finally {
 					// done updating the tree - set redraw back to true
@@ -488,9 +493,7 @@ public class FilteredTree extends AbstractFilteredViewerComposite<PatternFilter>
 	 * override.
 	 *
 	 * @param visible boolean
-	 * @deprecated As of 4.13 not used anymore
 	 */
-	@Deprecated(since = "2025-03", forRemoval = true)
 	protected void updateToolbar(boolean visible) {
 		// nothing to do
 	}


### PR DESCRIPTION
This partially reverts 3726516c0ab381d3d29e24e412f73679e830aba2 due to which the updateToolbar() method is no longer called by the default refresh job.

Subclasses may override updateToolbar() without also overriding doCreateRefreshJob() which in return means that their toolbar is not updated anymore.

Because this method is called again, the deprecation tag introduced with 176f5030b1ed724274f88552b8bec14e43111832 is also removed