### PR TITLE
Don't run in NPE if application is not available in BindingTable

### DIFF
--- a/bundles/org.eclipse.e4.ui.bindings/src/org/eclipse/e4/ui/bindings/internal/BindingTable.java
+++ b/bundles/org.eclipse.e4.ui.bindings/src/org/eclipse/e4/ui/bindings/internal/BindingTable.java
@@ -376,7 +376,7 @@ public class BindingTable {
 			return false;
 		}
 		String identifierId = command.getId();
-		if (contributionFactory == null) {
+		if (contributionFactory == null && application != null) {
 			contributionFactory = application.getContext().get(IContributionFactory.class);
 		}
 		if (contributionFactory == null) {


### PR DESCRIPTION
Before https://github.com/eclipse-platform/eclipse.platform.ui/issues/2859 `org.eclipse.e4.ui.bindings.tests` manage to run without application instance created/set in the global context, because `core-test` (and not `ui-test`) was used in
org.eclipse.e4.ui.bindings.tests/test.xml.

Thus `org.eclipse.test.coretestapplication` was used to run bindings tests, not `org.eclipse.test.uitestapplication`. Later one uses `org.eclipse.ui.ide.workbench` application by default which runs `E4Application.createE4Workbench()` and that one will create and set application via `E4Workbench.getServiceContext().set(MApplication.class, appModel);`.

For now there is no reason to change this behavior, we can simply allow application to be null in BindingTable which should not affect its behavior in a context that has no application defined.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2872