### PR TITLE
Reduce noise for traced e4 model data

### DIFF
--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/basic/impl/PartImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/basic/impl/PartImpl.java
@@ -1350,20 +1350,34 @@ public class PartImpl extends UIElementImpl implements MPart {
 		result.append(object);
 		result.append(", context: "); //$NON-NLS-1$
 		result.append(context);
-		result.append(", variables: "); //$NON-NLS-1$
-		result.append(variables);
-		result.append(", label: "); //$NON-NLS-1$
-		result.append(label);
-		result.append(", iconURI: "); //$NON-NLS-1$
-		result.append(iconURI);
-		result.append(", tooltip: "); //$NON-NLS-1$
-		result.append(tooltip);
-		result.append(", dirty: "); //$NON-NLS-1$
-		result.append(dirty);
-		result.append(", closeable: "); //$NON-NLS-1$
-		result.append(closeable);
-		result.append(", description: "); //$NON-NLS-1$
-		result.append(description);
+		if (variables != null && !variables.isEmpty()) {
+			result.append(", variables: "); //$NON-NLS-1$
+			result.append(variables);
+		}
+		if (label != null) {
+			result.append(", label: "); //$NON-NLS-1$
+			result.append(label);
+		}
+		if (iconURI != null) {
+			result.append(", iconURI: "); //$NON-NLS-1$
+			result.append(iconURI);
+		}
+		if (tooltip != null && !tooltip.isBlank()) {
+			result.append(", tooltip: "); //$NON-NLS-1$
+			result.append(tooltip);
+		}
+		if (dirty) {
+			result.append(", dirty: "); //$NON-NLS-1$
+			result.append(dirty);
+		}
+		if (closeable) {
+			result.append(", closeable: "); //$NON-NLS-1$
+			result.append(closeable);
+		}
+		if (description != null) {
+			result.append(", description: "); //$NON-NLS-1$
+			result.append(description);
+		}
 		result.append(')');
 		return result.toString();
 	}

--- a/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/impl/UIElementImpl.java
+++ b/bundles/org.eclipse.e4.ui.model.workbench/src/org/eclipse/e4/ui/model/application/ui/impl/UIElementImpl.java
@@ -862,18 +862,26 @@ public abstract class UIElementImpl extends ApplicationElementImpl implements MU
 		StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (widget: "); //$NON-NLS-1$
 		result.append(widget);
-		result.append(", renderer: "); //$NON-NLS-1$
-		result.append(renderer);
-		result.append(", toBeRendered: "); //$NON-NLS-1$
-		result.append(toBeRendered);
-		result.append(", onTop: "); //$NON-NLS-1$
-		result.append(onTop);
-		result.append(", visible: "); //$NON-NLS-1$
-		result.append(visible);
-		result.append(", containerData: "); //$NON-NLS-1$
-		result.append(containerData);
-		result.append(", accessibilityPhrase: "); //$NON-NLS-1$
-		result.append(accessibilityPhrase);
+		if (toBeRendered) {
+			result.append(", toBeRendered: "); //$NON-NLS-1$
+			result.append(toBeRendered);
+		}
+		if (onTop) {
+			result.append(", onTop: "); //$NON-NLS-1$
+			result.append(onTop);
+		}
+		if (visible) {
+			result.append(", visible: "); //$NON-NLS-1$
+			result.append(visible);
+		}
+		if (containerData != null) {
+			result.append(", containerData: "); //$NON-NLS-1$
+			result.append(containerData);
+		}
+		if (accessibilityPhrase != null) {
+			result.append(", accessibilityPhrase: "); //$NON-NLS-1$
+			result.append(accessibilityPhrase);
+		}
 		result.append(')');
 		return result.toString();
 	}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/e4/compatibility/CompatibilityPart.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/e4/compatibility/CompatibilityPart.java
@@ -21,6 +21,8 @@ package org.eclipse.ui.internal.e4.compatibility;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -487,10 +489,16 @@ public abstract class CompatibilityPart implements ISelectionChangedListener {
 		if (part != null) {
 			builder.append("partId="); //$NON-NLS-1$
 			builder.append(part.getElementId());
-			builder.append(", properties="); //$NON-NLS-1$
-			builder.append(part.getProperties());
-			builder.append(", tags="); //$NON-NLS-1$
-			builder.append(part.getTags());
+			Map<String, String> properties = part.getProperties();
+			if (properties != null && !properties.isEmpty()) {
+				builder.append(", properties="); //$NON-NLS-1$
+				builder.append(properties);
+			}
+			List<String> tags = part.getTags();
+			if (tags != null && !tags.isEmpty()) {
+				builder.append(", tags="); //$NON-NLS-1$
+				builder.append(tags);
+			}
 		}
 		if (wrapped != null) {
 			builder.append(", wrapped="); //$NON-NLS-1$
@@ -500,10 +508,14 @@ public abstract class CompatibilityPart implements ISelectionChangedListener {
 			builder.append(", legacyPart="); //$NON-NLS-1$
 			builder.append(legacyPart.getClass());
 		}
-		builder.append(", beingDisposed="); //$NON-NLS-1$
-		builder.append(beingDisposed);
-		builder.append(", alreadyDisposed="); //$NON-NLS-1$
-		builder.append(alreadyDisposed);
+		if (beingDisposed) {
+			builder.append(", beingDisposed="); //$NON-NLS-1$
+			builder.append(beingDisposed);
+		}
+		if (alreadyDisposed) {
+			builder.append(", alreadyDisposed="); //$NON-NLS-1$
+			builder.append(alreadyDisposed);
+		}
 		builder.append("]"); //$NON-NLS-1$
 		return builder.toString();
 	}


### PR DESCRIPTION
This reduces amount of data printed out if `/trace/focus` flag for `org.eclipse.e4.ui.workbench.swt` is set (and of course for all other e4 model related tracing).

Should help to see what's going on in
https://github.com/eclipse-platform/eclipse.platform.ui/issues/2839