### PR TITLE
Fix "Preferences" Context Menu Entry Label

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
@@ -124,7 +124,7 @@ Workbench_showInNoTargets = <No Applicable Views>
 Workbench_showInNoPerspectives = <No Applicable Perspectives>
 Workbench_noApplicableItems = <No Applicable Items>
 
-OpenPreferences_text = &Preferences
+OpenPreferences_text = &Preferences...
 OpenPreferences_toolTip = Preferences
 
 # --- Window Menu ---


### PR DESCRIPTION
Actions that open a dialog should be suffixed with "...". In the "Progress" view this was missing.

Compare e.g. with the "Templates" view. There the view pull down menu correctly shows "Preferences...". The "Progress" view had "Preferences" in it's pull down menu.

This PR does fix the pull down menu entry in the "Progress" view to show "Preferences..." as well.