### PR TITLE
Deprecate "fastViewWidthRatio" extension point attribute & friends

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/views/IViewDescriptor.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/views/IViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -86,7 +86,9 @@ public interface IViewDescriptor extends IWorkbenchPartDescriptor, IAdaptable {
 	 * Returns the default fast view width ratio for this view.
 	 *
 	 * @return the fast view width ratio
+	 * @deprecated discontinued support for fast views
 	 */
+	@Deprecated(since = "2025-06", forRemoval = true)
 	float getFastViewWidthRatio();
 
 	/**

--- a/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui; singleton:=true
-Bundle-Version: 3.207.100.qualifier
+Bundle-Version: 3.207.200.qualifier
 Bundle-Activator: org.eclipse.ui.internal.UIPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/bundles/org.eclipse.ui/schema/views.exsd
+++ b/bundles/org.eclipse.ui/schema/views.exsd
@@ -162,10 +162,15 @@ be associated with the view.
          <attribute name="fastViewWidthRatio" type="string">
             <annotation>
                <documentation>
-                  the percentage of the width of the workbench that the view will take up as an active fast view.
+                  &lt;b&gt;deprecated since 2025-06&lt;/b&gt; support for fast views has been discontinued.
+
+The percentage of the width of the workbench that the view will take up as an active fast view.
 This must be defined as a floating point value and lie between 0.05 and 0.95.
 If no value is supplied, a default ratio will be used.
                </documentation>
+               <appInfo>
+                  <meta.attribute deprecated="true"/>
+               </appInfo>
             </annotation>
          </attribute>
          <attribute name="allowMultiple" type="boolean">


### PR DESCRIPTION
Fast views are unsupported and the attribute is not even read from the extension point. The corresponding method in the IViewDescriptor has been deprecated as well.