### PR TITLE
Add SWT SVG fragment to E4 RCP feature

### DIFF
--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -295,6 +295,10 @@
          version="0.0.0"/>
 
    <plugin
+         id="org.eclipse.swt.svg"
+         version="0.0.0"/>
+
+   <plugin
          id="org.eclipse.jface"
          version="0.0.0"/>
 


### PR DESCRIPTION
The SVG fragment needs to be available in runtime and SDK products for the platform. This adds it to the feature that already includes the SWT bundle and native fragments.

This is an extract of https://github.com/eclipse-platform/eclipse.platform.ui/pull/2593 only containing the feature changes (potential other changes to be discussed in that other PR).

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1944