### PR TITLE
[Win32] Enable monitor-specific scaling by default

### DIFF
--- a/bundles/org.eclipse.ui.workbench/.settings/.api_filters
+++ b/bundles/org.eclipse.ui.workbench/.settings/.api_filters
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.ui.workbench" version="2">
+    <resource path="eclipseui/org/eclipse/ui/IWorkbenchPreferenceConstants.java" type="org.eclipse.ui.IWorkbenchPreferenceConstants">
+        <filter id="388194388">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.IWorkbenchPreferenceConstants"/>
+                <message_argument value="RESCALING_AT_RUNTIME"/>
+                <message_argument value="RESCALING_AT_RUNTIME"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/IWorkbenchPreferenceConstants.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/IWorkbenchPreferenceConstants.java
@@ -722,11 +722,10 @@ public interface IWorkbenchPreferenceConstants {
 
 	/**
 	 * <p>
-	 * <strong>EXPERIMENTAL</strong>. Whether the UI adapts to DPI changes at
-	 * runtime. It only effects Windows.
+	 * Whether the UI adapts to DPI changes at runtime. It only affects Windows.
 	 * </p>
 	 *
 	 * @since 3.134
 	 */
-	String RESCALING_AT_RUNTIME = "RESCALING_AT_RUNTIME"; //$NON-NLS-1$
+	String RESCALING_AT_RUNTIME = "monitorSpecificScaling"; //$NON-NLS-1$
 }

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
@@ -702,7 +702,7 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 			));
 		} else {
 			boolean rescaleAtRuntime = ConfigurationScope.INSTANCE.getNode(WorkbenchPlugin.PI_WORKBENCH)
-					.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME, false);
+					.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME, true);
 			System.setProperty(SWT_RESCALE_AT_RUNTIME_PROPERTY, Boolean.toString(rescaleAtRuntime));
 		}
 	}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchMessages.java
@@ -36,9 +36,9 @@ public class WorkbenchMessages extends NLS {
 
 	public static String HiDpiSettingsGroupTitle;
 
-	public static String RescaleAtRuntimeEnabled;
+	public static String RescaleAtRuntimeDescription;
 
-	public static String RescaleAtRuntimeDisclaimer;
+	public static String RescaleAtRuntimeEnabled;
 
 	public static String RescaleAtRuntimeSettingChangeWarningTitle;
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
@@ -55,7 +55,6 @@ import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.fieldassist.ControlDecoration;
 import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
-import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.jface.util.Util;
@@ -76,7 +75,6 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferenceConstants;
@@ -140,7 +138,7 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 			layout.horizontalSpacing = 10;
 			comp.setLayout(layout);
 			createThemeIndependentComposits(comp);
-			createHiDPISettingsGroup(comp);
+			createRescaleAtRuntimeCheckButton(comp);
 			return comp;
 		}
 
@@ -186,7 +184,7 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 		createHideIconsForViewTabs(comp);
 		createDependency(showFullTextForViewTabs, hideIconsForViewTabs);
 
-		createHiDPISettingsGroup(comp);
+		createRescaleAtRuntimeCheckButton(comp);
 
 		if (currentTheme != null) {
 			String colorsAndFontsThemeId = getColorAndFontThemeIdByThemeId(currentTheme.getId());
@@ -200,28 +198,17 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 		return comp;
 	}
 
-	private void createHiDPISettingsGroup(Composite parent) {
+	private void createRescaleAtRuntimeCheckButton(Composite parent) {
 		if (!OS.isWindows()) {
 			return;
 		}
 		createLabel(parent, ""); //$NON-NLS-1$
-		Group group = new Group(parent, SWT.LEFT);
-		group.setText(WorkbenchMessages.HiDpiSettingsGroupTitle);
-
-		GridData gridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
-		gridData.horizontalSpan = ((GridLayout) parent.getLayout()).numColumns;
-		group.setLayoutData(gridData);
-		group.setFont(parent.getFont());
-		GridLayout layout = new GridLayout(1, false);
-		group.setLayout(layout);
-		Label infoLabel = new Label(group, SWT.WRAP);
-		infoLabel.setText(WorkbenchMessages.RescaleAtRuntimeDisclaimer);
-		infoLabel.setLayoutData(GridDataFactory.defaultsFor(infoLabel).create());
-		createLabel(group, ""); //$NON-NLS-1$
 
 		boolean initialStateRescaleAtRuntime = ConfigurationScope.INSTANCE.getNode(WorkbenchPlugin.PI_WORKBENCH)
-				.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME, false);
-		rescaleAtRuntime = createCheckButton(group, WorkbenchMessages.RescaleAtRuntimeEnabled, initialStateRescaleAtRuntime);
+				.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME, true);
+		rescaleAtRuntime = createCheckButton(parent, WorkbenchMessages.RescaleAtRuntimeEnabled,
+				initialStateRescaleAtRuntime);
+		rescaleAtRuntime.setToolTipText(WorkbenchMessages.RescaleAtRuntimeDescription);
 	}
 
 	private void createThemeIndependentComposits(Composite comp) {
@@ -377,7 +364,7 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 			IEclipsePreferences configurationScopeNode = ConfigurationScope.INSTANCE
 					.getNode(WorkbenchPlugin.PI_WORKBENCH);
 			boolean initialStateRescaleAtRuntime = configurationScopeNode
-					.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME, false);
+					.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME, true);
 			isRescaleAtRuntimeChanged = initialStateRescaleAtRuntime != rescaleAtRuntime.getSelection();
 			configurationScopeNode.putBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME,
 					rescaleAtRuntime.getSelection());

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
@@ -503,8 +503,8 @@ ThemeChangeWarningTitle = Theme Changed
 RescaleAtRuntimeSettingChangeWarningTitle = DPI Setting Changed
 RescaleAtRuntimeSettingChangeWarningText = Restart for the DPI setting changes to take effect
 HiDpiSettingsGroupTitle = HiDPI settings
-RescaleAtRuntimeEnabled = Monitor-specific UI &scaling
-RescaleAtRuntimeDisclaimer = EXPERIMENTAL! Activating this option will dynamically scale all windows according to the monitor they are currently in. It is still in development and therefore considered experimental.
+RescaleAtRuntimeDescription = Activating this option will dynamically scale all windows according to the monitor they are currently in
+RescaleAtRuntimeEnabled = Use monitor-specific UI &scaling
 # --- Workbench -----
 WorkbenchPreference_openMode=Open mode
 WorkbenchPreference_doubleClick=D&ouble click


### PR DESCRIPTION
The monitor-specific UI scaling on Windows is disabled by default and can be activated via a preference.

This change inverts the default enablement: it enables the feature by default and allows to disable it via preference. The existing experimental preference is renamed to reset the configuration for every consumer. All information about the feature being experimental is removed.