### PR TITLE
In Project Explorer view, added a separator after the 'Refresh' command

### DIFF
--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/ResourceMgmtActionProvider.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/ResourceMgmtActionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2018 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredViewer;
@@ -147,6 +148,7 @@ public class ResourceMgmtActionProvider extends CommonActionProvider {
 		if (hasOpenProjects || selectionContainsNonProject) {
 			refreshAction.selectionChanged(selection);
 			menu.appendToGroup(ICommonMenuConstants.GROUP_BUILD, refreshAction);
+			menu.appendToGroup(ICommonMenuConstants.GROUP_BUILD, new Separator());
 		}
 		if (hasClosedProjects) {
 			openProjectAction.selectionChanged(selection);

--- a/tests/org.eclipse.ui.tests.navigator/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.navigator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundlename
 Bundle-SymbolicName: org.eclipse.ui.tests.navigator;singleton:=true
-Bundle-Version: 3.8.0.qualifier
+Bundle-Version: 3.8.100.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/ResourceMgmtActionProviderTests.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/ResourceMgmtActionProviderTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Dave Carpeneto and others.
+ * Copyright (c) 2025 Dave Carpeneto and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -211,7 +211,7 @@ public final class ResourceMgmtActionProviderTests extends NavigatorTestBase {
 	 */
 	private boolean menuHasContribution(String contribution) {
 		for (IContributionItem thisItem : manager.getItems()) {
-			if (thisItem.getId().equals(contribution)) {
+			if (thisItem.getId() != null && thisItem.getId().equals(contribution)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
In Project Explorer view, Added a separator between the 'Refresh' command which is dangerously close to the 'Close projects' and related menu.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/267

Before the pr, "Project Explorer" showed the context menu like below
![image](https://github.com/user-attachments/assets/2144221e-276a-4778-96f6-7e4baef25d25)

After the pr, "Project Explorer" was added with a separator which optically improves the context menu look.
![image](https://github.com/user-attachments/assets/ea123d4c-847a-4eb2-8e28-a7e024e35119)
