### PR TITLE
fix concurrent use of AbstractTextSearchResult.fMatchEvent #992

### DIFF
--- a/bundles/org.eclipse.search/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search; singleton:=true
-Bundle-Version: 3.17.100.qualifier
+Bundle-Version: 3.17.200.qualifier
 Bundle-Activator: org.eclipse.search.internal.ui.SearchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.search/newsearch/org/eclipse/search/ui/text/AbstractTextSearchResult.java
+++ b/bundles/org.eclipse.search/newsearch/org/eclipse/search/ui/text/AbstractTextSearchResult.java
@@ -44,7 +44,6 @@ public abstract class AbstractTextSearchResult implements ISearchResult {
 
 	private final ConcurrentMap<Object, Set<Match>> fElementsToMatches;
 	private final List<ISearchResultListener> fListeners;
-	private final MatchEvent fMatchEvent;
 	private final AtomicInteger matchCount;
 
 	private MatchFilter[] fMatchFilters;
@@ -55,7 +54,6 @@ public abstract class AbstractTextSearchResult implements ISearchResult {
 	protected AbstractTextSearchResult() {
 		fElementsToMatches= new ConcurrentHashMap<>();
 		fListeners= new ArrayList<>();
-		fMatchEvent= new MatchEvent(this);
 		matchCount = new AtomicInteger(0);
 		fMatchFilters= null; // filtering disabled by default
 	}
@@ -145,12 +143,14 @@ public abstract class AbstractTextSearchResult implements ISearchResult {
 	}
 
 	private MatchEvent getSearchResultEvent(Match match, int eventKind) {
+		MatchEvent fMatchEvent = new MatchEvent(this);
 		fMatchEvent.setKind(eventKind);
 		fMatchEvent.setMatch(match);
 		return fMatchEvent;
 	}
 
 	private MatchEvent getSearchResultEvent(Collection<Match> matches, int eventKind) {
+		MatchEvent fMatchEvent = new MatchEvent(this);
 		fMatchEvent.setKind(eventKind);
 		Match[] matchArray= matches.toArray(new Match[matches.size()]);
 		fMatchEvent.setMatches(matchArray);


### PR DESCRIPTION
Some search results where missing when the same object was concurrently passed to listeners. There is no point to reuse the instance.

https://github.com/eclipse-platform/eclipse.platform.ui/issues/992