### PR TITLE
Add keywords for the HiDPI configuration in preference pages.

### DIFF
--- a/bundles/org.eclipse.ui.ide/plugin.properties
+++ b/bundles/org.eclipse.ui.ide/plugin.properties
@@ -262,6 +262,7 @@ PreferenceKeywords.unassociated = unassociated
 PreferenceKeywords.Save = save
 PreferenceKeywords.Open = open
 PreferenceKeywords.Nature = nature
+PreferenceKeywords.HiDPI = hidpi dpi scaling monitor rescaling ui
 
 # TODO This stuff is just to help me work on the parsing of the menus extension
 # point. It is likely not in its final form yet.

--- a/bundles/org.eclipse.ui.ide/plugin.xml
+++ b/bundles/org.eclipse.ui.ide/plugin.xml
@@ -565,6 +565,10 @@
             id="org.eclipse.ui.ide.workspace.build"
             label="%PreferenceKeywords.Workspace.Build">
       </keyword>
+      <keyword
+            label="%PreferenceKeywords.HiDPI"
+            id="org.eclipse.ui.ide.hidpi">
+      </keyword>
    </extension>
    <extension
          point="org.eclipse.ui.preferencePages">
@@ -651,6 +655,7 @@
          <keywordReference id="org.eclipse.ui.ide.tabs"/>
          <keywordReference id="org.eclipse.ui.ide.titles"/>
          <keywordReference id="org.eclipse.ui.ide.apearancepage"/>
+         <keywordReference id="org.eclipse.ui.ide.hidpi"/>
       </page>
       <page
             name="%PreferencePages.ColorsAndFonts"


### PR DESCRIPTION
## How to test
1. Open the preferences pages (_Window > Preferences_)
2. Search for the added keywords --> the preference node **Appearance** under **General** should be found and highlighted _e.g._
![image](https://github.com/user-attachments/assets/2c26e175-702e-4a11-99a0-4eb79c7f59dd)


