### PR TITLE
Backport Fix : Limit macOS Version (14) check to Sonama for Splash screen issue (4.08)

### DIFF
--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/internal/Workbench.java
@@ -920,7 +920,7 @@ public final class Workbench extends EventManager implements IWorkbench,
 			 * (https://github.com/eclipse-platform/eclipse.platform.swt/issues/772) ,Splash
 			 * Screen gets flipped.As a workaround the image is flipped and returned.
 			 */
-			if (Integer.parseInt(System.getProperty("os.version").split("\\.")[0]) >= 14) { //$NON-NLS-1$ //$NON-NLS-2$
+			if (Integer.parseInt(System.getProperty("os.version").split("\\.")[0]) == 14) { //$NON-NLS-1$ //$NON-NLS-2$
 				GC gc = new GC(image);
 				Transform tr = new Transform(display);
 				tr.setElements(1, 0, 0, -1, 0, 0);

--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.111.51.qualifier
+Bundle-Version: 3.111.52.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.ui.workbench/pom.xml
+++ b/bundles/org.eclipse.ui.workbench/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.ui</groupId>
   <artifactId>org.eclipse.ui.workbench</artifactId>
-  <version>3.111.51-SNAPSHOT</version>
+  <version>3.111.52-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
Backport Fix https://github.com/eclipse-platform/eclipse.platform.ui/pull/2170 to R4_8 maintenance branch

The workaround for the issue was previously applied to macOS version 14 (Sonoma). However, with the release of macOS version 15 (Sequoia), the original issue has been fixed. Therefore, the workaround needs to only apply to macOS 14, as Sequoia (version 15) no longer requires the workaround.