### PR TITLE
Add SVGs to org.eclipse.ltk.ui.refactoring

### DIFF
--- a/bundles/org.eclipse.ltk.ui.refactoring/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ltk.ui.refactoring/META-INF/MANIFEST.MF
@@ -32,3 +32,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.team.core;bundle-version="[3.4.100,4.0.0)",
  org.eclipse.team.ui;bundle-version="[3.4.100,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.ltk.ui.refactoring/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ltk.ui.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.ltk.ui.refactoring
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ltk.ui.refactoring; singleton:=true
-Bundle-Version: 3.13.500.qualifier
+Bundle-Version: 3.13.600.qualifier
 Bundle-Activator: org.eclipse.ltk.internal.ui.refactoring.RefactoringUIPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/elcl16/date_mode.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/elcl16/date_mode.svg
@@ -1,0 +1,426 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="date_mode.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient8656">
+      <stop
+         id="stop8658"
+         offset="0"
+         style="stop-color:#2b568d;stop-opacity:1" />
+      <stop
+         style="stop-color:#5a9ccc;stop-opacity:1"
+         offset="0.5"
+         id="stop8660" />
+      <stop
+         id="stop8662"
+         offset="1"
+         style="stop-color:#5176a8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8650"
+       inkscape:collect="always">
+      <stop
+         id="stop8652"
+         offset="0"
+         style="stop-color:#55a4db;stop-opacity:1" />
+      <stop
+         id="stop8654"
+         offset="1"
+         style="stop-color:#d3e5f4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8636">
+      <stop
+         style="stop-color:#a79c68;stop-opacity:1"
+         offset="0"
+         id="stop8638" />
+      <stop
+         style="stop-color:#6e7a8d;stop-opacity:1"
+         offset="1"
+         id="stop8640" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13831">
+      <stop
+         style="stop-color:#055797;stop-opacity:1;"
+         offset="0"
+         id="stop13833" />
+      <stop
+         style="stop-color:#184785;stop-opacity:1"
+         offset="1"
+         id="stop13835" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13755">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757" />
+      <stop
+         id="stop13765"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13755"
+       id="linearGradient8584"
+       gradientUnits="userSpaceOnUse"
+       x1="28.004765"
+       y1="-5.6084509"
+       x2="28.004765"
+       y2="1.6087028" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13831"
+       id="linearGradient8586"
+       gradientUnits="userSpaceOnUse"
+       x1="30.033665"
+       y1="-6.1109905"
+       x2="30.033665"
+       y2="1.9089624" />
+    <linearGradient
+       id="linearGradient4994-4-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-9"
+         offset="0"
+         style="stop-color:#c5dff4;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-5" />
+      <stop
+         style="stop-color:#c5dff4;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8636"
+       id="linearGradient8626"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.3013063,24.971698)"
+       x1="8.0137892"
+       y1="1040.3126"
+       x2="8.0137892"
+       y2="1047.3126" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4910-4-0"
+       id="linearGradient8628"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20.220116,18.904698)"
+       x1="-13"
+       y1="1047.3622"
+       x2="-15"
+       y2="1047.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-4-5"
+       id="linearGradient8630"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20.220116,22.935898)"
+       x1="-11"
+       y1="1042.3622"
+       x2="-11"
+       y2="1044.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8650"
+       id="linearGradient8632"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(17.220116,24.904698)"
+       x1="-11.999303"
+       y1="1038.8951"
+       x2="-5.9993033"
+       y2="1038.8951" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8656"
+       id="linearGradient8634"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.6560497,22.936198)"
+       x1="8.0137892"
+       y1="1039.876"
+       x2="8.0137892"
+       y2="1041.8765" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask8789">
+      <g
+         style="fill:#ffffff;stroke:#ffffff;display:inline"
+         id="g8791"
+         transform="translate(-34.953207,8.004981)">
+        <path
+           transform="matrix(1.247029,0,0,1.247029,21.297363,1050.2608)"
+           d="m 30,-2 c 0,2.209139 -1.790861,4 -4,4 -2.209139,0 -4,-1.790861 -4,-4 0,-2.209139 1.790861,-4 4,-4 2.209139,0 4,1.790861 4,4 z"
+           sodipodi:ry="4"
+           sodipodi:rx="4"
+           sodipodi:cy="-2"
+           sodipodi:cx="26"
+           id="path8793"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.80190599;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path8795"
+           d="m 53.750446,1047.7972 0,-2.0313"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path8797"
+           d="m 53.750446,1047.7972 1.458408,2.3881"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      </g>
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter9575"
+       x="-0.20571429"
+       width="1.4114286"
+       y="-0.16"
+       height="1.32">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.6"
+         id="feGaussianBlur9577" />
+    </filter>
+    <linearGradient
+       gradientTransform="translate(0,1026.3622)"
+       y2="13.5"
+       x2="7.9998932"
+       y1="13.5"
+       x1="0"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4901"
+       xlink:href="#linearGradient4878-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4878-7">
+      <stop
+         style="stop-color:#4e8fbd;stop-opacity:1"
+         offset="0"
+         id="stop4880-4" />
+      <stop
+         style="stop-color:#4d5a5d;stop-opacity:1"
+         offset="1"
+         id="stop4882-0" />
+    </linearGradient>
+    <linearGradient
+       y2="13.5"
+       x2="6.9065013"
+       y1="13.5"
+       x1="-2.0840807"
+       gradientTransform="matrix(0,1,1,0,8.2220685,1057.2753)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3024"
+       xlink:href="#linearGradient4878-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="13.5"
+       x2="6.9065013"
+       y1="13.5"
+       x1="-2.0840807"
+       gradientTransform="matrix(0,1,1,0,8.2220685,1057.2753)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3024-1"
+       xlink:href="#linearGradient4878-7-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4878-7-9">
+      <stop
+         style="stop-color:#4e8fbd;stop-opacity:1"
+         offset="0"
+         id="stop4880-4-7" />
+      <stop
+         style="stop-color:#4d5a5d;stop-opacity:1"
+         offset="1"
+         id="stop4882-0-5" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter3903"
+       x="-0.1799976"
+       width="1.3599952"
+       y="-0.0900006"
+       height="1.1800012">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.374995"
+         id="feGaussianBlur3905" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="2.9780409"
+     inkscape:cy="7.2363771"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1297"
+     inkscape:window-height="795"
+     inkscape:window-x="154"
+     inkscape:window-y="49"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4092"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <g
+         id="g8579"
+         transform="translate(-34.953207,8.0049808)">
+        <path
+           transform="matrix(1.247029,0,0,1.247029,21.297363,1050.2608)"
+           d="m 30,-2 c 0,2.209139 -1.790861,4 -4,4 -2.209139,0 -4,-1.790861 -4,-4 0,-2.209139 1.790861,-4 4,-4 2.209139,0 4,1.790861 4,4 z"
+           sodipodi:ry="4"
+           sodipodi:rx="4"
+           sodipodi:cy="-2"
+           sodipodi:cx="26"
+           id="path13745"
+           style="fill:url(#linearGradient8584);fill-opacity:1;stroke:url(#linearGradient8586);stroke-width:0.80190599;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path13811"
+           d="m 53.750446,1047.7972 0,-2.0313"
+           style="fill:none;stroke:#1f4a83;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path13811-9"
+           d="m 53.750446,1047.7972 1.458408,2.3881"
+           style="fill:none;stroke:#1f4a83;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      </g>
+      <g
+         id="g8786"
+         mask="url(#mask8789)">
+        <path
+           inkscape:connector-curvature="0"
+           id="rect3997-9-1"
+           d="m 9.720116,1054.7669 0,2.0313 7,0 0,-2.0313 -7,0 z m 0,2.0625 0,6.9375 7,0 0,-6.9375 -7,0 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline;filter:url(#filter9575);stroke-dasharray:none" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline;filter:url(#filter3903)"
+           d="m 21.222068,1055.2753 1,0 0,7 2,0 -2.5,2.9998 -2.5,-2.9998 2,0 z"
+           id="path4108-9-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc" />
+      </g>
+      <g
+         id="g8620"
+         transform="translate(4.9993035,-8.0174516)">
+        <path
+           style="fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient8626);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+           d="m 4.7277893,1064.8326 7.0019247,0 0,6.9667 -7.0019247,0 z"
+           id="rect3997-9"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="fill:url(#linearGradient8628);fill-opacity:1;stroke:none;display:inline"
+           d="m 6.220116,1066.2658 0,5.0312 -0.9999997,0 0,-6.0312 z"
+           id="rect4853-82-7"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="fill:url(#linearGradient8630);fill-opacity:1;stroke:none;display:inline"
+           d="m 6.220116,1066.297 4.990578,0 0,-1 -5.9905777,0 z"
+           id="rect4853-82-0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="fill:url(#linearGradient8632);fill-opacity:1;stroke:url(#linearGradient8634);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+           d="m 4.7238283,1062.7971 7.0043327,0 0,2.0053 -7.0043327,0 z"
+           id="rect3997-9-9"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+      </g>
+      <path
+         style="font-size:4.9253788px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#2b568d;fill-opacity:1;stroke:#2b568d;stroke-width:0.44447169;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:Arial;-inkscape-font-specification:Arial"
+         d="M 3.4375 9.25 C 3.3621428 9.4023182 3.2124231 9.5568186 3.03125 9.71875 C 2.8500746 9.8806876 2.6483495 10.011168 2.40625 10.125 L 2.40625 10.53125 C 2.5409277 10.48155 2.7058496 10.411908 2.875 10.3125 C 3.0441484 10.213097 3.1770333 10.130658 3.28125 10.03125 L 3.28125 12.78125 L 3.71875 12.78125 L 3.71875 9.25 L 3.4375 9.25 z M 6 9.25 C 5.6649065 9.2500035 5.3863101 9.3260439 5.1875 9.5 C 4.9886888 9.6739626 4.8742127 9.918117 4.84375 10.25 L 5.28125 10.3125 C 5.2828526 10.091245 5.3436908 9.9063113 5.46875 9.78125 C 5.5938075 9.6561947 5.7603181 9.5937532 5.96875 9.59375 C 6.165956 9.5937532 6.3460948 9.6634096 6.46875 9.78125 C 6.5914015 9.8990964 6.656248 10.047198 6.65625 10.21875 C 6.656248 10.38229 6.5721764 10.535173 6.4375 10.71875 C 6.30282 10.902331 6.0394405 11.154502 5.65625 11.46875 C 5.4093389 11.670769 5.2244194 11.846083 5.09375 12 C 4.9630796 12.153919 4.8718223 12.310022 4.8125 12.46875 C 4.7756236 12.564949 4.7467932 12.677035 4.75 12.78125 L 7.09375 12.78125 L 7.09375 12.375 L 5.375 12.375 C 5.4230986 12.296438 5.4887467 12.202761 5.5625 12.125 C 5.6362514 12.04724 5.8027621 11.905552 6.0625 11.6875 C 6.3735411 11.424558 6.5848714 11.213213 6.71875 11.0625 C 6.8526244 10.91179 6.9422784 10.761284 7 10.625 C 7.0577168 10.488721 7.0937475 10.359844 7.09375 10.21875 C 7.0937475 9.9413796 6.9784552 9.7188407 6.78125 9.53125 C 6.5840405 9.3436658 6.3382974 9.2500035 6 9.25 z "
+         transform="translate(8.2201163,1049.2669)"
+         id="text9604-8-2-9" />
+      <path
+         style="fill:url(#linearGradient3024);fill-opacity:1;stroke:none;display:inline"
+         d="m 21.222068,1055.2753 1,0 0,7 2,0 -2.5,2.9998 -2.5,-2.9998 2,0 z"
+         id="path4108-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccc" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/elcl16/filter_ps.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/elcl16/filter_ps.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="filter_ps.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1047">
+      <stop
+         style="stop-color:#96a0b9;stop-opacity:1"
+         offset="0"
+         id="stop1043" />
+      <stop
+         style="stop-color:#77849d;stop-opacity:1"
+         offset="1"
+         id="stop1045" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1039">
+      <stop
+         style="stop-color:#fbffff;stop-opacity:1"
+         offset="0"
+         id="stop1035" />
+      <stop
+         style="stop-color:#b9e7ff;stop-opacity:1"
+         offset="1"
+         id="stop1037" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4989">
+      <stop
+         id="stop4991"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1;"
+         offset="0.5"
+         id="stop4995" />
+      <stop
+         id="stop4993"
+         offset="1"
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1039"
+       id="linearGradient1041"
+       x1="2.1048543"
+       y1="1039.3379"
+       x2="12.850951"
+       y2="1039.2937"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1047"
+       id="linearGradient1049"
+       x1="1"
+       y1="1044.8622"
+       x2="14"
+       y2="1044.8622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#444248"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="2.7020062"
+     inkscape:cy="8.7735937"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       id="path859"
+       style="fill:url(#linearGradient1041);stroke:url(#linearGradient1049);stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1"
+       d="m 7.504725,1043.8623 h 1.99055 M 1.5,1037.8622 h 12 v 2 l -4,4 v 6 l -3.0000002,2 H 5.5 v -8 l -4,-4 z" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/elcl16/prj_mode.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/elcl16/prj_mode.svg
@@ -1,0 +1,761 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="prj_mode.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4830">
+      <stop
+         style="stop-color:#2e49b0;stop-opacity:1"
+         offset="0"
+         id="stop4832" />
+      <stop
+         id="stop4836"
+         offset="0.5"
+         style="stop-color:#565f9e;stop-opacity:1" />
+      <stop
+         style="stop-color:#8591c8;stop-opacity:0"
+         offset="1"
+         id="stop4834" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4762">
+      <stop
+         style="stop-color:#ffd175;stop-opacity:1"
+         offset="0"
+         id="stop4764" />
+      <stop
+         style="stop-color:#fff1c2;stop-opacity:1"
+         offset="1"
+         id="stop4766" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4756">
+      <stop
+         style="stop-color:#92b5eb;stop-opacity:1"
+         offset="0"
+         id="stop4758" />
+      <stop
+         style="stop-color:#b1e1fd;stop-opacity:1"
+         offset="1"
+         id="stop4760" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4807"
+       inkscape:collect="always">
+      <stop
+         id="stop4809"
+         offset="0"
+         style="stop-color:#2846b3;stop-opacity:1" />
+      <stop
+         id="stop4811"
+         offset="1"
+         style="stop-color:#60649d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3967"
+       inkscape:collect="always">
+      <stop
+         id="stop3969"
+         offset="0"
+         style="stop-color:#84909f;stop-opacity:1" />
+      <stop
+         id="stop3971"
+         offset="1"
+         style="stop-color:#757c8a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955">
+      <stop
+         id="stop3957"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:0" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961" />
+      <stop
+         id="stop3963"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-58.381352,-1.4843182)"
+       x1="529.21912"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955"
+       id="linearGradient3945"
+       gradientUnits="userSpaceOnUse"
+       x1="523.00781"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294"
+       gradientTransform="translate(-60.558602,0)" />
+    <linearGradient
+       y2="385.15216"
+       x2="537.90186"
+       y1="397.56107"
+       x1="537.94318"
+       gradientTransform="matrix(0.95640793,0,1.3306873e-8,1.3548175,367.50712,24.15968)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4776"
+       xlink:href="#linearGradient4756"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="382.12424"
+       x2="546.58252"
+       y1="397.26389"
+       x1="546.63287"
+       gradientTransform="matrix(0.95640793,0,1.3306873e-8,1.3548175,367.50712,24.15968)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4778"
+       xlink:href="#linearGradient4807"
+       inkscape:collect="always" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter4929"
+       x="-0.13757156"
+       width="1.2751431"
+       y="-0.37744917"
+       height="1.7548983">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="3.5620748"
+         id="feGaussianBlur4931" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4762"
+       id="linearGradient4933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-60.558602,0)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       y2="373.77069"
+       x2="548.45923"
+       y1="398.98798"
+       x1="548.45923"
+       gradientTransform="translate(-60.558592,7.1608197e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4795"
+       xlink:href="#linearGradient4830"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5068">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5070" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5072" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4823">
+      <stop
+         id="stop4825"
+         offset="0"
+         style="stop-color:#fefdef;stop-opacity:1" />
+      <stop
+         id="stop4827"
+         offset="1"
+         style="stop-color:#fbdd83;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4863">
+      <stop
+         style="stop-color:#ba9726;stop-opacity:1;"
+         offset="0"
+         id="stop4865" />
+      <stop
+         style="stop-color:#997413;stop-opacity:1"
+         offset="1"
+         id="stop4867" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9"
+       id="radialGradient4534-5"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4528-9">
+      <stop
+         style="stop-color:#e0c576;stop-opacity:1;"
+         offset="0"
+         id="stop4530-0" />
+      <stop
+         style="stop-color:#9e7916;stop-opacity:1"
+         offset="1"
+         id="stop4532-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6"
+       id="linearGradient4526-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <linearGradient
+       id="linearGradient6281-8-0-1-6">
+      <stop
+         id="stop6283-0-2-2-1"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient3105"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(13.866995,1038.8271)"
+       x1="10"
+       y1="5"
+       x2="10.007812"
+       y2="6.9843998" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4863"
+       id="linearGradient3107"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(13.874807,2.4492957)"
+       x1="12.578125"
+       y1="1037.7841"
+       x2="12.578125"
+       y2="1043.7627" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4823"
+       id="linearGradient3109"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8479968,0,0,1.8479968,24.14231,1031.8602)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient3111"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(13.866995,2.4648957)"
+       x1="12"
+       y1="1043.3622"
+       x2="12"
+       y2="1045.3466" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient3113"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(13.866995,2.4648957)"
+       x1="13"
+       y1="1043.3622"
+       x2="15.007812"
+       y2="1043.3466" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient3115"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5333047,-0.8452528,1.5333047,0.8452528,-1566.5485,172.95576)"
+       x1="12"
+       y1="1042.3622"
+       x2="10.007812"
+       y2="1042.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient3117"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(40.491994,1.0273958)"
+       x1="10"
+       y1="1041.3622"
+       x2="8.0078125"
+       y2="1041.3466" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient3119"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(13.866995,2.4648957)"
+       x1="10"
+       y1="1040.3622"
+       x2="10.007812"
+       y2="1038.3466" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient3121"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(13.866995,2.4648957)"
+       x1="12"
+       y1="1038.3622"
+       x2="10.007812"
+       y2="1038.3466" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient3123"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(13.866995,2.4648957)"
+       x1="14"
+       y1="1041.3622"
+       x2="14"
+       y2="1043.3466" />
+    <linearGradient
+       gradientTransform="translate(5.09375,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1049.5981"
+       x2="-2.2873085"
+       y1="1044.6919"
+       x1="-2.2873085"
+       id="linearGradient4795-0"
+       xlink:href="#linearGradient4789"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="11.370661"
+       x2="9.6459417"
+       y1="11.370661"
+       x1="14.683416"
+       id="linearGradient4779"
+       xlink:href="#linearGradient4773"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1040.7981"
+       x2="10.96875"
+       y1="1040.7981"
+       x1="4.8479562"
+       id="linearGradient4769"
+       xlink:href="#linearGradient4763"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4763">
+      <stop
+         id="stop4765"
+         offset="0"
+         style="stop-color:#77a29d;stop-opacity:1;" />
+      <stop
+         id="stop4767"
+         offset="1"
+         style="stop-color:#1b867b;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4773">
+      <stop
+         id="stop4775"
+         offset="0"
+         style="stop-color:#8e4694;stop-opacity:1;" />
+      <stop
+         id="stop4777"
+         offset="1"
+         style="stop-color:#bc7bc1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4789">
+      <stop
+         id="stop4791"
+         offset="0"
+         style="stop-color:#4e8fbd;stop-opacity:1;" />
+      <stop
+         id="stop4793"
+         offset="1"
+         style="stop-color:#30495a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(5.09375,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1049.5981"
+       x2="-2.2873085"
+       y1="1044.6919"
+       x1="-2.2873085"
+       id="linearGradient4795-0-8"
+       xlink:href="#linearGradient4789-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4789-8">
+      <stop
+         id="stop4791-9"
+         offset="0"
+         style="stop-color:#4e8fbd;stop-opacity:1;" />
+      <stop
+         id="stop4793-8"
+         offset="1"
+         style="stop-color:#30495a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1049.5981"
+       x2="-2.2873085"
+       y1="1044.6919"
+       x1="-2.2873085"
+       gradientTransform="matrix(1.1559455,0,0,1.1559455,16.214689,-161.27538)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3121-4"
+       xlink:href="#linearGradient4789-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967-2"
+       id="linearGradient3939-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33025864,0,0,0.33025864,-169.89084,915.67217)"
+       x1="529.21912"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       id="linearGradient3967-2"
+       inkscape:collect="always">
+      <stop
+         id="stop3969-2"
+         offset="0"
+         style="stop-color:#84909f;stop-opacity:1" />
+      <stop
+         id="stop3971-6"
+         offset="1"
+         style="stop-color:#757c8a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="385.15216"
+       x2="537.90186"
+       y1="397.56107"
+       x1="537.94318"
+       gradientTransform="matrix(0.31586198,0,0,0.44744018,889.97376,1305.7859)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4776-1"
+       xlink:href="#linearGradient4756-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4756-0">
+      <stop
+         style="stop-color:#92b5eb;stop-opacity:1"
+         offset="0"
+         id="stop4758-5" />
+      <stop
+         style="stop-color:#b1e1fd;stop-opacity:1"
+         offset="1"
+         id="stop4760-2" />
+    </linearGradient>
+    <linearGradient
+       y2="382.12424"
+       x2="546.58252"
+       y1="397.26389"
+       x1="546.63287"
+       gradientTransform="matrix(0.31586198,0,0,0.44744018,889.97376,1305.7859)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4778-0"
+       xlink:href="#linearGradient4807-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4807-9"
+       inkscape:collect="always">
+      <stop
+         id="stop4809-2"
+         offset="0"
+         style="stop-color:#2846b3;stop-opacity:1" />
+      <stop
+         id="stop4811-5"
+         offset="1"
+         style="stop-color:#60649d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="373.77069"
+       x2="548.45923"
+       y1="398.98798"
+       x1="548.45923"
+       gradientTransform="matrix(0.33025864,0,0,0.33025864,-170.60989,916.16238)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4795-2"
+       xlink:href="#linearGradient4830-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4830-0">
+      <stop
+         style="stop-color:#2e49b0;stop-opacity:1"
+         offset="0"
+         id="stop4832-9" />
+      <stop
+         id="stop4836-4"
+         offset="0.5"
+         style="stop-color:#565f9e;stop-opacity:1" />
+      <stop
+         style="stop-color:#8591c8;stop-opacity:0"
+         offset="1"
+         id="stop4834-1" />
+    </linearGradient>
+    <linearGradient
+       y2="1049.5981"
+       x2="-2.2873085"
+       y1="1044.6919"
+       x1="-2.2873085"
+       gradientTransform="matrix(1.1559455,0,0,1.1559455,16.214689,-161.27538)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3121-4-4"
+       xlink:href="#linearGradient4789-8-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4789-8-0">
+      <stop
+         id="stop4791-9-1"
+         offset="0"
+         style="stop-color:#4e8fbd;stop-opacity:1;" />
+      <stop
+         id="stop4793-8-4"
+         offset="1"
+         style="stop-color:#30495a;stop-opacity:1;" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter4088"
+       x="-0.21388992"
+       width="1.4277798"
+       y="-0.083393345"
+       height="1.1667867">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.45300655"
+         id="feGaussianBlur4090" />
+    </filter>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4095">
+      <g
+         id="g4097"
+         style="fill:#ffffff;stroke:#ffffff">
+        <rect
+           y="1038.3623"
+           x="-3.5179139e-06"
+           height="1"
+           width="15"
+           id="rect4099"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline" />
+        <rect
+           ry="0.86692894"
+           rx="0.86692894"
+           y="1036.8934"
+           x="3.5311878"
+           height="5.49055"
+           width="4.9538798"
+           id="rect4101"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+        <path
+           sodipodi:nodetypes="sssssssss"
+           inkscape:connector-curvature="0"
+           id="path4103"
+           d="m 2.4025311,1038.8499 9.2623739,0 c 0.480282,0 0.866929,0.3867 0.866929,0.8669 l 0,6.6406 c 0,0.4803 -0.387846,0.833 -0.866929,0.8669 l -9.2623739,0.6563 c -0.4790798,0.034 -0.866929,-0.3867 -0.866929,-0.867 l 0,-7.2968 c 0,-0.4802 0.3866503,-0.8669 0.866929,-0.8669 z"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+        <rect
+           transform="matrix(1,0,-0.70828043,0.70593118,0,0)"
+           ry="1.1745304"
+           rx="0.82913768"
+           y="1477.2665"
+           x="1053.0723"
+           height="7.1540699"
+           width="9.7600222"
+           id="rect4105"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1.19019687;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+      </g>
+    </mask>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="8.4946093"
+     inkscape:cy="5.433444"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1139"
+     inkscape:window-height="829"
+     inkscape:window-x="439"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3947"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-129.51159,939.94639)"
+       style="display:inline"
+       id="g13862">
+      <g
+         transform="matrix(1.1835826,0,0,1.1835826,-75.612218,-85.237312)"
+         id="g13813">
+        <rect
+           style="fill:#51669b;fill-opacity:1;stroke:none;display:inline"
+           id="rect3142"
+           width="45.418949"
+           height="3.0279298"
+           x="456.03619"
+           y="370.01248" />
+        <rect
+           style="fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient3939);stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+           id="rect13693-3"
+           width="15"
+           height="16.625"
+           x="466.72839"
+           y="365.56506"
+           rx="2.625"
+           ry="2.625" />
+        <path
+           style="fill:url(#linearGradient4933);fill-opacity:1;stroke:#757c8a;stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+           d="m 463.3109,371.48923 28.04582,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,20.50858 c 0,1.45425 -1.17306,2.54291 -2.625,2.625 l -28.04582,1.58563 c -1.45194,0.0821 -2.625,-1.17075 -2.625,-2.625 l 0,-22.09421 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+           id="rect13693"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3945);stroke-width:3.02792978;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           d="m 462.79697,371.48977 19.55849,0"
+           id="path13797"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <g
+           id="g4914"
+           mask="url(#mask4917)">
+          <rect
+             transform="matrix(1,0,-0.70828043,0.70593118,0,0)"
+             ry="3.7184925"
+             rx="2.625"
+             y="542.8974"
+             x="860.68469"
+             height="22.649353"
+             width="30.899641"
+             id="rect13693-2-2"
+             style="opacity:0.5;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2.38039374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;filter:url(#filter4929)" />
+        </g>
+        <path
+           style="fill:none;stroke:url(#linearGradient4795);stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+           d="m 463.3109,371.48923 28.04582,0 c 1.45426,0 2.625,1.17075 2.625,2.625 l 0,20.10713 c 0,1.45425 -1.17437,2.52222 -2.625,2.625 l -28.04582,1.98708 c -1.45062,0.10278 -2.625,-1.17075 -2.625,-2.625 l 0,-22.09421 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+           id="rect13693-8"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+        <rect
+           style="fill:#51669b;fill-opacity:1;stroke:none;display:inline"
+           id="rect3142-7"
+           width="33.241615"
+           height="3.0279298"
+           x="468.21353"
+           y="382.12421" />
+        <rect
+           style="fill:url(#linearGradient4776);fill-opacity:1;stroke:url(#linearGradient4778);stroke-width:3.60383272;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+           id="rect13693-2"
+           width="29.552662"
+           height="21.662022"
+           x="861.35822"
+           y="543.39105"
+           rx="2.5105708"
+           ry="3.5563958"
+           transform="matrix(1,0,-0.70828042,0.70593119,0,0)" />
+      </g>
+    </g>
+    <g
+       id="g4092"
+       mask="url(#mask4095)"
+       style="opacity:0.5">
+      <path
+         sodipodi:nodetypes="cccccccc"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline;filter:url(#filter4088)"
+         d="m 12.957523,1039.3765 1.047264,0 0,9.9721 2.094528,0 -2.528759,3.0651 -2.554303,-3.0395 1.966814,0 z"
+         id="path3986-0"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3986"
+       d="m 12.957523,1039.3765 1.047264,0 0,9.9721 2.094528,0 -2.528759,3.0651 -2.554303,-3.0395 1.966814,0 z"
+       style="fill:url(#linearGradient3121-4);fill-opacity:1;stroke:none;display:inline"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/change.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/change.svg
@@ -1,0 +1,1444 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="change.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4343">
+      <stop
+         style="stop-color:#96b956;stop-opacity:1"
+         offset="0"
+         id="stop4345" />
+      <stop
+         style="stop-color:#abca52;stop-opacity:1"
+         offset="1"
+         id="stop4347" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4106">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1;"
+         offset="0"
+         id="stop4108" />
+      <stop
+         style="stop-color:#146d39;stop-opacity:1"
+         offset="1"
+         id="stop4110" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 8 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="16 : 8 : 1"
+       inkscape:persp3d-origin="8 : 5.3333333 : 1"
+       id="perspective3519" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12886-6-7-7"
+       x1="393.4772"
+       y1="375.17487"
+       x2="379.65567"
+       y2="371.10898"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1-8-7">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3-6-2" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4-9-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12884-4-7-0"
+       x1="395.68689"
+       y1="379.50586"
+       x2="385.57773"
+       y2="388.69827"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12882-2-0-9"
+       x1="404.8793"
+       y1="389.22861"
+       x2="397.7753"
+       y2="400.10037"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12880-3-5-6"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12878-2-7-1"
+       x1="413.01102"
+       y1="366.6012"
+       x2="429.94864"
+       y2="364.92181"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12876-4-0-6"
+       x1="674.84711"
+       y1="180.63965"
+       x2="675.20258"
+       y2="166.79221"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12868-4-7-0"
+       x1="396.0101"
+       y1="359.4902"
+       x2="396.21149"
+       y2="350.94641"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12888-3-7-3"
+       x1="390.38361"
+       y1="362.80048"
+       x2="381.86542"
+       y2="360.85596"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       r="12.952347"
+       fy="420.74988"
+       fx="433.5452"
+       cy="420.74988"
+       cx="433.5452"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient12821-7-6-3"
+       xlink:href="#linearGradient12717-5-0-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-5-0-4-3">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-6-3-0-0" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-9-4-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12896-6-4-1"
+       x1="427.53012"
+       y1="432.76639"
+       x2="425.4519"
+       y2="415.1088"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-5-0-4-3"
+       id="radialGradient12723-8-2-4-1"
+       cx="433.36786"
+       cy="424.34106"
+       fx="433.36786"
+       fy="424.34106"
+       r="12.027534"
+       gradientTransform="matrix(1.1614831,2.1855961e-7,-2.811228e-7,1.4939602,-69.981471,-211.63828)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="translate(3.974778e-6,-9.8142563e-6)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient12725-9-4-7-2"
+       id="linearGradient12731-1-9-5-9"
+       x1="683.16229"
+       y1="205.72604"
+       x2="661.94519"
+       y2="183.18417"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12725-9-4-7-2">
+      <stop
+         style="stop-color:#397b3b;stop-opacity:1;"
+         offset="0"
+         id="stop12727-3-9-8-9" />
+      <stop
+         style="stop-color:#397b3b;stop-opacity:0;"
+         offset="1"
+         id="stop12729-4-1-8-3" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="455.88452"
+       x1="420.88995"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4046"
+       xlink:href="#linearGradient12862-1-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7584-9-3">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-6-3" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-9-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-0-5">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-8-9" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-5-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4216-0"
+       id="linearGradient4382"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       x1="393.36197"
+       y1="381.15457"
+       x2="385.57773"
+       y2="388.69827" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4234-5">
+      <stop
+         style="stop-color:#203932;stop-opacity:1"
+         offset="0"
+         id="stop4236-7" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4238-1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       y2="364.92181"
+       x2="429.94864"
+       y1="366.6012"
+       x1="413.01102"
+       id="linearGradient12878-2-7-1-2-8-9"
+       xlink:href="#linearGradient4234-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4240-5">
+      <stop
+         style="stop-color:#284539;stop-opacity:1"
+         offset="0"
+         id="stop4242-0" />
+      <stop
+         style="stop-color:#385653;stop-opacity:1"
+         offset="1"
+         id="stop4244-3" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="166.79221"
+       x2="675.20258"
+       y1="180.63965"
+       x1="674.84711"
+       id="linearGradient12876-4-0-6-7-3-6"
+       xlink:href="#linearGradient4240-5"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.60364,-39.53384)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4198-8">
+      <stop
+         style="stop-color:#2d483d;stop-opacity:1"
+         offset="0"
+         id="stop4200-3" />
+      <stop
+         style="stop-color:#38564e;stop-opacity:1"
+         offset="1"
+         id="stop4202-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.60473,-96.3391)"
+       gradientUnits="userSpaceOnUse"
+       y2="350.94641"
+       x2="396.21149"
+       y1="359.4902"
+       x1="396.0101"
+       id="linearGradient12868-4-7-0-8-7-6"
+       xlink:href="#linearGradient4198-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4204-6">
+      <stop
+         style="stop-color:#28483d;stop-opacity:1"
+         offset="0"
+         id="stop4206-3" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4208-8" />
+    </linearGradient>
+    <linearGradient
+       y2="360.85596"
+       x2="381.86542"
+       y1="362.80048"
+       x1="390.38361"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4091-0"
+       xlink:href="#linearGradient4204-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4210-9">
+      <stop
+         style="stop-color:#284539;stop-opacity:1"
+         offset="0"
+         id="stop4212-8" />
+      <stop
+         style="stop-color:#385653;stop-opacity:1"
+         offset="1"
+         id="stop4214-5" />
+    </linearGradient>
+    <linearGradient
+       y2="371.10898"
+       x2="379.65567"
+       y1="375.17487"
+       x1="393.4772"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4100-2"
+       xlink:href="#linearGradient4210-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4216-0">
+      <stop
+         style="stop-color:#233e32;stop-opacity:1"
+         offset="0"
+         id="stop4218-3" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:0.8650133"
+         offset="1"
+         id="stop4220-8" />
+    </linearGradient>
+    <linearGradient
+       y2="388.69827"
+       x2="385.57773"
+       y1="381.15457"
+       x1="393.36197"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,940.00748)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4097-3"
+       xlink:href="#linearGradient4216-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4222-4">
+      <stop
+         style="stop-color:#203c37;stop-opacity:1"
+         offset="0"
+         id="stop4224-9" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4226-6" />
+    </linearGradient>
+    <linearGradient
+       y2="399.07361"
+       x2="396.94577"
+       y1="388.32217"
+       x1="400.52957"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4094-1"
+       xlink:href="#linearGradient4222-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4228-4">
+      <stop
+         style="stop-color:#203932;stop-opacity:1"
+         offset="0"
+         id="stop4230-4" />
+      <stop
+         style="stop-color:#314e4a;stop-opacity:1"
+         offset="1"
+         id="stop4232-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4228-4"
+       id="linearGradient4141-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4252-7">
+      <stop
+         style="stop-color:#1d6279;stop-opacity:1"
+         offset="0"
+         id="stop4254-1" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4256-4" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="447.02145"
+       x1="427.92853"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4190-8"
+       xlink:href="#linearGradient4252-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4258-3">
+      <stop
+         style="stop-color:#387a31;stop-opacity:1"
+         offset="0"
+         id="stop4260-4" />
+      <stop
+         style="stop-color:#397b3b;stop-opacity:0;"
+         offset="1"
+         id="stop4262-6" />
+    </linearGradient>
+    <linearGradient
+       y2="183.92403"
+       x2="666.19678"
+       y1="204.12044"
+       x1="684.11578"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.8909,996.82836)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4086-5"
+       xlink:href="#linearGradient4258-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="415.1088"
+       x2="425.4519"
+       y1="432.76639"
+       x1="427.53012"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4196"
+       xlink:href="#linearGradient4246"
+       inkscape:collect="always" />
+    <radialGradient
+       r="12.952347"
+       fy="420.74988"
+       fx="433.5452"
+       cy="420.74988"
+       cx="433.5452"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4194"
+       xlink:href="#linearGradient12717-5-0-4-3-4"
+       inkscape:collect="always" />
+    <radialGradient
+       r="12.027534"
+       fy="424.34106"
+       fx="433.36789"
+       cy="424.34106"
+       cx="433.36789"
+       gradientTransform="matrix(1.2231981,-0.08344257,0.10167677,1.4904962,-139.87254,-174.00694)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4192"
+       xlink:href="#linearGradient4515"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="447.02145"
+       x1="427.92853"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4190"
+       xlink:href="#linearGradient4252"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-75-5"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-4-2"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-16-6"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-75-5"
+       id="linearGradient3993-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       y2="183.92403"
+       x2="666.19678"
+       y1="204.12044"
+       x1="684.11578"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.8909,996.82836)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4086"
+       xlink:href="#linearGradient4258"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4472"
+       id="linearGradient3993"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-7-5"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-1-6"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-12-9"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-7-5"
+       id="linearGradient3915-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.27903302,0.27903303,0,-96.327735,115.6161)"
+       x1="396.0101"
+       y1="359.4902"
+       x2="396.21149"
+       y2="350.94641" />
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.60473,-96.339099)"
+       gradientUnits="userSpaceOnUse"
+       y2="350.94641"
+       x2="396.21149"
+       y1="359.4902"
+       x1="396.0101"
+       id="linearGradient12868-4-7-0-8"
+       xlink:href="#linearGradient4490"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="166.79221"
+       x2="675.20258"
+       y1="180.63965"
+       x1="674.84711"
+       id="linearGradient12876-4-0-6-7"
+       xlink:href="#linearGradient4484"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.60364,-39.53384)" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-9-7"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-8-0"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-0-6"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-9-7"
+       id="linearGradient3813-8"
+       gradientUnits="userSpaceOnUse"
+       x1="674.84711"
+       y1="180.63965"
+       x2="675.20258"
+       y2="166.79221"
+       gradientTransform="matrix(0,0.27903302,0.24756874,0,-39.521247,-178.59954)" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-1-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-9-6"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-1-4"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-1-9"
+       id="linearGradient3847-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.27903302,0.27903303,0,-96.353305,-104.6999)"
+       x1="413.01102"
+       y1="366.6012"
+       x2="429.94864"
+       y2="364.92181" />
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       gradientUnits="userSpaceOnUse"
+       y2="364.92181"
+       x2="429.94864"
+       y1="366.6012"
+       x1="413.01102"
+       id="linearGradient12878-2-7-1-2"
+       xlink:href="#linearGradient4478"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-75"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-4"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-16"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,264.63772,-229.51558)"
+       gradientUnits="userSpaceOnUse"
+       y2="381.80399"
+       x2="432.86548"
+       y1="378.7988"
+       x1="420.52402"
+       id="linearGradient12880-3-5-6-9"
+       xlink:href="#linearGradient12862-1-8-7-75"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-96-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-86-2"
+         offset="0"
+         style="stop-color:#203932;stop-opacity:1" />
+      <stop
+         id="stop12866-4-9-5-8-9"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-96-9"
+       id="linearGradient3881-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.27903302,0.27903303,0,-96.392939,-104.7384)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-7"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-1"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-12"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,265.19769,-229.45247)"
+       gradientUnits="userSpaceOnUse"
+       y2="350.94641"
+       x2="396.21149"
+       y1="359.4902"
+       x1="396.0101"
+       id="linearGradient12868-4-7-0-0"
+       xlink:href="#linearGradient12862-1-8-7-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-96"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-86"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-8"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,264.63772,-229.51558)"
+       gradientUnits="userSpaceOnUse"
+       y2="381.80399"
+       x2="432.86548"
+       y1="378.7988"
+       x1="420.52402"
+       id="linearGradient12880-3-5-6-6"
+       xlink:href="#linearGradient12862-1-8-7-96"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-1"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-9"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-1"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,264.63772,-229.51558)"
+       gradientUnits="userSpaceOnUse"
+       y2="364.92181"
+       x2="429.94864"
+       y1="366.6012"
+       x1="413.01102"
+       id="linearGradient12878-2-7-1-1"
+       xlink:href="#linearGradient12862-1-8-7-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-8"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-0"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="166.79221"
+       x2="675.20258"
+       y1="180.63965"
+       x1="674.84711"
+       id="linearGradient12876-4-0-6-3"
+       xlink:href="#linearGradient12862-1-8-7-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12717-5-0-4-3-4"
+       inkscape:collect="always">
+      <stop
+         id="stop12719-6-3-0-0-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop12721-9-4-5-0-6"
+         offset="1"
+         style="stop-color:#8ebc7b;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4246">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4248" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4250" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4252">
+      <stop
+         style="stop-color:#0d5269;stop-opacity:1"
+         offset="0"
+         id="stop4254" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4256" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4258">
+      <stop
+         style="stop-color:#387a31;stop-opacity:1"
+         offset="0"
+         id="stop4260" />
+      <stop
+         style="stop-color:#397b3b;stop-opacity:0;"
+         offset="1"
+         id="stop4262" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4472">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4474" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4476" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4478">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4480" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4482" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4484">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4486" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4488" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4490">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4492" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4494" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4515">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4517" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop4519" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4515-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4517-7" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop4519-4" />
+    </linearGradient>
+    <mask
+       id="mask7862"
+       maskUnits="userSpaceOnUse">
+      <g
+         id="g7864">
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.5;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           d="m 11.5,1039.6591 c -0.18722,10e-5 -0.383743,0.04 -0.65625,0.094 l 0,0.875 c -0.213492,0.042 -0.422114,0.072 -0.625,0.1562 -0.194391,0.083 -0.388449,0.2275 -0.5625,0.3438 l -0.625,-0.6252 c -0.462167,0.3084 -0.597312,0.4445 -0.90625,0.9062 l 0.625,0.625 c -0.121067,0.1808 -0.2597,0.3909 -0.34375,0.5938 -0.08385,0.2029 -0.113627,0.4115 -0.15625,0.625 l -0.90625,0 c -0.108682,0.5449 -0.108112,0.7362 0,1.2812 l 0.90625,0 c 0.08465,0.427 0.258374,0.8566 0.5,1.2188 l -0.625,0.5937 c 0.308933,0.4619 0.444082,0.5977 0.90625,0.9063 l 0.625,-0.5938 c 0.361804,0.2421 0.760581,0.4148 1.1875,0.5 l 0,0.875 c 0.545014,0.1081 0.76758,0.1087 1.3125,0 l 0,-0.875 c 0.426989,-0.085 0.8255,-0.2582 1.1875,-0.5 l 0.625,0.5938 c 0.46183,-0.309 0.597782,-0.4441 0.90625,-0.9063 l -0.625,-0.5937 c 0.242113,-0.3618 0.414842,-0.792 0.5,-1.2188 l 0.90625,0 c 0.108112,-0.545 0.108682,-0.7363 0,-1.2812 l -0.90625,0 c -0.08469,-0.4271 -0.258169,-0.8568 -0.5,-1.2188 l 0.625,-0.625 c -0.154067,-0.2313 -0.242615,-0.3988 -0.375,-0.5312 -0.13245,-0.1323 -0.299966,-0.2209 -0.53125,-0.375 l -0.625,0.625 c -0.361809,-0.2421 -0.760526,-0.415 -1.1875,-0.5 l 0,-0.875 c -0.27246,-0.054 -0.46903,-0.094 -0.65625,-0.094 z m 0,3.3125 c 0.500508,0 0.90625,0.4057 0.90625,0.9063 0,0.5005 -0.405742,0.9062 -0.90625,0.9062 -0.500508,0 -0.90625,-0.4057 -0.90625,-0.9062 0,-0.5006 0.405742,-0.9063 0.90625,-0.9063 z"
+           id="path7866"
+           inkscape:connector-curvature="0" />
+      </g>
+    </mask>
+    <linearGradient
+       id="linearGradient5103">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105" />
+      <stop
+         id="stop7550"
+         offset="0.26694915"
+         style="stop-color:#fef5d4;stop-opacity:1" />
+      <stop
+         id="stop7548"
+         offset="0.51694918"
+         style="stop-color:#fbe08e;stop-opacity:1" />
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="1"
+         id="stop5107" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5281">
+      <stop
+         id="stop5283"
+         offset="0"
+         style="stop-color:#e0b575;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f5ca75;stop-opacity:1"
+         offset="0.5"
+         id="stop5289" />
+      <stop
+         id="stop5285"
+         offset="1"
+         style="stop-color:#f5f5b5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5103-5">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105-9" />
+      <stop
+         id="stop7550-8"
+         offset="0.26694915"
+         style="stop-color:#fef5d4;stop-opacity:1" />
+      <stop
+         id="stop7548-2"
+         offset="0.51694918"
+         style="stop-color:#fbe08e;stop-opacity:1" />
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="1"
+         id="stop5107-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-20)"
+       gradientUnits="userSpaceOnUse"
+       y2="1064.8306"
+       x2="16.46875"
+       y1="1064.8306"
+       x1="4.2581835"
+       id="linearGradient7558-2"
+       xlink:href="#linearGradient7552-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7552-5"
+       inkscape:collect="always">
+      <stop
+         id="stop7554-6"
+         offset="0"
+         style="stop-color:#c08c29;stop-opacity:1" />
+      <stop
+         id="stop7556-9"
+         offset="1"
+         style="stop-color:#b17813;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4106"
+       id="linearGradient4112"
+       x1="10.225247"
+       y1="1030.4619"
+       x2="10.225247"
+       y2="1039.7833"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,10.337603)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4106-0"
+       id="linearGradient4112-8"
+       x1="10.225247"
+       y1="1030.4619"
+       x2="10.225247"
+       y2="1039.7833"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,10.337603)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4106-0">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1;"
+         offset="0"
+         id="stop4108-8" />
+      <stop
+         style="stop-color:#146d39;stop-opacity:1"
+         offset="1"
+         id="stop4110-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188"
+       id="linearGradient4194"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-6"
+       id="linearGradient4194-5"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-6">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-4" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-7" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,2.1909235,1035.842)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4245"
+       xlink:href="#linearGradient4188-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4266"
+       id="linearGradient4272"
+       x1="25.930252"
+       y1="1051.1136"
+       x2="25.930252"
+       y2="1047.26"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <filter
+       inkscape:collect="always"
+       id="filter4339"
+       x="-0.090256119"
+       width="1.1805122"
+       y="-0.1789842"
+       height="1.3579684">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.27970009"
+         id="feGaussianBlur4341" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient4349"
+       x1="11.032874"
+       y1="1048.5142"
+       x2="11.032874"
+       y2="1041.7299"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4266-7"
+       id="linearGradient4272-2"
+       x1="25.930252"
+       y1="1051.1136"
+       x2="25.930252"
+       y2="1047.26"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266-7">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268-0" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4106-02"
+       id="linearGradient4112-88"
+       x1="10.225247"
+       y1="1030.4619"
+       x2="10.225247"
+       y2="1039.7833"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,10.337603)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4106-02">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1;"
+         offset="0"
+         id="stop4108-86" />
+      <stop
+         style="stop-color:#146d39;stop-opacity:1"
+         offset="1"
+         id="stop4110-4" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter4525"
+       x="-0.1109419"
+       width="1.2218838"
+       y="-0.13066874"
+       height="1.2613375">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.38772681"
+         id="feGaussianBlur4527" />
+    </filter>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4529">
+      <rect
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-opacity:1;display:inline"
+         id="rect4531"
+         width="8.993515"
+         height="3.9996338"
+         x="2.4969711"
+         y="1046.86" />
+    </mask>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(-6.0000004,-11.968814)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4245-0"
+       xlink:href="#linearGradient4188-6-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-6-0">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-4-6" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-7-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-4"
+       id="linearGradient4194-58"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-6" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(0,1036.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4553"
+       xlink:href="#linearGradient4188-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-6-0"
+       id="linearGradient4582"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.0000001,1036.3934)"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4266-4"
+       id="linearGradient4272-6"
+       x1="25.930252"
+       y1="1051.1136"
+       x2="25.930252"
+       y2="1047.26"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266-4">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268-6" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270-39" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(0,1036.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4553-7"
+       xlink:href="#linearGradient4188-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4-3">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-6-1" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-6-0-7"
+       id="linearGradient4582-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.0000001,1036.3934)"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-6-0-7">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-4-6-2" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-7-4-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.26"
+       x2="25.930252"
+       y1="1051.1136"
+       x1="25.930252"
+       gradientTransform="translate(-20,2.7828126e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4609"
+       xlink:href="#linearGradient4266-4"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="6.7963599"
+     inkscape:cy="6.2053979"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="23"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="fill:#f1f5fa;fill-opacity:1;stroke:url(#linearGradient4609);stroke-opacity:1;display:inline"
+       id="rect4264"
+       width="8.993515"
+       height="3.9996338"
+       x="2.4969711"
+       y="1046.86" />
+    <rect
+       style="fill:url(#linearGradient4553-7);fill-opacity:1;stroke:none;display:inline"
+       id="rect4178"
+       width="4.0000005"
+       height="1.0000001"
+       x="6"
+       y="1048.3622" />
+    <rect
+       style="fill:url(#linearGradient4582-4);fill-opacity:1;stroke:none;display:inline"
+       id="rect4178-9"
+       width="0.9999997"
+       height="1.0000215"
+       x="4.0000005"
+       y="1048.3622" />
+    <g
+       style="display:inline"
+       id="layer1-5"
+       inkscape:label="Layer 1"
+       transform="translate(-10.051944,2.8637517)" />
+    <g
+       id="g4518"
+       style="filter:url(#filter4525);stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+       mask="url(#mask4529)">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path4108-1-1"
+         d="m 1.4560597,1047.0104 c 0.166408,-2.3394 3.0629699,-2.1562 3.0629699,-2.1562 l 0,1.9561 4.3860242,-3.4248 -4.3860242,-3.4965 0,1.9824 c -1.8676292,0.013 -5.798807,1.6782 -3.0629699,5.139 z"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+    </g>
+    <g
+       transform="matrix(0.7738738,0,0,0.7738738,-3.6954984,234.78238)"
+       inkscape:label="Layer 1"
+       id="layer1-7"
+       style="display:inline">
+      <path
+         style="fill:#abca52;fill-opacity:1;stroke:none;display:inline"
+         d="m 6.6568452,1049.5614 c 0.2150324,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133512,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+         id="path4108-1-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="fill:url(#linearGradient4349);fill-opacity:1;stroke:none;display:inline"
+         d="m 6.6568452,1049.5614 c 0.2150325,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133511,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+         id="path4108-1-3-4"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4112);stroke-width:1.29220033;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         d="m 6.6568452,1049.5614 c 0.2150324,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133512,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+         id="path4108-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <rect
+         style="fill:#2f9353;fill-opacity:1;stroke:none"
+         id="rect4122"
+         width="0.94941604"
+         height="1.1992624"
+         x="10.31146"
+         y="1042.3649" />
+      <rect
+         style="fill:#1d7a42;fill-opacity:1;stroke:none;display:inline"
+         id="rect4122-2"
+         width="0.94941604"
+         height="1.1992624"
+         x="10.304321"
+         y="1046.1245" />
+      <rect
+         style="fill:none;stroke:none"
+         id="rect4176"
+         width="1"
+         height="1"
+         x="4"
+         y="12"
+         transform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#cfdc63;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.58440065;marker:none;visibility:visible;display:inline;overflow:visible;filter:url(#filter4339);enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 11.90625,1043.0312 2.28125,1.8438 -2.28125,1.7812 0,-1.0937 -1.21875,-0.062 c 0,0 -1.1298804,-0.1 -2.375,0.3125 -0.4970996,0.1646 -1.0141192,0.5483 -1.5,0.9687 -9.736e-4,-0.029 -0.06306,-0.097 -0.0625,-0.125 0.00915,-0.4526 0.1773911,-0.7816 0.5625,-1.1562 0.7702178,-0.7493 2.483426,-1.2754 3.3125,-1.2812 l 1.28125,0 0,-1.1876 z"
+         id="path4108-1-3-4-6"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/composite_change.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/composite_change.svg
@@ -1,0 +1,1929 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="composite_change.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4343">
+      <stop
+         style="stop-color:#96b956;stop-opacity:1"
+         offset="0"
+         id="stop4345" />
+      <stop
+         style="stop-color:#abca52;stop-opacity:1"
+         offset="1"
+         id="stop4347" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4106">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1;"
+         offset="0"
+         id="stop4108" />
+      <stop
+         style="stop-color:#146d39;stop-opacity:1"
+         offset="1"
+         id="stop4110" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 8 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="16 : 8 : 1"
+       inkscape:persp3d-origin="8 : 5.3333333 : 1"
+       id="perspective3519" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12886-6-7-7"
+       x1="393.4772"
+       y1="375.17487"
+       x2="379.65567"
+       y2="371.10898"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1-8-7">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3-6-2" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4-9-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12884-4-7-0"
+       x1="395.68689"
+       y1="379.50586"
+       x2="385.57773"
+       y2="388.69827"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12882-2-0-9"
+       x1="404.8793"
+       y1="389.22861"
+       x2="397.7753"
+       y2="400.10037"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12880-3-5-6"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12878-2-7-1"
+       x1="413.01102"
+       y1="366.6012"
+       x2="429.94864"
+       y2="364.92181"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12876-4-0-6"
+       x1="674.84711"
+       y1="180.63965"
+       x2="675.20258"
+       y2="166.79221"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12868-4-7-0"
+       x1="396.0101"
+       y1="359.4902"
+       x2="396.21149"
+       y2="350.94641"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12888-3-7-3"
+       x1="390.38361"
+       y1="362.80048"
+       x2="381.86542"
+       y2="360.85596"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       r="12.952347"
+       fy="420.74988"
+       fx="433.5452"
+       cy="420.74988"
+       cx="433.5452"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient12821-7-6-3"
+       xlink:href="#linearGradient12717-5-0-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-5-0-4-3">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-6-3-0-0" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-9-4-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12896-6-4-1"
+       x1="427.53012"
+       y1="432.76639"
+       x2="425.4519"
+       y2="415.1088"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-5-0-4-3"
+       id="radialGradient12723-8-2-4-1"
+       cx="433.36786"
+       cy="424.34106"
+       fx="433.36786"
+       fy="424.34106"
+       r="12.027534"
+       gradientTransform="matrix(1.1614831,2.1855961e-7,-2.811228e-7,1.4939602,-69.981471,-211.63828)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="translate(3.974778e-6,-9.8142563e-6)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient12725-9-4-7-2"
+       id="linearGradient12731-1-9-5-9"
+       x1="683.16229"
+       y1="205.72604"
+       x2="661.94519"
+       y2="183.18417"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12725-9-4-7-2">
+      <stop
+         style="stop-color:#397b3b;stop-opacity:1;"
+         offset="0"
+         id="stop12727-3-9-8-9" />
+      <stop
+         style="stop-color:#397b3b;stop-opacity:0;"
+         offset="1"
+         id="stop12729-4-1-8-3" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="455.88452"
+       x1="420.88995"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4046"
+       xlink:href="#linearGradient12862-1-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7584-9-3">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-6-3" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-9-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-0-5">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-8-9" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-5-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4216-0"
+       id="linearGradient4382"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       x1="393.36197"
+       y1="381.15457"
+       x2="385.57773"
+       y2="388.69827" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4234-5">
+      <stop
+         style="stop-color:#203932;stop-opacity:1"
+         offset="0"
+         id="stop4236-7" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4238-1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       y2="364.92181"
+       x2="429.94864"
+       y1="366.6012"
+       x1="413.01102"
+       id="linearGradient12878-2-7-1-2-8-9"
+       xlink:href="#linearGradient4234-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4240-5">
+      <stop
+         style="stop-color:#284539;stop-opacity:1"
+         offset="0"
+         id="stop4242-0" />
+      <stop
+         style="stop-color:#385653;stop-opacity:1"
+         offset="1"
+         id="stop4244-3" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="166.79221"
+       x2="675.20258"
+       y1="180.63965"
+       x1="674.84711"
+       id="linearGradient12876-4-0-6-7-3-6"
+       xlink:href="#linearGradient4240-5"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.60364,-39.53384)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4198-8">
+      <stop
+         style="stop-color:#2d483d;stop-opacity:1"
+         offset="0"
+         id="stop4200-3" />
+      <stop
+         style="stop-color:#38564e;stop-opacity:1"
+         offset="1"
+         id="stop4202-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.60473,-96.3391)"
+       gradientUnits="userSpaceOnUse"
+       y2="350.94641"
+       x2="396.21149"
+       y1="359.4902"
+       x1="396.0101"
+       id="linearGradient12868-4-7-0-8-7-6"
+       xlink:href="#linearGradient4198-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4204-6">
+      <stop
+         style="stop-color:#28483d;stop-opacity:1"
+         offset="0"
+         id="stop4206-3" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4208-8" />
+    </linearGradient>
+    <linearGradient
+       y2="360.85596"
+       x2="381.86542"
+       y1="362.80048"
+       x1="390.38361"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4091-0"
+       xlink:href="#linearGradient4204-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4210-9">
+      <stop
+         style="stop-color:#284539;stop-opacity:1"
+         offset="0"
+         id="stop4212-8" />
+      <stop
+         style="stop-color:#385653;stop-opacity:1"
+         offset="1"
+         id="stop4214-5" />
+    </linearGradient>
+    <linearGradient
+       y2="371.10898"
+       x2="379.65567"
+       y1="375.17487"
+       x1="393.4772"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4100-2"
+       xlink:href="#linearGradient4210-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4216-0">
+      <stop
+         style="stop-color:#233e32;stop-opacity:1"
+         offset="0"
+         id="stop4218-3" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:0.8650133"
+         offset="1"
+         id="stop4220-8" />
+    </linearGradient>
+    <linearGradient
+       y2="388.69827"
+       x2="385.57773"
+       y1="381.15457"
+       x1="393.36197"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,940.00748)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4097-3"
+       xlink:href="#linearGradient4216-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4222-4">
+      <stop
+         style="stop-color:#203c37;stop-opacity:1"
+         offset="0"
+         id="stop4224-9" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4226-6" />
+    </linearGradient>
+    <linearGradient
+       y2="399.07361"
+       x2="396.94577"
+       y1="388.32217"
+       x1="400.52957"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4094-1"
+       xlink:href="#linearGradient4222-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4228-4">
+      <stop
+         style="stop-color:#203932;stop-opacity:1"
+         offset="0"
+         id="stop4230-4" />
+      <stop
+         style="stop-color:#314e4a;stop-opacity:1"
+         offset="1"
+         id="stop4232-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4228-4"
+       id="linearGradient4141-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4252-7">
+      <stop
+         style="stop-color:#1d6279;stop-opacity:1"
+         offset="0"
+         id="stop4254-1" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4256-4" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="447.02145"
+       x1="427.92853"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4190-8"
+       xlink:href="#linearGradient4252-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4258-3">
+      <stop
+         style="stop-color:#387a31;stop-opacity:1"
+         offset="0"
+         id="stop4260-4" />
+      <stop
+         style="stop-color:#397b3b;stop-opacity:0;"
+         offset="1"
+         id="stop4262-6" />
+    </linearGradient>
+    <linearGradient
+       y2="183.92403"
+       x2="666.19678"
+       y1="204.12044"
+       x1="684.11578"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.8909,996.82836)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4086-5"
+       xlink:href="#linearGradient4258-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="415.1088"
+       x2="425.4519"
+       y1="432.76639"
+       x1="427.53012"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4196"
+       xlink:href="#linearGradient4246"
+       inkscape:collect="always" />
+    <radialGradient
+       r="12.952347"
+       fy="420.74988"
+       fx="433.5452"
+       cy="420.74988"
+       cx="433.5452"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4194"
+       xlink:href="#linearGradient12717-5-0-4-3-4"
+       inkscape:collect="always" />
+    <radialGradient
+       r="12.027534"
+       fy="424.34106"
+       fx="433.36789"
+       cy="424.34106"
+       cx="433.36789"
+       gradientTransform="matrix(1.2231981,-0.08344257,0.10167677,1.4904962,-139.87254,-174.00694)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4192"
+       xlink:href="#linearGradient4515"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="447.02145"
+       x1="427.92853"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4190"
+       xlink:href="#linearGradient4252"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-75-5"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-4-2"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-16-6"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-75-5"
+       id="linearGradient3993-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       y2="183.92403"
+       x2="666.19678"
+       y1="204.12044"
+       x1="684.11578"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.8909,996.82836)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4086"
+       xlink:href="#linearGradient4258"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4472"
+       id="linearGradient3993"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-7-5"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-1-6"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-12-9"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-7-5"
+       id="linearGradient3915-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.27903302,0.27903303,0,-96.327735,115.6161)"
+       x1="396.0101"
+       y1="359.4902"
+       x2="396.21149"
+       y2="350.94641" />
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.60473,-96.339099)"
+       gradientUnits="userSpaceOnUse"
+       y2="350.94641"
+       x2="396.21149"
+       y1="359.4902"
+       x1="396.0101"
+       id="linearGradient12868-4-7-0-8"
+       xlink:href="#linearGradient4490"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="166.79221"
+       x2="675.20258"
+       y1="180.63965"
+       x1="674.84711"
+       id="linearGradient12876-4-0-6-7"
+       xlink:href="#linearGradient4484"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.60364,-39.53384)" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-9-7"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-8-0"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-0-6"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-9-7"
+       id="linearGradient3813-8"
+       gradientUnits="userSpaceOnUse"
+       x1="674.84711"
+       y1="180.63965"
+       x2="675.20258"
+       y2="166.79221"
+       gradientTransform="matrix(0,0.27903302,0.24756874,0,-39.521247,-178.59954)" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-1-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-9-6"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-1-4"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-1-9"
+       id="linearGradient3847-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.27903302,0.27903303,0,-96.353305,-104.6999)"
+       x1="413.01102"
+       y1="366.6012"
+       x2="429.94864"
+       y2="364.92181" />
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       gradientUnits="userSpaceOnUse"
+       y2="364.92181"
+       x2="429.94864"
+       y1="366.6012"
+       x1="413.01102"
+       id="linearGradient12878-2-7-1-2"
+       xlink:href="#linearGradient4478"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-75"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-4"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-16"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,264.63772,-229.51558)"
+       gradientUnits="userSpaceOnUse"
+       y2="381.80399"
+       x2="432.86548"
+       y1="378.7988"
+       x1="420.52402"
+       id="linearGradient12880-3-5-6-9"
+       xlink:href="#linearGradient12862-1-8-7-75"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-96-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-86-2"
+         offset="0"
+         style="stop-color:#203932;stop-opacity:1" />
+      <stop
+         id="stop12866-4-9-5-8-9"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-96-9"
+       id="linearGradient3881-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.27903302,0.27903303,0,-96.392939,-104.7384)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-7"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-1"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-12"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,265.19769,-229.45247)"
+       gradientUnits="userSpaceOnUse"
+       y2="350.94641"
+       x2="396.21149"
+       y1="359.4902"
+       x1="396.0101"
+       id="linearGradient12868-4-7-0-0"
+       xlink:href="#linearGradient12862-1-8-7-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-96"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-86"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-8"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,264.63772,-229.51558)"
+       gradientUnits="userSpaceOnUse"
+       y2="381.80399"
+       x2="432.86548"
+       y1="378.7988"
+       x1="420.52402"
+       id="linearGradient12880-3-5-6-6"
+       xlink:href="#linearGradient12862-1-8-7-96"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-1"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-9"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-1"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,264.63772,-229.51558)"
+       gradientUnits="userSpaceOnUse"
+       y2="364.92181"
+       x2="429.94864"
+       y1="366.6012"
+       x1="413.01102"
+       id="linearGradient12878-2-7-1-1"
+       xlink:href="#linearGradient12862-1-8-7-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-8"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-0"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="166.79221"
+       x2="675.20258"
+       y1="180.63965"
+       x1="674.84711"
+       id="linearGradient12876-4-0-6-3"
+       xlink:href="#linearGradient12862-1-8-7-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12717-5-0-4-3-4"
+       inkscape:collect="always">
+      <stop
+         id="stop12719-6-3-0-0-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop12721-9-4-5-0-6"
+         offset="1"
+         style="stop-color:#8ebc7b;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4246">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4248" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4250" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4252">
+      <stop
+         style="stop-color:#0d5269;stop-opacity:1"
+         offset="0"
+         id="stop4254" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4256" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4258">
+      <stop
+         style="stop-color:#387a31;stop-opacity:1"
+         offset="0"
+         id="stop4260" />
+      <stop
+         style="stop-color:#397b3b;stop-opacity:0;"
+         offset="1"
+         id="stop4262" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4472">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4474" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4476" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4478">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4480" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4482" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4484">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4486" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4488" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4490">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4492" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4494" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4515">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4517" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop4519" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4515-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4517-7" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop4519-4" />
+    </linearGradient>
+    <mask
+       id="mask7862"
+       maskUnits="userSpaceOnUse">
+      <g
+         id="g7864">
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.5;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           d="m 11.5,1039.6591 c -0.18722,10e-5 -0.383743,0.04 -0.65625,0.094 l 0,0.875 c -0.213492,0.042 -0.422114,0.072 -0.625,0.1562 -0.194391,0.083 -0.388449,0.2275 -0.5625,0.3438 l -0.625,-0.6252 c -0.462167,0.3084 -0.597312,0.4445 -0.90625,0.9062 l 0.625,0.625 c -0.121067,0.1808 -0.2597,0.3909 -0.34375,0.5938 -0.08385,0.2029 -0.113627,0.4115 -0.15625,0.625 l -0.90625,0 c -0.108682,0.5449 -0.108112,0.7362 0,1.2812 l 0.90625,0 c 0.08465,0.427 0.258374,0.8566 0.5,1.2188 l -0.625,0.5937 c 0.308933,0.4619 0.444082,0.5977 0.90625,0.9063 l 0.625,-0.5938 c 0.361804,0.2421 0.760581,0.4148 1.1875,0.5 l 0,0.875 c 0.545014,0.1081 0.76758,0.1087 1.3125,0 l 0,-0.875 c 0.426989,-0.085 0.8255,-0.2582 1.1875,-0.5 l 0.625,0.5938 c 0.46183,-0.309 0.597782,-0.4441 0.90625,-0.9063 l -0.625,-0.5937 c 0.242113,-0.3618 0.414842,-0.792 0.5,-1.2188 l 0.90625,0 c 0.108112,-0.545 0.108682,-0.7363 0,-1.2812 l -0.90625,0 c -0.08469,-0.4271 -0.258169,-0.8568 -0.5,-1.2188 l 0.625,-0.625 c -0.154067,-0.2313 -0.242615,-0.3988 -0.375,-0.5312 -0.13245,-0.1323 -0.299966,-0.2209 -0.53125,-0.375 l -0.625,0.625 c -0.361809,-0.2421 -0.760526,-0.415 -1.1875,-0.5 l 0,-0.875 c -0.27246,-0.054 -0.46903,-0.094 -0.65625,-0.094 z m 0,3.3125 c 0.500508,0 0.90625,0.4057 0.90625,0.9063 0,0.5005 -0.405742,0.9062 -0.90625,0.9062 -0.500508,0 -0.90625,-0.4057 -0.90625,-0.9062 0,-0.5006 0.405742,-0.9063 0.90625,-0.9063 z"
+           id="path7866"
+           inkscape:connector-curvature="0" />
+      </g>
+    </mask>
+    <linearGradient
+       id="linearGradient5103">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105" />
+      <stop
+         id="stop7550"
+         offset="0.26694915"
+         style="stop-color:#fef5d4;stop-opacity:1" />
+      <stop
+         id="stop7548"
+         offset="0.51694918"
+         style="stop-color:#fbe08e;stop-opacity:1" />
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="1"
+         id="stop5107" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5281">
+      <stop
+         id="stop5283"
+         offset="0"
+         style="stop-color:#e0b575;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f5ca75;stop-opacity:1"
+         offset="0.5"
+         id="stop5289" />
+      <stop
+         id="stop5285"
+         offset="1"
+         style="stop-color:#f5f5b5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5103-5">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105-9" />
+      <stop
+         id="stop7550-8"
+         offset="0.26694915"
+         style="stop-color:#fef5d4;stop-opacity:1" />
+      <stop
+         id="stop7548-2"
+         offset="0.51694918"
+         style="stop-color:#fbe08e;stop-opacity:1" />
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="1"
+         id="stop5107-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-20)"
+       gradientUnits="userSpaceOnUse"
+       y2="1064.8306"
+       x2="16.46875"
+       y1="1064.8306"
+       x1="4.2581835"
+       id="linearGradient7558-2"
+       xlink:href="#linearGradient7552-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7552-5"
+       inkscape:collect="always">
+      <stop
+         id="stop7554-6"
+         offset="0"
+         style="stop-color:#c08c29;stop-opacity:1" />
+      <stop
+         id="stop7556-9"
+         offset="1"
+         style="stop-color:#b17813;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4106"
+       id="linearGradient4112"
+       x1="10.225247"
+       y1="1030.4619"
+       x2="10.225247"
+       y2="1039.7833"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,10.337603)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4106-0"
+       id="linearGradient4112-8"
+       x1="10.225247"
+       y1="1030.4619"
+       x2="10.225247"
+       y2="1039.7833"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,10.337603)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4106-0">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1;"
+         offset="0"
+         id="stop4108-8" />
+      <stop
+         style="stop-color:#146d39;stop-opacity:1"
+         offset="1"
+         id="stop4110-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188"
+       id="linearGradient4194"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-6"
+       id="linearGradient4194-5"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-6">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-4" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-7" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,2.1909235,1035.842)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4245"
+       xlink:href="#linearGradient4188-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4266"
+       id="linearGradient4272"
+       x1="25.930252"
+       y1="1051.1136"
+       x2="25.930252"
+       y2="1047.26"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <filter
+       inkscape:collect="always"
+       id="filter4339"
+       x="-0.090256119"
+       width="1.1805122"
+       y="-0.1789842"
+       height="1.3579684">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.27970009"
+         id="feGaussianBlur4341" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient4349"
+       x1="11.032874"
+       y1="1048.5142"
+       x2="11.032874"
+       y2="1041.7299"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4266-7"
+       id="linearGradient4272-2"
+       x1="25.930252"
+       y1="1051.1136"
+       x2="25.930252"
+       y2="1047.26"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266-7">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268-0" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4106-02"
+       id="linearGradient4112-88"
+       x1="10.225247"
+       y1="1030.4619"
+       x2="10.225247"
+       y2="1039.7833"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,10.337603)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4106-02">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1;"
+         offset="0"
+         id="stop4108-86" />
+      <stop
+         style="stop-color:#146d39;stop-opacity:1"
+         offset="1"
+         id="stop4110-4" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter4525"
+       x="-0.1109419"
+       width="1.2218838"
+       y="-0.13066874"
+       height="1.2613375">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.38772681"
+         id="feGaussianBlur4527" />
+    </filter>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4529">
+      <rect
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-opacity:1;display:inline"
+         id="rect4531"
+         width="8.993515"
+         height="3.9996338"
+         x="2.4969711"
+         y="1046.86" />
+    </mask>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(-6.0000004,-11.968814)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4245-0"
+       xlink:href="#linearGradient4188-6-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-6-0">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-4-6" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-7-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-4"
+       id="linearGradient4194-58"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-6" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(0,1036.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4553"
+       xlink:href="#linearGradient4188-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-6-0"
+       id="linearGradient4582"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.0000001,1036.3934)"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4266-4"
+       id="linearGradient4272-6"
+       x1="25.930252"
+       y1="1051.1136"
+       x2="25.930252"
+       y2="1047.26"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266-4">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268-6" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270-39" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(3.0277276,1034.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4553-7"
+       xlink:href="#linearGradient4188-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4-3">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-6-1" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-6-0-7"
+       id="linearGradient4582-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.9964775,1034.2996)"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-6-0-7">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-4-6-2" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-7-4-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.26"
+       x2="25.930252"
+       y1="1051.1136"
+       x1="25.930252"
+       gradientTransform="translate(-16.972268,-1.9999972)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4609"
+       xlink:href="#linearGradient4266-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(3.0277276,1034.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4553-7-7"
+       xlink:href="#linearGradient4188-4-3-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4-3-7">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-6-1-0" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4-6-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-6-0-7-5"
+       id="linearGradient4582-4-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.9964775,1032.2996)"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-6-0-7-5">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-4-6-2-6" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-7-4-6-4" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(3.0277276,1032.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3262"
+       xlink:href="#linearGradient4188-4-3-7"
+       inkscape:collect="always" />
+    <mask
+       id="mask4181"
+       maskUnits="userSpaceOnUse">
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="path4183"
+         d="m 3.5193795,1037.8597 7.0096695,0 3.062057,3.0066 0,9.9546 -10.0717265,0 z"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <filter
+       height="1.240301"
+       y="-0.12015051"
+       width="1.2396997"
+       x="-0.11984986"
+       id="filter4177"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur4179"
+         stdDeviation="0.40384366"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       id="linearGradient5300-6-8">
+      <stop
+         id="stop5302-7-1"
+         offset="0"
+         style="stop-color:#4d4d4d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#727272;stop-opacity:1;"
+         offset="0.29405674"
+         id="stop5308-2-6" />
+      <stop
+         id="stop5304-3-8"
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5300-6-8"
+       id="linearGradient3208-6"
+       gradientUnits="userSpaceOnUse"
+       x1="2.65625"
+       y1="1049.3976"
+       x2="4.0822439"
+       y2="1050.5304" />
+    <linearGradient
+       id="linearGradient5077-5-8-7">
+      <stop
+         id="stop5079-7-9-4"
+         offset="0"
+         style="stop-color:#e4cf94;stop-opacity:1" />
+      <stop
+         style="stop-color:#ede0ba;stop-opacity:1"
+         offset="0.32186735"
+         id="stop5087-6-0-2" />
+      <stop
+         style="stop-color:#c1aa7e;stop-opacity:1"
+         offset="0.64764118"
+         id="stop5085-1-4-6" />
+      <stop
+         id="stop5081-8-7-6"
+         offset="1"
+         style="stop-color:#ad8865;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4902-3-3"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-7"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2-6"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.977903,-1.044194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-4"
+       xlink:href="#linearGradient4902-3-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5300-6">
+      <stop
+         id="stop5302-7"
+         offset="0"
+         style="stop-color:#4d4d4d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#727272;stop-opacity:1;"
+         offset="0.29405674"
+         id="stop5308-2" />
+      <stop
+         id="stop5304-3"
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1050.5304"
+       x2="4.0822439"
+       y1="1049.3976"
+       x1="2.65625"
+       id="linearGradient5306-8"
+       xlink:href="#linearGradient5300-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5077-5-8">
+      <stop
+         id="stop5079-7-9"
+         offset="0"
+         style="stop-color:#e4cf94;stop-opacity:1" />
+      <stop
+         style="stop-color:#ede0ba;stop-opacity:1"
+         offset="0.32186735"
+         id="stop5087-6-0" />
+      <stop
+         style="stop-color:#c1aa7e;stop-opacity:1"
+         offset="0.64764118"
+         id="stop5085-1-4" />
+      <stop
+         id="stop5081-8-7"
+         offset="1"
+         style="stop-color:#ad8865;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5077-5">
+      <stop
+         id="stop5079-7"
+         offset="0"
+         style="stop-color:#e4cf94;stop-opacity:1" />
+      <stop
+         style="stop-color:#ede0ba;stop-opacity:1"
+         offset="0.32186735"
+         id="stop5087-6" />
+      <stop
+         style="stop-color:#c1aa7e;stop-opacity:1"
+         offset="0.64764118"
+         id="stop5085-1" />
+      <stop
+         id="stop5081-8"
+         offset="1"
+         style="stop-color:#ad8865;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5300">
+      <stop
+         id="stop5302"
+         offset="0"
+         style="stop-color:#4d4d4d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#727272;stop-opacity:1;"
+         offset="0.29405674"
+         id="stop5308" />
+      <stop
+         id="stop5304"
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-14.678348,-0.26294396)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-6-5"
+       id="linearGradient4101-1"
+       gradientUnits="userSpaceOnUse"
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378" />
+    <linearGradient
+       id="linearGradient4994-6-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-1-4"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1;" />
+      <stop
+         id="stop4998-89-1"
+         offset="1"
+         style="stop-color:#dce7f7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientTransform="translate(-1.986544,-1.0535)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3526-9"
+       xlink:href="#linearGradient4994-6-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4994-6-5-8"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-1-4-1"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1;" />
+      <stop
+         id="stop4998-89-1-0"
+         offset="1"
+         style="stop-color:#dce7f7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.986544,-1.0535)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-8-8"
+       xlink:href="#linearGradient4902-3-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4902-3-1-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-9-9"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2-5-7"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientTransform="translate(-1.986544,-1.0535)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3575"
+       xlink:href="#linearGradient4994-6-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1047.26"
+       x2="25.930252"
+       y1="1051.1136"
+       x1="25.930252"
+       gradientTransform="translate(-16.972268,-1.9999972)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4609-3"
+       xlink:href="#linearGradient4266-4-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266-4-6">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268-6-3" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270-39-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.986544,-1.0535)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-8-8-7"
+       xlink:href="#linearGradient4902-3-1-1-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4902-3-1-1-9"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-9-9-1"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2-5-7-8"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter4480"
+       x="-0.10472362"
+       width="1.2094472"
+       y="-0.14049438"
+       height="1.2809888">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.35055525"
+         id="feGaussianBlur4482" />
+    </filter>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4487">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4489"
+         d="m 3.5107388,1037.8693 9.9833382,0 0,12.9865 -9.9833382,0 z"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter4339-7"
+       x="-0.090256117"
+       width="1.1805122"
+       y="-0.17898419"
+       height="1.3579684">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.27970009"
+         id="feGaussianBlur4341-1" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       id="filter4564"
+       x="-0.12776479"
+       width="1.2555296"
+       y="-0.11312493"
+       height="1.2262499">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.57699396"
+         id="feGaussianBlur4566" />
+    </filter>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4578">
+      <g
+         id="g4580">
+        <rect
+           y="1042.8712"
+           x="6.484375"
+           height="5.9883718"
+           width="8.0338383"
+           id="rect4582"
+           style="fill:#f1f5fa;fill-opacity:1;stroke:#ffffff;stroke-opacity:1;display:inline" />
+        <path
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+           d="m 3.5107388,1037.8693 9.9833382,0 0,12.9865 -9.9833382,0 z"
+           id="path4584"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+      </g>
+    </mask>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="5.8677761"
+     inkscape:cy="11.600448"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="23"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3"
+       d="m 3.5107388,1037.8504 9.5841942,0 0.487532,3.0066 0,9.9546 -10.0717262,0 z"
+       style="fill:url(#linearGradient3575);fill-opacity:1;stroke:none;display:inline" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001"
+       d="m 3.5107388,1037.8693 9.9833382,0 0,12.9865 -9.9833382,0 z"
+       style="fill:none;stroke:url(#linearGradient4908-2-8-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    <g
+       id="g4484"
+       mask="url(#mask4487)"
+       style="opacity:0.5">
+      <rect
+         y="1042.8712"
+         x="6.484375"
+         height="5.9883718"
+         width="8.0338383"
+         id="rect4264-4-5"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;filter:url(#filter4480)" />
+    </g>
+    <rect
+       style="fill:#f1f5fa;fill-opacity:1;stroke:url(#linearGradient4609);stroke-opacity:1;display:inline"
+       id="rect4264"
+       width="8.0338383"
+       height="5.9883718"
+       x="6.484375"
+       y="1042.8712" />
+    <rect
+       style="fill:url(#linearGradient4553-7);fill-opacity:1;stroke:none;display:inline"
+       id="rect4178"
+       width="3.0277271"
+       height="0.9999826"
+       x="10"
+       y="1046.3622" />
+    <rect
+       style="fill:url(#linearGradient4582-4);fill-opacity:1;stroke:none;display:inline"
+       id="rect4178-9"
+       width="1"
+       height="0.9999826"
+       x="8"
+       y="1046.3622" />
+    <g
+       style="display:inline"
+       id="layer1-5"
+       inkscape:label="Layer 1"
+       transform="translate(-10.051944,2.8637517)" />
+    <rect
+       style="fill:url(#linearGradient3262);fill-opacity:1;stroke:none;display:inline"
+       id="rect4178-1"
+       width="3.0277271"
+       height="0.9999826"
+       x="10"
+       y="1044.3622" />
+    <rect
+       style="fill:url(#linearGradient4582-4-4);fill-opacity:1;stroke:none;display:inline"
+       id="rect4178-9-7"
+       width="1"
+       height="0.9999826"
+       x="8"
+       y="1044.3622" />
+    <g
+       id="g4568"
+       mask="url(#mask4578)"
+       style="opacity:0.5">
+      <g
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:2.58440065000000008;stroke-miterlimit:4;stroke-dasharray:none;display:inline;filter:url(#filter4564)"
+         id="layer1-7-1"
+         inkscape:label="Layer 1"
+         transform="matrix(0.7738738,0,0,0.7738738,-2.6348376,234.78238)">
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="path4108-1-3-9"
+           d="m 6.6568452,1049.5614 c 0.2150324,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133512,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.58440065000000008;stroke-miterlimit:4;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="path4108-1-3-4-1"
+           d="m 6.6568452,1049.5614 c 0.2150325,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133511,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.58440065000000008;stroke-miterlimit:4;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="path4108-1-2"
+           d="m 6.6568452,1049.5614 c 0.2150324,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133512,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:2.58440065000000008;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <rect
+           y="1042.3649"
+           x="10.31146"
+           height="1.1992624"
+           width="0.94941604"
+           id="rect4122-9"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.58440065000000008;stroke-miterlimit:4;stroke-dasharray:none" />
+        <rect
+           y="1046.1245"
+           x="10.304321"
+           height="1.1992624"
+           width="0.94941604"
+           id="rect4122-2-9"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.58440065000000008;stroke-miterlimit:4;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4108-1-3-4-6-9"
+           d="m 11.90625,1043.0312 2.28125,1.8438 -2.28125,1.7812 0,-1.0937 -1.21875,-0.062 c 0,0 -1.1298804,-0.1 -2.375,0.3125 -0.4970996,0.1646 -1.0141192,0.5483 -1.5,0.9687 -9.736e-4,-0.029 -0.06306,-0.097 -0.0625,-0.125 0.00915,-0.4526 0.1773911,-0.7816 0.5625,-1.1562 0.7702178,-0.7493 2.483426,-1.2754 3.3125,-1.2812 l 1.28125,0 0,-1.1876 z"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2.58440065000000008;stroke-miterlimit:4;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;filter:url(#filter4339-7);enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+      </g>
+    </g>
+    <g
+       transform="matrix(0.7738738,0,0,0.7738738,-2.6348376,234.78238)"
+       inkscape:label="Layer 1"
+       id="layer1-7"
+       style="display:inline">
+      <path
+         style="fill:#abca52;fill-opacity:1;stroke:none;display:inline"
+         d="m 6.6568452,1049.5614 c 0.2150324,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133512,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+         id="path4108-1-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="fill:url(#linearGradient4349);fill-opacity:1;stroke:none;display:inline"
+         d="m 6.6568452,1049.5614 c 0.2150325,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133511,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+         id="path4108-1-3-4"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4112);stroke-width:1.29220033;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         d="m 6.6568452,1049.5614 c 0.2150324,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133512,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+         id="path4108-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <rect
+         style="fill:#2f9353;fill-opacity:1;stroke:none"
+         id="rect4122"
+         width="0.94941604"
+         height="1.1992624"
+         x="10.31146"
+         y="1042.3649" />
+      <rect
+         style="fill:#1d7a42;fill-opacity:1;stroke:none;display:inline"
+         id="rect4122-2"
+         width="0.94941604"
+         height="1.1992624"
+         x="10.304321"
+         y="1046.1245" />
+      <rect
+         style="fill:none;stroke:none"
+         id="rect4176"
+         width="1"
+         height="1"
+         x="4"
+         y="12"
+         transform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#cfdc63;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.58440065;marker:none;visibility:visible;display:inline;overflow:visible;filter:url(#filter4339);enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 11.90625,1043.0312 2.28125,1.8438 -2.28125,1.7812 0,-1.0937 -1.21875,-0.062 c 0,0 -1.1298804,-0.1 -2.375,0.3125 -0.4970996,0.1646 -1.0141192,0.5483 -1.5,0.9687 -9.736e-4,-0.029 -0.06306,-0.097 -0.0625,-0.125 0.00915,-0.4526 0.1773911,-0.7816 0.5625,-1.1562 0.7702178,-0.7493 2.483426,-1.2754 3.3125,-1.2812 l 1.28125,0 0,-1.1876 z"
+         id="path4108-1-3-4-6"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       style="display:inline"
+       id="layer1-6"
+       inkscape:label="Layer 1"
+       transform="translate(12.691804,-0.7906004)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/date_obj.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/date_obj.svg
@@ -1,0 +1,332 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="date_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3821">
+      <stop
+         style="stop-color:#6e7a8e;stop-opacity:1;"
+         offset="0"
+         id="stop3823" />
+      <stop
+         style="stop-color:#a79c68;stop-opacity:1"
+         offset="1"
+         id="stop3825" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3813">
+      <stop
+         style="stop-color:#55a4db;stop-opacity:1"
+         offset="0"
+         id="stop3815" />
+      <stop
+         style="stop-color:#c7e0f5;stop-opacity:1"
+         offset="1"
+         id="stop3817" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3797">
+      <stop
+         style="stop-color:#2b568d;stop-opacity:1"
+         offset="0"
+         id="stop3799" />
+      <stop
+         style="stop-color:#5176a8;stop-opacity:1"
+         offset="1"
+         id="stop3801" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13831">
+      <stop
+         style="stop-color:#055797;stop-opacity:1;"
+         offset="0"
+         id="stop13833" />
+      <stop
+         style="stop-color:#184785;stop-opacity:1"
+         offset="1"
+         id="stop13835" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13755">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757" />
+      <stop
+         id="stop13765"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13755"
+       id="linearGradient8584"
+       gradientUnits="userSpaceOnUse"
+       x1="28.004765"
+       y1="-5.6084509"
+       x2="28.004765"
+       y2="1.6087028" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13831"
+       id="linearGradient8586"
+       gradientUnits="userSpaceOnUse"
+       x1="30.033665"
+       y1="-6.1109905"
+       x2="30.033665"
+       y2="1.9089624" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797"
+       id="linearGradient3803"
+       x1="9.2568913"
+       y1="1054.2682"
+       x2="17.34898"
+       y2="1054.2682"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3813"
+       id="linearGradient3819"
+       x1="9.2256413"
+       y1="1055.7682"
+       x2="17.220118"
+       y2="1055.7682"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3821"
+       id="linearGradient3827"
+       x1="13.376367"
+       y1="1064.095"
+       x2="13.376367"
+       y2="1057.1886"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3821-8"
+       id="linearGradient3827-0"
+       x1="13.376367"
+       y1="1064.095"
+       x2="13.376367"
+       y2="1057.1886"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3821-8">
+      <stop
+         style="stop-color:#6e7a8e;stop-opacity:1;"
+         offset="0"
+         id="stop3823-0" />
+      <stop
+         style="stop-color:#a79c68;stop-opacity:1"
+         offset="1"
+         id="stop3825-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13755-7">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757-5" />
+      <stop
+         id="stop13765-2"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763-2"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759-3" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter3952"
+       x="-0.136875"
+       width="1.27375"
+       y="-0.10682927"
+       height="1.2136585">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.39921875"
+         id="feGaussianBlur3954" />
+    </filter>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask3959">
+      <g
+         style="fill:#ffffff;stroke:#ffffff;display:inline"
+         id="g3961"
+         transform="translate(-34.986137,7.993719)">
+        <path
+           transform="matrix(1.247029,0,0,1.247029,21.297363,1050.2608)"
+           d="m 30,-2 c 0,2.209139 -1.790861,4 -4,4 -2.209139,0 -4,-1.790861 -4,-4 0,-2.209139 1.790861,-4 4,-4 2.209139,0 4,1.790861 4,4 z"
+           sodipodi:ry="4"
+           sodipodi:rx="4"
+           sodipodi:cy="-2"
+           sodipodi:cx="26"
+           id="path3963"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.80190599;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path3965"
+           d="m 53.750446,1047.7972 0,-2.0313"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path3967"
+           d="m 53.750446,1047.7972 1.458408,2.3881"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      </g>
+    </mask>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.999999"
+     inkscape:cx="6.5503944"
+     inkscape:cy="-0.6197633"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="851"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4092"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <g
+         id="g8579"
+         transform="translate(-34.986137,7.9937193)">
+        <path
+           transform="matrix(1.247029,0,0,1.247029,21.297363,1050.2608)"
+           d="m 30,-2 c 0,2.209139 -1.790861,4 -4,4 -2.209139,0 -4,-1.790861 -4,-4 0,-2.209139 1.790861,-4 4,-4 2.209139,0 4,1.790861 4,4 z"
+           sodipodi:ry="4"
+           sodipodi:rx="4"
+           sodipodi:cy="-2"
+           sodipodi:cx="26"
+           id="path13745"
+           style="fill:url(#linearGradient8584);fill-opacity:1;stroke:url(#linearGradient8586);stroke-width:0.80190599;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path13811"
+           d="m 53.750446,1047.7972 0,-2.0313"
+           style="fill:none;stroke:#1f4a83;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path13811-9"
+           d="m 53.750446,1047.7972 1.458408,2.3881"
+           style="fill:none;stroke:#1f4a83;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      </g>
+      <g
+         id="g3956"
+         mask="url(#mask3959)"
+         style="opacity:0.75">
+        <path
+           id="rect3009-7-6"
+           transform="translate(8.2201163,1049.2669)"
+           d="M 1.5 5.5 L 1.5 7.5 L 1.5 14.46875 L 8.5 14.46875 L 8.5 7.5 L 8.5 5.5 L 1.5 5.5 z "
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;filter:url(#filter3952)" />
+      </g>
+      <rect
+         style="fill:#ebf9ff;fill-opacity:1;stroke:url(#linearGradient3827);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         id="rect3009-7"
+         width="7"
+         height="8.96875"
+         x="9.7201166"
+         y="1054.7668" />
+      <rect
+         style="fill:url(#linearGradient3819);fill-opacity:1;stroke:url(#linearGradient3803);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="rect3009"
+         width="6.9944768"
+         height="1.9973192"
+         x="9.7256413"
+         y="1054.7695" />
+      <path
+         style="fill:none;stroke:#2b568d;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 11.720115,1058.2747 0,3.9922"
+         id="path3829"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#2b568d;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 13.216193,1058.7606 1.502602,0 0,0.9489 -0.99319,1.1104 0,0.946 1.512472,0"
+         id="path3831"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/error_obj.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/error_obj.svg
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="error_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4880">
+      <stop
+         style="stop-color:#c93e35;stop-opacity:1;"
+         offset="0"
+         id="stop4882" />
+      <stop
+         style="stop-color:#c8192a;stop-opacity:1"
+         offset="1"
+         id="stop4884" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1"
+       id="linearGradient8163-2"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="477.77817"
+       x2="388.63736"
+       y2="458.68076" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1">
+      <stop
+         style="stop-color:#eb6d71;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8"
+         offset="0.5"
+         style="stop-color:#f13f53;stop-opacity:1" />
+      <stop
+         style="stop-color:#f7a29a;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4880"
+       id="linearGradient4886"
+       x1="393.43765"
+       y1="458.68076"
+       x2="393.43765"
+       y2="477.77817"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4880-4">
+      <stop
+         style="stop-color:#c93e35;stop-opacity:1;"
+         offset="0"
+         id="stop4882-5" />
+      <stop
+         style="stop-color:#c8192a;stop-opacity:1"
+         offset="1"
+         id="stop4884-5" />
+    </linearGradient>
+    <linearGradient
+       y2="477.77817"
+       x2="393.43765"
+       y1="458.68076"
+       x1="393.43765"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4986"
+       xlink:href="#linearGradient4880-4"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142135"
+     inkscape:cx="-30.039703"
+     inkscape:cy="80.717213"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="38"
+     inkscape:window-y="13"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4099" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient8163-2);fill-opacity:1;stroke:url(#linearGradient4886);stroke-width:2.10502887;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+         id="path10796-2-6-0"
+         sodipodi:cx="388.125"
+         sodipodi:cy="468.23718"
+         sodipodi:rx="10.625"
+         sodipodi:ry="10.625"
+         d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+         transform="matrix(0.47126833,0,0,0.47126833,-166.19459,836.10518)" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="M 11,3.15625 5,10.34375 5,11 l 0.75,0 5.9375,-7.09375 0,-0.75 z"
+         transform="translate(8.2201163,1049.2669)"
+         id="path4911-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 14.1875,1053.25 0.0625,1 c 0.22353,-0.011 0.341247,0.031 0.46875,0.125 0.127503,0.094 0.253587,0.2612 0.375,0.5 0.242825,0.4777 0.429979,1.2198 0.65625,2 0.226271,0.7802 0.505095,1.6148 1.03125,2.2812 0.526155,0.6665 1.365276,1.1485 2.46875,1.125 l -0.03125,-1 c -0.837969,0.018 -1.282983,-0.2771 -1.65625,-0.75 -0.373267,-0.4728 -0.626513,-1.1884 -0.84375,-1.9374 -0.217237,-0.7491 -0.387875,-1.5054 -0.71875,-2.1563 -0.165437,-0.3254 -0.38571,-0.6529 -0.6875,-0.875 -0.30179,-0.2221 -0.70353,-0.333 -1.125,-0.3125 z"
+         id="path4911-7-4"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:none;fill-opacity:1;stroke:url(#linearGradient4986);stroke-width:2.10502886999999990;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+         id="path10796-2-6-0-1"
+         sodipodi:cx="388.125"
+         sodipodi:cy="468.23718"
+         sodipodi:rx="10.625"
+         sodipodi:ry="10.625"
+         d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+         transform="matrix(0.47126833,0,0,0.47126833,-166.19459,836.10518)" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/fatalerror_obj.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/fatalerror_obj.svg
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="fatalerror_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4879">
+      <stop
+         style="stop-color:#ce2837;stop-opacity:1;"
+         offset="0"
+         id="stop4881" />
+      <stop
+         style="stop-color:#cf5a52;stop-opacity:1"
+         offset="1"
+         id="stop4883" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1"
+       id="linearGradient8163-2"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="477.79834"
+       x2="388.63736"
+       y2="458.70731" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1">
+      <stop
+         style="stop-color:#e96a6e;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8"
+         offset="0.5"
+         style="stop-color:#eb5560;stop-opacity:1" />
+      <stop
+         style="stop-color:#eb7c7c;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4879"
+       id="linearGradient4885"
+       x1="397.69363"
+       y1="477.79834"
+       x2="397.69363"
+       y2="456.58609"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313709"
+     inkscape:cx="27.351078"
+     inkscape:cy="-0.87515569"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="44"
+     inkscape:window-y="361"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4109" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient8163-2);fill-opacity:1;stroke:url(#linearGradient4885);stroke-width:2.10925341000000000;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+         id="path10796-2-6-0"
+         sodipodi:cx="388.125"
+         sodipodi:cy="468.23718"
+         sodipodi:rx="10.625"
+         sodipodi:ry="10.625"
+         d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+         transform="matrix(0.47142583,0,0,0.47142583,-166.26294,836.02042)" />
+      <g
+         id="g5025"
+         transform="matrix(1.1880342,0,0,1.1860465,34.354445,-196.67175)" />
+      <rect
+         style="fill:#ffffff;fill-opacity:1;stroke:none"
+         id="rect4110"
+         width="6.9375"
+         height="2.1461332"
+         x="13.251367"
+         y="1055.6937" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/file_change.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/file_change.svg
@@ -1,0 +1,2022 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="file_change.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4343">
+      <stop
+         style="stop-color:#96b956;stop-opacity:1"
+         offset="0"
+         id="stop4345" />
+      <stop
+         style="stop-color:#abca52;stop-opacity:1"
+         offset="1"
+         id="stop4347" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4106">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1;"
+         offset="0"
+         id="stop4108" />
+      <stop
+         style="stop-color:#146d39;stop-opacity:1"
+         offset="1"
+         id="stop4110" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 8 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="16 : 8 : 1"
+       inkscape:persp3d-origin="8 : 5.3333333 : 1"
+       id="perspective3519" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12886-6-7-7"
+       x1="393.4772"
+       y1="375.17487"
+       x2="379.65567"
+       y2="371.10898"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1-8-7">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3-6-2" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4-9-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12884-4-7-0"
+       x1="395.68689"
+       y1="379.50586"
+       x2="385.57773"
+       y2="388.69827"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12882-2-0-9"
+       x1="404.8793"
+       y1="389.22861"
+       x2="397.7753"
+       y2="400.10037"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12880-3-5-6"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12878-2-7-1"
+       x1="413.01102"
+       y1="366.6012"
+       x2="429.94864"
+       y2="364.92181"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12876-4-0-6"
+       x1="674.84711"
+       y1="180.63965"
+       x2="675.20258"
+       y2="166.79221"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12868-4-7-0"
+       x1="396.0101"
+       y1="359.4902"
+       x2="396.21149"
+       y2="350.94641"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12888-3-7-3"
+       x1="390.38361"
+       y1="362.80048"
+       x2="381.86542"
+       y2="360.85596"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       r="12.952347"
+       fy="420.74988"
+       fx="433.5452"
+       cy="420.74988"
+       cx="433.5452"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient12821-7-6-3"
+       xlink:href="#linearGradient12717-5-0-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-5-0-4-3">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-6-3-0-0" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-9-4-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12896-6-4-1"
+       x1="427.53012"
+       y1="432.76639"
+       x2="425.4519"
+       y2="415.1088"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-5-0-4-3"
+       id="radialGradient12723-8-2-4-1"
+       cx="433.36786"
+       cy="424.34106"
+       fx="433.36786"
+       fy="424.34106"
+       r="12.027534"
+       gradientTransform="matrix(1.1614831,2.1855961e-7,-2.811228e-7,1.4939602,-69.981471,-211.63828)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="translate(3.974778e-6,-9.8142563e-6)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient12725-9-4-7-2"
+       id="linearGradient12731-1-9-5-9"
+       x1="683.16229"
+       y1="205.72604"
+       x2="661.94519"
+       y2="183.18417"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12725-9-4-7-2">
+      <stop
+         style="stop-color:#397b3b;stop-opacity:1;"
+         offset="0"
+         id="stop12727-3-9-8-9" />
+      <stop
+         style="stop-color:#397b3b;stop-opacity:0;"
+         offset="1"
+         id="stop12729-4-1-8-3" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="455.88452"
+       x1="420.88995"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4046"
+       xlink:href="#linearGradient12862-1-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7584-9-3">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-6-3" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-9-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-0-5">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-8-9" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-5-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4216-0"
+       id="linearGradient4382"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       x1="393.36197"
+       y1="381.15457"
+       x2="385.57773"
+       y2="388.69827" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4234-5">
+      <stop
+         style="stop-color:#203932;stop-opacity:1"
+         offset="0"
+         id="stop4236-7" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4238-1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       y2="364.92181"
+       x2="429.94864"
+       y1="366.6012"
+       x1="413.01102"
+       id="linearGradient12878-2-7-1-2-8-9"
+       xlink:href="#linearGradient4234-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4240-5">
+      <stop
+         style="stop-color:#284539;stop-opacity:1"
+         offset="0"
+         id="stop4242-0" />
+      <stop
+         style="stop-color:#385653;stop-opacity:1"
+         offset="1"
+         id="stop4244-3" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="166.79221"
+       x2="675.20258"
+       y1="180.63965"
+       x1="674.84711"
+       id="linearGradient12876-4-0-6-7-3-6"
+       xlink:href="#linearGradient4240-5"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.60364,-39.53384)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4198-8">
+      <stop
+         style="stop-color:#2d483d;stop-opacity:1"
+         offset="0"
+         id="stop4200-3" />
+      <stop
+         style="stop-color:#38564e;stop-opacity:1"
+         offset="1"
+         id="stop4202-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.60473,-96.3391)"
+       gradientUnits="userSpaceOnUse"
+       y2="350.94641"
+       x2="396.21149"
+       y1="359.4902"
+       x1="396.0101"
+       id="linearGradient12868-4-7-0-8-7-6"
+       xlink:href="#linearGradient4198-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4204-6">
+      <stop
+         style="stop-color:#28483d;stop-opacity:1"
+         offset="0"
+         id="stop4206-3" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4208-8" />
+    </linearGradient>
+    <linearGradient
+       y2="360.85596"
+       x2="381.86542"
+       y1="362.80048"
+       x1="390.38361"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4091-0"
+       xlink:href="#linearGradient4204-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4210-9">
+      <stop
+         style="stop-color:#284539;stop-opacity:1"
+         offset="0"
+         id="stop4212-8" />
+      <stop
+         style="stop-color:#385653;stop-opacity:1"
+         offset="1"
+         id="stop4214-5" />
+    </linearGradient>
+    <linearGradient
+       y2="371.10898"
+       x2="379.65567"
+       y1="375.17487"
+       x1="393.4772"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4100-2"
+       xlink:href="#linearGradient4210-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4216-0">
+      <stop
+         style="stop-color:#233e32;stop-opacity:1"
+         offset="0"
+         id="stop4218-3" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:0.8650133"
+         offset="1"
+         id="stop4220-8" />
+    </linearGradient>
+    <linearGradient
+       y2="388.69827"
+       x2="385.57773"
+       y1="381.15457"
+       x1="393.36197"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,940.00748)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4097-3"
+       xlink:href="#linearGradient4216-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4222-4">
+      <stop
+         style="stop-color:#203c37;stop-opacity:1"
+         offset="0"
+         id="stop4224-9" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4226-6" />
+    </linearGradient>
+    <linearGradient
+       y2="399.07361"
+       x2="396.94577"
+       y1="388.32217"
+       x1="400.52957"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4094-1"
+       xlink:href="#linearGradient4222-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4228-4">
+      <stop
+         style="stop-color:#203932;stop-opacity:1"
+         offset="0"
+         id="stop4230-4" />
+      <stop
+         style="stop-color:#314e4a;stop-opacity:1"
+         offset="1"
+         id="stop4232-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4228-4"
+       id="linearGradient4141-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4252-7">
+      <stop
+         style="stop-color:#1d6279;stop-opacity:1"
+         offset="0"
+         id="stop4254-1" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4256-4" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="447.02145"
+       x1="427.92853"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4190-8"
+       xlink:href="#linearGradient4252-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4258-3">
+      <stop
+         style="stop-color:#387a31;stop-opacity:1"
+         offset="0"
+         id="stop4260-4" />
+      <stop
+         style="stop-color:#397b3b;stop-opacity:0;"
+         offset="1"
+         id="stop4262-6" />
+    </linearGradient>
+    <linearGradient
+       y2="183.92403"
+       x2="666.19678"
+       y1="204.12044"
+       x1="684.11578"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.8909,996.82836)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4086-5"
+       xlink:href="#linearGradient4258-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="415.1088"
+       x2="425.4519"
+       y1="432.76639"
+       x1="427.53012"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4196"
+       xlink:href="#linearGradient4246"
+       inkscape:collect="always" />
+    <radialGradient
+       r="12.952347"
+       fy="420.74988"
+       fx="433.5452"
+       cy="420.74988"
+       cx="433.5452"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4194"
+       xlink:href="#linearGradient12717-5-0-4-3-4"
+       inkscape:collect="always" />
+    <radialGradient
+       r="12.027534"
+       fy="424.34106"
+       fx="433.36789"
+       cy="424.34106"
+       cx="433.36789"
+       gradientTransform="matrix(1.2231981,-0.08344257,0.10167677,1.4904962,-139.87254,-174.00694)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4192"
+       xlink:href="#linearGradient4515"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="447.02145"
+       x1="427.92853"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4190"
+       xlink:href="#linearGradient4252"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-75-5"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-4-2"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-16-6"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-75-5"
+       id="linearGradient3993-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       y2="183.92403"
+       x2="666.19678"
+       y1="204.12044"
+       x1="684.11578"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.8909,996.82836)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4086"
+       xlink:href="#linearGradient4258"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4472"
+       id="linearGradient3993"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-7-5"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-1-6"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-12-9"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-7-5"
+       id="linearGradient3915-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.27903302,0.27903303,0,-96.327735,115.6161)"
+       x1="396.0101"
+       y1="359.4902"
+       x2="396.21149"
+       y2="350.94641" />
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.60473,-96.339099)"
+       gradientUnits="userSpaceOnUse"
+       y2="350.94641"
+       x2="396.21149"
+       y1="359.4902"
+       x1="396.0101"
+       id="linearGradient12868-4-7-0-8"
+       xlink:href="#linearGradient4490"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="166.79221"
+       x2="675.20258"
+       y1="180.63965"
+       x1="674.84711"
+       id="linearGradient12876-4-0-6-7"
+       xlink:href="#linearGradient4484"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.60364,-39.53384)" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-9-7"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-8-0"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-0-6"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-9-7"
+       id="linearGradient3813-8"
+       gradientUnits="userSpaceOnUse"
+       x1="674.84711"
+       y1="180.63965"
+       x2="675.20258"
+       y2="166.79221"
+       gradientTransform="matrix(0,0.27903302,0.24756874,0,-39.521247,-178.59954)" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-1-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-9-6"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-1-4"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-1-9"
+       id="linearGradient3847-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.27903302,0.27903303,0,-96.353305,-104.6999)"
+       x1="413.01102"
+       y1="366.6012"
+       x2="429.94864"
+       y2="364.92181" />
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       gradientUnits="userSpaceOnUse"
+       y2="364.92181"
+       x2="429.94864"
+       y1="366.6012"
+       x1="413.01102"
+       id="linearGradient12878-2-7-1-2"
+       xlink:href="#linearGradient4478"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-75"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-4"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-16"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,264.63772,-229.51558)"
+       gradientUnits="userSpaceOnUse"
+       y2="381.80399"
+       x2="432.86548"
+       y1="378.7988"
+       x1="420.52402"
+       id="linearGradient12880-3-5-6-9"
+       xlink:href="#linearGradient12862-1-8-7-75"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-96-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-86-2"
+         offset="0"
+         style="stop-color:#203932;stop-opacity:1" />
+      <stop
+         id="stop12866-4-9-5-8-9"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-96-9"
+       id="linearGradient3881-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.27903302,0.27903303,0,-96.392939,-104.7384)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-7"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-1"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-12"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,265.19769,-229.45247)"
+       gradientUnits="userSpaceOnUse"
+       y2="350.94641"
+       x2="396.21149"
+       y1="359.4902"
+       x1="396.0101"
+       id="linearGradient12868-4-7-0-0"
+       xlink:href="#linearGradient12862-1-8-7-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-96"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-86"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-8"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,264.63772,-229.51558)"
+       gradientUnits="userSpaceOnUse"
+       y2="381.80399"
+       x2="432.86548"
+       y1="378.7988"
+       x1="420.52402"
+       id="linearGradient12880-3-5-6-6"
+       xlink:href="#linearGradient12862-1-8-7-96"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-1"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-9"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-1"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,264.63772,-229.51558)"
+       gradientUnits="userSpaceOnUse"
+       y2="364.92181"
+       x2="429.94864"
+       y1="366.6012"
+       x1="413.01102"
+       id="linearGradient12878-2-7-1-1"
+       xlink:href="#linearGradient12862-1-8-7-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-8"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-0"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="166.79221"
+       x2="675.20258"
+       y1="180.63965"
+       x1="674.84711"
+       id="linearGradient12876-4-0-6-3"
+       xlink:href="#linearGradient12862-1-8-7-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12717-5-0-4-3-4"
+       inkscape:collect="always">
+      <stop
+         id="stop12719-6-3-0-0-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop12721-9-4-5-0-6"
+         offset="1"
+         style="stop-color:#8ebc7b;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4246">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4248" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4250" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4252">
+      <stop
+         style="stop-color:#0d5269;stop-opacity:1"
+         offset="0"
+         id="stop4254" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4256" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4258">
+      <stop
+         style="stop-color:#387a31;stop-opacity:1"
+         offset="0"
+         id="stop4260" />
+      <stop
+         style="stop-color:#397b3b;stop-opacity:0;"
+         offset="1"
+         id="stop4262" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4472">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4474" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4476" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4478">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4480" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4482" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4484">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4486" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4488" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4490">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4492" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4494" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4515">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4517" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop4519" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4515-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4517-7" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop4519-4" />
+    </linearGradient>
+    <mask
+       id="mask7862"
+       maskUnits="userSpaceOnUse">
+      <g
+         id="g7864">
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.5;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           d="m 11.5,1039.6591 c -0.18722,10e-5 -0.383743,0.04 -0.65625,0.094 l 0,0.875 c -0.213492,0.042 -0.422114,0.072 -0.625,0.1562 -0.194391,0.083 -0.388449,0.2275 -0.5625,0.3438 l -0.625,-0.6252 c -0.462167,0.3084 -0.597312,0.4445 -0.90625,0.9062 l 0.625,0.625 c -0.121067,0.1808 -0.2597,0.3909 -0.34375,0.5938 -0.08385,0.2029 -0.113627,0.4115 -0.15625,0.625 l -0.90625,0 c -0.108682,0.5449 -0.108112,0.7362 0,1.2812 l 0.90625,0 c 0.08465,0.427 0.258374,0.8566 0.5,1.2188 l -0.625,0.5937 c 0.308933,0.4619 0.444082,0.5977 0.90625,0.9063 l 0.625,-0.5938 c 0.361804,0.2421 0.760581,0.4148 1.1875,0.5 l 0,0.875 c 0.545014,0.1081 0.76758,0.1087 1.3125,0 l 0,-0.875 c 0.426989,-0.085 0.8255,-0.2582 1.1875,-0.5 l 0.625,0.5938 c 0.46183,-0.309 0.597782,-0.4441 0.90625,-0.9063 l -0.625,-0.5937 c 0.242113,-0.3618 0.414842,-0.792 0.5,-1.2188 l 0.90625,0 c 0.108112,-0.545 0.108682,-0.7363 0,-1.2812 l -0.90625,0 c -0.08469,-0.4271 -0.258169,-0.8568 -0.5,-1.2188 l 0.625,-0.625 c -0.154067,-0.2313 -0.242615,-0.3988 -0.375,-0.5312 -0.13245,-0.1323 -0.299966,-0.2209 -0.53125,-0.375 l -0.625,0.625 c -0.361809,-0.2421 -0.760526,-0.415 -1.1875,-0.5 l 0,-0.875 c -0.27246,-0.054 -0.46903,-0.094 -0.65625,-0.094 z m 0,3.3125 c 0.500508,0 0.90625,0.4057 0.90625,0.9063 0,0.5005 -0.405742,0.9062 -0.90625,0.9062 -0.500508,0 -0.90625,-0.4057 -0.90625,-0.9062 0,-0.5006 0.405742,-0.9063 0.90625,-0.9063 z"
+           id="path7866"
+           inkscape:connector-curvature="0" />
+      </g>
+    </mask>
+    <linearGradient
+       id="linearGradient5103">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105" />
+      <stop
+         id="stop7550"
+         offset="0.26694915"
+         style="stop-color:#fef5d4;stop-opacity:1" />
+      <stop
+         id="stop7548"
+         offset="0.51694918"
+         style="stop-color:#fbe08e;stop-opacity:1" />
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="1"
+         id="stop5107" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5281">
+      <stop
+         id="stop5283"
+         offset="0"
+         style="stop-color:#e0b575;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f5ca75;stop-opacity:1"
+         offset="0.5"
+         id="stop5289" />
+      <stop
+         id="stop5285"
+         offset="1"
+         style="stop-color:#f5f5b5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5103-5">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105-9" />
+      <stop
+         id="stop7550-8"
+         offset="0.26694915"
+         style="stop-color:#fef5d4;stop-opacity:1" />
+      <stop
+         id="stop7548-2"
+         offset="0.51694918"
+         style="stop-color:#fbe08e;stop-opacity:1" />
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="1"
+         id="stop5107-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-20)"
+       gradientUnits="userSpaceOnUse"
+       y2="1064.8306"
+       x2="16.46875"
+       y1="1064.8306"
+       x1="4.2581835"
+       id="linearGradient7558-2"
+       xlink:href="#linearGradient7552-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7552-5"
+       inkscape:collect="always">
+      <stop
+         id="stop7554-6"
+         offset="0"
+         style="stop-color:#c08c29;stop-opacity:1" />
+      <stop
+         id="stop7556-9"
+         offset="1"
+         style="stop-color:#b17813;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4106"
+       id="linearGradient4112"
+       x1="10.225247"
+       y1="1030.4619"
+       x2="10.225247"
+       y2="1039.7833"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,10.337603)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4106-0"
+       id="linearGradient4112-8"
+       x1="10.225247"
+       y1="1030.4619"
+       x2="10.225247"
+       y2="1039.7833"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,10.337603)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4106-0">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1;"
+         offset="0"
+         id="stop4108-8" />
+      <stop
+         style="stop-color:#146d39;stop-opacity:1"
+         offset="1"
+         id="stop4110-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188"
+       id="linearGradient4194"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-6"
+       id="linearGradient4194-5"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-6">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-4" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-7" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,2.1909235,1035.842)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4245"
+       xlink:href="#linearGradient4188-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4266"
+       id="linearGradient4272"
+       x1="25.930252"
+       y1="1051.1136"
+       x2="25.930252"
+       y2="1047.26"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <filter
+       inkscape:collect="always"
+       id="filter4339"
+       x="-0.090256119"
+       width="1.1805122"
+       y="-0.1789842"
+       height="1.3579684">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.27970009"
+         id="feGaussianBlur4341" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient4349"
+       x1="11.032874"
+       y1="1048.5142"
+       x2="11.032874"
+       y2="1041.7299"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4266-7"
+       id="linearGradient4272-2"
+       x1="25.930252"
+       y1="1051.1136"
+       x2="25.930252"
+       y2="1047.26"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266-7">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268-0" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4106-02"
+       id="linearGradient4112-88"
+       x1="10.225247"
+       y1="1030.4619"
+       x2="10.225247"
+       y2="1039.7833"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,10.337603)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4106-02">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1;"
+         offset="0"
+         id="stop4108-86" />
+      <stop
+         style="stop-color:#146d39;stop-opacity:1"
+         offset="1"
+         id="stop4110-4" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter4525"
+       x="-0.1109419"
+       width="1.2218838"
+       y="-0.13066874"
+       height="1.2613375">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.38772681"
+         id="feGaussianBlur4527" />
+    </filter>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(-6.0000004,-11.968814)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4245-0"
+       xlink:href="#linearGradient4188-6-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-6-0">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-4-6" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-7-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-4"
+       id="linearGradient4194-58"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-6" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(0,1036.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4553"
+       xlink:href="#linearGradient4188-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-6-0"
+       id="linearGradient4582"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.0000001,1036.3934)"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4266-4"
+       id="linearGradient4272-6"
+       x1="25.930252"
+       y1="1051.1136"
+       x2="25.930252"
+       y2="1047.26"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266-4">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268-6" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270-39" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(0,1036.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4553-7"
+       xlink:href="#linearGradient4188-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4-3">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-6-1" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-6-0-7"
+       id="linearGradient4582-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.0000001,1036.3934)"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-6-0-7">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-4-6-2" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-7-4-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.26"
+       x2="25.930252"
+       y1="1051.1136"
+       x1="25.930252"
+       gradientTransform="translate(-20,2.7828126e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4609"
+       xlink:href="#linearGradient4266-4"
+       inkscape:collect="always" />
+    <mask
+       id="mask4181"
+       maskUnits="userSpaceOnUse">
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="path4183"
+         d="m 3.5193795,1037.8597 7.0096695,0 3.062057,3.0066 0,9.9546 -10.0717265,0 z"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <filter
+       height="1.240301"
+       y="-0.12015051"
+       width="1.2396997"
+       x="-0.11984986"
+       id="filter4177"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur4179"
+         stdDeviation="0.40384366"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       id="linearGradient5300-6-8">
+      <stop
+         id="stop5302-7-1"
+         offset="0"
+         style="stop-color:#4d4d4d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#727272;stop-opacity:1;"
+         offset="0.29405674"
+         id="stop5308-2-6" />
+      <stop
+         id="stop5304-3-8"
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5300-6-8"
+       id="linearGradient3208-6"
+       gradientUnits="userSpaceOnUse"
+       x1="2.65625"
+       y1="1049.3976"
+       x2="4.0822439"
+       y2="1050.5304" />
+    <linearGradient
+       id="linearGradient5077-5-8-7">
+      <stop
+         id="stop5079-7-9-4"
+         offset="0"
+         style="stop-color:#e4cf94;stop-opacity:1" />
+      <stop
+         style="stop-color:#ede0ba;stop-opacity:1"
+         offset="0.32186735"
+         id="stop5087-6-0-2" />
+      <stop
+         style="stop-color:#c1aa7e;stop-opacity:1"
+         offset="0.64764118"
+         id="stop5085-1-4-6" />
+      <stop
+         id="stop5081-8-7-6"
+         offset="1"
+         style="stop-color:#ad8865;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       id="filter5428-9-1"
+       inkscape:collect="always"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur5430-2-9"
+         stdDeviation="0.22207033"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       id="linearGradient4902-3-3"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-7"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2-6"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.977903,-1.044194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-4"
+       xlink:href="#linearGradient4902-3-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5300-6"
+       id="linearGradient3208"
+       gradientUnits="userSpaceOnUse"
+       x1="2.65625"
+       y1="1049.3976"
+       x2="4.0822439"
+       y2="1050.5304" />
+    <linearGradient
+       id="linearGradient5300-6">
+      <stop
+         id="stop5302-7"
+         offset="0"
+         style="stop-color:#4d4d4d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#727272;stop-opacity:1;"
+         offset="0.29405674"
+         id="stop5308-2" />
+      <stop
+         id="stop5304-3"
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1050.5304"
+       x2="4.0822439"
+       y1="1049.3976"
+       x1="2.65625"
+       id="linearGradient5306-8"
+       xlink:href="#linearGradient5300-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5077-5-8">
+      <stop
+         id="stop5079-7-9"
+         offset="0"
+         style="stop-color:#e4cf94;stop-opacity:1" />
+      <stop
+         style="stop-color:#ede0ba;stop-opacity:1"
+         offset="0.32186735"
+         id="stop5087-6-0" />
+      <stop
+         style="stop-color:#c1aa7e;stop-opacity:1"
+         offset="0.64764118"
+         id="stop5085-1-4" />
+      <stop
+         id="stop5081-8-7"
+         offset="1"
+         style="stop-color:#ad8865;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1050.3188"
+       x2="1.9838035"
+       y1="1047.4242"
+       x1="-0.9810437"
+       gradientTransform="translate(4,-1036.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5196-0"
+       xlink:href="#linearGradient5077-5-8"
+       inkscape:collect="always" />
+    <filter
+       id="filter5428-9"
+       inkscape:collect="always"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur5430-2"
+         stdDeviation="0.22207033"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       id="linearGradient4908-52-3-2-9"
+       inkscape:collect="always">
+      <stop
+         id="stop4910-7-2-7-0"
+         offset="0"
+         style="stop-color:#986443;stop-opacity:1" />
+      <stop
+         id="stop4912-6-2-9-4"
+         offset="1"
+         style="stop-color:#994f1b;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(20,0)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4908-52-3-2-9"
+       id="linearGradient5173-0"
+       gradientUnits="userSpaceOnUse"
+       x1="-11.21119"
+       y1="1042.1598"
+       x2="-8.7005796"
+       y2="1044.6704" />
+    <linearGradient
+       id="linearGradient5077-5">
+      <stop
+         id="stop5079-7"
+         offset="0"
+         style="stop-color:#e4cf94;stop-opacity:1" />
+      <stop
+         style="stop-color:#ede0ba;stop-opacity:1"
+         offset="0.32186735"
+         id="stop5087-6" />
+      <stop
+         style="stop-color:#c1aa7e;stop-opacity:1"
+         offset="0.64764118"
+         id="stop5085-1" />
+      <stop
+         id="stop5081-8"
+         offset="1"
+         style="stop-color:#ad8865;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5300">
+      <stop
+         id="stop5302"
+         offset="0"
+         style="stop-color:#4d4d4d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#727272;stop-opacity:1;"
+         offset="0.29405674"
+         id="stop5308" />
+      <stop
+         id="stop5304"
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.977903,-1.044194)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-6"
+       id="linearGradient4101"
+       gradientUnits="userSpaceOnUse"
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378" />
+    <linearGradient
+       id="linearGradient4994-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-1"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1;" />
+      <stop
+         id="stop4998-89"
+         offset="1"
+         style="stop-color:#dce7f7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4894-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4896-8"
+         offset="0"
+         style="stop-color:#e0c88f;stop-opacity:1" />
+      <stop
+         id="stop4898-5"
+         offset="1"
+         style="stop-color:#d5b269;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(2.022097,-1.044194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.8116"
+       x2="9.5061646"
+       y1="1041.8126"
+       x1="8.5052109"
+       id="linearGradient4900-1"
+       xlink:href="#linearGradient4894-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4902-3"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.977903,-1.044194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2"
+       xlink:href="#linearGradient4902-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877-6">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4879-1" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop4881-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.977903,-3.044194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.394"
+       x2="11.997898"
+       y1="1043.394"
+       x1="9.9978981"
+       id="linearGradient4867-7"
+       xlink:href="#linearGradient4877-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4861-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4863-1"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4865-52"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.977903,-3.044194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.8571"
+       x2="14"
+       y1="1045.8571"
+       x1="7.0070496"
+       id="linearGradient4869-17"
+       xlink:href="#linearGradient4861-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5147-4">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop5149-5" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop5151-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.977903,-3.044194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.8571"
+       x2="14"
+       y1="1047.8571"
+       x1="7.0070496"
+       id="linearGradient4871-2"
+       xlink:href="#linearGradient5147-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5141-4">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop5143-8" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop5145-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.977903,-3.044194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1049.8571"
+       x2="14"
+       y1="1049.8571"
+       x1="7.0070496"
+       id="linearGradient4875-9"
+       xlink:href="#linearGradient5141-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5135-7">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop5137-4" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop5139-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.977903,-3.044194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1051.8571"
+       x2="12.016466"
+       y1="1051.8571"
+       x1="7.0070496"
+       id="linearGradient4873-1"
+       xlink:href="#linearGradient5135-7"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-1.977903,-3.044194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.394"
+       x2="11.997898"
+       y1="1043.394"
+       x1="9.9978981"
+       id="linearGradient4867-7-7"
+       xlink:href="#linearGradient4877-6-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877-6-6">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4879-1-5" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop4881-4-5" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.394"
+       x2="11.997898"
+       y1="1043.394"
+       x1="9.9978981"
+       gradientTransform="matrix(1.5156251,0,0,1,-7.1330704,-1.0441001)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3470"
+       xlink:href="#linearGradient4877-6-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1043.394"
+       x2="11.997898"
+       y1="1043.394"
+       x1="9.9978981"
+       gradientTransform="translate(-1.977903,-1.0441001)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3470-6"
+       xlink:href="#linearGradient4877-6-6-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877-6-6-6">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4879-1-5-1" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop4881-4-5-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.394"
+       x2="11.997898"
+       y1="1043.394"
+       x1="9.9978981"
+       gradientTransform="matrix(1.5156251,0,0,1,-7.1330704,0.9558999)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3504"
+       xlink:href="#linearGradient4877-6-6-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1043.394"
+       x2="11.997898"
+       y1="1043.394"
+       x1="9.9978981"
+       gradientTransform="matrix(1.5156251,0,0,1,-7.1330704,0.9558999)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3504-3"
+       xlink:href="#linearGradient4877-6-6-6-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877-6-6-6-1">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4879-1-5-1-8" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop4881-4-5-4-8" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask3646">
+      <g
+         id="g3648">
+        <rect
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-opacity:1;display:inline"
+           id="rect3650"
+           width="8.993515"
+           height="3.9996338"
+           x="2.4969711"
+           y="1046.86" />
+        <g
+           transform="translate(2.9800045,-0.9877)"
+           inkscape:label="Layer 1"
+           id="g3652"
+           style="fill:#ffffff;stroke:#ffffff;display:inline">
+          <path
+             style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline"
+             d="m 6.7693795,1037.8597 3.7596695,0 2.187057,2.1628 0,5.5797 -5.9467265,0 z"
+             id="path3654"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cccccc" />
+          <path
+             sodipodi:nodetypes="cccc"
+             style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline"
+             d="m 9.998718,1037.397 0,2.9737 2.196228,0 z"
+             id="path3656"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+             d="m 6.5193795,1037.8597 4.0096695,0 1.999557,2.2878 0,5.6734 -6.0092265,0 z"
+             id="path3658"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cccccc" />
+          <rect
+             style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline"
+             id="rect3660"
+             width="1.9999998"
+             height="1.0000463"
+             x="8.0199957"
+             y="1039.3499" />
+          <rect
+             style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline"
+             id="rect3662"
+             width="3.0312498"
+             height="1.0000463"
+             x="8.0199957"
+             y="1041.3499" />
+          <rect
+             style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline"
+             id="rect3664"
+             width="3.0312498"
+             height="1.0000463"
+             x="8.0199957"
+             y="1043.3499" />
+        </g>
+      </g>
+    </mask>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.999999"
+     inkscape:cx="0.96330951"
+     inkscape:cy="8.1138371"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="23"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="layer1-3"
+       inkscape:label="Layer 1"
+       transform="translate(2.9800045,-0.98769971)">
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="rect4001-3"
+         d="m 6.7693795,1037.8597 3.7596695,0 2.187057,2.1628 0,5.5797 -5.9467265,0 z"
+         style="fill:url(#linearGradient4101);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4884"
+         d="m 9.998718,1037.397 0,2.9737 2.196228,0 z"
+         style="fill:url(#linearGradient4900-1);fill-opacity:1;stroke:none;display:inline"
+         sodipodi:nodetypes="cccc" />
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="rect4001"
+         d="m 6.5193795,1037.8597 4.0096695,0 1.999557,2.2878 0,5.6734 -6.0092265,0 z"
+         style="fill:none;stroke:url(#linearGradient4908-2);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+      <rect
+         y="1039.3499"
+         x="8.0199957"
+         height="1.0000463"
+         width="1.9999998"
+         id="rect4001-1"
+         style="fill:url(#linearGradient4867-7);fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         y="1041.3499"
+         x="8.0199957"
+         height="1.0000463"
+         width="3.0312498"
+         id="rect4001-1-6"
+         style="fill:url(#linearGradient3470);fill-opacity:1;stroke:none;display:inline" />
+      <rect
+         y="1043.3499"
+         x="8.0199957"
+         height="1.0000463"
+         width="3.0312498"
+         id="rect4001-1-6-2"
+         style="fill:url(#linearGradient3504);fill-opacity:1;stroke:none;display:inline" />
+    </g>
+    <rect
+       style="fill:#f1f5fa;fill-opacity:1;stroke:url(#linearGradient4609);stroke-opacity:1;display:inline"
+       id="rect4264"
+       width="8.993515"
+       height="3.9996338"
+       x="2.4969711"
+       y="1046.86" />
+    <rect
+       style="fill:url(#linearGradient4553-7);fill-opacity:1;stroke:none;display:inline"
+       id="rect4178"
+       width="4.0000005"
+       height="1.0000001"
+       x="6"
+       y="1048.3622" />
+    <rect
+       style="fill:url(#linearGradient4582-4);fill-opacity:1;stroke:none;display:inline"
+       id="rect4178-9"
+       width="0.9999997"
+       height="1.0000215"
+       x="4.0000005"
+       y="1048.3622" />
+    <g
+       style="display:inline"
+       id="layer1-5"
+       inkscape:label="Layer 1"
+       transform="translate(-10.051944,2.8637517)" />
+    <g
+       id="g4518"
+       style="filter:url(#filter4525);stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+       mask="url(#mask3646)">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path4108-1-1"
+         d="m 1.4560597,1047.0104 c 0.166408,-2.3394 3.0629699,-2.1562 3.0629699,-2.1562 l 0,1.9561 4.3860242,-3.4248 -4.3860242,-3.4965 0,1.9824 c -1.8676292,0.013 -5.798807,1.6782 -3.0629699,5.139 z"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+    </g>
+    <g
+       transform="matrix(0.7738738,0,0,0.7738738,-3.6954984,234.78238)"
+       inkscape:label="Layer 1"
+       id="layer1-7"
+       style="display:inline">
+      <path
+         style="fill:#abca52;fill-opacity:1;stroke:none;display:inline"
+         d="m 6.6568452,1049.5614 c 0.2150324,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133512,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+         id="path4108-1-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="fill:url(#linearGradient4349);fill-opacity:1;stroke:none;display:inline"
+         d="m 6.6568452,1049.5614 c 0.2150325,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133511,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+         id="path4108-1-3-4"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4112);stroke-width:1.29220033;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         d="m 6.6568452,1049.5614 c 0.2150324,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133512,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+         id="path4108-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <rect
+         style="fill:#2f9353;fill-opacity:1;stroke:none"
+         id="rect4122"
+         width="0.94941604"
+         height="1.1992624"
+         x="10.31146"
+         y="1042.3649" />
+      <rect
+         style="fill:#1d7a42;fill-opacity:1;stroke:none;display:inline"
+         id="rect4122-2"
+         width="0.94941604"
+         height="1.1992624"
+         x="10.304321"
+         y="1046.1245" />
+      <rect
+         style="fill:none;stroke:none"
+         id="rect4176"
+         width="1"
+         height="1"
+         x="4"
+         y="12"
+         transform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#cfdc63;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.58440065;marker:none;visibility:visible;display:inline;overflow:visible;filter:url(#filter4339);enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 11.90625,1043.0312 2.28125,1.8438 -2.28125,1.7812 0,-1.0937 -1.21875,-0.062 c 0,0 -1.1298804,-0.1 -2.375,0.3125 -0.4970996,0.1646 -1.0141192,0.5483 -1.5,0.9687 -9.736e-4,-0.029 -0.06306,-0.097 -0.0625,-0.125 0.00915,-0.4526 0.1773911,-0.7816 0.5625,-1.1562 0.7702178,-0.7493 2.483426,-1.2754 3.3125,-1.2812 l 1.28125,0 0,-1.1876 z"
+         id="path4108-1-3-4-6"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/info_obj.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/info_obj.svg
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="info_tsk.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4890">
+      <stop
+         style="stop-color:#2857bd;stop-opacity:1;"
+         offset="0"
+         id="stop4892" />
+      <stop
+         style="stop-color:#3d5384;stop-opacity:1;"
+         offset="1"
+         id="stop4894" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4996-4">
+      <stop
+         style="stop-color:#02468c;stop-opacity:1"
+         offset="0"
+         id="stop4998-5" />
+      <stop
+         style="stop-color:#0e62a4;stop-opacity:1"
+         offset="1"
+         id="stop5000-5" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.7347"
+       x2="13.903196"
+       y1="1062.1353"
+       x1="13.903196"
+       gradientTransform="translate(38.469436,55.035191)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5028"
+       xlink:href="#linearGradient4996-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4890"
+       id="linearGradient4896"
+       x1="14.256123"
+       y1="1056.5471"
+       x2="18.340696"
+       y2="1056.5471"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4890"
+       id="linearGradient4898"
+       gradientUnits="userSpaceOnUse"
+       x1="16.307018"
+       y1="1055.0179"
+       x2="16.307018"
+       y2="1060.6793" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254832"
+     inkscape:cx="4.4561136"
+     inkscape:cy="6.7876447"
+     inkscape:document-units="px"
+     inkscape:current-layer="text4140-1-8"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="1387"
+     inkscape:window-y="399"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4099" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <g
+         style="font-size:15.07241725999999993px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient4896);fill-opacity:1;stroke:none;display:inline;font-family:Kozuka Mincho Pr6N H;-inkscape-font-specification:Kozuka Mincho Pr6N H Heavy"
+         id="text4140-1-8"
+         transform="matrix(1.0865583,0,0,1,-1.7201207,-0.04419418)">
+        <path
+           d="m 16.245657,1050.9177 c -0.355456,0.01 -0.65062,0.1291 -0.885494,0.3674 -0.234876,0.2383 -0.35671,0.5529 -0.365501,0.9439 0.0088,0.3981 0.130625,0.7172 0.365502,0.9571 0.234873,0.2399 0.530037,0.363 0.885493,0.3692 0.362672,-0.01 0.662232,-0.1293 0.898681,-0.3692 0.236442,-0.2399 0.358903,-0.559 0.367386,-0.9571 -0.0057,-0.3778 -0.122466,-0.6886 -0.35043,-0.9326 -0.227971,-0.244 -0.533183,-0.3702 -0.915637,-0.3787 z m 0.94955,3.3912 c -1.039986,0.4346 -2.019679,0.6808 -2.939084,0.7386 l 0,0.6029 c 0.435838,-0.02 0.70965,0.039 0.821436,0.1771 0.111784,0.1381 0.159513,0.476 0.143187,1.0136 l 0,3.4515 c 0.01539,0.5401 -0.03423,0.888 -0.148838,1.0438 -0.114613,0.1557 -0.386541,0.2248 -0.815785,0.2072 l 0,0.633 4.084573,0 0,-0.633 c -0.386544,0.017 -0.634608,-0.051 -0.744192,-0.2054 -0.109591,-0.1541 -0.157947,-0.4977 -0.145069,-1.0305 l 0,-5.8631 z"
+           style="fill:url(#linearGradient4898);fill-opacity:1"
+           id="path5058"
+           inkscape:connector-curvature="0" />
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-size:15.07241726px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient5028);fill-opacity:1;stroke:none;display:inline;font-family:Kozuka Mincho Pr6N H;-inkscape-font-specification:Kozuka Mincho Pr6N H Heavy"
+         x="50.288464"
+         y="1117.2119"
+         id="text4140-1-8-1"
+         sodipodi:linespacing="125%"><tspan
+           sodipodi:role="line"
+           id="tspan4142-7-8-7"
+           x="50.288464"
+           y="1117.2119"
+           style="fill:url(#linearGradient5028);fill-opacity:1">Kozuka Mincho Pr6N H</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/refactoring_obj.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/refactoring_obj.svg
@@ -1,0 +1,1952 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="refactoring_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4343">
+      <stop
+         style="stop-color:#96b956;stop-opacity:1"
+         offset="0"
+         id="stop4345" />
+      <stop
+         style="stop-color:#abca52;stop-opacity:1"
+         offset="1"
+         id="stop4347" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4106">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1;"
+         offset="0"
+         id="stop4108" />
+      <stop
+         style="stop-color:#146d39;stop-opacity:1"
+         offset="1"
+         id="stop4110" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 8 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="16 : 8 : 1"
+       inkscape:persp3d-origin="8 : 5.3333333 : 1"
+       id="perspective3519" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12886-6-7-7"
+       x1="393.4772"
+       y1="375.17487"
+       x2="379.65567"
+       y2="371.10898"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1-8-7">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3-6-2" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4-9-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12884-4-7-0"
+       x1="395.68689"
+       y1="379.50586"
+       x2="385.57773"
+       y2="388.69827"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12882-2-0-9"
+       x1="404.8793"
+       y1="389.22861"
+       x2="397.7753"
+       y2="400.10037"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12880-3-5-6"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12878-2-7-1"
+       x1="413.01102"
+       y1="366.6012"
+       x2="429.94864"
+       y2="364.92181"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12876-4-0-6"
+       x1="674.84711"
+       y1="180.63965"
+       x2="675.20258"
+       y2="166.79221"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12868-4-7-0"
+       x1="396.0101"
+       y1="359.4902"
+       x2="396.21149"
+       y2="350.94641"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12888-3-7-3"
+       x1="390.38361"
+       y1="362.80048"
+       x2="381.86542"
+       y2="360.85596"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       r="12.952347"
+       fy="420.74988"
+       fx="433.5452"
+       cy="420.74988"
+       cx="433.5452"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient12821-7-6-3"
+       xlink:href="#linearGradient12717-5-0-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-5-0-4-3">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-6-3-0-0" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-9-4-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12896-6-4-1"
+       x1="427.53012"
+       y1="432.76639"
+       x2="425.4519"
+       y2="415.1088"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-5-0-4-3"
+       id="radialGradient12723-8-2-4-1"
+       cx="433.36786"
+       cy="424.34106"
+       fx="433.36786"
+       fy="424.34106"
+       r="12.027534"
+       gradientTransform="matrix(1.1614831,2.1855961e-7,-2.811228e-7,1.4939602,-69.981471,-211.63828)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="translate(3.974778e-6,-9.8142563e-6)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient12725-9-4-7-2"
+       id="linearGradient12731-1-9-5-9"
+       x1="683.16229"
+       y1="205.72604"
+       x2="661.94519"
+       y2="183.18417"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12725-9-4-7-2">
+      <stop
+         style="stop-color:#397b3b;stop-opacity:1;"
+         offset="0"
+         id="stop12727-3-9-8-9" />
+      <stop
+         style="stop-color:#397b3b;stop-opacity:0;"
+         offset="1"
+         id="stop12729-4-1-8-3" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="455.88452"
+       x1="420.88995"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4046"
+       xlink:href="#linearGradient12862-1-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7584-9-3">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-6-3" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-9-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-0-5">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-8-9" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-5-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4216-0"
+       id="linearGradient4382"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       x1="393.36197"
+       y1="381.15457"
+       x2="385.57773"
+       y2="388.69827" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4234-5">
+      <stop
+         style="stop-color:#203932;stop-opacity:1"
+         offset="0"
+         id="stop4236-7" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4238-1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       y2="364.92181"
+       x2="429.94864"
+       y1="366.6012"
+       x1="413.01102"
+       id="linearGradient12878-2-7-1-2-8-9"
+       xlink:href="#linearGradient4234-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4240-5">
+      <stop
+         style="stop-color:#284539;stop-opacity:1"
+         offset="0"
+         id="stop4242-0" />
+      <stop
+         style="stop-color:#385653;stop-opacity:1"
+         offset="1"
+         id="stop4244-3" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="166.79221"
+       x2="675.20258"
+       y1="180.63965"
+       x1="674.84711"
+       id="linearGradient12876-4-0-6-7-3-6"
+       xlink:href="#linearGradient4240-5"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.60364,-39.53384)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4198-8">
+      <stop
+         style="stop-color:#2d483d;stop-opacity:1"
+         offset="0"
+         id="stop4200-3" />
+      <stop
+         style="stop-color:#38564e;stop-opacity:1"
+         offset="1"
+         id="stop4202-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.60473,-96.3391)"
+       gradientUnits="userSpaceOnUse"
+       y2="350.94641"
+       x2="396.21149"
+       y1="359.4902"
+       x1="396.0101"
+       id="linearGradient12868-4-7-0-8-7-6"
+       xlink:href="#linearGradient4198-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4204-6">
+      <stop
+         style="stop-color:#28483d;stop-opacity:1"
+         offset="0"
+         id="stop4206-3" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4208-8" />
+    </linearGradient>
+    <linearGradient
+       y2="360.85596"
+       x2="381.86542"
+       y1="362.80048"
+       x1="390.38361"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4091-0"
+       xlink:href="#linearGradient4204-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4210-9">
+      <stop
+         style="stop-color:#284539;stop-opacity:1"
+         offset="0"
+         id="stop4212-8" />
+      <stop
+         style="stop-color:#385653;stop-opacity:1"
+         offset="1"
+         id="stop4214-5" />
+    </linearGradient>
+    <linearGradient
+       y2="371.10898"
+       x2="379.65567"
+       y1="375.17487"
+       x1="393.4772"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4100-2"
+       xlink:href="#linearGradient4210-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4216-0">
+      <stop
+         style="stop-color:#233e32;stop-opacity:1"
+         offset="0"
+         id="stop4218-3" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:0.8650133"
+         offset="1"
+         id="stop4220-8" />
+    </linearGradient>
+    <linearGradient
+       y2="388.69827"
+       x2="385.57773"
+       y1="381.15457"
+       x1="393.36197"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,940.00748)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4097-3"
+       xlink:href="#linearGradient4216-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4222-4">
+      <stop
+         style="stop-color:#203c37;stop-opacity:1"
+         offset="0"
+         id="stop4224-9" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4226-6" />
+    </linearGradient>
+    <linearGradient
+       y2="399.07361"
+       x2="396.94577"
+       y1="388.32217"
+       x1="400.52957"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4094-1"
+       xlink:href="#linearGradient4222-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4228-4">
+      <stop
+         style="stop-color:#203932;stop-opacity:1"
+         offset="0"
+         id="stop4230-4" />
+      <stop
+         style="stop-color:#314e4a;stop-opacity:1"
+         offset="1"
+         id="stop4232-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4228-4"
+       id="linearGradient4141-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4252-7">
+      <stop
+         style="stop-color:#1d6279;stop-opacity:1"
+         offset="0"
+         id="stop4254-1" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4256-4" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="447.02145"
+       x1="427.92853"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4190-8"
+       xlink:href="#linearGradient4252-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4258-3">
+      <stop
+         style="stop-color:#387a31;stop-opacity:1"
+         offset="0"
+         id="stop4260-4" />
+      <stop
+         style="stop-color:#397b3b;stop-opacity:0;"
+         offset="1"
+         id="stop4262-6" />
+    </linearGradient>
+    <linearGradient
+       y2="183.92403"
+       x2="666.19678"
+       y1="204.12044"
+       x1="684.11578"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.8909,996.82836)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4086-5"
+       xlink:href="#linearGradient4258-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="415.1088"
+       x2="425.4519"
+       y1="432.76639"
+       x1="427.53012"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4196"
+       xlink:href="#linearGradient4246"
+       inkscape:collect="always" />
+    <radialGradient
+       r="12.952347"
+       fy="420.74988"
+       fx="433.5452"
+       cy="420.74988"
+       cx="433.5452"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4194"
+       xlink:href="#linearGradient12717-5-0-4-3-4"
+       inkscape:collect="always" />
+    <radialGradient
+       r="12.027534"
+       fy="424.34106"
+       fx="433.36789"
+       cy="424.34106"
+       cx="433.36789"
+       gradientTransform="matrix(1.2231981,-0.08344257,0.10167677,1.4904962,-139.87254,-174.00694)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4192"
+       xlink:href="#linearGradient4515"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="447.02145"
+       x1="427.92853"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4190"
+       xlink:href="#linearGradient4252"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-75-5"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-4-2"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-16-6"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-75-5"
+       id="linearGradient3993-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       y2="183.92403"
+       x2="666.19678"
+       y1="204.12044"
+       x1="684.11578"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.8909,996.82836)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4086"
+       xlink:href="#linearGradient4258"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4472"
+       id="linearGradient3993"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-7-5"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-1-6"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-12-9"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-7-5"
+       id="linearGradient3915-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.27903302,0.27903303,0,-96.327735,115.6161)"
+       x1="396.0101"
+       y1="359.4902"
+       x2="396.21149"
+       y2="350.94641" />
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.60473,-96.339099)"
+       gradientUnits="userSpaceOnUse"
+       y2="350.94641"
+       x2="396.21149"
+       y1="359.4902"
+       x1="396.0101"
+       id="linearGradient12868-4-7-0-8"
+       xlink:href="#linearGradient4490"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="166.79221"
+       x2="675.20258"
+       y1="180.63965"
+       x1="674.84711"
+       id="linearGradient12876-4-0-6-7"
+       xlink:href="#linearGradient4484"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.60364,-39.53384)" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-9-7"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-8-0"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-0-6"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-9-7"
+       id="linearGradient3813-8"
+       gradientUnits="userSpaceOnUse"
+       x1="674.84711"
+       y1="180.63965"
+       x2="675.20258"
+       y2="166.79221"
+       gradientTransform="matrix(0,0.27903302,0.24756874,0,-39.521247,-178.59954)" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-1-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-9-6"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-1-4"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-1-9"
+       id="linearGradient3847-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.27903302,0.27903303,0,-96.353305,-104.6999)"
+       x1="413.01102"
+       y1="366.6012"
+       x2="429.94864"
+       y2="364.92181" />
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       gradientUnits="userSpaceOnUse"
+       y2="364.92181"
+       x2="429.94864"
+       y1="366.6012"
+       x1="413.01102"
+       id="linearGradient12878-2-7-1-2"
+       xlink:href="#linearGradient4478"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-75"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-4"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-16"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,264.63772,-229.51558)"
+       gradientUnits="userSpaceOnUse"
+       y2="381.80399"
+       x2="432.86548"
+       y1="378.7988"
+       x1="420.52402"
+       id="linearGradient12880-3-5-6-9"
+       xlink:href="#linearGradient12862-1-8-7-75"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-96-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-86-2"
+         offset="0"
+         style="stop-color:#203932;stop-opacity:1" />
+      <stop
+         id="stop12866-4-9-5-8-9"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-96-9"
+       id="linearGradient3881-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.27903302,0.27903303,0,-96.392939,-104.7384)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-7"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-1"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-12"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,265.19769,-229.45247)"
+       gradientUnits="userSpaceOnUse"
+       y2="350.94641"
+       x2="396.21149"
+       y1="359.4902"
+       x1="396.0101"
+       id="linearGradient12868-4-7-0-0"
+       xlink:href="#linearGradient12862-1-8-7-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-96"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-86"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-8"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,264.63772,-229.51558)"
+       gradientUnits="userSpaceOnUse"
+       y2="381.80399"
+       x2="432.86548"
+       y1="378.7988"
+       x1="420.52402"
+       id="linearGradient12880-3-5-6-6"
+       xlink:href="#linearGradient12862-1-8-7-96"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-1"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-9"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-1"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,264.63772,-229.51558)"
+       gradientUnits="userSpaceOnUse"
+       y2="364.92181"
+       x2="429.94864"
+       y1="366.6012"
+       x1="413.01102"
+       id="linearGradient12878-2-7-1-1"
+       xlink:href="#linearGradient12862-1-8-7-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-8"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-0"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="166.79221"
+       x2="675.20258"
+       y1="180.63965"
+       x1="674.84711"
+       id="linearGradient12876-4-0-6-3"
+       xlink:href="#linearGradient12862-1-8-7-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12717-5-0-4-3-4"
+       inkscape:collect="always">
+      <stop
+         id="stop12719-6-3-0-0-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop12721-9-4-5-0-6"
+         offset="1"
+         style="stop-color:#8ebc7b;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4246">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4248" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4250" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4252">
+      <stop
+         style="stop-color:#0d5269;stop-opacity:1"
+         offset="0"
+         id="stop4254" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4256" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4258">
+      <stop
+         style="stop-color:#387a31;stop-opacity:1"
+         offset="0"
+         id="stop4260" />
+      <stop
+         style="stop-color:#397b3b;stop-opacity:0;"
+         offset="1"
+         id="stop4262" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4472">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4474" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4476" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4478">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4480" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4482" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4484">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4486" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4488" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4490">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4492" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4494" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4515">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4517" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop4519" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4515-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4517-7" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop4519-4" />
+    </linearGradient>
+    <mask
+       id="mask7862"
+       maskUnits="userSpaceOnUse">
+      <g
+         id="g7864">
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.5;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           d="m 11.5,1039.6591 c -0.18722,10e-5 -0.383743,0.04 -0.65625,0.094 l 0,0.875 c -0.213492,0.042 -0.422114,0.072 -0.625,0.1562 -0.194391,0.083 -0.388449,0.2275 -0.5625,0.3438 l -0.625,-0.6252 c -0.462167,0.3084 -0.597312,0.4445 -0.90625,0.9062 l 0.625,0.625 c -0.121067,0.1808 -0.2597,0.3909 -0.34375,0.5938 -0.08385,0.2029 -0.113627,0.4115 -0.15625,0.625 l -0.90625,0 c -0.108682,0.5449 -0.108112,0.7362 0,1.2812 l 0.90625,0 c 0.08465,0.427 0.258374,0.8566 0.5,1.2188 l -0.625,0.5937 c 0.308933,0.4619 0.444082,0.5977 0.90625,0.9063 l 0.625,-0.5938 c 0.361804,0.2421 0.760581,0.4148 1.1875,0.5 l 0,0.875 c 0.545014,0.1081 0.76758,0.1087 1.3125,0 l 0,-0.875 c 0.426989,-0.085 0.8255,-0.2582 1.1875,-0.5 l 0.625,0.5938 c 0.46183,-0.309 0.597782,-0.4441 0.90625,-0.9063 l -0.625,-0.5937 c 0.242113,-0.3618 0.414842,-0.792 0.5,-1.2188 l 0.90625,0 c 0.108112,-0.545 0.108682,-0.7363 0,-1.2812 l -0.90625,0 c -0.08469,-0.4271 -0.258169,-0.8568 -0.5,-1.2188 l 0.625,-0.625 c -0.154067,-0.2313 -0.242615,-0.3988 -0.375,-0.5312 -0.13245,-0.1323 -0.299966,-0.2209 -0.53125,-0.375 l -0.625,0.625 c -0.361809,-0.2421 -0.760526,-0.415 -1.1875,-0.5 l 0,-0.875 c -0.27246,-0.054 -0.46903,-0.094 -0.65625,-0.094 z m 0,3.3125 c 0.500508,0 0.90625,0.4057 0.90625,0.9063 0,0.5005 -0.405742,0.9062 -0.90625,0.9062 -0.500508,0 -0.90625,-0.4057 -0.90625,-0.9062 0,-0.5006 0.405742,-0.9063 0.90625,-0.9063 z"
+           id="path7866"
+           inkscape:connector-curvature="0" />
+      </g>
+    </mask>
+    <linearGradient
+       id="linearGradient5103">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105" />
+      <stop
+         id="stop7550"
+         offset="0.26694915"
+         style="stop-color:#fef5d4;stop-opacity:1" />
+      <stop
+         id="stop7548"
+         offset="0.51694918"
+         style="stop-color:#fbe08e;stop-opacity:1" />
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="1"
+         id="stop5107" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5281">
+      <stop
+         id="stop5283"
+         offset="0"
+         style="stop-color:#e0b575;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f5ca75;stop-opacity:1"
+         offset="0.5"
+         id="stop5289" />
+      <stop
+         id="stop5285"
+         offset="1"
+         style="stop-color:#f5f5b5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5103-5">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105-9" />
+      <stop
+         id="stop7550-8"
+         offset="0.26694915"
+         style="stop-color:#fef5d4;stop-opacity:1" />
+      <stop
+         id="stop7548-2"
+         offset="0.51694918"
+         style="stop-color:#fbe08e;stop-opacity:1" />
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="1"
+         id="stop5107-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-20)"
+       gradientUnits="userSpaceOnUse"
+       y2="1064.8306"
+       x2="16.46875"
+       y1="1064.8306"
+       x1="4.2581835"
+       id="linearGradient7558-2"
+       xlink:href="#linearGradient7552-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7552-5"
+       inkscape:collect="always">
+      <stop
+         id="stop7554-6"
+         offset="0"
+         style="stop-color:#c08c29;stop-opacity:1" />
+      <stop
+         id="stop7556-9"
+         offset="1"
+         style="stop-color:#b17813;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4106"
+       id="linearGradient4112"
+       x1="10.225247"
+       y1="1030.4619"
+       x2="10.225247"
+       y2="1039.7833"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,10.337603)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4106-0"
+       id="linearGradient4112-8"
+       x1="10.225247"
+       y1="1030.4619"
+       x2="10.225247"
+       y2="1039.7833"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,10.337603)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4106-0">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1;"
+         offset="0"
+         id="stop4108-8" />
+      <stop
+         style="stop-color:#146d39;stop-opacity:1"
+         offset="1"
+         id="stop4110-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188"
+       id="linearGradient4194"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-6"
+       id="linearGradient4194-5"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-6">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-4" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-7" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,2.1909235,1035.842)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4245"
+       xlink:href="#linearGradient4188-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4266"
+       id="linearGradient4272"
+       x1="25.930252"
+       y1="1051.1136"
+       x2="25.930252"
+       y2="1047.26"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <filter
+       inkscape:collect="always"
+       id="filter4339"
+       x="-0.090256119"
+       width="1.1805122"
+       y="-0.1789842"
+       height="1.3579684">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.27970009"
+         id="feGaussianBlur4341" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient4349"
+       x1="11.032874"
+       y1="1048.5142"
+       x2="11.032874"
+       y2="1041.7299"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4266-7"
+       id="linearGradient4272-2"
+       x1="25.930252"
+       y1="1051.1136"
+       x2="25.930252"
+       y2="1047.26"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266-7">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268-0" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4106-02"
+       id="linearGradient4112-88"
+       x1="10.225247"
+       y1="1030.4619"
+       x2="10.225247"
+       y2="1039.7833"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,10.337603)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4106-02">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1;"
+         offset="0"
+         id="stop4108-86" />
+      <stop
+         style="stop-color:#146d39;stop-opacity:1"
+         offset="1"
+         id="stop4110-4" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4529">
+      <rect
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-opacity:1;display:inline"
+         id="rect4531"
+         width="8.993515"
+         height="3.9996338"
+         x="2.4969711"
+         y="1046.86" />
+    </mask>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(-6.0000004,-11.968814)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4245-0"
+       xlink:href="#linearGradient4188-6-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-6-0">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-4-6" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-7-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-4"
+       id="linearGradient4194-58"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-6" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(0,1036.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4553"
+       xlink:href="#linearGradient4188-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-6-0"
+       id="linearGradient4582"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.0000001,1036.3934)"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4266-4"
+       id="linearGradient4272-6"
+       x1="25.930252"
+       y1="1051.1136"
+       x2="25.930252"
+       y2="1047.26"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266-4">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268-6" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270-39" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(3.0277276,1034.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4553-7"
+       xlink:href="#linearGradient4188-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4-3">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-6-1" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4-6" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(3.0277276,1034.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4553-7-7"
+       xlink:href="#linearGradient4188-4-3-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4-3-7">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-6-1-0" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4-6-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-6-0-7-5"
+       id="linearGradient4582-4-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.9964775,1032.2996)"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-6-0-7-5">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-4-6-2-6" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-7-4-6-4" />
+    </linearGradient>
+    <mask
+       id="mask4181"
+       maskUnits="userSpaceOnUse">
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="path4183"
+         d="m 3.5193795,1037.8597 7.0096695,0 3.062057,3.0066 0,9.9546 -10.0717265,0 z"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       id="linearGradient5300-6-8">
+      <stop
+         id="stop5302-7-1"
+         offset="0"
+         style="stop-color:#4d4d4d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#727272;stop-opacity:1;"
+         offset="0.29405674"
+         id="stop5308-2-6" />
+      <stop
+         id="stop5304-3-8"
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5300-6-8"
+       id="linearGradient3208-6"
+       gradientUnits="userSpaceOnUse"
+       x1="2.65625"
+       y1="1049.3976"
+       x2="4.0822439"
+       y2="1050.5304" />
+    <linearGradient
+       id="linearGradient5077-5-8-7">
+      <stop
+         id="stop5079-7-9-4"
+         offset="0"
+         style="stop-color:#e4cf94;stop-opacity:1" />
+      <stop
+         style="stop-color:#ede0ba;stop-opacity:1"
+         offset="0.32186735"
+         id="stop5087-6-0-2" />
+      <stop
+         style="stop-color:#c1aa7e;stop-opacity:1"
+         offset="0.64764118"
+         id="stop5085-1-4-6" />
+      <stop
+         id="stop5081-8-7-6"
+         offset="1"
+         style="stop-color:#ad8865;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4902-3-3"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-7"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2-6"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.977903,-1.044194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-4"
+       xlink:href="#linearGradient4902-3-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5300-6">
+      <stop
+         id="stop5302-7"
+         offset="0"
+         style="stop-color:#4d4d4d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#727272;stop-opacity:1;"
+         offset="0.29405674"
+         id="stop5308-2" />
+      <stop
+         id="stop5304-3"
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1050.5304"
+       x2="4.0822439"
+       y1="1049.3976"
+       x1="2.65625"
+       id="linearGradient5306-8"
+       xlink:href="#linearGradient5300-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5077-5-8">
+      <stop
+         id="stop5079-7-9"
+         offset="0"
+         style="stop-color:#e4cf94;stop-opacity:1" />
+      <stop
+         style="stop-color:#ede0ba;stop-opacity:1"
+         offset="0.32186735"
+         id="stop5087-6-0" />
+      <stop
+         style="stop-color:#c1aa7e;stop-opacity:1"
+         offset="0.64764118"
+         id="stop5085-1-4" />
+      <stop
+         id="stop5081-8-7"
+         offset="1"
+         style="stop-color:#ad8865;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5077-5">
+      <stop
+         id="stop5079-7"
+         offset="0"
+         style="stop-color:#e4cf94;stop-opacity:1" />
+      <stop
+         style="stop-color:#ede0ba;stop-opacity:1"
+         offset="0.32186735"
+         id="stop5087-6" />
+      <stop
+         style="stop-color:#c1aa7e;stop-opacity:1"
+         offset="0.64764118"
+         id="stop5085-1" />
+      <stop
+         id="stop5081-8"
+         offset="1"
+         style="stop-color:#ad8865;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5300">
+      <stop
+         id="stop5302"
+         offset="0"
+         style="stop-color:#4d4d4d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#727272;stop-opacity:1;"
+         offset="0.29405674"
+         id="stop5308" />
+      <stop
+         id="stop5304"
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-14.678348,-0.26294396)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-6-5"
+       id="linearGradient4101-1"
+       gradientUnits="userSpaceOnUse"
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378" />
+    <linearGradient
+       id="linearGradient4994-6-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-1-4"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1;" />
+      <stop
+         id="stop4998-89-1"
+         offset="1"
+         style="stop-color:#dce7f7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientTransform="translate(-1.986544,-1.0535)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3526-9"
+       xlink:href="#linearGradient4994-6-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4994-6-5-8"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-1-4-1"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1;" />
+      <stop
+         id="stop4998-89-1-0"
+         offset="1"
+         style="stop-color:#dce7f7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.986544,-1.0535)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-8-8"
+       xlink:href="#linearGradient4902-3-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4902-3-1-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-9-9"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2-5-7"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientTransform="translate(-1.986544,-1.0535)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3575"
+       xlink:href="#linearGradient4994-6-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1047.26"
+       x2="25.930252"
+       y1="1051.1136"
+       x1="25.930252"
+       gradientTransform="translate(-16.972268,-1.9999972)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4609-3"
+       xlink:href="#linearGradient4266-4-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266-4-6">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268-6-3" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270-39-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.986544,-1.0535)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-8-8-7"
+       xlink:href="#linearGradient4902-3-1-1-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4902-3-1-1-9"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-9-9-1"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2-5-7-8"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4487">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4489"
+         d="m 3.5107388,1037.8693 9.9833382,0 0,12.9865 -9.9833382,0 z"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter4564"
+       x="-0.12776479"
+       width="1.2555296"
+       y="-0.11312493"
+       height="1.2262499">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.57699396"
+         id="feGaussianBlur4566" />
+    </filter>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4578">
+      <g
+         id="g4580">
+        <rect
+           y="1042.8712"
+           x="6.484375"
+           height="5.9883718"
+           width="8.0338383"
+           id="rect4582"
+           style="fill:#f1f5fa;fill-opacity:1;stroke:#ffffff;stroke-opacity:1;display:inline" />
+        <path
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+           d="m 3.5107388,1037.8693 9.9833382,0 0,12.9865 -9.9833382,0 z"
+           id="path4584"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+      </g>
+    </mask>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(3.0277276,1034.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4553-7-1"
+       xlink:href="#linearGradient4188-4-3-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4-3-9">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-6-1-3" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4-6-4" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(3.0277276,1032.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3350"
+       xlink:href="#linearGradient4188-4-3-9"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(3.0277276,1032.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3350-2"
+       xlink:href="#linearGradient4188-4-3-9-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4-3-9-6">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-6-1-3-1" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4-6-4-5" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(3.0277276,1030.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3384"
+       xlink:href="#linearGradient4188-4-3-9-6"
+       inkscape:collect="always" />
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter4339-71"
+       x="-0.090256117"
+       width="1.1805122"
+       y="-0.17898419"
+       height="1.3579684">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.27970009"
+         id="feGaussianBlur4341-7" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       id="filter4242"
+       x="-0.11094204"
+       width="1.2218841"
+       y="-0.13066855"
+       height="1.2613371">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.50102133"
+         id="feGaussianBlur4244" />
+    </filter>
+    <linearGradient
+       gradientTransform="translate(-1.986544,-1.0535)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-8-8-3"
+       xlink:href="#linearGradient4902-3-1-1-98"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4902-3-1-1-98"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-9-9-6"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2-5-7-3"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4289">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4291"
+         d="m 7.5107388,1039.8693 7.9833382,0 0,10.0177 -7.9833382,0 z"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter4297"
+       x="-0.16641306"
+       width="1.3328261"
+       y="-0.19600282"
+       height="1.3920056">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.751532"
+         id="feGaussianBlur4299" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="5.1737784"
+     inkscape:cy="2.8631892"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="23"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3"
+       d="m 7.5107388,1039.8504 7.5841942,0 0.487532,3.0066 0,7.2983 -8.0717262,0 z"
+       style="fill:url(#linearGradient3575);fill-opacity:1;stroke:none;display:inline" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001"
+       d="m 7.5107388,1039.8693 7.9833382,0 0,10.0177 -7.9833382,0 z"
+       style="fill:none;stroke:url(#linearGradient4908-2-8-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    <rect
+       style="fill:url(#linearGradient4553-7);fill-opacity:1;stroke:none;display:inline"
+       id="rect4178"
+       width="5"
+       height="0.9999826"
+       x="9"
+       y="1046.3622" />
+    <g
+       style="display:inline"
+       id="layer1-5"
+       inkscape:label="Layer 1"
+       transform="translate(-10.051944,2.8637517)" />
+    <rect
+       style="fill:url(#linearGradient3350);fill-opacity:1;stroke:none;display:inline"
+       id="rect4178-1"
+       width="5"
+       height="0.9999826"
+       x="9"
+       y="1044.3622" />
+    <rect
+       style="fill:url(#linearGradient3384);fill-opacity:1;stroke:none;display:inline"
+       id="rect4178-1-6"
+       width="5"
+       height="0.9999826"
+       x="9"
+       y="1042.3622" />
+    <rect
+       style="fill:url(#linearGradient4582-4-4);fill-opacity:1;stroke:none;display:inline"
+       id="rect4178-9-7"
+       width="1"
+       height="0.9999826"
+       x="8"
+       y="1044.3622" />
+    <g
+       id="g4280"
+       mask="url(#mask4289)"
+       style="opacity:0.65">
+      <g
+         style="display:inline;fill:#ffffff;stroke:#ffffff;stroke-width:2.58440071000000016;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4297)"
+         id="layer1-7-5"
+         inkscape:label="Layer 1"
+         transform="matrix(0.7738738,0,0,0.7738738,-1.7598376,235.78238)">
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="path4108-1-3-43"
+           d="m 6.6568452,1049.5614 c 0.2150324,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133512,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline;stroke-width:2.58440071000000016;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="path4108-1-3-4-9"
+           d="m 6.6568452,1049.5614 c 0.2150325,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133511,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline;stroke-width:2.58440071000000016;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="path4108-1-9"
+           d="m 6.6568452,1049.5614 c 0.2150324,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133512,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:2.58440071000000016;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <rect
+           y="1042.3649"
+           x="10.31146"
+           height="1.1992624"
+           width="0.94941604"
+           id="rect4122-8"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.58440071000000016;stroke-miterlimit:4;stroke-dasharray:none" />
+        <rect
+           y="1046.1245"
+           x="10.304321"
+           height="1.1992624"
+           width="0.94941604"
+           id="rect4122-2-4"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline;stroke-width:2.58440071000000016;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4108-1-3-4-6-9"
+           d="m 11.90625,1043.0312 2.28125,1.8438 -2.28125,1.7812 0,-1.0937 -1.21875,-0.062 c 0,0 -1.1298804,-0.1 -2.375,0.3125 -0.4970996,0.1646 -1.0141192,0.5483 -1.5,0.9687 -9.736e-4,-0.029 -0.06306,-0.097 -0.0625,-0.125 0.00915,-0.4526 0.1773911,-0.7816 0.5625,-1.1562 0.7702178,-0.7493 2.483426,-1.2754 3.3125,-1.2812 l 1.28125,0 0,-1.1876 z"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2.58440071000000016;marker:none;visibility:visible;display:inline;overflow:visible;filter:url(#filter4339-71);enable-background:accumulate;font-family:Sans;stroke-miterlimit:4;stroke-dasharray:none" />
+      </g>
+    </g>
+    <g
+       transform="matrix(0.7738738,0,0,0.7738738,-1.7598376,235.78238)"
+       inkscape:label="Layer 1"
+       id="layer1-7"
+       style="display:inline">
+      <path
+         style="fill:#abca52;fill-opacity:1;stroke:none;display:inline"
+         d="m 6.6568452,1049.5614 c 0.2150324,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133512,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+         id="path4108-1-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="fill:url(#linearGradient4349);fill-opacity:1;stroke:none;display:inline"
+         d="m 6.6568452,1049.5614 c 0.2150325,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133511,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+         id="path4108-1-3-4"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4112);stroke-width:1.29220033;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         d="m 6.6568452,1049.5614 c 0.2150324,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133512,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+         id="path4108-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <rect
+         style="fill:#2f9353;fill-opacity:1;stroke:none"
+         id="rect4122"
+         width="0.94941604"
+         height="1.1992624"
+         x="10.31146"
+         y="1042.3649" />
+      <rect
+         style="fill:#1d7a42;fill-opacity:1;stroke:none;display:inline"
+         id="rect4122-2"
+         width="0.94941604"
+         height="1.1992624"
+         x="10.304321"
+         y="1046.1245" />
+      <rect
+         style="fill:none;stroke:none"
+         id="rect4176"
+         width="1"
+         height="1"
+         x="4"
+         y="12"
+         transform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#cfdc63;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.58440065;marker:none;visibility:visible;display:inline;overflow:visible;filter:url(#filter4339);enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 11.90625,1043.0312 2.28125,1.8438 -2.28125,1.7812 0,-1.0937 -1.21875,-0.062 c 0,0 -1.1298804,-0.1 -2.375,0.3125 -0.4970996,0.1646 -1.0141192,0.5483 -1.5,0.9687 -9.736e-4,-0.029 -0.06306,-0.097 -0.0625,-0.125 0.00915,-0.4526 0.1773911,-0.7816 0.5625,-1.1562 0.7702178,-0.7493 2.483426,-1.2754 3.3125,-1.2812 l 1.28125,0 0,-1.1876 z"
+         id="path4108-1-3-4-6"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       style="display:inline"
+       id="layer1-6"
+       inkscape:label="Layer 1"
+       transform="translate(12.691804,-0.7906004)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/refactorings_obj.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/refactorings_obj.svg
@@ -1,0 +1,2127 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="refactorings_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4372"
+       inkscape:collect="always">
+      <stop
+         id="stop4374"
+         offset="0"
+         style="stop-color:#b9c9e4;stop-opacity:1" />
+      <stop
+         id="stop4376"
+         offset="1"
+         style="stop-color:#6c81ad;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4343">
+      <stop
+         style="stop-color:#96b956;stop-opacity:1"
+         offset="0"
+         id="stop4345" />
+      <stop
+         style="stop-color:#abca52;stop-opacity:1"
+         offset="1"
+         id="stop4347" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4106">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1;"
+         offset="0"
+         id="stop4108" />
+      <stop
+         style="stop-color:#146d39;stop-opacity:1"
+         offset="1"
+         id="stop4110" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 8 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="16 : 8 : 1"
+       inkscape:persp3d-origin="8 : 5.3333333 : 1"
+       id="perspective3519" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12886-6-7-7"
+       x1="393.4772"
+       y1="375.17487"
+       x2="379.65567"
+       y2="371.10898"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1-8-7">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3-6-2" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4-9-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12884-4-7-0"
+       x1="395.68689"
+       y1="379.50586"
+       x2="385.57773"
+       y2="388.69827"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12882-2-0-9"
+       x1="404.8793"
+       y1="389.22861"
+       x2="397.7753"
+       y2="400.10037"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12880-3-5-6"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12878-2-7-1"
+       x1="413.01102"
+       y1="366.6012"
+       x2="429.94864"
+       y2="364.92181"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12876-4-0-6"
+       x1="674.84711"
+       y1="180.63965"
+       x2="675.20258"
+       y2="166.79221"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12868-4-7-0"
+       x1="396.0101"
+       y1="359.4902"
+       x2="396.21149"
+       y2="350.94641"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12888-3-7-3"
+       x1="390.38361"
+       y1="362.80048"
+       x2="381.86542"
+       y2="360.85596"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       r="12.952347"
+       fy="420.74988"
+       fx="433.5452"
+       cy="420.74988"
+       cx="433.5452"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient12821-7-6-3"
+       xlink:href="#linearGradient12717-5-0-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-5-0-4-3">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-6-3-0-0" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-9-4-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7"
+       id="linearGradient12896-6-4-1"
+       x1="427.53012"
+       y1="432.76639"
+       x2="425.4519"
+       y2="415.1088"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-5-0-4-3"
+       id="radialGradient12723-8-2-4-1"
+       cx="433.36786"
+       cy="424.34106"
+       fx="433.36786"
+       fy="424.34106"
+       r="12.027534"
+       gradientTransform="matrix(1.1614831,2.1855961e-7,-2.811228e-7,1.4939602,-69.981471,-211.63828)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="translate(3.974778e-6,-9.8142563e-6)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient12725-9-4-7-2"
+       id="linearGradient12731-1-9-5-9"
+       x1="683.16229"
+       y1="205.72604"
+       x2="661.94519"
+       y2="183.18417"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12725-9-4-7-2">
+      <stop
+         style="stop-color:#397b3b;stop-opacity:1;"
+         offset="0"
+         id="stop12727-3-9-8-9" />
+      <stop
+         style="stop-color:#397b3b;stop-opacity:0;"
+         offset="1"
+         id="stop12729-4-1-8-3" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="455.88452"
+       x1="420.88995"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4046"
+       xlink:href="#linearGradient12862-1-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7584-9-3">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-6-3" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-9-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-0-5">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-8-9" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-5-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4216-0"
+       id="linearGradient4382"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       x1="393.36197"
+       y1="381.15457"
+       x2="385.57773"
+       y2="388.69827" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4234-5">
+      <stop
+         style="stop-color:#203932;stop-opacity:1"
+         offset="0"
+         id="stop4236-7" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4238-1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       y2="364.92181"
+       x2="429.94864"
+       y1="366.6012"
+       x1="413.01102"
+       id="linearGradient12878-2-7-1-2-8-9"
+       xlink:href="#linearGradient4234-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4240-5">
+      <stop
+         style="stop-color:#284539;stop-opacity:1"
+         offset="0"
+         id="stop4242-0" />
+      <stop
+         style="stop-color:#385653;stop-opacity:1"
+         offset="1"
+         id="stop4244-3" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="166.79221"
+       x2="675.20258"
+       y1="180.63965"
+       x1="674.84711"
+       id="linearGradient12876-4-0-6-7-3-6"
+       xlink:href="#linearGradient4240-5"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.60364,-39.53384)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4198-8">
+      <stop
+         style="stop-color:#2d483d;stop-opacity:1"
+         offset="0"
+         id="stop4200-3" />
+      <stop
+         style="stop-color:#38564e;stop-opacity:1"
+         offset="1"
+         id="stop4202-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.60473,-96.3391)"
+       gradientUnits="userSpaceOnUse"
+       y2="350.94641"
+       x2="396.21149"
+       y1="359.4902"
+       x1="396.0101"
+       id="linearGradient12868-4-7-0-8-7-6"
+       xlink:href="#linearGradient4198-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4204-6">
+      <stop
+         style="stop-color:#28483d;stop-opacity:1"
+         offset="0"
+         id="stop4206-3" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4208-8" />
+    </linearGradient>
+    <linearGradient
+       y2="360.85596"
+       x2="381.86542"
+       y1="362.80048"
+       x1="390.38361"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4091-0"
+       xlink:href="#linearGradient4204-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4210-9">
+      <stop
+         style="stop-color:#284539;stop-opacity:1"
+         offset="0"
+         id="stop4212-8" />
+      <stop
+         style="stop-color:#385653;stop-opacity:1"
+         offset="1"
+         id="stop4214-5" />
+    </linearGradient>
+    <linearGradient
+       y2="371.10898"
+       x2="379.65567"
+       y1="375.17487"
+       x1="393.4772"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4100-2"
+       xlink:href="#linearGradient4210-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4216-0">
+      <stop
+         style="stop-color:#233e32;stop-opacity:1"
+         offset="0"
+         id="stop4218-3" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:0.8650133"
+         offset="1"
+         id="stop4220-8" />
+    </linearGradient>
+    <linearGradient
+       y2="388.69827"
+       x2="385.57773"
+       y1="381.15457"
+       x1="393.36197"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,940.00748)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4097-3"
+       xlink:href="#linearGradient4216-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4222-4">
+      <stop
+         style="stop-color:#203c37;stop-opacity:1"
+         offset="0"
+         id="stop4224-9" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4226-6" />
+    </linearGradient>
+    <linearGradient
+       y2="399.07361"
+       x2="396.94577"
+       y1="388.32217"
+       x1="400.52957"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4094-1"
+       xlink:href="#linearGradient4222-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4228-4">
+      <stop
+         style="stop-color:#203932;stop-opacity:1"
+         offset="0"
+         id="stop4230-4" />
+      <stop
+         style="stop-color:#314e4a;stop-opacity:1"
+         offset="1"
+         id="stop4232-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4228-4"
+       id="linearGradient4141-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.35472)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4252-7">
+      <stop
+         style="stop-color:#1d6279;stop-opacity:1"
+         offset="0"
+         id="stop4254-1" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4256-4" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="447.02145"
+       x1="427.92853"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4190-8"
+       xlink:href="#linearGradient4252-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4258-3">
+      <stop
+         style="stop-color:#387a31;stop-opacity:1"
+         offset="0"
+         id="stop4260-4" />
+      <stop
+         style="stop-color:#397b3b;stop-opacity:0;"
+         offset="1"
+         id="stop4262-6" />
+    </linearGradient>
+    <linearGradient
+       y2="183.92403"
+       x2="666.19678"
+       y1="204.12044"
+       x1="684.11578"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.8909,996.82836)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4086-5"
+       xlink:href="#linearGradient4258-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="415.1088"
+       x2="425.4519"
+       y1="432.76639"
+       x1="427.53012"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4196"
+       xlink:href="#linearGradient4246"
+       inkscape:collect="always" />
+    <radialGradient
+       r="12.952347"
+       fy="420.74988"
+       fx="433.5452"
+       cy="420.74988"
+       cx="433.5452"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4194"
+       xlink:href="#linearGradient12717-5-0-4-3-4"
+       inkscape:collect="always" />
+    <radialGradient
+       r="12.027534"
+       fy="424.34106"
+       fx="433.36789"
+       cy="424.34106"
+       cx="433.36789"
+       gradientTransform="matrix(1.2231981,-0.08344257,0.10167677,1.4904962,-139.87254,-174.00694)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4192"
+       xlink:href="#linearGradient4515"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="447.02145"
+       x1="427.92853"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4190"
+       xlink:href="#linearGradient4252"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-75-5"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-4-2"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-16-6"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-75-5"
+       id="linearGradient3993-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       y2="183.92403"
+       x2="666.19678"
+       y1="204.12044"
+       x1="684.11578"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.8909,996.82836)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4086"
+       xlink:href="#linearGradient4258"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4472"
+       id="linearGradient3993"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-7-5"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-1-6"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-12-9"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-7-5"
+       id="linearGradient3915-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.27903302,0.27903303,0,-96.327735,115.6161)"
+       x1="396.0101"
+       y1="359.4902"
+       x2="396.21149"
+       y2="350.94641" />
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.60473,-96.339099)"
+       gradientUnits="userSpaceOnUse"
+       y2="350.94641"
+       x2="396.21149"
+       y1="359.4902"
+       x1="396.0101"
+       id="linearGradient12868-4-7-0-8"
+       xlink:href="#linearGradient4490"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="166.79221"
+       x2="675.20258"
+       y1="180.63965"
+       x1="674.84711"
+       id="linearGradient12876-4-0-6-7"
+       xlink:href="#linearGradient4484"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.27903303,0,0,0.24756874,-178.60364,-39.53384)" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-9-7"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-8-0"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-0-6"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-9-7"
+       id="linearGradient3813-8"
+       gradientUnits="userSpaceOnUse"
+       x1="674.84711"
+       y1="180.63965"
+       x2="675.20258"
+       y2="166.79221"
+       gradientTransform="matrix(0,0.27903302,0.24756874,0,-39.521247,-178.59954)" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-1-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-9-6"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-1-4"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-1-9"
+       id="linearGradient3847-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.27903302,0.27903303,0,-96.353305,-104.6999)"
+       x1="413.01102"
+       y1="366.6012"
+       x2="429.94864"
+       y2="364.92181" />
+    <linearGradient
+       gradientTransform="matrix(0.27903303,0,0,0.27903304,-104.76098,-96.354723)"
+       gradientUnits="userSpaceOnUse"
+       y2="364.92181"
+       x2="429.94864"
+       y1="366.6012"
+       x1="413.01102"
+       id="linearGradient12878-2-7-1-2"
+       xlink:href="#linearGradient4478"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-75"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-4"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-16"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,264.63772,-229.51558)"
+       gradientUnits="userSpaceOnUse"
+       y2="381.80399"
+       x2="432.86548"
+       y1="378.7988"
+       x1="420.52402"
+       id="linearGradient12880-3-5-6-9"
+       xlink:href="#linearGradient12862-1-8-7-75"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-96-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-86-2"
+         offset="0"
+         style="stop-color:#203932;stop-opacity:1" />
+      <stop
+         id="stop12866-4-9-5-8-9"
+         offset="1"
+         style="stop-color:#31564a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-7-96-9"
+       id="linearGradient3881-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.27903302,0.27903303,0,-96.392939,-104.7384)"
+       x1="420.52402"
+       y1="378.7988"
+       x2="432.86548"
+       y2="381.80399" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-7"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-1"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-12"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,265.19769,-229.45247)"
+       gradientUnits="userSpaceOnUse"
+       y2="350.94641"
+       x2="396.21149"
+       y1="359.4902"
+       x1="396.0101"
+       id="linearGradient12868-4-7-0-0"
+       xlink:href="#linearGradient12862-1-8-7-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-96"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-86"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-8"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,264.63772,-229.51558)"
+       gradientUnits="userSpaceOnUse"
+       y2="381.80399"
+       x2="432.86548"
+       y1="378.7988"
+       x1="420.52402"
+       id="linearGradient12880-3-5-6-6"
+       xlink:href="#linearGradient12862-1-8-7-96"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-1"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-9"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-1"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.1270932,264.63772,-229.51558)"
+       gradientUnits="userSpaceOnUse"
+       y2="364.92181"
+       x2="429.94864"
+       y1="366.6012"
+       x1="413.01102"
+       id="linearGradient12878-2-7-1-1"
+       xlink:href="#linearGradient12862-1-8-7-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-8-7-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-2-8"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5-0"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="166.79221"
+       x2="675.20258"
+       y1="180.63965"
+       x1="674.84711"
+       id="linearGradient12876-4-0-6-3"
+       xlink:href="#linearGradient12862-1-8-7-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12717-5-0-4-3-4"
+       inkscape:collect="always">
+      <stop
+         id="stop12719-6-3-0-0-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop12721-9-4-5-0-6"
+         offset="1"
+         style="stop-color:#8ebc7b;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4246">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4248" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4250" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4252">
+      <stop
+         style="stop-color:#0d5269;stop-opacity:1"
+         offset="0"
+         id="stop4254" />
+      <stop
+         style="stop-color:#2d707c;stop-opacity:1"
+         offset="1"
+         id="stop4256" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4258">
+      <stop
+         style="stop-color:#387a31;stop-opacity:1"
+         offset="0"
+         id="stop4260" />
+      <stop
+         style="stop-color:#397b3b;stop-opacity:0;"
+         offset="1"
+         id="stop4262" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4472">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4474" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4476" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4478">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4480" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4482" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4484">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4486" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4488" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4490">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop4492" />
+      <stop
+         style="stop-color:#31564a;stop-opacity:1"
+         offset="1"
+         id="stop4494" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4515">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4517" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop4519" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4515-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4517-7" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop4519-4" />
+    </linearGradient>
+    <mask
+       id="mask7862"
+       maskUnits="userSpaceOnUse">
+      <g
+         id="g7864">
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.5;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           d="m 11.5,1039.6591 c -0.18722,10e-5 -0.383743,0.04 -0.65625,0.094 l 0,0.875 c -0.213492,0.042 -0.422114,0.072 -0.625,0.1562 -0.194391,0.083 -0.388449,0.2275 -0.5625,0.3438 l -0.625,-0.6252 c -0.462167,0.3084 -0.597312,0.4445 -0.90625,0.9062 l 0.625,0.625 c -0.121067,0.1808 -0.2597,0.3909 -0.34375,0.5938 -0.08385,0.2029 -0.113627,0.4115 -0.15625,0.625 l -0.90625,0 c -0.108682,0.5449 -0.108112,0.7362 0,1.2812 l 0.90625,0 c 0.08465,0.427 0.258374,0.8566 0.5,1.2188 l -0.625,0.5937 c 0.308933,0.4619 0.444082,0.5977 0.90625,0.9063 l 0.625,-0.5938 c 0.361804,0.2421 0.760581,0.4148 1.1875,0.5 l 0,0.875 c 0.545014,0.1081 0.76758,0.1087 1.3125,0 l 0,-0.875 c 0.426989,-0.085 0.8255,-0.2582 1.1875,-0.5 l 0.625,0.5938 c 0.46183,-0.309 0.597782,-0.4441 0.90625,-0.9063 l -0.625,-0.5937 c 0.242113,-0.3618 0.414842,-0.792 0.5,-1.2188 l 0.90625,0 c 0.108112,-0.545 0.108682,-0.7363 0,-1.2812 l -0.90625,0 c -0.08469,-0.4271 -0.258169,-0.8568 -0.5,-1.2188 l 0.625,-0.625 c -0.154067,-0.2313 -0.242615,-0.3988 -0.375,-0.5312 -0.13245,-0.1323 -0.299966,-0.2209 -0.53125,-0.375 l -0.625,0.625 c -0.361809,-0.2421 -0.760526,-0.415 -1.1875,-0.5 l 0,-0.875 c -0.27246,-0.054 -0.46903,-0.094 -0.65625,-0.094 z m 0,3.3125 c 0.500508,0 0.90625,0.4057 0.90625,0.9063 0,0.5005 -0.405742,0.9062 -0.90625,0.9062 -0.500508,0 -0.90625,-0.4057 -0.90625,-0.9062 0,-0.5006 0.405742,-0.9063 0.90625,-0.9063 z"
+           id="path7866"
+           inkscape:connector-curvature="0" />
+      </g>
+    </mask>
+    <linearGradient
+       id="linearGradient5103">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105" />
+      <stop
+         id="stop7550"
+         offset="0.26694915"
+         style="stop-color:#fef5d4;stop-opacity:1" />
+      <stop
+         id="stop7548"
+         offset="0.51694918"
+         style="stop-color:#fbe08e;stop-opacity:1" />
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="1"
+         id="stop5107" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5281">
+      <stop
+         id="stop5283"
+         offset="0"
+         style="stop-color:#e0b575;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f5ca75;stop-opacity:1"
+         offset="0.5"
+         id="stop5289" />
+      <stop
+         id="stop5285"
+         offset="1"
+         style="stop-color:#f5f5b5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5103-5">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105-9" />
+      <stop
+         id="stop7550-8"
+         offset="0.26694915"
+         style="stop-color:#fef5d4;stop-opacity:1" />
+      <stop
+         id="stop7548-2"
+         offset="0.51694918"
+         style="stop-color:#fbe08e;stop-opacity:1" />
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="1"
+         id="stop5107-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-20)"
+       gradientUnits="userSpaceOnUse"
+       y2="1064.8306"
+       x2="16.46875"
+       y1="1064.8306"
+       x1="4.2581835"
+       id="linearGradient7558-2"
+       xlink:href="#linearGradient7552-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7552-5"
+       inkscape:collect="always">
+      <stop
+         id="stop7554-6"
+         offset="0"
+         style="stop-color:#c08c29;stop-opacity:1" />
+      <stop
+         id="stop7556-9"
+         offset="1"
+         style="stop-color:#b17813;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4106"
+       id="linearGradient4112"
+       x1="10.225247"
+       y1="1030.4619"
+       x2="10.225247"
+       y2="1039.7833"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,10.337603)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4106-0"
+       id="linearGradient4112-8"
+       x1="10.225247"
+       y1="1030.4619"
+       x2="10.225247"
+       y2="1039.7833"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,10.337603)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4106-0">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1;"
+         offset="0"
+         id="stop4108-8" />
+      <stop
+         style="stop-color:#146d39;stop-opacity:1"
+         offset="1"
+         id="stop4110-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188"
+       id="linearGradient4194"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-6"
+       id="linearGradient4194-5"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-6">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-4" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-7" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,2.1909235,1035.842)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4245"
+       xlink:href="#linearGradient4188-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4266"
+       id="linearGradient4272"
+       x1="25.930252"
+       y1="1051.1136"
+       x2="25.930252"
+       y2="1047.26"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <filter
+       inkscape:collect="always"
+       id="filter4339"
+       x="-0.090256119"
+       width="1.1805122"
+       y="-0.1789842"
+       height="1.3579684">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.27970009"
+         id="feGaussianBlur4341" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4343"
+       id="linearGradient4349"
+       x1="11.032874"
+       y1="1048.5142"
+       x2="11.032874"
+       y2="1041.7299"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4266-7"
+       id="linearGradient4272-2"
+       x1="25.930252"
+       y1="1051.1136"
+       x2="25.930252"
+       y2="1047.26"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266-7">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268-0" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4106-02"
+       id="linearGradient4112-88"
+       x1="10.225247"
+       y1="1030.4619"
+       x2="10.225247"
+       y2="1039.7833"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,10.337603)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4106-02">
+      <stop
+         style="stop-color:#359b58;stop-opacity:1;"
+         offset="0"
+         id="stop4108-86" />
+      <stop
+         style="stop-color:#146d39;stop-opacity:1"
+         offset="1"
+         id="stop4110-4" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4529">
+      <rect
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-opacity:1;display:inline"
+         id="rect4531"
+         width="8.993515"
+         height="3.9996338"
+         x="2.4969711"
+         y="1046.86" />
+    </mask>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(-6.0000004,-11.968814)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4245-0"
+       xlink:href="#linearGradient4188-6-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-6-0">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-4-6" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-7-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-4"
+       id="linearGradient4194-58"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-6" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(0,1036.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4553"
+       xlink:href="#linearGradient4188-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-6-0"
+       id="linearGradient4582"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.0000001,1036.3934)"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4266-4"
+       id="linearGradient4272-6"
+       x1="25.930252"
+       y1="1051.1136"
+       x2="25.930252"
+       y2="1047.26"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266-4">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268-6" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270-39" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(1.0277276,1035.3346)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4553-7"
+       xlink:href="#linearGradient4188-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4-3">
+      <stop
+         style="stop-color:#b9c9e4;stop-opacity:1"
+         offset="0"
+         id="stop4190-6-1" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4-6" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(3.0277276,1034.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4553-7-7"
+       xlink:href="#linearGradient4188-4-3-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4-3-7">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-6-1-0" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4-6-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4188-6-0-7-5"
+       id="linearGradient4582-4-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.0242051,1031.283)"
+       x1="7"
+       y1="12.5"
+       x2="9"
+       y2="12.5" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-6-0-7-5">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-4-6-2-6" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-7-4-6-4" />
+    </linearGradient>
+    <mask
+       id="mask4181"
+       maskUnits="userSpaceOnUse">
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="path4183"
+         d="m 3.5193795,1037.8597 7.0096695,0 3.062057,3.0066 0,9.9546 -10.0717265,0 z"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       id="linearGradient5300-6-8">
+      <stop
+         id="stop5302-7-1"
+         offset="0"
+         style="stop-color:#4d4d4d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#727272;stop-opacity:1;"
+         offset="0.29405674"
+         id="stop5308-2-6" />
+      <stop
+         id="stop5304-3-8"
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5300-6-8"
+       id="linearGradient3208-6"
+       gradientUnits="userSpaceOnUse"
+       x1="2.65625"
+       y1="1049.3976"
+       x2="4.0822439"
+       y2="1050.5304" />
+    <linearGradient
+       id="linearGradient5077-5-8-7">
+      <stop
+         id="stop5079-7-9-4"
+         offset="0"
+         style="stop-color:#e4cf94;stop-opacity:1" />
+      <stop
+         style="stop-color:#ede0ba;stop-opacity:1"
+         offset="0.32186735"
+         id="stop5087-6-0-2" />
+      <stop
+         style="stop-color:#c1aa7e;stop-opacity:1"
+         offset="0.64764118"
+         id="stop5085-1-4-6" />
+      <stop
+         id="stop5081-8-7-6"
+         offset="1"
+         style="stop-color:#ad8865;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4902-3-3"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-7"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2-6"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.977903,-1.044194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-4"
+       xlink:href="#linearGradient4902-3-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5300-6">
+      <stop
+         id="stop5302-7"
+         offset="0"
+         style="stop-color:#4d4d4d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#727272;stop-opacity:1;"
+         offset="0.29405674"
+         id="stop5308-2" />
+      <stop
+         id="stop5304-3"
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1050.5304"
+       x2="4.0822439"
+       y1="1049.3976"
+       x1="2.65625"
+       id="linearGradient5306-8"
+       xlink:href="#linearGradient5300-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5077-5-8">
+      <stop
+         id="stop5079-7-9"
+         offset="0"
+         style="stop-color:#e4cf94;stop-opacity:1" />
+      <stop
+         style="stop-color:#ede0ba;stop-opacity:1"
+         offset="0.32186735"
+         id="stop5087-6-0" />
+      <stop
+         style="stop-color:#c1aa7e;stop-opacity:1"
+         offset="0.64764118"
+         id="stop5085-1-4" />
+      <stop
+         id="stop5081-8-7"
+         offset="1"
+         style="stop-color:#ad8865;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5077-5">
+      <stop
+         id="stop5079-7"
+         offset="0"
+         style="stop-color:#e4cf94;stop-opacity:1" />
+      <stop
+         style="stop-color:#ede0ba;stop-opacity:1"
+         offset="0.32186735"
+         id="stop5087-6" />
+      <stop
+         style="stop-color:#c1aa7e;stop-opacity:1"
+         offset="0.64764118"
+         id="stop5085-1" />
+      <stop
+         id="stop5081-8"
+         offset="1"
+         style="stop-color:#ad8865;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5300">
+      <stop
+         id="stop5302"
+         offset="0"
+         style="stop-color:#4d4d4d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#727272;stop-opacity:1;"
+         offset="0.29405674"
+         id="stop5308" />
+      <stop
+         id="stop5304"
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-14.678348,-0.26294396)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-6-5"
+       id="linearGradient4101-1"
+       gradientUnits="userSpaceOnUse"
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378" />
+    <linearGradient
+       id="linearGradient4994-6-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-1-4"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1;" />
+      <stop
+         id="stop4998-89-1"
+         offset="1"
+         style="stop-color:#dce7f7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientTransform="translate(-1.986544,-1.0535)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3526-9"
+       xlink:href="#linearGradient4994-6-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4994-6-5-8"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-1-4-1"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1;" />
+      <stop
+         id="stop4998-89-1-0"
+         offset="1"
+         style="stop-color:#dce7f7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.986544,-0.08122802)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-8-8"
+       xlink:href="#linearGradient4902-3-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4902-3-1-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-9-9"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2-5-7"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1054.6202"
+       x2="9.8946028"
+       y1="1042.6202"
+       x1="9.8946028"
+       gradientTransform="translate(-3.986544,-0.25800474)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3575"
+       xlink:href="#linearGradient4994-6-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1047.26"
+       x2="25.930252"
+       y1="1051.1136"
+       x1="25.930252"
+       gradientTransform="translate(-16.972268,-1.9999972)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4609-3"
+       xlink:href="#linearGradient4266-4-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266-4-6">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop4268-6-3" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop4270-39-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.986544,-1.0535)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-8-8-7"
+       xlink:href="#linearGradient4902-3-1-1-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4902-3-1-1-9"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-9-9-1"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2-5-7-8"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4487">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4489"
+         d="m 3.5107388,1037.8693 9.9833382,0 0,12.9865 -9.9833382,0 z"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4578">
+      <g
+         id="g4580">
+        <rect
+           y="1042.8712"
+           x="6.484375"
+           height="5.9883718"
+           width="8.0338383"
+           id="rect4582"
+           style="fill:#f1f5fa;fill-opacity:1;stroke:#ffffff;stroke-opacity:1;display:inline" />
+        <path
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+           d="m 3.5107388,1037.8693 9.9833382,0 0,12.9865 -9.9833382,0 z"
+           id="path4584"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+      </g>
+    </mask>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(3.0277276,1034.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4553-7-1"
+       xlink:href="#linearGradient4188-4-3-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4-3-9">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-6-1-3" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4-6-4" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(1.0277276,1033.3346)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3350"
+       xlink:href="#linearGradient4372"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(3.0277276,1032.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3350-2"
+       xlink:href="#linearGradient4188-4-3-9-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4188-4-3-9-6">
+      <stop
+         style="stop-color:#8297bc;stop-opacity:1"
+         offset="0"
+         id="stop4190-6-1-3-1" />
+      <stop
+         style="stop-color:#6c81ad;stop-opacity:1"
+         offset="1"
+         id="stop4192-4-6-4-5" />
+    </linearGradient>
+    <linearGradient
+       y2="12.5"
+       x2="9"
+       y1="12.5"
+       x1="7"
+       gradientTransform="translate(1.0277276,1031.3346)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3384"
+       xlink:href="#linearGradient4188-4-3-9-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-1.986544,-1.0535)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-8-8-3"
+       xlink:href="#linearGradient4902-3-1-1-98"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4902-3-1-1-98"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-9-9-6"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2-5-7-3"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4289">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4291"
+         d="m 7.5107388,1039.8693 7.9833382,0 0,10.0177 -7.9833382,0 z"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter4297"
+       x="-0.16641306"
+       width="1.3328261"
+       y="-0.19600282"
+       height="1.3920056">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.751532"
+         id="feGaussianBlur4299" />
+    </filter>
+    <linearGradient
+       gradientTransform="translate(-1.986544,-2.0812)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-8-8-4"
+       xlink:href="#linearGradient4902-3-1-1-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4902-3-1-1-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-9-9-18"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2-5-7-2"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientTransform="translate(-3.986544,-0.25800474)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3575-3"
+       xlink:href="#linearGradient4994-6-5-8-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4994-6-5-8-9"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-1-4-1-1"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1;" />
+      <stop
+         id="stop4998-89-1-0-7"
+         offset="1"
+         style="stop-color:#dce7f7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientTransform="translate(-1.986544,-2.258)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3357"
+       xlink:href="#linearGradient4994-6-5-8-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-3.986544,-0.08122802)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-8-8-1"
+       xlink:href="#linearGradient4902-3-1-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4902-3-1-1-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-9-9-4"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2-5-7-5"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter4188"
+       x="-0.13528956"
+       width="1.2705791"
+       y="-0.1078154"
+       height="1.2156308">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.45002596"
+         id="feGaussianBlur4190" />
+    </filter>
+    <linearGradient
+       gradientTransform="translate(-1.986544,-2.0812)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-8-8-4-9"
+       xlink:href="#linearGradient4902-3-1-1-7-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4902-3-1-1-7-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-9-9-18-8"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2-5-7-2-7"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4242">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4244"
+         d="m 7.5107388,1038.8417 7.9833382,0 0,10.0177 -7.9833382,0 z"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter4339-3"
+       x="-0.090256117"
+       width="1.1805122"
+       y="-0.17898419"
+       height="1.3579684">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.27970009"
+         id="feGaussianBlur4341-5" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       id="filter4321"
+       x="-0.11094204"
+       width="1.2218841"
+       y="-0.13066855"
+       height="1.2613371">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.50102133"
+         id="feGaussianBlur4323" />
+    </filter>
+    <linearGradient
+       gradientTransform="translate(-3.986544,-0.08122802)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-8-8-9"
+       xlink:href="#linearGradient4902-3-1-1-10"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4902-3-1-1-10"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-9-9-2"
+         offset="0"
+         style="stop-color:#b28a30;stop-opacity:1" />
+      <stop
+         id="stop4906-2-5-7-4"
+         offset="1"
+         style="stop-color:#7b703e;stop-opacity:1" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4368">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4370"
+         d="m 5.5107388,1040.8417 7.9833382,0 0,10.0177 -7.9833382,0 z"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="0.075681066"
+     inkscape:cy="7.952214"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="23"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-3"
+       d="m 7.5107388,1038.646 7.5841942,0 0.487532,3.0066 0,7.2983 -8.0717262,0 z"
+       style="fill:url(#linearGradient3357);fill-opacity:1;stroke:none;display:inline" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-2"
+       d="m 7.5107388,1038.8417 7.9833382,0 0,10.0177 -7.9833382,0 z"
+       style="fill:none;stroke:url(#linearGradient4908-2-8-8-4);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    <g
+       id="g4239"
+       mask="url(#mask4242)"
+       style="opacity:0.75">
+      <path
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline;filter:url(#filter4188);stroke-dasharray:none"
+         d="m 5.5107388,1040.8417 7.9833382,0 0,10.0177 -7.9833382,0 z"
+         id="rect4001-5"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3"
+       d="m 5.5107388,1040.646 7.5841942,0 0.487532,3.0066 0,7.2983 -8.0717262,0 z"
+       style="fill:url(#linearGradient3575);fill-opacity:1;stroke:none;display:inline" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001"
+       d="m 5.5107388,1040.8417 7.9833382,0 0,10.0177 -7.9833382,0 z"
+       style="fill:none;stroke:url(#linearGradient4908-2-8-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    <rect
+       style="fill:url(#linearGradient4553-7);fill-opacity:1;stroke:none;display:inline"
+       id="rect4178"
+       width="5"
+       height="0.9999826"
+       x="7"
+       y="1047.3344" />
+    <g
+       style="display:inline"
+       id="layer1-5"
+       inkscape:label="Layer 1"
+       transform="translate(-10.051944,2.8637517)" />
+    <rect
+       style="fill:url(#linearGradient3350);fill-opacity:1;stroke:none;display:inline"
+       id="rect4178-1"
+       width="5"
+       height="0.9999826"
+       x="7"
+       y="1045.3344" />
+    <rect
+       style="fill:url(#linearGradient3384);fill-opacity:1;stroke:none;display:inline"
+       id="rect4178-1-6"
+       width="5"
+       height="0.9999826"
+       x="7"
+       y="1043.3344" />
+    <rect
+       style="fill:url(#linearGradient4582-4-4);fill-opacity:1;stroke:none;display:inline"
+       id="rect4178-9-7"
+       width="1"
+       height="0.9999826"
+       x="7.0277271"
+       y="1043.3458" />
+    <g
+       id="g4325"
+       mask="url(#mask4368)"
+       style="opacity:0.75">
+      <g
+         style="display:inline;fill:#ffffff;stroke:#ffffff;filter:url(#filter4321);stroke-width:2.58440071000000016;stroke-miterlimit:4;stroke-dasharray:none"
+         id="layer1-7-9"
+         inkscape:label="Layer 1"
+         transform="matrix(0.7738738,0,0,0.7738738,-2.73211,234.76601)">
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="path4108-1-3-2"
+           d="m 6.6568452,1049.5614 c 0.2150324,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133512,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline;stroke-width:2.58440071000000016;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="path4108-1-3-4-8"
+           d="m 6.6568452,1049.5614 c 0.2150325,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133511,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline;stroke-width:2.58440071000000016;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="path4108-1-7"
+           d="m 6.6568452,1049.5614 c 0.2150324,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133512,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:2.58440071000000016;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <rect
+           y="1042.3649"
+           x="10.31146"
+           height="1.1992624"
+           width="0.94941604"
+           id="rect4122-5"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.58440071000000016;stroke-miterlimit:4;stroke-dasharray:none" />
+        <rect
+           y="1046.1245"
+           x="10.304321"
+           height="1.1992624"
+           width="0.94941604"
+           id="rect4122-2-2"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline;stroke-width:2.58440071000000016;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4108-1-3-4-6-8"
+           d="m 11.90625,1043.0312 2.28125,1.8438 -2.28125,1.7812 0,-1.0937 -1.21875,-0.062 c 0,0 -1.1298804,-0.1 -2.375,0.3125 -0.4970996,0.1646 -1.0141192,0.5483 -1.5,0.9687 -9.736e-4,-0.029 -0.06306,-0.097 -0.0625,-0.125 0.00915,-0.4526 0.1773911,-0.7816 0.5625,-1.1562 0.7702178,-0.7493 2.483426,-1.2754 3.3125,-1.2812 l 1.28125,0 0,-1.1876 z"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2.58440071000000016;marker:none;visibility:visible;display:inline;overflow:visible;filter:url(#filter4339-3);enable-background:accumulate;font-family:Sans;stroke-miterlimit:4;stroke-dasharray:none" />
+      </g>
+    </g>
+    <g
+       transform="matrix(0.7738738,0,0,0.7738738,-2.73211,234.76601)"
+       inkscape:label="Layer 1"
+       id="layer1-7"
+       style="display:inline">
+      <path
+         style="fill:#abca52;fill-opacity:1;stroke:none;display:inline"
+         d="m 6.6568452,1049.5614 c 0.2150324,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133512,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+         id="path4108-1-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="fill:url(#linearGradient4349);fill-opacity:1;stroke:none;display:inline"
+         d="m 6.6568452,1049.5614 c 0.2150325,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133511,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+         id="path4108-1-3-4"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4112);stroke-width:1.29220033;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         d="m 6.6568452,1049.5614 c 0.2150324,-3.023 3.9579708,-2.7863 3.9579708,-2.7863 l 0,2.5277 5.667622,-4.4255 -5.667622,-4.5182 0,2.5616 c -2.4133512,0.017 -7.4932205,2.1686 -3.9579708,6.6407 z"
+         id="path4108-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <rect
+         style="fill:#2f9353;fill-opacity:1;stroke:none"
+         id="rect4122"
+         width="0.94941604"
+         height="1.1992624"
+         x="10.31146"
+         y="1042.3649" />
+      <rect
+         style="fill:#1d7a42;fill-opacity:1;stroke:none;display:inline"
+         id="rect4122-2"
+         width="0.94941604"
+         height="1.1992624"
+         x="10.304321"
+         y="1046.1245" />
+      <rect
+         style="fill:none;stroke:none"
+         id="rect4176"
+         width="1"
+         height="1"
+         x="4"
+         y="12"
+         transform="matrix(1.2922004,0,0,1.2922004,4.7753243,1035.8017)" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#cfdc63;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.58440065;marker:none;visibility:visible;display:inline;overflow:visible;filter:url(#filter4339);enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 11.90625,1043.0312 2.28125,1.8438 -2.28125,1.7812 0,-1.0937 -1.21875,-0.062 c 0,0 -1.1298804,-0.1 -2.375,0.3125 -0.4970996,0.1646 -1.0141192,0.5483 -1.5,0.9687 -9.736e-4,-0.029 -0.06306,-0.097 -0.0625,-0.125 0.00915,-0.4526 0.1773911,-0.7816 0.5625,-1.1562 0.7702178,-0.7493 2.483426,-1.2754 3.3125,-1.2812 l 1.28125,0 0,-1.1876 z"
+         id="path4108-1-3-4-6"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       style="display:inline"
+       id="layer1-6"
+       inkscape:label="Layer 1"
+       transform="translate(12.691804,-0.7906004)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/text_edit.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/text_edit.svg
@@ -1,0 +1,620 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="text_edit.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5135-7"
+       id="linearGradient4873-1"
+       x1="7.0070496"
+       y1="1051.8571"
+       x2="12.016466"
+       y2="1051.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       id="linearGradient5135-7"
+       inkscape:collect="always">
+      <stop
+         id="stop5137-4"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5139-0"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5141-4"
+       id="linearGradient4875-9"
+       x1="7.0070496"
+       y1="1049.8571"
+       x2="14"
+       y2="1049.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       id="linearGradient5141-4"
+       inkscape:collect="always">
+      <stop
+         id="stop5143-8"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5145-8"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5147-4"
+       id="linearGradient4871-2"
+       x1="7.0070496"
+       y1="1047.8571"
+       x2="14"
+       y2="1047.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       id="linearGradient5147-4"
+       inkscape:collect="always">
+      <stop
+         id="stop5149-5"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5151-5"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861-1"
+       id="linearGradient4869-17"
+       x1="7.0070496"
+       y1="1045.8571"
+       x2="14"
+       y2="1045.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861-1">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4863-1" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop4865-52" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877-6"
+       id="linearGradient4867-7"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       id="linearGradient4877-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4879-1"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4881-4"
+         offset="1"
+         style="stop-color:#5e76a3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient4908-2"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-1.044194)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902-3">
+      <stop
+         style="stop-color:#b28a30;stop-opacity:1"
+         offset="0"
+         id="stop4904-2" />
+      <stop
+         style="stop-color:#7b703e;stop-opacity:1"
+         offset="1"
+         id="stop4906-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894-6"
+       id="linearGradient4900-1"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.022097,-1.044194)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4894-6">
+      <stop
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0"
+         id="stop4896-8" />
+      <stop
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1"
+         id="stop4898-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-6">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996-1" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998-89" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101"
+       xlink:href="#linearGradient4994-6"
+       inkscape:collect="always"
+       gradientTransform="translate(-1.977903,-1.044194)" />
+    <linearGradient
+       id="linearGradient5300">
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:1;"
+         offset="0"
+         id="stop5302" />
+      <stop
+         id="stop5308"
+         offset="0.29405674"
+         style="stop-color:#727272;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:1"
+         offset="1"
+         id="stop5304" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5077-5">
+      <stop
+         style="stop-color:#e4cf94;stop-opacity:1"
+         offset="0"
+         id="stop5079-7" />
+      <stop
+         id="stop5087-6"
+         offset="0.32186735"
+         style="stop-color:#ede0ba;stop-opacity:1" />
+      <stop
+         id="stop5085-1"
+         offset="0.64764118"
+         style="stop-color:#c1aa7e;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad8865;stop-opacity:1"
+         offset="1"
+         id="stop5081-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.6704"
+       x2="-8.7005796"
+       y1="1042.1598"
+       x1="-11.21119"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5173-0"
+       xlink:href="#linearGradient4908-52-3-2-9"
+       inkscape:collect="always"
+       gradientTransform="translate(20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4908-52-3-2-9">
+      <stop
+         style="stop-color:#986443;stop-opacity:1"
+         offset="0"
+         id="stop4910-7-2-7-0" />
+      <stop
+         style="stop-color:#994f1b;stop-opacity:1"
+         offset="1"
+         id="stop4912-6-2-9-4" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter5428-9">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.22207033"
+         id="feGaussianBlur5430-2" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5077-5-8"
+       id="linearGradient5196-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4,-1036.3622)"
+       x1="-0.9810437"
+       y1="1047.4242"
+       x2="1.9838035"
+       y2="1050.3188" />
+    <linearGradient
+       id="linearGradient5077-5-8">
+      <stop
+         style="stop-color:#e4cf94;stop-opacity:1"
+         offset="0"
+         id="stop5079-7-9" />
+      <stop
+         id="stop5087-6-0"
+         offset="0.32186735"
+         style="stop-color:#ede0ba;stop-opacity:1" />
+      <stop
+         id="stop5085-1-4"
+         offset="0.64764118"
+         style="stop-color:#c1aa7e;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad8865;stop-opacity:1"
+         offset="1"
+         id="stop5081-8-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5300-6"
+       id="linearGradient5306-8"
+       x1="2.65625"
+       y1="1049.3976"
+       x2="4.0822439"
+       y2="1050.5304"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5300-6">
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:1;"
+         offset="0"
+         id="stop5302-7" />
+      <stop
+         id="stop5308-2"
+         offset="0.29405674"
+         style="stop-color:#727272;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:1"
+         offset="1"
+         id="stop5304-3" />
+    </linearGradient>
+    <linearGradient
+       y2="1050.5304"
+       x2="4.0822439"
+       y1="1049.3976"
+       x1="2.65625"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3208"
+       xlink:href="#linearGradient5300-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3-3"
+       id="linearGradient4908-2-4"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-1.044194)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902-3-3">
+      <stop
+         style="stop-color:#b28a30;stop-opacity:1"
+         offset="0"
+         id="stop4904-2-7" />
+      <stop
+         style="stop-color:#7b703e;stop-opacity:1"
+         offset="1"
+         id="stop4906-2-6" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter5428-9-1">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.22207033"
+         id="feGaussianBlur5430-2-9" />
+    </filter>
+    <linearGradient
+       id="linearGradient5077-5-8-7">
+      <stop
+         style="stop-color:#e4cf94;stop-opacity:1"
+         offset="0"
+         id="stop5079-7-9-4" />
+      <stop
+         id="stop5087-6-0-2"
+         offset="0.32186735"
+         style="stop-color:#ede0ba;stop-opacity:1" />
+      <stop
+         id="stop5085-1-4-6"
+         offset="0.64764118"
+         style="stop-color:#c1aa7e;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad8865;stop-opacity:1"
+         offset="1"
+         id="stop5081-8-7-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1050.5304"
+       x2="4.0822439"
+       y1="1049.3976"
+       x1="2.65625"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3208-6"
+       xlink:href="#linearGradient5300-6-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5300-6-8">
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:1;"
+         offset="0"
+         id="stop5302-7-1" />
+      <stop
+         id="stop5308-2-6"
+         offset="0.29405674"
+         style="stop-color:#727272;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:1"
+         offset="1"
+         id="stop5304-3-8" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter4177"
+       x="-0.11984986"
+       width="1.2396997"
+       y="-0.12015051"
+       height="1.240301">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.40384366"
+         id="feGaussianBlur4179" />
+    </filter>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4181">
+      <path
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 3.5193795,1037.8597 7.0096695,0 3.062057,3.0066 0,9.9546 -10.0717265,0 z"
+         id="path4183"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+    </mask>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8.0000004"
+     inkscape:cx="10.666768"
+     inkscape:cy="4.4401945"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1440"
+     inkscape:window-height="779"
+     inkscape:window-x="98"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4101);fill-opacity:1;stroke:none;display:inline"
+       d="m 3.5193795,1037.8597 7.0096695,0 3.062057,3.0066 0,9.9546 -10.0717265,0 z"
+       id="rect4001-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:url(#linearGradient4900-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 9.998718,1037.397 0,3.9112 3.977478,0 z"
+       id="path4884"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:url(#linearGradient4908-2);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+       d="m 3.5193795,1037.8597 7.0096695,0 3.062057,3.0066 0,9.9546 -10.0717265,0 z"
+       id="rect4001"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <rect
+       style="fill:url(#linearGradient4867-7);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1"
+       width="3.9929504"
+       height="1.0103934"
+       x="5.0291462"
+       y="1040.3074" />
+    <rect
+       style="fill:url(#linearGradient4869-17);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7"
+       width="6.9929504"
+       height="1.0103934"
+       x="5.0291462"
+       y="1042.3074" />
+    <rect
+       style="fill:url(#linearGradient4871-2);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4"
+       width="6.9929504"
+       height="1.0103934"
+       x="5.0291462"
+       y="1044.3074" />
+    <rect
+       style="fill:url(#linearGradient4875-9);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4-0"
+       width="6.9929504"
+       height="1.0103934"
+       x="5.0291462"
+       y="1046.3074" />
+    <rect
+       style="fill:url(#linearGradient4873-1);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4-0-9"
+       width="5.0094166"
+       height="1.0103934"
+       x="5.0291462"
+       y="1048.3074" />
+    <g
+       id="g3395"
+       style="stroke:#ffffff;stroke-width:1.5;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4177)"
+       mask="url(#mask4181)">
+      <g
+         style="display:inline;fill:#ffffff;stroke:#ffffff;stroke-width:2.11441896;stroke-miterlimit:4;stroke-dasharray:none"
+         id="layer1-5-0"
+         inkscape:label="Layer 1"
+         transform="matrix(-0.70941475,0,0,0.70941475,9.6234575,302.66333)">
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="path5226-6-14-1-5-6"
+           d="m 12.866728,1043.3715 -5.928369,5.8862 -5.461084,2.5938 2.59375,-5.4564 5.8445857,-5.9039 c 1.2698873,0.6025 2.2104673,1.6169 2.9511173,2.8807 z"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;stroke:#ffffff;stroke-width:2.11441896;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path5424-4"
+           d="M 9.9307747,1040.4939 4.0625,1046.3935 5,1047.2997 l 6.118275,-6.0558 c -0.362696,-0.2963 -0.752826,-0.5438 -1.1875003,-0.75 z"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.11441896;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path5226-6-14-1-5-2-0"
+           d="m 12.493275,1042.7752 -5.962025,6.087 0.40625,0.4063 5.930775,-5.8996 c -0.120121,-0.205 -0.24381,-0.4026 -0.375,-0.5937 z"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.11441896;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path5226-6-14-1-5-2-7-6"
+           d="m 6.536718,1048.8567 -1.548139,-1.5456 6.120492,-6.0629 c 0.52506,0.4288 0.980135,0.9451 1.380966,1.5292 z"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.11441896;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path5426-2"
+           d="m 4.984376,1047.2528 6.118276,-6.0089"
+           style="opacity:0.50000000000000000;fill:#ffffff;stroke:#ffffff;stroke-width:2.11441896;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;filter:url(#filter5428-9-1)" />
+        <path
+           transform="translate(0,1036.3622)"
+           sodipodi:nodetypes="cccccccccc"
+           inkscape:connector-curvature="0"
+           id="path5006-9"
+           d="M 5.40625,8.6875 4.09375,10 2.6875,12.9375 l 1.375,1.28125 -0.03125,0.0625 2.9375,-1.40625 0.75,-0.75 0.1875,-2 L 5.1875,9.96875 c 0,0 0.127199,-0.74275 0.21875,-1.28125 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline;stroke-width:2.11441896;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0"
+           id="path5006-1-9"
+           d="m 3.25,1049.1435 c -0.211528,0.024 -0.41079,0.089 -0.5625,0.1562 l -1.21875,2.5625 2.5625,-1.2187 0.03125,-0.062 c 0.121601,-0.3002 0.273127,-0.8318 -0.09375,-1.2188 -0.132606,-0.1402 -0.331591,-0.1963 -0.5,-0.2187 -0.08057,-0.011 -0.138928,-0.01 -0.21875,0 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline;stroke-width:2.11441896;stroke-miterlimit:4;stroke-dasharray:none" />
+      </g>
+    </g>
+    <g
+       transform="matrix(-0.70941475,0,0,0.70941475,9.6234575,302.66333)"
+       inkscape:label="Layer 1"
+       id="layer1-5"
+       style="display:inline">
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:none;stroke:url(#linearGradient5173-0);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 12.866728,1043.3715 -5.928369,5.8862 -5.461084,2.5938 2.59375,-5.4564 5.8445857,-5.9039 c 1.2698873,0.6025 2.2104673,1.6169 2.9511173,2.8807 z"
+         id="path5226-6-14-1-5"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffcb72;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="M 9.9307747,1040.4939 4.0625,1046.3935 5,1047.2997 l 6.118275,-6.0558 c -0.362696,-0.2963 -0.752826,-0.5438 -1.1875003,-0.75 z"
+         id="path5424"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#e5a856;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 12.493275,1042.7752 -5.962025,6.087 0.40625,0.4063 5.930775,-5.8996 c -0.120121,-0.205 -0.24381,-0.4026 -0.375,-0.5937 z"
+         id="path5226-6-14-1-5-2"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#fbbc67;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 6.536718,1048.8567 -1.548139,-1.5456 6.120492,-6.0629 c 0.52506,0.4288 0.980135,0.9451 1.380966,1.5292 z"
+         id="path5226-6-14-1-5-2-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="opacity:0.5;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;filter:url(#filter5428-9)"
+         d="m 4.984376,1047.2528 6.118276,-6.0089"
+         id="path5426"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:url(#linearGradient5196-0);fill-opacity:1;stroke:none;display:inline"
+         d="M 5.40625,8.6875 4.09375,10 2.6875,12.9375 l 1.375,1.28125 -0.03125,0.0625 2.9375,-1.40625 0.75,-0.75 0.1875,-2 L 5.1875,9.96875 c 0,0 0.127199,-0.74275 0.21875,-1.28125 z"
+         id="path5006"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc"
+         transform="translate(0,1036.3622)" />
+      <path
+         style="fill:url(#linearGradient3208);fill-opacity:1;stroke:none;display:inline"
+         d="m 3.25,1049.1435 c -0.211528,0.024 -0.41079,0.089 -0.5625,0.1562 l -1.21875,2.5625 2.5625,-1.2187 0.03125,-0.062 c 0.121601,-0.3002 0.273127,-0.8318 -0.09375,-1.2188 -0.132606,-0.1402 -0.331591,-0.1963 -0.5,-0.2187 -0.08057,-0.011 -0.138928,-0.01 -0.21875,0 z"
+         id="path5006-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/time_obj.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/time_obj.svg
@@ -1,0 +1,25226 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="time_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13922">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop13924" />
+      <stop
+         style="stop-color:#6e83ae;stop-opacity:1"
+         offset="1"
+         id="stop13926" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13831">
+      <stop
+         style="stop-color:#055797;stop-opacity:1;"
+         offset="0"
+         id="stop13833" />
+      <stop
+         style="stop-color:#184785;stop-opacity:1"
+         offset="1"
+         id="stop13835" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13755">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757" />
+      <stop
+         id="stop13765"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7824">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop7826" />
+      <stop
+         style="stop-color:#b8b8b8;stop-opacity:0;"
+         offset="1"
+         id="stop7828" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7491">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7493" />
+      <stop
+         style="stop-color:#a0b0cc;stop-opacity:1;"
+         offset="1"
+         id="stop7495" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7254">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7246">
+      <stop
+         style="stop-color:#3979bd;stop-opacity:1;"
+         offset="0"
+         id="stop7248" />
+      <stop
+         style="stop-color:#3979bd;stop-opacity:1;"
+         offset="1"
+         id="stop7250" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6799">
+      <stop
+         style="stop-color:#a6bacf;stop-opacity:1;"
+         offset="0"
+         id="stop6801" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5238">
+      <stop
+         style="stop-color:#6d83ac;stop-opacity:1;"
+         offset="0"
+         id="stop5240" />
+      <stop
+         style="stop-color:#aeb9ce;stop-opacity:1;"
+         offset="1"
+         id="stop5242" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5148">
+      <stop
+         style="stop-color:#166b9f;stop-opacity:1"
+         offset="0"
+         id="stop5150" />
+      <stop
+         style="stop-color:#6b8fa5;stop-opacity:1;"
+         offset="1"
+         id="stop5152" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5328">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5330" />
+      <stop
+         style="stop-color:#464646;stop-opacity:1;"
+         offset="1"
+         id="stop5332" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5209">
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="0"
+         id="stop5211" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:1;"
+         offset="1"
+         id="stop5213" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4961">
+      <stop
+         style="stop-color:#df9a39;stop-opacity:1;"
+         offset="0"
+         id="stop4963" />
+      <stop
+         style="stop-color:#b55829;stop-opacity:1;"
+         offset="1"
+         id="stop4965" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4938">
+      <stop
+         style="stop-color:#8bc7d7;stop-opacity:1;"
+         offset="0"
+         id="stop4940" />
+      <stop
+         style="stop-color:#17477c;stop-opacity:1;"
+         offset="1"
+         id="stop4942" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4928">
+      <stop
+         style="stop-color:#4dac81;stop-opacity:1;"
+         offset="0"
+         id="stop4930" />
+      <stop
+         style="stop-color:#058048;stop-opacity:1;"
+         offset="1"
+         id="stop4932" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4918">
+      <stop
+         style="stop-color:#d48a4b;stop-opacity:1;"
+         offset="0"
+         id="stop4920" />
+      <stop
+         style="stop-color:#b1623a;stop-opacity:1;"
+         offset="1"
+         id="stop4922" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4907">
+      <stop
+         style="stop-color:#b86c44;stop-opacity:1;"
+         offset="0"
+         id="stop4909" />
+      <stop
+         style="stop-color:#8f4017;stop-opacity:1;"
+         offset="1"
+         id="stop4911" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4789">
+      <stop
+         style="stop-color:#4e8fbd;stop-opacity:1;"
+         offset="0"
+         id="stop4791" />
+      <stop
+         style="stop-color:#30495a;stop-opacity:1;"
+         offset="1"
+         id="stop4793" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4781">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4783" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4785" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4773">
+      <stop
+         style="stop-color:#8e4694;stop-opacity:1;"
+         offset="0"
+         id="stop4775" />
+      <stop
+         style="stop-color:#bc7bc1;stop-opacity:1;"
+         offset="1"
+         id="stop4777" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4763">
+      <stop
+         style="stop-color:#77a29d;stop-opacity:1;"
+         offset="0"
+         id="stop4765" />
+      <stop
+         style="stop-color:#1b867b;stop-opacity:1;"
+         offset="1"
+         id="stop4767" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13858" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13860" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13850">
+      <stop
+         id="stop13852"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13854"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13834">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13836" />
+      <stop
+         style="stop-color:#807e66;stop-opacity:0;"
+         offset="1"
+         id="stop13838" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799">
+      <stop
+         style="stop-color:#b9772f;stop-opacity:1"
+         offset="0"
+         id="stop13801" />
+      <stop
+         id="stop13809"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop13807"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop13811" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop13803" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090" />
+      <stop
+         id="stop12096"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001" />
+      <stop
+         id="stop12007"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971" />
+      <stop
+         id="stop11979"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689" />
+      <stop
+         id="stop11695"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150" />
+      <stop
+         id="stop11152"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11128">
+      <stop
+         style="stop-color:#e4d09d;stop-opacity:1"
+         offset="0"
+         id="stop11130" />
+      <stop
+         id="stop11136"
+         offset="0.27413794"
+         style="stop-color:#f6ecb2;stop-opacity:1" />
+      <stop
+         style="stop-color:#b58a68;stop-opacity:1"
+         offset="1"
+         id="stop11132" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856">
+      <stop
+         id="stop10858"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860" />
+      <stop
+         id="stop10862"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800" />
+      <stop
+         id="stop10806"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10748">
+      <stop
+         id="stop10750"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754" />
+      <stop
+         id="stop10756"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450" />
+      <stop
+         id="stop10458"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442" />
+      <stop
+         id="stop10521"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10432">
+      <stop
+         id="stop10434"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436" />
+      <stop
+         id="stop10438"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10414">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416" />
+      <stop
+         id="stop10422"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10396">
+      <stop
+         style="stop-color:#1b3e79;stop-opacity:1;"
+         offset="0"
+         id="stop10398" />
+      <stop
+         id="stop10404"
+         offset="0.5"
+         style="stop-color:#728fbf;stop-opacity:1" />
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="1"
+         id="stop10400" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10157">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159" />
+      <stop
+         id="stop10165"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9914"
+       inkscape:collect="always">
+      <stop
+         id="stop9916"
+         offset="0"
+         style="stop-color:#4a6fa4;stop-opacity:1" />
+      <stop
+         id="stop9918"
+         offset="1"
+         style="stop-color:#4e86ca;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9908"
+       inkscape:collect="always">
+      <stop
+         id="stop9910"
+         offset="0"
+         style="stop-color:#525f72;stop-opacity:1" />
+      <stop
+         id="stop9912"
+         offset="1"
+         style="stop-color:#9e884e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9605">
+      <stop
+         style="stop-color:#2a5bbf;stop-opacity:1;"
+         offset="0"
+         id="stop9607" />
+      <stop
+         style="stop-color:#2a5bbf;stop-opacity:0;"
+         offset="1"
+         id="stop9609" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9510">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9512" />
+      <stop
+         id="stop9514"
+         offset="0.35636142"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9516" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334" />
+      <stop
+         id="stop9340"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9324">
+      <stop
+         id="stop9326"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.30000001"
+         id="stop9328" />
+      <stop
+         id="stop9330"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9312">
+      <stop
+         style="stop-color:#cf6c00;stop-opacity:1"
+         offset="0"
+         id="stop9314" />
+      <stop
+         id="stop9322"
+         offset="0.36339331"
+         style="stop-color:#f5db48;stop-opacity:0.24200913" />
+      <stop
+         style="stop-color:#c36000;stop-opacity:1"
+         offset="1"
+         id="stop9316" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9299">
+      <stop
+         style="stop-color:#929baa;stop-opacity:1"
+         offset="0"
+         id="stop9301" />
+      <stop
+         style="stop-color:#cac3a5;stop-opacity:1"
+         offset="1"
+         id="stop9303" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9291">
+      <stop
+         style="stop-color:#e9f8ff;stop-opacity:1;"
+         offset="0"
+         id="stop9293" />
+      <stop
+         style="stop-color:#f5f6f9;stop-opacity:1"
+         offset="1"
+         id="stop9295" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8661"
+       inkscape:collect="always">
+      <stop
+         id="stop8663"
+         offset="0"
+         style="stop-color:#c6e7f9;stop-opacity:1" />
+      <stop
+         id="stop8665"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8653">
+      <stop
+         style="stop-color:#676656;stop-opacity:1;"
+         offset="0"
+         id="stop8655" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop8657" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9">
+      <stop
+         id="stop7561-3-3-4-48"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1" />
+      <stop
+         id="stop7565-8-8-3-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6" />
+      <stop
+         id="stop7114-9-0-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4320">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4322" />
+      <stop
+         id="stop4324"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4326" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4329">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4331" />
+      <stop
+         id="stop4333"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4335" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8">
+      <stop
+         id="stop7561-3-3-4-48-7"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7" />
+      <stop
+         id="stop7565-8-8-3-2-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7" />
+      <stop
+         id="stop7114-9-0-1-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3256">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3258" />
+      <stop
+         id="stop3260"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3262" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3265">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3267" />
+      <stop
+         id="stop3269"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3271" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-2">
+      <stop
+         id="stop7561-3-3-4-48-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-76" />
+      <stop
+         id="stop7565-8-8-3-2-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-22">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-8" />
+      <stop
+         id="stop7114-9-0-1-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3506">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3508" />
+      <stop
+         id="stop3510"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3512" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3515">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3517" />
+      <stop
+         id="stop3519"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3521" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1">
+      <stop
+         id="stop7561-3-3-4-48-7-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3" />
+      <stop
+         id="stop7565-8-8-3-2-0-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9" />
+      <stop
+         id="stop7114-9-0-1-4-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4133">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4135" />
+      <stop
+         id="stop4137"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4139" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4142">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4144" />
+      <stop
+         id="stop4146"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4148" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1" />
+      <stop
+         id="stop7114-9-0-1-4-6-2"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4356" />
+      <stop
+         id="stop4358"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4360" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4365" />
+      <stop
+         id="stop4367"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4369" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-5">
+      <stop
+         id="stop7561-3-3-4-48-7-4-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-0" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-3"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4356-1" />
+      <stop
+         id="stop4358-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4360-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4365-6" />
+      <stop
+         id="stop4367-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4369-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-5">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-7" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-0" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5692" />
+      <stop
+         id="stop5694"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5696" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5701" />
+      <stop
+         id="stop5703"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5705" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-9">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-2"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-0" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-5"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-2" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-16"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5692-0" />
+      <stop
+         id="stop5694-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5696-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5701-6" />
+      <stop
+         id="stop5703-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5705-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-2" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-8" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6127" />
+      <stop
+         id="stop6129"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6131" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6136" />
+      <stop
+         id="stop6138"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6140" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6127-4" />
+      <stop
+         id="stop6129-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6131-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6136-6" />
+      <stop
+         id="stop6138-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6140-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-92">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-6" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-55"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-72">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-5" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6293">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6295" />
+      <stop
+         id="stop6297"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6299" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6302">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6304" />
+      <stop
+         id="stop6306"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6308" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6321">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6323" />
+      <stop
+         id="stop6325"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6327" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6330">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6332" />
+      <stop
+         id="stop6334"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6336" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-3-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-2-2" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-3-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-8-5" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-4-5"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-0-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6349">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6351" />
+      <stop
+         id="stop6353"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6355" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6358">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6360" />
+      <stop
+         id="stop6362"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6364" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8-0"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4-7" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0-7"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6940">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6942" />
+      <stop
+         id="stop6944"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6946" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6949">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6951" />
+      <stop
+         id="stop6953"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6955" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6-1">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8-0-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4-7-3" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8-6-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9-4-8" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0-7-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4-1-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7106">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7108" />
+      <stop
+         id="stop7110"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7112" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7115">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7117" />
+      <stop
+         id="stop7119"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7121" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7686-9"
+       id="linearGradient7692-4"
+       x1="1303.0625"
+       y1="610.34235"
+       x2="1303.0625"
+       y2="723.85583"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7686-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7688-7" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7690-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-140)"
+       y2="723.85583"
+       x2="1303.0625"
+       y1="610.34235"
+       x1="1303.0625"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7755-5"
+       xlink:href="#linearGradient7686-9-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7686-9-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7688-7-1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7690-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2"
+       id="linearGradient8159-0"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-9"
+       id="linearGradient8143-2"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-9">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-4" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,2.6171875e-6)"
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8180-3"
+       xlink:href="#linearGradient8153-2-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-8">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-7" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,2.6171875e-6)"
+       y2="283.2832"
+       x2="657.71722"
+       y1="283.2832"
+       x1="617.06256"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8182"
+       xlink:href="#linearGradient8137-9-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-9-5">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-4-2" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-6"
+       id="linearGradient8291-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-6">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-6" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-1">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-4" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-4">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-78" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-93">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-9" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8498"
+       id="linearGradient8504"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8498">
+      <stop
+         style="stop-color:#d9f4ff;stop-opacity:1"
+         offset="0"
+         id="stop8500" />
+      <stop
+         style="stop-color:#f9fcff;stop-opacity:1"
+         offset="1"
+         id="stop8502" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8659"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8661"
+       id="linearGradient8681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137"
+       id="linearGradient8683"
+       gradientUnits="userSpaceOnUse"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2"
+       id="linearGradient8685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337"
+       id="linearGradient8687"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8689"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8691"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8693"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8695"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8697"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-93"
+       id="linearGradient8699"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-4"
+       id="linearGradient8701"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-1"
+       id="linearGradient8703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375262)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291"
+       id="linearGradient9297"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299"
+       id="linearGradient9305"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332-9"
+       id="linearGradient9338-8"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient9332-9">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334-5" />
+      <stop
+         id="stop9340-2"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9324-7"
+       id="linearGradient9318"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient9324-7">
+      <stop
+         id="stop9326-0"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.30000001"
+         id="stop9328-1" />
+      <stop
+         id="stop9330-5"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291-8"
+       id="linearGradient9297-1"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9291-8">
+      <stop
+         style="stop-color:#e9f8ff;stop-opacity:1;"
+         offset="0"
+         id="stop9293-7" />
+      <stop
+         style="stop-color:#f5f6f9;stop-opacity:1"
+         offset="1"
+         id="stop9295-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299-1"
+       id="linearGradient9305-8"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9299-1">
+      <stop
+         style="stop-color:#929baa;stop-opacity:1"
+         offset="0"
+         id="stop9301-6" />
+      <stop
+         style="stop-color:#cac3a5;stop-opacity:1"
+         offset="1"
+         id="stop9303-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332-6">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334-52" />
+      <stop
+         id="stop9340-23"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9312-9">
+      <stop
+         style="stop-color:#cf6c00;stop-opacity:1"
+         offset="0"
+         id="stop9314-5" />
+      <stop
+         id="stop9322-0"
+         offset="0.36339331"
+         style="stop-color:#f5db48;stop-opacity:0.24200913" />
+      <stop
+         style="stop-color:#c36000;stop-opacity:1"
+         offset="1"
+         id="stop9316-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       y2="472.63525"
+       x2="556.25635"
+       y1="472.63525"
+       x1="526.85181"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9415-5"
+       xlink:href="#linearGradient9510-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9510-3">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9512-4" />
+      <stop
+         id="stop9514-9"
+         offset="0.35636142"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9516-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8661-5"
+       inkscape:collect="always">
+      <stop
+         id="stop8663-3"
+         offset="0"
+         style="stop-color:#c6e7f9;stop-opacity:1" />
+      <stop
+         id="stop8665-5"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-6">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-1" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-0">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-9" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-2">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-7" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-2"
+       id="linearGradient8697-5"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8653-2">
+      <stop
+         style="stop-color:#676656;stop-opacity:1;"
+         offset="0"
+         id="stop8655-9" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop8657-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-4-4">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-78-0" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-0-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-1-3"
+       id="linearGradient8703-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375262)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-1-3">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-4-2" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-2-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9605"
+       id="linearGradient9962"
+       gradientUnits="userSpaceOnUse"
+       x1="213.82529"
+       y1="441.62799"
+       x2="227.09628"
+       y2="454.31174" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332-6"
+       id="linearGradient9964"
+       gradientUnits="userSpaceOnUse"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9312-9"
+       id="linearGradient9966"
+       gradientUnits="userSpaceOnUse"
+       x1="526.4375"
+       y1="448.46484"
+       x2="556.9375"
+       y2="448.46484" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9510-3"
+       id="linearGradient9968"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8661-5"
+       id="linearGradient9970"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-6"
+       id="linearGradient9972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0)"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-0"
+       id="linearGradient9974"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-2"
+       id="linearGradient9976"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0.34375)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9908"
+       id="linearGradient9978"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="306.07397"
+       x2="641.07611"
+       y2="281.43512" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-2"
+       id="linearGradient9980"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-4-4"
+       id="linearGradient9982"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9914"
+       id="linearGradient9984"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0.34375262)"
+       x1="636.09375"
+       y1="279.41037"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332"
+       id="linearGradient9997"
+       gradientUnits="userSpaceOnUse"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9312"
+       id="linearGradient9999"
+       gradientUnits="userSpaceOnUse"
+       x1="526.4375"
+       y1="448.46484"
+       x2="556.9375"
+       y2="448.46484" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9510"
+       id="linearGradient10001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291-8"
+       id="linearGradient10003"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299-1"
+       id="linearGradient10005"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-5"
+       id="linearGradient10163-8"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10157-5">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-7" />
+      <stop
+         id="stop10165-2"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-3"
+       id="linearGradient10155-1"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-3">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-0" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-6"
+       id="linearGradient10155-5"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-6">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-5" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2"
+       id="linearGradient10163-2"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10157-2">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8" />
+      <stop
+         id="stop10165-3"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39"
+       id="linearGradient10155-7"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10149-6-5">
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="0"
+         id="stop10151-5-7" />
+      <stop
+         id="stop10394"
+         offset="0.5"
+         style="stop-color:#b9c7df;stop-opacity:1" />
+      <stop
+         style="stop-color:#567ebc;stop-opacity:1"
+         offset="1"
+         id="stop10153-8-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-4"
+       id="linearGradient10454-7"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10448-4">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-4" />
+      <stop
+         id="stop10458-7"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-9"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-1" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-2"
+       id="linearGradient10446-9"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10440-2">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-4" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9"
+       id="linearGradient10454-9"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10448-9">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3" />
+      <stop
+         id="stop10458-8"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1"
+       id="linearGradient10446-7"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10440-1">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43" />
+      <stop
+         id="stop10521-1"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10546-3"
+       xlink:href="#linearGradient10448-9-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-7">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5" />
+      <stop
+         id="stop10458-8-0"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4-1"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2-9" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10548-3"
+       xlink:href="#linearGradient10440-1-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-1-0">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-2" />
+      <stop
+         id="stop10521-1-2"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10546-8"
+       xlink:href="#linearGradient10448-9-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-6">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-8" />
+      <stop
+         id="stop10458-8-7"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4-7"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2-1" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10548-1"
+       xlink:href="#linearGradient10440-1-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-1-3">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-0" />
+      <stop
+         id="stop10521-1-4"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-9-7-0">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6" />
+      <stop
+         id="stop10456-4-1-5"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-0-0">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-2-0" />
+      <stop
+         id="stop10521-1-2-5"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-4-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0"
+       id="linearGradient10770"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-0-0"
+       id="linearGradient10772"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       x1="334.375"
+       y1="529.06494"
+       x2="334.375"
+       y2="518.67365" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748"
+       id="linearGradient10774"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-3"
+       id="linearGradient10776"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       x1="334.375"
+       y1="532.30212"
+       x2="334.375"
+       y2="515.73615" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448"
+       id="linearGradient10778"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440"
+       id="linearGradient10780"
+       gradientUnits="userSpaceOnUse"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414"
+       id="linearGradient10782"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432"
+       id="linearGradient10784"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157"
+       id="linearGradient10786"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10396"
+       id="linearGradient10788"
+       gradientUnits="userSpaceOnUse"
+       x1="302.3125"
+       y1="532.98718"
+       x2="302.3125"
+       y2="514.67456" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2"
+       id="linearGradient10790"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39"
+       id="linearGradient10792"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-6-5"
+       id="linearGradient10794"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.88388349,2.6171875e-6)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="511.38498" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-8"
+       id="linearGradient10804-7"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10798-8">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-2" />
+      <stop
+         id="stop10806-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1"
+       id="linearGradient10804-8"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10798-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5" />
+      <stop
+         id="stop10806-6"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2" />
+      <stop
+         id="stop10806-6-8"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10835-2"
+       xlink:href="#linearGradient10856-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6">
+      <stop
+         id="stop10858-0"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7" />
+      <stop
+         id="stop10862-3"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8"
+       id="radialGradient11144-4"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)" />
+    <linearGradient
+       id="linearGradient11146-8">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7" />
+      <stop
+         id="stop11152-8"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-7"
+       id="radialGradient11144-2"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)" />
+    <linearGradient
+       id="linearGradient11146-7">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9" />
+      <stop
+         id="stop11152-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11169-6"
+       xlink:href="#linearGradient11146-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-8-7">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8" />
+      <stop
+         id="stop11152-8-8"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11063-6"
+       xlink:href="#linearGradient10856-6-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-3">
+      <stop
+         id="stop10858-0-7"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9" />
+      <stop
+         id="stop10862-3-3"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1" />
+      <stop
+         id="stop10806-6-8-5"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-4"
+       id="radialGradient11268-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-4">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4" />
+      <stop
+         id="stop11152-9"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-3"
+       id="radialGradient11270-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-8-3">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5" />
+      <stop
+         id="stop11152-8-4"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-7-5"
+       id="radialGradient11272-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-154.64572)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-7-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6" />
+      <stop
+         id="stop11152-6-7"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-7-5"
+       id="radialGradient11274-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-154.64572)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-8-7-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3" />
+      <stop
+         id="stop11152-8-8-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11298-3"
+       xlink:href="#linearGradient10856-6-3-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-3-0">
+      <stop
+         id="stop10858-0-7-6"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1" />
+      <stop
+         id="stop10862-3-3-8"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10880-5-3-4"
+       xlink:href="#linearGradient10798-1-9-3-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8" />
+      <stop
+         id="stop10806-6-8-5-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390"
+       xlink:href="#linearGradient10798-1-9-3-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-4-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-7" />
+      <stop
+         id="stop11152-9-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-4">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-5" />
+      <stop
+         id="stop11152-8-4-9"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-3">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-4" />
+      <stop
+         id="stop11152-6-7-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-6">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-1" />
+      <stop
+         id="stop11152-8-8-6-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-1">
+      <stop
+         id="stop10858-0-7-6-1"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-7" />
+      <stop
+         id="stop10862-3-3-8-4"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-0"
+       xlink:href="#linearGradient10798-1-9-3-7-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2" />
+      <stop
+         id="stop10806-6-8-5-3-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11520-3"
+       xlink:href="#linearGradient10798-1-9-3-7-1-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-6" />
+      <stop
+         id="stop10806-6-8-5-3-2-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11520-8"
+       xlink:href="#linearGradient10798-1-9-3-7-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5" />
+      <stop
+         id="stop10806-6-8-5-3-2-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-2"
+       id="radialGradient11685-7"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-1"
+       id="linearGradient11693-0"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-1">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-9" />
+      <stop
+         id="stop11695-3"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11888-8"
+       id="linearGradient11894-2"
+       x1="342.37973"
+       y1="457.29816"
+       x2="358.60471"
+       y2="444.57022"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11888-8">
+      <stop
+         style="stop-color:#a7c8ec;stop-opacity:1"
+         offset="0"
+         id="stop11890-4" />
+      <stop
+         style="stop-color:#b4def6;stop-opacity:1"
+         offset="1"
+         id="stop11892-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11888-4"
+       id="linearGradient11894-5"
+       x1="342.37973"
+       y1="457.29816"
+       x2="358.60471"
+       y2="444.57022"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11888-4">
+      <stop
+         style="stop-color:#a7c8ec;stop-opacity:1"
+         offset="0"
+         id="stop11890-8" />
+      <stop
+         style="stop-color:#b4def6;stop-opacity:1"
+         offset="1"
+         id="stop11892-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-3" />
+      <stop
+         id="stop11979-8"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-7"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-1" />
+      <stop
+         id="stop12096-1"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-7">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-9" />
+      <stop
+         id="stop12007-1"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-7"
+       id="radialGradient11685-5"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-94" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-9"
+       id="linearGradient11693-2"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-9">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-1" />
+      <stop
+         id="stop11695-2"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-8"
+       id="radialGradient11685-3"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-8"
+       id="linearGradient11693-26"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-8">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-6" />
+      <stop
+         id="stop11695-6"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2-2">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-3-7" />
+      <stop
+         id="stop11979-8-6"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-7-6"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-6-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2-1">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-1-8" />
+      <stop
+         id="stop12096-1-8"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-2-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-7-2">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-9-2" />
+      <stop
+         id="stop12007-1-3"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-2-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8" />
+      <stop
+         id="stop10806-6-8-5-3-2-95"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-9">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-7" />
+      <stop
+         id="stop11979-0"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-6"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-7" />
+      <stop
+         id="stop12096-6"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-1" />
+      <stop
+         id="stop12007-4"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5-2" />
+      <stop
+         id="stop10806-6-8-5-3-2-3-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-3"
+       id="radialGradient11685-2"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-91" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-02" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-2"
+       id="linearGradient11693-3"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-2">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-3" />
+      <stop
+         id="stop11695-9"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-10" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-9"
+       id="radialGradient12723-3"
+       cx="433.36786"
+       cy="424.34106"
+       fx="433.36786"
+       fy="424.34106"
+       r="12.027534"
+       gradientTransform="matrix(1.1614831,2.1855961e-7,-2.811228e-7,1.4939602,-69.981471,-211.63828)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-9">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-7" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-5">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-6" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-9" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-5"
+       id="radialGradient12739-4"
+       cx="433.5452"
+       cy="420.74988"
+       fx="433.5452"
+       fy="420.74988"
+       r="12.952347"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1"
+       id="linearGradient12904-2"
+       x1="420.88995"
+       y1="455.88452"
+       x2="440.35345"
+       y2="417.26108"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11146-4-0">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-1" />
+      <stop
+         id="stop11152-9-9"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-2" />
+      <stop
+         id="stop11152-8-4-3"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-8" />
+      <stop
+         id="stop11152-6-7-5"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-9">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-19" />
+      <stop
+         id="stop11152-8-8-6-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-5">
+      <stop
+         id="stop10858-0-7-6-9"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-9" />
+      <stop
+         id="stop10862-3-3-8-6"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-9"
+       xlink:href="#linearGradient10798-1-9-3-7-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20" />
+      <stop
+         id="stop10806-6-8-5-3-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13197-7"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4" />
+      <stop
+         id="stop10806-6-8-5-3-9-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-4"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13197-3"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6" />
+      <stop
+         id="stop10806-6-8-5-3-9-24"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13333-0-1"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-5">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2-1"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13850-2">
+      <stop
+         id="stop13852-4"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13854-7"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856-0">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13858-8" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13860-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799-7">
+      <stop
+         style="stop-color:#b9772f;stop-opacity:1"
+         offset="0"
+         id="stop13801-4" />
+      <stop
+         id="stop13809-4"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop13807-7"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop13811-8" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop13803-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1-8">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3-6" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4-9" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="455.88452"
+       x1="420.88995"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13011-8"
+       xlink:href="#linearGradient12862-1-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11969-9-0">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-7-1" />
+      <stop
+         id="stop11979-0-0"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-6-1"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7-6">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-7-9" />
+      <stop
+         id="stop12096-6-2"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-1-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9-8">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-1-9" />
+      <stop
+         id="stop12007-4-6"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-3-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5-2-6" />
+      <stop
+         id="stop10806-6-8-5-3-2-3-3-7"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2-2-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687-2-2">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-3-7" />
+      <stop
+         id="stop11695-9-8"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-10-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-4-4">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-72" />
+      <stop
+         id="stop11152-9-0"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-2">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-9" />
+      <stop
+         id="stop11152-8-4-35"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-30">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-9" />
+      <stop
+         id="stop11152-6-7-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-7">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-8" />
+      <stop
+         id="stop11152-8-8-6-3"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-0">
+      <stop
+         id="stop10858-0-7-6-0"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-0" />
+      <stop
+         id="stop10862-3-3-8-2"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-1"
+       xlink:href="#linearGradient10798-1-9-3-7-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-4" />
+      <stop
+         id="stop10806-6-8-5-3-1"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4918-5">
+      <stop
+         style="stop-color:#d48a4b;stop-opacity:1;"
+         offset="0"
+         id="stop4920-9" />
+      <stop
+         style="stop-color:#b1623a;stop-opacity:1;"
+         offset="1"
+         id="stop4922-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4907-9">
+      <stop
+         style="stop-color:#b86c44;stop-opacity:1;"
+         offset="0"
+         id="stop4909-5" />
+      <stop
+         style="stop-color:#8f4017;stop-opacity:1;"
+         offset="1"
+         id="stop4911-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4928-4">
+      <stop
+         style="stop-color:#4dac81;stop-opacity:1;"
+         offset="0"
+         id="stop4930-9" />
+      <stop
+         style="stop-color:#058048;stop-opacity:1;"
+         offset="1"
+         id="stop4932-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4938-8">
+      <stop
+         style="stop-color:#8bc7d7;stop-opacity:1;"
+         offset="0"
+         id="stop4940-4" />
+      <stop
+         style="stop-color:#17477c;stop-opacity:1;"
+         offset="1"
+         id="stop4942-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4961-6"
+       id="linearGradient4983-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4.625,0)"
+       x1="15.073242"
+       y1="1040.0764"
+       x2="18.744612"
+       y2="1049.2014" />
+    <linearGradient
+       id="linearGradient4961-6">
+      <stop
+         style="stop-color:#df9a39;stop-opacity:1;"
+         offset="0"
+         id="stop4963-0" />
+      <stop
+         style="stop-color:#b55829;stop-opacity:1;"
+         offset="1"
+         id="stop4965-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5328-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5330-9" />
+      <stop
+         style="stop-color:#464646;stop-opacity:1;"
+         offset="1"
+         id="stop5332-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5209-0">
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="0"
+         id="stop5211-9" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:1;"
+         offset="1"
+         id="stop5213-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5397">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5399" />
+      <stop
+         style="stop-color:#464646;stop-opacity:1;"
+         offset="1"
+         id="stop5401" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5404">
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="0"
+         id="stop5406" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:1;"
+         offset="1"
+         id="stop5408" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5411">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5413" />
+      <stop
+         style="stop-color:#464646;stop-opacity:1;"
+         offset="1"
+         id="stop5415" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5418">
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="0"
+         id="stop5420" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:1;"
+         offset="1"
+         id="stop5422" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4855">
+      <stop
+         style="stop-color:#0d5c9a;stop-opacity:1;"
+         offset="0"
+         id="stop4857" />
+      <stop
+         style="stop-color:#3583c0;stop-opacity:1;"
+         offset="1"
+         id="stop4859" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5148-9"
+       id="linearGradient5154-9"
+       x1="3.8473835"
+       y1="4.0062027"
+       x2="2.9380388"
+       y2="3.0118337"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5148-9">
+      <stop
+         style="stop-color:#05507d;stop-opacity:1;"
+         offset="0"
+         id="stop5150-6" />
+      <stop
+         style="stop-color:#6b8fa5;stop-opacity:1;"
+         offset="1"
+         id="stop5152-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,1036.3622)"
+       y2="3.0118337"
+       x2="2.9380388"
+       y1="4.0062027"
+       x1="3.8473835"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5171-5"
+       xlink:href="#linearGradient5148-9-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5148-9-8">
+      <stop
+         style="stop-color:#05507d;stop-opacity:1;"
+         offset="0"
+         id="stop5150-6-3" />
+      <stop
+         style="stop-color:#6b8fa5;stop-opacity:1;"
+         offset="1"
+         id="stop5152-5-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5238-1"
+       id="linearGradient5244-0"
+       x1="12.531334"
+       y1="1041.9091"
+       x2="8.8389864"
+       y2="1041.9091"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5238-1">
+      <stop
+         style="stop-color:#6d83ac;stop-opacity:1;"
+         offset="0"
+         id="stop5240-9" />
+      <stop
+         style="stop-color:#aeb9ce;stop-opacity:1;"
+         offset="1"
+         id="stop5242-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.1377778,0,0,1,-0.79222222,2.0000504)"
+       y2="1041.9091"
+       x2="8.8389864"
+       y1="1041.9091"
+       x1="12.531334"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5261-8"
+       xlink:href="#linearGradient5238-1-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5238-1-3">
+      <stop
+         style="stop-color:#6d83ac;stop-opacity:1;"
+         offset="0"
+         id="stop5240-9-6" />
+      <stop
+         style="stop-color:#aeb9ce;stop-opacity:1;"
+         offset="1"
+         id="stop5242-5-0" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.9091"
+       x2="8.8389864"
+       y1="1041.9091"
+       x1="12.531334"
+       gradientTransform="matrix(0.84444446,0,0,1,0.92569446,3.93755)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5295-7"
+       xlink:href="#linearGradient5238-1-3-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5238-1-3-6">
+      <stop
+         style="stop-color:#6d83ac;stop-opacity:1;"
+         offset="0"
+         id="stop5240-9-6-9" />
+      <stop
+         style="stop-color:#aeb9ce;stop-opacity:1;"
+         offset="1"
+         id="stop5242-5-0-3" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.9091"
+       x2="8.8389864"
+       y1="1041.9091"
+       x1="12.531334"
+       gradientTransform="translate(0.03125007,6.00005)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5329-5"
+       xlink:href="#linearGradient5238-1-3-6-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5238-1-3-6-4">
+      <stop
+         style="stop-color:#6d83ac;stop-opacity:1;"
+         offset="0"
+         id="stop5240-9-6-9-8" />
+      <stop
+         style="stop-color:#aeb9ce;stop-opacity:1;"
+         offset="1"
+         id="stop5242-5-0-3-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5"
+       id="linearGradient6899-2"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6893-5">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:0;"
+         offset="1"
+         id="stop6897-2" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,1039.1906)"
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6916-3"
+       xlink:href="#linearGradient6893-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6893-5-8">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:0;"
+         offset="1"
+         id="stop6897-2-6" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.1065878,0,0,0.3047951,-0.87851916,1044.7521)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6950-4"
+       xlink:href="#linearGradient6893-5-8-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6893-5-8-5">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-1" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:0;"
+         offset="1"
+         id="stop6897-2-6-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-5"
+       id="linearGradient6805-5"
+       x1="5.1146584"
+       y1="1047.6122"
+       x2="6.0002952"
+       y2="1047.6122"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-3.09375)" />
+    <linearGradient
+       id="linearGradient6799-5">
+      <stop
+         style="stop-color:#a6bacf;stop-opacity:1;"
+         offset="0"
+         id="stop6801-6" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7254-6"
+       id="linearGradient7260-9"
+       x1="15.000595"
+       y1="2"
+       x2="1.875"
+       y2="2"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient7254-6">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-5" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7254-62"
+       id="linearGradient7260-7"
+       x1="15.000595"
+       y1="2"
+       x2="1.875"
+       y2="2"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient7254-62">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-0" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.93721973,0,0,1,1036.9601,-3.593733)"
+       y2="2"
+       x2="1.875"
+       y1="2"
+       x1="15.000595"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7277-1"
+       xlink:href="#linearGradient7254-6-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7254-6-4">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-5-4" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-7-4" />
+    </linearGradient>
+    <linearGradient
+       y2="2"
+       x2="1.875"
+       y1="2"
+       x1="15.000595"
+       gradientTransform="matrix(0.93721973,0,0,1,1036.9602,-16.656233)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7362-2"
+       xlink:href="#linearGradient7254-6-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7254-6-4-3">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-5-4-1" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-7-4-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-9">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-6" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-0">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-8" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-9-3">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-6-3" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-9-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-0-5">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-8-9" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-5-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7824-4"
+       id="linearGradient7830-9"
+       x1="36.936684"
+       y1="1048.2251"
+       x2="36.936684"
+       y2="1039.3534"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient7824-4">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop7826-9" />
+      <stop
+         style="stop-color:#dfdfdf;stop-opacity:1;"
+         offset="1"
+         id="stop7828-1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-26.899086,0.04105339)"
+       y2="1043.1044"
+       x2="36.936684"
+       y1="1048.2251"
+       x1="36.936684"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7847-5"
+       xlink:href="#linearGradient7824-4-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7824-4-0">
+      <stop
+         style="stop-color:#b1b1b1;stop-opacity:1;"
+         offset="0"
+         id="stop7826-9-7" />
+      <stop
+         style="stop-color:#e2e2e2;stop-opacity:1;"
+         offset="1"
+         id="stop7828-1-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7824-4-0-4">
+      <stop
+         style="stop-color:#b1b1b1;stop-opacity:1;"
+         offset="0"
+         id="stop7826-9-7-5" />
+      <stop
+         style="stop-color:#e2e2e2;stop-opacity:1;"
+         offset="1"
+         id="stop7828-1-4-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7824-4-7"
+       id="linearGradient7906-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-26.899086,0.04105339)"
+       x1="36.936684"
+       y1="1048.2251"
+       x2="36.936684"
+       y2="1043.1044" />
+    <linearGradient
+       id="linearGradient7824-4-7">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop7826-9-8" />
+      <stop
+         style="stop-color:#dfdfdf;stop-opacity:1;"
+         offset="1"
+         id="stop7828-1-7" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11520-0-3-1"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3995"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3995-1"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8136"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6"
+       id="linearGradient8163"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8"
+         offset="0.5"
+         style="stop-color:#3c8d49;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4e173;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1"
+       id="linearGradient4120"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1043.588"
+       x2="32.166149"
+       y1="1037.5026"
+       x1="32.166149"
+       id="linearGradient9335"
+       xlink:href="#linearGradient9329"
+       inkscape:collect="always" />
+    <radialGradient
+       gradientTransform="matrix(0.77257883,-1.3315319e-7,1.3315322e-7,0.772579,89.457223,108.43693)"
+       gradientUnits="userSpaceOnUse"
+       r="10.625"
+       fy="476.81119"
+       fx="393.35513"
+       cy="476.81119"
+       cx="393.35513"
+       id="radialGradient9327"
+       xlink:href="#linearGradient9321"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1-3">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7-3" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8-4"
+         offset="0.5"
+         style="stop-color:#3c8d49;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4e173;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1-3"
+       id="linearGradient8163-2-7"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1056.2894"
+       x2="15.633883"
+       y1="1054.6906"
+       x1="16.965528"
+       id="linearGradient9282"
+       xlink:href="#linearGradient9276"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7-4" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8-9"
+         offset="0.5"
+         style="stop-color:#3c8d49;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4e173;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1-2"
+       id="linearGradient8163-2-9"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient7824-0">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop7826-7" />
+      <stop
+         style="stop-color:#b8b8b8;stop-opacity:0;"
+         offset="1"
+         id="stop7828-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-4">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-0" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-94" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-8">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-8" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7491-4">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7493-5" />
+      <stop
+         style="stop-color:#a0b0cc;stop-opacity:1;"
+         offset="1"
+         id="stop7495-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7254-1">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-7" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7246-1">
+      <stop
+         style="stop-color:#3979bd;stop-opacity:1;"
+         offset="0"
+         id="stop7248-5" />
+      <stop
+         style="stop-color:#3979bd;stop-opacity:1;"
+         offset="1"
+         id="stop7250-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6799-7">
+      <stop
+         style="stop-color:#a6bacf;stop-opacity:1;"
+         offset="0"
+         id="stop6801-61" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5238-2">
+      <stop
+         style="stop-color:#6d83ac;stop-opacity:1;"
+         offset="0"
+         id="stop5240-3" />
+      <stop
+         style="stop-color:#aeb9ce;stop-opacity:1;"
+         offset="1"
+         id="stop5242-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5148-2">
+      <stop
+         style="stop-color:#166b9f;stop-opacity:1"
+         offset="0"
+         id="stop5150-1" />
+      <stop
+         style="stop-color:#6b8fa5;stop-opacity:1;"
+         offset="1"
+         id="stop5152-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5328-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5330-5" />
+      <stop
+         style="stop-color:#464646;stop-opacity:1;"
+         offset="1"
+         id="stop5332-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5209-6">
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="0"
+         id="stop5211-1" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:1;"
+         offset="1"
+         id="stop5213-89" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4961-27">
+      <stop
+         style="stop-color:#df9a39;stop-opacity:1;"
+         offset="0"
+         id="stop4963-9" />
+      <stop
+         style="stop-color:#b55829;stop-opacity:1;"
+         offset="1"
+         id="stop4965-54" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4938-3">
+      <stop
+         style="stop-color:#8bc7d7;stop-opacity:1;"
+         offset="0"
+         id="stop4940-12" />
+      <stop
+         style="stop-color:#17477c;stop-opacity:1;"
+         offset="1"
+         id="stop4942-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4928-3">
+      <stop
+         style="stop-color:#4dac81;stop-opacity:1;"
+         offset="0"
+         id="stop4930-4" />
+      <stop
+         style="stop-color:#058048;stop-opacity:1;"
+         offset="1"
+         id="stop4932-11" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4918-3">
+      <stop
+         style="stop-color:#d48a4b;stop-opacity:1;"
+         offset="0"
+         id="stop4920-8" />
+      <stop
+         style="stop-color:#b1623a;stop-opacity:1;"
+         offset="1"
+         id="stop4922-74" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4907-2">
+      <stop
+         style="stop-color:#b86c44;stop-opacity:1;"
+         offset="0"
+         id="stop4909-7" />
+      <stop
+         style="stop-color:#8f4017;stop-opacity:1;"
+         offset="1"
+         id="stop4911-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4789-9">
+      <stop
+         style="stop-color:#4e8fbd;stop-opacity:1;"
+         offset="0"
+         id="stop4791-31" />
+      <stop
+         style="stop-color:#30495a;stop-opacity:1;"
+         offset="1"
+         id="stop4793-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4781-8">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4783-65" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4785-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4773-2">
+      <stop
+         style="stop-color:#8e4694;stop-opacity:1;"
+         offset="0"
+         id="stop4775-86" />
+      <stop
+         style="stop-color:#bc7bc1;stop-opacity:1;"
+         offset="1"
+         id="stop4777-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4763-2">
+      <stop
+         style="stop-color:#77a29d;stop-opacity:1;"
+         offset="0"
+         id="stop4765-4" />
+      <stop
+         style="stop-color:#1b867b;stop-opacity:1;"
+         offset="1"
+         id="stop4767-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856-6">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13858-5" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13860-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13850-9">
+      <stop
+         id="stop13852-0"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13854-0"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13834-61">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13836-38" />
+      <stop
+         style="stop-color:#807e66;stop-opacity:0;"
+         offset="1"
+         id="stop13838-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799-3">
+      <stop
+         style="stop-color:#b9772f;stop-opacity:1"
+         offset="0"
+         id="stop13801-44" />
+      <stop
+         id="stop13809-60"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop13807-6"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop13811-6" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop13803-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-8">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-4" />
+      <stop
+         id="stop12096-9"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-3">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-7" />
+      <stop
+         id="stop12007-8"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-29">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-1" />
+      <stop
+         id="stop11979-3"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-5"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687-84">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-07" />
+      <stop
+         id="stop11695-63"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-1">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-5" />
+      <stop
+         id="stop11152-4"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11128-2">
+      <stop
+         style="stop-color:#e4d09d;stop-opacity:1"
+         offset="0"
+         id="stop11130-0" />
+      <stop
+         id="stop11136-97"
+         offset="0.27413794"
+         style="stop-color:#f6ecb2;stop-opacity:1" />
+      <stop
+         style="stop-color:#b58a68;stop-opacity:1"
+         offset="1"
+         id="stop11132-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-7">
+      <stop
+         id="stop10858-2"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-6" />
+      <stop
+         id="stop10862-0"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-16">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-57" />
+      <stop
+         id="stop10806-5"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-41" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10748-2">
+      <stop
+         id="stop10750-0"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752-0" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754-1" />
+      <stop
+         id="stop10756-4"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758-6"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-0">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-7" />
+      <stop
+         id="stop10458-17"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-7"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-7" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-3">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-3" />
+      <stop
+         id="stop10521-5"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10432-9">
+      <stop
+         id="stop10434-8"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436-18" />
+      <stop
+         id="stop10438-2"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10414-6">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416-6" />
+      <stop
+         id="stop10422-03"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10396-0">
+      <stop
+         style="stop-color:#1b3e79;stop-opacity:1;"
+         offset="0"
+         id="stop10398-1" />
+      <stop
+         id="stop10404-2"
+         offset="0.5"
+         style="stop-color:#728fbf;stop-opacity:1" />
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="1"
+         id="stop10400-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10157-0">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-94" />
+      <stop
+         id="stop10165-7"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9914-3"
+       inkscape:collect="always">
+      <stop
+         id="stop9916-5"
+         offset="0"
+         style="stop-color:#4a6fa4;stop-opacity:1" />
+      <stop
+         id="stop9918-1"
+         offset="1"
+         style="stop-color:#4e86ca;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9908-2"
+       inkscape:collect="always">
+      <stop
+         id="stop9910-01"
+         offset="0"
+         style="stop-color:#525f72;stop-opacity:1" />
+      <stop
+         id="stop9912-6"
+         offset="1"
+         style="stop-color:#9e884e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9605-4">
+      <stop
+         style="stop-color:#2a5bbf;stop-opacity:1;"
+         offset="0"
+         id="stop9607-06" />
+      <stop
+         style="stop-color:#2a5bbf;stop-opacity:0;"
+         offset="1"
+         id="stop9609-18" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9510-9">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9512-8" />
+      <stop
+         id="stop9514-4"
+         offset="0.35636142"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9516-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332-4">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334-3" />
+      <stop
+         id="stop9340-9"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9324-8">
+      <stop
+         id="stop9326-08"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.30000001"
+         id="stop9328-7" />
+      <stop
+         id="stop9330-7"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9312-8">
+      <stop
+         style="stop-color:#cf6c00;stop-opacity:1"
+         offset="0"
+         id="stop9314-3" />
+      <stop
+         id="stop9322-83"
+         offset="0.36339331"
+         style="stop-color:#f5db48;stop-opacity:0.24200913" />
+      <stop
+         style="stop-color:#c36000;stop-opacity:1"
+         offset="1"
+         id="stop9316-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9299-10">
+      <stop
+         style="stop-color:#929baa;stop-opacity:1"
+         offset="0"
+         id="stop9301-7" />
+      <stop
+         style="stop-color:#cac3a5;stop-opacity:1"
+         offset="1"
+         id="stop9303-34" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9291-9">
+      <stop
+         style="stop-color:#e9f8ff;stop-opacity:1;"
+         offset="0"
+         id="stop9293-6" />
+      <stop
+         style="stop-color:#f5f6f9;stop-opacity:1"
+         offset="1"
+         id="stop9295-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8661-1"
+       inkscape:collect="always">
+      <stop
+         id="stop8663-09"
+         offset="0"
+         style="stop-color:#c6e7f9;stop-opacity:1" />
+      <stop
+         id="stop8665-9"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8653-6">
+      <stop
+         style="stop-color:#676656;stop-opacity:1;"
+         offset="0"
+         id="stop8655-834" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop8657-84" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-9">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-9" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-25" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-5">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-33" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-7">
+      <stop
+         id="stop7561-3-3-4-48-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-3" />
+      <stop
+         id="stop7565-8-8-3-2-80"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-80" />
+      <stop
+         id="stop7114-9-0-1-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4320-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4322-9" />
+      <stop
+         id="stop4324-89"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4326-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4329-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4331-2" />
+      <stop
+         id="stop4333-8"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4335-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-89">
+      <stop
+         id="stop7561-3-3-4-48-7-07"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-81" />
+      <stop
+         id="stop7565-8-8-3-2-0-5"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-6" />
+      <stop
+         id="stop7114-9-0-1-4-12"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-42" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3256-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3258-8" />
+      <stop
+         id="stop3260-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3262-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3265-6">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3267-5" />
+      <stop
+         id="stop3269-3"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3271-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-2-2">
+      <stop
+         id="stop7561-3-3-4-48-5-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-76-6" />
+      <stop
+         id="stop7565-8-8-3-2-7-1"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-22-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-8-21" />
+      <stop
+         id="stop7114-9-0-1-1-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-4-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3506-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3508-62" />
+      <stop
+         id="stop3510-9"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3512-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3515-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3517-0" />
+      <stop
+         id="stop3519-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3521-39" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-1">
+      <stop
+         id="stop7561-3-3-4-48-7-4-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-1" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-9"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-3" />
+      <stop
+         id="stop7114-9-0-1-4-6-25"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-25" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4133-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4135-6" />
+      <stop
+         id="stop4137-7"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4139-72" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4142-29">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4144-4" />
+      <stop
+         id="stop4146-19"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4148-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-98">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-25"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-5" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-4"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-91">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-250" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-83"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4356-9" />
+      <stop
+         id="stop4358-67"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4360-99" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4365-69" />
+      <stop
+         id="stop4367-35"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4369-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-5-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-5-6"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-0-5" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-2-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-3-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-4-5" />
+      <stop
+         id="stop7114-9-0-1-4-6-3-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-3-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354-1-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4356-1-6" />
+      <stop
+         id="stop4358-6-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4360-2-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363-3-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4365-6-3" />
+      <stop
+         id="stop4367-1-5"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4369-3-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-5-3">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-8-2"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-7-8" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-7-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-9-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-0-36" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-1-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-5-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690-62">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5692-1" />
+      <stop
+         id="stop5694-46"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5696-29" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5701-5" />
+      <stop
+         id="stop5703-03"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5705-64" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-9-9">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-2-29"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-0-34" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-5-4"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-2-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-2-59" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-16-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-6-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690-4-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5692-0-28" />
+      <stop
+         id="stop5694-4-8"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5696-5-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699-0-58">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5701-6-12" />
+      <stop
+         id="stop5703-0-5"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5705-3-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6-4">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-3-44"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-2-4" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-3-4"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-8-93" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-4-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-0-77" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6127-7" />
+      <stop
+         id="stop6129-3"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6131-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134-38">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6136-2" />
+      <stop
+         id="stop6138-52"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6140-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-3">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-7"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-29" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-53">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-43" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-2"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-11" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125-7-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6127-4-2" />
+      <stop
+         id="stop6129-0-5"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6131-6-35" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134-4-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6136-6-2" />
+      <stop
+         id="stop6138-0-2"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6140-7-26" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-92-4">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-4-0"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-6-7" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-55-03"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-72-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-5-0" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-6-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-2-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6293-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6295-10" />
+      <stop
+         id="stop6297-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6299-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6302-50">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6304-0" />
+      <stop
+         id="stop6306-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6308-54" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-9">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4-64" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9-1" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6321-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6323-14" />
+      <stop
+         id="stop6325-8"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6327-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6330-92">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6332-0" />
+      <stop
+         id="stop6334-7"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6336-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6-6-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-3-3-0"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-2-2-7" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-3-8-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7-9-56">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-8-5-73" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-4-5-8"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-0-1-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6349-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6351-2" />
+      <stop
+         id="stop6353-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6355-57" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6358-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6360-45" />
+      <stop
+         id="stop6362-7"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6364-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6-8">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8-0-30"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4-7-2" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8-6-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9-4-6" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0-7-7"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4-1-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6940-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6942-5" />
+      <stop
+         id="stop6944-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6946-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6949-26">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6951-06" />
+      <stop
+         id="stop6953-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6955-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6-1-17">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8-0-8-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4-7-3-0" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8-6-8-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3-0-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9-4-8-8" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0-7-1-30"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4-1-9-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7106-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7108-9" />
+      <stop
+         id="stop7110-03"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7112-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7115-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7117-57" />
+      <stop
+         id="stop7119-7"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7121-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7686-9-9"
+       id="linearGradient7692-4-8"
+       x1="1303.0625"
+       y1="610.34235"
+       x2="1303.0625"
+       y2="723.85583"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7686-9-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7688-7-3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7690-5-07" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-140)"
+       y2="723.85583"
+       x2="1303.0625"
+       y1="610.34235"
+       x1="1303.0625"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7755-5-47"
+       xlink:href="#linearGradient7686-9-7-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7686-9-7-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7688-7-1-3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7690-5-0-71" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-08"
+       id="linearGradient8159-0-0"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-08">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-3" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-9-01"
+       id="linearGradient8143-2-5"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-9-01">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-4-4" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-1-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,2.6171875e-6)"
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8180-3-6"
+       xlink:href="#linearGradient8153-2-8-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-8-2">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-7-03" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-3-56" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,2.6171875e-6)"
+       y2="283.2832"
+       x2="657.71722"
+       y1="283.2832"
+       x1="617.06256"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8182-6"
+       xlink:href="#linearGradient8137-9-5-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-9-5-6">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-4-2-7" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-1-9-67" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-6-1"
+       id="linearGradient8291-2-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-6-1">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-6-9" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-6-16" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-1-2">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-4-7" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-2-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-4-7">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-78-6" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-0-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-93-1">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-9-3" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-8-99" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8498-9"
+       id="linearGradient8504-5"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8498-9">
+      <stop
+         style="stop-color:#d9f4ff;stop-opacity:1"
+         offset="0"
+         id="stop8500-2" />
+      <stop
+         style="stop-color:#f9fcff;stop-opacity:1"
+         offset="1"
+         id="stop8502-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-6"
+       id="linearGradient8659-53"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8661-1"
+       id="linearGradient8681-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-5"
+       id="linearGradient8683-4"
+       gradientUnits="userSpaceOnUse"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-08"
+       id="linearGradient8685-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-9"
+       id="linearGradient8687-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-6"
+       id="linearGradient8689-2"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-6"
+       id="linearGradient8691-79"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-6"
+       id="linearGradient8693-2"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-6"
+       id="linearGradient8695-3"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-6"
+       id="linearGradient8697-73"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-93-1"
+       id="linearGradient8699-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-4-7"
+       id="linearGradient8701-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-1-2"
+       id="linearGradient8703-78"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375262)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291-9"
+       id="linearGradient9297-58"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299-10"
+       id="linearGradient9305-3"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332-9-41"
+       id="linearGradient9338-8-2"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient9332-9-41">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334-5-1" />
+      <stop
+         id="stop9340-2-59"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336-4-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9324-7-6"
+       id="linearGradient9318-10"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient9324-7-6">
+      <stop
+         id="stop9326-0-4"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.30000001"
+         id="stop9328-1-5" />
+      <stop
+         id="stop9330-5-3"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291-8-8"
+       id="linearGradient9297-1-0"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9291-8-8">
+      <stop
+         style="stop-color:#e9f8ff;stop-opacity:1;"
+         offset="0"
+         id="stop9293-7-9" />
+      <stop
+         style="stop-color:#f5f6f9;stop-opacity:1"
+         offset="1"
+         id="stop9295-3-13" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299-1-74"
+       id="linearGradient9305-8-4"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9299-1-74">
+      <stop
+         style="stop-color:#929baa;stop-opacity:1"
+         offset="0"
+         id="stop9301-6-6" />
+      <stop
+         style="stop-color:#cac3a5;stop-opacity:1"
+         offset="1"
+         id="stop9303-8-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332-6-6">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334-52-5" />
+      <stop
+         id="stop9340-23-2"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336-3-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9312-9-10">
+      <stop
+         style="stop-color:#cf6c00;stop-opacity:1"
+         offset="0"
+         id="stop9314-5-3" />
+      <stop
+         id="stop9322-0-15"
+         offset="0.36339331"
+         style="stop-color:#f5db48;stop-opacity:0.24200913" />
+      <stop
+         style="stop-color:#c36000;stop-opacity:1"
+         offset="1"
+         id="stop9316-6-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       y2="472.63525"
+       x2="556.25635"
+       y1="472.63525"
+       x1="526.85181"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9415-5-2"
+       xlink:href="#linearGradient9510-3-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9510-3-2">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9512-4-1" />
+      <stop
+         id="stop9514-9-7"
+         offset="0.35636142"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9516-6-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8661-5-8"
+       inkscape:collect="always">
+      <stop
+         id="stop8663-3-2"
+         offset="0"
+         style="stop-color:#c6e7f9;stop-opacity:1" />
+      <stop
+         id="stop8665-5-3"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-6-63">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-1-0" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-6-35" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-0-28">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-9-0" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-5-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-2-2">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-7-25" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-8-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-2-0"
+       id="linearGradient8697-5-1"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8653-2-0">
+      <stop
+         style="stop-color:#676656;stop-opacity:1;"
+         offset="0"
+         id="stop8655-9-8" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop8657-2-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-4-4-07">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-78-0-9" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-0-7-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-1-3-34"
+       id="linearGradient8703-1-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375262)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-1-3-34">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-4-2-1" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-2-6-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9605-4"
+       id="linearGradient9962-4"
+       gradientUnits="userSpaceOnUse"
+       x1="213.82529"
+       y1="441.62799"
+       x2="227.09628"
+       y2="454.31174" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332-6-6"
+       id="linearGradient9964-8"
+       gradientUnits="userSpaceOnUse"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9312-9-10"
+       id="linearGradient9966-5"
+       gradientUnits="userSpaceOnUse"
+       x1="526.4375"
+       y1="448.46484"
+       x2="556.9375"
+       y2="448.46484" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9510-3-2"
+       id="linearGradient9968-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8661-5-8"
+       id="linearGradient9970-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-6-63"
+       id="linearGradient9972-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0)"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-0-28"
+       id="linearGradient9974-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-2-2"
+       id="linearGradient9976-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0.34375)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9908-2"
+       id="linearGradient9978-3"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="306.07397"
+       x2="641.07611"
+       y2="281.43512" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-2-0"
+       id="linearGradient9980-9"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-4-4-07"
+       id="linearGradient9982-58"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9914-3"
+       id="linearGradient9984-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0.34375262)"
+       x1="636.09375"
+       y1="279.41037"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332-4"
+       id="linearGradient9997-7"
+       gradientUnits="userSpaceOnUse"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9312-8"
+       id="linearGradient9999-9"
+       gradientUnits="userSpaceOnUse"
+       x1="526.4375"
+       y1="448.46484"
+       x2="556.9375"
+       y2="448.46484" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9510-9"
+       id="linearGradient10001-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291-8-8"
+       id="linearGradient10003-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299-1-74"
+       id="linearGradient10005-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-5-1"
+       id="linearGradient10163-8-7"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10157-5-1">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-7-9" />
+      <stop
+         id="stop10165-2-0"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-3-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-3-17"
+       id="linearGradient10155-1-4"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-3-17">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-0-5" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-7-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-6-24"
+       id="linearGradient10155-5-3"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-6-24">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-5-12" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-8-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-8"
+       id="linearGradient10163-2-0"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10157-2-8">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8-7" />
+      <stop
+         id="stop10165-3-4"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39-8"
+       id="linearGradient10155-7-6"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39-8">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3-0" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10149-6-5-7">
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="0"
+         id="stop10151-5-7-4" />
+      <stop
+         id="stop10394-31"
+         offset="0.5"
+         style="stop-color:#b9c7df;stop-opacity:1" />
+      <stop
+         style="stop-color:#567ebc;stop-opacity:1"
+         offset="1"
+         id="stop10153-8-1-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-4-3"
+       id="linearGradient10454-7-6"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10448-4-3">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-4-01" />
+      <stop
+         id="stop10458-7-9"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-9-0"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-1-4" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-2-29" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-2-4"
+       id="linearGradient10446-9-31"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10440-2-4">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-4-8" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-4-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-5"
+       id="linearGradient10454-9-0"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10448-9-5">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-59" />
+      <stop
+         id="stop10458-8-32"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4-87"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2-48" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-14" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-55"
+       id="linearGradient10446-7-3"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10440-1-55">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-26" />
+      <stop
+         id="stop10521-1-8"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-92" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10546-3-9"
+       xlink:href="#linearGradient10448-9-7-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-7-5">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-9" />
+      <stop
+         id="stop10458-8-0-4"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4-1-50"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2-9-5" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-88" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10548-3-0"
+       xlink:href="#linearGradient10440-1-0-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-1-0-1">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-2-3" />
+      <stop
+         id="stop10521-1-2-2"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-4-2" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10546-8-2"
+       xlink:href="#linearGradient10448-9-6-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-6-7">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-8-0" />
+      <stop
+         id="stop10458-8-7-3"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4-7-1"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2-1-3" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-8-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10548-1-7"
+       xlink:href="#linearGradient10440-1-3-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-1-3-0">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-0-95" />
+      <stop
+         id="stop10521-1-4-58"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-2-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-9-7-0-78">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6-3" />
+      <stop
+         id="stop10456-4-1-5-7"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-0-0-3">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-2-0-9" />
+      <stop
+         id="stop10521-1-2-5-1"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-4-0-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-78"
+       id="linearGradient10770-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-0-0-3"
+       id="linearGradient10772-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       x1="334.375"
+       y1="529.06494"
+       x2="334.375"
+       y2="518.67365" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748-2"
+       id="linearGradient10774-01"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-3-0"
+       id="linearGradient10776-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       x1="334.375"
+       y1="532.30212"
+       x2="334.375"
+       y2="515.73615" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-0"
+       id="linearGradient10778-4"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-3"
+       id="linearGradient10780-8"
+       gradientUnits="userSpaceOnUse"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414-6"
+       id="linearGradient10782-6"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432-9"
+       id="linearGradient10784-09"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-0"
+       id="linearGradient10786-3"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10396-0"
+       id="linearGradient10788-0"
+       gradientUnits="userSpaceOnUse"
+       x1="302.3125"
+       y1="532.98718"
+       x2="302.3125"
+       y2="514.67456" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-8"
+       id="linearGradient10790-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39-8"
+       id="linearGradient10792-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-6-5-7"
+       id="linearGradient10794-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.88388349,2.6171875e-6)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="511.38498" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-8-3"
+       id="linearGradient10804-7-6"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10798-8-3">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-2-5" />
+      <stop
+         id="stop10806-9-6"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-3-58" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-94"
+       id="linearGradient10804-8-3"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10798-1-94">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-8" />
+      <stop
+         id="stop10806-6-39"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-4" />
+      <stop
+         id="stop10806-6-8-58"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10835-2-1"
+       xlink:href="#linearGradient10856-6-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-5">
+      <stop
+         id="stop10858-0-5"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-1" />
+      <stop
+         id="stop10862-3-96"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-5"
+       id="radialGradient11144-4-4"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)" />
+    <linearGradient
+       id="linearGradient11146-8-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-42" />
+      <stop
+         id="stop11152-8-53"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-7-6"
+       id="radialGradient11144-2-2"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)" />
+    <linearGradient
+       id="linearGradient11146-7-6">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-82" />
+      <stop
+         id="stop11152-6-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11169-6-6"
+       xlink:href="#linearGradient11146-8-7-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-8-7-3">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-9" />
+      <stop
+         id="stop11152-8-8-4"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11063-6-5"
+       xlink:href="#linearGradient10856-6-3-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-3-6">
+      <stop
+         id="stop10858-0-7-2"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-53" />
+      <stop
+         id="stop10862-3-3-5"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-6" />
+      <stop
+         id="stop10806-6-8-5-1"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-4" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-4-6"
+       id="radialGradient11268-5-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-4-6">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-2" />
+      <stop
+         id="stop11152-9-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-3-25"
+       id="radialGradient11270-4-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-8-3-25">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-51" />
+      <stop
+         id="stop11152-8-4-0"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-7-5-51"
+       id="radialGradient11272-3-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-154.64572)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-7-5-51">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-76" />
+      <stop
+         id="stop11152-6-7-0"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-7-5-2"
+       id="radialGradient11274-3-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-154.64572)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-8-7-5-2">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-4" />
+      <stop
+         id="stop11152-8-8-6-33"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11298-3-6"
+       xlink:href="#linearGradient10856-6-3-0-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-3-0-2">
+      <stop
+         id="stop10858-0-7-6-8"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-23" />
+      <stop
+         id="stop10862-3-3-8-43"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10880-5-3-4-4"
+       xlink:href="#linearGradient10798-1-9-3-7-36"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-36">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-84" />
+      <stop
+         id="stop10806-6-8-5-3-7"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-3" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-98"
+       xlink:href="#linearGradient10798-1-9-3-7-36"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-4-5-0">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-7-0" />
+      <stop
+         id="stop11152-9-2-8"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-4-80">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-5-5" />
+      <stop
+         id="stop11152-8-4-9-1"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-3-4">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-4-3" />
+      <stop
+         id="stop11152-6-7-2-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-6-39">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-1-2" />
+      <stop
+         id="stop11152-8-8-6-6-1"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-1-9">
+      <stop
+         id="stop10858-0-7-6-1-8"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-7-2" />
+      <stop
+         id="stop10862-3-3-8-4-3"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-0-4"
+       xlink:href="#linearGradient10798-1-9-3-7-1-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-0">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-23" />
+      <stop
+         id="stop10806-6-8-5-3-2-1"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-9" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11520-3-8"
+       xlink:href="#linearGradient10798-1-9-3-7-1-2-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-2-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-6-89" />
+      <stop
+         id="stop10806-6-8-5-3-2-9-1"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-6-3" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11520-8-5"
+       xlink:href="#linearGradient10798-1-9-3-7-1-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5-4" />
+      <stop
+         id="stop10806-6-8-5-3-2-3-253"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2-8" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-2-2"
+       id="radialGradient11685-7-9"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-2-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-9-8" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-1-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-1-1"
+       id="linearGradient11693-0-0"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-1-1">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-9-4" />
+      <stop
+         id="stop11695-3-8"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-9-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11888-8-3"
+       id="linearGradient11894-2-9"
+       x1="342.37973"
+       y1="457.29816"
+       x2="358.60471"
+       y2="444.57022"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11888-8-3">
+      <stop
+         style="stop-color:#a7c8ec;stop-opacity:1"
+         offset="0"
+         id="stop11890-4-59" />
+      <stop
+         style="stop-color:#b4def6;stop-opacity:1"
+         offset="1"
+         id="stop11892-1-79" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11888-4-1"
+       id="linearGradient11894-5-80"
+       x1="342.37973"
+       y1="457.29816"
+       x2="358.60471"
+       y2="444.57022"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11888-4-1">
+      <stop
+         style="stop-color:#a7c8ec;stop-opacity:1"
+         offset="0"
+         id="stop11890-8-4" />
+      <stop
+         style="stop-color:#b4def6;stop-opacity:1"
+         offset="1"
+         id="stop11892-8-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2-5">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-3-5" />
+      <stop
+         id="stop11979-8-5"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-7-09"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-6-28" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2-2">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-1-4" />
+      <stop
+         id="stop12096-1-5"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-2-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-7-44">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-9-0" />
+      <stop
+         id="stop12007-1-5"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-2-1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-7-5"
+       id="radialGradient11685-5-1"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-7-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-94-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-0-08" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-9-8"
+       id="linearGradient11693-2-3"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-9-8">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-1-7" />
+      <stop
+         id="stop11695-2-2"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-1-6" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-8-3"
+       id="radialGradient11685-3-9"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-8-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-3-81" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-6-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-8-3"
+       id="linearGradient11693-26-3"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-8-3">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-6-84" />
+      <stop
+         id="stop11695-6-8"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-5-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2-2-15">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-3-7-4" />
+      <stop
+         id="stop11979-8-6-1"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-7-6-3"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-6-6-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2-1-3">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-1-8-5" />
+      <stop
+         id="stop12096-1-8-8"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-2-4-56" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-7-2-9">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-9-2-0" />
+      <stop
+         id="stop12007-1-3-8"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-2-8-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-3">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-6" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-06"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-97" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-9-8">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-7-9" />
+      <stop
+         id="stop11979-0-4"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-6-15"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-8-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7-666">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-7-6" />
+      <stop
+         id="stop12096-6-7"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-1-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9-4">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-1-0" />
+      <stop
+         id="stop12007-4-61"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-3-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2-14">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5-2-95" />
+      <stop
+         id="stop10806-6-8-5-3-2-3-3-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2-2-3" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-3-1"
+       id="radialGradient11685-2-4"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-3-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-91-52" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-02-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-2-68"
+       id="linearGradient11693-3-1"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-2-68">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-3-82" />
+      <stop
+         id="stop11695-9-7"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-10-7" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-9-2"
+       id="radialGradient12723-3-1"
+       cx="433.36786"
+       cy="424.34106"
+       fx="433.36786"
+       fy="424.34106"
+       r="12.027534"
+       gradientTransform="matrix(1.1614831,2.1855961e-7,-2.811228e-7,1.4939602,-69.981471,-211.63828)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-9-2">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-7-6" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-6-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-5-4">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-6-9" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-9-4" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-5-4"
+       id="radialGradient12739-4-60"
+       cx="433.5452"
+       cy="420.74988"
+       fx="433.5452"
+       fy="420.74988"
+       r="12.952347"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1-3">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3-62" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-3"
+       id="linearGradient12904-2-5"
+       x1="420.88995"
+       y1="455.88452"
+       x2="440.35345"
+       y2="417.26108"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11146-4-0-8">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-1-8" />
+      <stop
+         id="stop11152-9-9-1"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-5-21">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-2-4" />
+      <stop
+         id="stop11152-8-4-3-9"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-5-82">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-8-45" />
+      <stop
+         id="stop11152-6-7-5-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-9-9">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-19-9" />
+      <stop
+         id="stop11152-8-8-6-2-8"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-5-3">
+      <stop
+         id="stop10858-0-7-6-9-8"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-9-6" />
+      <stop
+         id="stop10862-3-3-8-6-9"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-9-8"
+       xlink:href="#linearGradient10798-1-9-3-7-6-66"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-66">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-38"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-2" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13197-7-6"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-7" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-5"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-7" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-4-82"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-8" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-02"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-89">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3-28" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-5">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-5" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-7" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13197-3-67"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-8">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-7" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-81"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-5"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-0" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-0" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13333-0-1-7"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-5-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3-1-5" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2-1-5"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2-3-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13850-2-14">
+      <stop
+         id="stop13852-4-86"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13854-7-4"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856-0-6">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13858-8-8" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13860-4-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799-7-83">
+      <stop
+         style="stop-color:#b9772f;stop-opacity:1"
+         offset="0"
+         id="stop13801-4-5" />
+      <stop
+         id="stop13809-4-5"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop13807-7-1"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop13811-8-5" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop13803-6-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1-8-8">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3-6-4" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4-9-0" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="455.88452"
+       x1="420.88995"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13011-8-54"
+       xlink:href="#linearGradient12862-1-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11969-9-0-7">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-7-1-2" />
+      <stop
+         id="stop11979-0-0-1"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-6-1-4"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-8-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7-6-9">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-7-9-0" />
+      <stop
+         id="stop12096-6-2-3"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-1-3-03" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9-8-5">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-1-9-0" />
+      <stop
+         id="stop12007-4-6-7"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-3-6-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-78">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-3" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-6"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-44" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2-1-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5-2-6-9" />
+      <stop
+         id="stop10806-6-8-5-3-2-3-3-7-5"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2-2-2-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687-2-2-74">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-3-7-7" />
+      <stop
+         id="stop11695-9-8-3"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-10-4-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-4-4-0">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-72-88" />
+      <stop
+         id="stop11152-9-0-15"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-2-23">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-9-2" />
+      <stop
+         id="stop11152-8-4-35-4"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-30-66">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-9-6" />
+      <stop
+         id="stop11152-6-7-6-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-7-9">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-8-0" />
+      <stop
+         id="stop11152-8-8-6-3-4"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-0-9">
+      <stop
+         id="stop10858-0-7-6-0-3"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-0-1" />
+      <stop
+         id="stop10862-3-3-8-2-1"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-1-9"
+       xlink:href="#linearGradient10798-1-9-3-7-7-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-7-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-4-5" />
+      <stop
+         id="stop10806-6-8-5-3-1-55"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-0-60" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4918-5-5">
+      <stop
+         style="stop-color:#d48a4b;stop-opacity:1;"
+         offset="0"
+         id="stop4920-9-9" />
+      <stop
+         style="stop-color:#b1623a;stop-opacity:1;"
+         offset="1"
+         id="stop4922-9-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4907-9-6">
+      <stop
+         style="stop-color:#b86c44;stop-opacity:1;"
+         offset="0"
+         id="stop4909-5-34" />
+      <stop
+         style="stop-color:#8f4017;stop-opacity:1;"
+         offset="1"
+         id="stop4911-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4928-4-05">
+      <stop
+         style="stop-color:#4dac81;stop-opacity:1;"
+         offset="0"
+         id="stop4930-9-3" />
+      <stop
+         style="stop-color:#058048;stop-opacity:1;"
+         offset="1"
+         id="stop4932-8-91" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4938-8-2">
+      <stop
+         style="stop-color:#8bc7d7;stop-opacity:1;"
+         offset="0"
+         id="stop4940-4-88" />
+      <stop
+         style="stop-color:#17477c;stop-opacity:1;"
+         offset="1"
+         id="stop4942-8-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4961-6-6"
+       id="linearGradient4983-5-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4.625,0)"
+       x1="15.073242"
+       y1="1040.0764"
+       x2="18.744612"
+       y2="1049.2014" />
+    <linearGradient
+       id="linearGradient4961-6-6">
+      <stop
+         style="stop-color:#df9a39;stop-opacity:1;"
+         offset="0"
+         id="stop4963-0-0" />
+      <stop
+         style="stop-color:#b55829;stop-opacity:1;"
+         offset="1"
+         id="stop4965-3-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5328-5-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5330-9-9" />
+      <stop
+         style="stop-color:#464646;stop-opacity:1;"
+         offset="1"
+         id="stop5332-8-02" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5209-0-2">
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="0"
+         id="stop5211-9-1" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:1;"
+         offset="1"
+         id="stop5213-4-54" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5397-44">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5399-25" />
+      <stop
+         style="stop-color:#464646;stop-opacity:1;"
+         offset="1"
+         id="stop5401-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5404-42">
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="0"
+         id="stop5406-1" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:1;"
+         offset="1"
+         id="stop5408-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5411-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5413-7" />
+      <stop
+         style="stop-color:#464646;stop-opacity:1;"
+         offset="1"
+         id="stop5415-95" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5418-5">
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="0"
+         id="stop5420-4" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:1;"
+         offset="1"
+         id="stop5422-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4855-14">
+      <stop
+         style="stop-color:#0d5c9a;stop-opacity:1;"
+         offset="0"
+         id="stop4857-3" />
+      <stop
+         style="stop-color:#3583c0;stop-opacity:1;"
+         offset="1"
+         id="stop4859-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5148-9-2"
+       id="linearGradient5154-9-1"
+       x1="3.8473835"
+       y1="4.0062027"
+       x2="2.9380388"
+       y2="3.0118337"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5148-9-2">
+      <stop
+         style="stop-color:#05507d;stop-opacity:1;"
+         offset="0"
+         id="stop5150-6-2" />
+      <stop
+         style="stop-color:#6b8fa5;stop-opacity:1;"
+         offset="1"
+         id="stop5152-5-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,1036.3622)"
+       y2="3.0118337"
+       x2="2.9380388"
+       y1="4.0062027"
+       x1="3.8473835"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5171-5-8"
+       xlink:href="#linearGradient5148-9-8-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5148-9-8-2">
+      <stop
+         style="stop-color:#05507d;stop-opacity:1;"
+         offset="0"
+         id="stop5150-6-3-2" />
+      <stop
+         style="stop-color:#6b8fa5;stop-opacity:1;"
+         offset="1"
+         id="stop5152-5-4-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5238-1-5"
+       id="linearGradient5244-0-8"
+       x1="12.531334"
+       y1="1041.9091"
+       x2="8.8389864"
+       y2="1041.9091"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5238-1-5">
+      <stop
+         style="stop-color:#6d83ac;stop-opacity:1;"
+         offset="0"
+         id="stop5240-9-8" />
+      <stop
+         style="stop-color:#aeb9ce;stop-opacity:1;"
+         offset="1"
+         id="stop5242-5-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.1377778,0,0,1,-0.79222222,2.0000504)"
+       y2="1041.9091"
+       x2="8.8389864"
+       y1="1041.9091"
+       x1="12.531334"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5261-8-9"
+       xlink:href="#linearGradient5238-1-3-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5238-1-3-4">
+      <stop
+         style="stop-color:#6d83ac;stop-opacity:1;"
+         offset="0"
+         id="stop5240-9-6-4" />
+      <stop
+         style="stop-color:#aeb9ce;stop-opacity:1;"
+         offset="1"
+         id="stop5242-5-0-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.9091"
+       x2="8.8389864"
+       y1="1041.9091"
+       x1="12.531334"
+       gradientTransform="matrix(0.84444446,0,0,1,0.92569446,3.93755)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5295-7-9"
+       xlink:href="#linearGradient5238-1-3-6-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5238-1-3-6-8">
+      <stop
+         style="stop-color:#6d83ac;stop-opacity:1;"
+         offset="0"
+         id="stop5240-9-6-9-5" />
+      <stop
+         style="stop-color:#aeb9ce;stop-opacity:1;"
+         offset="1"
+         id="stop5242-5-0-3-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.9091"
+       x2="8.8389864"
+       y1="1041.9091"
+       x1="12.531334"
+       gradientTransform="translate(0.03125007,6.00005)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5329-5-6"
+       xlink:href="#linearGradient5238-1-3-6-4-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5238-1-3-6-4-0">
+      <stop
+         style="stop-color:#6d83ac;stop-opacity:1;"
+         offset="0"
+         id="stop5240-9-6-9-8-7" />
+      <stop
+         style="stop-color:#aeb9ce;stop-opacity:1;"
+         offset="1"
+         id="stop5242-5-0-3-1-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-2"
+       id="linearGradient6899-2-7"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6893-5-2">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-6" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:0;"
+         offset="1"
+         id="stop6897-2-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,1039.1906)"
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6916-3-7"
+       xlink:href="#linearGradient6893-5-8-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6893-5-8-1">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-3" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:0;"
+         offset="1"
+         id="stop6897-2-6-2" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.1065878,0,0,0.3047951,-0.87851916,1044.7521)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6950-4-1"
+       xlink:href="#linearGradient6893-5-8-5-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6893-5-8-5-6">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-1-3" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:0;"
+         offset="1"
+         id="stop6897-2-6-4-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-5-2"
+       id="linearGradient6805-5-3"
+       x1="5.1146584"
+       y1="1047.6122"
+       x2="6.0002952"
+       y2="1047.6122"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-3.09375)" />
+    <linearGradient
+       id="linearGradient6799-5-2">
+      <stop
+         style="stop-color:#a6bacf;stop-opacity:1;"
+         offset="0"
+         id="stop6801-6-8" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-6-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7254-6-1"
+       id="linearGradient7260-9-0"
+       x1="15.000595"
+       y1="2"
+       x2="1.875"
+       y2="2"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient7254-6-1">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-5-2" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-7-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7254-62-5"
+       id="linearGradient7260-7-0"
+       x1="15.000595"
+       y1="2"
+       x2="1.875"
+       y2="2"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient7254-62-5">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-0-4" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-0-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.93721973,0,0,1,1036.9601,-3.593733)"
+       y2="2"
+       x2="1.875"
+       y1="2"
+       x1="15.000595"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7277-1-7"
+       xlink:href="#linearGradient7254-6-4-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7254-6-4-9">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-5-4-3" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-7-4-4" />
+    </linearGradient>
+    <linearGradient
+       y2="2"
+       x2="1.875"
+       y1="2"
+       x1="15.000595"
+       gradientTransform="matrix(0.93721973,0,0,1,1036.9602,-16.656233)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7362-2-7"
+       xlink:href="#linearGradient7254-6-4-3-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7254-6-4-3-8">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-5-4-1-8" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-7-4-8-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-9-6">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-6-38" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-9-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-0-6">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-8-1" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-5-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-5-2">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-4-3" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-5-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1-8">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-6-5" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-9-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-9-3-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-6-3-8" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-9-9-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-0-5-3">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="stop7594-8-9-3" />
+      <stop
+         style="stop-color:#875f1e;stop-opacity:1;"
+         offset="1"
+         id="stop7596-5-6-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7824-4-07"
+       id="linearGradient7830-9-8"
+       x1="36.936684"
+       y1="1048.2251"
+       x2="36.936684"
+       y2="1039.3534"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient7824-4-07">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop7826-9-9" />
+      <stop
+         style="stop-color:#dfdfdf;stop-opacity:1;"
+         offset="1"
+         id="stop7828-1-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-26.899086,0.04105339)"
+       y2="1043.1044"
+       x2="36.936684"
+       y1="1048.2251"
+       x1="36.936684"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7847-5-4"
+       xlink:href="#linearGradient7824-4-0-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7824-4-0-3">
+      <stop
+         style="stop-color:#b1b1b1;stop-opacity:1;"
+         offset="0"
+         id="stop7826-9-7-1" />
+      <stop
+         style="stop-color:#e2e2e2;stop-opacity:1;"
+         offset="1"
+         id="stop7828-1-4-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7824-4-0-4-3">
+      <stop
+         style="stop-color:#b1b1b1;stop-opacity:1;"
+         offset="0"
+         id="stop7826-9-7-5-1" />
+      <stop
+         style="stop-color:#e2e2e2;stop-opacity:1;"
+         offset="1"
+         id="stop7828-1-4-3-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7824-4-7-9"
+       id="linearGradient7906-2-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-26.899086,0.04105339)"
+       x1="36.936684"
+       y1="1048.2251"
+       x2="36.936684"
+       y2="1043.1044" />
+    <linearGradient
+       id="linearGradient7824-4-7-9">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop7826-9-8-0" />
+      <stop
+         style="stop-color:#dfdfdf;stop-opacity:1;"
+         offset="1"
+         id="stop7828-1-7-2" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11520-0-3-1-1"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-3">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-9" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3995-7"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3995-1-4"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-2" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-5"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-8" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8136-2"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-7"
+       id="linearGradient8163-8"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1-28"
+       id="linearGradient8163-2"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1-28">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7-2" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8-94"
+         offset="0.5"
+         style="stop-color:#3c8d49;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4e173;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3-4" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1045.0624"
+       x2="6.3342748"
+       y1="1046.0566"
+       x1="8.0461559"
+       id="linearGradient9263"
+       xlink:href="#linearGradient9257"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5068-9"
+       inkscape:collect="always">
+      <stop
+         id="stop5070-9"
+         offset="0"
+         style="stop-color:#7593c1;stop-opacity:1" />
+      <stop
+         id="stop5072-5"
+         offset="1"
+         style="stop-color:#5a78ab;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-27.005631,-6.0220971)"
+       gradientUnits="userSpaceOnUse"
+       y2="1051.9485"
+       x2="31.230719"
+       y1="1043.726"
+       x1="31.230719"
+       id="linearGradient5074-1"
+       xlink:href="#linearGradient5068-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5056-0">
+      <stop
+         id="stop5058-4"
+         offset="0"
+         style="stop-color:#97adce;stop-opacity:1" />
+      <stop
+         style="stop-color:#e0e8f0;stop-opacity:1"
+         offset="0.2858389"
+         id="stop5066-9" />
+      <stop
+         style="stop-color:#98aece;stop-opacity:1"
+         offset="0.60006815"
+         id="stop5064-3" />
+      <stop
+         id="stop5060-1"
+         offset="1"
+         style="stop-color:#7e9bca;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-27.005631,-6.0220971)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.9135"
+       x2="34.041382"
+       y1="1047.9135"
+       x1="29.105539"
+       id="linearGradient5062-9"
+       xlink:href="#linearGradient5056-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7160">
+      <stop
+         id="stop7162"
+         offset="0"
+         style="stop-color:#105c9c;stop-opacity:1;" />
+      <stop
+         style="stop-color:#568cb9;stop-opacity:1"
+         offset="0.61277843"
+         id="stop7166" />
+      <stop
+         id="stop7164"
+         offset="1"
+         style="stop-color:#cedeea;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7139">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7141" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7143" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784-4">
+      <stop
+         style="stop-color:#b68e69;stop-opacity:1"
+         offset="0"
+         id="stop4786-0" />
+      <stop
+         id="stop4792-9"
+         offset="0.94238818"
+         style="stop-color:#d5ae7d;stop-opacity:1" />
+      <stop
+         style="stop-color:#c69863;stop-opacity:1"
+         offset="1"
+         id="stop4788-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4805-8">
+      <stop
+         style="stop-color:#4b82b6;stop-opacity:1"
+         offset="0"
+         id="stop4807-8" />
+      <stop
+         id="stop4815-2"
+         offset="0.79358917"
+         style="stop-color:#9ab7d5;stop-opacity:1" />
+      <stop
+         style="stop-color:#a2bcd8;stop-opacity:1"
+         offset="1"
+         id="stop4809-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5591-5">
+      <stop
+         style="stop-color:#e0e566;stop-opacity:1;"
+         offset="0"
+         id="stop5593-5" />
+      <stop
+         style="stop-color:#b0b456;stop-opacity:1;"
+         offset="1"
+         id="stop5595-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5583-7">
+      <stop
+         style="stop-color:#426e4a;stop-opacity:1;"
+         offset="0"
+         id="stop5585-1" />
+      <stop
+         style="stop-color:#669f71;stop-opacity:1;"
+         offset="1"
+         id="stop5587-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5328-52">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5330-7" />
+      <stop
+         style="stop-color:#464646;stop-opacity:1;"
+         offset="1"
+         id="stop5332-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5209-1">
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="0"
+         id="stop5211-4" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:1;"
+         offset="1"
+         id="stop5213-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4961-3">
+      <stop
+         style="stop-color:#df9a39;stop-opacity:1;"
+         offset="0"
+         id="stop4963-2" />
+      <stop
+         style="stop-color:#b55829;stop-opacity:1;"
+         offset="1"
+         id="stop4965-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4938-1">
+      <stop
+         style="stop-color:#8bc7d7;stop-opacity:1;"
+         offset="0"
+         id="stop4940-6" />
+      <stop
+         style="stop-color:#17477c;stop-opacity:1;"
+         offset="1"
+         id="stop4942-85" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4928-7">
+      <stop
+         style="stop-color:#4dac81;stop-opacity:1;"
+         offset="0"
+         id="stop4930-6" />
+      <stop
+         style="stop-color:#058048;stop-opacity:1;"
+         offset="1"
+         id="stop4932-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4918-8">
+      <stop
+         style="stop-color:#d48a4b;stop-opacity:1;"
+         offset="0"
+         id="stop4920-92" />
+      <stop
+         style="stop-color:#b1623a;stop-opacity:1;"
+         offset="1"
+         id="stop4922-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4907-95">
+      <stop
+         style="stop-color:#b86c44;stop-opacity:1;"
+         offset="0"
+         id="stop4909-43" />
+      <stop
+         style="stop-color:#8f4017;stop-opacity:1;"
+         offset="1"
+         id="stop4911-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4789-2">
+      <stop
+         style="stop-color:#4e8fbd;stop-opacity:1;"
+         offset="0"
+         id="stop4791-3" />
+      <stop
+         style="stop-color:#30495a;stop-opacity:1;"
+         offset="1"
+         id="stop4793-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4781-4">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4783-1" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4785-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4773-3">
+      <stop
+         style="stop-color:#8e4694;stop-opacity:1;"
+         offset="0"
+         id="stop4775-8" />
+      <stop
+         style="stop-color:#bc7bc1;stop-opacity:1;"
+         offset="1"
+         id="stop4777-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4763-4">
+      <stop
+         style="stop-color:#77a29d;stop-opacity:1;"
+         offset="0"
+         id="stop4765-2" />
+      <stop
+         style="stop-color:#1b867b;stop-opacity:1;"
+         offset="1"
+         id="stop4767-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856-7">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13858-9" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13860-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13850-1">
+      <stop
+         id="stop13852-9"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13854-8"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13834-6">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13836-5" />
+      <stop
+         style="stop-color:#807e66;stop-opacity:0;"
+         offset="1"
+         id="stop13838-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799-2">
+      <stop
+         style="stop-color:#b9772f;stop-opacity:1"
+         offset="0"
+         id="stop13801-8" />
+      <stop
+         id="stop13809-6"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop13807-0"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop13811-2" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop13803-48" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-6">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-5" />
+      <stop
+         id="stop12096-0"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-0">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-0" />
+      <stop
+         id="stop12007-6"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-3">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-8" />
+      <stop
+         id="stop11979-9"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-3"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687-4">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-60" />
+      <stop
+         id="stop11695-66"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-18" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-49">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-6" />
+      <stop
+         id="stop11152-37"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11128-88">
+      <stop
+         style="stop-color:#e4d09d;stop-opacity:1"
+         offset="0"
+         id="stop11130-2" />
+      <stop
+         id="stop11136-9"
+         offset="0.27413794"
+         style="stop-color:#f6ecb2;stop-opacity:1" />
+      <stop
+         style="stop-color:#b58a68;stop-opacity:1"
+         offset="1"
+         id="stop11132-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-3">
+      <stop
+         id="stop10858-5"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-9" />
+      <stop
+         id="stop10862-8"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-4">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-0" />
+      <stop
+         id="stop10806-7"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10748-3">
+      <stop
+         id="stop10750-61"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752-5" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754-4" />
+      <stop
+         id="stop10756-2"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758-0"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-97">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-37" />
+      <stop
+         id="stop10458-2"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-6"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-0" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-6">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-5" />
+      <stop
+         id="stop10521-75"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-41" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10432-2">
+      <stop
+         id="stop10434-0"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436-0" />
+      <stop
+         id="stop10438-1"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10414-46">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416-0" />
+      <stop
+         id="stop10422-7"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10396-77">
+      <stop
+         style="stop-color:#1b3e79;stop-opacity:1;"
+         offset="0"
+         id="stop10398-7" />
+      <stop
+         id="stop10404-73"
+         offset="0.5"
+         style="stop-color:#728fbf;stop-opacity:1" />
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="1"
+         id="stop10400-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10157-59">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-9" />
+      <stop
+         id="stop10165-8"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9914-8"
+       inkscape:collect="always">
+      <stop
+         id="stop9916-2"
+         offset="0"
+         style="stop-color:#4a6fa4;stop-opacity:1" />
+      <stop
+         id="stop9918-6"
+         offset="1"
+         style="stop-color:#4e86ca;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9908-6"
+       inkscape:collect="always">
+      <stop
+         id="stop9910-0"
+         offset="0"
+         style="stop-color:#525f72;stop-opacity:1" />
+      <stop
+         id="stop9912-3"
+         offset="1"
+         style="stop-color:#9e884e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9605-8">
+      <stop
+         style="stop-color:#2a5bbf;stop-opacity:1;"
+         offset="0"
+         id="stop9607-01" />
+      <stop
+         style="stop-color:#2a5bbf;stop-opacity:0;"
+         offset="1"
+         id="stop9609-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9510-5">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9512-0" />
+      <stop
+         id="stop9514-94"
+         offset="0.35636142"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9516-78" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332-3">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334-51" />
+      <stop
+         id="stop9340-20"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9324-6">
+      <stop
+         id="stop9326-4"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.30000001"
+         id="stop9328-0" />
+      <stop
+         id="stop9330-6"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9312-1">
+      <stop
+         style="stop-color:#cf6c00;stop-opacity:1"
+         offset="0"
+         id="stop9314-8" />
+      <stop
+         id="stop9322-9"
+         offset="0.36339331"
+         style="stop-color:#f5db48;stop-opacity:0.24200913" />
+      <stop
+         style="stop-color:#c36000;stop-opacity:1"
+         offset="1"
+         id="stop9316-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9299-4">
+      <stop
+         style="stop-color:#929baa;stop-opacity:1"
+         offset="0"
+         id="stop9301-1" />
+      <stop
+         style="stop-color:#cac3a5;stop-opacity:1"
+         offset="1"
+         id="stop9303-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9291-3">
+      <stop
+         style="stop-color:#e9f8ff;stop-opacity:1;"
+         offset="0"
+         id="stop9293-9" />
+      <stop
+         style="stop-color:#f5f6f9;stop-opacity:1"
+         offset="1"
+         id="stop9295-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8661-8"
+       inkscape:collect="always">
+      <stop
+         id="stop8663-0"
+         offset="0"
+         style="stop-color:#c6e7f9;stop-opacity:1" />
+      <stop
+         id="stop8665-8"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8653-77">
+      <stop
+         style="stop-color:#676656;stop-opacity:1;"
+         offset="0"
+         id="stop8655-83" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop8657-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-3">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-71" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-7">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-3" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-49" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-6">
+      <stop
+         id="stop7561-3-3-4-48-51"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-0" />
+      <stop
+         id="stop7565-8-8-3-2-9"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-96">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-83" />
+      <stop
+         id="stop7114-9-0-1-48"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-49" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4320-92">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4322-5" />
+      <stop
+         id="stop4324-5"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4326-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4329-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4331-3" />
+      <stop
+         id="stop4333-74"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4335-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-8">
+      <stop
+         id="stop7561-3-3-4-48-7-0"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-8" />
+      <stop
+         id="stop7565-8-8-3-2-0-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-06">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-8" />
+      <stop
+         id="stop7114-9-0-1-4-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-98" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3256-97">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3258-2" />
+      <stop
+         id="stop3260-2"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3262-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3265-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3267-8" />
+      <stop
+         id="stop3269-90"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3271-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-2-81">
+      <stop
+         id="stop7561-3-3-4-48-5-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-76-8" />
+      <stop
+         id="stop7565-8-8-3-2-7-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-22-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-8-2" />
+      <stop
+         id="stop7114-9-0-1-1-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-4-25" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3506-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3508-6" />
+      <stop
+         id="stop3510-2"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3512-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3515-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3517-3" />
+      <stop
+         id="stop3519-9"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3521-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-46">
+      <stop
+         id="stop7561-3-3-4-48-7-4-1"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-82" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-1"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-19">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-7" />
+      <stop
+         id="stop7114-9-0-1-4-6-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4133-95">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4135-2" />
+      <stop
+         id="stop4137-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4139-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4142-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4144-9" />
+      <stop
+         id="stop4146-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4148-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-1">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-95"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-3" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-25" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-8"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-67" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4356-2" />
+      <stop
+         id="stop4358-2"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4360-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4365-1" />
+      <stop
+         id="stop4367-9"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4369-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-5-9">
+      <stop
+         id="stop7561-3-3-4-48-7-4-5-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-0-2" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-2-5"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-3-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-4-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-3-9"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-3-12" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354-1-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4356-1-0" />
+      <stop
+         id="stop4358-6-8"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4360-2-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363-3-93">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4365-6-9" />
+      <stop
+         id="stop4367-1-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4369-3-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-5-9">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-8-9"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-7-7" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-7-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-9-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-0-3" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-1-5"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-5-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690-6">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5692-6" />
+      <stop
+         id="stop5694-58"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5696-25" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5701-4" />
+      <stop
+         id="stop5703-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5705-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-9-1">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-2-6"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-0-3" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-5-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-2-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-2-5" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-16-3"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-6-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690-4-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5692-0-2" />
+      <stop
+         id="stop5694-4-5"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5696-5-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699-0-6">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5701-6-1" />
+      <stop
+         id="stop5703-0-8"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5705-3-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6-21">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-3-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-2-6" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-3-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7-91">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-8-50" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-4-3"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-0-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6127-92" />
+      <stop
+         id="stop6129-9"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6131-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134-44">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6136-0" />
+      <stop
+         id="stop6138-5"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6140-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-63">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-2" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-88"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-5" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-8"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125-7-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6127-4-5" />
+      <stop
+         id="stop6129-0-7"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6131-6-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134-4-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6136-6-4" />
+      <stop
+         id="stop6138-0-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6140-7-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-92-2">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-4-9"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-6-3" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-55-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-72-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-5-7" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-6-87"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-2-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6293-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6295-3" />
+      <stop
+         id="stop6297-8"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6299-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6302-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6304-2" />
+      <stop
+         id="stop6306-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6308-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-7">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8-2"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4-9" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9-3" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4-32" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6321-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6323-1" />
+      <stop
+         id="stop6325-3"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6327-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6330-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6332-3" />
+      <stop
+         id="stop6334-5"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6336-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6-6-22">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-3-3-2"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-2-2-6" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-3-8-4"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7-9-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-8-5-7" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-4-5-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-0-1-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6349-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6351-0" />
+      <stop
+         id="stop6353-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6355-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6358-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6360-1" />
+      <stop
+         id="stop6362-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6364-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6-7">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8-0-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4-7-00" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8-6-4"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9-4-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0-7-9"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4-1-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6940-6">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6942-4" />
+      <stop
+         id="stop6944-8"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6946-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6949-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6951-6" />
+      <stop
+         id="stop6953-8"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6955-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6-1-1">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8-0-8-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4-7-3-8" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8-6-8-4"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3-0-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9-4-8-2" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0-7-1-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4-1-9-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7106-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7108-6" />
+      <stop
+         id="stop7110-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7112-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7115-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7117-5" />
+      <stop
+         id="stop7119-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7121-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7686-9-8"
+       id="linearGradient7692-4-3"
+       x1="1303.0625"
+       y1="610.34235"
+       x2="1303.0625"
+       y2="723.85583"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7686-9-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7688-7-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7690-5-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-140)"
+       y2="723.85583"
+       x2="1303.0625"
+       y1="610.34235"
+       x1="1303.0625"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7755-5-2"
+       xlink:href="#linearGradient7686-9-7-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7686-9-7-6">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7688-7-1-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7690-5-0-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-45"
+       id="linearGradient8159-0-7"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-45">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-79" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-9-02"
+       id="linearGradient8143-2-3"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-9-02">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-4-23" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-1-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,2.6171875e-6)"
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8180-3-7"
+       xlink:href="#linearGradient8153-2-8-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-8-1">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-7-5" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-3-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,2.6171875e-6)"
+       y2="283.2832"
+       x2="657.71722"
+       y1="283.2832"
+       x1="617.06256"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8182-4"
+       xlink:href="#linearGradient8137-9-5-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-9-5-0">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-4-2-2" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-1-9-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-6-6"
+       id="linearGradient8291-2-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-6-6">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-6-1" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-6-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-1-17">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-4-3" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-2-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-4-0">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-78-4" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-0-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-93-3">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-9-0" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-8-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8498-03"
+       id="linearGradient8504-29"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8498-03">
+      <stop
+         style="stop-color:#d9f4ff;stop-opacity:1"
+         offset="0"
+         id="stop8500-8" />
+      <stop
+         style="stop-color:#f9fcff;stop-opacity:1"
+         offset="1"
+         id="stop8502-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-77"
+       id="linearGradient8659-5"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8661-8"
+       id="linearGradient8681-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-7"
+       id="linearGradient8683-70"
+       gradientUnits="userSpaceOnUse"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-45"
+       id="linearGradient8685-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-3"
+       id="linearGradient8687-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-77"
+       id="linearGradient8689-3"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-77"
+       id="linearGradient8691-0"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-77"
+       id="linearGradient8693-7"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-77"
+       id="linearGradient8695-4"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-77"
+       id="linearGradient8697-7"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-93-3"
+       id="linearGradient8699-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-4-0"
+       id="linearGradient8701-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-1-17"
+       id="linearGradient8703-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375262)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291-3"
+       id="linearGradient9297-10"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299-4"
+       id="linearGradient9305-0"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332-9-3"
+       id="linearGradient9338-8-8"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient9332-9-3">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334-5-4" />
+      <stop
+         id="stop9340-2-5"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336-4-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9324-7-4"
+       id="linearGradient9318-1"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient9324-7-4">
+      <stop
+         id="stop9326-0-5"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.30000001"
+         id="stop9328-1-6" />
+      <stop
+         id="stop9330-5-20"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291-8-66"
+       id="linearGradient9297-1-35"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9291-8-66">
+      <stop
+         style="stop-color:#e9f8ff;stop-opacity:1;"
+         offset="0"
+         id="stop9293-7-6" />
+      <stop
+         style="stop-color:#f5f6f9;stop-opacity:1"
+         offset="1"
+         id="stop9295-3-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299-1-7"
+       id="linearGradient9305-8-6"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9299-1-7">
+      <stop
+         style="stop-color:#929baa;stop-opacity:1"
+         offset="0"
+         id="stop9301-6-7" />
+      <stop
+         style="stop-color:#cac3a5;stop-opacity:1"
+         offset="1"
+         id="stop9303-8-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332-6-9">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334-52-1" />
+      <stop
+         id="stop9340-23-6"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336-3-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9312-9-7">
+      <stop
+         style="stop-color:#cf6c00;stop-opacity:1"
+         offset="0"
+         id="stop9314-5-2" />
+      <stop
+         id="stop9322-0-7"
+         offset="0.36339331"
+         style="stop-color:#f5db48;stop-opacity:0.24200913" />
+      <stop
+         style="stop-color:#c36000;stop-opacity:1"
+         offset="1"
+         id="stop9316-6-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       y2="472.63525"
+       x2="556.25635"
+       y1="472.63525"
+       x1="526.85181"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9415-5-5"
+       xlink:href="#linearGradient9510-3-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9510-3-1">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9512-4-3" />
+      <stop
+         id="stop9514-9-9"
+         offset="0.35636142"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9516-6-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8661-5-5"
+       inkscape:collect="always">
+      <stop
+         id="stop8663-3-9"
+         offset="0"
+         style="stop-color:#c6e7f9;stop-opacity:1" />
+      <stop
+         id="stop8665-5-2"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-6-6">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-1-5" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-6-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-0-2">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-9-4" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-5-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-2-4">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-7-2" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-8-79" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-2-3"
+       id="linearGradient8697-5-2"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8653-2-3">
+      <stop
+         style="stop-color:#676656;stop-opacity:1;"
+         offset="0"
+         id="stop8655-9-7" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop8657-2-31" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-4-4-5">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-78-0-78" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-0-7-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-1-3-3"
+       id="linearGradient8703-1-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375262)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-1-3-3">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-4-2-2" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-2-6-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9605-8"
+       id="linearGradient9962-11"
+       gradientUnits="userSpaceOnUse"
+       x1="213.82529"
+       y1="441.62799"
+       x2="227.09628"
+       y2="454.31174" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332-6-9"
+       id="linearGradient9964-5"
+       gradientUnits="userSpaceOnUse"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9312-9-7"
+       id="linearGradient9966-9"
+       gradientUnits="userSpaceOnUse"
+       x1="526.4375"
+       y1="448.46484"
+       x2="556.9375"
+       y2="448.46484" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9510-3-1"
+       id="linearGradient9968-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8661-5-5"
+       id="linearGradient9970-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-6-6"
+       id="linearGradient9972-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0)"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-0-2"
+       id="linearGradient9974-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-2-4"
+       id="linearGradient9976-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0.34375)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9908-6"
+       id="linearGradient9978-5"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="306.07397"
+       x2="641.07611"
+       y2="281.43512" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-2-3"
+       id="linearGradient9980-3"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-4-4-5"
+       id="linearGradient9982-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9914-8"
+       id="linearGradient9984-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0.34375262)"
+       x1="636.09375"
+       y1="279.41037"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332-3"
+       id="linearGradient9997-9"
+       gradientUnits="userSpaceOnUse"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9312-1"
+       id="linearGradient9999-1"
+       gradientUnits="userSpaceOnUse"
+       x1="526.4375"
+       y1="448.46484"
+       x2="556.9375"
+       y2="448.46484" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9510-5"
+       id="linearGradient10001-34"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291-8-66"
+       id="linearGradient10003-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299-1-7"
+       id="linearGradient10005-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-5-65"
+       id="linearGradient10163-8-63"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10157-5-65">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-7-2" />
+      <stop
+         id="stop10165-2-8"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-3-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-3-3"
+       id="linearGradient10155-1-0"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-3-3">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-0-1" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-7-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-6-22"
+       id="linearGradient10155-5-5"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-6-22">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-5-1" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-8-74" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-2"
+       id="linearGradient10163-2-8"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10157-2-2">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8-3" />
+      <stop
+         id="stop10165-3-6"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39-3"
+       id="linearGradient10155-7-0"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39-3">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3-5" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72-28" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10149-6-5-0">
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="0"
+         id="stop10151-5-7-7" />
+      <stop
+         id="stop10394-2"
+         offset="0.5"
+         style="stop-color:#b9c7df;stop-opacity:1" />
+      <stop
+         style="stop-color:#567ebc;stop-opacity:1"
+         offset="1"
+         id="stop10153-8-1-25" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-4-1"
+       id="linearGradient10454-7-9"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10448-4-1">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-4-0" />
+      <stop
+         id="stop10458-7-8"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-9-5"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-1-0" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-2-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-2-0"
+       id="linearGradient10446-9-9"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10440-2-0">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-4-5" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-4-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-1"
+       id="linearGradient10454-9-4"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10448-9-1">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-0" />
+      <stop
+         id="stop10458-8-4"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4-8"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2-5" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-54"
+       id="linearGradient10446-7-2"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10440-1-54">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-1" />
+      <stop
+         id="stop10521-1-3"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10546-3-5"
+       xlink:href="#linearGradient10448-9-7-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-7-8">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-2" />
+      <stop
+         id="stop10458-8-0-7"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4-1-9"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2-9-6" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10548-3-7"
+       xlink:href="#linearGradient10440-1-0-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-1-0-7">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-2-1" />
+      <stop
+         id="stop10521-1-2-9"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-4-03" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10546-8-4"
+       xlink:href="#linearGradient10448-9-6-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-6-1">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-8-7" />
+      <stop
+         id="stop10458-8-7-53"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4-7-3"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2-1-2" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-8-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10548-1-1"
+       xlink:href="#linearGradient10440-1-3-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-1-3-2">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-0-9" />
+      <stop
+         id="stop10521-1-4-0"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-2-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-9-7-0-7">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6-4" />
+      <stop
+         id="stop10456-4-1-5-5"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-0-0-8">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-2-0-0" />
+      <stop
+         id="stop10521-1-2-5-7"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-4-0-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-7"
+       id="linearGradient10770-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-0-0-8"
+       id="linearGradient10772-31"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       x1="334.375"
+       y1="529.06494"
+       x2="334.375"
+       y2="518.67365" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748-3"
+       id="linearGradient10774-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-3-2"
+       id="linearGradient10776-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       x1="334.375"
+       y1="532.30212"
+       x2="334.375"
+       y2="515.73615" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-97"
+       id="linearGradient10778-3"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-6"
+       id="linearGradient10780-0"
+       gradientUnits="userSpaceOnUse"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414-46"
+       id="linearGradient10782-1"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432-2"
+       id="linearGradient10784-9"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-59"
+       id="linearGradient10786-0"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10396-77"
+       id="linearGradient10788-4"
+       gradientUnits="userSpaceOnUse"
+       x1="302.3125"
+       y1="532.98718"
+       x2="302.3125"
+       y2="514.67456" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-2"
+       id="linearGradient10790-29"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39-3"
+       id="linearGradient10792-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-6-5-0"
+       id="linearGradient10794-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.88388349,2.6171875e-6)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="511.38498" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-8-8"
+       id="linearGradient10804-7-4"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10798-8-8">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-2-2" />
+      <stop
+         id="stop10806-9-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-3-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-93"
+       id="linearGradient10804-8-5"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10798-1-93">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-28" />
+      <stop
+         id="stop10806-6-7"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-48" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-14">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-3" />
+      <stop
+         id="stop10806-6-8-55"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-2" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10835-2-6"
+       xlink:href="#linearGradient10856-6-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-8">
+      <stop
+         id="stop10858-0-9"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-2" />
+      <stop
+         id="stop10862-3-9"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-9"
+       id="radialGradient11144-4-5"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)" />
+    <linearGradient
+       id="linearGradient11146-8-9">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-4" />
+      <stop
+         id="stop11152-8-5"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-7-58"
+       id="radialGradient11144-2-0"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)" />
+    <linearGradient
+       id="linearGradient11146-7-58">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-8" />
+      <stop
+         id="stop11152-6-0"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11169-6-13"
+       xlink:href="#linearGradient11146-8-7-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-8-7-2">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-2" />
+      <stop
+         id="stop11152-8-8-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11063-6-7"
+       xlink:href="#linearGradient10856-6-3-03"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-3-03">
+      <stop
+         id="stop10858-0-7-1"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-3" />
+      <stop
+         id="stop10862-3-3-37"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-0">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-9" />
+      <stop
+         id="stop10806-6-8-5-5"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-5" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-4-3"
+       id="radialGradient11268-5-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-4-3">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-78" />
+      <stop
+         id="stop11152-9-3"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-3-3"
+       id="radialGradient11270-4-79"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-8-3-3">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-91" />
+      <stop
+         id="stop11152-8-4-82"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-7-5-0"
+       id="radialGradient11272-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-154.64572)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-7-5-0">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-1" />
+      <stop
+         id="stop11152-6-7-8"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-7-5-8"
+       id="radialGradient11274-3-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-154.64572)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-8-7-5-8">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-6" />
+      <stop
+         id="stop11152-8-8-6-0"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11298-3-9"
+       xlink:href="#linearGradient10856-6-3-0-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-3-0-3">
+      <stop
+         id="stop10858-0-7-6-00"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-8" />
+      <stop
+         id="stop10862-3-3-8-7"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10880-5-3-4-6"
+       xlink:href="#linearGradient10798-1-9-3-7-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-3">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-5" />
+      <stop
+         id="stop10806-6-8-5-3-6"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-58" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-3"
+       xlink:href="#linearGradient10798-1-9-3-7-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-4-5-94">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-7-8" />
+      <stop
+         id="stop11152-9-2-3"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-4-9">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-5-76" />
+      <stop
+         id="stop11152-8-4-9-45"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-3-86">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-4-15" />
+      <stop
+         id="stop11152-6-7-2-5"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-6-1">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-1-9" />
+      <stop
+         id="stop11152-8-8-6-6-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-1-4">
+      <stop
+         id="stop10858-0-7-6-1-5"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-7-4" />
+      <stop
+         id="stop10862-3-3-8-4-2"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-0-5"
+       xlink:href="#linearGradient10798-1-9-3-7-1-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-3">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-2" />
+      <stop
+         id="stop10806-6-8-5-3-2-6"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-8" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11520-3-2"
+       xlink:href="#linearGradient10798-1-9-3-7-1-2-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-2-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-6-6" />
+      <stop
+         id="stop10806-6-8-5-3-2-9-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-6-9" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11520-8-4"
+       xlink:href="#linearGradient10798-1-9-3-7-1-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-5">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5-6" />
+      <stop
+         id="stop10806-6-8-5-3-2-3-25"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2-3" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-2-6"
+       id="radialGradient11685-7-5"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-2-6">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-9-6" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-1-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-1-4"
+       id="linearGradient11693-0-4"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-1-4">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-9-6" />
+      <stop
+         id="stop11695-3-2"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-9-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11888-8-2"
+       id="linearGradient11894-2-8"
+       x1="342.37973"
+       y1="457.29816"
+       x2="358.60471"
+       y2="444.57022"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11888-8-2">
+      <stop
+         style="stop-color:#a7c8ec;stop-opacity:1"
+         offset="0"
+         id="stop11890-4-5" />
+      <stop
+         style="stop-color:#b4def6;stop-opacity:1"
+         offset="1"
+         id="stop11892-1-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11888-4-0"
+       id="linearGradient11894-5-1"
+       x1="342.37973"
+       y1="457.29816"
+       x2="358.60471"
+       y2="444.57022"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11888-4-0">
+      <stop
+         style="stop-color:#a7c8ec;stop-opacity:1"
+         offset="0"
+         id="stop11890-8-1" />
+      <stop
+         style="stop-color:#b4def6;stop-opacity:1"
+         offset="1"
+         id="stop11892-8-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2-1">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-3-76" />
+      <stop
+         id="stop11979-8-0"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-7-0"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-6-24" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2-3">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-1-3" />
+      <stop
+         id="stop12096-1-6"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-2-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-7-8">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-9-23" />
+      <stop
+         id="stop12007-1-4"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-2-3" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-7-36"
+       id="radialGradient11685-5-4"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-7-36">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-94-8" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-0-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-9-3"
+       id="linearGradient11693-2-7"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-9-3">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-1-9" />
+      <stop
+         id="stop11695-2-8"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-1-0" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-8-8"
+       id="radialGradient11685-3-0"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-8-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-3-80" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-6-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-8-43"
+       id="linearGradient11693-26-1"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-8-43">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-6-6" />
+      <stop
+         id="stop11695-6-39"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-5-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2-2-1">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-3-7-9" />
+      <stop
+         id="stop11979-8-6-8"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-7-6-2"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-6-6-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2-1-4">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-1-8-0" />
+      <stop
+         id="stop12096-1-8-2"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-2-4-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-7-2-19">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-9-2-8" />
+      <stop
+         id="stop12007-1-3-9"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-2-8-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-13" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-5"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-9-4">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-7-25" />
+      <stop
+         id="stop11979-0-3"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-6-89"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-8-28" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7-7">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-7-0" />
+      <stop
+         id="stop12096-6-1"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-1-48" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9-1">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-1-93" />
+      <stop
+         id="stop12007-4-5"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-3-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5-2-9" />
+      <stop
+         id="stop10806-6-8-5-3-2-3-3-8"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2-2-0" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-3-7"
+       id="radialGradient11685-2-14"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-3-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-91-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-02-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-2-0"
+       id="linearGradient11693-3-5"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-2-0">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-3-9" />
+      <stop
+         id="stop11695-9-28"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-10-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-9-5"
+       id="radialGradient12723-3-4"
+       cx="433.36786"
+       cy="424.34106"
+       fx="433.36786"
+       fy="424.34106"
+       r="12.027534"
+       gradientTransform="matrix(1.1614831,2.1855961e-7,-2.811228e-7,1.4939602,-69.981471,-211.63828)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-9-5">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-7-04" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-6-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-5-0">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-6-5" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-9-1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-5-0"
+       id="radialGradient12739-4-1"
+       cx="433.5452"
+       cy="420.74988"
+       fx="433.5452"
+       fy="420.74988"
+       r="12.952347"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1-5">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3-9" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-5"
+       id="linearGradient12904-2-8"
+       x1="420.88995"
+       y1="455.88452"
+       x2="440.35345"
+       y2="417.26108"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11146-4-0-38">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-1-7" />
+      <stop
+         id="stop11152-9-9-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-5-6">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-2-9" />
+      <stop
+         id="stop11152-8-4-3-3"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-5-8">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-8-1" />
+      <stop
+         id="stop11152-6-7-5-0"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-9-3">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-19-38" />
+      <stop
+         id="stop11152-8-8-6-2-4"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-5-80">
+      <stop
+         id="stop10858-0-7-6-9-1"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-9-5" />
+      <stop
+         id="stop10862-3-3-8-6-4"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-9-1"
+       xlink:href="#linearGradient10798-1-9-3-7-6-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-3">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-7" />
+      <stop
+         id="stop10806-6-8-5-3-9-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13197-7-8"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-5">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-6" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-0" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-4-8"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-93"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-93">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-6" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3-7" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2-8"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-4">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-5"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13197-3-6"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-6" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-6"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-4" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-1"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13333-0-1-9"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-5-5">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3-1-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2-1-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2-3-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13850-2-1">
+      <stop
+         id="stop13852-4-5"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13854-7-2"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856-0-3">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13858-8-1" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13860-4-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799-7-8">
+      <stop
+         style="stop-color:#b9772f;stop-opacity:1"
+         offset="0"
+         id="stop13801-4-8" />
+      <stop
+         id="stop13809-4-2"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop13807-7-7"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop13811-8-7" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop13803-6-12" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1-8-6">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3-6-0" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4-9-4" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="455.88452"
+       x1="420.88995"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13011-8-9"
+       xlink:href="#linearGradient12862-1-8-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11969-9-0-4">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-7-1-6" />
+      <stop
+         id="stop11979-0-0-0"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-6-1-3"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-8-0-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7-6-24">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-7-9-5" />
+      <stop
+         id="stop12096-6-2-8"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-1-3-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9-8-1">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-1-9-2" />
+      <stop
+         id="stop12007-4-6-1"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-3-6-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-8" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2-1-5">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5-2-6-2" />
+      <stop
+         id="stop10806-6-8-5-3-2-3-3-7-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2-2-2-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687-2-2-8">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-3-7-3" />
+      <stop
+         id="stop11695-9-8-8"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-10-4-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-4-4-9">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-72-86" />
+      <stop
+         id="stop11152-9-0-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-2-2">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-9-38" />
+      <stop
+         id="stop11152-8-4-35-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-30-6">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-9-2" />
+      <stop
+         id="stop11152-6-7-6-7"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-7-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-8-7" />
+      <stop
+         id="stop11152-8-8-6-3-8"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-0-2">
+      <stop
+         id="stop10858-0-7-6-0-7"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-0-8" />
+      <stop
+         id="stop10862-3-3-8-2-0"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-1-2"
+       xlink:href="#linearGradient10798-1-9-3-7-7-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-7-0">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-4-89" />
+      <stop
+         id="stop10806-6-8-5-3-1-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-0-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4918-5-2">
+      <stop
+         style="stop-color:#d48a4b;stop-opacity:1;"
+         offset="0"
+         id="stop4920-9-05" />
+      <stop
+         style="stop-color:#b1623a;stop-opacity:1;"
+         offset="1"
+         id="stop4922-9-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4907-9-2">
+      <stop
+         style="stop-color:#b86c44;stop-opacity:1;"
+         offset="0"
+         id="stop4909-5-7" />
+      <stop
+         style="stop-color:#8f4017;stop-opacity:1;"
+         offset="1"
+         id="stop4911-0-67" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4928-4-8">
+      <stop
+         style="stop-color:#4dac81;stop-opacity:1;"
+         offset="0"
+         id="stop4930-9-7" />
+      <stop
+         style="stop-color:#058048;stop-opacity:1;"
+         offset="1"
+         id="stop4932-8-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4938-8-1">
+      <stop
+         style="stop-color:#8bc7d7;stop-opacity:1;"
+         offset="0"
+         id="stop4940-4-6" />
+      <stop
+         style="stop-color:#17477c;stop-opacity:1;"
+         offset="1"
+         id="stop4942-8-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4961-6-5"
+       id="linearGradient4983-5-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4.625,0)"
+       x1="15.073242"
+       y1="1040.0764"
+       x2="18.744612"
+       y2="1049.2014" />
+    <linearGradient
+       id="linearGradient4961-6-5">
+      <stop
+         style="stop-color:#df9a39;stop-opacity:1;"
+         offset="0"
+         id="stop4963-0-8" />
+      <stop
+         style="stop-color:#b55829;stop-opacity:1;"
+         offset="1"
+         id="stop4965-3-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5328-5-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5330-9-0" />
+      <stop
+         style="stop-color:#464646;stop-opacity:1;"
+         offset="1"
+         id="stop5332-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5209-0-7">
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="0"
+         id="stop5211-9-2" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:1;"
+         offset="1"
+         id="stop5213-4-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5397-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5399-2" />
+      <stop
+         style="stop-color:#464646;stop-opacity:1;"
+         offset="1"
+         id="stop5401-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5404-4">
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="0"
+         id="stop5406-8" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:1;"
+         offset="1"
+         id="stop5408-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5411-46">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5413-8" />
+      <stop
+         style="stop-color:#464646;stop-opacity:1;"
+         offset="1"
+         id="stop5415-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5418-8">
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="0"
+         id="stop5420-35" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:1;"
+         offset="1"
+         id="stop5422-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5583-7"
+       id="linearGradient5589-1"
+       x1="2.03125"
+       y1="9.1435204"
+       x2="2.03125"
+       y2="4.671875"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5591-5"
+       id="linearGradient5597-5"
+       x1="2.03125"
+       y1="7.8880248"
+       x2="2.03125"
+       y2="9.1435204"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5591-4-8"
+       id="linearGradient5597-1-5"
+       x1="2.03125"
+       y1="7.8880248"
+       x2="2.03125"
+       y2="9.1435204"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5591-4-8">
+      <stop
+         style="stop-color:#e0e566;stop-opacity:1;"
+         offset="0"
+         id="stop5593-0-4" />
+      <stop
+         style="stop-color:#b0b456;stop-opacity:1;"
+         offset="1"
+         id="stop5595-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5583-2-4"
+       id="linearGradient5589-8-5"
+       x1="2.03125"
+       y1="9.1435204"
+       x2="2.03125"
+       y2="4.671875"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5583-2-4">
+      <stop
+         style="stop-color:#426e4a;stop-opacity:1;"
+         offset="0"
+         id="stop5585-3-7" />
+      <stop
+         style="stop-color:#669f71;stop-opacity:1;"
+         offset="1"
+         id="stop5587-3-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4919-1-4"
+       id="linearGradient4925-7-1"
+       x1="-10"
+       y1="1045.3622"
+       x2="-10"
+       y2="1043.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4919-1-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4921-2-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4923-6-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4919-9-3"
+       id="linearGradient4925-4-0"
+       x1="-10"
+       y1="1045.3622"
+       x2="-10"
+       y2="1043.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4919-9-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4921-4-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4923-60-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-2,2.000062)"
+       y2="1050.0707"
+       x2="8.0137892"
+       y1="1036.6622"
+       x1="8.0137892"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4791-5"
+       xlink:href="#linearGradient4810-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4810-0"
+       inkscape:collect="always">
+      <stop
+         id="stop4812-7"
+         offset="0"
+         style="stop-color:#bfb688;stop-opacity:1;" />
+      <stop
+         id="stop4814-6"
+         offset="1"
+         style="stop-color:#8694ae;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5057-7-8"
+       id="linearGradient5065-1-7"
+       x1="6"
+       y1="1050.8623"
+       x2="11"
+       y2="1050.8623"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2,-2.000037)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5057-7-8">
+      <stop
+         style="stop-color:#677da9;stop-opacity:1;"
+         offset="0"
+         id="stop5059-1-3" />
+      <stop
+         style="stop-color:#b4bbd1;stop-opacity:1"
+         offset="1"
+         id="stop5061-1-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-13"
+       gradientTransform="translate(25,-4.000037)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-1-4"
+       xlink:href="#linearGradient4910-4-7-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-7-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-4-1" />
+      <stop
+         style="stop-color:#d1eeff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-0-9" />
+    </linearGradient>
+    <linearGradient
+       y2="1050.0707"
+       x2="8.0137892"
+       y1="1036.6622"
+       x1="8.0137892"
+       gradientTransform="translate(0,2.000063)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4121-5-5"
+       xlink:href="#linearGradient4810-5-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4810-5-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4812-1-7"
+         offset="0"
+         style="stop-color:#bfb688;stop-opacity:1;" />
+      <stop
+         id="stop4814-7-4"
+         offset="1"
+         style="stop-color:#8694ae;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-13"
+       gradientTransform="translate(16,2)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4063-1-7"
+       xlink:href="#linearGradient4910-4-7-5-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-7-5-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-4-2-4" />
+      <stop
+         style="stop-color:#d1eeff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-0-7-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4818-8"
+       id="linearGradient4824-8"
+       x1="12.03229"
+       y1="1038.3472"
+       x2="14.871766"
+       y2="1041.3081"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4818-8">
+      <stop
+         style="stop-color:#eb9186;stop-opacity:1;"
+         offset="0"
+         id="stop4820-1" />
+      <stop
+         style="stop-color:#e06b5e;stop-opacity:1"
+         offset="1"
+         id="stop4822-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4962-2-7-3"
+       id="linearGradient4838-1-2"
+       x1="3.5628386"
+       y1="11.335736"
+       x2="3.5628386"
+       y2="13.61885"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4962-2-7-3">
+      <stop
+         style="stop-color:#f6928e;stop-opacity:1"
+         offset="0"
+         id="stop4964-2-4-2" />
+      <stop
+         style="stop-color:#f13f53;stop-opacity:1"
+         offset="1"
+         id="stop4966-1-0-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-0-5-9">
+      <stop
+         id="stop7594-8-9-7"
+         offset="0"
+         style="stop-color:#b08319;stop-opacity:1" />
+      <stop
+         id="stop7596-5-6-2"
+         offset="1"
+         style="stop-color:#9a680f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(8.3535536,-0.17677672)"
+       y2="1038.951"
+       x2="21.91415"
+       y1="1043.3785"
+       x1="21.91415"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7610-7-6"
+       xlink:href="#linearGradient7592-0-5-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7584-9-3-6">
+      <stop
+         id="stop7586-6-3-5"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1;" />
+      <stop
+         id="stop7588-9-9-0"
+         offset="1"
+         style="stop-color:#ffebb7;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1-82">
+      <stop
+         id="stop7594-6-3"
+         offset="0"
+         style="stop-color:#ad7212;stop-opacity:1;" />
+      <stop
+         id="stop7596-9-0"
+         offset="1"
+         style="stop-color:#875f1e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1046.6238"
+       x2="23.107393"
+       y1="1042.9795"
+       x1="23.107393"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7610-5"
+       xlink:href="#linearGradient7592-1-82"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7584-5-0">
+      <stop
+         id="stop7586-4-0"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1;" />
+      <stop
+         id="stop7588-5-8"
+         offset="1"
+         style="stop-color:#ffebb7;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1040.7345"
+       x2="22.519354"
+       y1="1042.0283"
+       x1="22.519354"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7608-3"
+       xlink:href="#linearGradient7584-5-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7592-0-55">
+      <stop
+         id="stop7594-8-6"
+         offset="0"
+         style="stop-color:#ad7212;stop-opacity:1;" />
+      <stop
+         id="stop7596-5-63"
+         offset="1"
+         style="stop-color:#875f1e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1046.6238"
+       x2="23.107393"
+       y1="1042.9795"
+       x1="23.107393"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7610-7"
+       xlink:href="#linearGradient7592-0-55"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7584-9-7">
+      <stop
+         id="stop7586-6-8"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1;" />
+      <stop
+         id="stop7588-9-95"
+         offset="1"
+         style="stop-color:#ffebb7;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1040.7345"
+       x2="22.519354"
+       y1="1042.0283"
+       x1="22.519354"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7608-9"
+       xlink:href="#linearGradient7584-9-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1046.6238"
+       x2="23.107393"
+       y1="1042.9795"
+       x1="23.107393"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7610"
+       xlink:href="#linearGradient7592-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1040.7345"
+       x2="22.519354"
+       y1="1042.0283"
+       x1="22.519354"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7608"
+       xlink:href="#linearGradient7584-4"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1046.6238"
+       x2="23.107393"
+       y1="1042.9795"
+       x1="23.107393"
+       id="linearGradient7598"
+       xlink:href="#linearGradient7592-7"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1040.7345"
+       x2="22.519354"
+       y1="1042.0283"
+       x1="22.519354"
+       id="linearGradient7590"
+       xlink:href="#linearGradient7584-4"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.99637681,0,0,1,0.05123962,1036.3622)"
+       gradientUnits="userSpaceOnUse"
+       y2="3.0732041"
+       x2="14.142135"
+       y1="3.0732041"
+       x1="1.9445436"
+       id="linearGradient7497"
+       xlink:href="#linearGradient7491-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7254-6-4-3-1">
+      <stop
+         id="stop7256-5-4-1-3"
+         offset="0"
+         style="stop-color:#5b6c89;stop-opacity:1;" />
+      <stop
+         id="stop7258-7-4-8-6"
+         offset="1"
+         style="stop-color:#95a3ba;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7254-6-4-3-1"
+       id="linearGradient7362-2-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93721973,0,0,1,1036.9602,-16.656233)"
+       x1="15.000595"
+       y1="2"
+       x2="1.875"
+       y2="2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7254-6-4-7"
+       id="linearGradient7362"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93721973,0,0,1,1036.9602,-16.656233)"
+       x1="15.000595"
+       y1="2"
+       x2="-28.335314"
+       y2="2" />
+    <linearGradient
+       id="linearGradient7254-6-4-7">
+      <stop
+         id="stop7256-5-4-0"
+         offset="0"
+         style="stop-color:#5b6c89;stop-opacity:1;" />
+      <stop
+         id="stop7258-7-4-48"
+         offset="1"
+         style="stop-color:#95a3ba;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7254-6-4-7"
+       id="linearGradient7277-1-1"
+       gradientUnits="userSpaceOnUse"
+       x1="15.000595"
+       y1="2"
+       x2="1.875"
+       y2="2"
+       gradientTransform="matrix(0.93721973,0,0,1,1036.9601,-3.593733)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7254-62-7"
+       id="linearGradient7328"
+       gradientUnits="userSpaceOnUse"
+       x1="15.000595"
+       y1="2"
+       x2="-17.187742"
+       y2="2"
+       gradientTransform="translate(-16.0625,1038.3622)" />
+    <linearGradient
+       id="linearGradient7254-62-7">
+      <stop
+         id="stop7256-0-5"
+         offset="0"
+         style="stop-color:#5b6c89;stop-opacity:1;" />
+      <stop
+         id="stop7258-0-8"
+         offset="1"
+         style="stop-color:#95a3ba;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="2"
+       x2="1.875"
+       y1="2"
+       x1="15.000595"
+       id="linearGradient7260-7-3"
+       xlink:href="#linearGradient7254-62-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7254-6-8"
+       id="linearGradient7277"
+       gradientUnits="userSpaceOnUse"
+       x1="15.000595"
+       y1="2"
+       x2="-3.2642515"
+       y2="2"
+       gradientTransform="matrix(0.93721973,0,0,1,1036.9601,-3.593733)" />
+    <linearGradient
+       id="linearGradient7254-6-8">
+      <stop
+         id="stop7256-5-41"
+         offset="0"
+         style="stop-color:#5b6c89;stop-opacity:1;" />
+      <stop
+         id="stop7258-7-8"
+         offset="1"
+         style="stop-color:#95a3ba;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="2"
+       x2="1.875"
+       y1="2"
+       x1="15.000595"
+       id="linearGradient7260-9-02"
+       xlink:href="#linearGradient7254-6-8"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1.375"
+       x2="-8"
+       y1="2"
+       x1="15.000595"
+       id="linearGradient7260"
+       xlink:href="#linearGradient7254-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6799-5-3">
+      <stop
+         id="stop6801-6-6"
+         offset="0"
+         style="stop-color:#a6bacf;stop-opacity:1;" />
+      <stop
+         id="stop6803-6-2"
+         offset="1"
+         style="stop-color:#798da2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-3.09375)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.6122"
+       x2="6.0002952"
+       y1="1047.6122"
+       x1="5.1146584"
+       id="linearGradient6805-5-0"
+       xlink:href="#linearGradient6799-5-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6893-5-8-5-8"
+       inkscape:collect="always">
+      <stop
+         id="stop6895-8-7-1-1"
+         offset="0"
+         style="stop-color:#7795b6;stop-opacity:1;" />
+      <stop
+         id="stop6897-2-6-4-83"
+         offset="1"
+         style="stop-color:#7795b6;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-5-8"
+       id="linearGradient6950-4-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1065878,0,0,0.3047951,-0.87851916,1044.7521)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-8"
+       inkscape:collect="always">
+      <stop
+         id="stop6895-8-7-6"
+         offset="0"
+         style="stop-color:#7795b6;stop-opacity:1;" />
+      <stop
+         id="stop6897-2-6-7"
+         offset="1"
+         style="stop-color:#7795b6;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-8"
+       id="linearGradient6916-3-2"
+       gradientUnits="userSpaceOnUse"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983"
+       gradientTransform="translate(0,1039.1906)" />
+    <linearGradient
+       id="linearGradient6893-5-7"
+       inkscape:collect="always">
+      <stop
+         id="stop6895-8-2"
+         offset="0"
+         style="stop-color:#7795b6;stop-opacity:1;" />
+      <stop
+         id="stop6897-2-0"
+         offset="1"
+         style="stop-color:#7795b6;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       id="linearGradient6899-2-9"
+       xlink:href="#linearGradient6893-5-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5238-1-3-6-4-3">
+      <stop
+         id="stop5240-9-6-9-8-9"
+         offset="0"
+         style="stop-color:#6d83ac;stop-opacity:1;" />
+      <stop
+         id="stop5242-5-0-3-1-5"
+         offset="1"
+         style="stop-color:#aeb9ce;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5238-1-3-6-4-3"
+       id="linearGradient5329-5-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.03125007,6.00005)"
+       x1="12.531334"
+       y1="1041.9091"
+       x2="8.8389864"
+       y2="1041.9091" />
+    <linearGradient
+       id="linearGradient5238-1-3-6-41">
+      <stop
+         id="stop5240-9-6-9-0"
+         offset="0"
+         style="stop-color:#6d83ac;stop-opacity:1;" />
+      <stop
+         id="stop5242-5-0-3-3"
+         offset="1"
+         style="stop-color:#aeb9ce;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5238-1-3-6-41"
+       id="linearGradient5295-7-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.84444446,0,0,1,0.92569446,3.93755)"
+       x1="12.531334"
+       y1="1041.9091"
+       x2="8.8389864"
+       y2="1041.9091" />
+    <linearGradient
+       id="linearGradient5238-1-3-7">
+      <stop
+         id="stop5240-9-6-7"
+         offset="0"
+         style="stop-color:#6d83ac;stop-opacity:1;" />
+      <stop
+         id="stop5242-5-0-0"
+         offset="1"
+         style="stop-color:#aeb9ce;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5238-1-3-7"
+       id="linearGradient5261-8-2"
+       gradientUnits="userSpaceOnUse"
+       x1="12.531334"
+       y1="1041.9091"
+       x2="8.8389864"
+       y2="1041.9091"
+       gradientTransform="matrix(1.1377778,0,0,1,-0.79222222,2.0000504)" />
+    <linearGradient
+       id="linearGradient5238-1-2">
+      <stop
+         id="stop5240-9-2"
+         offset="0"
+         style="stop-color:#6d83ac;stop-opacity:1;" />
+      <stop
+         id="stop5242-5-01"
+         offset="1"
+         style="stop-color:#aeb9ce;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1041.9091"
+       x2="8.8389864"
+       y1="1041.9091"
+       x1="12.531334"
+       id="linearGradient5244-0-4"
+       xlink:href="#linearGradient5238-1-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5148-9-8-7">
+      <stop
+         id="stop5150-6-3-3"
+         offset="0"
+         style="stop-color:#05507d;stop-opacity:1;" />
+      <stop
+         id="stop5152-5-4-3"
+         offset="1"
+         style="stop-color:#6b8fa5;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5148-9-8-7"
+       id="linearGradient5171-5-5"
+       gradientUnits="userSpaceOnUse"
+       x1="3.8473835"
+       y1="4.0062027"
+       x2="2.9380388"
+       y2="3.0118337"
+       gradientTransform="translate(0,1036.3622)" />
+    <linearGradient
+       id="linearGradient5148-9-24">
+      <stop
+         id="stop5150-6-9"
+         offset="0"
+         style="stop-color:#05507d;stop-opacity:1;" />
+      <stop
+         id="stop5152-5-1"
+         offset="1"
+         style="stop-color:#6b8fa5;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="3.0118337"
+       x2="2.9380388"
+       y1="4.0062027"
+       x1="3.8473835"
+       id="linearGradient5154-9-9"
+       xlink:href="#linearGradient5148-9-24"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4855-1">
+      <stop
+         id="stop4857-1"
+         offset="0"
+         style="stop-color:#0d5c9a;stop-opacity:1;" />
+      <stop
+         id="stop4859-0"
+         offset="1"
+         style="stop-color:#3583c0;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5418-2">
+      <stop
+         id="stop5420-3"
+         offset="0"
+         style="stop-color:#5c5c5c;stop-opacity:1;" />
+      <stop
+         id="stop5422-4"
+         offset="1"
+         style="stop-color:#aeaeae;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5411-4">
+      <stop
+         id="stop5413-9"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop5415-5"
+         offset="1"
+         style="stop-color:#464646;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5404-1">
+      <stop
+         id="stop5406-2"
+         offset="0"
+         style="stop-color:#5c5c5c;stop-opacity:1;" />
+      <stop
+         id="stop5408-1"
+         offset="1"
+         style="stop-color:#aeaeae;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5397-4">
+      <stop
+         id="stop5399-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop5401-6"
+         offset="1"
+         style="stop-color:#464646;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5209-0-6">
+      <stop
+         id="stop5211-9-7"
+         offset="0"
+         style="stop-color:#5c5c5c;stop-opacity:1;" />
+      <stop
+         id="stop5213-4-1"
+         offset="1"
+         style="stop-color:#aeaeae;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5328-5-6">
+      <stop
+         id="stop5330-9-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop5332-8-6"
+         offset="1"
+         style="stop-color:#464646;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4961-6-1">
+      <stop
+         id="stop4963-0-5"
+         offset="0"
+         style="stop-color:#df9a39;stop-opacity:1;" />
+      <stop
+         id="stop4965-3-6"
+         offset="1"
+         style="stop-color:#b55829;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1049.2014"
+       x2="18.744612"
+       y1="1040.0764"
+       x1="15.073242"
+       gradientTransform="translate(-4.625,0)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4983-5-4"
+       xlink:href="#linearGradient4961-6-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4938-8-7">
+      <stop
+         id="stop4940-4-8"
+         offset="0"
+         style="stop-color:#8bc7d7;stop-opacity:1;" />
+      <stop
+         id="stop4942-8-9"
+         offset="1"
+         style="stop-color:#17477c;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4928-4-0">
+      <stop
+         id="stop4930-9-6"
+         offset="0"
+         style="stop-color:#4dac81;stop-opacity:1;" />
+      <stop
+         id="stop4932-8-9"
+         offset="1"
+         style="stop-color:#058048;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4907-9-9">
+      <stop
+         id="stop4909-5-3"
+         offset="0"
+         style="stop-color:#b86c44;stop-opacity:1;" />
+      <stop
+         id="stop4911-0-6"
+         offset="1"
+         style="stop-color:#8f4017;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4918-5-9">
+      <stop
+         id="stop4920-9-0"
+         offset="0"
+         style="stop-color:#d48a4b;stop-opacity:1;" />
+      <stop
+         id="stop4922-9-8"
+         offset="1"
+         style="stop-color:#b1623a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-7-5">
+      <stop
+         id="stop10800-5-2-1-8-4-8"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-1-5" />
+      <stop
+         id="stop10802-1-5-3-0-0-6"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-7-5"
+       id="linearGradient11390-1-3"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10856-6-3-0-0-4">
+      <stop
+         style="stop-color:#7d75ac;stop-opacity:1"
+         offset="0"
+         id="stop10858-0-7-6-0-1" />
+      <stop
+         id="stop10860-7-9-1-0-3"
+         offset="0.5"
+         style="stop-color:#574a96;stop-opacity:1" />
+      <stop
+         style="stop-color:#9f99c8;stop-opacity:1"
+         offset="1"
+         id="stop10862-3-3-8-2-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-7-0">
+      <stop
+         id="stop11150-7-8-3-8-1"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-8-6-3-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-30-8">
+      <stop
+         id="stop11150-9-6-9-4"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-6-7-6-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-2-0">
+      <stop
+         id="stop11150-7-5-9-3"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-4-35-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-4-4-3">
+      <stop
+         id="stop11150-4-72-8"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687-2-2-7">
+      <stop
+         id="stop11689-3-7-2"
+         offset="0"
+         style="stop-color:#bdb692;stop-opacity:1;" />
+      <stop
+         style="stop-color:#869097;stop-opacity:1"
+         offset="0.5"
+         id="stop11695-9-8-6" />
+      <stop
+         id="stop11691-10-4-9"
+         offset="1"
+         style="stop-color:#c3cace;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2-1-0">
+      <stop
+         id="stop10800-5-2-1-8-2-5-2-6-8"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-3-3-7-3" />
+      <stop
+         id="stop10802-1-5-3-0-2-2-2-2-8"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-1">
+      <stop
+         id="stop10800-5-2-1-8-2-8-1-1"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-95-0-5-08" />
+      <stop
+         id="stop10802-1-5-3-0-2-0-9-9"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9-8-4">
+      <stop
+         id="stop12001-1-9-4"
+         offset="0"
+         style="stop-color:#f8b098;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8decd;stop-opacity:1"
+         offset="0.5"
+         id="stop12007-4-6-0" />
+      <stop
+         id="stop12003-3-6-5"
+         offset="1"
+         style="stop-color:#f8b098;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7-6-2">
+      <stop
+         id="stop12090-7-9-4"
+         offset="0"
+         style="stop-color:#84a7d5;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a9cded;stop-opacity:1"
+         offset="0.5"
+         id="stop12096-6-2-5" />
+      <stop
+         id="stop12092-1-3-0"
+         offset="1"
+         style="stop-color:#95b8e0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-9-0-5">
+      <stop
+         id="stop11971-7-1-0"
+         offset="0"
+         style="stop-color:#6f93c7;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.29546595"
+         id="stop11979-0-0-9" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.57727957"
+         id="stop11977-6-1-2" />
+      <stop
+         id="stop11973-8-0-8"
+         offset="1"
+         style="stop-color:#6f93c7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-4"
+       id="linearGradient13011-8-5"
+       gradientUnits="userSpaceOnUse"
+       x1="420.88995"
+       y1="455.88452"
+       x2="440.35345"
+       y2="417.26108" />
+    <linearGradient
+       id="linearGradient12862-1-8-4"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-7"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-5"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799-7-9">
+      <stop
+         id="stop13801-4-7"
+         offset="0"
+         style="stop-color:#b9772f;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop13809-4-9" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop13807-7-8" />
+      <stop
+         id="stop13811-8-0"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop13803-6-1"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856-0-9">
+      <stop
+         id="stop13858-8-3"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13860-4-5"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13850-2-4">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13852-4-8" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13854-7-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-5-8">
+      <stop
+         id="stop10800-5-2-1-8-20-4-5-3-1-7"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-2-0-2-1-0" />
+      <stop
+         id="stop10802-1-5-3-0-4-6-4-2-3-1"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5-8"
+       id="linearGradient13333-0-1-2"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-5">
+      <stop
+         id="stop10800-5-2-1-8-20-4-0-2-3"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-2-2-7-8" />
+      <stop
+         id="stop10802-1-5-3-0-4-6-8-5-9"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-5">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-1"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-98">
+      <stop
+         id="stop10800-5-2-1-8-20-6-9"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-1" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-3"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-98"
+       id="linearGradient13197-3-8"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-0">
+      <stop
+         id="stop10800-5-2-1-8-20-4-0-23"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-2-2-1" />
+      <stop
+         id="stop10802-1-5-3-0-4-6-8-9"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-8">
+      <stop
+         id="stop10800-5-2-1-8-20-4-5-3-2"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-2-0-2-3" />
+      <stop
+         id="stop10802-1-5-3-0-4-6-4-2-4"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-9">
+      <stop
+         id="stop10800-5-2-1-8-20-4-5-2"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-2-0-1" />
+      <stop
+         id="stop10802-1-5-3-0-4-6-4-9"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-9"
+       id="linearGradient13296-4-3"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-1">
+      <stop
+         id="stop10800-5-2-1-8-20-4-4"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-2-3" />
+      <stop
+         id="stop10802-1-5-3-0-4-6-6"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-1"
+       id="linearGradient13197-7-5"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-80">
+      <stop
+         id="stop10800-5-2-1-8-20-0"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-8" />
+      <stop
+         id="stop10802-1-5-3-0-4-80"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-80"
+       id="linearGradient11390-9-9"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10856-6-3-0-5-8">
+      <stop
+         style="stop-color:#7d75ac;stop-opacity:1"
+         offset="0"
+         id="stop10858-0-7-6-9-4" />
+      <stop
+         id="stop10860-7-9-1-9-7"
+         offset="0.5"
+         style="stop-color:#574a96;stop-opacity:1" />
+      <stop
+         style="stop-color:#9f99c8;stop-opacity:1"
+         offset="1"
+         id="stop10862-3-3-8-6-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-9-4">
+      <stop
+         id="stop11150-7-8-3-19-3"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-8-6-2-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-5-3">
+      <stop
+         id="stop11150-9-6-8-4"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-6-7-5-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-5-2">
+      <stop
+         id="stop11150-7-5-2-8"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-4-3-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-4-0-3">
+      <stop
+         id="stop11150-4-1-3"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-9-6" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="417.26108"
+       x2="440.35345"
+       y1="455.88452"
+       x1="420.88995"
+       id="linearGradient12904-2-4"
+       xlink:href="#linearGradient12862-1-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-0"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-0"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-2"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       r="12.952347"
+       fy="420.74988"
+       fx="433.5452"
+       cy="420.74988"
+       cx="433.5452"
+       id="radialGradient12739-4-6"
+       xlink:href="#linearGradient12717-5-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12717-5-5"
+       inkscape:collect="always">
+      <stop
+         id="stop12719-6-1"
+         offset="0"
+         style="stop-color:#e4f1d8;stop-opacity:1" />
+      <stop
+         id="stop12721-9-7"
+         offset="1"
+         style="stop-color:#8ebc7b;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12717-9-1"
+       inkscape:collect="always">
+      <stop
+         id="stop12719-7-0"
+         offset="0"
+         style="stop-color:#e4f1d8;stop-opacity:1" />
+      <stop
+         id="stop12721-6-1"
+         offset="1"
+         style="stop-color:#8ebc7b;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1614831,2.1855961e-7,-2.811228e-7,1.4939602,-69.981471,-211.63828)"
+       r="12.027534"
+       fy="424.34106"
+       fx="433.36786"
+       cy="424.34106"
+       cx="433.36786"
+       id="radialGradient12723-3-5"
+       xlink:href="#linearGradient12717-9-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11687-2-6">
+      <stop
+         id="stop11689-3-8"
+         offset="0"
+         style="stop-color:#bdb692;stop-opacity:1;" />
+      <stop
+         style="stop-color:#869097;stop-opacity:1"
+         offset="0.5"
+         id="stop11695-9-2" />
+      <stop
+         id="stop11691-10-5"
+         offset="1"
+         style="stop-color:#c3cace;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="478.80402"
+       x2="390.76602"
+       y1="458.54279"
+       x1="390.76602"
+       id="linearGradient11693-3-2"
+       xlink:href="#linearGradient11687-2-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11679-3-4"
+       inkscape:collect="always">
+      <stop
+         id="stop11681-91-4"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.72146118" />
+      <stop
+         id="stop11683-02-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="11.849554"
+       fy="465.42303"
+       fx="385.7438"
+       cy="465.42303"
+       cx="385.7438"
+       id="radialGradient11685-2-1"
+       xlink:href="#linearGradient11679-3-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2-3">
+      <stop
+         id="stop10800-5-2-1-8-2-5-2-5"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-3-3-6" />
+      <stop
+         id="stop10802-1-5-3-0-2-2-2-6"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9-5">
+      <stop
+         id="stop12001-1-6"
+         offset="0"
+         style="stop-color:#f8b098;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8decd;stop-opacity:1"
+         offset="0.5"
+         id="stop12007-4-2" />
+      <stop
+         id="stop12003-3-5"
+         offset="1"
+         style="stop-color:#f8b098;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7-66">
+      <stop
+         id="stop12090-7-3"
+         offset="0"
+         style="stop-color:#84a7d5;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a9cded;stop-opacity:1"
+         offset="0.5"
+         id="stop12096-6-9" />
+      <stop
+         id="stop12092-1-4"
+         offset="1"
+         style="stop-color:#95b8e0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-9-3">
+      <stop
+         id="stop11971-7-2"
+         offset="0"
+         style="stop-color:#6f93c7;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.29546595"
+         id="stop11979-0-6" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.57727957"
+         id="stop11977-6-8" />
+      <stop
+         id="stop11973-8-2"
+         offset="1"
+         style="stop-color:#6f93c7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-5">
+      <stop
+         id="stop10800-5-2-1-8-2-8-4"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-95-2" />
+      <stop
+         id="stop10802-1-5-3-0-2-0-5"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-7-2-1">
+      <stop
+         id="stop12001-9-2-9"
+         offset="0"
+         style="stop-color:#f8b098;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8decd;stop-opacity:1"
+         offset="0.5"
+         id="stop12007-1-3-6" />
+      <stop
+         id="stop12003-2-8-4"
+         offset="1"
+         style="stop-color:#f8b098;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2-1-6">
+      <stop
+         id="stop12090-1-8-1"
+         offset="0"
+         style="stop-color:#84a7d5;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a9cded;stop-opacity:1"
+         offset="0.5"
+         id="stop12096-1-8-5" />
+      <stop
+         id="stop12092-2-4-5"
+         offset="1"
+         style="stop-color:#95b8e0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2-2-7">
+      <stop
+         id="stop11971-3-7-6"
+         offset="0"
+         style="stop-color:#6f93c7;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.29546595"
+         id="stop11979-8-6-4" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.57727957"
+         id="stop11977-7-6-5" />
+      <stop
+         id="stop11973-6-6-8"
+         offset="1"
+         style="stop-color:#6f93c7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687-8-4">
+      <stop
+         id="stop11689-6-8"
+         offset="0"
+         style="stop-color:#bdb692;stop-opacity:1;" />
+      <stop
+         style="stop-color:#869097;stop-opacity:1"
+         offset="0.5"
+         id="stop11695-6-3" />
+      <stop
+         id="stop11691-5-9"
+         offset="1"
+         style="stop-color:#c3cace;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="478.80402"
+       x2="390.76602"
+       y1="458.54279"
+       x1="390.76602"
+       id="linearGradient11693-26-9"
+       xlink:href="#linearGradient11687-8-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11679-8-5"
+       inkscape:collect="always">
+      <stop
+         id="stop11681-3-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.72146118" />
+      <stop
+         id="stop11683-6-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="11.849554"
+       fy="465.42303"
+       fx="385.7438"
+       cy="465.42303"
+       cx="385.7438"
+       id="radialGradient11685-3-6"
+       xlink:href="#linearGradient11679-8-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11687-9-7">
+      <stop
+         id="stop11689-1-6"
+         offset="0"
+         style="stop-color:#bdb692;stop-opacity:1;" />
+      <stop
+         style="stop-color:#869097;stop-opacity:1"
+         offset="0.5"
+         id="stop11695-2-3" />
+      <stop
+         id="stop11691-1-5"
+         offset="1"
+         style="stop-color:#c3cace;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="478.80402"
+       x2="390.76602"
+       y1="458.54279"
+       x1="390.76602"
+       id="linearGradient11693-2-8"
+       xlink:href="#linearGradient11687-9-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11679-7-3"
+       inkscape:collect="always">
+      <stop
+         id="stop11681-94-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.72146118" />
+      <stop
+         id="stop11683-0-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="11.849554"
+       fy="465.42303"
+       fx="385.7438"
+       cy="465.42303"
+       cx="385.7438"
+       id="radialGradient11685-5-9"
+       xlink:href="#linearGradient11679-7-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11999-7-4">
+      <stop
+         id="stop12001-9-8"
+         offset="0"
+         style="stop-color:#f8b098;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8decd;stop-opacity:1"
+         offset="0.5"
+         id="stop12007-1-6" />
+      <stop
+         id="stop12003-2-0"
+         offset="1"
+         style="stop-color:#f8b098;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2-8">
+      <stop
+         id="stop12090-1-0"
+         offset="0"
+         style="stop-color:#84a7d5;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a9cded;stop-opacity:1"
+         offset="0.5"
+         id="stop12096-1-1" />
+      <stop
+         id="stop12092-2-8"
+         offset="1"
+         style="stop-color:#95b8e0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2-3">
+      <stop
+         id="stop11971-3-9"
+         offset="0"
+         style="stop-color:#6f93c7;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.29546595"
+         id="stop11979-8-1" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.57727957"
+         id="stop11977-7-8" />
+      <stop
+         id="stop11973-6-2"
+         offset="1"
+         style="stop-color:#6f93c7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11888-4-3"
+       inkscape:collect="always">
+      <stop
+         id="stop11890-8-7"
+         offset="0"
+         style="stop-color:#a7c8ec;stop-opacity:1" />
+      <stop
+         id="stop11892-8-9"
+         offset="1"
+         style="stop-color:#b4def6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="444.57022"
+       x2="358.60471"
+       y1="457.29816"
+       x1="342.37973"
+       id="linearGradient11894-5-8"
+       xlink:href="#linearGradient11888-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11888-8-8"
+       inkscape:collect="always">
+      <stop
+         id="stop11890-4-3"
+         offset="0"
+         style="stop-color:#a7c8ec;stop-opacity:1" />
+      <stop
+         id="stop11892-1-7"
+         offset="1"
+         style="stop-color:#b4def6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="444.57022"
+       x2="358.60471"
+       y1="457.29816"
+       x1="342.37973"
+       id="linearGradient11894-2-5"
+       xlink:href="#linearGradient11888-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11687-1-7">
+      <stop
+         id="stop11689-9-0"
+         offset="0"
+         style="stop-color:#bdb692;stop-opacity:1;" />
+      <stop
+         style="stop-color:#869097;stop-opacity:1"
+         offset="0.5"
+         id="stop11695-3-9" />
+      <stop
+         id="stop11691-9-5"
+         offset="1"
+         style="stop-color:#c3cace;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="478.80402"
+       x2="390.76602"
+       y1="458.54279"
+       x1="390.76602"
+       id="linearGradient11693-0-3"
+       xlink:href="#linearGradient11687-1-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11679-2-3"
+       inkscape:collect="always">
+      <stop
+         id="stop11681-9-1"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.72146118" />
+      <stop
+         id="stop11683-1-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="11.849554"
+       fy="465.42303"
+       fx="385.7438"
+       cy="465.42303"
+       cx="385.7438"
+       id="radialGradient11685-7-0"
+       xlink:href="#linearGradient11679-2-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-3">
+      <stop
+         id="stop10800-5-2-1-8-2-5-22"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-2-2-7"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-1-3"
+       id="linearGradient11520-8-1"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-2-5">
+      <stop
+         id="stop10800-5-2-1-8-2-6-8"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-9-8" />
+      <stop
+         id="stop10802-1-5-3-0-2-6-0"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-2-5"
+       id="linearGradient11520-3-0"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-9">
+      <stop
+         id="stop10800-5-2-1-8-2-59"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-2-5"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-9"
+       id="linearGradient11390-0-2"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10856-6-3-0-1-2">
+      <stop
+         style="stop-color:#7d75ac;stop-opacity:1"
+         offset="0"
+         id="stop10858-0-7-6-1-6" />
+      <stop
+         id="stop10860-7-9-1-7-8"
+         offset="0.5"
+         style="stop-color:#574a96;stop-opacity:1" />
+      <stop
+         style="stop-color:#9f99c8;stop-opacity:1"
+         offset="1"
+         id="stop10862-3-3-8-4-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-6-3">
+      <stop
+         id="stop11150-7-8-3-1-5"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-8-6-6-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-3-8">
+      <stop
+         id="stop11150-9-6-4-1"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-6-7-2-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-4-8">
+      <stop
+         id="stop11150-7-5-5-7"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-4-9-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-4-5-9">
+      <stop
+         id="stop11150-4-7-3"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-2-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-14"
+       id="linearGradient11390-5"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-14">
+      <stop
+         id="stop10800-5-2-1-8-8"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-20" />
+      <stop
+         id="stop10802-1-5-3-0-5"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-14"
+       id="linearGradient10880-5-3-4-3"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10856-6-3-0-19">
+      <stop
+         style="stop-color:#7d75ac;stop-opacity:1"
+         offset="0"
+         id="stop10858-0-7-6-04" />
+      <stop
+         id="stop10860-7-9-1-2"
+         offset="0.5"
+         style="stop-color:#574a96;stop-opacity:1" />
+      <stop
+         style="stop-color:#9f99c8;stop-opacity:1"
+         offset="1"
+         id="stop10862-3-3-8-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10856-6-3-0-19"
+       id="linearGradient11298-3-0"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient11146-8-7-5-1">
+      <stop
+         id="stop11150-7-8-3-3"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-8-6-63" />
+    </linearGradient>
+    <radialGradient
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-154.64572)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11274-3-3"
+       xlink:href="#linearGradient11146-8-7-5-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-7-5-7">
+      <stop
+         id="stop11150-9-6-7"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-6-7-4" />
+    </linearGradient>
+    <radialGradient
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-154.64572)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11272-3-0"
+       xlink:href="#linearGradient11146-7-5-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-8-3-45">
+      <stop
+         id="stop11150-7-5-6"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-4-8" />
+    </linearGradient>
+    <radialGradient
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11270-4-7"
+       xlink:href="#linearGradient11146-8-3-45"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-4-9">
+      <stop
+         id="stop11150-4-0"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-8" />
+    </linearGradient>
+    <radialGradient
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11268-5-2"
+       xlink:href="#linearGradient11146-4-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-3">
+      <stop
+         id="stop10800-5-2-1-2"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-4" />
+      <stop
+         id="stop10802-1-5-3-1"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-1">
+      <stop
+         style="stop-color:#7d75ac;stop-opacity:1"
+         offset="0"
+         id="stop10858-0-7-7" />
+      <stop
+         id="stop10860-7-9-5"
+         offset="0.5"
+         style="stop-color:#574a96;stop-opacity:1" />
+      <stop
+         style="stop-color:#9f99c8;stop-opacity:1"
+         offset="1"
+         id="stop10862-3-3-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10856-6-3-1"
+       id="linearGradient11063-6-4"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient11146-8-7-9">
+      <stop
+         id="stop11150-7-8-0"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-8-3" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-7-9"
+       id="radialGradient11169-6-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-7-9">
+      <stop
+         id="stop11150-9-61"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-6-77" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)"
+       gradientUnits="userSpaceOnUse"
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       id="radialGradient11144-2-7"
+       xlink:href="#linearGradient11146-7-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-8-39">
+      <stop
+         id="stop11150-7-58"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)"
+       gradientUnits="userSpaceOnUse"
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       id="radialGradient11144-4-1"
+       xlink:href="#linearGradient11146-8-39"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-9">
+      <stop
+         style="stop-color:#7d75ac;stop-opacity:1"
+         offset="0"
+         id="stop10858-0-2" />
+      <stop
+         id="stop10860-7-5"
+         offset="0.5"
+         style="stop-color:#574a96;stop-opacity:1" />
+      <stop
+         style="stop-color:#9f99c8;stop-opacity:1"
+         offset="1"
+         id="stop10862-3-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10856-6-9"
+       id="linearGradient10835-2-5"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-1">
+      <stop
+         id="stop10800-5-2-0"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-4" />
+      <stop
+         id="stop10802-1-5-8"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-90">
+      <stop
+         id="stop10800-5-5"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-3" />
+      <stop
+         id="stop10802-1-4"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       id="linearGradient10804-8-7"
+       xlink:href="#linearGradient10798-1-90"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-8-0">
+      <stop
+         id="stop10800-2-8"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-9-5" />
+      <stop
+         id="stop10802-3-0"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       id="linearGradient10804-7-1"
+       xlink:href="#linearGradient10798-8-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="511.38498"
+       x2="322.875"
+       y1="536.61243"
+       x1="322.875"
+       gradientTransform="translate(0.88388349,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10794-9"
+       xlink:href="#linearGradient10149-6-5-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="504.44818"
+       x2="322.875"
+       y1="536.61243"
+       x1="322.875"
+       gradientTransform="translate(0,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10792-5"
+       xlink:href="#linearGradient10149-39-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="542.73901"
+       x2="305"
+       y1="504.36218"
+       x1="305"
+       gradientTransform="translate(0,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10790-2"
+       xlink:href="#linearGradient10157-2-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="514.67456"
+       x2="302.3125"
+       y1="532.98718"
+       x1="302.3125"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10788-2"
+       xlink:href="#linearGradient10396-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="514.75818"
+       x2="306.05069"
+       y1="532.08228"
+       x1="306.05069"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10786-7"
+       xlink:href="#linearGradient10157-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="519.36218"
+       x2="289.8125"
+       y1="528.73804"
+       x1="289.8125"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10784-0"
+       xlink:href="#linearGradient10432-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="519.08923"
+       x2="298.34253"
+       y1="528.1048"
+       x1="298.34253"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10782-8"
+       xlink:href="#linearGradient10414-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10780-2"
+       xlink:href="#linearGradient10440-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10778-5"
+       xlink:href="#linearGradient10448-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="515.73615"
+       x2="334.375"
+       y1="532.30212"
+       x1="334.375"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10776-3"
+       xlink:href="#linearGradient10440-1-3-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="515.53949"
+       x2="324.1601"
+       y1="532.15552"
+       x1="324.1601"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10774-0"
+       xlink:href="#linearGradient10748-9"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="518.67365"
+       x2="334.375"
+       y1="529.06494"
+       x1="334.375"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10772-3"
+       xlink:href="#linearGradient10440-1-0-0-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="518.28192"
+       x2="323.98331"
+       y1="529.30121"
+       x1="324.1601"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10770-6"
+       xlink:href="#linearGradient10448-9-7-0-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-1-0-0-4">
+      <stop
+         id="stop10442-43-2-0-8"
+         offset="0"
+         style="stop-color:#ae7603;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e8d8a3;stop-opacity:1"
+         offset="0.5"
+         id="stop10521-1-2-5-2" />
+      <stop
+         id="stop10444-3-4-0-3"
+         offset="1"
+         style="stop-color:#bb9221;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-9-7-0-2">
+      <stop
+         id="stop10450-3-5-6-2"
+         offset="0"
+         style="stop-color:#cf9307;stop-opacity:1" />
+      <stop
+         style="stop-color:#f7d87b;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-4-1-5-1" />
+      <stop
+         id="stop10452-22-7-8-7"
+         offset="1"
+         style="stop-color:#ebb313;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-3-3">
+      <stop
+         id="stop10442-43-0-1"
+         offset="0"
+         style="stop-color:#ae7603;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e8d8a3;stop-opacity:1"
+         offset="0.5"
+         id="stop10521-1-4-5" />
+      <stop
+         id="stop10444-3-2-5"
+         offset="1"
+         style="stop-color:#bb9221;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-3-3"
+       id="linearGradient10548-1-0"
+       gradientUnits="userSpaceOnUse"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientTransform="translate(7.4375,2.6171875e-6)" />
+    <linearGradient
+       id="linearGradient10448-9-6-3">
+      <stop
+         id="stop10450-3-8-6"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe38d;stop-opacity:1"
+         offset="0.25"
+         id="stop10458-8-7-5" />
+      <stop
+         style="stop-color:#fdf5d2;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-4-7-2" />
+      <stop
+         id="stop10460-2-1-8"
+         offset="0.75"
+         style="stop-color:#ffeba7;stop-opacity:1" />
+      <stop
+         id="stop10452-22-8-1"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-6-3"
+       id="linearGradient10546-8-6"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientTransform="translate(7.4375,2.6171875e-6)" />
+    <linearGradient
+       id="linearGradient10440-1-0-3">
+      <stop
+         id="stop10442-43-2-4"
+         offset="0"
+         style="stop-color:#ae7603;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e8d8a3;stop-opacity:1"
+         offset="0.5"
+         id="stop10521-1-2-7" />
+      <stop
+         id="stop10444-3-4-4"
+         offset="1"
+         style="stop-color:#bb9221;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-0-3"
+       id="linearGradient10548-3-1"
+       gradientUnits="userSpaceOnUse"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientTransform="translate(7.4375,2.6171875e-6)" />
+    <linearGradient
+       id="linearGradient10448-9-7-6">
+      <stop
+         id="stop10450-3-5-4"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe38d;stop-opacity:1"
+         offset="0.25"
+         id="stop10458-8-0-5" />
+      <stop
+         style="stop-color:#fdf5d2;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-4-1-3" />
+      <stop
+         id="stop10460-2-9-0"
+         offset="0.75"
+         style="stop-color:#ffeba7;stop-opacity:1" />
+      <stop
+         id="stop10452-22-7-89"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-6"
+       id="linearGradient10546-3-0"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientTransform="translate(7.4375,2.6171875e-6)" />
+    <linearGradient
+       id="linearGradient10440-1-5">
+      <stop
+         id="stop10442-43-9"
+         offset="0"
+         style="stop-color:#ae7603;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e8d8a3;stop-opacity:1"
+         offset="0.5"
+         id="stop10521-1-5" />
+      <stop
+         id="stop10444-3-1"
+         offset="1"
+         style="stop-color:#bb9221;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       id="linearGradient10446-7-1"
+       xlink:href="#linearGradient10440-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-78">
+      <stop
+         id="stop10450-3-58"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe38d;stop-opacity:1"
+         offset="0.25"
+         id="stop10458-8-3" />
+      <stop
+         style="stop-color:#fdf5d2;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-4-2" />
+      <stop
+         id="stop10460-2-4"
+         offset="0.75"
+         style="stop-color:#ffeba7;stop-opacity:1" />
+      <stop
+         id="stop10452-22-1"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       id="linearGradient10454-9-5"
+       xlink:href="#linearGradient10448-9-78"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-2-7"
+       inkscape:collect="always">
+      <stop
+         id="stop10442-4-3"
+         offset="0"
+         style="stop-color:#ae7603;stop-opacity:1;" />
+      <stop
+         id="stop10444-4-1"
+         offset="1"
+         style="stop-color:#bb9221;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       id="linearGradient10446-9-3"
+       xlink:href="#linearGradient10440-2-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-4-4">
+      <stop
+         id="stop10450-4-4"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe38d;stop-opacity:1"
+         offset="0.25"
+         id="stop10458-7-2" />
+      <stop
+         style="stop-color:#fdf5d2;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-9-7" />
+      <stop
+         id="stop10460-1-9"
+         offset="0.75"
+         style="stop-color:#ffeba7;stop-opacity:1" />
+      <stop
+         id="stop10452-2-2"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       id="linearGradient10454-7-4"
+       xlink:href="#linearGradient10448-4-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10149-6-5-6">
+      <stop
+         id="stop10151-5-7-5"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#b9c7df;stop-opacity:1"
+         offset="0.5"
+         id="stop10394-3" />
+      <stop
+         id="stop10153-8-1-2"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10149-39-5"
+       inkscape:collect="always">
+      <stop
+         id="stop10151-3-9"
+         offset="0"
+         style="stop-color:#1d4d9d;stop-opacity:1" />
+      <stop
+         id="stop10153-72-2"
+         offset="1"
+         style="stop-color:#638ac8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="504.44818"
+       x2="322.875"
+       y1="536.61243"
+       x1="322.875"
+       id="linearGradient10155-7-9"
+       xlink:href="#linearGradient10149-39-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10157-2-5">
+      <stop
+         id="stop10159-8-1"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:1" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.5"
+         id="stop10165-3-3" />
+      <stop
+         id="stop10161-5-9"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="542.73901"
+       x2="305"
+       y1="504.36218"
+       x1="305"
+       id="linearGradient10163-2-6"
+       xlink:href="#linearGradient10157-2-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10149-6-2"
+       inkscape:collect="always">
+      <stop
+         id="stop10151-5-72"
+         offset="0"
+         style="stop-color:#1d4d9d;stop-opacity:1" />
+      <stop
+         id="stop10153-8-7"
+         offset="1"
+         style="stop-color:#638ac8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="504.44818"
+       x2="322.875"
+       y1="536.61243"
+       x1="322.875"
+       id="linearGradient10155-5-6"
+       xlink:href="#linearGradient10149-6-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10149-3-1"
+       inkscape:collect="always">
+      <stop
+         id="stop10151-0-9"
+         offset="0"
+         style="stop-color:#1d4d9d;stop-opacity:1" />
+      <stop
+         id="stop10153-7-1"
+         offset="1"
+         style="stop-color:#638ac8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="504.44818"
+       x2="322.875"
+       y1="536.61243"
+       x1="322.875"
+       id="linearGradient10155-1-7"
+       xlink:href="#linearGradient10149-3-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10157-5-6">
+      <stop
+         id="stop10159-7-7"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:1" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.5"
+         id="stop10165-2-6" />
+      <stop
+         id="stop10161-3-7"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="542.73901"
+       x2="305"
+       y1="504.36218"
+       x1="305"
+       id="linearGradient10163-8-6"
+       xlink:href="#linearGradient10157-5-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="463.04114"
+       x2="567.47571"
+       y1="489.69833"
+       x1="567.47571"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10005-6"
+       xlink:href="#linearGradient9299-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="463.98975"
+       x2="548.41693"
+       y1="488.59351"
+       x1="548.41693"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10003-5"
+       xlink:href="#linearGradient9291-8-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="472.63525"
+       x2="556.25635"
+       y1="472.63525"
+       x1="526.85181"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10001-3"
+       xlink:href="#linearGradient9510-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="448.46484"
+       x2="556.9375"
+       y1="448.46484"
+       x1="526.4375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9999-0"
+       xlink:href="#linearGradient9312-98"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="460.34375"
+       x2="555.01776"
+       y1="460.34375"
+       x1="528.36798"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9997-2"
+       xlink:href="#linearGradient9332-1"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="269.33588"
+       x2="636.09375"
+       y1="279.41037"
+       x1="636.09375"
+       gradientTransform="translate(-33.506824,0.34375262)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9984-6"
+       xlink:href="#linearGradient9914-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9982-5"
+       xlink:href="#linearGradient8153-2-4-4-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="276.3064"
+       x2="641.07611"
+       y1="308.68875"
+       x1="641.07611"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9980-4"
+       xlink:href="#linearGradient8653-2-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="281.43512"
+       x2="641.07611"
+       y1="306.07397"
+       x1="641.07611"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9978-1"
+       xlink:href="#linearGradient9908-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="269.33588"
+       x2="636.09375"
+       y1="275.53125"
+       x1="636.09375"
+       gradientTransform="translate(-33.506824,0.34375)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9976-0"
+       xlink:href="#linearGradient8337-2-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientTransform="translate(-33.506824,3e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9974-5"
+       xlink:href="#linearGradient8153-2-0-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="283.2832"
+       x2="657.71722"
+       y1="283.2832"
+       x1="617.06256"
+       gradientTransform="translate(-33.506824,0)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9972-4"
+       xlink:href="#linearGradient8137-6-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="308.57455"
+       x2="636.99469"
+       y1="277.45544"
+       x1="636.99469"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9970-3"
+       xlink:href="#linearGradient8661-5-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="472.63525"
+       x2="556.25635"
+       y1="472.63525"
+       x1="526.85181"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9968-8"
+       xlink:href="#linearGradient9510-3-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="448.46484"
+       x2="556.9375"
+       y1="448.46484"
+       x1="526.4375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9966-0"
+       xlink:href="#linearGradient9312-9-1"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="460.34375"
+       x2="555.01776"
+       y1="460.34375"
+       x1="528.36798"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9964-0"
+       xlink:href="#linearGradient9332-6-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="454.31174"
+       x2="227.09628"
+       y1="441.62799"
+       x1="213.82529"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9962-1"
+       xlink:href="#linearGradient9605-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8337-1-3-8"
+       inkscape:collect="always">
+      <stop
+         id="stop8339-4-2-3"
+         offset="0"
+         style="stop-color:#4e86ca;stop-opacity:1;" />
+      <stop
+         id="stop8341-2-6-7"
+         offset="1"
+         style="stop-color:#4e86ca;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="269.33588"
+       x2="636.09375"
+       y1="275.53125"
+       x1="636.09375"
+       gradientTransform="translate(0,0.34375262)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8703-1-7"
+       xlink:href="#linearGradient8337-1-3-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8153-2-4-4-0"
+       inkscape:collect="always">
+      <stop
+         id="stop8155-7-78-0-7"
+         offset="0"
+         style="stop-color:#75b1e3;stop-opacity:1;" />
+      <stop
+         id="stop8157-7-0-7-4"
+         offset="1"
+         style="stop-color:#c1def7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8653-2-8"
+       inkscape:collect="always">
+      <stop
+         id="stop8655-9-9"
+         offset="0"
+         style="stop-color:#676656;stop-opacity:1;" />
+      <stop
+         id="stop8657-2-3"
+         offset="1"
+         style="stop-color:#9e884e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="276.3064"
+       x2="641.07611"
+       y1="308.68875"
+       x1="641.07611"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8697-5-0"
+       xlink:href="#linearGradient8653-2-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8337-2-5"
+       inkscape:collect="always">
+      <stop
+         id="stop8339-7-7"
+         offset="0"
+         style="stop-color:#4e86ca;stop-opacity:1;" />
+      <stop
+         id="stop8341-8-7"
+         offset="1"
+         style="stop-color:#4e86ca;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8153-2-0-3"
+       inkscape:collect="always">
+      <stop
+         id="stop8155-7-9-8"
+         offset="0"
+         style="stop-color:#75b1e3;stop-opacity:1;" />
+      <stop
+         id="stop8157-7-5-8"
+         offset="1"
+         style="stop-color:#c1def7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8137-6-2"
+       inkscape:collect="always">
+      <stop
+         id="stop8139-1-9"
+         offset="0"
+         style="stop-color:#326097;stop-opacity:1" />
+      <stop
+         id="stop8141-6-0"
+         offset="1"
+         style="stop-color:#2e73c5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8661-5-3">
+      <stop
+         style="stop-color:#c6e7f9;stop-opacity:1"
+         offset="0"
+         id="stop8663-3-0" />
+      <stop
+         style="stop-color:#f9fcff;stop-opacity:1"
+         offset="1"
+         id="stop8665-5-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9510-3-0">
+      <stop
+         id="stop9512-4-0"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.35636142"
+         id="stop9514-9-4" />
+      <stop
+         id="stop9516-6-8"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9510-3-0"
+       id="linearGradient9415-5-3"
+       gradientUnits="userSpaceOnUse"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)" />
+    <linearGradient
+       id="linearGradient9312-9-1">
+      <stop
+         id="stop9314-5-1"
+         offset="0"
+         style="stop-color:#cf6c00;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5db48;stop-opacity:0.24200913"
+         offset="0.36339331"
+         id="stop9322-0-1" />
+      <stop
+         id="stop9316-6-7"
+         offset="1"
+         style="stop-color:#c36000;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332-6-2">
+      <stop
+         id="stop9334-52-6"
+         offset="0"
+         style="stop-color:#f5b517;stop-opacity:1" />
+      <stop
+         style="stop-color:#fcf79e;stop-opacity:1"
+         offset="0.33703175"
+         id="stop9340-23-0" />
+      <stop
+         id="stop9336-3-6"
+         offset="1"
+         style="stop-color:#f5ae19;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9299-1-5"
+       inkscape:collect="always">
+      <stop
+         id="stop9301-6-4"
+         offset="0"
+         style="stop-color:#929baa;stop-opacity:1" />
+      <stop
+         id="stop9303-8-0"
+         offset="1"
+         style="stop-color:#cac3a5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="463.04114"
+       x2="567.47571"
+       y1="489.69833"
+       x1="567.47571"
+       id="linearGradient9305-8-5"
+       xlink:href="#linearGradient9299-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9291-8-6"
+       inkscape:collect="always">
+      <stop
+         id="stop9293-7-7"
+         offset="0"
+         style="stop-color:#e9f8ff;stop-opacity:1;" />
+      <stop
+         id="stop9295-3-1"
+         offset="1"
+         style="stop-color:#f5f6f9;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="463.98975"
+       x2="548.41693"
+       y1="488.59351"
+       x1="548.41693"
+       id="linearGradient9297-1-3"
+       xlink:href="#linearGradient9291-8-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9324-7-3">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9326-0-0" />
+      <stop
+         id="stop9328-1-2"
+         offset="0.30000001"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9330-5-2" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="472.63525"
+       x2="556.25635"
+       y1="472.63525"
+       x1="526.85181"
+       id="linearGradient9318-8"
+       xlink:href="#linearGradient9324-7-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9332-9-4">
+      <stop
+         id="stop9334-5-5"
+         offset="0"
+         style="stop-color:#f5b517;stop-opacity:1" />
+      <stop
+         style="stop-color:#fcf79e;stop-opacity:1"
+         offset="0.33703175"
+         id="stop9340-2-7" />
+      <stop
+         id="stop9336-4-9"
+         offset="1"
+         style="stop-color:#f5ae19;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="460.34375"
+       x2="555.01776"
+       y1="460.34375"
+       x1="528.36798"
+       id="linearGradient9338-8-7"
+       xlink:href="#linearGradient9332-9-4"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="463.04114"
+       x2="567.47571"
+       y1="489.69833"
+       x1="567.47571"
+       id="linearGradient9305-7"
+       xlink:href="#linearGradient9299-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="463.98975"
+       x2="548.41693"
+       y1="488.59351"
+       x1="548.41693"
+       id="linearGradient9297-5"
+       xlink:href="#linearGradient9291-80"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="269.33588"
+       x2="636.09375"
+       y1="275.53125"
+       x1="636.09375"
+       gradientTransform="translate(0,0.34375262)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8703-6"
+       xlink:href="#linearGradient8337-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientTransform="translate(0,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8701-2"
+       xlink:href="#linearGradient8153-2-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="283.2832"
+       x2="657.71722"
+       y1="283.2832"
+       x1="617.06256"
+       gradientTransform="translate(0,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8699-9"
+       xlink:href="#linearGradient8137-93-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="276.3064"
+       x2="641.07611"
+       y1="308.68875"
+       x1="641.07611"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8697-4"
+       xlink:href="#linearGradient8653-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="276.3064"
+       x2="641.07611"
+       y1="308.68875"
+       x1="641.07611"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8695-8"
+       xlink:href="#linearGradient8653-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="276.3064"
+       x2="641.07611"
+       y1="308.68875"
+       x1="641.07611"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8693-3"
+       xlink:href="#linearGradient8653-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="276.3064"
+       x2="641.07611"
+       y1="308.68875"
+       x1="641.07611"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8691-7"
+       xlink:href="#linearGradient8653-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="276.3064"
+       x2="641.07611"
+       y1="308.68875"
+       x1="641.07611"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8689-6"
+       xlink:href="#linearGradient8653-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="269.33588"
+       x2="636.09375"
+       y1="275.53125"
+       x1="636.09375"
+       gradientTransform="translate(0,0.34375)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8687-5"
+       xlink:href="#linearGradient8337-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientTransform="translate(0,3e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8685-0"
+       xlink:href="#linearGradient8153-2-40"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="283.2832"
+       x2="657.71722"
+       y1="283.2832"
+       x1="617.06256"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8683-7"
+       xlink:href="#linearGradient8137-1"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="308.57455"
+       x2="636.99469"
+       y1="277.45544"
+       x1="636.99469"
+       gradientTransform="translate(0,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8681-0"
+       xlink:href="#linearGradient8661-50"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="276.3064"
+       x2="641.07611"
+       y1="308.68875"
+       x1="641.07611"
+       id="linearGradient8659-6"
+       xlink:href="#linearGradient8653-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8498-0"
+       inkscape:collect="always">
+      <stop
+         id="stop8500-7"
+         offset="0"
+         style="stop-color:#d9f4ff;stop-opacity:1" />
+      <stop
+         id="stop8502-0"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="308.57455"
+       x2="636.99469"
+       y1="277.45544"
+       x1="636.99469"
+       id="linearGradient8504-2"
+       xlink:href="#linearGradient8498-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8137-93-8"
+       inkscape:collect="always">
+      <stop
+         id="stop8139-9-4"
+         offset="0"
+         style="stop-color:#326097;stop-opacity:1" />
+      <stop
+         id="stop8141-8-9"
+         offset="1"
+         style="stop-color:#2e73c5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8153-2-4-3"
+       inkscape:collect="always">
+      <stop
+         id="stop8155-7-78-1"
+         offset="0"
+         style="stop-color:#75b1e3;stop-opacity:1;" />
+      <stop
+         id="stop8157-7-0-4"
+         offset="1"
+         style="stop-color:#c1def7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8337-1-1"
+       inkscape:collect="always">
+      <stop
+         id="stop8339-4-6"
+         offset="0"
+         style="stop-color:#4e86ca;stop-opacity:1;" />
+      <stop
+         id="stop8341-2-8"
+         offset="1"
+         style="stop-color:#4e86ca;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8153-2-6-4"
+       inkscape:collect="always">
+      <stop
+         id="stop8155-7-6-8"
+         offset="0"
+         style="stop-color:#75b1e3;stop-opacity:1;" />
+      <stop
+         id="stop8157-7-6-2"
+         offset="1"
+         style="stop-color:#c1def7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientTransform="translate(0,3e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8291-2-6"
+       xlink:href="#linearGradient8153-2-6-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8137-9-5-4"
+       inkscape:collect="always">
+      <stop
+         id="stop8139-4-2-9"
+         offset="0"
+         style="stop-color:#326097;stop-opacity:1" />
+      <stop
+         id="stop8141-1-9-5"
+         offset="1"
+         style="stop-color:#2e73c5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-9-5-4"
+       id="linearGradient8182-5"
+       gradientUnits="userSpaceOnUse"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832"
+       gradientTransform="translate(0,2.6171875e-6)" />
+    <linearGradient
+       id="linearGradient8153-2-8-0"
+       inkscape:collect="always">
+      <stop
+         id="stop8155-7-7-0"
+         offset="0"
+         style="stop-color:#75b1e3;stop-opacity:1;" />
+      <stop
+         id="stop8157-7-3-4"
+         offset="1"
+         style="stop-color:#c1def7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-8-0"
+       id="linearGradient8180-3-5"
+       gradientUnits="userSpaceOnUse"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238"
+       gradientTransform="translate(0,2.6171875e-6)" />
+    <linearGradient
+       id="linearGradient8137-9-0"
+       inkscape:collect="always">
+      <stop
+         id="stop8139-4-6"
+         offset="0"
+         style="stop-color:#326097;stop-opacity:1" />
+      <stop
+         id="stop8141-1-7"
+         offset="1"
+         style="stop-color:#2e73c5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="283.2832"
+       x2="657.71722"
+       y1="283.2832"
+       x1="617.06256"
+       id="linearGradient8143-2-1"
+       xlink:href="#linearGradient8137-9-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8153-2-40"
+       inkscape:collect="always">
+      <stop
+         id="stop8155-7-0"
+         offset="0"
+         style="stop-color:#75b1e3;stop-opacity:1;" />
+      <stop
+         id="stop8157-7-53"
+         offset="1"
+         style="stop-color:#c1def7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       id="linearGradient8159-0-3"
+       xlink:href="#linearGradient8153-2-40"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7686-9-7-0"
+       inkscape:collect="always">
+      <stop
+         id="stop7688-7-1-7"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop7690-5-0-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7686-9-7-0"
+       id="linearGradient7755-5-4"
+       gradientUnits="userSpaceOnUse"
+       x1="1303.0625"
+       y1="610.34235"
+       x2="1303.0625"
+       y2="723.85583"
+       gradientTransform="translate(0,-140)" />
+    <linearGradient
+       id="linearGradient7686-9-2"
+       inkscape:collect="always">
+      <stop
+         id="stop7688-7-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop7690-5-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="723.85583"
+       x2="1303.0625"
+       y1="610.34235"
+       x1="1303.0625"
+       id="linearGradient7692-4-2"
+       xlink:href="#linearGradient7686-9-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7115-5">
+      <stop
+         id="stop7117-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7119-5" />
+      <stop
+         id="stop7121-1"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7106-1">
+      <stop
+         id="stop7108-1"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7110-3" />
+      <stop
+         id="stop7112-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3-0-3">
+      <stop
+         id="stop7104-0-1-6-7-9-1-4-9-4-8-4"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-3-0-7-1-3" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-8-4-1-9-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6-1-2">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-5-8-0-8-9" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-1-4-7-3-7"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-1-8-6-8-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6949-2">
+      <stop
+         id="stop6951-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6953-3" />
+      <stop
+         id="stop6955-7"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6940-3">
+      <stop
+         id="stop6942-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6944-2" />
+      <stop
+         id="stop6946-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3-7">
+      <stop
+         id="stop7104-0-1-6-7-9-1-4-9-4-87"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-3-0-7-3" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-8-4-1-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6-9">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-5-8-0-3" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-1-4-7-0"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-1-8-6-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6358-4">
+      <stop
+         id="stop6360-4"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6362-4" />
+      <stop
+         id="stop6364-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6349-5">
+      <stop
+         id="stop6351-7"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6353-4" />
+      <stop
+         id="stop6355-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7-9-5">
+      <stop
+         id="stop7104-0-1-6-7-9-1-8-5-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-4-5-1" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-0-1-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6-6-2">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-3-3-8" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-2-2-8"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-3-8-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6330-9">
+      <stop
+         id="stop6332-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6334-3" />
+      <stop
+         id="stop6336-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6321-4">
+      <stop
+         id="stop6323-4"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6325-0" />
+      <stop
+         id="stop6327-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-9">
+      <stop
+         id="stop7104-0-1-6-7-9-1-4-9-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-3-0-9" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-8-4-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-0">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-5-8-3" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-1-4-6"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-1-8-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6302-2">
+      <stop
+         id="stop6304-9"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6306-1" />
+      <stop
+         id="stop6308-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6293-2">
+      <stop
+         id="stop6295-1"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6297-4" />
+      <stop
+         id="stop6299-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-72-6">
+      <stop
+         id="stop7104-0-1-6-7-9-1-5-1"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-6-8" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-2-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-92-8">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-4-2" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-6-5"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-55-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134-4-5">
+      <stop
+         id="stop6136-6-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6138-0-3" />
+      <stop
+         id="stop6140-7-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125-7-1">
+      <stop
+         id="stop6127-4-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6129-0-3" />
+      <stop
+         id="stop6131-6-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-54">
+      <stop
+         id="stop7104-0-1-6-7-9-1-4-4"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-3-1" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-8-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-6">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-5-5" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-1-8"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-1-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134-3">
+      <stop
+         id="stop6136-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6138-7" />
+      <stop
+         id="stop6140-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125-9">
+      <stop
+         id="stop6127-9"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6129-7" />
+      <stop
+         id="stop6131-69"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7-93">
+      <stop
+         id="stop7104-0-1-6-7-9-1-8-9"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-4-6" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-0-7"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6-2">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-3-5" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-2-0"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-3-83" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699-0-5">
+      <stop
+         id="stop5701-6-4"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop5703-0-9" />
+      <stop
+         id="stop5705-3-1"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690-4-9">
+      <stop
+         id="stop5692-0-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop5694-4-2" />
+      <stop
+         id="stop5696-5-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-2-4">
+      <stop
+         id="stop7104-0-1-6-7-9-1-2-1"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-16-9" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-6-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-9-7">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-2-2" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-0-2"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-5-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699-5">
+      <stop
+         id="stop5701-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop5703-6" />
+      <stop
+         id="stop5705-7"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690-3">
+      <stop
+         id="stop5692-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop5694-5" />
+      <stop
+         id="stop5696-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-9-8">
+      <stop
+         id="stop7104-0-1-6-7-9-1-0-1"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-1-9" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-5-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-5-0">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-8-3" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-7-9"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-7-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363-3-9">
+      <stop
+         id="stop4365-6-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop4367-1-2" />
+      <stop
+         id="stop4369-3-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354-1-9">
+      <stop
+         id="stop4356-1-7"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop4358-6-6" />
+      <stop
+         id="stop4360-2-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-3-8">
+      <stop
+         id="stop7104-0-1-6-7-9-4-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-3-1" />
+      <stop
+         id="stop7106-25-7-1-2-9-3-1"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-5-2">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-5-4" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-0-6"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-2-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363-2">
+      <stop
+         id="stop4365-65"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop4367-3" />
+      <stop
+         id="stop4369-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354-2">
+      <stop
+         id="stop4356-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop4358-8" />
+      <stop
+         id="stop4360-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-1">
+      <stop
+         id="stop7104-0-1-6-7-9-1-58"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-61" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-24"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-8">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-9" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-07"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4142-2">
+      <stop
+         id="stop4144-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop4146-8" />
+      <stop
+         id="stop4148-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4133-9">
+      <stop
+         id="stop4135-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop4137-9" />
+      <stop
+         id="stop4139-7"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-0">
+      <stop
+         id="stop7104-0-1-6-7-9-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-8" />
+      <stop
+         id="stop7106-25-7-1-2-9-1"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-8">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-0" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-8"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3515-3">
+      <stop
+         id="stop3517-7"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3519-4" />
+      <stop
+         id="stop3521-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3506-5">
+      <stop
+         id="stop3508-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3510-3" />
+      <stop
+         id="stop3512-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-22-4">
+      <stop
+         id="stop7104-0-1-6-8-9"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-1-9" />
+      <stop
+         id="stop7106-25-7-1-4-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-2-8">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-5-3" />
+      <stop
+         id="stop7563-1-3-0-1-76-4"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-7-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3265-0">
+      <stop
+         id="stop3267-9"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3269-9" />
+      <stop
+         id="stop3271-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3256-9">
+      <stop
+         id="stop3258-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3260-5" />
+      <stop
+         id="stop3262-1"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-0">
+      <stop
+         id="stop7104-0-1-6-7-7"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-3" />
+      <stop
+         id="stop7106-25-7-1-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-3">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-8" />
+      <stop
+         id="stop7563-1-3-0-1-7-37"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4329-8">
+      <stop
+         id="stop4331-7"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop4333-7" />
+      <stop
+         id="stop4335-8"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4320-9">
+      <stop
+         id="stop4322-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop4324-8" />
+      <stop
+         id="stop4326-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-9">
+      <stop
+         id="stop7104-0-1-6-84"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-14" />
+      <stop
+         id="stop7106-25-7-1-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-0">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-6" />
+      <stop
+         id="stop7563-1-3-0-1-1"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8137-1"
+       inkscape:collect="always">
+      <stop
+         id="stop8139-6"
+         offset="0"
+         style="stop-color:#326097;stop-opacity:1" />
+      <stop
+         id="stop8141-4"
+         offset="1"
+         style="stop-color:#2e73c5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8337-5"
+       inkscape:collect="always">
+      <stop
+         id="stop8339-1"
+         offset="0"
+         style="stop-color:#4e86ca;stop-opacity:1;" />
+      <stop
+         id="stop8341-20"
+         offset="1"
+         style="stop-color:#4e86ca;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8653-7"
+       inkscape:collect="always">
+      <stop
+         id="stop8655-8"
+         offset="0"
+         style="stop-color:#676656;stop-opacity:1;" />
+      <stop
+         id="stop8657-3"
+         offset="1"
+         style="stop-color:#9e884e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8661-50">
+      <stop
+         style="stop-color:#c6e7f9;stop-opacity:1"
+         offset="0"
+         id="stop8663-9" />
+      <stop
+         style="stop-color:#f9fcff;stop-opacity:1"
+         offset="1"
+         id="stop8665-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9291-80"
+       inkscape:collect="always">
+      <stop
+         id="stop9293-1"
+         offset="0"
+         style="stop-color:#e9f8ff;stop-opacity:1;" />
+      <stop
+         id="stop9295-2"
+         offset="1"
+         style="stop-color:#f5f6f9;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9299-6"
+       inkscape:collect="always">
+      <stop
+         id="stop9301-60"
+         offset="0"
+         style="stop-color:#929baa;stop-opacity:1" />
+      <stop
+         id="stop9303-3"
+         offset="1"
+         style="stop-color:#cac3a5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9312-98">
+      <stop
+         id="stop9314-1"
+         offset="0"
+         style="stop-color:#cf6c00;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5db48;stop-opacity:0.24200913"
+         offset="0.36339331"
+         id="stop9322-8" />
+      <stop
+         id="stop9316-2"
+         offset="1"
+         style="stop-color:#c36000;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9324-73">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9326-3" />
+      <stop
+         id="stop9328-5"
+         offset="0.30000001"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9330-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332-1">
+      <stop
+         id="stop9334-7"
+         offset="0"
+         style="stop-color:#f5b517;stop-opacity:1" />
+      <stop
+         style="stop-color:#fcf79e;stop-opacity:1"
+         offset="0.33703175"
+         id="stop9340-7" />
+      <stop
+         id="stop9336-7"
+         offset="1"
+         style="stop-color:#f5ae19;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9510-4">
+      <stop
+         id="stop9512-6"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.35636142"
+         id="stop9514-0" />
+      <stop
+         id="stop9516-7"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9605-0"
+       inkscape:collect="always">
+      <stop
+         id="stop9607-0"
+         offset="0"
+         style="stop-color:#2a5bbf;stop-opacity:1;" />
+      <stop
+         id="stop9609-1"
+         offset="1"
+         style="stop-color:#2a5bbf;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9908-4">
+      <stop
+         style="stop-color:#525f72;stop-opacity:1"
+         offset="0"
+         id="stop9910-1" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop9912-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9914-5">
+      <stop
+         style="stop-color:#4a6fa4;stop-opacity:1"
+         offset="0"
+         id="stop9916-7" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop9918-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10157-6">
+      <stop
+         id="stop10159-0"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:1" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.5"
+         id="stop10165-1" />
+      <stop
+         id="stop10161-6"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10396-7">
+      <stop
+         id="stop10398-3"
+         offset="0"
+         style="stop-color:#1b3e79;stop-opacity:1;" />
+      <stop
+         style="stop-color:#728fbf;stop-opacity:1"
+         offset="0.5"
+         id="stop10404-7" />
+      <stop
+         id="stop10400-2"
+         offset="1"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10414-4">
+      <stop
+         id="stop10416-2"
+         offset="0"
+         style="stop-color:#5078b9;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6d8cbd;stop-opacity:1"
+         offset="0.5"
+         id="stop10422-0" />
+      <stop
+         id="stop10418-9"
+         offset="1"
+         style="stop-color:#5f88c9;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10432-3">
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="0"
+         id="stop10434-6" />
+      <stop
+         id="stop10436-1"
+         offset="0.5"
+         style="stop-color:#4e6da1;stop-opacity:1" />
+      <stop
+         style="stop-color:#567ebc;stop-opacity:1"
+         offset="1"
+         id="stop10438-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-8">
+      <stop
+         id="stop10442-40"
+         offset="0"
+         style="stop-color:#ae7603;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e8d8a3;stop-opacity:1"
+         offset="0.5"
+         id="stop10521-7" />
+      <stop
+         id="stop10444-6"
+         offset="1"
+         style="stop-color:#bb9221;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-2">
+      <stop
+         id="stop10450-9"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe38d;stop-opacity:1"
+         offset="0.25"
+         id="stop10458-1" />
+      <stop
+         style="stop-color:#fdf5d2;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-3" />
+      <stop
+         id="stop10460-5"
+         offset="0.75"
+         style="stop-color:#ffeba7;stop-opacity:1" />
+      <stop
+         id="stop10452-9"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10748-9">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10750-6" />
+      <stop
+         id="stop10752-3"
+         offset="0.25"
+         style="stop-color:#f1ce66;stop-opacity:1" />
+      <stop
+         id="stop10754-7"
+         offset="0.5"
+         style="stop-color:#f6e5a6;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1cf6c;stop-opacity:1"
+         offset="0.75"
+         id="stop10756-8" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10758-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-6">
+      <stop
+         id="stop10800-1"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-8" />
+      <stop
+         id="stop10802-4"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-4">
+      <stop
+         style="stop-color:#7d75ac;stop-opacity:1"
+         offset="0"
+         id="stop10858-6" />
+      <stop
+         id="stop10860-0"
+         offset="0.5"
+         style="stop-color:#574a96;stop-opacity:1" />
+      <stop
+         style="stop-color:#9f99c8;stop-opacity:1"
+         offset="1"
+         id="stop10862-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11128-8">
+      <stop
+         id="stop11130-9"
+         offset="0"
+         style="stop-color:#e4d09d;stop-opacity:1" />
+      <stop
+         style="stop-color:#f6ecb2;stop-opacity:1"
+         offset="0.27413794"
+         id="stop11136-3" />
+      <stop
+         id="stop11132-4"
+         offset="1"
+         style="stop-color:#b58a68;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-6">
+      <stop
+         id="stop11150-1"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687-5">
+      <stop
+         id="stop11689-0"
+         offset="0"
+         style="stop-color:#bdb692;stop-opacity:1;" />
+      <stop
+         style="stop-color:#869097;stop-opacity:1"
+         offset="0.5"
+         id="stop11695-90" />
+      <stop
+         id="stop11691-0"
+         offset="1"
+         style="stop-color:#c3cace;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-28">
+      <stop
+         id="stop11971-6"
+         offset="0"
+         style="stop-color:#6f93c7;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.29546595"
+         id="stop11979-02" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.57727957"
+         id="stop11977-4" />
+      <stop
+         id="stop11973-86"
+         offset="1"
+         style="stop-color:#6f93c7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-8">
+      <stop
+         id="stop12001-6"
+         offset="0"
+         style="stop-color:#f8b098;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8decd;stop-opacity:1"
+         offset="0.5"
+         id="stop12007-5" />
+      <stop
+         id="stop12003-0"
+         offset="1"
+         style="stop-color:#f8b098;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-27">
+      <stop
+         id="stop12090-79"
+         offset="0"
+         style="stop-color:#84a7d5;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a9cded;stop-opacity:1"
+         offset="0.5"
+         id="stop12096-3" />
+      <stop
+         id="stop12092-19"
+         offset="1"
+         style="stop-color:#95b8e0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799-4">
+      <stop
+         id="stop13801-1"
+         offset="0"
+         style="stop-color:#b9772f;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop13809-1" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop13807-3" />
+      <stop
+         id="stop13811-87"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop13803-4"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13834-2">
+      <stop
+         id="stop13836-3"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13838-3"
+         offset="1"
+         style="stop-color:#807e66;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13850-5">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13852-43" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13854-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856-2">
+      <stop
+         id="stop13858-7"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13860-9"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4763-1">
+      <stop
+         id="stop4765-8"
+         offset="0"
+         style="stop-color:#77a29d;stop-opacity:1;" />
+      <stop
+         id="stop4767-9"
+         offset="1"
+         style="stop-color:#1b867b;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4773-5">
+      <stop
+         id="stop4775-7"
+         offset="0"
+         style="stop-color:#8e4694;stop-opacity:1;" />
+      <stop
+         id="stop4777-6"
+         offset="1"
+         style="stop-color:#bc7bc1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4781-1">
+      <stop
+         id="stop4783-6"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop4785-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4789-3">
+      <stop
+         id="stop4791-2"
+         offset="0"
+         style="stop-color:#4e8fbd;stop-opacity:1;" />
+      <stop
+         id="stop4793-2"
+         offset="1"
+         style="stop-color:#30495a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4907-1">
+      <stop
+         id="stop4909-4"
+         offset="0"
+         style="stop-color:#b86c44;stop-opacity:1;" />
+      <stop
+         id="stop4911-2"
+         offset="1"
+         style="stop-color:#8f4017;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4918-2">
+      <stop
+         id="stop4920-7"
+         offset="0"
+         style="stop-color:#d48a4b;stop-opacity:1;" />
+      <stop
+         id="stop4922-6"
+         offset="1"
+         style="stop-color:#b1623a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4928-1">
+      <stop
+         id="stop4930-1"
+         offset="0"
+         style="stop-color:#4dac81;stop-opacity:1;" />
+      <stop
+         id="stop4932-5"
+         offset="1"
+         style="stop-color:#058048;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4938-5">
+      <stop
+         id="stop4940-1"
+         offset="0"
+         style="stop-color:#8bc7d7;stop-opacity:1;" />
+      <stop
+         id="stop4942-7"
+         offset="1"
+         style="stop-color:#17477c;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4961-2">
+      <stop
+         id="stop4963-4"
+         offset="0"
+         style="stop-color:#df9a39;stop-opacity:1;" />
+      <stop
+         id="stop4965-5"
+         offset="1"
+         style="stop-color:#b55829;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5209-4">
+      <stop
+         id="stop5211-8"
+         offset="0"
+         style="stop-color:#5c5c5c;stop-opacity:1;" />
+      <stop
+         id="stop5213-8"
+         offset="1"
+         style="stop-color:#aeaeae;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5328-4">
+      <stop
+         id="stop5330-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop5332-9"
+         offset="1"
+         style="stop-color:#464646;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5148-3">
+      <stop
+         id="stop5150-3"
+         offset="0"
+         style="stop-color:#166b9f;stop-opacity:1" />
+      <stop
+         id="stop5152-1"
+         offset="1"
+         style="stop-color:#6b8fa5;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5238-5">
+      <stop
+         id="stop5240-8"
+         offset="0"
+         style="stop-color:#6d83ac;stop-opacity:1;" />
+      <stop
+         id="stop5242-7"
+         offset="1"
+         style="stop-color:#aeb9ce;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6799-78">
+      <stop
+         id="stop6801-5"
+         offset="0"
+         style="stop-color:#a6bacf;stop-opacity:1;" />
+      <stop
+         id="stop6803-8"
+         offset="1"
+         style="stop-color:#798da2;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7246-17">
+      <stop
+         id="stop7248-2"
+         offset="0"
+         style="stop-color:#3979bd;stop-opacity:1;" />
+      <stop
+         id="stop7250-3"
+         offset="1"
+         style="stop-color:#3979bd;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7254-3">
+      <stop
+         id="stop7256-8"
+         offset="0"
+         style="stop-color:#5b6c89;stop-opacity:1;" />
+      <stop
+         id="stop7258-76"
+         offset="1"
+         style="stop-color:#95a3ba;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7491-8">
+      <stop
+         id="stop7493-1"
+         offset="0"
+         style="stop-color:#5b6c89;stop-opacity:1;" />
+      <stop
+         id="stop7495-6"
+         offset="1"
+         style="stop-color:#a0b0cc;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-4">
+      <stop
+         id="stop7586-7"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1;" />
+      <stop
+         id="stop7588-8"
+         offset="1"
+         style="stop-color:#ffebb7;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-7">
+      <stop
+         id="stop7594-9"
+         offset="0"
+         style="stop-color:#ad7212;stop-opacity:1;" />
+      <stop
+         id="stop7596-3"
+         offset="1"
+         style="stop-color:#875f1e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7160"
+       id="linearGradient7001"
+       x1="6"
+       y1="0.99996567"
+       x2="6"
+       y2="3.4376659"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(14.308131,1036.0155)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6995-6"
+       id="linearGradient7001-1"
+       x1="6"
+       y1="0.99996567"
+       x2="6"
+       y2="3.9999657"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6995-6">
+      <stop
+         style="stop-color:#105c9c;stop-opacity:1;"
+         offset="0"
+         id="stop6997-8" />
+      <stop
+         style="stop-color:#cedeea;stop-opacity:1"
+         offset="1"
+         id="stop6999-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(14.308131,1040.0155)"
+       y2="3.9999657"
+       x2="6"
+       y1="0.99996567"
+       x1="6"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7018"
+       xlink:href="#linearGradient6995-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-5.6918693,1040.0155)"
+       y2="3.9999657"
+       x2="6"
+       y1="0.99996567"
+       x1="6"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7018-7"
+       xlink:href="#linearGradient6995-6-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6995-6-7">
+      <stop
+         style="stop-color:#105c9c;stop-opacity:1;"
+         offset="0"
+         id="stop6997-8-1" />
+      <stop
+         style="stop-color:#cedeea;stop-opacity:1"
+         offset="1"
+         id="stop6999-8-2" />
+    </linearGradient>
+    <linearGradient
+       y2="3.9999657"
+       x2="6"
+       y1="0.99996567"
+       x1="6"
+       gradientTransform="translate(14.308131,1044.0155)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7052"
+       xlink:href="#linearGradient6995-6-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="3.9999657"
+       x2="6"
+       y1="0.99996567"
+       x1="6"
+       gradientTransform="translate(14.308131,1044.0155)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7052-0"
+       xlink:href="#linearGradient6995-6-7-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6995-6-7-4">
+      <stop
+         style="stop-color:#105c9c;stop-opacity:1;"
+         offset="0"
+         id="stop6997-8-1-9" />
+      <stop
+         style="stop-color:#cedeea;stop-opacity:1"
+         offset="1"
+         id="stop6999-8-2-4" />
+    </linearGradient>
+    <linearGradient
+       y2="3.9999657"
+       x2="6"
+       y1="0.99996567"
+       x1="6"
+       gradientTransform="matrix(0.16666671,0,0,1,23.141464,1044.0155)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7086-0"
+       xlink:href="#linearGradient6995-6-7-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6995-6-7-4-3">
+      <stop
+         style="stop-color:#105c9c;stop-opacity:1;"
+         offset="0"
+         id="stop6997-8-1-9-6" />
+      <stop
+         style="stop-color:#cedeea;stop-opacity:1"
+         offset="1"
+         id="stop6999-8-2-4-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7139"
+       id="linearGradient7145"
+       x1="23.30813"
+       y1="1046.5155"
+       x2="25.308131"
+       y2="1046.5155"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-48.616261,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7139"
+       id="linearGradient7147"
+       x1="20.30813"
+       y1="1046.5155"
+       x2="22.30813"
+       y2="1046.5155"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-42.130127,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7160-1"
+       id="linearGradient7001-8"
+       x1="6"
+       y1="0.99996567"
+       x2="6"
+       y2="3.4376659"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(14.308131,1036.0155)" />
+    <linearGradient
+       id="linearGradient7160-1">
+      <stop
+         id="stop7162-2"
+         offset="0"
+         style="stop-color:#105c9c;stop-opacity:1;" />
+      <stop
+         style="stop-color:#568cb9;stop-opacity:1"
+         offset="0.61277843"
+         id="stop7166-4" />
+      <stop
+         id="stop7164-9"
+         offset="1"
+         style="stop-color:#cedeea;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="3.4376659"
+       x2="6"
+       y1="0.99996567"
+       x1="6"
+       gradientTransform="translate(14.308131,1040.0155)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7184"
+       xlink:href="#linearGradient7160-1"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="3.4376659"
+       x2="6"
+       y1="0.99996567"
+       x1="6"
+       gradientTransform="translate(14.308131,1040.0155)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7184-8"
+       xlink:href="#linearGradient7160-1-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7160-1-2">
+      <stop
+         id="stop7162-2-7"
+         offset="0"
+         style="stop-color:#105c9c;stop-opacity:1;" />
+      <stop
+         style="stop-color:#568cb9;stop-opacity:1"
+         offset="0.61277843"
+         id="stop7166-4-1" />
+      <stop
+         id="stop7164-9-7"
+         offset="1"
+         style="stop-color:#cedeea;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="3.4376659"
+       x2="6"
+       y1="0.99996567"
+       x1="6"
+       gradientTransform="translate(14.308131,1044.0155)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7221"
+       xlink:href="#linearGradient7160-1-2"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-27.005631,-6.0220971)"
+       gradientUnits="userSpaceOnUse"
+       y2="1051.9485"
+       x2="31.230719"
+       y1="1043.726"
+       x1="31.230719"
+       id="linearGradient5074"
+       xlink:href="#linearGradient5068"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-27.005631,-6.0220971)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.9135"
+       x2="34.041382"
+       y1="1047.9135"
+       x1="29.105539"
+       id="linearGradient5062"
+       xlink:href="#linearGradient5056"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4846-6"
+       id="linearGradient4937-6"
+       gradientUnits="userSpaceOnUse"
+       x1="5"
+       y1="1"
+       x2="5"
+       y2="6"
+       gradientTransform="translate(6,1036.3622)" />
+    <linearGradient
+       id="linearGradient4846-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4848-8"
+         offset="0"
+         style="stop-color:#937e48;stop-opacity:1" />
+      <stop
+         id="stop4850-57"
+         offset="1"
+         style="stop-color:#7c724f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="6"
+       x2="5"
+       y1="1"
+       x1="5"
+       id="linearGradient4852-21"
+       xlink:href="#linearGradient4846-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4923-2">
+      <stop
+         id="stop4925-3"
+         offset="0"
+         style="stop-color:#ffd991;stop-opacity:1;" />
+      <stop
+         id="stop4927-2"
+         offset="1"
+         style="stop-color:#ffcd6f;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(6,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.8622"
+       x2="4"
+       y1="1039.8622"
+       x1="3"
+       id="linearGradient4904-4"
+       xlink:href="#linearGradient4898-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4898-7">
+      <stop
+         id="stop4900-6"
+         offset="0"
+         style="stop-color:#ffd991;stop-opacity:1;" />
+      <stop
+         id="stop4902-1"
+         offset="1"
+         style="stop-color:#ffcd6f;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(6,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.3622"
+       x2="4.5773602"
+       y1="1038.3622"
+       x1="4.5773602"
+       id="linearGradient4906-2"
+       xlink:href="#linearGradient4898-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4846-4"
+       id="linearGradient4937"
+       gradientUnits="userSpaceOnUse"
+       x1="5"
+       y1="1"
+       x2="5"
+       y2="6"
+       gradientTransform="translate(0,1042.3622)" />
+    <linearGradient
+       id="linearGradient4846-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4848-5"
+         offset="0"
+         style="stop-color:#937e48;stop-opacity:1" />
+      <stop
+         id="stop4850-5"
+         offset="1"
+         style="stop-color:#7c724f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="6"
+       x2="5"
+       y1="1"
+       x1="5"
+       id="linearGradient4852-2"
+       xlink:href="#linearGradient4846-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4923">
+      <stop
+         id="stop4925"
+         offset="0"
+         style="stop-color:#ffd991;stop-opacity:1;" />
+      <stop
+         id="stop4927"
+         offset="1"
+         style="stop-color:#ffcd6f;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,6)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.8622"
+       x2="4"
+       y1="1039.8622"
+       x1="3"
+       id="linearGradient4904-8"
+       xlink:href="#linearGradient4898-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4898-9">
+      <stop
+         id="stop4900-4"
+         offset="0"
+         style="stop-color:#ffd991;stop-opacity:1;" />
+      <stop
+         id="stop4902-8"
+         offset="1"
+         style="stop-color:#ffcd6f;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,6)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.3622"
+       x2="4.5773602"
+       y1="1038.3622"
+       x1="4.5773602"
+       id="linearGradient4906-0"
+       xlink:href="#linearGradient4898-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1039.3622"
+       x2="4.5773602"
+       y1="1038.3622"
+       x1="4.5773602"
+       id="linearGradient4906"
+       xlink:href="#linearGradient4898"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1039.8622"
+       x2="4"
+       y1="1039.8622"
+       x1="3"
+       id="linearGradient4904"
+       xlink:href="#linearGradient4898"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="6"
+       x2="5"
+       y1="1"
+       x1="5"
+       id="linearGradient4852"
+       xlink:href="#linearGradient4846"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4962-2-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4964-2-4"
+         offset="0"
+         style="stop-color:#f6928e;stop-opacity:1" />
+      <stop
+         id="stop4966-1-0"
+         offset="1"
+         style="stop-color:#f13f53;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="13.61885"
+       x2="3.5628386"
+       y1="11.335736"
+       x1="3.5628386"
+       id="linearGradient4838-1"
+       xlink:href="#linearGradient4962-2-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4818"
+       inkscape:collect="always">
+      <stop
+         id="stop4820"
+         offset="0"
+         style="stop-color:#eb9186;stop-opacity:1;" />
+      <stop
+         id="stop4822"
+         offset="1"
+         style="stop-color:#e06b5e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-4,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1041.3081"
+       x2="14.871766"
+       y1="1038.3472"
+       x1="12.03229"
+       id="linearGradient4824"
+       xlink:href="#linearGradient4818"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4910-4-7-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4912-8-4-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0" />
+      <stop
+         id="stop4914-8-0-7"
+         offset="1"
+         style="stop-color:#d1eeff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4910-4-7-5"
+       id="linearGradient4063-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(16,2)"
+       x1="-13"
+       y1="1047.3622"
+       x2="-15"
+       y2="1047.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4810-5">
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1;"
+         offset="0"
+         id="stop4812-1" />
+      <stop
+         style="stop-color:#8694ae;stop-opacity:1"
+         offset="1"
+         id="stop4814-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4810-5"
+       id="linearGradient4121-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.000063)"
+       x1="8.0137892"
+       y1="1036.6622"
+       x2="8.0137892"
+       y2="1050.0707" />
+    <linearGradient
+       id="linearGradient4910-4-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4912-8-4"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0" />
+      <stop
+         id="stop4914-8-0"
+         offset="1"
+         style="stop-color:#d1eeff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4910-4-7"
+       id="linearGradient5062-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(25,-4.000037)"
+       x1="-13"
+       y1="1047.3622"
+       x2="-15"
+       y2="1047.3622" />
+    <linearGradient
+       id="linearGradient5057-7"
+       inkscape:collect="always">
+      <stop
+         id="stop5059-1"
+         offset="0"
+         style="stop-color:#677da9;stop-opacity:1;" />
+      <stop
+         id="stop5061-1"
+         offset="1"
+         style="stop-color:#b4bbd1;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(2,-2.000037)"
+       gradientUnits="userSpaceOnUse"
+       y2="1050.8623"
+       x2="11"
+       y1="1050.8623"
+       x1="6"
+       id="linearGradient5065-1"
+       xlink:href="#linearGradient5057-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4810">
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1;"
+         offset="0"
+         id="stop4812" />
+      <stop
+         style="stop-color:#8694ae;stop-opacity:1"
+         offset="1"
+         id="stop4814" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4810"
+       id="linearGradient4791"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0137892"
+       y1="1036.6622"
+       x2="8.0137892"
+       y2="1050.0707"
+       gradientTransform="translate(-2,2.000062)" />
+    <linearGradient
+       id="linearGradient4919-9"
+       inkscape:collect="always">
+      <stop
+         id="stop4921-4"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4923-60"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1043.3622"
+       x2="-10"
+       y1="1045.3622"
+       x1="-10"
+       id="linearGradient4925-4"
+       xlink:href="#linearGradient4919-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4919-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4921-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4923-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1043.3622"
+       x2="-10"
+       y1="1045.3622"
+       x1="-10"
+       id="linearGradient4925-7"
+       xlink:href="#linearGradient4919-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5583-2">
+      <stop
+         id="stop5585-3"
+         offset="0"
+         style="stop-color:#426e4a;stop-opacity:1;" />
+      <stop
+         id="stop5587-3"
+         offset="1"
+         style="stop-color:#669f71;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="4.671875"
+       x2="2.03125"
+       y1="9.1435204"
+       x1="2.03125"
+       id="linearGradient5589-8"
+       xlink:href="#linearGradient5583-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5591-4">
+      <stop
+         id="stop5593-0"
+         offset="0"
+         style="stop-color:#e0e566;stop-opacity:1;" />
+      <stop
+         id="stop5595-5"
+         offset="1"
+         style="stop-color:#b0b456;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="9.1435204"
+       x2="2.03125"
+       y1="7.8880248"
+       x1="2.03125"
+       id="linearGradient5597-1"
+       xlink:href="#linearGradient5591-4"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="9.1435204"
+       x2="2.03125"
+       y1="7.8880248"
+       x1="2.03125"
+       id="linearGradient5597"
+       xlink:href="#linearGradient5591"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="4.671875"
+       x2="2.03125"
+       y1="9.1435204"
+       x1="2.03125"
+       id="linearGradient5589"
+       xlink:href="#linearGradient5583"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5418-0">
+      <stop
+         id="stop5420-5"
+         offset="0"
+         style="stop-color:#5c5c5c;stop-opacity:1;" />
+      <stop
+         id="stop5422-46"
+         offset="1"
+         style="stop-color:#aeaeae;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5411-1">
+      <stop
+         id="stop5413-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop5415-6"
+         offset="1"
+         style="stop-color:#464646;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5404-8">
+      <stop
+         id="stop5406-6"
+         offset="0"
+         style="stop-color:#5c5c5c;stop-opacity:1;" />
+      <stop
+         id="stop5408-0"
+         offset="1"
+         style="stop-color:#aeaeae;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5397-8">
+      <stop
+         id="stop5399-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop5401-2"
+         offset="1"
+         style="stop-color:#464646;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5209-0-21">
+      <stop
+         id="stop5211-9-6"
+         offset="0"
+         style="stop-color:#5c5c5c;stop-opacity:1;" />
+      <stop
+         id="stop5213-4-3"
+         offset="1"
+         style="stop-color:#aeaeae;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5328-5-7">
+      <stop
+         id="stop5330-9-1"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop5332-8-3"
+         offset="1"
+         style="stop-color:#464646;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4961-6-7">
+      <stop
+         id="stop4963-0-2"
+         offset="0"
+         style="stop-color:#df9a39;stop-opacity:1;" />
+      <stop
+         id="stop4965-3-64"
+         offset="1"
+         style="stop-color:#b55829;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1049.2014"
+       x2="18.744612"
+       y1="1040.0764"
+       x1="15.073242"
+       gradientTransform="translate(-4.625,0)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4983-5-2"
+       xlink:href="#linearGradient4961-6-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4938-8-6">
+      <stop
+         id="stop4940-4-60"
+         offset="0"
+         style="stop-color:#8bc7d7;stop-opacity:1;" />
+      <stop
+         id="stop4942-8-7"
+         offset="1"
+         style="stop-color:#17477c;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4928-4-4">
+      <stop
+         id="stop4930-9-69"
+         offset="0"
+         style="stop-color:#4dac81;stop-opacity:1;" />
+      <stop
+         id="stop4932-8-85"
+         offset="1"
+         style="stop-color:#058048;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4907-9-3">
+      <stop
+         id="stop4909-5-9"
+         offset="0"
+         style="stop-color:#b86c44;stop-opacity:1;" />
+      <stop
+         id="stop4911-0-4"
+         offset="1"
+         style="stop-color:#8f4017;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4918-5-27">
+      <stop
+         id="stop4920-9-8"
+         offset="0"
+         style="stop-color:#d48a4b;stop-opacity:1;" />
+      <stop
+         id="stop4922-9-58"
+         offset="1"
+         style="stop-color:#b1623a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-7-1">
+      <stop
+         id="stop10800-5-2-1-8-4-2"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-1-29" />
+      <stop
+         id="stop10802-1-5-3-0-0-82"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-7-1"
+       id="linearGradient11390-1-4"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10856-6-3-0-0-5">
+      <stop
+         style="stop-color:#7d75ac;stop-opacity:1"
+         offset="0"
+         id="stop10858-0-7-6-0-5" />
+      <stop
+         id="stop10860-7-9-1-0-4"
+         offset="0.5"
+         style="stop-color:#574a96;stop-opacity:1" />
+      <stop
+         style="stop-color:#9f99c8;stop-opacity:1"
+         offset="1"
+         id="stop10862-3-3-8-2-03" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-7-2">
+      <stop
+         id="stop11150-7-8-3-8-77"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-8-6-3-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-30-0">
+      <stop
+         id="stop11150-9-6-9-42"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-6-7-6-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-2-4">
+      <stop
+         id="stop11150-7-5-9-4"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-4-35-25" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-4-4-2">
+      <stop
+         id="stop11150-4-72-2"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-154" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687-2-2-0">
+      <stop
+         id="stop11689-3-7-24"
+         offset="0"
+         style="stop-color:#bdb692;stop-opacity:1;" />
+      <stop
+         style="stop-color:#869097;stop-opacity:1"
+         offset="0.5"
+         id="stop11695-9-8-9" />
+      <stop
+         id="stop11691-10-4-0"
+         offset="1"
+         style="stop-color:#c3cace;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2-1-2">
+      <stop
+         id="stop10800-5-2-1-8-2-5-2-6-88"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-3-3-7-1" />
+      <stop
+         id="stop10802-1-5-3-0-2-2-2-2-86"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-0">
+      <stop
+         id="stop10800-5-2-1-8-2-8-1-5"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-95-0-3" />
+      <stop
+         id="stop10802-1-5-3-0-2-0-9-91"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9-8-6">
+      <stop
+         id="stop12001-1-9-3"
+         offset="0"
+         style="stop-color:#f8b098;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8decd;stop-opacity:1"
+         offset="0.5"
+         id="stop12007-4-6-4" />
+      <stop
+         id="stop12003-3-6-9"
+         offset="1"
+         style="stop-color:#f8b098;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7-6-6">
+      <stop
+         id="stop12090-7-9-05"
+         offset="0"
+         style="stop-color:#84a7d5;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a9cded;stop-opacity:1"
+         offset="0.5"
+         id="stop12096-6-2-9" />
+      <stop
+         id="stop12092-1-3-4"
+         offset="1"
+         style="stop-color:#95b8e0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-9-0-9">
+      <stop
+         id="stop11971-7-1-9"
+         offset="0"
+         style="stop-color:#6f93c7;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.29546595"
+         id="stop11979-0-0-5" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.57727957"
+         id="stop11977-6-1-5" />
+      <stop
+         id="stop11973-8-0-5"
+         offset="1"
+         style="stop-color:#6f93c7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1-8-49"
+       id="linearGradient13011-8-1"
+       gradientUnits="userSpaceOnUse"
+       x1="420.88995"
+       y1="455.88452"
+       x2="440.35345"
+       y2="417.26108" />
+    <linearGradient
+       id="linearGradient12862-1-8-49"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-6-3"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-9-1"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799-7-6">
+      <stop
+         id="stop13801-4-6"
+         offset="0"
+         style="stop-color:#b9772f;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop13809-4-6" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop13807-7-2" />
+      <stop
+         id="stop13811-8-9"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop13803-6-0"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856-0-2">
+      <stop
+         id="stop13858-8-32"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13860-4-4"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13850-2-40">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13852-4-88" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13854-7-15" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-5-57">
+      <stop
+         id="stop10800-5-2-1-8-20-4-5-3-1-4"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-2-0-2-1-7" />
+      <stop
+         id="stop10802-1-5-3-0-4-6-4-2-3-3"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5-57"
+       id="linearGradient13333-0-1-95"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6">
+      <stop
+         id="stop10800-5-2-1-8-20-4-0-2-4"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-2-2-7-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-6-8-5-1"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-7">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-6"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-7" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-83"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-3"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-5" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-0"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-0"
+       id="linearGradient13197-3-3"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-21">
+      <stop
+         id="stop10800-5-2-1-8-20-4-0-4"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-2-2-9" />
+      <stop
+         id="stop10802-1-5-3-0-4-6-8-90"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-84">
+      <stop
+         id="stop10800-5-2-1-8-20-4-5-3-0"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-2-0-2-5" />
+      <stop
+         id="stop10802-1-5-3-0-4-6-4-2-47"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-5">
+      <stop
+         id="stop10800-5-2-1-8-20-4-5-5"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-2-0-15" />
+      <stop
+         id="stop10802-1-5-3-0-4-6-4-5"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-5"
+       id="linearGradient13296-4-83"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-8">
+      <stop
+         id="stop10800-5-2-1-8-20-4-64"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-2-6" />
+      <stop
+         id="stop10802-1-5-3-0-4-6-89"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-8"
+       id="linearGradient13197-7-4"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-7">
+      <stop
+         id="stop10800-5-2-1-8-20-25"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-5" />
+      <stop
+         id="stop10802-1-5-3-0-4-21"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-6-7"
+       id="linearGradient11390-9-0"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10856-6-3-0-5-5">
+      <stop
+         style="stop-color:#7d75ac;stop-opacity:1"
+         offset="0"
+         id="stop10858-0-7-6-9-89" />
+      <stop
+         id="stop10860-7-9-1-9-0"
+         offset="0.5"
+         style="stop-color:#574a96;stop-opacity:1" />
+      <stop
+         style="stop-color:#9f99c8;stop-opacity:1"
+         offset="1"
+         id="stop10862-3-3-8-6-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-9-6">
+      <stop
+         id="stop11150-7-8-3-19-0"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-8-6-2-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-5-87">
+      <stop
+         id="stop11150-9-6-8-8"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-6-7-5-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-5-27">
+      <stop
+         id="stop11150-7-5-2-6"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-4-3-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-4-0-0">
+      <stop
+         id="stop11150-4-1-5"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-9-5" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="417.26108"
+       x2="440.35345"
+       y1="455.88452"
+       x1="420.88995"
+       id="linearGradient12904-2-2"
+       xlink:href="#linearGradient12862-1-89"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12862-1-89"
+       inkscape:collect="always">
+      <stop
+         id="stop12864-3-2"
+         offset="0"
+         style="stop-color:#2d493b;stop-opacity:1;" />
+      <stop
+         id="stop12866-4-8"
+         offset="1"
+         style="stop-color:#296c79;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       r="12.952347"
+       fy="420.74988"
+       fx="433.5452"
+       cy="420.74988"
+       cx="433.5452"
+       id="radialGradient12739-4-0"
+       xlink:href="#linearGradient12717-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient12717-5-8"
+       inkscape:collect="always">
+      <stop
+         id="stop12719-6-0"
+         offset="0"
+         style="stop-color:#e4f1d8;stop-opacity:1" />
+      <stop
+         id="stop12721-9-2"
+         offset="1"
+         style="stop-color:#8ebc7b;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12717-9-8"
+       inkscape:collect="always">
+      <stop
+         id="stop12719-7-2"
+         offset="0"
+         style="stop-color:#e4f1d8;stop-opacity:1" />
+      <stop
+         id="stop12721-6-7"
+         offset="1"
+         style="stop-color:#8ebc7b;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1614831,2.1855961e-7,-2.811228e-7,1.4939602,-69.981471,-211.63828)"
+       r="12.027534"
+       fy="424.34106"
+       fx="433.36786"
+       cy="424.34106"
+       cx="433.36786"
+       id="radialGradient12723-3-57"
+       xlink:href="#linearGradient12717-9-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11687-2-8">
+      <stop
+         id="stop11689-3-2"
+         offset="0"
+         style="stop-color:#bdb692;stop-opacity:1;" />
+      <stop
+         style="stop-color:#869097;stop-opacity:1"
+         offset="0.5"
+         id="stop11695-9-6" />
+      <stop
+         id="stop11691-10-27"
+         offset="1"
+         style="stop-color:#c3cace;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="478.80402"
+       x2="390.76602"
+       y1="458.54279"
+       x1="390.76602"
+       id="linearGradient11693-3-3"
+       xlink:href="#linearGradient11687-2-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11679-3-6"
+       inkscape:collect="always">
+      <stop
+         id="stop11681-91-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.72146118" />
+      <stop
+         id="stop11683-02-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="11.849554"
+       fy="465.42303"
+       fx="385.7438"
+       cy="465.42303"
+       cx="385.7438"
+       id="radialGradient11685-2-8"
+       xlink:href="#linearGradient11679-3-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2-8">
+      <stop
+         id="stop10800-5-2-1-8-2-5-2-3"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-3-3-86" />
+      <stop
+         id="stop10802-1-5-3-0-2-2-2-9"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9-82">
+      <stop
+         id="stop12001-1-4"
+         offset="0"
+         style="stop-color:#f8b098;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8decd;stop-opacity:1"
+         offset="0.5"
+         id="stop12007-4-52" />
+      <stop
+         id="stop12003-3-99"
+         offset="1"
+         style="stop-color:#f8b098;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7-2">
+      <stop
+         id="stop12090-7-1"
+         offset="0"
+         style="stop-color:#84a7d5;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a9cded;stop-opacity:1"
+         offset="0.5"
+         id="stop12096-6-4" />
+      <stop
+         id="stop12092-1-9"
+         offset="1"
+         style="stop-color:#95b8e0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-9-2">
+      <stop
+         id="stop11971-7-4"
+         offset="0"
+         style="stop-color:#6f93c7;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.29546595"
+         id="stop11979-0-5" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.57727957"
+         id="stop11977-6-88" />
+      <stop
+         id="stop11973-8-1"
+         offset="1"
+         style="stop-color:#6f93c7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-4">
+      <stop
+         id="stop10800-5-2-1-8-2-8-60"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-95-3" />
+      <stop
+         id="stop10802-1-5-3-0-2-0-6"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-7-2-12">
+      <stop
+         id="stop12001-9-2-6"
+         offset="0"
+         style="stop-color:#f8b098;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8decd;stop-opacity:1"
+         offset="0.5"
+         id="stop12007-1-3-0" />
+      <stop
+         id="stop12003-2-8-49"
+         offset="1"
+         style="stop-color:#f8b098;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2-1-68">
+      <stop
+         id="stop12090-1-8-8"
+         offset="0"
+         style="stop-color:#84a7d5;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a9cded;stop-opacity:1"
+         offset="0.5"
+         id="stop12096-1-8-27" />
+      <stop
+         id="stop12092-2-4-7"
+         offset="1"
+         style="stop-color:#95b8e0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2-2-2">
+      <stop
+         id="stop11971-3-7-3"
+         offset="0"
+         style="stop-color:#6f93c7;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.29546595"
+         id="stop11979-8-6-41" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.57727957"
+         id="stop11977-7-6-52" />
+      <stop
+         id="stop11973-6-6-31"
+         offset="1"
+         style="stop-color:#6f93c7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687-8-1">
+      <stop
+         id="stop11689-6-4"
+         offset="0"
+         style="stop-color:#bdb692;stop-opacity:1;" />
+      <stop
+         style="stop-color:#869097;stop-opacity:1"
+         offset="0.5"
+         id="stop11695-6-9" />
+      <stop
+         id="stop11691-5-5"
+         offset="1"
+         style="stop-color:#c3cace;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="478.80402"
+       x2="390.76602"
+       y1="458.54279"
+       x1="390.76602"
+       id="linearGradient11693-26-12"
+       xlink:href="#linearGradient11687-8-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11679-8-4"
+       inkscape:collect="always">
+      <stop
+         id="stop11681-3-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.72146118" />
+      <stop
+         id="stop11683-6-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="11.849554"
+       fy="465.42303"
+       fx="385.7438"
+       cy="465.42303"
+       cx="385.7438"
+       id="radialGradient11685-3-1"
+       xlink:href="#linearGradient11679-8-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11687-9-6">
+      <stop
+         id="stop11689-1-66"
+         offset="0"
+         style="stop-color:#bdb692;stop-opacity:1;" />
+      <stop
+         style="stop-color:#869097;stop-opacity:1"
+         offset="0.5"
+         id="stop11695-2-6" />
+      <stop
+         id="stop11691-1-67"
+         offset="1"
+         style="stop-color:#c3cace;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="478.80402"
+       x2="390.76602"
+       y1="458.54279"
+       x1="390.76602"
+       id="linearGradient11693-2-5"
+       xlink:href="#linearGradient11687-9-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11679-7-9"
+       inkscape:collect="always">
+      <stop
+         id="stop11681-94-4"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.72146118" />
+      <stop
+         id="stop11683-0-1"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="11.849554"
+       fy="465.42303"
+       fx="385.7438"
+       cy="465.42303"
+       cx="385.7438"
+       id="radialGradient11685-5-8"
+       xlink:href="#linearGradient11679-7-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11999-7-0">
+      <stop
+         id="stop12001-9-6"
+         offset="0"
+         style="stop-color:#f8b098;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8decd;stop-opacity:1"
+         offset="0.5"
+         id="stop12007-1-9" />
+      <stop
+         id="stop12003-2-7"
+         offset="1"
+         style="stop-color:#f8b098;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2-0">
+      <stop
+         id="stop12090-1-89"
+         offset="0"
+         style="stop-color:#84a7d5;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a9cded;stop-opacity:1"
+         offset="0.5"
+         id="stop12096-1-3" />
+      <stop
+         id="stop12092-2-6"
+         offset="1"
+         style="stop-color:#95b8e0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2-7">
+      <stop
+         id="stop11971-3-3"
+         offset="0"
+         style="stop-color:#6f93c7;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.29546595"
+         id="stop11979-8-58" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.57727957"
+         id="stop11977-7-5" />
+      <stop
+         id="stop11973-6-69"
+         offset="1"
+         style="stop-color:#6f93c7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11888-4-15"
+       inkscape:collect="always">
+      <stop
+         id="stop11890-8-41"
+         offset="0"
+         style="stop-color:#a7c8ec;stop-opacity:1" />
+      <stop
+         id="stop11892-8-3"
+         offset="1"
+         style="stop-color:#b4def6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="444.57022"
+       x2="358.60471"
+       y1="457.29816"
+       x1="342.37973"
+       id="linearGradient11894-5-0"
+       xlink:href="#linearGradient11888-4-15"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11888-8-38"
+       inkscape:collect="always">
+      <stop
+         id="stop11890-4-4"
+         offset="0"
+         style="stop-color:#a7c8ec;stop-opacity:1" />
+      <stop
+         id="stop11892-1-8"
+         offset="1"
+         style="stop-color:#b4def6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="444.57022"
+       x2="358.60471"
+       y1="457.29816"
+       x1="342.37973"
+       id="linearGradient11894-2-3"
+       xlink:href="#linearGradient11888-8-38"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11687-1-9">
+      <stop
+         id="stop11689-9-3"
+         offset="0"
+         style="stop-color:#bdb692;stop-opacity:1;" />
+      <stop
+         style="stop-color:#869097;stop-opacity:1"
+         offset="0.5"
+         id="stop11695-3-81" />
+      <stop
+         id="stop11691-9-0"
+         offset="1"
+         style="stop-color:#c3cace;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="478.80402"
+       x2="390.76602"
+       y1="458.54279"
+       x1="390.76602"
+       id="linearGradient11693-0-6"
+       xlink:href="#linearGradient11687-1-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11679-2-38"
+       inkscape:collect="always">
+      <stop
+         id="stop11681-9-7"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.72146118" />
+      <stop
+         id="stop11683-1-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="11.849554"
+       fy="465.42303"
+       fx="385.7438"
+       cy="465.42303"
+       cx="385.7438"
+       id="radialGradient11685-7-08"
+       xlink:href="#linearGradient11679-2-38"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-51">
+      <stop
+         id="stop10800-5-2-1-8-2-5-1"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-3-5" />
+      <stop
+         id="stop10802-1-5-3-0-2-2-9"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-1-51"
+       id="linearGradient11520-8-40"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-2-4">
+      <stop
+         id="stop10800-5-2-1-8-2-6-5"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-9-0" />
+      <stop
+         id="stop10802-1-5-3-0-2-6-4"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-2-4"
+       id="linearGradient11520-3-82"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-5">
+      <stop
+         id="stop10800-5-2-1-8-2-55"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-0" />
+      <stop
+         id="stop10802-1-5-3-0-2-92"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-5"
+       id="linearGradient11390-0-7"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10856-6-3-0-1-8">
+      <stop
+         style="stop-color:#7d75ac;stop-opacity:1"
+         offset="0"
+         id="stop10858-0-7-6-1-0" />
+      <stop
+         id="stop10860-7-9-1-7-1"
+         offset="0.5"
+         style="stop-color:#574a96;stop-opacity:1" />
+      <stop
+         style="stop-color:#9f99c8;stop-opacity:1"
+         offset="1"
+         id="stop10862-3-3-8-4-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-6-5">
+      <stop
+         id="stop11150-7-8-3-1-97"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-8-6-6-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-3-1">
+      <stop
+         id="stop11150-9-6-4-9"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-6-7-2-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-4-1">
+      <stop
+         id="stop11150-7-5-5-4"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-4-9-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-4-5-8">
+      <stop
+         id="stop11150-4-7-7"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-2-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-142"
+       id="linearGradient11390-2"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-142">
+      <stop
+         id="stop10800-5-2-1-8-53"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-8" />
+      <stop
+         id="stop10802-1-5-3-0-9"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-142"
+       id="linearGradient10880-5-3-4-5"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10856-6-3-0-198">
+      <stop
+         style="stop-color:#7d75ac;stop-opacity:1"
+         offset="0"
+         id="stop10858-0-7-6-98" />
+      <stop
+         id="stop10860-7-9-1-91"
+         offset="0.5"
+         style="stop-color:#574a96;stop-opacity:1" />
+      <stop
+         style="stop-color:#9f99c8;stop-opacity:1"
+         offset="1"
+         id="stop10862-3-3-8-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10856-6-3-0-198"
+       id="linearGradient11298-3-3"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient11146-8-7-5-82">
+      <stop
+         id="stop11150-7-8-3-34"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-8-6-02" />
+    </linearGradient>
+    <radialGradient
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-154.64572)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11274-3-9"
+       xlink:href="#linearGradient11146-8-7-5-82"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-7-5-9">
+      <stop
+         id="stop11150-9-6-2"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-6-7-1" />
+    </linearGradient>
+    <radialGradient
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-154.64572)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11272-3-3"
+       xlink:href="#linearGradient11146-7-5-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-8-3-51">
+      <stop
+         id="stop11150-7-5-4"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-4-36" />
+    </linearGradient>
+    <radialGradient
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11270-4-0"
+       xlink:href="#linearGradient11146-8-3-51"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-4-8">
+      <stop
+         id="stop11150-4-00"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-88" />
+    </linearGradient>
+    <radialGradient
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11268-5-9"
+       xlink:href="#linearGradient11146-4-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-36">
+      <stop
+         id="stop10800-5-2-1-84"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-7" />
+      <stop
+         id="stop10802-1-5-3-3"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-2">
+      <stop
+         style="stop-color:#7d75ac;stop-opacity:1"
+         offset="0"
+         id="stop10858-0-7-3" />
+      <stop
+         id="stop10860-7-9-4"
+         offset="0.5"
+         style="stop-color:#574a96;stop-opacity:1" />
+      <stop
+         style="stop-color:#9f99c8;stop-opacity:1"
+         offset="1"
+         id="stop10862-3-3-34" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10856-6-3-2"
+       id="linearGradient11063-6-8"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient11146-8-7-24">
+      <stop
+         id="stop11150-7-8-33"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-8-62" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-7-24"
+       id="radialGradient11169-6-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-7-51">
+      <stop
+         id="stop11150-9-7"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-6-60" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)"
+       gradientUnits="userSpaceOnUse"
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       id="radialGradient11144-2-1"
+       xlink:href="#linearGradient11146-7-51"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-8-55">
+      <stop
+         id="stop11150-7-1"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-0" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)"
+       gradientUnits="userSpaceOnUse"
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       id="radialGradient11144-4-2"
+       xlink:href="#linearGradient11146-8-55"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-4">
+      <stop
+         style="stop-color:#7d75ac;stop-opacity:1"
+         offset="0"
+         id="stop10858-0-6" />
+      <stop
+         id="stop10860-7-26"
+         offset="0.5"
+         style="stop-color:#574a96;stop-opacity:1" />
+      <stop
+         style="stop-color:#9f99c8;stop-opacity:1"
+         offset="1"
+         id="stop10862-3-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10856-6-4"
+       id="linearGradient10835-2-4"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-5">
+      <stop
+         id="stop10800-5-2-6"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-6" />
+      <stop
+         id="stop10802-1-5-1"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-5">
+      <stop
+         id="stop10800-5-6"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-2" />
+      <stop
+         id="stop10802-1-53"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       id="linearGradient10804-8-4"
+       xlink:href="#linearGradient10798-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-8-2">
+      <stop
+         id="stop10800-2-6"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-9-63" />
+      <stop
+         id="stop10802-3-9"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       id="linearGradient10804-7-8"
+       xlink:href="#linearGradient10798-8-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="511.38498"
+       x2="322.875"
+       y1="536.61243"
+       x1="322.875"
+       gradientTransform="translate(0.88388349,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10794-6"
+       xlink:href="#linearGradient10149-6-5-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="504.44818"
+       x2="322.875"
+       y1="536.61243"
+       x1="322.875"
+       gradientTransform="translate(0,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10792-2"
+       xlink:href="#linearGradient10149-39-59"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="542.73901"
+       x2="305"
+       y1="504.36218"
+       x1="305"
+       gradientTransform="translate(0,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10790-3"
+       xlink:href="#linearGradient10157-2-9"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="514.67456"
+       x2="302.3125"
+       y1="532.98718"
+       x1="302.3125"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10788-25"
+       xlink:href="#linearGradient10396-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="514.75818"
+       x2="306.05069"
+       y1="532.08228"
+       x1="306.05069"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10786-4"
+       xlink:href="#linearGradient10157-03"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="519.36218"
+       x2="289.8125"
+       y1="528.73804"
+       x1="289.8125"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10784-5"
+       xlink:href="#linearGradient10432-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="519.08923"
+       x2="298.34253"
+       y1="528.1048"
+       x1="298.34253"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10782-64"
+       xlink:href="#linearGradient10414-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10780-9"
+       xlink:href="#linearGradient10440-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10778-51"
+       xlink:href="#linearGradient10448-41"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="515.73615"
+       x2="334.375"
+       y1="532.30212"
+       x1="334.375"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10776-5"
+       xlink:href="#linearGradient10440-1-3-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="515.53949"
+       x2="324.1601"
+       y1="532.15552"
+       x1="324.1601"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10774-1"
+       xlink:href="#linearGradient10748-26"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="518.67365"
+       x2="334.375"
+       y1="529.06494"
+       x1="334.375"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10772-86"
+       xlink:href="#linearGradient10440-1-0-0-83"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="518.28192"
+       x2="323.98331"
+       y1="529.30121"
+       x1="324.1601"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10770-5"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-1-0-0-83">
+      <stop
+         id="stop10442-43-2-0-97"
+         offset="0"
+         style="stop-color:#ae7603;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e8d8a3;stop-opacity:1"
+         offset="0.5"
+         id="stop10521-1-2-5-6" />
+      <stop
+         id="stop10444-3-4-0-4"
+         offset="1"
+         style="stop-color:#bb9221;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-9-7-0-5">
+      <stop
+         id="stop10450-3-5-6-8"
+         offset="0"
+         style="stop-color:#cf9307;stop-opacity:1" />
+      <stop
+         style="stop-color:#f7d87b;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-4-1-5-3" />
+      <stop
+         id="stop10452-22-7-8-94"
+         offset="1"
+         style="stop-color:#ebb313;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-3-7">
+      <stop
+         id="stop10442-43-0-6"
+         offset="0"
+         style="stop-color:#ae7603;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e8d8a3;stop-opacity:1"
+         offset="0.5"
+         id="stop10521-1-4-3" />
+      <stop
+         id="stop10444-3-2-56"
+         offset="1"
+         style="stop-color:#bb9221;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-3-7"
+       id="linearGradient10548-1-08"
+       gradientUnits="userSpaceOnUse"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientTransform="translate(7.4375,2.6171875e-6)" />
+    <linearGradient
+       id="linearGradient10448-9-6-4">
+      <stop
+         id="stop10450-3-8-8"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe38d;stop-opacity:1"
+         offset="0.25"
+         id="stop10458-8-7-6" />
+      <stop
+         style="stop-color:#fdf5d2;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-4-7-0" />
+      <stop
+         id="stop10460-2-1-9"
+         offset="0.75"
+         style="stop-color:#ffeba7;stop-opacity:1" />
+      <stop
+         id="stop10452-22-8-30"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-6-4"
+       id="linearGradient10546-8-8"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientTransform="translate(7.4375,2.6171875e-6)" />
+    <linearGradient
+       id="linearGradient10440-1-0-18">
+      <stop
+         id="stop10442-43-2-2"
+         offset="0"
+         style="stop-color:#ae7603;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e8d8a3;stop-opacity:1"
+         offset="0.5"
+         id="stop10521-1-2-8" />
+      <stop
+         id="stop10444-3-4-01"
+         offset="1"
+         style="stop-color:#bb9221;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-0-18"
+       id="linearGradient10548-3-9"
+       gradientUnits="userSpaceOnUse"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientTransform="translate(7.4375,2.6171875e-6)" />
+    <linearGradient
+       id="linearGradient10448-9-7-58">
+      <stop
+         id="stop10450-3-5-3"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe38d;stop-opacity:1"
+         offset="0.25"
+         id="stop10458-8-0-78" />
+      <stop
+         style="stop-color:#fdf5d2;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-4-1-37" />
+      <stop
+         id="stop10460-2-9-9"
+         offset="0.75"
+         style="stop-color:#ffeba7;stop-opacity:1" />
+      <stop
+         id="stop10452-22-7-3"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-58"
+       id="linearGradient10546-3-95"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientTransform="translate(7.4375,2.6171875e-6)" />
+    <linearGradient
+       id="linearGradient10440-1-03">
+      <stop
+         id="stop10442-43-13"
+         offset="0"
+         style="stop-color:#ae7603;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e8d8a3;stop-opacity:1"
+         offset="0.5"
+         id="stop10521-1-37" />
+      <stop
+         id="stop10444-3-0"
+         offset="1"
+         style="stop-color:#bb9221;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       id="linearGradient10446-7-27"
+       xlink:href="#linearGradient10440-1-03"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-8">
+      <stop
+         id="stop10450-3-80"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe38d;stop-opacity:1"
+         offset="0.25"
+         id="stop10458-8-1" />
+      <stop
+         style="stop-color:#fdf5d2;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-4-3" />
+      <stop
+         id="stop10460-2-2"
+         offset="0.75"
+         style="stop-color:#ffeba7;stop-opacity:1" />
+      <stop
+         id="stop10452-22-2"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       id="linearGradient10454-9-05"
+       xlink:href="#linearGradient10448-9-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-2-9"
+       inkscape:collect="always">
+      <stop
+         id="stop10442-4-4"
+         offset="0"
+         style="stop-color:#ae7603;stop-opacity:1;" />
+      <stop
+         id="stop10444-4-5"
+         offset="1"
+         style="stop-color:#bb9221;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       id="linearGradient10446-9-5"
+       xlink:href="#linearGradient10440-2-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-4-5">
+      <stop
+         id="stop10450-4-5"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe38d;stop-opacity:1"
+         offset="0.25"
+         id="stop10458-7-26" />
+      <stop
+         style="stop-color:#fdf5d2;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-9-8" />
+      <stop
+         id="stop10460-1-92"
+         offset="0.75"
+         style="stop-color:#ffeba7;stop-opacity:1" />
+      <stop
+         id="stop10452-2-9"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       id="linearGradient10454-7-3"
+       xlink:href="#linearGradient10448-4-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10149-6-5-4">
+      <stop
+         id="stop10151-5-7-8"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#b9c7df;stop-opacity:1"
+         offset="0.5"
+         id="stop10394-1" />
+      <stop
+         id="stop10153-8-1-4"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10149-39-59"
+       inkscape:collect="always">
+      <stop
+         id="stop10151-3-3"
+         offset="0"
+         style="stop-color:#1d4d9d;stop-opacity:1" />
+      <stop
+         id="stop10153-72-287"
+         offset="1"
+         style="stop-color:#638ac8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="504.44818"
+       x2="322.875"
+       y1="536.61243"
+       x1="322.875"
+       id="linearGradient10155-7-05"
+       xlink:href="#linearGradient10149-39-59"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10157-2-9">
+      <stop
+         id="stop10159-8-31"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:1" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.5"
+         id="stop10165-3-48" />
+      <stop
+         id="stop10161-5-2"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="542.73901"
+       x2="305"
+       y1="504.36218"
+       x1="305"
+       id="linearGradient10163-2-2"
+       xlink:href="#linearGradient10157-2-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10149-6-9"
+       inkscape:collect="always">
+      <stop
+         id="stop10151-5-0"
+         offset="0"
+         style="stop-color:#1d4d9d;stop-opacity:1" />
+      <stop
+         id="stop10153-8-4"
+         offset="1"
+         style="stop-color:#638ac8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="504.44818"
+       x2="322.875"
+       y1="536.61243"
+       x1="322.875"
+       id="linearGradient10155-5-1"
+       xlink:href="#linearGradient10149-6-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10149-3-6"
+       inkscape:collect="always">
+      <stop
+         id="stop10151-0-3"
+         offset="0"
+         style="stop-color:#1d4d9d;stop-opacity:1" />
+      <stop
+         id="stop10153-7-0"
+         offset="1"
+         style="stop-color:#638ac8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="504.44818"
+       x2="322.875"
+       y1="536.61243"
+       x1="322.875"
+       id="linearGradient10155-1-3"
+       xlink:href="#linearGradient10149-3-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10157-5-0">
+      <stop
+         id="stop10159-7-77"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:1" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.5"
+         id="stop10165-2-4" />
+      <stop
+         id="stop10161-3-31"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="542.73901"
+       x2="305"
+       y1="504.36218"
+       x1="305"
+       id="linearGradient10163-8-68"
+       xlink:href="#linearGradient10157-5-0"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="463.04114"
+       x2="567.47571"
+       y1="489.69833"
+       x1="567.47571"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10005-5"
+       xlink:href="#linearGradient9299-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="463.98975"
+       x2="548.41693"
+       y1="488.59351"
+       x1="548.41693"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10003-4"
+       xlink:href="#linearGradient9291-8-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="472.63525"
+       x2="556.25635"
+       y1="472.63525"
+       x1="526.85181"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10001-7"
+       xlink:href="#linearGradient9510-1"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="448.46484"
+       x2="556.9375"
+       y1="448.46484"
+       x1="526.4375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9999-08"
+       xlink:href="#linearGradient9312-87"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="460.34375"
+       x2="555.01776"
+       y1="460.34375"
+       x1="528.36798"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9997-29"
+       xlink:href="#linearGradient9332-98"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="269.33588"
+       x2="636.09375"
+       y1="279.41037"
+       x1="636.09375"
+       gradientTransform="translate(-33.506824,0.34375262)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9984-1"
+       xlink:href="#linearGradient9914-9"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9982-4"
+       xlink:href="#linearGradient8153-2-4-4-1"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="276.3064"
+       x2="641.07611"
+       y1="308.68875"
+       x1="641.07611"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9980-32"
+       xlink:href="#linearGradient8653-2-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="281.43512"
+       x2="641.07611"
+       y1="306.07397"
+       x1="641.07611"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9978-53"
+       xlink:href="#linearGradient9908-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="269.33588"
+       x2="636.09375"
+       y1="275.53125"
+       x1="636.09375"
+       gradientTransform="translate(-33.506824,0.34375)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9976-7"
+       xlink:href="#linearGradient8337-2-41"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientTransform="translate(-33.506824,3e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9974-41"
+       xlink:href="#linearGradient8153-2-0-9"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="283.2832"
+       x2="657.71722"
+       y1="283.2832"
+       x1="617.06256"
+       gradientTransform="translate(-33.506824,0)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9972-03"
+       xlink:href="#linearGradient8137-6-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="308.57455"
+       x2="636.99469"
+       y1="277.45544"
+       x1="636.99469"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9970-19"
+       xlink:href="#linearGradient8661-5-59"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="472.63525"
+       x2="556.25635"
+       y1="472.63525"
+       x1="526.85181"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9968-7"
+       xlink:href="#linearGradient9510-3-28"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="448.46484"
+       x2="556.9375"
+       y1="448.46484"
+       x1="526.4375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9966-7"
+       xlink:href="#linearGradient9312-9-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="460.34375"
+       x2="555.01776"
+       y1="460.34375"
+       x1="528.36798"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9964-1"
+       xlink:href="#linearGradient9332-6-22"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="454.31174"
+       x2="227.09628"
+       y1="441.62799"
+       x1="213.82529"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9962-6"
+       xlink:href="#linearGradient9605-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8337-1-3-2"
+       inkscape:collect="always">
+      <stop
+         id="stop8339-4-2-7"
+         offset="0"
+         style="stop-color:#4e86ca;stop-opacity:1;" />
+      <stop
+         id="stop8341-2-6-9"
+         offset="1"
+         style="stop-color:#4e86ca;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="269.33588"
+       x2="636.09375"
+       y1="275.53125"
+       x1="636.09375"
+       gradientTransform="translate(0,0.34375262)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8703-1-58"
+       xlink:href="#linearGradient8337-1-3-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8153-2-4-4-1"
+       inkscape:collect="always">
+      <stop
+         id="stop8155-7-78-0-3"
+         offset="0"
+         style="stop-color:#75b1e3;stop-opacity:1;" />
+      <stop
+         id="stop8157-7-0-7-9"
+         offset="1"
+         style="stop-color:#c1def7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8653-2-5"
+       inkscape:collect="always">
+      <stop
+         id="stop8655-9-92"
+         offset="0"
+         style="stop-color:#676656;stop-opacity:1;" />
+      <stop
+         id="stop8657-2-54"
+         offset="1"
+         style="stop-color:#9e884e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="276.3064"
+       x2="641.07611"
+       y1="308.68875"
+       x1="641.07611"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8697-5-8"
+       xlink:href="#linearGradient8653-2-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8337-2-41"
+       inkscape:collect="always">
+      <stop
+         id="stop8339-7-0"
+         offset="0"
+         style="stop-color:#4e86ca;stop-opacity:1;" />
+      <stop
+         id="stop8341-8-4"
+         offset="1"
+         style="stop-color:#4e86ca;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8153-2-0-9"
+       inkscape:collect="always">
+      <stop
+         id="stop8155-7-9-05"
+         offset="0"
+         style="stop-color:#75b1e3;stop-opacity:1;" />
+      <stop
+         id="stop8157-7-5-3"
+         offset="1"
+         style="stop-color:#c1def7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8137-6-8"
+       inkscape:collect="always">
+      <stop
+         id="stop8139-1-50"
+         offset="0"
+         style="stop-color:#326097;stop-opacity:1" />
+      <stop
+         id="stop8141-6-7"
+         offset="1"
+         style="stop-color:#2e73c5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8661-5-59">
+      <stop
+         style="stop-color:#c6e7f9;stop-opacity:1"
+         offset="0"
+         id="stop8663-3-1" />
+      <stop
+         style="stop-color:#f9fcff;stop-opacity:1"
+         offset="1"
+         id="stop8665-5-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9510-3-28">
+      <stop
+         id="stop9512-4-07"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.35636142"
+         id="stop9514-9-2" />
+      <stop
+         id="stop9516-6-2"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9510-3-28"
+       id="linearGradient9415-5-35"
+       gradientUnits="userSpaceOnUse"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)" />
+    <linearGradient
+       id="linearGradient9312-9-3">
+      <stop
+         id="stop9314-5-6"
+         offset="0"
+         style="stop-color:#cf6c00;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5db48;stop-opacity:0.24200913"
+         offset="0.36339331"
+         id="stop9322-0-3" />
+      <stop
+         id="stop9316-6-0"
+         offset="1"
+         style="stop-color:#c36000;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332-6-22">
+      <stop
+         id="stop9334-52-17"
+         offset="0"
+         style="stop-color:#f5b517;stop-opacity:1" />
+      <stop
+         style="stop-color:#fcf79e;stop-opacity:1"
+         offset="0.33703175"
+         id="stop9340-23-4" />
+      <stop
+         id="stop9336-3-82"
+         offset="1"
+         style="stop-color:#f5ae19;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9299-1-1"
+       inkscape:collect="always">
+      <stop
+         id="stop9301-6-5"
+         offset="0"
+         style="stop-color:#929baa;stop-opacity:1" />
+      <stop
+         id="stop9303-8-5"
+         offset="1"
+         style="stop-color:#cac3a5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="463.04114"
+       x2="567.47571"
+       y1="489.69833"
+       x1="567.47571"
+       id="linearGradient9305-8-3"
+       xlink:href="#linearGradient9299-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9291-8-2"
+       inkscape:collect="always">
+      <stop
+         id="stop9293-7-8"
+         offset="0"
+         style="stop-color:#e9f8ff;stop-opacity:1;" />
+      <stop
+         id="stop9295-3-10"
+         offset="1"
+         style="stop-color:#f5f6f9;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="463.98975"
+       x2="548.41693"
+       y1="488.59351"
+       x1="548.41693"
+       id="linearGradient9297-1-5"
+       xlink:href="#linearGradient9291-8-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9324-7-47">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9326-0-46" />
+      <stop
+         id="stop9328-1-3"
+         offset="0.30000001"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9330-5-6" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="472.63525"
+       x2="556.25635"
+       y1="472.63525"
+       x1="526.85181"
+       id="linearGradient9318-3"
+       xlink:href="#linearGradient9324-7-47"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9332-9-30">
+      <stop
+         id="stop9334-5-8"
+         offset="0"
+         style="stop-color:#f5b517;stop-opacity:1" />
+      <stop
+         style="stop-color:#fcf79e;stop-opacity:1"
+         offset="0.33703175"
+         id="stop9340-2-9" />
+      <stop
+         id="stop9336-4-1"
+         offset="1"
+         style="stop-color:#f5ae19;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="460.34375"
+       x2="555.01776"
+       y1="460.34375"
+       x1="528.36798"
+       id="linearGradient9338-8-5"
+       xlink:href="#linearGradient9332-9-30"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="463.04114"
+       x2="567.47571"
+       y1="489.69833"
+       x1="567.47571"
+       id="linearGradient9305-4"
+       xlink:href="#linearGradient9299-7"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="463.98975"
+       x2="548.41693"
+       y1="488.59351"
+       x1="548.41693"
+       id="linearGradient9297-6"
+       xlink:href="#linearGradient9291-34"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="269.33588"
+       x2="636.09375"
+       y1="275.53125"
+       x1="636.09375"
+       gradientTransform="translate(0,0.34375262)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8703-0"
+       xlink:href="#linearGradient8337-1-9"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientTransform="translate(0,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8701-1"
+       xlink:href="#linearGradient8153-2-4-32"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="283.2832"
+       x2="657.71722"
+       y1="283.2832"
+       x1="617.06256"
+       gradientTransform="translate(0,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8699-5"
+       xlink:href="#linearGradient8137-93-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="276.3064"
+       x2="641.07611"
+       y1="308.68875"
+       x1="641.07611"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8697-9"
+       xlink:href="#linearGradient8653-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="276.3064"
+       x2="641.07611"
+       y1="308.68875"
+       x1="641.07611"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8695-5"
+       xlink:href="#linearGradient8653-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="276.3064"
+       x2="641.07611"
+       y1="308.68875"
+       x1="641.07611"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8693-1"
+       xlink:href="#linearGradient8653-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="276.3064"
+       x2="641.07611"
+       y1="308.68875"
+       x1="641.07611"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8691-1"
+       xlink:href="#linearGradient8653-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="276.3064"
+       x2="641.07611"
+       y1="308.68875"
+       x1="641.07611"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8689-4"
+       xlink:href="#linearGradient8653-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="269.33588"
+       x2="636.09375"
+       y1="275.53125"
+       x1="636.09375"
+       gradientTransform="translate(0,0.34375)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8687-2"
+       xlink:href="#linearGradient8337-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientTransform="translate(0,3e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8685-83"
+       xlink:href="#linearGradient8153-2-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="283.2832"
+       x2="657.71722"
+       y1="283.2832"
+       x1="617.06256"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8683-5"
+       xlink:href="#linearGradient8137-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="308.57455"
+       x2="636.99469"
+       y1="277.45544"
+       x1="636.99469"
+       gradientTransform="translate(0,2.6171875e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8681-8"
+       xlink:href="#linearGradient8661-0"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="276.3064"
+       x2="641.07611"
+       y1="308.68875"
+       x1="641.07611"
+       id="linearGradient8659-57"
+       xlink:href="#linearGradient8653-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8498-7"
+       inkscape:collect="always">
+      <stop
+         id="stop8500-3"
+         offset="0"
+         style="stop-color:#d9f4ff;stop-opacity:1" />
+      <stop
+         id="stop8502-1"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="308.57455"
+       x2="636.99469"
+       y1="277.45544"
+       x1="636.99469"
+       id="linearGradient8504-3"
+       xlink:href="#linearGradient8498-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8137-93-7"
+       inkscape:collect="always">
+      <stop
+         id="stop8139-9-9"
+         offset="0"
+         style="stop-color:#326097;stop-opacity:1" />
+      <stop
+         id="stop8141-8-2"
+         offset="1"
+         style="stop-color:#2e73c5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8153-2-4-32"
+       inkscape:collect="always">
+      <stop
+         id="stop8155-7-78-44"
+         offset="0"
+         style="stop-color:#75b1e3;stop-opacity:1;" />
+      <stop
+         id="stop8157-7-0-42"
+         offset="1"
+         style="stop-color:#c1def7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8337-1-9"
+       inkscape:collect="always">
+      <stop
+         id="stop8339-4-26"
+         offset="0"
+         style="stop-color:#4e86ca;stop-opacity:1;" />
+      <stop
+         id="stop8341-2-5"
+         offset="1"
+         style="stop-color:#4e86ca;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8153-2-6-3"
+       inkscape:collect="always">
+      <stop
+         id="stop8155-7-6-99"
+         offset="0"
+         style="stop-color:#75b1e3;stop-opacity:1;" />
+      <stop
+         id="stop8157-7-6-5"
+         offset="1"
+         style="stop-color:#c1def7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientTransform="translate(0,3e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8291-2-1"
+       xlink:href="#linearGradient8153-2-6-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8137-9-5-7"
+       inkscape:collect="always">
+      <stop
+         id="stop8139-4-2-27"
+         offset="0"
+         style="stop-color:#326097;stop-opacity:1" />
+      <stop
+         id="stop8141-1-9-65"
+         offset="1"
+         style="stop-color:#2e73c5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-9-5-7"
+       id="linearGradient8182-2"
+       gradientUnits="userSpaceOnUse"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832"
+       gradientTransform="translate(0,2.6171875e-6)" />
+    <linearGradient
+       id="linearGradient8153-2-8-9"
+       inkscape:collect="always">
+      <stop
+         id="stop8155-7-7-1"
+         offset="0"
+         style="stop-color:#75b1e3;stop-opacity:1;" />
+      <stop
+         id="stop8157-7-3-6"
+         offset="1"
+         style="stop-color:#c1def7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-8-9"
+       id="linearGradient8180-3-71"
+       gradientUnits="userSpaceOnUse"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238"
+       gradientTransform="translate(0,2.6171875e-6)" />
+    <linearGradient
+       id="linearGradient8137-9-6"
+       inkscape:collect="always">
+      <stop
+         id="stop8139-4-67"
+         offset="0"
+         style="stop-color:#326097;stop-opacity:1" />
+      <stop
+         id="stop8141-1-67"
+         offset="1"
+         style="stop-color:#2e73c5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="283.2832"
+       x2="657.71722"
+       y1="283.2832"
+       x1="617.06256"
+       id="linearGradient8143-2-56"
+       xlink:href="#linearGradient8137-9-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient8153-2-5"
+       inkscape:collect="always">
+      <stop
+         id="stop8155-7-62"
+         offset="0"
+         style="stop-color:#75b1e3;stop-opacity:1;" />
+      <stop
+         id="stop8157-7-03"
+         offset="1"
+         style="stop-color:#c1def7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       id="linearGradient8159-0-4"
+       xlink:href="#linearGradient8153-2-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7686-9-7-4"
+       inkscape:collect="always">
+      <stop
+         id="stop7688-7-1-50"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop7690-5-0-1"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7686-9-7-4"
+       id="linearGradient7755-5-3"
+       gradientUnits="userSpaceOnUse"
+       x1="1303.0625"
+       y1="610.34235"
+       x2="1303.0625"
+       y2="723.85583"
+       gradientTransform="translate(0,-140)" />
+    <linearGradient
+       id="linearGradient7686-9-1"
+       inkscape:collect="always">
+      <stop
+         id="stop7688-7-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop7690-5-08"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="723.85583"
+       x2="1303.0625"
+       y1="610.34235"
+       x1="1303.0625"
+       id="linearGradient7692-4-37"
+       xlink:href="#linearGradient7686-9-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7115-89">
+      <stop
+         id="stop7117-30"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7119-74" />
+      <stop
+         id="stop7121-78"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7106-8">
+      <stop
+         id="stop7108-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7110-7" />
+      <stop
+         id="stop7112-70"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3-0-2">
+      <stop
+         id="stop7104-0-1-6-7-9-1-4-9-4-8-9"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-3-0-7-1-03" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-8-4-1-9-8"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6-1-4">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-5-8-0-8-8" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-1-4-7-3-3"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-1-8-6-8-01" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6949-17">
+      <stop
+         id="stop6951-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6953-0" />
+      <stop
+         id="stop6955-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6940-0">
+      <stop
+         id="stop6942-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6944-1" />
+      <stop
+         id="stop6946-1"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3-55">
+      <stop
+         id="stop7104-0-1-6-7-9-1-4-9-4-40"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-3-0-7-2" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-8-4-1-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6-2">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-5-8-0-2" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-1-4-7-36"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-1-8-6-71" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6358-9">
+      <stop
+         id="stop6360-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6362-3" />
+      <stop
+         id="stop6364-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6349-57">
+      <stop
+         id="stop6351-74"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6353-5" />
+      <stop
+         id="stop6355-7"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7-9-8">
+      <stop
+         id="stop7104-0-1-6-7-9-1-8-5-4"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-4-5-9" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-0-1-26"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6-6-0">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-3-3-5" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-2-2-67"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-3-8-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6330-7">
+      <stop
+         id="stop6332-06"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6334-0" />
+      <stop
+         id="stop6336-7"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6321-48">
+      <stop
+         id="stop6323-49"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6325-2" />
+      <stop
+         id="stop6327-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-1">
+      <stop
+         id="stop7104-0-1-6-7-9-1-4-9-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-3-0-8" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-8-4-31"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-95">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-5-8-6" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-1-4-4"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-1-8-82" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6302-0">
+      <stop
+         id="stop6304-4"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6306-5" />
+      <stop
+         id="stop6308-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6293-6">
+      <stop
+         id="stop6295-7"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6297-5" />
+      <stop
+         id="stop6299-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-72-5">
+      <stop
+         id="stop7104-0-1-6-7-9-1-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-6-1" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-2-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-92-0">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-4-3" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-6-4"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-55-00" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134-4-2">
+      <stop
+         id="stop6136-6-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6138-0-40" />
+      <stop
+         id="stop6140-7-7"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125-7-5">
+      <stop
+         id="stop6127-4-1"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6129-0-2" />
+      <stop
+         id="stop6131-6-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-3">
+      <stop
+         id="stop7104-0-1-6-7-9-1-4-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-3-5" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-8-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-4">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-5-3" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-1-21"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-1-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134-7">
+      <stop
+         id="stop6136-29"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6138-75" />
+      <stop
+         id="stop6140-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125-82">
+      <stop
+         id="stop6127-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop6129-2" />
+      <stop
+         id="stop6131-03"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7-8">
+      <stop
+         id="stop7104-0-1-6-7-9-1-8-7"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-4-30" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-0-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6-9">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-3-30" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-2-7"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-3-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699-0-4">
+      <stop
+         id="stop5701-6-44"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop5703-0-4" />
+      <stop
+         id="stop5705-3-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690-4-81">
+      <stop
+         id="stop5692-0-25"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop5694-4-7" />
+      <stop
+         id="stop5696-5-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-2-8">
+      <stop
+         id="stop7104-0-1-6-7-9-1-2-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-16-7" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-6-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-9-6">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-2-3" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-0-4"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-5-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699-3">
+      <stop
+         id="stop5701-44"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop5703-05" />
+      <stop
+         id="stop5705-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690-64">
+      <stop
+         id="stop5692-9"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop5694-2" />
+      <stop
+         id="stop5696-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-9-91">
+      <stop
+         id="stop7104-0-1-6-7-9-1-0-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-1-0" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-5-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-5-2">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-8-1" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-7-4"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-7-62" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363-3-36">
+      <stop
+         id="stop4365-6-1"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop4367-1-8" />
+      <stop
+         id="stop4369-3-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354-1-3">
+      <stop
+         id="stop4356-1-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop4358-6-82" />
+      <stop
+         id="stop4360-2-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-3-3">
+      <stop
+         id="stop7104-0-1-6-7-9-4-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-3-5" />
+      <stop
+         id="stop7106-25-7-1-2-9-3-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-5-4">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-5-41" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-0-61"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-2-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363-6">
+      <stop
+         id="stop4365-658"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop4367-2" />
+      <stop
+         id="stop4369-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354-76">
+      <stop
+         id="stop4356-93"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop4358-5" />
+      <stop
+         id="stop4360-7"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-3">
+      <stop
+         id="stop7104-0-1-6-7-9-1-9"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-2-67" />
+      <stop
+         id="stop7106-25-7-1-2-9-0-99"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-91">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-3-250" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-4-8"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-0-39" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4142-8">
+      <stop
+         id="stop4144-25"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop4146-5" />
+      <stop
+         id="stop4148-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4133-94">
+      <stop
+         id="stop4135-1"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop4137-96" />
+      <stop
+         id="stop4139-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-8">
+      <stop
+         id="stop7104-0-1-6-7-9-67"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-6-7" />
+      <stop
+         id="stop7106-25-7-1-2-9-22"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-53">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-4-2" />
+      <stop
+         id="stop7563-1-3-0-1-7-3-5"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-3-25" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3515-1">
+      <stop
+         id="stop3517-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3519-1" />
+      <stop
+         id="stop3521-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3506-2">
+      <stop
+         id="stop3508-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3510-0" />
+      <stop
+         id="stop3512-39"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-22-7">
+      <stop
+         id="stop7104-0-1-6-8-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-1-2" />
+      <stop
+         id="stop7106-25-7-1-4-95"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-2-82">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-5-1" />
+      <stop
+         id="stop7563-1-3-0-1-76-1"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-7-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3265-9">
+      <stop
+         id="stop3267-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3269-4" />
+      <stop
+         id="stop3271-61"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3256-58">
+      <stop
+         id="stop3258-62"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3260-65" />
+      <stop
+         id="stop3262-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-1">
+      <stop
+         id="stop7104-0-1-6-7-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-4-4" />
+      <stop
+         id="stop7106-25-7-1-2-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-890">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-7-7" />
+      <stop
+         id="stop7563-1-3-0-1-7-815"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-0-86" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4329-9">
+      <stop
+         id="stop4331-72"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop4333-2" />
+      <stop
+         id="stop4335-82"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4320-6">
+      <stop
+         id="stop4322-81"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop4324-9" />
+      <stop
+         id="stop4326-8"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-3">
+      <stop
+         id="stop7104-0-1-6-808"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop7114-9-0-1-8" />
+      <stop
+         id="stop7106-25-7-1-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-3">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop7561-3-3-4-48-3" />
+      <stop
+         id="stop7563-1-3-0-1-37"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49599999;"
+         offset="1"
+         id="stop7565-8-8-3-2-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8137-2"
+       inkscape:collect="always">
+      <stop
+         id="stop8139-5"
+         offset="0"
+         style="stop-color:#326097;stop-opacity:1" />
+      <stop
+         id="stop8141-5"
+         offset="1"
+         style="stop-color:#2e73c5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8337-8"
+       inkscape:collect="always">
+      <stop
+         id="stop8339-49"
+         offset="0"
+         style="stop-color:#4e86ca;stop-opacity:1;" />
+      <stop
+         id="stop8341-9"
+         offset="1"
+         style="stop-color:#4e86ca;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8653-8"
+       inkscape:collect="always">
+      <stop
+         id="stop8655-3"
+         offset="0"
+         style="stop-color:#676656;stop-opacity:1;" />
+      <stop
+         id="stop8657-4"
+         offset="1"
+         style="stop-color:#9e884e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8661-0">
+      <stop
+         style="stop-color:#c6e7f9;stop-opacity:1"
+         offset="0"
+         id="stop8663-99" />
+      <stop
+         style="stop-color:#f9fcff;stop-opacity:1"
+         offset="1"
+         id="stop8665-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9291-34"
+       inkscape:collect="always">
+      <stop
+         id="stop9293-96"
+         offset="0"
+         style="stop-color:#e9f8ff;stop-opacity:1;" />
+      <stop
+         id="stop9295-51"
+         offset="1"
+         style="stop-color:#f5f6f9;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9299-7"
+       inkscape:collect="always">
+      <stop
+         id="stop9301-10"
+         offset="0"
+         style="stop-color:#929baa;stop-opacity:1" />
+      <stop
+         id="stop9303-7"
+         offset="1"
+         style="stop-color:#cac3a5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9312-87">
+      <stop
+         id="stop9314-7"
+         offset="0"
+         style="stop-color:#cf6c00;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5db48;stop-opacity:0.24200913"
+         offset="0.36339331"
+         id="stop9322-838" />
+      <stop
+         id="stop9316-3"
+         offset="1"
+         style="stop-color:#c36000;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9324-9">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9326-8" />
+      <stop
+         id="stop9328-8"
+         offset="0.30000001"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9330-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332-98">
+      <stop
+         id="stop9334-4"
+         offset="0"
+         style="stop-color:#f5b517;stop-opacity:1" />
+      <stop
+         style="stop-color:#fcf79e;stop-opacity:1"
+         offset="0.33703175"
+         id="stop9340-1" />
+      <stop
+         id="stop9336-43"
+         offset="1"
+         style="stop-color:#f5ae19;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9510-1">
+      <stop
+         id="stop9512-64"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.35636142"
+         id="stop9514-06" />
+      <stop
+         id="stop9516-18"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9605-1"
+       inkscape:collect="always">
+      <stop
+         id="stop9607-2"
+         offset="0"
+         style="stop-color:#2a5bbf;stop-opacity:1;" />
+      <stop
+         id="stop9609-0"
+         offset="1"
+         style="stop-color:#2a5bbf;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9908-8">
+      <stop
+         style="stop-color:#525f72;stop-opacity:1"
+         offset="0"
+         id="stop9910-3" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop9912-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9914-9">
+      <stop
+         style="stop-color:#4a6fa4;stop-opacity:1"
+         offset="0"
+         id="stop9916-4" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop9918-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10157-03">
+      <stop
+         id="stop10159-80"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:1" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.5"
+         id="stop10165-12" />
+      <stop
+         id="stop10161-50"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10396-8">
+      <stop
+         id="stop10398-2"
+         offset="0"
+         style="stop-color:#1b3e79;stop-opacity:1;" />
+      <stop
+         style="stop-color:#728fbf;stop-opacity:1"
+         offset="0.5"
+         id="stop10404-6" />
+      <stop
+         id="stop10400-6"
+         offset="1"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10414-5">
+      <stop
+         id="stop10416-9"
+         offset="0"
+         style="stop-color:#5078b9;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6d8cbd;stop-opacity:1"
+         offset="0.5"
+         id="stop10422-9" />
+      <stop
+         id="stop10418-81"
+         offset="1"
+         style="stop-color:#5f88c9;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10432-7">
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="0"
+         id="stop10434-7" />
+      <stop
+         id="stop10436-3"
+         offset="0.5"
+         style="stop-color:#4e6da1;stop-opacity:1" />
+      <stop
+         style="stop-color:#567ebc;stop-opacity:1"
+         offset="1"
+         id="stop10438-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-0">
+      <stop
+         id="stop10442-7"
+         offset="0"
+         style="stop-color:#ae7603;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e8d8a3;stop-opacity:1"
+         offset="0.5"
+         id="stop10521-17" />
+      <stop
+         id="stop10444-7"
+         offset="1"
+         style="stop-color:#bb9221;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-41">
+      <stop
+         id="stop10450-2"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe38d;stop-opacity:1"
+         offset="0.25"
+         id="stop10458-0" />
+      <stop
+         style="stop-color:#fdf5d2;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-0" />
+      <stop
+         id="stop10460-14"
+         offset="0.75"
+         style="stop-color:#ffeba7;stop-opacity:1" />
+      <stop
+         id="stop10452-6"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10748-26">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10750-01" />
+      <stop
+         id="stop10752-6"
+         offset="0.25"
+         style="stop-color:#f1ce66;stop-opacity:1" />
+      <stop
+         id="stop10754-5"
+         offset="0.5"
+         style="stop-color:#f6e5a6;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1cf6c;stop-opacity:1"
+         offset="0.75"
+         id="stop10756-7" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10758-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-42">
+      <stop
+         id="stop10800-09"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#418a4d;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-73" />
+      <stop
+         id="stop10802-7"
+         offset="1"
+         style="stop-color:#a4c589;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-76">
+      <stop
+         style="stop-color:#7d75ac;stop-opacity:1"
+         offset="0"
+         id="stop10858-3" />
+      <stop
+         id="stop10860-61"
+         offset="0.5"
+         style="stop-color:#574a96;stop-opacity:1" />
+      <stop
+         style="stop-color:#9f99c8;stop-opacity:1"
+         offset="1"
+         id="stop10862-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11128-9">
+      <stop
+         id="stop11130-8"
+         offset="0"
+         style="stop-color:#e4d09d;stop-opacity:1" />
+      <stop
+         style="stop-color:#f6ecb2;stop-opacity:1"
+         offset="0.27413794"
+         id="stop11136-4" />
+      <stop
+         id="stop11132-0"
+         offset="1"
+         style="stop-color:#b58a68;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-2">
+      <stop
+         id="stop11150-91"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-35" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687-6">
+      <stop
+         id="stop11689-37"
+         offset="0"
+         style="stop-color:#bdb692;stop-opacity:1;" />
+      <stop
+         style="stop-color:#869097;stop-opacity:1"
+         offset="0.5"
+         id="stop11695-8" />
+      <stop
+         id="stop11691-8"
+         offset="1"
+         style="stop-color:#c3cace;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-0">
+      <stop
+         id="stop11971-66"
+         offset="0"
+         style="stop-color:#6f93c7;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.29546595"
+         id="stop11979-1" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:0;"
+         offset="0.57727957"
+         id="stop11977-8" />
+      <stop
+         id="stop11973-49"
+         offset="1"
+         style="stop-color:#6f93c7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-38">
+      <stop
+         id="stop12001-93"
+         offset="0"
+         style="stop-color:#f8b098;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8decd;stop-opacity:1"
+         offset="0.5"
+         id="stop12007-44" />
+      <stop
+         id="stop12003-6"
+         offset="1"
+         style="stop-color:#f8b098;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-0">
+      <stop
+         id="stop12090-9"
+         offset="0"
+         style="stop-color:#84a7d5;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a9cded;stop-opacity:1"
+         offset="0.5"
+         id="stop12096-00" />
+      <stop
+         id="stop12092-61"
+         offset="1"
+         style="stop-color:#95b8e0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799-6">
+      <stop
+         id="stop13801-0"
+         offset="0"
+         style="stop-color:#b9772f;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop13809-2" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop13807-4" />
+      <stop
+         id="stop13811-86"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop13803-5"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13834-0">
+      <stop
+         id="stop13836-2"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13838-8"
+         offset="1"
+         style="stop-color:#807e66;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13850-98">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13852-6" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13854-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856-27">
+      <stop
+         id="stop13858-79"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13860-31"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4763-3">
+      <stop
+         id="stop4765-87"
+         offset="0"
+         style="stop-color:#77a29d;stop-opacity:1;" />
+      <stop
+         id="stop4767-4"
+         offset="1"
+         style="stop-color:#1b867b;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4773-34">
+      <stop
+         id="stop4775-1"
+         offset="0"
+         style="stop-color:#8e4694;stop-opacity:1;" />
+      <stop
+         id="stop4777-1"
+         offset="1"
+         style="stop-color:#bc7bc1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4781-43">
+      <stop
+         id="stop4783-12"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop4785-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4789-92">
+      <stop
+         id="stop4791-7"
+         offset="0"
+         style="stop-color:#4e8fbd;stop-opacity:1;" />
+      <stop
+         id="stop4793-95"
+         offset="1"
+         style="stop-color:#30495a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4907-5">
+      <stop
+         id="stop4909-76"
+         offset="0"
+         style="stop-color:#b86c44;stop-opacity:1;" />
+      <stop
+         id="stop4911-18"
+         offset="1"
+         style="stop-color:#8f4017;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4918-22">
+      <stop
+         id="stop4920-1"
+         offset="0"
+         style="stop-color:#d48a4b;stop-opacity:1;" />
+      <stop
+         id="stop4922-68"
+         offset="1"
+         style="stop-color:#b1623a;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4928-14">
+      <stop
+         id="stop4930-2"
+         offset="0"
+         style="stop-color:#4dac81;stop-opacity:1;" />
+      <stop
+         id="stop4932-3"
+         offset="1"
+         style="stop-color:#058048;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4938-15">
+      <stop
+         id="stop4940-2"
+         offset="0"
+         style="stop-color:#8bc7d7;stop-opacity:1;" />
+      <stop
+         id="stop4942-76"
+         offset="1"
+         style="stop-color:#17477c;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4961-1">
+      <stop
+         id="stop4963-7"
+         offset="0"
+         style="stop-color:#df9a39;stop-opacity:1;" />
+      <stop
+         id="stop4965-1"
+         offset="1"
+         style="stop-color:#b55829;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5209-2">
+      <stop
+         id="stop5211-45"
+         offset="0"
+         style="stop-color:#5c5c5c;stop-opacity:1;" />
+      <stop
+         id="stop5213-5"
+         offset="1"
+         style="stop-color:#aeaeae;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5328-40">
+      <stop
+         id="stop5330-94"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop5332-88"
+         offset="1"
+         style="stop-color:#464646;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5583">
+      <stop
+         id="stop5585"
+         offset="0"
+         style="stop-color:#426e4a;stop-opacity:1;" />
+      <stop
+         id="stop5587"
+         offset="1"
+         style="stop-color:#669f71;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5591">
+      <stop
+         id="stop5593"
+         offset="0"
+         style="stop-color:#e0e566;stop-opacity:1;" />
+      <stop
+         id="stop5595"
+         offset="1"
+         style="stop-color:#b0b456;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4805">
+      <stop
+         id="stop4807"
+         offset="0"
+         style="stop-color:#4b82b6;stop-opacity:1" />
+      <stop
+         style="stop-color:#9ab7d5;stop-opacity:1"
+         offset="0.79358917"
+         id="stop4815" />
+      <stop
+         id="stop4809"
+         offset="1"
+         style="stop-color:#a2bcd8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         id="stop4786"
+         offset="0"
+         style="stop-color:#b68e69;stop-opacity:1" />
+      <stop
+         style="stop-color:#d5ae7d;stop-opacity:1"
+         offset="0.94238818"
+         id="stop4792" />
+      <stop
+         id="stop4788"
+         offset="1"
+         style="stop-color:#c69863;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4846"
+       inkscape:collect="always">
+      <stop
+         id="stop4848"
+         offset="0"
+         style="stop-color:#937e48;stop-opacity:1" />
+      <stop
+         id="stop4850"
+         offset="1"
+         style="stop-color:#7c724f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4898">
+      <stop
+         id="stop4900"
+         offset="0"
+         style="stop-color:#ffd991;stop-opacity:1;" />
+      <stop
+         id="stop4902"
+         offset="1"
+         style="stop-color:#ffcd6f;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5056">
+      <stop
+         id="stop5058"
+         offset="0"
+         style="stop-color:#97adce;stop-opacity:1" />
+      <stop
+         style="stop-color:#e0e8f0;stop-opacity:1"
+         offset="0.2858389"
+         id="stop5066" />
+      <stop
+         style="stop-color:#98aece;stop-opacity:1"
+         offset="0.60006815"
+         id="stop5064" />
+      <stop
+         id="stop5060"
+         offset="1"
+         style="stop-color:#7e9bca;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5068"
+       inkscape:collect="always">
+      <stop
+         id="stop5070"
+         offset="0"
+         style="stop-color:#7593c1;stop-opacity:1" />
+      <stop
+         id="stop5072"
+         offset="1"
+         style="stop-color:#5a78ab;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9257"
+       inkscape:collect="always">
+      <stop
+         id="stop9259"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop9261"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9276"
+       inkscape:collect="always">
+      <stop
+         id="stop9278"
+         offset="0"
+         style="stop-color:#9dd560;stop-opacity:1" />
+      <stop
+         id="stop9280"
+         offset="1"
+         style="stop-color:#499851;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9321"
+       inkscape:collect="always">
+      <stop
+         id="stop9323"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop9325"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9329">
+      <stop
+         id="stop9331"
+         offset="0"
+         style="stop-color:#f8d060;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8e898;stop-opacity:1"
+         offset="0.5"
+         id="stop9337" />
+      <stop
+         id="stop9333"
+         offset="1"
+         style="stop-color:#f8f8e8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1-28-0"
+       id="linearGradient8163-2-1"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1-28-0">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7-2-4" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8-94-0"
+         offset="0.5"
+         style="stop-color:#3c8d49;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4e173;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3-4-7" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1056.2894"
+       x2="15.633883"
+       y1="1054.6906"
+       x1="16.965528"
+       id="linearGradient9282-5"
+       xlink:href="#linearGradient9276-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9276-9"
+       inkscape:collect="always">
+      <stop
+         id="stop9278-0"
+         offset="0"
+         style="stop-color:#9dd560;stop-opacity:1" />
+      <stop
+         id="stop9280-5"
+         offset="1"
+         style="stop-color:#499851;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.77257883,-1.3315319e-7,1.3315322e-7,0.772579,89.457223,108.43693)"
+       gradientUnits="userSpaceOnUse"
+       r="10.625"
+       fy="476.81119"
+       fx="393.35513"
+       cy="476.81119"
+       cx="393.35513"
+       id="radialGradient9327-1"
+       xlink:href="#linearGradient9321-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9321-2"
+       inkscape:collect="always">
+      <stop
+         id="stop9323-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop9325-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9321-2"
+       id="radialGradient13739"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.77257883,-1.3315319e-7,1.3315322e-7,0.772579,89.457223,108.43693)"
+       cx="393.35513"
+       cy="476.81119"
+       fx="393.35513"
+       fy="476.81119"
+       r="10.625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1-28-0"
+       id="linearGradient13741"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9276-9"
+       id="linearGradient13743"
+       gradientUnits="userSpaceOnUse"
+       x1="16.965528"
+       y1="1054.6906"
+       x2="15.633883"
+       y2="1056.2894" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13755"
+       id="linearGradient13761"
+       x1="28.004765"
+       y1="-5.6084509"
+       x2="28.004765"
+       y2="1.6087028"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13755-0"
+       id="linearGradient13761-0"
+       x1="28.004765"
+       y1="-5.6084509"
+       x2="28.004765"
+       y2="1.6087028"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient13755-0">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757-6" />
+      <stop
+         id="stop13765-5"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763-1"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13831"
+       id="linearGradient13837"
+       x1="30.033665"
+       y1="-6.1109905"
+       x2="30.033665"
+       y2="1.9089624"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13755-3"
+       id="linearGradient13761-7"
+       x1="28.004765"
+       y1="-5.6084509"
+       x2="28.004765"
+       y2="1.6087028"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient13755-3">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757-5" />
+      <stop
+         id="stop13765-0"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763-0"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759-65" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13831-8"
+       id="linearGradient13837-1"
+       x1="30.033665"
+       y1="-6.1109905"
+       x2="30.033665"
+       y2="1.9089624"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13831-8">
+      <stop
+         style="stop-color:#055797;stop-opacity:1;"
+         offset="0"
+         id="stop13833-2" />
+      <stop
+         style="stop-color:#184785;stop-opacity:1"
+         offset="1"
+         id="stop13835-7" />
+    </linearGradient>
+    <linearGradient
+       y2="1.6087028"
+       x2="28.004765"
+       y1="-5.6084509"
+       x1="28.004765"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13862"
+       xlink:href="#linearGradient13755-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1.9089624"
+       x2="30.033665"
+       y1="-6.1109905"
+       x1="30.033665"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13864"
+       xlink:href="#linearGradient13831-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13755-3"
+       id="linearGradient13906"
+       gradientUnits="userSpaceOnUse"
+       x1="28.004765"
+       y1="-5.6084509"
+       x2="28.004765"
+       y2="1.6087028" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13831-8"
+       id="linearGradient13908"
+       gradientUnits="userSpaceOnUse"
+       x1="30.033665"
+       y1="-6.1109905"
+       x2="30.033665"
+       y2="1.9089624" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13922"
+       id="linearGradient13928"
+       x1="11"
+       y1="8.5"
+       x2="16"
+       y2="8.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13922-6"
+       id="linearGradient13928-8"
+       x1="11"
+       y1="8.5"
+       x2="16"
+       y2="8.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13922-6">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop13924-9" />
+      <stop
+         style="stop-color:#6e83ae;stop-opacity:1"
+         offset="1"
+         id="stop13926-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(8.220116,1051.267)"
+       y2="8.5"
+       x2="16"
+       y1="8.5"
+       x1="11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13945"
+       xlink:href="#linearGradient13922-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13922-5"
+       id="linearGradient13928-5"
+       x1="11"
+       y1="8.5"
+       x2="16"
+       y2="8.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13922-5">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop13924-0" />
+      <stop
+         style="stop-color:#6e83ae;stop-opacity:1"
+         offset="1"
+         id="stop13926-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(8.220116,1053.267)"
+       y2="8.5"
+       x2="16"
+       y1="8.5"
+       x1="11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13945-8"
+       xlink:href="#linearGradient13922-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13922-7"
+       id="linearGradient13928-50"
+       x1="11"
+       y1="8.5"
+       x2="16"
+       y2="8.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13922-7">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop13924-3" />
+      <stop
+         style="stop-color:#6e83ae;stop-opacity:1"
+         offset="1"
+         id="stop13926-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(8.220116,1055.267)"
+       y2="8.5"
+       x2="16"
+       y1="8.5"
+       x1="11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13945-1"
+       xlink:href="#linearGradient13922-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient13755-3-4">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757-5-1" />
+      <stop
+         id="stop13765-0-7"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763-0-0"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759-65-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1-28-0-3">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7-2-4-2" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8-94-0-7"
+         offset="0.5"
+         style="stop-color:#3c8d49;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4e173;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3-4-7-8" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask14146">
+      <g
+         style="fill:#ffffff;stroke:#ffffff;display:inline"
+         id="g14148"
+         transform="matrix(0.73426076,0,0,0.73426076,3.6725146,281.72245)">
+        <path
+           transform="matrix(1.247029,0,0,1.247029,-18.103841,1064.137)"
+           d="m 30,-2 c 0,2.209139 -1.790861,4 -4,4 -2.209139,0 -4,-1.790861 -4,-4 0,-2.209139 1.790861,-4 4,-4 2.209139,0 4,1.790861 4,4 z"
+           sodipodi:ry="4"
+           sodipodi:rx="4"
+           sodipodi:cy="-2"
+           sodipodi:cx="26"
+           id="path14150"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.80190599;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path14152"
+           d="m 14.349242,1061.6734 0,-2.0313"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path14154"
+           d="m 14.349242,1061.6734 1.458408,2.3881"
+           style="fill:#ffffff;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      </g>
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter14156"
+       x="-0.18"
+       width="1.36"
+       y="-0.18"
+       height="1.36">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.99291734"
+         id="feGaussianBlur14158" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13755"
+       id="linearGradient8584"
+       gradientUnits="userSpaceOnUse"
+       x1="28.004765"
+       y1="-5.6084509"
+       x2="28.004765"
+       y2="1.6087028" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13831"
+       id="linearGradient8586"
+       gradientUnits="userSpaceOnUse"
+       x1="30.033665"
+       y1="-6.1109905"
+       x2="30.033665"
+       y2="1.9089624" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="9.1737121"
+     inkscape:cy="7.5389861"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="867"
+     inkscape:window-height="637"
+     inkscape:window-x="142"
+     inkscape:window-y="77"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4092"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <g
+         id="g8579"
+         transform="translate(-36.986137,8.9772527)">
+        <path
+           transform="matrix(1.247029,0,0,1.247029,21.297363,1050.2608)"
+           d="m 30,-2 c 0,2.209139 -1.790861,4 -4,4 -2.209139,0 -4,-1.790861 -4,-4 0,-2.209139 1.790861,-4 4,-4 2.209139,0 4,1.790861 4,4 z"
+           sodipodi:ry="4"
+           sodipodi:rx="4"
+           sodipodi:cy="-2"
+           sodipodi:cx="26"
+           id="path13745"
+           style="fill:url(#linearGradient8584);fill-opacity:1;stroke:url(#linearGradient8586);stroke-width:0.80190599;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path13811"
+           d="m 53.750446,1047.7972 0,-2.0313"
+           style="fill:none;stroke:#1f4a83;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path13811-9"
+           d="m 53.750446,1047.7972 1.458408,2.3881"
+           style="fill:none;stroke:#1f4a83;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/warning_obj.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/obj16/warning_obj.svg
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="warning.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5091">
+      <stop
+         style="stop-color:#c6852e;stop-opacity:1"
+         offset="0"
+         id="stop5093" />
+      <stop
+         style="stop-color:#e1a555;stop-opacity:1"
+         offset="1"
+         id="stop5095" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5081">
+      <stop
+         style="stop-color:#ffe69e;stop-opacity:1"
+         offset="0"
+         id="stop5083" />
+      <stop
+         id="stop5089"
+         offset="0.37960318"
+         style="stop-color:#ffc85a;stop-opacity:1" />
+      <stop
+         style="stop-color:#fffcd3;stop-opacity:1"
+         offset="1"
+         id="stop5085" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5091"
+       id="linearGradient4200"
+       gradientUnits="userSpaceOnUse"
+       x1="6.3885393"
+       y1="7.2369323"
+       x2="6.3885393"
+       y2="0.39338252"
+       gradientTransform="matrix(1.0698871,0,0,1.0698871,15.590192,1043.527)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5081"
+       id="radialGradient4963"
+       cx="19.36529"
+       cy="1051.1095"
+       fx="19.36529"
+       fy="1051.1095"
+       r="3.7734281"
+       gradientTransform="matrix(2.8249601,0,0,1.7930635,-35.371372,-833.43041)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="-11.10583"
+     inkscape:cy="-21.989605"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8472"
+     showgrid="true"
+     inkscape:window-width="1280"
+     inkscape:window-height="1024"
+     inkscape:window-x="150"
+     inkscape:window-y="138"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4202"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8472"
+       transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)">
+      <g
+         id="g4193"
+         transform="matrix(1.4166388,0,0,1.4166388,-3.2411359,-441.5072)"
+         style="opacity:1">
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0"
+           id="path4292"
+           d="m 18.599249,1044.4966 -2.362015,4.3798 c -0.648383,1.0968 -0.206291,2.7732 1.003019,2.7928 l 1.5596,0 1.069887,0 1.5596,0 c 1.209311,-0.019 1.651402,-1.6961 1.003019,-2.7928 l -2.362015,-4.3798 c -0.314859,-0.5957 -1.196998,-0.4999 -1.471095,0 z"
+           style="fill:url(#radialGradient4963);fill-opacity:1;stroke:url(#linearGradient4200);stroke-width:0.75522922999999986;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           transform="matrix(1.125929,0,0,1.125929,15.411638,1043.5862)"
+           d="m 4.109375,5.484375 c 0,0.345178 -0.279822,0.625 -0.625,0.625 -0.345178,0 -0.625,-0.279822 -0.625,-0.625 0,-0.345178 0.279822,-0.625 0.625,-0.625 0.345178,0 0.625,0.279822 0.625,0.625 z"
+           sodipodi:ry="0.625"
+           sodipodi:rx="0.625"
+           sodipodi:cy="5.484375"
+           sodipodi:cx="3.484375"
+           id="path4253"
+           style="fill:#7b5113;fill-opacity:1;stroke:none"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="sccsccs"
+           inkscape:connector-curvature="0"
+           id="path4253-7"
+           d="m 19.350026,1045.7152 c -0.378471,0 -0.700512,0.3368 -0.700512,0.774 l 0.09137,1.4889 c 0,0.3887 0.272722,0.7037 0.609141,0.7037 0.336419,0 0.609139,-0.315 0.609139,-0.7037 l 0.06091,-1.4889 c 0,-0.4372 -0.291583,-0.774 -0.670056,-0.774 z"
+           style="fill:#7b5113;fill-opacity:1;stroke:none;display:inline" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/ovr16/workspace_ovr.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/ovr16/workspace_ovr.svg
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="7"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="workspace_ovr.svg.2014_03_19_02_28_35.0.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3851"
+       inkscape:collect="always">
+      <stop
+         id="stop3853"
+         offset="0"
+         style="stop-color:#f4f7fb;stop-opacity:1" />
+      <stop
+         id="stop3855"
+         offset="1"
+         style="stop-color:#d5f3ff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3845"
+       inkscape:collect="always">
+      <stop
+         id="stop3847"
+         offset="0"
+         style="stop-color:#96792f;stop-opacity:1" />
+      <stop
+         id="stop3849"
+         offset="1"
+         style="stop-color:#6b5b37;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3787">
+      <stop
+         style="stop-color:#2b568d;stop-opacity:1"
+         offset="0"
+         id="stop3789" />
+      <stop
+         style="stop-color:#296dc0;stop-opacity:1"
+         offset="1"
+         id="stop3791" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3779">
+      <stop
+         style="stop-color:#81beed;stop-opacity:1"
+         offset="0"
+         id="stop3781" />
+      <stop
+         style="stop-color:#c0e0fb;stop-opacity:1"
+         offset="1"
+         id="stop3783" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient4908-2"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-1.044194)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902-3">
+      <stop
+         style="stop-color:#b4903d;stop-opacity:1"
+         offset="0"
+         id="stop4904-2" />
+      <stop
+         style="stop-color:#7a734f;stop-opacity:1"
+         offset="1"
+         id="stop4906-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894-6"
+       id="linearGradient4900-1"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.022097,-1.981694)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4894-6">
+      <stop
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0"
+         id="stop4896-8" />
+      <stop
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1"
+         id="stop4898-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-6">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996-1" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998-89" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101"
+       xlink:href="#linearGradient4994-6"
+       inkscape:collect="always"
+       gradientTransform="translate(-1.977903,-1.044194)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3779"
+       id="linearGradient3785"
+       x1="21.959064"
+       y1="1045.3617"
+       x2="27.056976"
+       y2="1045.3617"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787"
+       id="linearGradient3793"
+       x1="21"
+       y1="1046.8617"
+       x2="25.900826"
+       y2="1046.8617"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3779-1"
+       id="linearGradient3785-0"
+       x1="21.959064"
+       y1="1045.3617"
+       x2="27.056976"
+       y2="1045.3617"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3779-1">
+      <stop
+         style="stop-color:#81beed;stop-opacity:1"
+         offset="0"
+         id="stop3781-5" />
+      <stop
+         style="stop-color:#c0e0fb;stop-opacity:1"
+         offset="1"
+         id="stop3783-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-8"
+       id="linearGradient3793-9"
+       x1="21"
+       y1="1046.8617"
+       x2="25.900826"
+       y2="1046.8617"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3787-8">
+      <stop
+         style="stop-color:#2b568d;stop-opacity:1"
+         offset="0"
+         id="stop3789-5" />
+      <stop
+         style="stop-color:#296dc0;stop-opacity:1"
+         offset="1"
+         id="stop3791-2" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-20,1.9999766)"
+       y2="1046.2965"
+       x2="27.056976"
+       y1="1049.1743"
+       x1="27.056976"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3814"
+       xlink:href="#linearGradient3851"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-20,1.9999766)"
+       y2="1049.6455"
+       x2="21"
+       y1="1046.8617"
+       x1="21"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3816"
+       xlink:href="#linearGradient3845"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627418"
+     inkscape:cx="-3.9318645"
+     inkscape:cy="-0.12891162"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1440"
+     inkscape:window-height="900"
+     inkscape:window-x="156"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1044.3622)">
+    <rect
+       style="fill:url(#linearGradient3814);fill-opacity:1;stroke:url(#linearGradient3816);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="rect3009-5"
+       width="4.9944763"
+       height="3.9971924"
+       x="1.5"
+       y="1047.8632" />
+    <rect
+       style="fill:url(#linearGradient3785);fill-opacity:1;stroke:url(#linearGradient3793);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect3009"
+       width="4.9944758"
+       height="1.9971566"
+       x="1.5"
+       y="1045.8632" />
+    <rect
+       style="fill:#8c95a1;fill-opacity:1;stroke:none"
+       id="rect3024"
+       width="1"
+       height="3"
+       x="3"
+       y="1048.3622" />
+    <rect
+       style="fill:#8c95a1;fill-opacity:1;stroke:none"
+       id="rect3026"
+       width="2"
+       height="1"
+       x="4"
+       y="1049.3622" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/icons/full/wizban/refactor_wiz.svg
+++ b/bundles/org.eclipse.ltk.ui.refactoring/icons/full/wizban/refactor_wiz.svg
@@ -1,0 +1,1246 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="refactor_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4688">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4690" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4692" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4680">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4682" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4684" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4672">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4674" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4676" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient6375-6"
+       x1="50.702839"
+       y1="1052.4476"
+       x2="22.530088"
+       y2="1014.1386"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66235895,0,0,0.70707433,23.086815,294.27483)" />
+    <linearGradient
+       id="linearGradient4994"
+       inkscape:collect="always">
+      <stop
+         id="stop4996"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop4998"
+         offset="1"
+         style="stop-color:#dbe2eb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4238"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2925445,0,0,2.4122725,22.897231,-1497.2379)"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228" />
+    <linearGradient
+       id="linearGradient4902"
+       inkscape:collect="always">
+      <stop
+         id="stop4904"
+         offset="0"
+         style="stop-color:#c7b571;stop-opacity:1;" />
+      <stop
+         id="stop4906"
+         offset="1"
+         style="stop-color:#9a9a8f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6411"
+       id="linearGradient4240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66235895,0,0,0.70707433,23.086815,294.27481)"
+       x1="52.166088"
+       y1="1020.8994"
+       x2="47.429596"
+       y2="1023.1616" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6411">
+      <stop
+         style="stop-color:#4f605c;stop-opacity:1"
+         offset="0"
+         id="stop6413" />
+      <stop
+         style="stop-color:#dbe2eb;stop-opacity:0"
+         offset="1"
+         id="stop6415" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4258"
+       id="linearGradient4264"
+       x1="59.220116"
+       y1="1021.2669"
+       x2="62.220116"
+       y2="1025.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1922461,0,0,1.2728781,-16.63892,-290.35442)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4258">
+      <stop
+         style="stop-color:#f4ae5f;stop-opacity:1;"
+         offset="0"
+         id="stop4260" />
+      <stop
+         id="stop4266"
+         offset="0.41542953"
+         style="stop-color:#eec290;stop-opacity:1" />
+      <stop
+         style="stop-color:#c7700e;stop-opacity:1"
+         offset="1"
+         id="stop4262" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient4335"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.55555556,0,0,0.55549259,33.32008,459.29714)"
+       x1="50.702839"
+       y1="1052.4476"
+       x2="22.530088"
+       y2="1014.1386" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4337"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9228786,0,0,1.8951324,33.149538,-948.08933)"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6411"
+       id="linearGradient4339"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.55555556,0,0,0.55549259,33.32008,459.29712)"
+       x1="52.166088"
+       y1="1020.8994"
+       x2="47.429596"
+       y2="1023.1616" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4258"
+       id="linearGradient4341"
+       gradientUnits="userSpaceOnUse"
+       x1="59.220116"
+       y1="1021.2669"
+       x2="62.220116"
+       y2="1025.2668" />
+    <filter
+       height="1.2013515"
+       y="-0.10067577"
+       width="1.2017672"
+       x="-0.1"
+       id="filter4285-9"
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur4287-9"
+         stdDeviation="0.10000000000000001"
+         inkscape:collect="always" />
+    </filter>
+    <filter
+       height="1.2013515"
+       y="-0.10067577"
+       width="1.2017672"
+       x="-0.1"
+       id="filter4285-9-8"
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur4287-9-4"
+         stdDeviation="0.10000000000000001"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4527"
+       id="linearGradient4533"
+       x1="29.521629"
+       y1="29.827848"
+       x2="31.546745"
+       y2="39.175972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.1306086,986.28561)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4527">
+      <stop
+         style="stop-color:#68b367;stop-opacity:1"
+         offset="0"
+         id="stop4529" />
+      <stop
+         style="stop-color:#5eaa6e;stop-opacity:1"
+         offset="1"
+         id="stop4531" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4578"
+       id="linearGradient4584"
+       x1="42.780308"
+       y1="1025.5621"
+       x2="40.143147"
+       y2="1039.7532"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-8.0895077,-12.981287)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4578">
+      <stop
+         style="stop-color:#c5f0b4;stop-opacity:1"
+         offset="0"
+         id="stop4580" />
+      <stop
+         style="stop-color:#80c171;stop-opacity:1"
+         offset="1"
+         id="stop4582" />
+    </linearGradient>
+    <filter
+       height="1.2013515"
+       y="-0.10067577"
+       width="1.2017672"
+       x="-0.1"
+       id="filter4285-9-8-1"
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur4287-9-4-2"
+         stdDeviation="0.10000000000000001"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4258"
+       id="linearGradient4341-5"
+       gradientUnits="userSpaceOnUse"
+       x1="59.220116"
+       y1="1021.2669"
+       x2="62.220116"
+       y2="1025.2668" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient4630"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.55555556,0,0,0.55549259,33.32008,459.29714)"
+       x1="50.702839"
+       y1="1052.4476"
+       x2="22.530088"
+       y2="1014.1386" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4632"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9228786,0,0,1.8951324,33.149538,-948.08933)"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6411"
+       id="linearGradient4634"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.55555556,0,0,0.55549259,33.32008,459.29712)"
+       x1="52.166088"
+       y1="1020.8994"
+       x2="47.429596"
+       y2="1023.1616" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4672"
+       id="linearGradient4678"
+       x1="8"
+       y1="26.5"
+       x2="17"
+       y2="26.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4680"
+       id="linearGradient4686"
+       x1="11"
+       y1="31.5"
+       x2="21"
+       y2="31.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4688"
+       id="linearGradient4694"
+       x1="8"
+       y1="37.5"
+       x2="18"
+       y2="37.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4308"
+       id="linearGradient4314"
+       x1="49.217129"
+       y1="1041.0833"
+       x2="75.020309"
+       y2="1023.2908"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4308">
+      <stop
+         style="stop-color:#d5d2d9;stop-opacity:1"
+         offset="0"
+         id="stop4310" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.328"
+         offset="1"
+         id="stop4312" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4344"
+       x="-0.027383927"
+       width="1.0547678"
+       y="-0.085576579"
+       height="1.1711532">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.57051052"
+         id="feGaussianBlur4346" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4344-8"
+       x="-0.027383927"
+       width="1.0547678"
+       y="-0.085576579"
+       height="1.1711532">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.57051052"
+         id="feGaussianBlur4346-1" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4308"
+       id="linearGradient5763"
+       gradientUnits="userSpaceOnUse"
+       x1="49.217129"
+       y1="1041.0833"
+       x2="75.020309"
+       y2="1023.2908" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4344-8-9"
+       x="-0.027383927"
+       width="1.0547678"
+       y="-0.085576579"
+       height="1.1711532">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.57051052"
+         id="feGaussianBlur4346-1-7" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4308"
+       id="linearGradient5809"
+       gradientUnits="userSpaceOnUse"
+       x1="49.217129"
+       y1="1041.0833"
+       x2="75.020309"
+       y2="1023.2908" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#bcbcbc"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="17.060606"
+     inkscape:cx="39.500001"
+     inkscape:cy="33"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-5-8-3"
+       d="m 61.725004,1022.8099 21.27431,-0.1009 1.654984,3.7793 -20.678174,12.1198 -29.322882,0.1009 z"
+       style="display:inline;opacity:0.32900002;fill:url(#linearGradient5809);fill-opacity:1;stroke:none;filter:url(#filter4344-8-9)"
+       transform="matrix(0.58090292,0,0,0.41711614,-19.334783,593.3449)" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-5"
+       d="m 61.725004,1022.8099 21.27431,-0.1009 1.654984,3.7793 -20.678174,12.1198 -29.322882,0.1009 z"
+       style="display:inline;opacity:0.62999998;fill:url(#linearGradient5763);fill-opacity:1;stroke:none;filter:url(#filter4344)"
+       transform="matrix(0.81385308,0,0,0.61823795,4.2568856,399.93119)" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-5-8"
+       d="m 61.725004,1022.8099 21.27431,-0.1009 1.654984,3.7793 -20.678174,12.1198 -29.322882,0.1009 z"
+       style="display:inline;opacity:0.32900002;fill:url(#linearGradient4314);fill-opacity:1;stroke:none;filter:url(#filter4344-8)"
+       transform="matrix(0.58090292,0,0,0.41711614,-15.153049,598.3199)" />
+    <g
+       transform="matrix(0.92787456,0,0,0.92766861,-334.80763,585.97703)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-width:0.30075619;stroke-opacity:1" />
+    </g>
+    <g
+       id="text6430-2"
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(3.3253216,0,0,3.3245835,49.654056,-2426.2108)" />
+    <g
+       transform="matrix(3.1391206,0,0,3.5217855,49.654056,-2426.2108)"
+       style="font-style:normal;font-weight:normal;font-size:15.56941891px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="text3782-3" />
+    <g
+       id="g4268-8"
+       style="display:inline"
+       transform="matrix(0.88977825,0,0,0.88984413,-37.401253,94.541491)">
+      <path
+         style="display:inline;fill:url(#linearGradient4335);fill-opacity:1;stroke:none"
+         d="m 43.990186,1021.0407 14.219285,0.062 4.263971,4.7864 0.284152,18.985 -18.97284,0 z"
+         id="rect4001-3-4-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4337);stroke-width:1.12383389;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 43.720145,1020.7707 13.971021,0 c 0,0 3.560398,0.7981 2.532625,2.6317 -0.03187,0.057 2.602258,3.0478 2.602258,3.0478 l 0,17.9178 -19.105904,0 z"
+         id="rect4001-1-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccscccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient4339);fill-opacity:1;stroke:none"
+         d="m 57.361866,1020.69 4.902246,5.6018 0,5.8213 -7.353058,-5.0921 c 1.008912,-2.0421 1.739834,-4.1752 2.450799,-6.331 z"
+         id="rect4001-3-9-0-0"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="display:inline;fill:url(#linearGradient4341);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 57.221715,1020.2064 c 1.131076,1.4702 2.495035,3.4365 1.484101,6.6497 2.326258,-1.2554 4.682171,-0.5441 4.682171,-0.5441 0,-3 -3.762735,-6.247 -6.166272,-6.1056 z"
+         id="path5675-4-4"
+         sodipodi:nodetypes="cccc" />
+    </g>
+    <g
+       id="g11331-3-1-1-00"
+       style="display:inline"
+       transform="matrix(0,-0.14879357,0.14879357,0,3.0151033,1093.2759)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-1" />
+    </g>
+    <g
+       id="g7590-7-0"
+       style="display:inline"
+       transform="matrix(1.122791,0,0,1.122791,51.605476,-118.01412)" />
+    <g
+       id="g7827-7-5"
+       style="display:inline"
+       transform="matrix(0.45489265,0,0,0.45489265,119.65899,561.31682)" />
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,71.714017,852.06346)"
+       style="display:inline"
+       id="g11331-3-1-1-0">
+      <g
+         id="g13408-8-4"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4"
+       d="m 35.45972,1008.8038 16.29082,-0.1952 6.27458,7.3158 0.0609,23.4616 -22.504471,0.1952 z"
+       style="display:inline;fill:url(#linearGradient6375-6);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccscccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-1"
+       d="m 35.499996,1008.8808 16.069976,0 c 0,0 4.831789,1.013 3.606431,3.347 -0.038,0.073 3.323597,3.9796 3.323597,3.9796 l 0,23.6381 -23.000004,0 z"
+       style="fill:none;stroke:url(#linearGradient4238);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-9-0"
+       d="m 51.75054,1008.8594 6.24946,7.1305 0,7.4102 -9.171466,-6.482 c 1.202872,-2.5994 2.07431,-5.3145 2.921956,-8.0587 z"
+       style="display:inline;fill:url(#linearGradient4240);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       id="path5675-4"
+       d="m 51.583446,1008.3529 c 1.348521,1.8713 2.974695,4.2652 1.769413,8.3553 2.773472,-1.598 5.647141,-0.7504 5.647141,-0.7504 0,-3.8185 -4.550947,-7.7849 -7.416554,-7.6049 z"
+       style="display:inline;fill:url(#linearGradient4264);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4285-9)"
+       id="path4252-6"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="0.49178758"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="-3.0800218"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.9823895,-2.1047 -1.6734053,-2.5419 2.1987064,2.0209 2.4513363,-1.6427 -2.0383649,2.1623 1.7419712,2.4882 -2.2030799,-2.0431 z"
+       transform="matrix(0,0.69810267,-0.69299598,0,776.667,1009.1028)"
+       inkscape:transform-center-x="-0.015534896"
+       inkscape:transform-center-y="0.22008011" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4285-9-8)"
+       id="path4252-6-3"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="0.49178758"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="-3.0800218"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.9823895,-2.1047 -1.6734053,-2.5419 2.1987064,2.0209 2.4513363,-1.6427 -2.0383649,2.1623 1.7419712,2.4882 -2.2030799,-2.0431 z"
+       transform="matrix(0,0.56760589,-0.57097849,0,610.79974,1003.3382)"
+       inkscape:transform-center-x="-0.012805237"
+       inkscape:transform-center-y="0.19102986" />
+    <g
+       id="g4268-8-5"
+       style="display:inline"
+       transform="matrix(0.88977825,0,0,0.88984413,-33.401252,99.537447)">
+      <path
+         style="display:inline;fill:url(#linearGradient4630);fill-opacity:1;stroke:none"
+         d="m 43.990186,1021.0407 14.219285,0.062 4.263971,4.7864 0.284152,18.985 -18.97284,0 z"
+         id="rect4001-3-4-3-5"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4632);stroke-width:1.12383389;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 43.720145,1020.7707 13.971021,0 c 0,0 3.560398,0.7981 2.532625,2.6317 -0.03187,0.057 2.602258,3.0478 2.602258,3.0478 l 0,17.9178 -19.105904,0 z"
+         id="rect4001-1-1-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccscccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient4634);fill-opacity:1;stroke:none"
+         d="m 57.361866,1020.69 4.902246,5.6018 0,5.8213 -7.353058,-5.0921 c 1.008912,-2.0421 1.739834,-4.1752 2.450799,-6.331 z"
+         id="rect4001-3-9-0-0-4"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="display:inline;fill:url(#linearGradient4341-5);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 57.221715,1020.2064 c 1.131076,1.4702 2.495035,3.4365 1.484101,6.6497 2.326258,-1.2554 4.682171,-0.5441 4.682171,-0.5441 0,-3 -3.762735,-6.247 -6.166272,-6.1056 z"
+         id="path5675-4-4-9"
+         sodipodi:nodetypes="cccc" />
+    </g>
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4285-9-8-1)"
+       id="path4252-6-3-4"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="0.49178758"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="-3.0800218"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.9823895,-2.1047 -1.6734053,-2.5419 2.1987064,2.0209 2.4513363,-1.6427 -2.0383649,2.1623 1.7419712,2.4882 -2.2030799,-2.0431 z"
+       transform="matrix(0,0.56760589,-0.57097849,0,614.79974,1008.3382)"
+       inkscape:transform-center-x="-0.012805237"
+       inkscape:transform-center-y="0.19102986" />
+    <path
+       style="display:inline;opacity:1;fill:url(#linearGradient4678);fill-opacity:1;stroke:#596d8c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.5,24.5 8,0 0,4 -8,0 z"
+       id="rect4645"
+       inkscape:connector-curvature="0"
+       transform="translate(0,986.3622)" />
+    <path
+       style="display:inline;opacity:1;fill:url(#linearGradient4686);fill-opacity:1;stroke:#596d8c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11.5,29.5 9,0 0,4 -9,0 z"
+       id="rect4645-1"
+       inkscape:connector-curvature="0"
+       transform="translate(0,986.3622)" />
+    <path
+       style="display:inline;opacity:1;fill:url(#linearGradient4694);fill-opacity:1;stroke:#596d8c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.5,35.5 9,0 0,4 -9,0 z"
+       id="rect4645-5"
+       inkscape:connector-curvature="0"
+       transform="translate(0,986.3622)" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 38,1036.3622 8,0"
+       id="path4696"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 38,1033.3622 11,0"
+       id="path4696-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 38,1030.3622 12,0"
+       id="path4696-4"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 38,1016.3622 11,0"
+       id="path4696-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 38,1019.3622 11,0"
+       id="path4696-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 38,1022.3622 11,0"
+       id="path4696-8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 38,1025.3622 9,0"
+       id="path4696-2"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="scscszs"
+       inkscape:connector-curvature="0"
+       id="path4522"
+       d="m 40.795495,1013.2551 c -0.24182,-0.7378 -4.276215,4.6418 -4.276215,4.6418 -11.44876,-7.9356 -17.573348,1.4122 -16.632852,8.3285 0.287455,2.114 2.873263,-9.5491 13.24418,-4.9398 0,0 -6.161054,4.0913 -5.456972,5.1523 0.390532,0.5886 13.008987,0.7195 13.731155,-0.03 0.722169,-0.75 -0.343071,-12.3401 -0.609296,-13.1524 z"
+       style="fill:url(#linearGradient4533);fill-opacity:1;fill-rule:evenodd;stroke:#398a43;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccscc"
+       inkscape:connector-curvature="0"
+       id="path4522-3"
+       d="m 40.580418,1026.1978 c 0.335464,-3.4409 -0.540551,-10.8513 -0.558812,-11.097 -0.130143,0.1351 -3.305251,4.1177 -3.305251,4.1177 -13.489832,-9.4517 -15.979945,3.8837 -15.944315,4.5632 0,0 4.159907,-8.1407 14.425918,-2.5964 -3.722931,2.2 -6.36447,4.7334 -6.416153,4.8694"
+       style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4584);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/PreviewWizardPage.java
+++ b/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/PreviewWizardPage.java
@@ -219,7 +219,6 @@ public class PreviewWizardPage extends RefactoringWizardPage implements IPreview
 
 		public FilterDropDownAction() {
 			setImageDescriptor(RefactoringPluginImages.DESC_ELCL_FILTER);
-			setDisabledImageDescriptor(RefactoringPluginImages.DESC_DLCL_FILTER);
 			setText(RefactoringUIMessages.PreviewWizardPage_filterChanges);
 			setToolTipText(RefactoringUIMessages.PreviewWizardPage_filterChanges);
 			setMenuCreator(this);

--- a/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringPluginImages.java
+++ b/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringPluginImages.java
@@ -42,7 +42,6 @@ public class RefactoringPluginImages {
 	private static final String T_OBJ= "obj16"; 		//$NON-NLS-1$
 	private static final String T_OVR= "ovr16"; 		//$NON-NLS-1$
 	private static final String T_ELCL= "elcl16"; 	//$NON-NLS-1$
-	private static final String T_DLCL= "dlcl16"; 	//$NON-NLS-1$
 
 	public static final ImageDescriptor DESC_WIZBAN_REFACTOR= createUnManaged(T_WIZBAN, "refactor_wiz.svg"); 			//$NON-NLS-1$
 
@@ -64,16 +63,11 @@ public class RefactoringPluginImages {
 	public static final String IMG_OBJS_REFACTORING_TIME= NAME_PREFIX + "time_obj.svg"; //$NON-NLS-1$
 
 	public static final ImageDescriptor DESC_ELCL_FILTER= createUnManaged(T_ELCL, "filter_ps.svg"); //$NON-NLS-1$
-	public static final ImageDescriptor DESC_DLCL_FILTER= createUnManaged(T_DLCL, "filter_ps.png"); //$NON-NLS-1$
 
 	/** @since 3.2 */
 	public static final ImageDescriptor DESC_ELCL_SORT_PROJECT= createUnManaged(T_ELCL, "prj_mode.svg"); //$NON-NLS-1$
 	/** @since 3.2 */
-	public static final ImageDescriptor DESC_DLCL_SORT_PROJECT= createUnManaged(T_DLCL, "prj_mode.png"); //$NON-NLS-1$
-	/** @since 3.2 */
 	public static final ImageDescriptor DESC_ELCL_SORT_DATE= createUnManaged(T_ELCL, "date_mode.svg"); //$NON-NLS-1$
-	/** @since 3.2 */
-	public static final ImageDescriptor DESC_DLCL_SORT_DATE= createUnManaged(T_DLCL, "date_mode.png"); //$NON-NLS-1$
 
 	public static final ImageDescriptor DESC_OBJS_REFACTORING_FATAL= createManaged(T_OBJ, IMG_OBJS_REFACTORING_FATAL);
 	public static final ImageDescriptor DESC_OBJS_REFACTORING_ERROR= createManaged(T_OBJ, IMG_OBJS_REFACTORING_ERROR);

--- a/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringPluginImages.java
+++ b/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringPluginImages.java
@@ -44,7 +44,7 @@ public class RefactoringPluginImages {
 	private static final String T_ELCL= "elcl16"; 	//$NON-NLS-1$
 	private static final String T_DLCL= "dlcl16"; 	//$NON-NLS-1$
 
-	public static final ImageDescriptor DESC_WIZBAN_REFACTOR= createUnManaged(T_WIZBAN, "refactor_wiz.png"); 			//$NON-NLS-1$
+	public static final ImageDescriptor DESC_WIZBAN_REFACTOR= createUnManaged(T_WIZBAN, "refactor_wiz.svg"); 			//$NON-NLS-1$
 
 	/** @since 3.2 */
 	public static final ImageDescriptor DESC_WIZBAN_SHOW_HISTORY= createUnManaged(T_WIZBAN, "show_history_wiz.png"); 			//$NON-NLS-1$
@@ -53,25 +53,25 @@ public class RefactoringPluginImages {
 	/** @since 3.2 */
 	public static final ImageDescriptor DESC_WIZBAN_CREATE_SCRIPT= createUnManaged(T_WIZBAN, "create_rescript_wiz.png"); 			//$NON-NLS-1$
 
-	public static final String IMG_OBJS_REFACTORING_FATAL= NAME_PREFIX + "fatalerror_obj.png"; //$NON-NLS-1$
-	public static final String IMG_OBJS_REFACTORING_ERROR= NAME_PREFIX + "error_obj.png"; //$NON-NLS-1$
-	public static final String IMG_OBJS_REFACTORING_WARNING= NAME_PREFIX + "warning_obj.png"; //$NON-NLS-1$
-	public static final String IMG_OBJS_REFACTORING_INFO= NAME_PREFIX + "info_obj.png"; 	//$NON-NLS-1$
+	public static final String IMG_OBJS_REFACTORING_FATAL= NAME_PREFIX + "fatalerror_obj.svg"; //$NON-NLS-1$
+	public static final String IMG_OBJS_REFACTORING_ERROR= NAME_PREFIX + "error_obj.svg"; //$NON-NLS-1$
+	public static final String IMG_OBJS_REFACTORING_WARNING= NAME_PREFIX + "warning_obj.svg"; //$NON-NLS-1$
+	public static final String IMG_OBJS_REFACTORING_INFO= NAME_PREFIX + "info_obj.svg"; 	//$NON-NLS-1$
 
 	/** @since 3.2 */
-	public static final String IMG_OBJS_REFACTORING_DATE= NAME_PREFIX + "date_obj.png"; //$NON-NLS-1$
+	public static final String IMG_OBJS_REFACTORING_DATE= NAME_PREFIX + "date_obj.svg"; //$NON-NLS-1$
 	/** @since 3.2 */
-	public static final String IMG_OBJS_REFACTORING_TIME= NAME_PREFIX + "time_obj.png"; //$NON-NLS-1$
+	public static final String IMG_OBJS_REFACTORING_TIME= NAME_PREFIX + "time_obj.svg"; //$NON-NLS-1$
 
-	public static final ImageDescriptor DESC_ELCL_FILTER= createUnManaged(T_ELCL, "filter_ps.png"); //$NON-NLS-1$
+	public static final ImageDescriptor DESC_ELCL_FILTER= createUnManaged(T_ELCL, "filter_ps.svg"); //$NON-NLS-1$
 	public static final ImageDescriptor DESC_DLCL_FILTER= createUnManaged(T_DLCL, "filter_ps.png"); //$NON-NLS-1$
 
 	/** @since 3.2 */
-	public static final ImageDescriptor DESC_ELCL_SORT_PROJECT= createUnManaged(T_ELCL, "prj_mode.png"); //$NON-NLS-1$
+	public static final ImageDescriptor DESC_ELCL_SORT_PROJECT= createUnManaged(T_ELCL, "prj_mode.svg"); //$NON-NLS-1$
 	/** @since 3.2 */
 	public static final ImageDescriptor DESC_DLCL_SORT_PROJECT= createUnManaged(T_DLCL, "prj_mode.png"); //$NON-NLS-1$
 	/** @since 3.2 */
-	public static final ImageDescriptor DESC_ELCL_SORT_DATE= createUnManaged(T_ELCL, "date_mode.png"); //$NON-NLS-1$
+	public static final ImageDescriptor DESC_ELCL_SORT_DATE= createUnManaged(T_ELCL, "date_mode.svg"); //$NON-NLS-1$
 	/** @since 3.2 */
 	public static final ImageDescriptor DESC_DLCL_SORT_DATE= createUnManaged(T_DLCL, "date_mode.png"); //$NON-NLS-1$
 
@@ -81,20 +81,20 @@ public class RefactoringPluginImages {
 	public static final ImageDescriptor DESC_OBJS_REFACTORING_INFO= createManaged(T_OBJ, IMG_OBJS_REFACTORING_INFO);
 
 	/** @since 3.2 */
-	public static final ImageDescriptor DESC_OBJS_REFACTORING_DATE= createUnManaged(T_OBJ, "date_obj.png"); //$NON-NLS-1$
+	public static final ImageDescriptor DESC_OBJS_REFACTORING_DATE= createUnManaged(T_OBJ, "date_obj.svg"); //$NON-NLS-1$
 	/** @since 3.2 */
-	public static final ImageDescriptor DESC_OBJS_REFACTORING_TIME= createUnManaged(T_OBJ, "time_obj.png"); //$NON-NLS-1$
+	public static final ImageDescriptor DESC_OBJS_REFACTORING_TIME= createUnManaged(T_OBJ, "time_obj.svg"); //$NON-NLS-1$
 	/** @since 3.2 */
-	public static final ImageDescriptor DESC_OBJS_REFACTORING= createUnManaged(T_OBJ, "refactoring_obj.png"); //$NON-NLS-1$
+	public static final ImageDescriptor DESC_OBJS_REFACTORING= createUnManaged(T_OBJ, "refactoring_obj.svg"); //$NON-NLS-1$
 	/** @since 3.2 */
-	public static final ImageDescriptor DESC_OBJS_REFACTORING_COLL= createUnManaged(T_OBJ, "refactorings_obj.png"); //$NON-NLS-1$
+	public static final ImageDescriptor DESC_OBJS_REFACTORING_COLL= createUnManaged(T_OBJ, "refactorings_obj.svg"); //$NON-NLS-1$
 	/** @since 3.2 */
-	public static final ImageDescriptor DESC_OVR_WORKSPACE= createUnManaged(T_OVR, "workspace_ovr.png"); //$NON-NLS-1$
+	public static final ImageDescriptor DESC_OVR_WORKSPACE= createUnManaged(T_OVR, "workspace_ovr.svg"); //$NON-NLS-1$
 
-	public static final ImageDescriptor DESC_OBJS_DEFAULT_CHANGE= createUnManaged(T_OBJ, "change.png"); //$NON-NLS-1$
-	public static final ImageDescriptor DESC_OBJS_COMPOSITE_CHANGE= createUnManaged(T_OBJ, "composite_change.png"); //$NON-NLS-1$
-	public static final ImageDescriptor DESC_OBJS_FILE_CHANGE= createUnManaged(T_OBJ, "file_change.png"); //$NON-NLS-1$
-	public static final ImageDescriptor DESC_OBJS_TEXT_EDIT= createUnManaged(T_OBJ, "text_edit.png"); //$NON-NLS-1$
+	public static final ImageDescriptor DESC_OBJS_DEFAULT_CHANGE= createUnManaged(T_OBJ, "change.svg"); //$NON-NLS-1$
+	public static final ImageDescriptor DESC_OBJS_COMPOSITE_CHANGE= createUnManaged(T_OBJ, "composite_change.svg"); //$NON-NLS-1$
+	public static final ImageDescriptor DESC_OBJS_FILE_CHANGE= createUnManaged(T_OBJ, "file_change.svg"); //$NON-NLS-1$
+	public static final ImageDescriptor DESC_OBJS_TEXT_EDIT= createUnManaged(T_OBJ, "text_edit.svg"); //$NON-NLS-1$
 
 	/**
 	 * Returns the image managed under the given key in this registry.

--- a/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/history/SortableRefactoringHistoryControl.java
+++ b/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/history/SortableRefactoringHistoryControl.java
@@ -228,12 +228,10 @@ public class SortableRefactoringHistoryControl extends RefactoringHistoryControl
 			fSortProjects.setToolTipText(RefactoringUIMessages.BrowseRefactoringHistoryControl_sort_project);
 			fSortProjects.setDescription(RefactoringUIMessages.BrowseRefactoringHistoryControl_sort_project_description);
 			fSortProjects.setImageDescriptor(RefactoringPluginImages.DESC_ELCL_SORT_PROJECT);
-			fSortProjects.setDisabledImageDescriptor(RefactoringPluginImages.DESC_DLCL_SORT_PROJECT);
 			fSortTimestamps.setText(RefactoringUIMessages.BrowseRefactoringHistoryControl_sort_date);
 			fSortTimestamps.setToolTipText(RefactoringUIMessages.BrowseRefactoringHistoryControl_sort_date);
 			fSortTimestamps.setDescription(RefactoringUIMessages.BrowseRefactoringHistoryControl_sort_date_description);
 			fSortTimestamps.setImageDescriptor(RefactoringPluginImages.DESC_ELCL_SORT_DATE);
-			fSortTimestamps.setDisabledImageDescriptor(RefactoringPluginImages.DESC_DLCL_SORT_DATE);
 			manager.appendToGroup(TOOLBAR_SORT_GROUP, fSortProjects);
 			manager.appendToGroup(TOOLBAR_SORT_GROUP, fSortTimestamps);
 			manager.update(true);


### PR DESCRIPTION
This PR adds SVGs for all icons in the bundles `org.eclipse.ltk.ui.refactoring` except for the following as these are not available as SVG yet:

wizban/apply_rescript_wiz.svg
wizban/create_rescript_wiz.svg
wizban/show_history_wiz.svg

See also this [PR](https://github.com/eclipse-platform/eclipse.platform/pull/1797) for more information.