### PR TITLE
Ensure active part receives focus on perspective switch

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench;singleton:=true
-Bundle-Version: 1.17.0.qualifier
+Bundle-Version: 1.17.100.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartServiceImpl.java
@@ -767,11 +767,7 @@ public class PartServiceImpl implements EPartService {
 			partActivationHistory.activate(part, activateBranch);
 
 			if (requiresFocus) {
-				IEclipseContext context = part.getContext();
-				if (context != null) {
-					IPresentationEngine pe = context.get(IPresentationEngine.class);
-					pe.focusGui(part);
-				}
+				focusPart(part);
 			}
 
 			// store the activation time to sort the parts in MRU order
@@ -1512,5 +1508,13 @@ public class PartServiceImpl implements EPartService {
 			}
 		}
 		return outerContainer;
+	}
+
+	private static void focusPart(MPart part) {
+		IEclipseContext context = part.getContext();
+		if (context != null) {
+			IPresentationEngine pe = context.get(IPresentationEngine.class);
+			pe.focusGui(part);
+		}
 	}
 }


### PR DESCRIPTION
When switching a perspective, if a view exists in both the old and the
new perspective, it doesn't gain focus after the perspective switch.
This is contrary to the case in which a view is open only in the new
perspective. Since editors are shared between perspectives, the same bug
always occurs for editors - the editor will lose focus on a perspective
switch.

This change adds part focusing code on the code branch, on which the
active part already exists in the new perspective. This ensures the
active part gains focus.

Note that this change doesn't preserve focus of the active part in each
perspective. I.e. if View A is active in perspective X and View B was
active in perspective Y, upon switching to perspective Y, View A will
become active if it exists. The change only ensures that focus is not
lost altogether.

Fixes: #2839