### PR TITLE
Do not show Contribution Item if the Property Tester is not

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ContributionsAnalyzer.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/ContributionsAnalyzer.java
@@ -260,7 +260,7 @@ public final class ContributionsAnalyzer {
 		}
 		boolean ret = false;
 		try {
-			ret = ref.evaluate(eContext) != EvaluationResult.FALSE;
+			ret = ref.evaluate(eContext) == EvaluationResult.TRUE;
 		} catch (Exception e) {
 			if (DEBUG) {
 				trace("isVisible exception", e); //$NON-NLS-1$


### PR DESCRIPTION
instantiated.

By default each contribution item is visible when the platform ui is created. Later Menu/Toolbar listeners check with VisibleWhen expression to show/hide the Item. If the bundle containing Property tester is not loaded then the visibility remains true.
We can hide the contribution if the property tester is not loaded.

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/2900