### PR TITLE
Make ContentTypes->default text editor as Generic Code Editor.

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/registry/EditorRegistry.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/registry/EditorRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1358,6 +1358,13 @@ public class EditorRegistry extends EventManager implements IEditorRegistry, IEx
 		String key = IPreferenceConstants.DEFAULT_EDITOR_FOR_CONTENT_TYPE + contentType.getId();
 		String defaultEditorId = store.getString(key);
 		IEditorDescriptor descriptor = null;
+		if (defaultEditorId.isEmpty() && contentType.getId().contentEquals("org.eclipse.core.runtime.text")) { //$NON-NLS-1$
+			IEditorDescriptor genericEditor = descriptors.stream()
+					.filter(e -> "org.eclipse.ui.genericeditor.GenericEditor".equals(e.getId())) //$NON-NLS-1$
+					.findFirst().orElse(null);
+			store.setValue(key, genericEditor.getId());
+			return genericEditor;
+		}
 		if (defaultEditorId != null && !defaultEditorId.isBlank()) {
 			descriptor = descriptors.stream().filter(d -> defaultEditorId.equals(d.getId())).findFirst().orElse(null);
 		}


### PR DESCRIPTION
Make ContentTypes->default text editor as Generic Code Editor. 

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2527

**Before the pr**
When i come to Content Types page ->
1st screen
![image](https://github.com/user-attachments/assets/71b6c981-74ae-4a70-862b-053c51459677)

2nd screen when i select Text
![image](https://github.com/user-attachments/assets/d24cc950-8fb7-4ecb-a98a-c9e3c9dde334)

3rd screen when i open a text file
![image](https://github.com/user-attachments/assets/2b2521d3-4fd3-45e0-8842-f23f14325d83)


**After the pr changes**
When i come to Content Types page ->
1st screen
![image](https://github.com/user-attachments/assets/64d5cd33-92c8-47ff-85d0-89c9c931e788)

2nd screen when i select Text
![image](https://github.com/user-attachments/assets/4add3e3e-5271-4ee6-8ad0-4d697fbc686d)

3rd screen when i open a text file
![image](https://github.com/user-attachments/assets/c2d4db4a-0d86-463e-9b77-1b8f5bf36928)

