### PR TITLE
Jenkinsfile: Use Tycho 4.0.13 way to display api tools warnings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,12 +28,15 @@ pipeline {
 			post {
 				always {
 					archiveArtifacts artifacts: '*.log,**/target/**/*.log', allowEmptyArchive: true
-					junit '**/target/surefire-reports/TEST-*.xml'
+					junit allowEmptyResults: true, testResults: '**/target/surefire-reports/TEST-*.xml'
 					discoverGitReferenceBuild referenceJob: 'eclipse.platform.ui/master'
-					recordIssues(publishAllIssues:false, ignoreQualityGate:true,
-						tool: eclipse(name: 'Compiler and API Tools', pattern: '**/target/compilelogs/*.xml'),
-						qualityGates: [[threshold: 1, type: 'DELTA', unstable: true]])
-					recordIssues publishAllIssues:false, tools: [mavenConsole(), javaDoc()]
+					recordIssues enabledForFailure: true, publishAllIssues:false, ignoreQualityGate:true,
+						tools: [
+							eclipse(name: 'Compiler', pattern: '**/target/compilelogs/*.xml'),
+							issues(name: 'API Tools', id: 'apitools', pattern: '**/target/apianalysis/*.xml')
+						],
+						qualityGates: [[threshold: 1, type: 'DELTA', unstable: true]]
+					recordIssues enabledForFailure: true, publishAllIssues:false, tools: [mavenConsole(), javaDoc()]
 				}
 			}
 		}


### PR DESCRIPTION
Also make sure the issues are published even in case of a failed build, as otherwise they are not visualized.