### PR TITLE
Move FilteredTree parent assignment to abstract base class

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.36.0.qualifier
+Bundle-Version: 3.36.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractFilteredViewerComposite.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractFilteredViewerComposite.java
@@ -84,6 +84,7 @@ public abstract class AbstractFilteredViewerComposite<T extends ViewerFilter> ex
 	 */
 	public AbstractFilteredViewerComposite(Composite parent, int style, long refreshJobDelayInMillis) {
 		super(parent, style);
+		this.parent = parent;
 		this.refreshJobDelayInMillis = refreshJobDelayInMillis;
 	}
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/dialogs/FilteredTree.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/dialogs/FilteredTree.java
@@ -135,7 +135,6 @@ public class FilteredTree extends AbstractFilteredViewerComposite<PatternFilter>
 	 */
 	public FilteredTree(Composite parent, boolean useNewLook, boolean useFastHashLookup) {
 		super(parent, SWT.NONE, DEFAULT_REFRESH_TIME);
-		this.parent = parent;
 		if (treeViewer != null) {
 			treeViewer.setUseHashlookup(useFastHashLookup);
 		}
@@ -180,7 +179,6 @@ public class FilteredTree extends AbstractFilteredViewerComposite<PatternFilter>
 	public FilteredTree(Composite parent, int treeStyle, PatternFilter filter, boolean useNewLook,
 			boolean useFastHashLookup, long refreshJobDelayInMillis) {
 		super(parent, SWT.NONE, refreshJobDelayInMillis);
-		this.parent = parent;
 		init(treeStyle, filter);
 		if (treeViewer != null) {
 			treeViewer.setUseHashlookup(useFastHashLookup);
@@ -211,7 +209,6 @@ public class FilteredTree extends AbstractFilteredViewerComposite<PatternFilter>
 	@Deprecated
 	protected FilteredTree(Composite parent) {
 		super(parent, SWT.NONE, DEFAULT_REFRESH_TIME);
-		this.parent = parent;
 	}
 
 	/**


### PR DESCRIPTION
The "parent" field is not set properly for the e4 FilteredTree and FilteredTable when using the protected constructor. Move the assignment to the common base class to avoid undesirable NullPointerExceptions.

Amends 176f5030b1ed724274f88552b8bec14e43111832