### PR TITLE
Increment the index after the element was added to the list

### DIFF
--- a/bundles/org.eclipse.e4.ui.model.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.model.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.ui.model.workbench;singleton:=true
-Bundle-Version: 2.4.500.qualifier
+Bundle-Version: 2.4.600.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/internal/ModelUtils.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/internal/ModelUtils.java
@@ -198,6 +198,7 @@ public class ModelUtils {
 					list.add(element);
 				} else {
 					list.add(index, element);
+					index++;
 				}
 			}
 		}


### PR DESCRIPTION
Currently elements are merged in reverse order if an insert index is give because the add is always performed at the original index.

This now do the following:
- on each insert operation the index is incremented if given
- if the index is larger than the list size the element is added instead

Fixes 
- https://github.com/eclipse-platform/eclipse.platform.ui/issues/2799