### PR TITLE
Add missing package versions to eclipse databinding

### DIFF
--- a/bundles/org.eclipse.core.databinding.beans/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding.beans/META-INF/MANIFEST.MF
@@ -5,8 +5,8 @@ Bundle-SymbolicName: org.eclipse.core.databinding.beans
 Bundle-Version: 1.10.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Export-Package: org.eclipse.core.databinding.beans,
- org.eclipse.core.databinding.beans.typed,
+Export-Package: org.eclipse.core.databinding.beans;version="1.0.0",
+ org.eclipse.core.databinding.beans.typed;version="1.0.0",
  org.eclipse.core.internal.databinding.beans;x-internal:=true
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.core.databinding.observable;bundle-version="[1.2.0,2.0.0)",

--- a/bundles/org.eclipse.core.databinding.beans/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding.beans/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.databinding.beans
-Bundle-Version: 1.10.300.qualifier
+Bundle-Version: 1.10.400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.databinding.beans;version="1.0.0",

--- a/bundles/org.eclipse.core.databinding.observable/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding.observable/META-INF/MANIFEST.MF
@@ -5,14 +5,14 @@ Bundle-SymbolicName: org.eclipse.core.databinding.observable
 Bundle-Version: 1.13.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Export-Package: org.eclipse.core.databinding.observable,
- org.eclipse.core.databinding.observable.list;x-internal:=false,
- org.eclipse.core.databinding.observable.map,
- org.eclipse.core.databinding.observable.masterdetail,
- org.eclipse.core.databinding.observable.set;x-internal:=false,
- org.eclipse.core.databinding.observable.sideeffect,
- org.eclipse.core.databinding.observable.value;x-internal:=false,
- org.eclipse.core.databinding.util,
+Export-Package: org.eclipse.core.databinding.observable;version="1.0.0",
+ org.eclipse.core.databinding.observable.list;version="1.0.0",
+ org.eclipse.core.databinding.observable.map;version="1.0.0",
+ org.eclipse.core.databinding.observable.masterdetail;version="1.0.0",
+ org.eclipse.core.databinding.observable.set;version="1.0.0",
+ org.eclipse.core.databinding.observable.sideeffect;version="1.0.0",
+ org.eclipse.core.databinding.observable.value;version="1.0.0",
+ org.eclipse.core.databinding.util;version="1.0.0",
  org.eclipse.core.internal.databinding.identity;x-friends:="org.eclipse.core.databinding.property",
  org.eclipse.core.internal.databinding.observable;x-internal:=true,
  org.eclipse.core.internal.databinding.observable.masterdetail;x-friends:="org.eclipse.jface.tests.databinding",

--- a/bundles/org.eclipse.core.databinding.observable/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding.observable/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.databinding.observable
-Bundle-Version: 1.13.300.qualifier
+Bundle-Version: 1.13.400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.databinding.observable;version="1.0.0",

--- a/bundles/org.eclipse.core.databinding.property/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding.property/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.databinding.property
-Bundle-Version: 1.10.300.qualifier
+Bundle-Version: 1.10.400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.databinding.property;version="1.0.0",

--- a/bundles/org.eclipse.core.databinding.property/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding.property/META-INF/MANIFEST.MF
@@ -5,11 +5,11 @@ Bundle-SymbolicName: org.eclipse.core.databinding.property
 Bundle-Version: 1.10.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Export-Package: org.eclipse.core.databinding.property,
- org.eclipse.core.databinding.property.list,
- org.eclipse.core.databinding.property.map,
- org.eclipse.core.databinding.property.set,
- org.eclipse.core.databinding.property.value,
+Export-Package: org.eclipse.core.databinding.property;version="1.0.0",
+ org.eclipse.core.databinding.property.list;version="1.0.0",
+ org.eclipse.core.databinding.property.map;version="1.0.0",
+ org.eclipse.core.databinding.property.set;version="1.0.0",
+ org.eclipse.core.databinding.property.value;version="1.0.0",
  org.eclipse.core.internal.databinding.property;x-internal:=true,
  org.eclipse.core.internal.databinding.property.list;x-internal:=true,
  org.eclipse.core.internal.databinding.property.map;x-internal:=true,

--- a/bundles/org.eclipse.core.databinding/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.databinding
-Bundle-Version: 1.13.400.qualifier
+Bundle-Version: 1.13.500.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.databinding;version="1.0.0",

--- a/bundles/org.eclipse.core.databinding/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding/META-INF/MANIFEST.MF
@@ -5,12 +5,12 @@ Bundle-SymbolicName: org.eclipse.core.databinding
 Bundle-Version: 1.13.400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Export-Package: org.eclipse.core.databinding,
- org.eclipse.core.databinding.bind,
- org.eclipse.core.databinding.bind.steps,
- org.eclipse.core.databinding.conversion;x-internal:=false,
- org.eclipse.core.databinding.conversion.text;x-internal:=false,
- org.eclipse.core.databinding.validation;x-internal:=false,
+Export-Package: org.eclipse.core.databinding;version="1.0.0",
+ org.eclipse.core.databinding.bind;version="1.0.0",
+ org.eclipse.core.databinding.bind.steps;version="1.0.0",
+ org.eclipse.core.databinding.conversion;version="1.0.0",
+ org.eclipse.core.databinding.conversion.text;version="1.0.0",
+ org.eclipse.core.databinding.validation;version="1.0.0",
  org.eclipse.core.internal.databinding;x-friends:="org.eclipse.core.databinding.beans",
  org.eclipse.core.internal.databinding.conversion;x-friends:="org.eclipse.jface.tests.databinding",
  org.eclipse.core.internal.databinding.validation;x-friends:="org.eclipse.jface.tests.databinding"


### PR DESCRIPTION
Currently there are no package versions for the databinding bundles, this makes it impossible to import these packages reliable from any consumers.

This now adds version 1.0 to all non internal packages of the databinding framework