### PR TITLE
Add workaround for Linux into FindReplaceDialog again #2865

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -148,7 +148,9 @@ class FindReplaceDialog extends Dialog {
 			// XXX: Workaround for Combo bug on Linux (see bug 404202 and bug 410603)
 			if (fIgnoreNextEvent) {
 				fIgnoreNextEvent = false;
+				return;
 			}
+			modificationHandler.run();
 		}
 	}
 


### PR DESCRIPTION
In response to: https://github.com/eclipse-platform/eclipse.platform.ui/pull/2876#discussion_r2021326068

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2865