### PR TITLE
Suppress warnings for Key Class

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/AbstractKeyFormatter.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/AbstractKeyFormatter.java
@@ -35,6 +35,7 @@ import org.eclipse.ui.keys.NaturalKey;
  *
  * @since 3.0
  */
+@SuppressWarnings("removal")
 public abstract class AbstractKeyFormatter implements IKeyFormatter {
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/AbstractModifierKeyComparator.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/AbstractModifierKeyComparator.java
@@ -16,6 +16,7 @@ package org.eclipse.ui.internal.keys;
 import java.util.Comparator;
 import org.eclipse.ui.keys.ModifierKey;
 
+@SuppressWarnings("removal")
 abstract class AbstractModifierKeyComparator implements Comparator<ModifierKey> {
 
 	@Override

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/AlphabeticModifierKeyComparator.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/AlphabeticModifierKeyComparator.java
@@ -22,6 +22,7 @@ import org.eclipse.ui.keys.ModifierKey;
  *
  * @since 3.0
  */
+@SuppressWarnings("removal")
 public class AlphabeticModifierKeyComparator implements Comparator<ModifierKey> {
 
 	@Override

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/CompactKeyFormatter.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/CompactKeyFormatter.java
@@ -34,6 +34,7 @@ import org.eclipse.ui.keys.NaturalKey;
  */
 public class CompactKeyFormatter extends NativeKeyFormatter {
 
+	@SuppressWarnings("removal")
 	@Override
 	public String format(KeySequence keySequence) {
 		StringBuilder stringBuffer = new StringBuilder();
@@ -67,6 +68,7 @@ public class CompactKeyFormatter extends NativeKeyFormatter {
 		return stringBuffer.toString();
 	}
 
+	@SuppressWarnings("removal")
 	public String formatKeyStrokes(Set<ModifierKey> modifierKeys, List<?> naturalKeys) {
 		StringBuilder stringBuffer = new StringBuilder();
 		String keyDelimiter = getKeyDelimiter();

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/EmacsKeyFormatter.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/EmacsKeyFormatter.java
@@ -16,7 +16,6 @@ package org.eclipse.ui.internal.keys;
 
 import java.util.Comparator;
 import java.util.ResourceBundle;
-
 import org.eclipse.ui.internal.util.Util;
 import org.eclipse.ui.keys.Key;
 import org.eclipse.ui.keys.KeySequence;
@@ -50,6 +49,7 @@ public class EmacsKeyFormatter extends AbstractKeyFormatter {
 	 * @param key The key to format; must not be <code>null</code>.
 	 * @return The key formatted as a string; should not be <code>null</code>.
 	 */
+	@SuppressWarnings("removal")
 	@Override
 	public String format(Key key) {
 		if (key instanceof ModifierKey) {
@@ -62,11 +62,13 @@ public class EmacsKeyFormatter extends AbstractKeyFormatter {
 		return super.format(key).toLowerCase();
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	protected String getKeyDelimiter() {
 		return Util.translateString(RESOURCE_BUNDLE, KEY_DELIMITER_KEY, KeyStroke.KEY_DELIMITER, false, false);
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	protected String getKeyStrokeDelimiter() {
 		return Util.translateString(RESOURCE_BUNDLE, KEY_STROKE_DELIMITER_KEY, KeySequence.KEY_STROKE_DELIMITER, false,

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/FormalKeyFormatter.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/FormalKeyFormatter.java
@@ -15,7 +15,6 @@
 package org.eclipse.ui.internal.keys;
 
 import java.util.Comparator;
-
 import org.eclipse.ui.keys.Key;
 import org.eclipse.ui.keys.KeySequence;
 import org.eclipse.ui.keys.KeyStroke;
@@ -34,16 +33,19 @@ public class FormalKeyFormatter extends AbstractKeyFormatter {
 	 */
 	private static final Comparator FORMAL_MODIFIER_KEY_COMPARATOR = new AlphabeticModifierKeyComparator();
 
+	@SuppressWarnings("removal")
 	@Override
 	public String format(Key key) {
 		return key.toString();
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	protected String getKeyDelimiter() {
 		return KeyStroke.KEY_DELIMITER;
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	protected String getKeyStrokeDelimiter() {
 		return KeySequence.KEY_STROKE_DELIMITER;

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/MacKeyFormatter.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/MacKeyFormatter.java
@@ -17,7 +17,6 @@ package org.eclipse.ui.internal.keys;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.ResourceBundle;
-
 import org.eclipse.ui.internal.util.Util;
 import org.eclipse.ui.keys.CharacterKey;
 import org.eclipse.ui.keys.Key;
@@ -25,6 +24,7 @@ import org.eclipse.ui.keys.KeySequence;
 import org.eclipse.ui.keys.ModifierKey;
 import org.eclipse.ui.keys.SpecialKey;
 
+@SuppressWarnings("removal")
 public final class MacKeyFormatter extends AbstractKeyFormatter {
 
 	private static final class MacModifierKeyComparator extends AbstractModifierKeyComparator {

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/NativeKeyFormatter.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/NativeKeyFormatter.java
@@ -32,6 +32,7 @@ import org.eclipse.ui.keys.SpecialKey;
  *
  * @since 3.0
  */
+@SuppressWarnings("removal")
 public class NativeKeyFormatter extends AbstractKeyFormatter {
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/NativeModifierKeyComparator.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/NativeModifierKeyComparator.java
@@ -25,6 +25,7 @@ import org.eclipse.ui.keys.ModifierKey;
  *
  * @since 3.0
  */
+@SuppressWarnings("removal")
 class NativeModifierKeyComparator implements Comparator<ModifierKey> {
 
 	/**


### PR DESCRIPTION
This PR adds @SuppressWarnings("deprecation") to avoid warnings caused by the usage of the deprecated Key class, which is marked for removal since 2024-03.