### PR TITLE
Add required capability for SVG support to org.eclipse.ui

### DIFF
--- a/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.4.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.ui
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui; singleton:=true
-Bundle-Version: 3.207.100.qualifier
+Bundle-Version: 3.207.200.qualifier
 Bundle-Activator: org.eclipse.ui.internal.UIPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName


### PR DESCRIPTION
In order to use SVGs as icons, an according rasterizer has to be present. This is achieved by adding an according required OSGi capability.

In order to prevent issues that we had for SWT tests (https://github.com/eclipse-platform/eclipse.platform.swt/issues/1944) also in production code, I propose to add the required capability to one of the UI bundles that will contain SVG before actually adding them. This is supposed to avoid that it breaks the build or the generated products because the according rasterizer fragment might be missing in the deployed products (runtime, SDK).