### PR TITLE
Add activity support for keybindings

### DIFF
--- a/bundles/org.eclipse.e4.ui.bindings/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.bindings/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.bindings;singleton:=true
-Bundle-Version: 0.14.500.qualifier
+Bundle-Version: 0.14.600.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -20,7 +20,9 @@ Require-Bundle: org.eclipse.swt;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.core.commands;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.e4.core.contexts;bundle-version="1.0.0",
  org.eclipse.e4.core.di;bundle-version="1.1.0",
- org.eclipse.e4.ui.services;bundle-version="1.0.0"
+ org.eclipse.e4.ui.services;bundle-version="1.0.0",
+ org.eclipse.e4.core.services;bundle-version="2.5.100",
+ org.eclipse.e4.ui.model.workbench
 Export-Package: org.eclipse.e4.ui.bindings;
   x-friends:="org.eclipse.e4.ui.workbench,
    org.eclipse.e4.ui.workbench.renderers.swt,

--- a/bundles/org.eclipse.e4.ui.bindings/src/org/eclipse/e4/ui/bindings/internal/BindingTableManager.java
+++ b/bundles/org.eclipse.e4.ui.bindings/src/org/eclipse/e4/ui/bindings/internal/BindingTableManager.java
@@ -257,4 +257,13 @@ public class BindingTableManager {
 		}
 		return 0;
 	}
+
+	public void activitiesChanged() {
+		for (Context ctx : definedTables.getContexts()) {
+			BindingTable table = getTable(ctx.getId());
+			if (table != null) {
+				table.activitiesChanged();
+			}
+		}
+	}
 }

--- a/bundles/org.eclipse.e4.ui.workbench.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.swt;singleton:=true
-Bundle-Version: 0.17.700.qualifier
+Bundle-Version: 0.17.800.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -32,7 +32,11 @@ Require-Bundle: org.eclipse.e4.ui.workbench;bundle-version="0.10.0",
 Require-Capability: osgi.extender; filter:="(&(osgi.extender=osgi.component)(version>=1.2)(!(version>=2.0)))"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Export-Package: org.eclipse.e4.ui.internal.workbench.swt;x-friends:="org.eclipse.e4.ui.workbench.addons.swt,org.eclipse.e4.ui.workbench.renderers.swt,org.eclipse.ui.workbench",
+Export-Package: org.eclipse.e4.ui.internal.workbench.swt;
+  x-friends:="org.eclipse.e4.ui.workbench.addons.swt,
+   org.eclipse.e4.ui.workbench.renderers.swt,
+   org.eclipse.ui.workbench,
+   org.eclipse.e4.ui.bindings.tests",
  org.eclipse.e4.ui.internal.workbench.swt.handlers;x-internal:=true,
  org.eclipse.e4.ui.workbench.swt,
  org.eclipse.e4.ui.workbench.swt.factories;x-friends:="org.eclipse.e4.ui.workbench.renderers.swt,org.eclipse.ui.workbench",

--- a/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/workbench/swt/util/BindingProcessingAddon.java
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/workbench/swt/util/BindingProcessingAddon.java
@@ -158,7 +158,7 @@ public class BindingProcessingAddon {
 		final Context bindingContext = contextManager.getContext(bindingTable.getBindingContext().getElementId());
 		BindingTable table = bindingTables.getTable(bindingTable.getBindingContext().getElementId());
 		if (table == null) {
-			table = new BindingTable(bindingContext);
+			table = new BindingTable(bindingContext, application);
 			bindingTables.addTable(table);
 		}
 		for (MKeyBinding binding : bindingTable.getBindings()) {
@@ -290,7 +290,7 @@ public class BindingProcessingAddon {
 				if (newObj instanceof MBindingTable) {
 					MBindingTable bt = (MBindingTable) newObj;
 					final Context bindingContext = contextManager.getContext(bt.getBindingContext().getElementId());
-					final BindingTable table = new BindingTable(bindingContext);
+					final BindingTable table = new BindingTable(bindingContext, application);
 					bindingTables.addTable(table);
 					List<MKeyBinding> bindings = bt.getBindings();
 					for (MKeyBinding binding : bindings) {
@@ -436,6 +436,12 @@ public class BindingProcessingAddon {
 		}
 
 		activateContexts(elementObj);
+	}
+
+	@Inject
+	@Optional
+	private void subscribeActivitiesChangedTopic(@UIEventTopic(UIEvents.UILifeCycle.ACTIVITIES_CHANGED) Event event) {
+		bindingTables.activitiesChanged();
 	}
 
 }

--- a/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench;singleton:=true
-Bundle-Version: 1.17.0.qualifier
+Bundle-Version: 1.18.0.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/workbench/UIEvents.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/workbench/UIEvents.java
@@ -348,6 +348,13 @@ public class UIEvents {
 		 */
 		String THEME_DEFINITION_CHANGED = TOPIC + TOPIC_SEP
 				+ "themeDefinitionChanged"; //$NON-NLS-1$
+
+		/**
+		 * Sent when activities changed (activity enabled/disabled)
+		 *
+		 * @since 1.18
+		 */
+		String ACTIVITIES_CHANGED = TOPIC + TOPIC_SEP + "activitiesChanged"; //$NON-NLS-1$
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/CategoryPatternFilter.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/CategoryPatternFilter.java
@@ -19,6 +19,8 @@ import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.jface.bindings.Binding;
 import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.ui.activities.IActivityManager;
+import org.eclipse.ui.activities.IIdentifier;
 import org.eclipse.ui.dialogs.PatternFilter;
 import org.eclipse.ui.internal.keys.model.BindingElement;
 
@@ -26,8 +28,11 @@ class CategoryPatternFilter extends PatternFilter {
 	private boolean filterCategories;
 	final Category uncategorized;
 
-	public CategoryPatternFilter(boolean filterCategories, Category c) {
+	private IActivityManager activityManager;
+
+	public CategoryPatternFilter(boolean filterCategories, Category c, IActivityManager activityManager) {
 		uncategorized = c;
+		this.activityManager = activityManager;
 		filterCategories(filterCategories);
 	}
 
@@ -55,8 +60,18 @@ class CategoryPatternFilter extends PatternFilter {
 			} catch (NotDefinedException e) {
 				return false;
 			}
+			if (!isActive(cmd)) {
+				return false;
+			}
 		}
 		return super.isLeafMatch(viewer, element);
+	}
+
+	private boolean isActive(final ParameterizedCommand command) {
+		String identifierId = command.getId();
+		IIdentifier identifier = activityManager.getIdentifier(identifierId);
+		boolean enabled = identifier.isEnabled();
+		return enabled;
 	}
 
 	private ParameterizedCommand getCommand(Object element) {

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/NewKeysPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/NewKeysPreferencePage.java
@@ -93,6 +93,7 @@ import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.activities.IActivityManager;
 import org.eclipse.ui.commands.ICommandImageService;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.dialogs.FilteredTree;
@@ -202,6 +203,12 @@ public class NewKeysPreferencePage extends PreferencePage implements IWorkbenchP
 	private ICommandService commandService;
 
 	private IWorkbench fWorkbench;
+
+	/**
+	 * The workbench's activity manager. This activity manager is used to see if
+	 * certain commands should be filtered from the user interface.
+	 */
+	private IActivityManager activityManager;
 
 	/**
 	 * A FilteredTree that provides a combo which is used to organize and display
@@ -472,7 +479,7 @@ public class NewKeysPreferencePage extends PreferencePage implements IWorkbenchP
 
 		IDialogSettings settings = getDialogSettings();
 
-		fPatternFilter = new CategoryPatternFilter(true, commandService.getCategory(null));
+		fPatternFilter = new CategoryPatternFilter(true, commandService.getCategory(null), activityManager);
 		if (settings.get(TAG_FILTER_UNCAT) != null) {
 			fPatternFilter.filterCategories(settings.getBoolean(TAG_FILTER_UNCAT));
 		}
@@ -854,7 +861,7 @@ public class NewKeysPreferencePage extends PreferencePage implements IWorkbenchP
 	}
 
 	private void createTree(Composite parent) {
-		fPatternFilter = new CategoryPatternFilter(true, fDefaultCategory);
+		fPatternFilter = new CategoryPatternFilter(true, fDefaultCategory, activityManager);
 		fPatternFilter.filterCategories(true);
 
 		GridData gridData;
@@ -1089,6 +1096,7 @@ public class NewKeysPreferencePage extends PreferencePage implements IWorkbenchP
 		fBindingService = workbench.getService(IBindingService.class);
 
 		commandImageService = workbench.getService(ICommandImageService.class);
+		activityManager = workbench.getActivitySupport().getActivityManager();
 	}
 
 	@Override

--- a/tests/org.eclipse.e4.ui.bindings.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.bindings.tests/META-INF/MANIFEST.MF
@@ -2,20 +2,23 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.e4.ui.bindings.tests
-Bundle-Version: 0.14.300.qualifier
+Bundle-Version: 0.14.400.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.eclipse.e4.core.commands,
  org.eclipse.e4.ui.services,
  org.eclipse.jface.bindings,
  org.eclipse.jface.bindings.keys,
  org.osgi.framework;version="1.5.0"
-Require-Bundle: org.eclipse.core.commands;bundle-version="3.5.0",
+Require-Bundle: org.eclipse.core.commands;bundle-version="3.12.400",
  org.junit,
- org.eclipse.e4.ui.bindings;bundle-version="0.9.0",
- org.eclipse.swt;bundle-version="3.6.0",
+ org.eclipse.e4.ui.bindings;bundle-version="0.14.600",
+ org.eclipse.swt;bundle-version="3.130.0",
  org.eclipse.e4.core.contexts,
  org.eclipse.e4.core.di,
- org.mockito.mockito-core
+ org.mockito.mockito-core,
+ org.eclipse.e4.ui.model.workbench,
+ org.eclipse.e4.ui.workbench;bundle-version="1.18.0",
+ org.eclipse.e4.ui.workbench.swt
 Eclipse-BundleShape: dir
 Export-Package: org.eclipse.e4.ui.bindings.tests;x-internal:=true
 Automatic-Module-Name: org.eclipse.e4.ui.bindings.tests

--- a/tests/org.eclipse.e4.ui.bindings.tests/src/org/eclipse/e4/ui/bindings/tests/BindingLookupTest.java
+++ b/tests/org.eclipse.e4.ui.bindings.tests/src/org/eclipse/e4/ui/bindings/tests/BindingLookupTest.java
@@ -37,6 +37,7 @@ import org.eclipse.e4.ui.bindings.BindingServiceAddon;
 import org.eclipse.e4.ui.bindings.EBindingService;
 import org.eclipse.e4.ui.bindings.internal.BindingTable;
 import org.eclipse.e4.ui.bindings.internal.BindingTableManager;
+import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.services.ContextServiceAddon;
 import org.eclipse.e4.ui.services.EContextService;
 import org.eclipse.jface.bindings.Binding;
@@ -64,6 +65,7 @@ public class BindingLookupTest {
 	private static final String TEST_ID2 = "test.id2";
 
 	private IEclipseContext workbenchContext;
+	private MApplication application;
 
 	private void defineCommands(IEclipseContext context) {
 		ECommandService cs = workbenchContext.get(ECommandService.class);
@@ -79,7 +81,7 @@ public class BindingLookupTest {
 		ContextInjectionFactory.make(CommandServiceAddon.class, workbenchContext);
 		ContextInjectionFactory.make(ContextServiceAddon.class, workbenchContext);
 		ContextInjectionFactory.make(BindingServiceAddon.class, workbenchContext);
-
+		application = globalContext.get(MApplication.class);
 		defineCommands(workbenchContext);
 		defineContexts(workbenchContext);
 		defineBindingTables(workbenchContext);
@@ -100,9 +102,9 @@ public class BindingLookupTest {
 	private void defineBindingTables(IEclipseContext context) {
 		BindingTableManager btm = context.get(BindingTableManager.class);
 		ContextManager cm = context.get(ContextManager.class);
-		btm.addTable(new BindingTable(cm.getContext(ID_DIALOG_AND_WINDOW)));
-		btm.addTable(new BindingTable(cm.getContext(ID_WINDOW)));
-		btm.addTable(new BindingTable(cm.getContext(ID_DIALOG)));
+		btm.addTable(new BindingTable(cm.getContext(ID_DIALOG_AND_WINDOW), application));
+		btm.addTable(new BindingTable(cm.getContext(ID_WINDOW), application));
+		btm.addTable(new BindingTable(cm.getContext(ID_DIALOG), application));
 	}
 
 	@After

--- a/tests/org.eclipse.e4.ui.bindings.tests/src/org/eclipse/e4/ui/bindings/tests/KeyDispatcherTest.java
+++ b/tests/org.eclipse.e4.ui.bindings.tests/src/org/eclipse/e4/ui/bindings/tests/KeyDispatcherTest.java
@@ -38,6 +38,7 @@ import org.eclipse.e4.ui.bindings.EBindingService;
 import org.eclipse.e4.ui.bindings.internal.BindingTable;
 import org.eclipse.e4.ui.bindings.internal.BindingTableManager;
 import org.eclipse.e4.ui.bindings.keys.KeyBindingDispatcher;
+import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.services.ContextServiceAddon;
 import org.eclipse.e4.ui.services.EContextService;
 import org.eclipse.jface.bindings.Binding;
@@ -94,6 +95,7 @@ public class KeyDispatcherTest {
 	private CallHandler twoStrokeHandler;
 	private KeyBindingDispatcher dispatcher;
 	private Listener listener;
+	private MApplication application;
 
 	private void defineCommands(IEclipseContext context) {
 		ECommandService cs = workbenchContext
@@ -135,6 +137,7 @@ public class KeyDispatcherTest {
 		ContextInjectionFactory.make(CommandServiceAddon.class, workbenchContext);
 		ContextInjectionFactory.make(ContextServiceAddon.class, workbenchContext);
 		ContextInjectionFactory.make(BindingServiceAddon.class, workbenchContext);
+		application = globalContext.get(MApplication.class);
 		defineContexts(workbenchContext);
 		defineBindingTables(workbenchContext);
 		defineCommands(workbenchContext);
@@ -161,9 +164,9 @@ public class KeyDispatcherTest {
 	private void defineBindingTables(IEclipseContext context) {
 		BindingTableManager btm = context.get(BindingTableManager.class);
 		ContextManager cm = context.get(ContextManager.class);
-		btm.addTable(new BindingTable(cm.getContext(ID_DIALOG_AND_WINDOW)));
-		btm.addTable(new BindingTable(cm.getContext(ID_WINDOW)));
-		btm.addTable(new BindingTable(cm.getContext(ID_DIALOG)));
+		btm.addTable(new BindingTable(cm.getContext(ID_DIALOG_AND_WINDOW), application));
+		btm.addTable(new BindingTable(cm.getContext(ID_WINDOW), application));
+		btm.addTable(new BindingTable(cm.getContext(ID_DIALOG), application));
 	}
 
 	@After

--- a/tests/org.eclipse.e4.ui.bindings.tests/src/org/eclipse/e4/ui/bindings/tests/TestUtil.java
+++ b/tests/org.eclipse.e4.ui.bindings.tests/src/org/eclipse/e4/ui/bindings/tests/TestUtil.java
@@ -13,9 +13,8 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.bindings.tests;
 
-import org.eclipse.e4.core.contexts.EclipseContextFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
-import org.osgi.framework.FrameworkUtil;
+import org.eclipse.e4.ui.internal.workbench.swt.E4Application;
 
 public class TestUtil {
 
@@ -24,9 +23,7 @@ public class TestUtil {
 	public static IEclipseContext getGlobalContext() {
 		if (appContext == null) {
 			synchronized (TestUtil.class) {
-				IEclipseContext serviceContext = EclipseContextFactory
-						.getServiceContext(FrameworkUtil.getBundle(TestUtil.class).getBundleContext());
-				appContext = serviceContext.createChild();
+				appContext = E4Application.createDefaultContext();
 			}
 		}
 


### PR DESCRIPTION
Currently Eclipse processes key bindings from "disabled" activities, activity support for key bindings was broken during e4 transition in 2010.

This change re-implements activity support for keybindings contributions.

- Don't show filtered key bindings in Keys preference page
- Hide bindings for filtered keys to BindingTableManager
- Fail command execution for filtered activity
- Update bindings state if enabled activities change

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2859
