### PR TITLE
Add a way to cancel if workspace is in use #2628 

### DIFF
--- a/bundles/org.eclipse.ui.ide.application/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide.application/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide.application;singleton:=true
-Bundle-Version: 1.5.600.qualifier
+Bundle-Version: 1.5.700.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui.ide;bundle-version="[3.21.0,4.0.0)",

--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
@@ -123,6 +123,13 @@ public class IDEApplication implements IApplication, IExecutableExtension {
 	private static final int RETRY_LOAD = 0;
 
 	/**
+	 * Return value when the user wants to cancel launch since workspace already
+	 * occupied
+	 */
+	private static final int CANCEL_LAUNCH = 2;
+	private static final int CANCEL_LAUNCH_DEFAULT = -1;
+
+	/**
 	 * A special return code that will be recognized by the PDE launcher and used to
 	 * show an error dialog if the workspace is locked.
 	 */
@@ -374,8 +381,9 @@ public class IDEApplication implements IApplication, IExecutableExtension {
 
 			MessageDialog dialog = new MessageDialog(null, IDEWorkbenchMessages.IDEApplication_workspaceInUseTitle,
 					null, NLS.bind(IDEWorkbenchMessages.IDEApplication_workspaceInUseMessage, workspaceUrl.getFile()),
-					MessageDialog.ERROR, 1, IDEWorkbenchMessages.IDEApplication_workspaceInUse_Retry,
-					IDEWorkbenchMessages.IDEApplication_workspaceInUse_Choose) {
+					MessageDialog.ERROR, 2, IDEWorkbenchMessages.IDEApplication_workspaceInUse_Retry,
+					IDEWorkbenchMessages.IDEApplication_workspaceInUse_Choose,
+					IDEWorkbenchMessages.IDEApplication_workspaceInUse_Cancel) {
 				@Override
 				protected Control createCustomArea(Composite parent) {
 					if (lockInfo == null || lockInfo.isBlank()) {
@@ -393,6 +401,11 @@ public class IDEApplication implements IApplication, IExecutableExtension {
 			};
 			// the return value influences the next loop's iteration
 			returnValue = dialog.open();
+
+			if (returnValue == CANCEL_LAUNCH || returnValue == CANCEL_LAUNCH_DEFAULT) {
+				return EXIT_OK;
+			}
+
 			// Remember the locked workspace as recent workspace
 			launchData.writePersistedData();
 		}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/IDEWorkbenchMessages.java
@@ -1043,6 +1043,7 @@ public class IDEWorkbenchMessages extends NLS {
 	public static String IDEApplication_workspaceInUseMessage;
 	public static String IDEApplication_workspaceInUse_Choose;
 	public static String IDEApplication_workspaceInUse_Retry;
+	public static String IDEApplication_workspaceInUse_Cancel;
 	public static String IDEApplication_workspaceEmptyTitle;
 	public static String IDEApplication_workspaceEmptyMessage;
 	public static String IDEApplication_workspaceInvalidTitle;

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
@@ -1067,6 +1067,7 @@ IDEApplication_workspaceInUseTitle=Workspace Unavailable
 IDEApplication_workspaceInUseMessage=Please choose another workspace as ''{0}'' is currently in use.
 IDEApplication_workspaceInUse_Choose=&Choose
 IDEApplication_workspaceInUse_Retry=&Retry
+IDEApplication_workspaceInUse_Cancel=&Cancel
 IDEApplication_workspaceEmptyTitle=Workspace Required
 IDEApplication_workspaceEmptyMessage=Workspace field must not be empty; enter a path to continue.
 IDEApplication_workspaceInvalidTitle=Invalid Workspace


### PR DESCRIPTION
Added #3rd Cancel button, close window button behaves as Cancel button, hence cancels launch 
Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/issues/2628

![FINAL_RESULT](https://github.com/user-attachments/assets/d986d556-c661-458d-b1b9-55b29828c3d1)
