### PR TITLE
Prevent StatusLine from  SWT Invalid thread access

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/action/StatusLine.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/action/StatusLine.java
@@ -373,15 +373,11 @@ import org.eclipse.swt.widgets.ToolItem;
 	}
 
 	private void inUIThread(Runnable r) {
-		if (Display.getCurrent() != null) {
-			r.run();
-		} else {
-			getDisplay().asyncExec(() -> {
-				if (!isDisposed()) {
-					r.run();
-				}
-			});
-		}
+		getDisplay().execute(() -> {
+			if (!isDisposed()) {
+				r.run();
+			}
+		});
 	}
 
 	/**
@@ -584,7 +580,7 @@ import org.eclipse.swt.widgets.ToolItem;
 		if (changed) {
 			fTaskName = s;
 			fBaseTaskName = s;
-			updateMessageLabel();
+			inUIThread(this::updateMessageLabel);
 		}
 	}
 
@@ -659,7 +655,7 @@ import org.eclipse.swt.widgets.ToolItem;
 		boolean changed = !Objects.equals(fTaskName, text);
 		if (changed) {
 			fTaskName = text;
-			updateMessageLabel();
+			inUIThread(this::updateMessageLabel);
 		}
 	}
 


### PR DESCRIPTION
Since monitor methods may be invoked from any thread, make sure we wrap all SWT operations in UI Thread.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3718