### PR TITLE
[PoC] Add option to hide the Cancel button of jobs in the progress view

### DIFF
--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/IProgressConstants.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/IProgressConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2014 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -165,4 +165,15 @@ public interface IProgressConstants {
 			PROPERTY_PREFIX, "inTaskBarIcon"); //$NON-NLS-1$
 
 	public static final String RUN_IN_BACKGROUND = "RUN_IN_BACKGROUND"; //$NON-NLS-1$
+
+	/**
+	 * This property provides a hint to the progress UI to hide the "Cancel" button,
+	 * effectively making the job uncancellable by the user.
+	 * <p>
+	 * The property must be of type {@code Boolean}.
+	 * </p>
+	 *
+	 * @since 0.4.700
+	 */
+	QualifiedName CANCELLABLE = new QualifiedName(PROPERTY_PREFIX, "cancellable"); //$NON-NLS-1$
 }

--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/JobInfo.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/JobInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2020 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.e4.ui.progress.IProgressConstants;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.graphics.Image;
@@ -374,7 +375,16 @@ public class JobInfo extends JobTreeElement {
 
 	@Override
 	public boolean isCancellable() {
-		return super.isCancellable();
+		return super.isCancellable() || isJobCancellable();
+	}
+
+	private boolean isJobCancellable() {
+		Boolean cancellable = (Boolean) job.getProperty(IProgressConstants.CANCELLABLE);
+		// cancellable by default
+		if (cancellable == null) {
+			return true;
+		}
+		return cancellable;
 	}
 
 	@Override

--- a/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressInfoItem.java
+++ b/bundles/org.eclipse.e4.ui.progress/src/org/eclipse/e4/ui/progress/internal/ProgressInfoItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2017 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -656,6 +656,15 @@ public class ProgressInfoItem extends Composite {
 
 		}
 		JobInfo[] infos = getJobInfos();
+
+		for (JobInfo jobInfo : getJobInfos()) {
+			// Hide cancel button if job not cancellable
+			if (!jobInfo.isCancellable()) {
+				actionBar.setVisible(false);
+				return;
+			}
+		}
+		actionBar.setVisible(true);
 
 		for (JobInfo info : infos) {
 			// Only disable if there is an unresponsive operation

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/JobInfo.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/JobInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2020 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -24,6 +24,7 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.ui.progress.IProgressConstants2;
 
 /**
  * JobInfo is the class that keeps track of the tree structure for objects that
@@ -317,7 +318,16 @@ public class JobInfo extends JobTreeElement {
 
 	@Override
 	public boolean isCancellable() {
-		return super.isCancellable();
+		return super.isCancellable() || isJobCancellable();
+	}
+
+	private boolean isJobCancellable() {
+		Boolean cancellable = (Boolean) job.getProperty(IProgressConstants2.CANCELLABLE);
+		// cancellable by default
+		if (cancellable == null) {
+			return true;
+		}
+		return cancellable;
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressInfoItem.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressInfoItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2015 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -636,6 +636,15 @@ public class ProgressInfoItem extends Composite {
 			actionButton.setDisabledImage(JFaceResources.getImage(DISABLED_STOP_IMAGE_KEY));
 
 		}
+
+		for (JobInfo jobInfo : getJobInfos()) {
+			// Hide cancel button if job not cancellable
+			if (!jobInfo.isCancellable()) {
+				actionBar.setVisible(false);
+				return;
+			}
+		}
+		actionBar.setVisible(true);
 
 		for (JobInfo jobInfo : getJobInfos()) {
 			// Only disable if there is an unresponsive operation

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/progress/IProgressConstants2.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/progress/IProgressConstants2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2020 IBM Corporation and others.
+ * Copyright (c) 2010, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -60,4 +60,15 @@ public interface IProgressConstants2 extends IProgressConstants {
 	 * </p>
 	 */
 	QualifiedName SHOW_IN_TASKBAR_ICON_PROPERTY = new QualifiedName(PROPERTY_PREFIX, "inTaskBarIcon"); //$NON-NLS-1$
+
+	/**
+	 * This property provides a hint to the progress UI to hide the "Cancel" button,
+	 * effectively making the job uncancellable by the user.
+	 * <p>
+	 * The property must be of type {@code Boolean}.
+	 * </p>
+	 *
+	 * @since 3.135
+	 */
+	QualifiedName CANCELLABLE = new QualifiedName(IProgressConstants.PROPERTY_PREFIX, "cancellable"); //$NON-NLS-1$
 }

--- a/examples/org.eclipse.e4.ui.examples.job/src/org/eclipse/e4/ui/examples/jobs/views/JobsView.java
+++ b/examples/org.eclipse.e4.ui.examples.job/src/org/eclipse/e4/ui/examples/jobs/views/JobsView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 Wojciech Sudol and others.
+ * Copyright (c) 2014, 2025 Wojciech Sudol and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -62,6 +62,7 @@ public class JobsView {
 	private Text quantityField, delayField, rescheduleDelay;
 	private Button schedulingRuleField;
 	private Button noPromptField;
+	private Button cancellableField;
 
 	Composite parent;
 
@@ -110,6 +111,7 @@ public class JobsView {
 		boolean keepOne = keepOneField.getSelection();
 		boolean gotoAction = gotoActionField.getSelection();
 		boolean schedulingRule = schedulingRuleField.getSelection();
+		boolean cancellable = cancellableField.getSelection();
 
 		int groupIncrement = IProgressMonitor.UNKNOWN;
 		IProgressMonitor group = new NullProgressMonitor();
@@ -134,6 +136,8 @@ public class JobsView {
 				result = new TestJob(duration, lock, failure, unknown,
 						reschedule, rescheduleWait);
 
+			result.setProperty(IProgressConstants.CANCELLABLE, Boolean
+					.valueOf(cancellable));
 			result.setProperty(IProgressConstants.KEEP_PROPERTY, Boolean
 					.valueOf(keep));
 			result.setProperty(IProgressConstants.KEEPONE_PROPERTY, Boolean
@@ -459,6 +463,13 @@ public class JobsView {
 		noPromptField
 				.setToolTipText("Set the IProgressConstants.NO_IMMEDIATE_ERROR_PROMPT_PROPERTY to true");
 		noPromptField.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		// cancellable
+		cancellableField = new Button(group, SWT.CHECK);
+		cancellableField.setText("Cancellable"); //$NON-NLS-1$
+		cancellableField.setToolTipText("Whether the job can be cancelled by the user"); //$NON-NLS-1$
+		cancellableField.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+		cancellableField.setSelection(true);
 	}
 
 	protected void doRun(long duration, IProgressMonitor monitor) {

--- a/examples/org.eclipse.ui.examples.job/src/org/eclipse/ui/examples/jobs/views/JobsView.java
+++ b/examples/org.eclipse.ui.examples.job/src/org/eclipse/ui/examples/jobs/views/JobsView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2019 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -45,6 +45,7 @@ import org.eclipse.ui.examples.jobs.TestJobRule;
 import org.eclipse.ui.examples.jobs.UITestJob;
 import org.eclipse.ui.part.ViewPart;
 import org.eclipse.ui.progress.IProgressConstants;
+import org.eclipse.ui.progress.IProgressConstants2;
 import org.eclipse.ui.progress.IProgressService;
 
 /**
@@ -59,6 +60,7 @@ public class JobsView extends ViewPart {
 	private Text quantityField, delayField, rescheduleDelay;
 	private Button schedulingRuleField;
 	private Button noPromptField;
+	private Button cancellableField;
 
 	protected void busyCursorWhile() {
 		try {
@@ -95,6 +97,7 @@ public class JobsView extends ViewPart {
 		boolean keepOne = keepOneField.getSelection();
 		boolean gotoAction = gotoActionField.getSelection();
 		boolean schedulingRule = schedulingRuleField.getSelection();
+		boolean cancellable = cancellableField.getSelection();
 
 		int groupIncrement = IProgressMonitor.UNKNOWN;
 		IProgressMonitor group = new NullProgressMonitor();
@@ -119,6 +122,8 @@ public class JobsView extends ViewPart {
 				result = new TestJob(duration, lock, failure, unknown,
 						reschedule, rescheduleWait);
 
+			result.setProperty(IProgressConstants2.CANCELLABLE, Boolean
+					.valueOf(cancellable));
 			result.setProperty(IProgressConstants.KEEP_PROPERTY, Boolean
 					.valueOf(keep));
 			result.setProperty(IProgressConstants.KEEPONE_PROPERTY, Boolean
@@ -427,6 +432,13 @@ public class JobsView extends ViewPart {
 		noPromptField.setText("No Prompt"); //$NON-NLS-1$
 		noPromptField.setToolTipText("Set the IProgressConstants.NO_IMMEDIATE_ERROR_PROMPT_PROPERTY to true"); //$NON-NLS-1$
 		noPromptField.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		// cancellable
+		cancellableField = new Button(group, SWT.CHECK);
+		cancellableField.setText("Cancellable"); //$NON-NLS-1$
+		cancellableField.setToolTipText("Whether the job can be cancelled by the user"); //$NON-NLS-1$
+		cancellableField.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+		cancellableField.setSelection(true);
 	}
 
 	protected void doRun(long duration, IProgressMonitor monitor) {


### PR DESCRIPTION
For long-running jobs that can't be reliably cancelled, it should be possible to hide the Cancel button, so that the job can still be used to provide feedback to the user without having to worry about the potential cancellation in the progress monitor.

This behavior is currently controlled via a property that needs to be set for the job before it is scheduled. But it might also be worthwhile to add this API directly to the Job class.

Note: In order to ensure an equal width for cancellable and non-cancellable jobs, the button is created, but simply turned invisible. This should also make it easier to dynamically hide/show the button, if such a functionality is needed at a later stage.

Relates to:
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=155479
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=102343