### PR TITLE
Adjusting the Size of Splash Shell a/c to image

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
@@ -820,8 +820,14 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 
 					if (splashShell == null)
 						return;
-					if (background != null)
+					if (background != null) {
 						splashShell.setBackgroundImage(background);
+						Rectangle imageBounds = background.getBounds();
+						Rectangle shellBounds = splashShell.getBounds();
+						if (imageBounds.width > shellBounds.width || imageBounds.height > shellBounds.height) {
+							splashShell.setSize(imageBounds.width, imageBounds.height);
+						}
+					}
 				}
 
 				Dictionary<String, Object> properties = new Hashtable<>();


### PR DESCRIPTION
The splash is initialized by the Equinox native launcher while image is set by SWT. SWT uses "correctly scaled images". This inconsistency leads to image cut off during start up.

![image](https://github.com/user-attachments/assets/cb816934-d9e4-4fef-92ad-bd79a8c49b6e)

### Proposed Solution

We are adjusting the size of the shell with the size of the image in case of inconsistency. 