### PR TITLE
Sporadic "Widget is disposed" exception in ToolBarManagerRenderer

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/ToolBarManagerRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/ToolBarManagerRenderer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2020 IBM Corporation and others.
+ * Copyright (c) 2009, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -429,11 +429,15 @@ public class ToolBarManagerRenderer extends SWTPartRenderer {
 			IEclipseContext parentContext = getContextForParent(element);
 
 			CSSRenderingUtils cssUtils = parentContext.get(CSSRenderingUtils.class);
-			if (cssUtils != null) {
+			if (cssUtils != null && !newTB.isDisposed()) {
 				MUIElement modelElement = (MUIElement) newTB.getData(AbstractPartRenderer.OWNING_ME);
 				boolean draggable = ((modelElement != null) && (modelElement.getTags().contains(IPresentationEngine.DRAGGABLE)));
 				renderedCtrl = cssUtils.frameMeIfPossible(newTB, null, vertical, draggable);
 			}
+		}
+
+		if (renderedCtrl != null && renderedCtrl.isDisposed()) {
+			return null;
 		}
 
 		return renderedCtrl;

--- a/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.ui.tests;singleton:=true
-Bundle-Version: 0.15.600.qualifier
+Bundle-Version: 0.15.700.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.emf.ecore.xmi;bundle-version="2.4.0",


### PR DESCRIPTION
In case the toolbar item is contributed via an extension point, it might happen that the corresponding widget is disposed, immediately after creation. To avoid any errors further down the invocation chain, the call to createWidget() must then return null, rather than the invalid widget.

One use-case where this might happen is if the handler bound to this toolbar item tries to access the workbench window. If the window hasn't been created yet, this can force a recreation of the toolbar, disposing the current widget in the process.

See the following commits for similar problems:
- 228b669f78bf581e127371bdf199d736a923f62b
- e4d8434b1448f05d859452300671b4306fda5587