### PR TITLE
Draw completion proposals always as focused

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/TableOwnerDrawSupport.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/TableOwnerDrawSupport.java
@@ -70,7 +70,7 @@ public class TableOwnerDrawSupport implements Listener {
 		return (StyleRange[])item.getData(STYLED_RANGES_KEY + column);
 	}
 
-	private TableOwnerDrawSupport(Table table) {
+	public TableOwnerDrawSupport(Table table) {
 		int orientation= table.getStyle() & (SWT.LEFT_TO_RIGHT | SWT.RIGHT_TO_LEFT);
 		fSharedLayout= new TextLayout(table.getDisplay());
 		fSharedLayout.setOrientation(orientation);

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/contentassist/CompletionProposalDrawSupport.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/contentassist/CompletionProposalDrawSupport.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2025 SAP SE.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     SAP SE - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jface.internal.text.contentassist;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Table;
+
+import org.eclipse.jface.internal.text.TableOwnerDrawSupport;
+
+/**
+ * Provides custom drawing support for completion proposals. This class ensures that completion
+ * proposals are always rendered with a focused appearance.
+ *
+ * <p>
+ * This drawing behavior addresses the particular situation where the code completion is triggered
+ * via keyboard shortcut, leaving the editor focused. In such cases, without this custom drawing
+ * support, the completion proposal would appear unfocused, leading to a suboptimal coloring.
+ * </p>
+ */
+public class CompletionProposalDrawSupport implements Listener {
+
+	private final TableOwnerDrawSupport fTableOwnerDrawSupport;
+
+	private CompletionProposalDrawSupport(Table table) {
+		fTableOwnerDrawSupport= new TableOwnerDrawSupport(table);
+	}
+
+	public static void install(Table table) {
+		CompletionProposalDrawSupport listener= new CompletionProposalDrawSupport(table);
+		table.addListener(SWT.Dispose, listener);
+		table.addListener(SWT.MeasureItem, listener);
+		table.addListener(SWT.EraseItem, listener);
+		table.addListener(SWT.PaintItem, listener);
+	}
+
+	@Override
+	public void handleEvent(Event event) {
+		if (event.widget instanceof Control control && !control.isFocusControl() && (event.type == SWT.EraseItem || event.type == SWT.PaintItem) && event.gc != null) {
+			Color background= event.widget.getDisplay().getSystemColor(SWT.COLOR_TITLE_BACKGROUND);
+			Color foreground= event.widget.getDisplay().getSystemColor(SWT.COLOR_WHITE);
+			event.gc.setBackground(background);
+			event.gc.setForeground(foreground);
+		}
+
+		fTableOwnerDrawSupport.handleEvent(event);
+	}
+
+}

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/link/contentassist/CompletionProposalPopup2.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/link/contentassist/CompletionProposalPopup2.java
@@ -40,6 +40,7 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
 
 import org.eclipse.jface.internal.text.TableOwnerDrawSupport;
+import org.eclipse.jface.internal.text.contentassist.CompletionProposalDrawSupport;
 import org.eclipse.jface.preference.JFacePreferences;
 import org.eclipse.jface.resource.ColorRegistry;
 import org.eclipse.jface.resource.JFaceColors;
@@ -274,7 +275,7 @@ class CompletionProposalPopup2 implements IContentAssistListener2 {
 
 		fIsColoredLabelsSupportEnabled= fContentAssistant.isColoredLabelsSupportEnabled();
 		if (fIsColoredLabelsSupportEnabled) {
-			TableOwnerDrawSupport.install(fProposalTable);
+			CompletionProposalDrawSupport.install(fProposalTable);
 		}
 
 		fProposalTable.setLocation(0, 0);

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/CompletionProposalPopup.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/CompletionProposalPopup.java
@@ -79,6 +79,7 @@ import org.eclipse.jface.bindings.keys.SWTKeySupport;
 import org.eclipse.jface.contentassist.IContentAssistSubjectControl;
 import org.eclipse.jface.internal.text.InformationControlReplacer;
 import org.eclipse.jface.internal.text.TableOwnerDrawSupport;
+import org.eclipse.jface.internal.text.contentassist.CompletionProposalDrawSupport;
 import org.eclipse.jface.preference.JFacePreferences;
 import org.eclipse.jface.resource.JFaceColors;
 import org.eclipse.jface.resource.JFaceResources;
@@ -628,7 +629,7 @@ class CompletionProposalPopup implements IContentAssistListener {
 
 		fIsColoredLabelsSupportEnabled= fContentAssistant.isColoredLabelsSupportEnabled();
 		if (fIsColoredLabelsSupportEnabled) {
-			TableOwnerDrawSupport.install(fProposalTable);
+			CompletionProposalDrawSupport.install(fProposalTable);
 		}
 
 		fProposalTable.setLocation(0, 0);


### PR DESCRIPTION
### Problem description
When opening the completion proposals via the keyboard, the focus will stay in the editor to be able to accept further user input. This is causing the completion proposal to be drawn in non focus colors. This colors can lead to UX problems, especially in dark theme. With this fix, the completion proposals are always drawn in focused colors.

Before the fix in dark theme, it was hard to sport the selected proposal:
![image](https://github.com/user-attachments/assets/25873297-ab8a-4d0c-a0f1-8d0c18bcb17d)

With the fix, the proposal is colored in the focus color:
![image](https://github.com/user-attachments/assets/b6f6b14d-b676-4eec-9c5e-18e778db790d)

### How to retest

1. Open a text editor and run the code completion (ctrl+space)
2. Check that the selected completion proposal is colored in the focused color

Fixes #1688