### PR TITLE
FindReplaceDialog: preserve replace button enablement #2863

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench.texteditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench.texteditor; singleton:=true
-Bundle-Version: 3.19.100.qualifier
+Bundle-Version: 3.19.200.qualifier
 Bundle-Activator: org.eclipse.ui.internal.texteditor.TextEditorPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -154,8 +154,6 @@ class FindReplaceDialog extends Dialog {
 			fFindField.addModifyListener(event -> {
 				decorate();
 			});
-
-			updateButtonState(!findReplaceLogic.isActive(SearchOptions.INCREMENTAL));
 		}
 	}
 
@@ -629,9 +627,6 @@ class FindReplaceDialog extends Dialog {
 	 * @return the input panel
 	 */
 	private Composite createInputPanel(Composite parent) {
-
-		ModifyListener listener = e -> updateButtonState();
-
 		Composite panel = new Composite(parent, SWT.NULL);
 		GridLayout layout = new GridLayout();
 		layout.numColumns = 2;
@@ -652,7 +647,10 @@ class FindReplaceDialog extends Dialog {
 				ITextEditorActionDefinitionIds.CONTENT_ASSIST_PROPOSALS, new char[0], true);
 		setGridData(fFindField, SWT.FILL, true, SWT.CENTER, false);
 		addDecorationMargin(fFindField);
-		fFindModifyListener = new InputModifyListener(this::updateFindString);
+		fFindModifyListener = new InputModifyListener(() -> {
+			updateFindString();
+			updateButtonState(!findReplaceLogic.isActive(SearchOptions.INCREMENTAL));
+		});
 		fFindField.addModifyListener(fFindModifyListener);
 
 		fReplaceLabel = new Label(panel, SWT.LEFT);
@@ -671,9 +669,9 @@ class FindReplaceDialog extends Dialog {
 			if (okToUse(fReplaceField)) {
 				findReplaceLogic.setReplaceString(fReplaceField.getText());
 			}
+			updateButtonState();
 		});
 		fReplaceField.addModifyListener(fReplaceModifyListener);
-		fReplaceField.addModifyListener(listener);
 
 		return panel;
 	}

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.workbench.texteditor.tests
-Bundle-Version: 3.14.700.qualifier
+Bundle-Version: 3.14.800.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
@@ -236,6 +236,8 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 	@Test
 	public void testSimpleReplace() {
 		initializeTextViewerWithFindReplaceUI("ABCD ABCD ABCD");
+		dialog.select(SearchOptions.INCREMENTAL);
+
 		dialog.setFindText("ABCD");
 		dialog.setReplaceText("abcd");
 		dialog.performReplace();

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DialogAccess.java
@@ -218,21 +218,29 @@ class DialogAccess implements IFindReplaceUIAccess {
 
 	@Override
 	public void performReplaceAll() {
-		replaceAllButton.notifyListeners(SWT.Selection, null);
+		if (replaceAllButton.getEnabled()) {
+			replaceAllButton.notifyListeners(SWT.Selection, null);
+		}
 	}
 
 	@Override
 	public void performReplace() {
-		replaceButton.notifyListeners(SWT.Selection, null);
+		if (replaceButton.getEnabled()) {
+			replaceButton.notifyListeners(SWT.Selection, null);
+		}
 	}
 
 	public void performFindNext() {
-		findNextButton.notifyListeners(SWT.Selection, null);
+		if (findNextButton.getEnabled()) {
+			findNextButton.notifyListeners(SWT.Selection, null);
+		}
 	}
 
 	@Override
 	public void performReplaceAndFind() {
-		replaceFindButton.notifyListeners(SWT.Selection, null);
+		if (replaceFindButton.getEnabled()) {
+			replaceFindButton.notifyListeners(SWT.Selection, null);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
When typing into the replace input field of the FindReplaceDialog, the replace buttons currently become disabled in case incremental search is not activated. This requires another find to be explicitly triggered. The reason is that button enablement handling for changes in the find and replace input fields have erroneously been merged.

This change corrects the enablement calculation for changes to the replace input field by reverting to the original separation between how buttons are enabled based on changes in the find input and in the replace input field.

Tests did not find the issue as they did not check for enablement of the according buttons. This change also corrects that.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2863