### PR TITLE
Provide Explicit "isDarkTheme" Attribute

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt.theme/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.css.swt.theme;singleton:=true
-Bundle-Version: 0.14.500.qualifier
+Bundle-Version: 0.14.600.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.css.swt.theme/schema/org.eclipse.e4.ui.css.swt.theme.exsd
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/schema/org.eclipse.e4.ui.css.swt.theme.exsd
@@ -134,6 +134,13 @@
                </documentation>
             </annotation>
          </attribute>
+         <attribute name="isDarkTheme" type="boolean">
+            <annotation>
+               <documentation>
+                  Set this to true if the theme uses dark background.
+               </documentation>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 

--- a/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/Theme.java
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/Theme.java
@@ -19,6 +19,7 @@ public class Theme implements ITheme {
 	private String id;
 	private String label;
 	private String osVersion;
+	private String isDark;
 
 	public Theme(String id, String label) {
 		this.id = id;
@@ -44,9 +45,24 @@ public class Theme implements ITheme {
 	}
 
 	@Override
+	public boolean isDark() {
+		if (isDark == null) {
+			// fallback for themes that don't yet set the "isDark" attribute
+			// will be removed in a later release
+			return id.contains("dark");
+		} else {
+			return Boolean.parseBoolean(isDark);
+		}
+	}
+
+	public void setIsDark(String isDark) {
+		this.isDark = isDark;
+	}
+
+	@Override
 	public String toString() {
 		return "Theme [id=" + id + ", label='" + label + "', osVersion="
-				+ osVersion + "]";
+				+ osVersion + " isDark=" + isDark + "]";
 	}
 
 

--- a/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/theme/ITheme.java
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/theme/ITheme.java
@@ -26,4 +26,10 @@ public interface ITheme {
 	 * @return the label
 	 */
 	String getLabel();
+
+	/**
+	 *
+	 * @return does the theme use a dark background color
+	 */
+	boolean isDark();
 }

--- a/bundles/org.eclipse.e4.ui.swt.gtk/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.swt.gtk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.e4.ui.swt.gtk;singleton:=true
-Bundle-Version: 1.2.200.qualifier
+Bundle-Version: 1.2.300.qualifier
 Fragment-Host: org.eclipse.e4.ui.css.swt.theme;bundle-version="0.10.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: fragment-gtk

--- a/bundles/org.eclipse.e4.ui.swt.gtk/src/org/eclipse/e4/ui/swt/internal/gtk/DarkThemeProcessor.java
+++ b/bundles/org.eclipse.e4.ui.swt.gtk/src/org/eclipse/e4/ui/swt/internal/gtk/DarkThemeProcessor.java
@@ -40,12 +40,11 @@ public class DarkThemeProcessor {
 				return;
 			}
 			ITheme theme = (ITheme) event.getProperty("theme");
-			final boolean isDark = theme.getId().contains("dark"); //$NON-NLS-1$
 			Display display = (Display) event.getProperty(IThemeEngine.Events.DEVICE);
 
 			// not using UISynchronize as this is specific to SWT/GTK
 			// scenarios
-			display.asyncExec(() -> OS.setDarkThemePreferred(isDark));
+			display.asyncExec(() -> OS.setDarkThemePreferred(theme.isDark()));
 		};
 		// using the IEventBroker explicitly because the @EventTopic annotation
 		// is unpredictable with processors within the debugger

--- a/bundles/org.eclipse.e4.ui.swt.win32/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.swt.win32/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.e4.ui.swt.win32;singleton:=true
-Bundle-Version: 1.2.300.qualifier
+Bundle-Version: 1.2.400.qualifier
 Fragment-Host: org.eclipse.e4.ui.css.swt.theme;bundle-version="0.10.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: fragment-win32

--- a/bundles/org.eclipse.e4.ui.swt.win32/src/org/eclipse/e4/ui/swt/internal/win32/DarkThemeProcessor.java
+++ b/bundles/org.eclipse.e4.ui.swt.win32/src/org/eclipse/e4/ui/swt/internal/win32/DarkThemeProcessor.java
@@ -39,8 +39,7 @@ public class DarkThemeProcessor {
 				return;
 			}
 			ITheme theme = (ITheme) event.getProperty("theme");
-			boolean isDark = theme.getId().contains("dark"); //$NON-NLS-1$
-			OS.setTheme (isDark);
+			OS.setTheme (theme.isDark());
 		};
 		// using the IEventBroker explicitly because the @EventTopic annotation
 		// is unpredictable with processors within the debugger

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Eclipse-PlatformFilter: (osgi.ws=cocoa)
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.renderers.swt.cocoa;singleton:=true
-Bundle-Version: 0.14.400.qualifier
+Bundle-Version: 0.14.500.qualifier
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.e4.ui.workbench.renderers.swt;bundle-version="[0.10.0,1.0.0)"

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/src/org/eclipse/e4/ui/swt/internal/cocoa/CocoaDarkThemeProcessor.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/src/org/eclipse/e4/ui/swt/internal/cocoa/CocoaDarkThemeProcessor.java
@@ -39,12 +39,11 @@ public class CocoaDarkThemeProcessor {
 				return;
 			}
 			ITheme theme = (ITheme) event.getProperty("theme"); //$NON-NLS-1$
-			final boolean isDark = theme.getId().contains("dark"); //$NON-NLS-1$
 			Display display = (Display) event.getProperty(IThemeEngine.Events.DEVICE);
 
 			// not using UISynchronize as this is specific to SWT/Mac
 			// scenarios
-			display.asyncExec(() -> OS.setTheme(isDark));
+			display.asyncExec(() -> OS.setTheme(theme.isDark()));
 		};
 		// using the IEventBroker explicitly because the @EventTopic annotation
 		// is unpredictable with processors within the debugger
@@ -52,9 +51,11 @@ public class CocoaDarkThemeProcessor {
 	}
 
 	/**
-	 * Unsubscribes the {@code eventHandler} from the {@code eventBroker} to cleanup the resources
+	 * Unsubscribes the {@code eventHandler} from the {@code eventBroker} to cleanup
+	 * the resources
 	 *
-	 * Assumption : Both {@code eventHandler} and {@code eventBroker} are initialized and non null
+	 * Assumption : Both {@code eventHandler} and {@code eventBroker} are
+	 * initialized and non null
 	 */
 	@PreDestroy
 	public void cleanUp() {

--- a/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.themes;singleton:=true
-Bundle-Version: 1.2.2700.qualifier
+Bundle-Version: 1.2.2800.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.e4.ui.css.swt.theme

--- a/bundles/org.eclipse.ui.themes/plugin.xml
+++ b/bundles/org.eclipse.ui.themes/plugin.xml
@@ -9,29 +9,33 @@
             label="%theme.classic">
       </theme>
     <theme
-        basestylesheeturi="css/e4-dark_linux.css"
-        id="org.eclipse.e4.ui.css.theme.e4_dark"
-        label="%theme.dark"
-        os="linux">
+          basestylesheeturi="css/e4-dark_linux.css"
+          id="org.eclipse.e4.ui.css.theme.e4_dark"
+          isDarkTheme="true"
+          label="%theme.dark"
+          os="linux">
     </theme>
     <theme
-        basestylesheeturi="css/e4-dark_win.css"
-        id="org.eclipse.e4.ui.css.theme.e4_dark"
-        label="%theme.dark"
-        os="win32">
+          basestylesheeturi="css/e4-dark_win.css"
+          id="org.eclipse.e4.ui.css.theme.e4_dark"
+          isDarkTheme="true"
+          label="%theme.dark"
+          os="win32">
     </theme>
     <theme
-        basestylesheeturi="css/e4-dark_mac1013.css"
-        id="org.eclipse.e4.ui.css.theme.e4_dark"
-        label="%theme.dark"
-        os="macosx"
-        os_version="10.11,10.12,10.13">
+          basestylesheeturi="css/e4-dark_mac1013.css"
+          id="org.eclipse.e4.ui.css.theme.e4_dark"
+          isDarkTheme="true"
+          label="%theme.dark"
+          os="macosx"
+          os_version="10.11,10.12,10.13">
     </theme>
     <theme
-        basestylesheeturi="css/e4-dark_mac.css"
-        id="org.eclipse.e4.ui.css.theme.e4_dark"
-        label="%theme.dark"
-        os="macosx">
+          basestylesheeturi="css/e4-dark_mac.css"
+          id="org.eclipse.e4.ui.css.theme.e4_dark"
+          isDarkTheme="true"
+          label="%theme.dark"
+          os="macosx">
     </theme>
       <theme
             basestylesheeturi="css/e4_default_gtk.css"

--- a/tests/org.eclipse.e4.ui.tests.css.swt/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.e4.ui.tests.css.swt; singleton:=true
-Bundle-Version: 0.12.800.qualifier
+Bundle-Version: 0.12.900.qualifier
 Require-Bundle: org.eclipse.e4.ui.css.core,
  org.eclipse.e4.ui.css.swt,
  org.eclipse.e4.ui.css.swt.theme;bundle-version="0.9.1",

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ThemeTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/ThemeTest.java
@@ -57,7 +57,9 @@ public class ThemeTest extends CSSSWTTestCase {
 	@Override
 	@AfterEach
 	public void tearDown() {
-		themeListenerRegistration.unregister();
+		if (themeListenerRegistration != null) {
+			themeListenerRegistration.unregister();
+		}
 		super.tearDown();
 	}
 
@@ -92,6 +94,34 @@ public class ThemeTest extends CSSSWTTestCase {
 		IThemeManager manager = context.getService(themeManagerReference);
 		assertNotNull(manager, "Theme manager service not available");
 		return manager.getEngineForDisplay(display);
+	}
+
+	@Test
+	void settingIsDarkToTrueShoulReportThemeIsDark() {
+		Theme theme = new Theme("IdDoesntCare", "DescriptionDoesntCare");
+		theme.setIsDark("true");
+		assertTrue(theme.isDark(), "Theme should report to be dark");
+	}
+
+	@Test
+	void settingIsDarkToFalseShoulReportThemeIsNotDark() {
+		Theme theme = new Theme("IdDoesntCare", "DescriptionDoesntCare");
+		theme.setIsDark("false");
+		assertFalse(theme.isDark(), "Theme should report to be NOT dark");
+	}
+
+	@Test
+	void settingIsDarkToNullShoulReportThemeIsNotDark() {
+		Theme theme = new Theme("IdDoesntCare", "DescriptionDoesntCare");
+		theme.setIsDark(null);
+		assertFalse(theme.isDark(), "Theme should report to be NOT dark");
+	}
+
+	@Test
+	void settingIsDarkToInvalidValueShoulReportThemeIsNotDark() {
+		Theme theme = new Theme("IdDoesntCare", "DescriptionDoesntCare");
+		theme.setIsDark("invalid");
+		assertFalse(theme.isDark(), "Theme should report to be NOT dark");
 	}
 
 }


### PR DESCRIPTION
Up to now we had some heuristics to check if a theme is a dark theme. This now makes this explicit.

- Add attribute to extension point
- Fill this attribute for the platforms dark theme
- Remove heuristics and now check this explicit flag

See also https://github.com/eclipse-platform/eclipse.platform.ui/pull/2797#issue-2850971179