### PR TITLE
Restore original Problems view sort order for severity and priority

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerEntry.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerEntry.java
@@ -410,4 +410,31 @@ class MarkerEntry extends MarkerSupportItem implements IAdaptable {
 		MarkerEntry other = (MarkerEntry) obj;
 		return Objects.equals(marker, other.marker);
 	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("MarkerEntry ["); //$NON-NLS-1$
+		if (category != null) {
+			builder.append("category="); //$NON-NLS-1$
+			builder.append(category);
+			builder.append(", "); //$NON-NLS-1$
+		}
+		if (marker != null) {
+			builder.append(marker);
+			builder.append(", "); //$NON-NLS-1$
+		}
+		if (markerType != null) {
+			builder.append("markerType="); //$NON-NLS-1$
+			builder.append(markerType);
+			builder.append(", "); //$NON-NLS-1$
+		}
+		if (markerTypeName != null) {
+			builder.append("markerTypeName="); //$NON-NLS-1$
+			builder.append(markerTypeName);
+		}
+		builder.append("]"); //$NON-NLS-1$
+		return builder.toString();
+	}
+
 }

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerPriorityField.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerPriorityField.java
@@ -100,8 +100,10 @@ public class MarkerPriorityField extends MarkerField {
 
 	@Override
 	public int compare(MarkerItem item1, MarkerItem item2) {
-		return Integer.compare(item1.getAttributeValue(IMarker.PRIORITY, IMarker.PRIORITY_NORMAL),
-				item2.getAttributeValue(IMarker.PRIORITY, IMarker.PRIORITY_NORMAL));
+		// Higher values of priority have higher importance and should be sorted first,
+		// so we invert comparison order for priority
+		return Integer.compare(item2.getAttributeValue(IMarker.PRIORITY, IMarker.PRIORITY_NORMAL),
+				item1.getAttributeValue(IMarker.PRIORITY, IMarker.PRIORITY_NORMAL));
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerProblemSeverityAndMessageField.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerProblemSeverityAndMessageField.java
@@ -31,8 +31,10 @@ public class MarkerProblemSeverityAndMessageField extends
 
 	@Override
 	public int compare(MarkerItem item1, MarkerItem item2) {
-		int c = Integer.compare(MarkerSupportInternalUtilities.getSeverity(item1),
-				MarkerSupportInternalUtilities.getSeverity(item2));
+		// Higher values of severity have higher importance and should be sorted first,
+		// so we invert comparison order for severity
+		int c = Integer.compare(MarkerSupportInternalUtilities.getSeverity(item2),
+				MarkerSupportInternalUtilities.getSeverity(item1));
 		if (c != 0) {
 			return c;
 		}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerSeverityAndDescriptionField.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerSeverityAndDescriptionField.java
@@ -35,8 +35,10 @@ public class MarkerSeverityAndDescriptionField extends MarkerDescriptionField {
 
 	@Override
 	public int compare(MarkerItem item1, MarkerItem item2) {
-		int c = Integer.compare(MarkerSupportInternalUtilities.getSeverity(item1),
-				MarkerSupportInternalUtilities.getSeverity(item2));
+		// Higher values of severity have higher importance and should be sorted first,
+		// so we invert comparison order for severity
+		int c = Integer.compare(MarkerSupportInternalUtilities.getSeverity(item2),
+				MarkerSupportInternalUtilities.getSeverity(item1));
 		if (c != 0) {
 			return c;
 		}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerSeverityField.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerSeverityField.java
@@ -46,7 +46,9 @@ public class MarkerSeverityField extends MarkerField {
 
 	@Override
 	public int compare(MarkerItem item1, MarkerItem item2) {
-		return Integer.compare(MarkerSupportInternalUtilities.getSeverity(item1),
-				MarkerSupportInternalUtilities.getSeverity(item2));
+		// Higher values of severity have higher importance and should be sorted first,
+		// so we invert comparison order for severity
+		return Integer.compare(MarkerSupportInternalUtilities.getSeverity(item2),
+				MarkerSupportInternalUtilities.getSeverity(item1));
 	}
 }


### PR DESCRIPTION
Regression from f13fb4997f5e7849da26285938a3a0aea1769747.

One part of the regression was already fixed via
935b1dba41dd1e8f52a840c5057ae1eb925db159 (in `QuickFixPage`).

This change fixes remaining regressions that affect sort order of
markers where severity and priority attributes are involved.

Markers with higher values of severity/priority should be always sorted
first by default (the opposite to the "natural" sort order), because we
want that the *most important* markers are shown to the user by default
(without scrolling and filtering).

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2845
