### PR TITLE
Check if widget is disposed in async job

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StructuredViewer.java
@@ -423,7 +423,9 @@ public abstract class StructuredViewer extends ContentViewer implements IPostSel
 
 		@Override
 		public void run() {
-			doUpdateItem(widget, element, fullMap);
+			if (!widget.isDisposed()) {
+				doUpdateItem(widget, element, fullMap);
+			}
 		}
 	}
 


### PR DESCRIPTION
An async job that access a widget should check if the widget is already disposed and abort execution if this is the case. 