### PR TITLE
Add activities support to DynamicMenuContributionItem

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
@@ -457,7 +457,6 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 	 *                specializes this workbench instance
 	 * @since 3.0
 	 */
-	@SuppressWarnings("restriction")
 	private Workbench(Display display, final WorkbenchAdvisor advisor, MApplication app, IEclipseContext appContext) {
 		this.advisor = Objects.requireNonNull(advisor);
 		this.display = Objects.requireNonNull(display);

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchContributionFactory.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchContributionFactory.java
@@ -25,7 +25,6 @@ import org.osgi.framework.Bundle;
  * from the {@link Workbench} services.
  *
  */
-@SuppressWarnings("restriction")
 class WorkbenchContributionFactory implements IContributionFactory {
 
 	private static final String BUNDLE_CLASS_PREFIX = "bundleclass://"; //$NON-NLS-1$
@@ -58,8 +57,11 @@ class WorkbenchContributionFactory implements IContributionFactory {
 
 	@Override
 	public boolean isEnabled(String uriString) {
-		if (uriString != null && uriString.startsWith(BUNDLE_CLASS_PREFIX)) {
-			String identifierId = uriString.substring(BUNDLE_CLASS_PREFIX.length());
+		if (uriString != null) {
+			String identifierId = uriString;
+			if (uriString.startsWith(BUNDLE_CLASS_PREFIX)) {
+				identifierId = uriString.substring(BUNDLE_CLASS_PREFIX.length());
+			}
 			if (activitySupport == null) {
 				activitySupport = context.get(IWorkbenchActivitySupport.class);
 			}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/menus/DynamicMenuContributionItem.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/menus/DynamicMenuContributionItem.java
@@ -17,6 +17,7 @@ package org.eclipse.ui.internal.menus;
 
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.ILog;
+import org.eclipse.e4.core.services.contributions.IContributionFactory;
 import org.eclipse.jface.action.ContributionItem;
 import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.jface.action.IContributionManager;
@@ -45,6 +46,7 @@ public class DynamicMenuContributionItem extends ContributionItem {
 	private final IServiceLocator locator;
 	private boolean alreadyFailed;
 	private ContributionItem loadedDynamicContribution;
+	private IContributionFactory factory;
 
 	/**
 	 * Creates a DynamicMenuContributionItem
@@ -58,6 +60,7 @@ public class DynamicMenuContributionItem extends ContributionItem {
 
 		this.locator = locator;
 		this.dynamicAddition = dynamicAddition;
+		this.factory = locator.getService(IContributionFactory.class);
 	}
 
 	@Override
@@ -128,6 +131,9 @@ public class DynamicMenuContributionItem extends ContributionItem {
 			} catch (RuntimeException e) {
 				reportErrorForContribution(loadedDynamicContribution, e);
 			}
+		}
+		if (factory != null && !factory.isEnabled(getId())) {
+			return false;
 		}
 		return super.isVisible();
 	}


### PR DESCRIPTION
The PR https://github.com/eclipse-platform/eclipse.platform.ui/pull/2768 was not complete. 
Dynamic **menus** are not filtered with that PR but will be filtered with the provided change.

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/2217