### PR TITLE
Revert "spare control characters from content assist trigger"

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/ContentAssistant.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/ContentAssistant.java
@@ -340,7 +340,7 @@ public class ContentAssistant implements IContentAssistant, IContentAssistantExt
 			if (e.character == 0 && (e.keyCode & SWT.KEYCODE_BIT) == 0)
 				return;
 
-			if (e.character != 0 && (e.stateMask == SWT.ALT || e.stateMask == SWT.CONTROL || e.stateMask == SWT.COMMAND))
+			if (e.character != 0 && (e.stateMask == SWT.ALT))
 				return;
 
 			TriggerType triggerType= getAutoActivationTriggerType(e.character);


### PR DESCRIPTION
This reverts commit aa42db11608ae15948c45836be3bb4a0a6d3827d, as the change has to be done on the JDT side [1].

[1] https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2086

Closes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2723