### PR TITLE
[StickyScrolling] Prevent out of bounds errors by validating sticky l…

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyLine.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyLine.java
@@ -55,7 +55,7 @@ public class StickyLine implements IStickyLine {
 		StyledText textWidget= sourceViewer.getTextWidget();
 		int widgetLineNumber = getWidgetLineNumber();
 
-		if (widgetLineNumber > textWidget.getLineCount()) {
+		if (widgetLineNumber >= textWidget.getLineCount()) {
 			return null;
 		}
 

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -441,7 +441,7 @@ public class StickyScrollingControl {
 	private boolean areStickyLinesOutDated(StyledText textWidget) {
 		if (stickyLines.size() > 0) {
 			int lastStickyLineNumber = stickyLines.get(stickyLines.size() - 1).getLineNumber();
-			return lastStickyLineNumber > textWidget.getLineCount();
+			return lastStickyLineNumber >= textWidget.getLineCount();
 		}
 		return false;
 	}

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyLineTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyLineTest.java
@@ -100,9 +100,10 @@ public class StickyLineTest {
 		textWidget.setText("line1\nline2\nline3");
 
 		StickyLine stickyLineOutOfBound = new StickyLine(10, sourceViewer);
-		StyleRange[] styleRanges = stickyLineOutOfBound.getStyleRanges();
+		assertNull(stickyLineOutOfBound.getStyleRanges());
 
-		assertNull(styleRanges);
+		stickyLineOutOfBound = new StickyLine(3, sourceViewer);
+		assertNull(stickyLineOutOfBound.getStyleRanges());
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
@@ -256,7 +256,7 @@ public class StickyScrollingControlTest {
 	public void testDontLayoutOutDatedStickyLinesOnResize() {
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
 
-		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 10", 10));
+		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 1", 1));
 		stickyScrollingControl.setStickyLines(stickyLines);
 
 		Canvas stickyControlCanvas = getStickyControlCanvas(shell);
@@ -329,6 +329,7 @@ public class StickyScrollingControlTest {
 	@Test
 	public void testLimitStickyLinesToTextWidgetHeight() {
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
+		sourceViewer.getTextWidget().setText("line1\nline2");
 		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 2", 1));
 		stickyScrollingControl.setStickyLines(stickyLines);
 


### PR DESCRIPTION
…ine number

Handle cases where the sticky line number exceeds the total number of lines to prevent out of bounds errors. Since widgetLineNumber is 0-based, ensure it is not equal to or greater than the line count.

Fixes #2765