### PR TITLE
introduce FinalLineCodeMining to draw minings at the end of the document

### DIFF
--- a/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.text
-Bundle-Version: 3.27.100.qualifier
+Bundle-Version: 3.28.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningDocumentFooterAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningDocumentFooterAnnotation.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+* Copyright (c) 2025 SAP SE
+*
+* This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+******************************************************************************/
+package org.eclipse.jface.internal.text.codemining;
+
+import static org.eclipse.jface.internal.text.codemining.CodeMiningLineHeaderAnnotation.disposeMinings;
+import static org.eclipse.jface.internal.text.codemining.CodeMiningLineHeaderAnnotation.getMultilineHeight;
+import static org.eclipse.jface.internal.text.codemining.CodeMiningLineHeaderAnnotation.hasAtLeastOneResolvedMiningNotEmpty;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Rectangle;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.codemining.ICodeMining;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.jface.text.source.inlined.LineFooterAnnotation;
+
+/**
+ * Code Mining annotation at the end of the document.
+ *
+ */
+public class CodeMiningDocumentFooterAnnotation extends LineFooterAnnotation implements ICodeMiningAnnotation {
+
+	/**
+	 * List of resolved minings which contains current resolved minings and last resolved minings
+	 * and null if mining is not resolved.
+	 */
+	private ICodeMining[] fResolvedMinings;
+
+	/**
+	 * List of current resolved/unresolved minings
+	 */
+	private final List<ICodeMining> fMinings;
+
+	/**
+	 * List of bounds minings
+	 */
+	private final List<Rectangle> fBounds;
+
+	/**
+	 * The current progress monitor
+	 */
+	private IProgressMonitor fMonitor;
+
+	/**
+	 * Code mining annotation constructor.
+	 *
+	 * @param position the position
+	 * @param viewer the viewer
+	 * @param onMouseHover the consumer to be called on mouse hover. If set, the implementor needs
+	 *            to take care of setting the cursor if wanted.
+	 * @param onMouseOut the consumer to be called on mouse out. If set, the implementor needs to
+	 *            take care of resetting the cursor.
+	 * @param onMouseMove the consumer to be called on mouse move
+	 */
+	public CodeMiningDocumentFooterAnnotation(Position position, ISourceViewer viewer, Consumer<MouseEvent> onMouseHover, Consumer<MouseEvent> onMouseOut, Consumer<MouseEvent> onMouseMove) {
+		super(position, viewer, onMouseHover, onMouseOut, onMouseMove);
+		fResolvedMinings= null;
+		fMinings= new ArrayList<>();
+		fBounds= new ArrayList<>();
+	}
+
+	@Override
+	public int getHeight() {
+		return hasAtLeastOneResolvedMiningNotEmpty(fMinings, fResolvedMinings)
+				? getMultilineHeight(null, fMinings, super.getTextWidget(), super.getHeight())
+				: 0;
+	}
+
+	@Override
+	public void update(List<ICodeMining> minings, IProgressMonitor monitor) {
+		if (fResolvedMinings == null || (fResolvedMinings.length != minings.size())) {
+			// size of resolved minings are different from size of minings to update, initialize it with size of minings to update
+			fResolvedMinings= new ICodeMining[minings.size()];
+		}
+		// fill valid resolved minings with old minings.
+		int length= Math.min(fMinings.size(), minings.size());
+		for (int i= 0; i < length; i++) {
+			ICodeMining mining= fMinings.get(i);
+			if (mining.getLabel() != null) {
+				fResolvedMinings[i]= mining;
+			}
+		}
+		disposeMinings(fMinings);
+		fMonitor= monitor;
+		fMinings.addAll(minings);
+	}
+
+	@Override
+	public void markDeleted(boolean deleted) {
+		super.markDeleted(deleted);
+		if (deleted) {
+			disposeMinings(fMinings);
+			fResolvedMinings= null;
+		}
+	}
+
+	@Override
+	public void draw(GC gc, StyledText textWidget, int offset, int length, Color color, int x, int y) {
+		int singleLineHeight= super.getHeight();
+		CodeMiningLineHeaderAnnotation.draw(fMinings, fBounds, singleLineHeight, fResolvedMinings, gc, textWidget, color, x, y, new Runnable() {
+
+			@Override
+			public void run() {
+				redraw();
+			}
+		});
+	}
+
+	@Override
+	public void redraw() {
+		// redraw codemining annotation is done only if all current minings are resolved.
+		List<ICodeMining> minings= new ArrayList<>(fMinings);
+		for (ICodeMining mining : minings) {
+			if (!mining.isResolved()) {
+				// one of mining is not resolved, resolve it and then redraw the annotation.
+				mining.resolve(getViewer(), fMonitor).thenRunAsync(() -> {
+					this.redraw();
+				});
+				return;
+			}
+		}
+		// all minings are resolved, redraw the annotation
+		super.redraw();
+	}
+
+	@Override
+	public Consumer<MouseEvent> getAction(MouseEvent e) {
+		ICodeMining mining= CodeMiningManager.getValidCodeMiningAtLocation(fResolvedMinings, fBounds, e.x, e.y);
+		return mining != null ? mining.getAction() : null;
+	}
+
+	@Override
+	public boolean isInVisibleLines() {
+		return super.isInVisibleLines();
+	}
+}

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningManager.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningManager.java
@@ -42,6 +42,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.codemining.DocumentFooterCodeMining;
 import org.eclipse.jface.text.codemining.ICodeMining;
 import org.eclipse.jface.text.codemining.ICodeMiningProvider;
 import org.eclipse.jface.text.codemining.LineContentCodeMining;
@@ -272,9 +273,16 @@ public class CodeMiningManager implements Runnable {
 					mouseOut= first.getMouseOut();
 					mouseMove= first.getMouseMove();
 				}
-				ann= inLineHeader
-						? new CodeMiningLineHeaderAnnotation(pos, viewer, mouseHover, mouseOut, mouseMove)
-						: new CodeMiningLineContentAnnotation(pos, viewer, afterPosition, mouseHover, mouseOut, mouseMove);
+				if (inLineHeader) {
+					ann= new CodeMiningLineHeaderAnnotation(pos, viewer, mouseHover, mouseOut, mouseMove);
+				} else {
+					boolean inFooter= !minings.isEmpty() ? (first instanceof DocumentFooterCodeMining) : false;
+					if (inFooter) {
+						ann= new CodeMiningDocumentFooterAnnotation(pos, viewer, mouseHover, mouseOut, mouseMove);
+					} else {
+						ann= new CodeMiningLineContentAnnotation(pos, viewer, afterPosition, mouseHover, mouseOut, mouseMove);
+					}
+				}
 			} else if (ann instanceof ICodeMiningAnnotation && ((ICodeMiningAnnotation) ann).isInVisibleLines()) {
 				// annotation is in visible lines
 				annotationsToRedraw.add((ICodeMiningAnnotation) ann);

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/codemining/DocumentFooterCodeMining.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/codemining/DocumentFooterCodeMining.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+* Copyright (c) 2025 SAP SE
+*
+* This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+******************************************************************************/
+package org.eclipse.jface.text.codemining;
+
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Point;
+
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.Position;
+
+/**
+ * A code mining rendered at the start of the line, located at the very end of the document.
+ *
+ * @since 3.28
+ */
+public class DocumentFooterCodeMining extends AbstractCodeMining {
+
+	public DocumentFooterCodeMining(IDocument document, ICodeMiningProvider provider, Consumer<MouseEvent> action) {
+		super(new Position(document.getLength(), 0), provider, action);
+	}
+
+	@Override
+	public Point draw(GC gc, StyledText textWidget, Color color, int x, int y) {
+		return LineHeaderCodeMining.draw(getLabel(), gc, textWidget, x, y, new Callable<Point>() {
+
+			@Override
+			public Point call() throws Exception {
+				return DocumentFooterCodeMining.super.draw(gc, textWidget, color, x, y);
+			}
+		});
+	}
+}

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/codemining/LineHeaderCodeMining.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/codemining/LineHeaderCodeMining.java
@@ -14,6 +14,7 @@
  */
 package org.eclipse.jface.text.codemining;
 
+import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 
 import org.eclipse.swt.custom.StyledText;
@@ -79,7 +80,17 @@ public abstract class LineHeaderCodeMining extends AbstractCodeMining {
 
 	@Override
 	public Point draw(GC gc, StyledText textWidget, Color color, int x, int y) {
-		String title= getLabel() != null ? getLabel() : "no command"; //$NON-NLS-1$
+		return draw(getLabel(), gc, textWidget, x, y, new Callable<Point>() {
+
+			@Override
+			public Point call() throws Exception {
+				return LineHeaderCodeMining.super.draw(gc, textWidget, color, x, y);
+			}
+		});
+	}
+
+	static Point draw(String label, GC gc, StyledText textWidget, int x, int y, Callable<Point> superDrawCallable) {
+		String title= label != null ? label : "no command"; //$NON-NLS-1$
 		String[] lines= title.split("\\r?\\n|\\r"); //$NON-NLS-1$
 		if (lines.length > 1) {
 			Point result= new Point(0, 0);
@@ -92,7 +103,11 @@ public abstract class LineHeaderCodeMining extends AbstractCodeMining {
 			}
 			return result;
 		} else {
-			return super.draw(gc, textWidget, color, x, y);
+			try {
+				return superDrawCallable.call();
+			} catch (Exception e) {
+				return null;
+			}
 		}
 	}
 }

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineFooterAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineFooterAnnotation.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+* Copyright (c) 2025 SAP SE
+*
+* This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+******************************************************************************/
+package org.eclipse.jface.text.source.inlined;
+
+import java.util.function.Consumer;
+
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.events.MouseEvent;
+
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.source.ISourceViewer;
+
+/**
+ * Inlined annotation which is drawn after a line and which takes some place with a given height.
+ *
+ * @since 3.28
+ */
+public class LineFooterAnnotation extends AbstractInlinedAnnotation {
+
+
+	protected LineFooterAnnotation(Position position, ISourceViewer viewer, Consumer<MouseEvent> onMouseHover, Consumer<MouseEvent> onMouseOut, Consumer<MouseEvent> onMouseMove) {
+		super(position, viewer, onMouseHover, onMouseOut, onMouseMove);
+	}
+
+	/**
+	 * Returns the annotation height. By default, returns the {@link StyledText#getLineHeight()}.
+	 *
+	 * @return the annotation height.
+	 */
+	public int getHeight() {
+		StyledText styledText= super.getTextWidget();
+		return styledText.getLineHeight();
+	}
+
+	@Override
+	boolean contains(int x, int y) {
+		return (x >= this.fX && y >= this.fY && y <= this.fY + getHeight());
+	}
+}

--- a/tests/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jface.text.tests
-Bundle-Version: 3.13.800.qualifier
+Bundle-Version: 3.13.900.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: 


### PR DESCRIPTION
It is currently not possible to render a Line Code Mining at the very end of the document when the last character is not a line break. This pull request introduces the class FinalLineCodeMining which allows to achieve this requirement.