### PR TITLE
introduce getMouseHover, getMouseOut and getMouseMove in ICodeMining

### DIFF
--- a/bundles/org.eclipse.jface.text/.settings/.api_filters
+++ b/bundles/org.eclipse.jface.text/.settings/.api_filters
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.jface.text" version="2">
+    <resource path="src/org/eclipse/jface/text/codemining/ICodeMining.java" type="org.eclipse.jface.text.codemining.ICodeMining">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.text.codemining.ICodeMining"/>
+                <message_argument value="getMouseHover()"/>
+            </message_arguments>
+        </filter>
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.text.codemining.ICodeMining"/>
+                <message_argument value="getMouseMove()"/>
+            </message_arguments>
+        </filter>
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.jface.text.codemining.ICodeMining"/>
+                <message_argument value="getMouseOut()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineContentAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineContentAnnotation.java
@@ -70,11 +70,7 @@ public class CodeMiningLineContentAnnotation extends LineContentAnnotation imple
 	 * @param viewer   the viewer
 	 */
 	public CodeMiningLineContentAnnotation(Position position, ISourceViewer viewer) {
-		super(position, viewer);
-		fResolvedMinings= null;
-		fMinings= new ArrayList<>();
-		fBounds= new ArrayList<>();
-		afterPosition= false;
+		this(position, viewer, false);
 	}
 
 	/**
@@ -84,7 +80,23 @@ public class CodeMiningLineContentAnnotation extends LineContentAnnotation imple
 	 * @param viewer the viewer
 	 */
 	public CodeMiningLineContentAnnotation(Position position, ISourceViewer viewer, boolean afterPosition) {
-		super(position, viewer);
+		this(position, viewer, afterPosition, null, null, null);
+	}
+
+	/**
+	 * Code mining annotation constructor.
+	 *
+	 * @param position the position
+	 * @param viewer the viewer
+	 * @param onMouseHover the consumer to be called on mouse hover. If set, the implementor needs
+	 *            to take care of setting the cursor if wanted.
+	 * @param onMouseOut the consumer to be called on mouse out. If set, the implementor needs to
+	 *            take care of resetting the cursor.
+	 * @param onMouseMove the consumer to be called on mouse move
+	 */
+	public CodeMiningLineContentAnnotation(Position position, ISourceViewer viewer, boolean afterPosition, Consumer<MouseEvent> onMouseHover, Consumer<MouseEvent> onMouseOut,
+			Consumer<MouseEvent> onMouseMove) {
+		super(position, viewer, onMouseHover, onMouseOut, onMouseMove);
 		fResolvedMinings= null;
 		fMinings= new ArrayList<>();
 		fBounds= new ArrayList<>();

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineHeaderAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineHeaderAnnotation.java
@@ -69,7 +69,22 @@ public class CodeMiningLineHeaderAnnotation extends LineHeaderAnnotation impleme
 	 * @param viewer the viewer
 	 */
 	public CodeMiningLineHeaderAnnotation(Position position, ISourceViewer viewer) {
-		super(position, viewer);
+		this(position, viewer, null, null, null);
+	}
+
+	/**
+	 * Code mining annotation constructor.
+	 *
+	 * @param position the position
+	 * @param viewer the viewer
+	 * @param onMouseHover the consumer to be called on mouse hover. If set, the implementor needs
+	 *            to take care of setting the cursor if wanted.
+	 * @param onMouseOut the consumer to be called on mouse out. If set, the implementor needs to
+	 *            take care of resetting the cursor.
+	 * @param onMouseMove the consumer to be called on mouse move
+	 */
+	public CodeMiningLineHeaderAnnotation(Position position, ISourceViewer viewer, Consumer<MouseEvent> onMouseHover, Consumer<MouseEvent> onMouseOut, Consumer<MouseEvent> onMouseMove) {
+		super(position, viewer, onMouseHover, onMouseOut, onMouseMove);
 		fResolvedMinings= null;
 		fMinings= new ArrayList<>();
 		fBounds= new ArrayList<>();

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningManager.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningManager.java
@@ -23,11 +23,13 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.osgi.framework.Bundle;
 
+import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.graphics.Rectangle;
 
 import org.eclipse.core.runtime.Assert;
@@ -262,7 +264,17 @@ public class CodeMiningManager implements Runnable {
 				if (first instanceof LineContentCodeMining m) {
 					afterPosition= m.isAfterPosition();
 				}
-				ann= inLineHeader ? new CodeMiningLineHeaderAnnotation(pos, viewer) : new CodeMiningLineContentAnnotation(pos, viewer, afterPosition);
+				Consumer<MouseEvent> mouseHover= null;
+				Consumer<MouseEvent> mouseOut= null;
+				Consumer<MouseEvent> mouseMove= null;
+				if (first != null) {
+					mouseHover= first.getMouseHover();
+					mouseOut= first.getMouseOut();
+					mouseMove= first.getMouseMove();
+				}
+				ann= inLineHeader
+						? new CodeMiningLineHeaderAnnotation(pos, viewer, mouseHover, mouseOut, mouseMove)
+						: new CodeMiningLineContentAnnotation(pos, viewer, afterPosition, mouseHover, mouseOut, mouseMove);
 			} else if (ann instanceof ICodeMiningAnnotation && ((ICodeMiningAnnotation) ann).isInVisibleLines()) {
 				// annotation is in visible lines
 				annotationsToRedraw.add((ICodeMiningAnnotation) ann);

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/codemining/ICodeMining.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/codemining/ICodeMining.java
@@ -16,6 +16,7 @@ package org.eclipse.jface.text.codemining;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.graphics.Color;
@@ -114,6 +115,43 @@ public interface ICodeMining {
 	 * @return the action to execute when mining is clicked and null otherwise.
 	 */
 	Consumer<MouseEvent> getAction();
+
+	/**
+	 * Returns a consumer which is called when mouse is hovered over the code mining. If set, the
+	 * implementor needs to take care of setting the cursor if wanted.
+	 *
+	 * @since 3.27
+	 */
+	default Consumer<MouseEvent> getMouseHover() {
+		return e -> {
+			if (e.widget instanceof StyledText st) {
+				st.setCursor(st.getDisplay().getSystemCursor(SWT.CURSOR_HAND));
+			}
+		};
+	}
+
+	/**
+	 * Returns a consumer which is called when mouse is moved out of code mining. If set, the
+	 * implementor needs to take care of resetting the cursor.
+	 *
+	 * @since 3.27
+	 */
+	default Consumer<MouseEvent> getMouseOut() {
+		return e -> {
+			if (e.widget instanceof StyledText st) {
+				st.setCursor(null);
+			}
+		};
+	}
+
+	/**
+	 * Returns a consumer which is called when mouse is moved inside the code mining.
+	 *
+	 * @since 3.27
+	 */
+	default Consumer<MouseEvent> getMouseMove() {
+		return null;
+	}
 
 	/**
 	 * Dispose the mining. Typically shuts down or cancels all related asynchronous operations.

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/AbstractInlinedAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/AbstractInlinedAnnotation.java
@@ -62,15 +62,40 @@ public abstract class AbstractInlinedAnnotation extends Annotation {
 
 	int fY;
 
+	private final Consumer<MouseEvent> onMouseHover;
+
+	private final Consumer<MouseEvent> onMouseOut;
+
+	private final Consumer<MouseEvent> onMouseMove;
+
 	/**
 	 * Inlined annotation constructor.
 	 *
 	 * @param position the position where the annotation must be drawn.
-	 * @param viewer   the {@link ISourceViewer} where the annotation must be drawn.
+	 * @param viewer the {@link ISourceViewer} where the annotation must be drawn.
 	 */
 	protected AbstractInlinedAnnotation(Position position, ISourceViewer viewer) {
+		this(position, viewer, null, null, null);
+	}
+
+	/**
+	 * Inlined annotation constructor.
+	 *
+	 * @param position the position where the annotation must be drawn.
+	 * @param viewer the {@link ISourceViewer} where the annotation must be drawn.
+	 * @param onMouseHover the consumer to be called on mouse hover. If set, the implementor needs
+	 *            to take care of setting the cursor if wanted.
+	 * @param onMouseOut the consumer to be called on mouse out. If set, the implementor needs to
+	 *            take care of resetting the cursor.
+	 * @param onMouseMove the consumer to be called on mouse move
+	 * @since 3.27
+	 */
+	protected AbstractInlinedAnnotation(Position position, ISourceViewer viewer, Consumer<MouseEvent> onMouseHover, Consumer<MouseEvent> onMouseOut, Consumer<MouseEvent> onMouseMove) {
 		super(TYPE, false, ""); //$NON-NLS-1$
 		this.position= position;
+		this.onMouseHover= onMouseHover;
+		this.onMouseOut= onMouseOut;
+		this.onMouseMove= onMouseMove;
 	}
 
 	/**
@@ -165,8 +190,24 @@ public abstract class AbstractInlinedAnnotation extends Annotation {
 	 * @param e the mouse event
 	 */
 	public void onMouseHover(MouseEvent e) {
-		StyledText styledText= (StyledText) e.widget;
-		styledText.setCursor(styledText.getDisplay().getSystemCursor(SWT.CURSOR_HAND));
+		if (onMouseHover != null) {
+			onMouseHover.accept(e);
+		} else {
+			StyledText styledText= (StyledText) e.widget;
+			styledText.setCursor(styledText.getDisplay().getSystemCursor(SWT.CURSOR_HAND));
+		}
+	}
+
+	/**
+	 * Called when mouse moved in the inlined annotation.
+	 *
+	 * @param e the mouse event
+	 * @since 3.27
+	 */
+	public void onMouseMove(MouseEvent e) {
+		if (onMouseMove != null) {
+			onMouseMove.accept(e);
+		}
 	}
 
 	/**
@@ -175,8 +216,12 @@ public abstract class AbstractInlinedAnnotation extends Annotation {
 	 * @param e the mouse event
 	 */
 	public void onMouseOut(MouseEvent e) {
-		StyledText styledText= (StyledText) e.widget;
-		styledText.setCursor(null);
+		if (onMouseOut != null) {
+			onMouseOut.accept(e);
+		} else {
+			StyledText styledText= (StyledText) e.widget;
+			styledText.setCursor(null);
+		}
 	}
 
 	/**

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationDrawingStrategy.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationDrawingStrategy.java
@@ -198,9 +198,17 @@ class InlinedAnnotationDrawingStrategy implements IDrawingStrategy {
 			annotation.draw(gc, textWidget, offset, length, color, x, y);
 		} else if (textWidget.getLineVerticalIndent(line) > 0) {
 			// Here vertical indent is done, the redraw of the full line width is done to avoid annotation clipping
-			Rectangle bounds= textWidget.getTextBounds(offset, offset);
 			Rectangle client= textWidget.getClientArea();
-			textWidget.redraw(0, bounds.y, client.width, bounds.height, false);
+			int y, height;
+			if (offset < charCount) {
+				Rectangle bounds= textWidget.getTextBounds(offset, offset);
+				y= bounds.y;
+				height= bounds.height;
+			} else {
+				y= 0;
+				height= client.height;
+			}
+			textWidget.redraw(0, y, client.width, height, false);
 		} else {
 			if (offset >= charCount) {
 				if (charCount > 0) {

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationSupport.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationSupport.java
@@ -290,7 +290,7 @@ public class InlinedAnnotationSupport {
 			update(e);
 			if (oldAnnotation != null) {
 				if (oldAnnotation.equals(fAnnotation)) {
-					// Same annotations which was hovered, do nothing.
+					fAnnotation.onMouseMove(e);
 					return;
 				} else {
 					oldAnnotation.onMouseOut(e);

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineContentAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineContentAnnotation.java
@@ -13,8 +13,11 @@
  */
 package org.eclipse.jface.text.source.inlined;
 
+import java.util.function.Consumer;
+
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontMetrics;
 import org.eclipse.swt.graphics.GC;
@@ -48,7 +51,23 @@ public class LineContentAnnotation extends AbstractInlinedAnnotation {
 	 * @param viewer   the {@link ISourceViewer} where the annotation must be drawn.
 	 */
 	public LineContentAnnotation(Position position, ISourceViewer viewer) {
-		super(position, viewer);
+		this(position, viewer, null, null, null);
+	}
+
+	/**
+	 * Line content annotation constructor.
+	 *
+	 * @param position the position where the annotation must be drawn.
+	 * @param viewer the {@link ISourceViewer} where the annotation must be drawn.
+	 * @param onMouseHover the consumer to be called on mouse hover. If set, the implementor needs
+	 *            to take care of setting the cursor if wanted.
+	 * @param onMouseOut the consumer to be called on mouse out. If set, the implementor needs to
+	 *            take care of resetting the cursor.
+	 * @param onMouseMove the consumer to be called on mouse move
+	 * @since 3.27
+	 */
+	public LineContentAnnotation(Position position, ISourceViewer viewer, Consumer<MouseEvent> onMouseHover, Consumer<MouseEvent> onMouseOut, Consumer<MouseEvent> onMouseMove) {
+		super(position, viewer, onMouseHover, onMouseOut, onMouseMove);
 	}
 
 	/**

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineHeaderAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineHeaderAnnotation.java
@@ -13,7 +13,10 @@
  */
 package org.eclipse.jface.text.source.inlined;
 
+import java.util.function.Consumer;
+
 import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.events.MouseEvent;
 
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.source.ISourceViewer;
@@ -34,7 +37,23 @@ public class LineHeaderAnnotation extends AbstractInlinedAnnotation {
 	 * @param viewer the {@link ISourceViewer} where the annotation must be drawn.
 	 */
 	public LineHeaderAnnotation(Position position, ISourceViewer viewer) {
-		super(position, viewer);
+		this(position, viewer, null, null, null);
+	}
+
+	/**
+	 * Line header annotation constructor.
+	 *
+	 * @param position the position where the annotation must be drawn.
+	 * @param viewer the {@link ISourceViewer} where the annotation must be drawn.
+	 * @param onMouseHover the consumer to be called on mouse hover. If set, the implementor needs
+	 *            to take care of setting the cursor if wanted.
+	 * @param onMouseOut the consumer to be called on mouse out. If set, the implementor needs to
+	 *            take care of resetting the cursor.
+	 * @param onMouseMove the consumer to be called on mouse move
+	 * @since 3.27
+	 */
+	public LineHeaderAnnotation(Position position, ISourceViewer viewer, Consumer<MouseEvent> onMouseHover, Consumer<MouseEvent> onMouseOut, Consumer<MouseEvent> onMouseMove) {
+		super(position, viewer, onMouseHover, onMouseOut, onMouseMove);
 		oldLine= -1;
 	}
 


### PR DESCRIPTION
This change allows code mining implementors to react on mouse move events and call setCursor on the text widget for example.


We would like to implement a similar feature like shown in the following screenshot based on the eclipse code minings.
![vscode_links](https://github.com/user-attachments/assets/65a4e765-dde3-4f21-a725-837d16392e9c)
The code mining text color can already be set by overriding the draw method of LineHeaderCodeMining. The mouse cursor handle currently cannot be currently specified by the implementor; it is hard coded in AbstractInlinedAnnotation. This pull request introduces the methods getMouseHover, getMouseOut and getMouseMove in the ICodeMining interface so that the implementor can influence what mouse cursor is shown when hovering and moving over the mining. This API is very low level and technical, but it gives the implementor all possibilities to provide its own link-like controls in the code minings. 
