### PR TITLE
Make GenericEditor default editor for org.eclipse.core.runtime.text

### DIFF
--- a/bundles/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.ui.genericeditor;singleton:=true
-Bundle-Version: 1.3.500.qualifier
+Bundle-Version: 1.3.600.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ui.workbench.texteditor;bundle-version="3.10.0",

--- a/bundles/org.eclipse.ui.genericeditor/plugin.xml
+++ b/bundles/org.eclipse.ui.genericeditor/plugin.xml
@@ -32,7 +32,7 @@
       <editor
             class="org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor"
             contributorClass="org.eclipse.ui.editors.text.TextEditorActionContributor"
-            default="false"
+            default="true"
             icon="icons/full/obj16/generic_editor.png"
             id="org.eclipse.ui.genericeditor.GenericEditor"
             name="%genericEditor_name">


### PR DESCRIPTION
Make generic editor default for the base `org.eclipse.core.runtime.text` content type.

This shouldn't be a breaking change, given that with b3137d146f60760c214f2f96152c526251a5531c customers expecting "old classic" text editor to be opened by default could customize their products by adding this line in product customization file:

`org.eclipse.ui.workbench/defaultEditorForContentType_org.eclipse.core.runtime.text=org.eclipse.ui.DefaultTextEditor`

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2527