### PR TITLE
Add SVGs to org.eclipse.ui

### DIFF
--- a/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.4.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.ui
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.ui/icons/full/elcl16/backward_nav.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/backward_nav.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="backward_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="arrow_background">
+      <stop
+         style="stop-color:#ffffee;stop-opacity:1"
+         offset="0"
+         id="background_stop_0" />
+      <stop
+         style="stop-color:#ffecad;stop-opacity:1"
+         offset="1"
+         id="background_stop_1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="arrow_stroke">
+      <stop
+         style="stop-color:#ba7f0d;stop-opacity:1"
+         offset="0"
+         id="stroke_stop_0" />
+      <stop
+         style="stop-color:#a2660b;stop-opacity:1"
+         offset="1"
+         id="stroke_stop_1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#arrow_stroke"
+       id="linearGradient4747"
+       x1="11.0625"
+       y1="1038.5497"
+       x2="11.0625"
+       y2="1049.912"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,16,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#arrow_background"
+       id="linearGradient4755"
+       x1="4.5"
+       y1="1042.047"
+       x2="4.5"
+       y2="1046.4902"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,16,0)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="2.8457129"
+     inkscape:cy="5.7052771"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1363"
+     inkscape:window-height="1057"
+     inkscape:window-x="675"
+     inkscape:window-y="356"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 7.5,1038.8622 0,3 5.78125,0 c 0.667867,0 1.21875,0.5509 1.21875,1.2188 l 0,2.5625 c 0,0.6678 -0.550883,1.2187 -1.21875,1.2187 l -5.78125,0 0,3 -1,0 -5.5,-5.5 5.5,-5.5 1,0 z"
+       id="back_arrow"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/button_menu.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/button_menu.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="10"
+   height="5"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="button_menu.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="triangle_stroke">
+      <stop
+         style="stop-color:#5900cd;stop-opacity:1;"
+         offset="0"
+         id="triangle_stop_0" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="triangle_stop_1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.8005698,0,0,0.8005698,-1.3139245,1044.5914)"
+       y2="5.859375"
+       x2="7.25"
+       y1="7.765625"
+       x1="5.09375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4763"
+       xlink:href="#triangle_stroke"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="7.1069051"
+     inkscape:cy="1.3661201"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="959"
+     inkscape:window-y="465"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1047.3622)">
+    <path
+       style="fill:#44324a;fill-opacity:1;stroke:url(#linearGradient4763);stroke-width:0.80056977px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+       d="m 1.0877849,1047.7937 7.9806802,0 -3.9528134,4.0779 z"
+       id="path3970"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/close_view.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/close_view.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="close_view.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="6.6544358"
+     inkscape:cy="6.1857534"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4794"
+     showgrid="true"
+     inkscape:window-width="1536"
+     inkscape:window-height="982"
+     inkscape:window-x="624"
+     inkscape:window-y="523"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g4794"
+       transform="matrix(0.97551468,0,0,0.97551468,9.2809852,25.497327)">
+      <path
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none"
+         d="m 4.0078125,4.96875 0.029297,1.0214844 0.9003906,0 2.2949219,2.296875 0,0.40625 -2.2949219,2.2968746 -0.9003906,0 -0.029297,1.021485 1.9511719,0 2.0488281,-2.0507815 2.0507815,2.0507815 1.951172,0 -0.03125,-1.021485 -0.898438,0 -2.3027342,-2.302734 -0.013672,0.00781 0,-0.4101563 0.013672,0.00781 2.3027342,-2.3027344 0.898438,0 0.03125,-1.0214844 -1.951172,0 L 8.0078125,7.0195312 5.9589844,4.96875 Z"
+         transform="matrix(1.0250999,0,0,1.0250999,-9.513937,1036.2375)"
+         id="close_x"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccccccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/collapseall.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/collapseall.svg
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="collapseall.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(18,-3)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9"
+       xlink:href="#blue_gradient_left"
+       inkscape:collect="always" />
+           <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(20,-1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9-5"
+       xlink:href="#blue_gradient_left"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="blue_gradient_left">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="blue_gradient_left_stop_0" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="blue_gradient_left_stop_1" />
+    </linearGradient>
+       
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1"
+       xlink:href="#blue_gradient_top"
+       inkscape:collect="always"
+       gradientTransform="translate(18,-3)" />
+       
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1-1"
+       xlink:href="#blue_gradient_top"
+       inkscape:collect="always"
+       gradientTransform="translate(20,-1)" />
+    <linearGradient
+       id="blue_gradient_top"
+       inkscape:collect="always">
+      <stop
+         id="blue_gradient_top_stop_0"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="blue_gradient_top_stop_1"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+       
+    <linearGradient
+       y2="1043.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="translate(22,4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4970"
+       xlink:href="#minus_shadow_gradient"
+       inkscape:collect="always" />
+    <linearGradient
+       id="minus_shadow_gradient">
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="0"
+         id="minus_shadow_gradient_stop_0" />
+      <stop
+         id="minus_shadow_gradient_stop_1"
+         offset="0.5"
+         style="stop-color:#c3e9ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="1"
+         id="minus_shadow_gradient_stop_2" />
+    </linearGradient>
+
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="8.1029364"
+     inkscape:cy="7.6300717"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1138"
+     inkscape:window-height="951"
+     inkscape:window-x="1043"
+     inkscape:window-y="364"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#ffffff;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       d="m 3,1039.2997 8.971875,0 0.02812,9.1563 -8.971875,0 z"
+       id="front_background-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#a6afc4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 2,1038.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="back_rect"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:url(#linearGradient5062-9);fill-opacity:1.0;stroke:none;display:inline"
+       d="m 5,1041.3622 0,7 -2,0 0,-9 z"
+       id="back_left_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1);fill-opacity:1.0;stroke:none;display:inline"
+       d="m 5,1041.3622 7,0 0,-2 -9,0 z"
+       id="back_top_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 4,1040.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="front_rect"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 5,1041.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="front_background"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4970);fill-opacity:1.0;stroke:none;display:inline"
+       d="m 8,1047.3622 5,0 c 1,0 1,-1 0,-1 l -5,0 c -1,0 -1,1 0,1 z"
+       id="minus_sign_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5062-9-5);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 0,7 -2,0 0,-9 z"
+       id="left_top_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 7,0 0,-2 -9,0 z"
+       id="front_top_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="fill:#01467a;fill-opacity:1;stroke:none;display:inline"
+       id="minus_sign"
+       width="1"
+       height="7"
+       x="1045.3622"
+       y="-13"
+       transform="matrix(0,1,-1,0,0,0)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/expandall.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/expandall.svg
@@ -1,0 +1,334 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="expandall.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4989">
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="0"
+         id="stop4991" />
+      <stop
+         id="stop4995"
+         offset="0.5"
+         style="stop-color:#c3e9ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="1"
+         id="stop4993" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1"
+       xlink:href="#linearGradient4994-4-7"
+       inkscape:collect="always"
+       gradientTransform="translate(18,-3)" />
+    <linearGradient
+       id="linearGradient4994-4-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(18,-3)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9"
+       xlink:href="#linearGradient4910-4-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-4"
+       id="linearGradient4889-2"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9,0,0,0.9,-17.7,103.93622)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-4">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885-5" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-4-7"
+       id="linearGradient4889-2-1"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9,0,0,0.9,-15.7,105.93622)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-4-7">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885-5-1" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887-5-1" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(20,-1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9-5"
+       xlink:href="#linearGradient4910-4-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8-7" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1-1"
+       xlink:href="#linearGradient4994-4-7-4"
+       inkscape:collect="always"
+       gradientTransform="translate(20,-1)" />
+    <linearGradient
+       id="linearGradient4994-4-7-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4-2"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="translate(22,4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4970"
+       xlink:href="#linearGradient4989"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4989-1">
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="0"
+         id="stop4991-2" />
+      <stop
+         id="stop4995-3"
+         offset="0.5"
+         style="stop-color:#c3e9ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="1"
+         id="stop4993-3" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="matrix(0,1,-1,0,1053.3622,1058.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5050"
+       xlink:href="#linearGradient4989-1"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.9999998"
+     inkscape:cx="1.5251501"
+     inkscape:cy="27.213599"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="75"
+     inkscape:window-y="75"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 2,1038.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="rect3997-9-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 3,1039.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="rect3997-9-1-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient5062-9);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 0,7 -2,0 0,-9 z"
+       id="rect4853-82-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 7,0 0,-2 -9,0 z"
+       id="rect4853-82-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 4,1040.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="rect3997-9-1-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 5,1041.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="rect3997-9-1-1-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4970);fill-opacity:1;stroke:none;display:inline"
+       d="m 8,1047.3622 5,0 c 1,0 1,-1 0,-1 l -5,0 c -1,0 -1,1 0,1 z"
+       id="rect4853-82-0-6-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5062-9-5);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 0,7 -2,0 0,-9 z"
+       id="rect4853-82-7-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 7,0 0,-2 -9,0 z"
+       id="rect4853-82-0-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5050);fill-opacity:1;stroke:none;display:inline"
+       d="m 10,1044.3622 0,5 c 0,1 1,1 1,0 l 0,-5 c 0,-1 -1,-1 -1,0 z"
+       id="rect4853-82-0-6-8-41"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="fill:#01467a;fill-opacity:1;stroke:none"
+       id="rect4167"
+       width="1"
+       height="7"
+       x="9"
+       y="1042.3622" />
+    <rect
+       style="fill:#01467a;fill-opacity:1;stroke:none;display:inline"
+       id="rect4167-8"
+       width="1"
+       height="7"
+       x="1045.3622"
+       y="-13"
+       transform="matrix(0,1,-1,0,0,0)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/forward_nav.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/forward_nav.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="forward_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#ffffee;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#ffecad;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#ba7f0d;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#a2660b;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="11.0625"
+       y1="1038.5497"
+       x2="11.0625"
+       y2="1049.912"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="4.5"
+       y1="1042.047"
+       x2="4.5"
+       y2="1046.4902"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="-0.57568266"
+     inkscape:cy="2.7852926"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="104"
+     inkscape:window-y="89"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 8.5,1038.8622 0,3 -5.78125,0 c -0.6678671,0 -1.21875,0.5509 -1.21875,1.2188 l 0,2.5625 c 0,0.6678 0.5508829,1.2187 1.21875,1.2187 l 5.78125,0 0,3 1,0 5.5,-5.5 -5.5,-5.5 -1,0 z"
+       id="rect3968"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/home_nav.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/home_nav.svg
@@ -1,0 +1,330 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="home_nav.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5000">
+      <stop
+         style="stop-color:#fffbce;stop-opacity:1;"
+         offset="0"
+         id="stop5002" />
+      <stop
+         style="stop-color:#ffcf73;stop-opacity:1"
+         offset="1"
+         id="stop5004" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4990">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4992" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4994" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4962">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4964" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4966" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4901">
+      <stop
+         style="stop-color:#5b7aac;stop-opacity:1"
+         offset="0"
+         id="stop4903" />
+      <stop
+         style="stop-color:#13347c;stop-opacity:1"
+         offset="1"
+         id="stop4905" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4893">
+      <stop
+         style="stop-color:#dff2fe;stop-opacity:1;"
+         offset="0"
+         id="stop4895" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop4897" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4832">
+      <stop
+         style="stop-color:#edeb02;stop-opacity:1;"
+         offset="0"
+         id="stop4834" />
+      <stop
+         style="stop-color:#6cc13a;stop-opacity:1"
+         offset="1"
+         id="stop4836" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4818"
+       inkscape:collect="always">
+      <stop
+         id="stop4820"
+         offset="0"
+         style="stop-color:#296166;stop-opacity:1" />
+      <stop
+         id="stop4822"
+         offset="1"
+         style="stop-color:#274184;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4776">
+      <stop
+         style="stop-color:#39845b;stop-opacity:1;"
+         offset="0"
+         id="stop4778" />
+      <stop
+         style="stop-color:#367a5d;stop-opacity:1"
+         offset="1"
+         id="stop4780" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4764">
+      <stop
+         style="stop-color:#6f736b;stop-opacity:1"
+         offset="0"
+         id="stop4766" />
+      <stop
+         style="stop-color:#a6967b;stop-opacity:1"
+         offset="1"
+         id="stop4768" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4764"
+       id="linearGradient4770"
+       x1="8.4092102"
+       y1="8.7891455"
+       x2="8.4092102"
+       y2="1.1254452"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4776"
+       id="linearGradient4782"
+       x1="10.582661"
+       y1="1043.6017"
+       x2="10.582661"
+       y2="1046.0001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2,0)" />
+    <linearGradient
+       y2="1047.6909"
+       x2="10.582661"
+       y1="1043.6017"
+       x1="10.582661"
+       gradientTransform="translate(-2,3.9999517)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4799"
+       xlink:href="#linearGradient4818"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4832"
+       id="linearGradient4838"
+       x1="11.953301"
+       y1="1048.0667"
+       x2="11.953301"
+       y2="1051.5563"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4893"
+       id="linearGradient4899"
+       x1="10.672073"
+       y1="1051.7124"
+       x2="10.672073"
+       y2="1039.9114"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4901"
+       id="linearGradient4907"
+       x1="27.048151"
+       y1="1051.9556"
+       x2="27.048151"
+       y2="1043.3688"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-22,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4962"
+       id="linearGradient4968"
+       x1="5.81739"
+       y1="1041.0914"
+       x2="4.7714186"
+       y2="1040.0861"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4990"
+       id="linearGradient4996"
+       x1="10"
+       y1="1041.3622"
+       x2="9"
+       y2="1042.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4990"
+       id="linearGradient4998"
+       x1="7"
+       y1="1041.3622"
+       x2="8"
+       y2="1042.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5000"
+       id="linearGradient5006"
+       x1="11"
+       y1="1"
+       x2="11"
+       y2="9"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="19.547345"
+     inkscape:cy="6.4098931"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1389"
+     inkscape:window-height="982"
+     inkscape:window-x="49"
+     inkscape:window-y="165"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4899);fill-opacity:1;stroke:url(#linearGradient4907);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+       d="m 3.639246,1044.01 4.871803,-4.9944 4.871802,4.9944 c 0.04798,0.049 0.124028,0.055 0.124028,0.124 l 0,7.6443 c 0,0.069 -0.05532,0.1241 -0.124028,0.1241 l -9.743605,0 c -0.06871,0 -0.124028,-0.055 -0.124028,-0.1241 l 0,-7.6443 c 0,-0.069 0.05532,-0.124 0.124028,-0.124 z"
+       id="rect4774-4-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="scssssssss" />
+    <rect
+       style="fill:#9f453a;fill-opacity:1;stroke:#aeaa73;stroke-width:0.64999998000000003;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect4762"
+       width="1.3515625"
+       height="4.5546875"
+       x="4.3203125"
+       y="1.3359375"
+       transform="translate(0,1036.3622)"
+       rx="0.16010694"
+       ry="0.16010694" />
+    <rect
+       style="fill:url(#linearGradient4968);fill-opacity:1;stroke:none;display:inline;opacity:0.5"
+       id="rect4762-8"
+       width="2.0034266"
+       height="3.4940274"
+       x="3.9943805"
+       y="1038.7588"
+       rx="0.23732717"
+       ry="0.12282249" />
+    <rect
+       style="fill:#edeb02;fill-opacity:1;stroke:url(#linearGradient4782);stroke-width:0.66977459;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect4774"
+       width="2.3239722"
+       height="2.3239722"
+       x="7.3380146"
+       y="1043.7002"
+       rx="0.12402803"
+       ry="0.12402803" />
+    <rect
+       style="fill:url(#linearGradient4838);fill-opacity:1;stroke:url(#linearGradient4799);stroke-width:0.66977459;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       id="rect4774-4"
+       width="2.3239722"
+       height="4.1801276"
+       x="7.3380146"
+       y="1047.7002"
+       rx="0.12402803"
+       ry="0.12402803" />
+    <path
+       style="fill:url(#linearGradient4998);fill-opacity:1;stroke:none;display:inline;opacity:0.5"
+       d="m 3.1531968,1043.8654 5.3578522,-5.4927 -5e-7,8.1726 -5.3578517,0 -0.136402,-0.1366 0,-2.4069 z"
+       id="rect4774-4-4-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="fill:url(#linearGradient4996);fill-opacity:1;stroke:none;display:inline;opacity:0.5"
+       d="m 8.511049,1038.3727 5.357851,5.4927 0.136402,0.1364 0,2.4069 -0.136402,0.1366 -5.3578515,0 z"
+       id="rect4774-4-4-5-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="fill:url(#linearGradient5006);fill-opacity:1;stroke:url(#linearGradient4770);stroke-width:0.64999998000000003;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="M 8.46875 1.6875 C 8.4278236 1.6875 8.4063599 1.6873901 8.375 1.71875 L 7.6875 2.40625 L 2.15625 7.9375 C 2.0935302 8.0002198 2.0935302 8.0935302 2.15625 8.15625 L 2.84375 8.84375 C 2.9064698 8.9064698 2.9997802 8.9064698 3.0625 8.84375 L 8.5 3.4375 L 13.90625 8.84375 C 13.96897 8.9064698 14.06228 8.9064698 14.125 8.84375 L 14.8125 8.15625 C 14.87522 8.0935302 14.87522 8.0002198 14.8125 7.9375 L 9.28125 2.40625 L 8.59375 1.71875 C 8.5623901 1.6873901 8.5096764 1.6875 8.46875 1.6875 z "
+       transform="translate(0,1036.3622)"
+       id="rect3973" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/linkto_help.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/linkto_help.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="linkto_help.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877">
+      <stop
+         style="stop-color:#f7fdff;stop-opacity:1"
+         offset="0"
+         id="stop4879" />
+      <stop
+         style="stop-color:#e8f0f5;stop-opacity:1"
+         offset="1"
+         id="stop4881" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4883"
+       x1="12.108335"
+       y1="2.7923172"
+       x2="12.108335"
+       y2="17.832731"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999999"
+     inkscape:cx="9.2128289"
+     inkscape:cy="8.5632458"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="900"
+     inkscape:window-x="210"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient4883);fill-opacity:1;stroke:#546782;stroke-width:1.51549268;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path4110"
+         sodipodi:cx="11.9375"
+         sodipodi:cy="11.6875"
+         sodipodi:rx="9.875"
+         sodipodi:ry="9.875"
+         d="m 21.8125,11.6875 a 9.875,9.875 0 1 1 -19.75,0 9.875,9.875 0 1 1 19.75,0 z"
+         transform="matrix(0.65985142,0,0,0.65985142,8.3743896,1049.555)" />
+      <path
+         style="font-size:20.03678703px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#475b78;fill-opacity:1;stroke:none;font-family:Reznor;-inkscape-font-specification:Reznor Bold"
+         d="m 16.198558,1052.2089 c -0.989362,0 -1.779246,0.2751 -2.381946,0.8285 -0.602703,0.5534 -0.916817,1.32 -0.952778,2.2784 l 1.636293,0.2071 c 0.0538,-1.185 0.596173,-1.7606 1.594868,-1.7606 0.422752,0 0.765773,0.1082 1.035628,0.3522 0.269846,0.244 0.393533,0.5573 0.393539,0.932 -6e-6,0.3486 -0.120825,0.6499 -0.372826,0.9113 -0.134793,0.1394 -0.402883,0.3481 -0.80779,0.6008 -0.36868,0.2265 -0.607999,0.4852 -0.72494,0.8077 -0.108163,0.2702 -0.165704,0.6852 -0.165701,1.2428 l 0,0.7456 1.512018,0 0,-0.4764 c -5e-6,-0.5489 0.236445,-0.9703 0.704227,-1.2841 0.611892,-0.4183 1.029572,-0.7896 1.263467,-1.0771 0.323648,-0.4183 0.497094,-0.9226 0.497101,-1.5327 -7e-6,-0.8366 -0.33497,-1.5277 -0.97349,-2.0505 -0.611904,-0.488 -1.367142,-0.725 -2.25767,-0.725 z"
+         id="text4882"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccccccccsccsccccc" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#475b78;fill-opacity:1;stroke:none;display:inline"
+         id="path4908-1"
+         sodipodi:cx="11.932427"
+         sodipodi:cy="16.531185"
+         sodipodi:rx="0.64356911"
+         sodipodi:ry="0.39774758"
+         d="m 12.575997,16.531185 a 0.64356911,0.39774758 0 1 1 -1.287139,0 0.64356911,0.39774758 0 1 1 1.287139,0 z"
+         transform="matrix(1.7775683,0,0,2.4520496,-5.0999685,1020.5689)" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/min_view.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/min_view.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="min_view.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="0.97848455"
+     inkscape:cy="5.6112743"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="959"
+     inkscape:window-y="465"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <image
+       y="1036.363"
+       x="0.043339729"
+       id="image3978"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAD1JREFU OI1j/P//PwMlgIki3aMGjBoABSzoAg4JDniT5oEFBxiR+YzoSZmRkRGvAf///8dvAKlg4AORYgMA Ia0RF2B51n8AAAAASUVORK5CYII= "
+       height="16"
+       width="16" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.80000000000000004;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect3981"
+       width="8.087534"
+       height="2.0771263"
+       x="4.0216699"
+       y="9.9453983"
+       transform="translate(0,1036.3622)"
+       ry="0" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/progress_rem.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/progress_rem.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="remove_exc.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4852-7">
+      <stop
+         style="stop-color:#707070;stop-opacity:1"
+         offset="0"
+         id="stop4854-4" />
+      <stop
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         offset="1"
+         id="stop4856-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4844-4">
+      <stop
+         style="stop-color:#414141;stop-opacity:1;"
+         offset="0"
+         id="stop4846-8" />
+      <stop
+         style="stop-color:#535353;stop-opacity:1;"
+         offset="1"
+         id="stop4848-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="matrix(0.99104673,0,0,1.0377289,-0.03213967,-39.635801)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4047"
+       xlink:href="#linearGradient4852-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="matrix(0.99104673,0,0,1.0377289,-0.03213967,-39.635801)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4049"
+       xlink:href="#linearGradient4844-4"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999998"
+     inkscape:cx="5.5301136"
+     inkscape:cy="7.9227098"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="963"
+     inkscape:window-y="622"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4047);fill-opacity:1;stroke:url(#linearGradient4049);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       d="m 13.267004,1038.2068 c -0.463993,-0.4858 -1.211033,-0.4858 -1.675002,-10e-5 l -3.0849275,3.2304 -3.0849031,-3.2303 c -0.4639226,-0.4858 -1.2110333,-0.4858 -1.6750018,0 l -0.8523552,0.8927 c -0.4639479,0.4856 -0.463936,1.2678 3.62e-5,1.7537 l 3.0848535,3.2303 -3.084858,3.2302 c -0.4640179,0.4858 -0.4640062,1.268 -1.34e-5,1.7538 l 0.852401,0.8927 c 0.4639431,0.4858 1.2109842,0.4858 1.6750016,0 l 3.084908,-3.2302 3.1063417,3.2526 c 0.463945,0.4859 1.210985,0.4859 1.675003,0 l 0.852355,-0.8925 c 0.463969,-0.4859 0.459308,-1.2632 -3.6e-5,-1.7539 l -3.106344,-3.2527 3.084908,-3.2302 c 0.46399,-0.4859 0.463978,-1.2681 3.4e-5,-1.7538 z"
+       id="rect4043"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccccssccsccsccss" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/progress_remall.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/progress_remall.svg
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="removea_exc.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4119">
+      <stop
+         id="stop4121"
+         offset="0"
+         style="stop-color:#2b2b2b;stop-opacity:1;" />
+      <stop
+         id="stop4123"
+         offset="1"
+         style="stop-color:#686861;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4113"
+       inkscape:collect="always">
+      <stop
+         id="stop4115"
+         offset="0"
+         style="stop-color:#d8d8d8;stop-opacity:1" />
+      <stop
+         id="stop4117"
+         offset="1"
+         style="stop-color:#d8d8d8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4852-7">
+      <stop
+         style="stop-color:#707070;stop-opacity:1"
+         offset="0"
+         id="stop4854-4" />
+      <stop
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         offset="1"
+         id="stop4856-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4844-4">
+      <stop
+         style="stop-color:#313131;stop-opacity:1;"
+         offset="0"
+         id="stop4846-8" />
+      <stop
+         style="stop-color:#696969;stop-opacity:1;"
+         offset="1"
+         id="stop4848-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="matrix(0.85131056,0,0,0.85131056,3.1105797,157.79848)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4047"
+       xlink:href="#linearGradient4852-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="matrix(0.85131056,0,0,0.85131056,3.1105797,157.79848)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4049"
+       xlink:href="#linearGradient4844-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4113"
+       id="linearGradient4109"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.85131056,0,0,0.85131056,-0.812566,152.8602)"
+       x1="4.7528968"
+       y1="1051.0466"
+       x2="4.7528968"
+       y2="1038.5814" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4119"
+       id="linearGradient4111"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.85131056,0,0,0.85131056,-0.812566,152.8602)"
+       x1="8.6566515"
+       y1="1050.7386"
+       x2="8.6566515"
+       y2="1037.7" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="9.4041766"
+     inkscape:cy="9.0380727"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="199"
+     inkscape:window-y="506"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4109);fill-opacity:1;stroke:url(#linearGradient4111);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       d="m 10.611417,1037.0786 c -0.39857,-0.3986 -1.040279,-0.3986 -1.438829,-10e-5 l -2.649957,2.65 -2.6499362,-2.6499 c -0.3985102,-0.3986 -1.0402794,-0.3986 -1.4388289,0 l -0.7321744,0.7322 c -0.3985317,0.3984 -0.3985216,1.0401 3.12e-5,1.4388 l 2.6498934,2.65 -2.6498973,2.6498 c -0.398592,0.3986 -0.3985819,1.0403 -1.14e-5,1.4389 l 0.7322136,0.7322 c 0.3985277,0.3985 1.0402371,0.3985 1.4388286,0 l 2.6499404,-2.6499 2.668352,2.6683 c 0.398529,0.3986 1.040238,0.3986 1.43883,0 l 0.732174,-0.7321 c 0.39855,-0.3986 0.394547,-1.0363 -3.2e-5,-1.4389 l -2.668352,-2.6683 2.649939,-2.6499 c 0.398568,-0.3987 0.398558,-1.0404 2.9e-5,-1.4389 z"
+       id="rect4043-2-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccccssccsccsccss" />
+    <path
+       style="fill:url(#linearGradient4047);fill-opacity:1;stroke:url(#linearGradient4049);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       d="m 14.534563,1042.0169 c -0.39857,-0.3986 -1.040279,-0.3986 -1.438829,-10e-5 l -2.649957,2.65 -2.6499365,-2.6499 c -0.3985102,-0.3986 -1.0402794,-0.3986 -1.4388289,0 l -0.7321744,0.7322 c -0.3985317,0.3984 -0.3985216,1.0401 3.12e-5,1.4388 l 2.6498934,2.65 -2.6498973,2.6498 c -0.398592,0.3986 -0.3985819,1.0403 -1.14e-5,1.4389 l 0.7322136,0.7322 c 0.3985277,0.3985 1.0402371,0.3985 1.4388286,0 l 2.6499407,-2.6499 2.668352,2.6683 c 0.398529,0.3986 1.040238,0.3986 1.43883,0 l 0.732174,-0.7321 c 0.39855,-0.3986 0.394547,-1.0363 -3.2e-5,-1.4389 l -2.668352,-2.6683 2.649939,-2.6499 c 0.398568,-0.3987 0.398558,-1.0404 2.9e-5,-1.4389 z"
+       id="rect4043-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccccssccsccsccss" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/progress_stop.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/progress_stop.svg
@@ -1,0 +1,4572 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="ch_cancel.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4774">
+      <stop
+         style="stop-color:#c01020;stop-opacity:1"
+         offset="0"
+         id="stop4776" />
+      <stop
+         id="stop4782"
+         offset="0.5"
+         style="stop-color:#b83838;stop-opacity:1" />
+      <stop
+         style="stop-color:#c85848;stop-opacity:1"
+         offset="1"
+         id="stop4778" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4760">
+      <stop
+         id="stop4762"
+         offset="0"
+         style="stop-color:#e85050;stop-opacity:1" />
+      <stop
+         style="stop-color:#e83038;stop-opacity:1"
+         offset="0.49362174"
+         id="stop4764" />
+      <stop
+         id="stop4772"
+         offset="0.63784295"
+         style="stop-color:#e82030;stop-opacity:1" />
+      <stop
+         id="stop4766"
+         offset="1"
+         style="stop-color:#e83840;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4750">
+      <stop
+         id="stop4752"
+         offset="0"
+         style="stop-color:#f8b0a8;stop-opacity:1" />
+      <stop
+         style="stop-color:#f07878;stop-opacity:1"
+         offset="0.5"
+         id="stop4754" />
+      <stop
+         id="stop4756"
+         offset="1"
+         style="stop-color:#f8a8a8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6642">
+      <stop
+         style="stop-color:#e83038;stop-opacity:1;"
+         offset="0"
+         id="stop6644" />
+      <stop
+         style="stop-color:#af131a;stop-opacity:1;"
+         offset="1"
+         id="stop6646" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13858" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13860" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13850">
+      <stop
+         id="stop13852"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13854"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13834">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13836" />
+      <stop
+         style="stop-color:#807e66;stop-opacity:0;"
+         offset="1"
+         id="stop13838" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799">
+      <stop
+         style="stop-color:#b9772f;stop-opacity:1"
+         offset="0"
+         id="stop13801" />
+      <stop
+         id="stop13809"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop13807"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop13811" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop13803" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090" />
+      <stop
+         id="stop12096"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001" />
+      <stop
+         id="stop12007"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971" />
+      <stop
+         id="stop11979"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689" />
+      <stop
+         id="stop11695"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150" />
+      <stop
+         id="stop11152"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11128">
+      <stop
+         style="stop-color:#e4d09d;stop-opacity:1"
+         offset="0"
+         id="stop11130" />
+      <stop
+         id="stop11136"
+         offset="0.27413794"
+         style="stop-color:#f6ecb2;stop-opacity:1" />
+      <stop
+         style="stop-color:#b58a68;stop-opacity:1"
+         offset="1"
+         id="stop11132" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856">
+      <stop
+         id="stop10858"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860" />
+      <stop
+         id="stop10862"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800" />
+      <stop
+         id="stop10806"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10748">
+      <stop
+         id="stop10750"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754" />
+      <stop
+         id="stop10756"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450" />
+      <stop
+         id="stop10458"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442" />
+      <stop
+         id="stop10521"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10432">
+      <stop
+         id="stop10434"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436" />
+      <stop
+         id="stop10438"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10414">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416" />
+      <stop
+         id="stop10422"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10396">
+      <stop
+         style="stop-color:#1b3e79;stop-opacity:1;"
+         offset="0"
+         id="stop10398" />
+      <stop
+         id="stop10404"
+         offset="0.5"
+         style="stop-color:#728fbf;stop-opacity:1" />
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="1"
+         id="stop10400" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10157">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159" />
+      <stop
+         id="stop10165"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9914"
+       inkscape:collect="always">
+      <stop
+         id="stop9916"
+         offset="0"
+         style="stop-color:#4a6fa4;stop-opacity:1" />
+      <stop
+         id="stop9918"
+         offset="1"
+         style="stop-color:#4e86ca;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9908"
+       inkscape:collect="always">
+      <stop
+         id="stop9910"
+         offset="0"
+         style="stop-color:#525f72;stop-opacity:1" />
+      <stop
+         id="stop9912"
+         offset="1"
+         style="stop-color:#9e884e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9605">
+      <stop
+         style="stop-color:#2a5bbf;stop-opacity:1;"
+         offset="0"
+         id="stop9607" />
+      <stop
+         style="stop-color:#2a5bbf;stop-opacity:0;"
+         offset="1"
+         id="stop9609" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9510">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9512" />
+      <stop
+         id="stop9514"
+         offset="0.35636142"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9516" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334" />
+      <stop
+         id="stop9340"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9324">
+      <stop
+         id="stop9326"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.30000001"
+         id="stop9328" />
+      <stop
+         id="stop9330"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9312">
+      <stop
+         style="stop-color:#cf6c00;stop-opacity:1"
+         offset="0"
+         id="stop9314" />
+      <stop
+         id="stop9322"
+         offset="0.36339331"
+         style="stop-color:#f5db48;stop-opacity:0.24200913" />
+      <stop
+         style="stop-color:#c36000;stop-opacity:1"
+         offset="1"
+         id="stop9316" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9299">
+      <stop
+         style="stop-color:#929baa;stop-opacity:1"
+         offset="0"
+         id="stop9301" />
+      <stop
+         style="stop-color:#cac3a5;stop-opacity:1"
+         offset="1"
+         id="stop9303" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9291">
+      <stop
+         style="stop-color:#e9f8ff;stop-opacity:1;"
+         offset="0"
+         id="stop9293" />
+      <stop
+         style="stop-color:#f5f6f9;stop-opacity:1"
+         offset="1"
+         id="stop9295" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8661"
+       inkscape:collect="always">
+      <stop
+         id="stop8663"
+         offset="0"
+         style="stop-color:#c6e7f9;stop-opacity:1" />
+      <stop
+         id="stop8665"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8653">
+      <stop
+         style="stop-color:#676656;stop-opacity:1;"
+         offset="0"
+         id="stop8655" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop8657" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9">
+      <stop
+         id="stop7561-3-3-4-48"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1" />
+      <stop
+         id="stop7565-8-8-3-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6" />
+      <stop
+         id="stop7114-9-0-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4320">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4322" />
+      <stop
+         id="stop4324"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4326" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4329">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4331" />
+      <stop
+         id="stop4333"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4335" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8">
+      <stop
+         id="stop7561-3-3-4-48-7"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7" />
+      <stop
+         id="stop7565-8-8-3-2-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7" />
+      <stop
+         id="stop7114-9-0-1-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3256">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3258" />
+      <stop
+         id="stop3260"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3262" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3265">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3267" />
+      <stop
+         id="stop3269"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3271" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-2">
+      <stop
+         id="stop7561-3-3-4-48-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-76" />
+      <stop
+         id="stop7565-8-8-3-2-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-22">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-8" />
+      <stop
+         id="stop7114-9-0-1-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3506">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3508" />
+      <stop
+         id="stop3510"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3512" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3515">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3517" />
+      <stop
+         id="stop3519"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3521" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1">
+      <stop
+         id="stop7561-3-3-4-48-7-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3" />
+      <stop
+         id="stop7565-8-8-3-2-0-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9" />
+      <stop
+         id="stop7114-9-0-1-4-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4133">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4135" />
+      <stop
+         id="stop4137"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4139" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4142">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4144" />
+      <stop
+         id="stop4146"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4148" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1" />
+      <stop
+         id="stop7114-9-0-1-4-6-2"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4356" />
+      <stop
+         id="stop4358"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4360" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4365" />
+      <stop
+         id="stop4367"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4369" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-5">
+      <stop
+         id="stop7561-3-3-4-48-7-4-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-0" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-3"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4356-1" />
+      <stop
+         id="stop4358-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4360-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4365-6" />
+      <stop
+         id="stop4367-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4369-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-5">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-7" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-0" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5692" />
+      <stop
+         id="stop5694"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5696" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5701" />
+      <stop
+         id="stop5703"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5705" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-9">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-2"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-0" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-5"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-2" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-16"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5692-0" />
+      <stop
+         id="stop5694-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5696-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5701-6" />
+      <stop
+         id="stop5703-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5705-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-2" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-8" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6127" />
+      <stop
+         id="stop6129"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6131" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6136" />
+      <stop
+         id="stop6138"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6140" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6127-4" />
+      <stop
+         id="stop6129-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6131-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6136-6" />
+      <stop
+         id="stop6138-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6140-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-92">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-6" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-55"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-72">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-5" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6293">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6295" />
+      <stop
+         id="stop6297"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6299" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6302">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6304" />
+      <stop
+         id="stop6306"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6308" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6321">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6323" />
+      <stop
+         id="stop6325"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6327" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6330">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6332" />
+      <stop
+         id="stop6334"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6336" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-3-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-2-2" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-3-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-8-5" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-4-5"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-0-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6349">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6351" />
+      <stop
+         id="stop6353"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6355" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6358">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6360" />
+      <stop
+         id="stop6362"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6364" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8-0"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4-7" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0-7"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6940">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6942" />
+      <stop
+         id="stop6944"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6946" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6949">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6951" />
+      <stop
+         id="stop6953"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6955" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6-1">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8-0-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4-7-3" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8-6-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9-4-8" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0-7-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4-1-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7106">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7108" />
+      <stop
+         id="stop7110"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7112" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7115">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7117" />
+      <stop
+         id="stop7119"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7121" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7686-9"
+       id="linearGradient7692-4"
+       x1="1303.0625"
+       y1="610.34235"
+       x2="1303.0625"
+       y2="723.85583"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7686-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7688-7" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7690-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-140)"
+       y2="723.85583"
+       x2="1303.0625"
+       y1="610.34235"
+       x1="1303.0625"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7755-5"
+       xlink:href="#linearGradient7686-9-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7686-9-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7688-7-1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7690-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2"
+       id="linearGradient8159-0"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-9"
+       id="linearGradient8143-2"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-9">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-4" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,2.6171875e-6)"
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8180-3"
+       xlink:href="#linearGradient8153-2-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-8">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-7" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,2.6171875e-6)"
+       y2="283.2832"
+       x2="657.71722"
+       y1="283.2832"
+       x1="617.06256"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8182"
+       xlink:href="#linearGradient8137-9-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-9-5">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-4-2" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-6"
+       id="linearGradient8291-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-6">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-6" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-1">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-4" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-4">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-78" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-93">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-9" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8498"
+       id="linearGradient8504"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8498">
+      <stop
+         style="stop-color:#d9f4ff;stop-opacity:1"
+         offset="0"
+         id="stop8500" />
+      <stop
+         style="stop-color:#f9fcff;stop-opacity:1"
+         offset="1"
+         id="stop8502" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8659"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8661"
+       id="linearGradient8681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137"
+       id="linearGradient8683"
+       gradientUnits="userSpaceOnUse"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2"
+       id="linearGradient8685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337"
+       id="linearGradient8687"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8689"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8691"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8693"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8695"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8697"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-93"
+       id="linearGradient8699"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-4"
+       id="linearGradient8701"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-1"
+       id="linearGradient8703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375262)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291"
+       id="linearGradient9297"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299"
+       id="linearGradient9305"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332-9"
+       id="linearGradient9338-8"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient9332-9">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334-5" />
+      <stop
+         id="stop9340-2"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9324-7"
+       id="linearGradient9318"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient9324-7">
+      <stop
+         id="stop9326-0"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.30000001"
+         id="stop9328-1" />
+      <stop
+         id="stop9330-5"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291-8"
+       id="linearGradient9297-1"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9291-8">
+      <stop
+         style="stop-color:#e9f8ff;stop-opacity:1;"
+         offset="0"
+         id="stop9293-7" />
+      <stop
+         style="stop-color:#f5f6f9;stop-opacity:1"
+         offset="1"
+         id="stop9295-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299-1"
+       id="linearGradient9305-8"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9299-1">
+      <stop
+         style="stop-color:#929baa;stop-opacity:1"
+         offset="0"
+         id="stop9301-6" />
+      <stop
+         style="stop-color:#cac3a5;stop-opacity:1"
+         offset="1"
+         id="stop9303-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332-6">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334-52" />
+      <stop
+         id="stop9340-23"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9312-9">
+      <stop
+         style="stop-color:#cf6c00;stop-opacity:1"
+         offset="0"
+         id="stop9314-5" />
+      <stop
+         id="stop9322-0"
+         offset="0.36339331"
+         style="stop-color:#f5db48;stop-opacity:0.24200913" />
+      <stop
+         style="stop-color:#c36000;stop-opacity:1"
+         offset="1"
+         id="stop9316-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       y2="472.63525"
+       x2="556.25635"
+       y1="472.63525"
+       x1="526.85181"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9415-5"
+       xlink:href="#linearGradient9510-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9510-3">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9512-4" />
+      <stop
+         id="stop9514-9"
+         offset="0.35636142"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9516-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8661-5"
+       inkscape:collect="always">
+      <stop
+         id="stop8663-3"
+         offset="0"
+         style="stop-color:#c6e7f9;stop-opacity:1" />
+      <stop
+         id="stop8665-5"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-6">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-1" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-0">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-9" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-2">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-7" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-2"
+       id="linearGradient8697-5"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8653-2">
+      <stop
+         style="stop-color:#676656;stop-opacity:1;"
+         offset="0"
+         id="stop8655-9" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop8657-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-4-4">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-78-0" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-0-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-1-3"
+       id="linearGradient8703-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375262)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-1-3">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-4-2" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-2-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9605"
+       id="linearGradient9962"
+       gradientUnits="userSpaceOnUse"
+       x1="213.82529"
+       y1="441.62799"
+       x2="227.09628"
+       y2="454.31174" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332-6"
+       id="linearGradient9964"
+       gradientUnits="userSpaceOnUse"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9312-9"
+       id="linearGradient9966"
+       gradientUnits="userSpaceOnUse"
+       x1="526.4375"
+       y1="448.46484"
+       x2="556.9375"
+       y2="448.46484" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9510-3"
+       id="linearGradient9968"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8661-5"
+       id="linearGradient9970"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-6"
+       id="linearGradient9972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0)"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-0"
+       id="linearGradient9974"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-2"
+       id="linearGradient9976"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0.34375)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9908"
+       id="linearGradient9978"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="306.07397"
+       x2="641.07611"
+       y2="281.43512" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-2"
+       id="linearGradient9980"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-4-4"
+       id="linearGradient9982"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9914"
+       id="linearGradient9984"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0.34375262)"
+       x1="636.09375"
+       y1="279.41037"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332"
+       id="linearGradient9997"
+       gradientUnits="userSpaceOnUse"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9312"
+       id="linearGradient9999"
+       gradientUnits="userSpaceOnUse"
+       x1="526.4375"
+       y1="448.46484"
+       x2="556.9375"
+       y2="448.46484" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9510"
+       id="linearGradient10001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291-8"
+       id="linearGradient10003"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299-1"
+       id="linearGradient10005"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-5"
+       id="linearGradient10163-8"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10157-5">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-7" />
+      <stop
+         id="stop10165-2"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-3"
+       id="linearGradient10155-1"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-3">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-0" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-6"
+       id="linearGradient10155-5"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-6">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-5" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2"
+       id="linearGradient10163-2"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10157-2">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8" />
+      <stop
+         id="stop10165-3"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39"
+       id="linearGradient10155-7"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10149-6-5">
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="0"
+         id="stop10151-5-7" />
+      <stop
+         id="stop10394"
+         offset="0.5"
+         style="stop-color:#b9c7df;stop-opacity:1" />
+      <stop
+         style="stop-color:#567ebc;stop-opacity:1"
+         offset="1"
+         id="stop10153-8-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-4"
+       id="linearGradient10454-7"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10448-4">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-4" />
+      <stop
+         id="stop10458-7"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-9"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-1" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-2"
+       id="linearGradient10446-9"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10440-2">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-4" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9"
+       id="linearGradient10454-9"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10448-9">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3" />
+      <stop
+         id="stop10458-8"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1"
+       id="linearGradient10446-7"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10440-1">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43" />
+      <stop
+         id="stop10521-1"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10546-3"
+       xlink:href="#linearGradient10448-9-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-7">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5" />
+      <stop
+         id="stop10458-8-0"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4-1"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2-9" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10548-3"
+       xlink:href="#linearGradient10440-1-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-1-0">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-2" />
+      <stop
+         id="stop10521-1-2"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10546-8"
+       xlink:href="#linearGradient10448-9-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-6">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-8" />
+      <stop
+         id="stop10458-8-7"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4-7"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2-1" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10548-1"
+       xlink:href="#linearGradient10440-1-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-1-3">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-0" />
+      <stop
+         id="stop10521-1-4"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-9-7-0">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6" />
+      <stop
+         id="stop10456-4-1-5"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-0-0">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-2-0" />
+      <stop
+         id="stop10521-1-2-5"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-4-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0"
+       id="linearGradient10770"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-0-0"
+       id="linearGradient10772"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       x1="334.375"
+       y1="529.06494"
+       x2="334.375"
+       y2="518.67365" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748"
+       id="linearGradient10774"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-3"
+       id="linearGradient10776"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       x1="334.375"
+       y1="532.30212"
+       x2="334.375"
+       y2="515.73615" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448"
+       id="linearGradient10778"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440"
+       id="linearGradient10780"
+       gradientUnits="userSpaceOnUse"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414"
+       id="linearGradient10782"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432"
+       id="linearGradient10784"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157"
+       id="linearGradient10786"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10396"
+       id="linearGradient10788"
+       gradientUnits="userSpaceOnUse"
+       x1="302.3125"
+       y1="532.98718"
+       x2="302.3125"
+       y2="514.67456" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2"
+       id="linearGradient10790"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39"
+       id="linearGradient10792"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-6-5"
+       id="linearGradient10794"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.88388349,2.6171875e-6)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="511.38498" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-8"
+       id="linearGradient10804-7"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10798-8">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-2" />
+      <stop
+         id="stop10806-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1"
+       id="linearGradient10804-8"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10798-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5" />
+      <stop
+         id="stop10806-6"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2" />
+      <stop
+         id="stop10806-6-8"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10835-2"
+       xlink:href="#linearGradient10856-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6">
+      <stop
+         id="stop10858-0"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7" />
+      <stop
+         id="stop10862-3"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8"
+       id="radialGradient11144-4"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)" />
+    <linearGradient
+       id="linearGradient11146-8">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7" />
+      <stop
+         id="stop11152-8"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-7"
+       id="radialGradient11144-2"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)" />
+    <linearGradient
+       id="linearGradient11146-7">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9" />
+      <stop
+         id="stop11152-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11169-6"
+       xlink:href="#linearGradient11146-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-8-7">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8" />
+      <stop
+         id="stop11152-8-8"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11063-6"
+       xlink:href="#linearGradient10856-6-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-3">
+      <stop
+         id="stop10858-0-7"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9" />
+      <stop
+         id="stop10862-3-3"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1" />
+      <stop
+         id="stop10806-6-8-5"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-4"
+       id="radialGradient11268-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-4">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4" />
+      <stop
+         id="stop11152-9"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-3"
+       id="radialGradient11270-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-8-3">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5" />
+      <stop
+         id="stop11152-8-4"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-7-5"
+       id="radialGradient11272-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-154.64572)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-7-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6" />
+      <stop
+         id="stop11152-6-7"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-7-5"
+       id="radialGradient11274-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-154.64572)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-8-7-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3" />
+      <stop
+         id="stop11152-8-8-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11298-3"
+       xlink:href="#linearGradient10856-6-3-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-3-0">
+      <stop
+         id="stop10858-0-7-6"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1" />
+      <stop
+         id="stop10862-3-3-8"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10880-5-3-4"
+       xlink:href="#linearGradient10798-1-9-3-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8" />
+      <stop
+         id="stop10806-6-8-5-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390"
+       xlink:href="#linearGradient10798-1-9-3-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-4-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-7" />
+      <stop
+         id="stop11152-9-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-4">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-5" />
+      <stop
+         id="stop11152-8-4-9"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-3">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-4" />
+      <stop
+         id="stop11152-6-7-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-6">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-1" />
+      <stop
+         id="stop11152-8-8-6-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-1">
+      <stop
+         id="stop10858-0-7-6-1"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-7" />
+      <stop
+         id="stop10862-3-3-8-4"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-0"
+       xlink:href="#linearGradient10798-1-9-3-7-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2" />
+      <stop
+         id="stop10806-6-8-5-3-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11520-3"
+       xlink:href="#linearGradient10798-1-9-3-7-1-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-6" />
+      <stop
+         id="stop10806-6-8-5-3-2-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11520-8"
+       xlink:href="#linearGradient10798-1-9-3-7-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5" />
+      <stop
+         id="stop10806-6-8-5-3-2-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-2"
+       id="radialGradient11685-7"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-1"
+       id="linearGradient11693-0"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-1">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-9" />
+      <stop
+         id="stop11695-3"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11888-8"
+       id="linearGradient11894-2"
+       x1="342.37973"
+       y1="457.29816"
+       x2="358.60471"
+       y2="444.57022"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11888-8">
+      <stop
+         style="stop-color:#a7c8ec;stop-opacity:1"
+         offset="0"
+         id="stop11890-4" />
+      <stop
+         style="stop-color:#b4def6;stop-opacity:1"
+         offset="1"
+         id="stop11892-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11888-4"
+       id="linearGradient11894-5"
+       x1="342.37973"
+       y1="457.29816"
+       x2="358.60471"
+       y2="444.57022"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11888-4">
+      <stop
+         style="stop-color:#a7c8ec;stop-opacity:1"
+         offset="0"
+         id="stop11890-8" />
+      <stop
+         style="stop-color:#b4def6;stop-opacity:1"
+         offset="1"
+         id="stop11892-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-3" />
+      <stop
+         id="stop11979-8"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-7"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-1" />
+      <stop
+         id="stop12096-1"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-7">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-9" />
+      <stop
+         id="stop12007-1"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-7"
+       id="radialGradient11685-5"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-94" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-9"
+       id="linearGradient11693-2"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-9">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-1" />
+      <stop
+         id="stop11695-2"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-8"
+       id="radialGradient11685-3"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-8"
+       id="linearGradient11693-26"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-8">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-6" />
+      <stop
+         id="stop11695-6"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2-2">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-3-7" />
+      <stop
+         id="stop11979-8-6"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-7-6"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-6-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2-1">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-1-8" />
+      <stop
+         id="stop12096-1-8"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-2-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-7-2">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-9-2" />
+      <stop
+         id="stop12007-1-3"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-2-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8" />
+      <stop
+         id="stop10806-6-8-5-3-2-95"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-9">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-7" />
+      <stop
+         id="stop11979-0"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-6"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-7" />
+      <stop
+         id="stop12096-6"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-1" />
+      <stop
+         id="stop12007-4"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5-2" />
+      <stop
+         id="stop10806-6-8-5-3-2-3-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-3"
+       id="radialGradient11685-2"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-91" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-02" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-2"
+       id="linearGradient11693-3"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-2">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-3" />
+      <stop
+         id="stop11695-9"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-10" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-9"
+       id="radialGradient12723-3"
+       cx="433.36786"
+       cy="424.34106"
+       fx="433.36786"
+       fy="424.34106"
+       r="12.027534"
+       gradientTransform="matrix(1.1614831,2.1855961e-7,-2.811228e-7,1.4939602,-69.981471,-211.63828)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-9">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-7" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-5">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-6" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-9" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-5"
+       id="radialGradient12739-4"
+       cx="433.5452"
+       cy="420.74988"
+       fx="433.5452"
+       fy="420.74988"
+       r="12.952347"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1"
+       id="linearGradient12904-2"
+       x1="420.88995"
+       y1="455.88452"
+       x2="440.35345"
+       y2="417.26108"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11146-4-0">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-1" />
+      <stop
+         id="stop11152-9-9"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-2" />
+      <stop
+         id="stop11152-8-4-3"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-8" />
+      <stop
+         id="stop11152-6-7-5"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-9">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-19" />
+      <stop
+         id="stop11152-8-8-6-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-5">
+      <stop
+         id="stop10858-0-7-6-9"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-9" />
+      <stop
+         id="stop10862-3-3-8-6"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-9"
+       xlink:href="#linearGradient10798-1-9-3-7-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20" />
+      <stop
+         id="stop10806-6-8-5-3-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13197-7"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4" />
+      <stop
+         id="stop10806-6-8-5-3-9-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-4"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13197-3"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6" />
+      <stop
+         id="stop10806-6-8-5-3-9-24"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13468-0"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-9-6"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13333-0-1"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-5">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2-1"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2-3" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13551"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient13850-2">
+      <stop
+         id="stop13852-4"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13854-7"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856-0">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13858-8" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13860-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799-7">
+      <stop
+         style="stop-color:#b9772f;stop-opacity:1"
+         offset="0"
+         id="stop13801-4" />
+      <stop
+         id="stop13809-4"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop13807-7"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop13811-8" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop13803-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1-8">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3-6" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4-9" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="455.88452"
+       x1="420.88995"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13011-8"
+       xlink:href="#linearGradient12862-1-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11969-9-0">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-7-1" />
+      <stop
+         id="stop11979-0-0"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-6-1"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7-6">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-7-9" />
+      <stop
+         id="stop12096-6-2"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-1-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9-8">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-1-9" />
+      <stop
+         id="stop12007-4-6"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-3-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5-2-6" />
+      <stop
+         id="stop10806-6-8-5-3-2-3-3-7"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2-2-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687-2-2">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-3-7" />
+      <stop
+         id="stop11695-9-8"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-10-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13468-0-8"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-9-6-5"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13551-0"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-5-8">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2-1-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2-3-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5029"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-4" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-1"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5029-2"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5-8-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-5-8-5">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3-1-1-7" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2-1-2-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2-3-4-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-9-6-5-6-8"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2-6-7-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-9">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-8" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-4"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6001-2"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-2">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-8-7" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-4-1"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-6-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6001-4"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-7">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-8-72" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-4-16"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-6-0" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6038-4-1"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-7-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-7-0">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-8-72-8" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-4-16-4"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-6-0-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-7">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-7" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-3"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13468-0-8-4"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-8" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-9" />
+    </linearGradient>
+    <linearGradient
+       y2="462.11539"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3929-5"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-8-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-3-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-9-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6642"
+       id="linearGradient6648"
+       x1="8.2203207"
+       y1="1043.3812"
+       x2="8.2203207"
+       y2="1049.0878"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="translate(0.397748,0.19882835)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4729"
+       id="linearGradient4735"
+       x1="7.5007138"
+       y1="1040.3939"
+       x2="7.5007138"
+       y2="1048.3102"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4729">
+      <stop
+         style="stop-color:#f8b0a8;stop-opacity:1"
+         offset="0"
+         id="stop4731" />
+      <stop
+         id="stop4737"
+         offset="0.5"
+         style="stop-color:#f07878;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8a8a8;stop-opacity:1"
+         offset="1"
+         id="stop4733" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6642-7"
+       id="linearGradient6648-1"
+       x1="8.2203207"
+       y1="1043.3812"
+       x2="8.2203207"
+       y2="1049.0878"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient6642-7">
+      <stop
+         id="stop4758"
+         offset="0"
+         style="stop-color:#cb2129;stop-opacity:1;" />
+      <stop
+         style="stop-color:#bd1a21;stop-opacity:1;"
+         offset="0.75"
+         id="stop4770" />
+      <stop
+         style="stop-color:#af131a;stop-opacity:1;"
+         offset="1"
+         id="stop6646-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0.397748,0.19882835)"
+       y2="1048.1158"
+       x2="8.2203207"
+       y1="1041.1198"
+       x1="8.2203207"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4783"
+       xlink:href="#linearGradient4760"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4750"
+       id="linearGradient4748"
+       x1="18.277163"
+       y1="4.5243545"
+       x2="18.277163"
+       y2="12.6786"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-10,1036.3622)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4774"
+       id="linearGradient4780"
+       x1="15.820688"
+       y1="1049.7999"
+       x2="15.820688"
+       y2="1039.7346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-10,0)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="12.963467"
+     inkscape:cy="7.0594162"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="851"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3958" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;color:#000000;fill:url(#linearGradient4783);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4780);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans"
+       id="rect6562"
+       width="10.011972"
+       height="9.9912109"
+       x="3.4962158"
+       y="1039.864"
+       rx="1.3052979"
+       ry="1.3052979" />
+    <rect
+       style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;color:#000000;fill:none;stroke:url(#linearGradient4735);stroke-width:1;stroke-miterlimit:4;stroke-opacity:0.69158876;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans"
+       id="rect6562-9"
+       width="8.0096645"
+       height="8.0024414"
+       x="4.4926262"
+       y="1040.8654"
+       rx="0.30935922"
+       ry="0.30935922" />
+    <rect
+       style="fill:none;stroke:url(#linearGradient4748)"
+       id="rect4740"
+       width="8.0100994"
+       height="8.0082979"
+       x="4.4903278"
+       y="1040.8599"
+       rx="0.30935922"
+       ry="0.30935922" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/refresh_nav.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/refresh_nav.svg
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="refresh_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4271">
+      <stop
+         style="stop-color:#eace89;stop-opacity:1"
+         offset="0"
+         id="stop4273" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop4275" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4205">
+      <stop
+         id="stop4207"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop4209"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#fbf0b4;stop-opacity:1"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-9-3">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1"
+         offset="0"
+         id="stop7586-6-3" />
+      <stop
+         style="stop-color:#fbf0b4;stop-opacity:1"
+         offset="1"
+         id="stop7588-9-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-21.977903,-1.044194)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-6-6"
+       id="linearGradient4101-1"
+       gradientUnits="userSpaceOnUse"
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378" />
+    <linearGradient
+       id="linearGradient4994-6-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-1-8"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1;" />
+      <stop
+         id="stop4998-89-8"
+         offset="1"
+         style="stop-color:#dce7f7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.98884218,0,0,1,-17.844521,-1.044194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1040.3303"
+       x2="9.9874563"
+       y1="1042.2307"
+       x1="7.9987183"
+       id="linearGradient4900-1-2"
+       xlink:href="#linearGradient4894-6-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4894-6-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4896-8-7"
+         offset="0"
+         style="stop-color:#e0c88f;stop-opacity:1" />
+      <stop
+         id="stop4898-5-1"
+         offset="1"
+         style="stop-color:#d5b269;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-21.977903,-1.044194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1052.3228"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908-2-2"
+       xlink:href="#linearGradient4902-3-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4902-3-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4904-2-0"
+         offset="0"
+         style="stop-color:#c7b571;stop-opacity:1" />
+      <stop
+         id="stop4906-2-4"
+         offset="1"
+         style="stop-color:#989891;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter7367"
+       x="-0.24086171"
+       width="1.4817234"
+       y="-0.14369156"
+       height="1.2873831">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.68314364"
+         id="feGaussianBlur7369" />
+    </filter>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7379">
+      <path
+         inkscape:connector-curvature="0"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 3.96875,1037.456 0,0.5 0,12.9375 0,0.5 0.5,0 10.0625,0 0.5,0 0,-0.5 0,-9.9375 0,-0.2187 -0.15625,-0.1563 -3.0625,-3 -0.15625,-0.125 -0.1875,0 -7,0 -0.5,0 z"
+         id="path7381" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4271"
+       id="linearGradient4203"
+       x1="40.310833"
+       y1="1033.4677"
+       x2="40.310833"
+       y2="1031.4677"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0118198,0,0,0.99842494,-16.477923,10.635196)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4271"
+       id="linearGradient4203-0"
+       x1="40.310833"
+       y1="1033.4677"
+       x2="40.310833"
+       y2="1031.4677"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0118198,0,0,-0.99842494,66.481578,2079.0731)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="0.84424732"
+     inkscape:cy="1.1910078"
+     inkscape:document-units="px"
+     inkscape:current-layer="g7056"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="805"
+     inkscape:window-y="330"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid6258" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g7604"
+       transform="matrix(0.99581353,0,0,1.0033203,-12.436822,-3.4898583)">
+      <g
+         transform="translate(33.47427,0.06694822)"
+         style="display:inline"
+         id="layer1-2"
+         inkscape:label="Layer 1">
+        <path
+           sodipodi:nodetypes="cccccc"
+           inkscape:connector-curvature="0"
+           id="rect4001-3"
+           d="m -16.48062,1037.8597 7.009669,0 3.062057,3.0066 0,9.9546 -10.071726,0 z"
+           style="display:inline;fill:url(#linearGradient4101-1);fill-opacity:1;stroke:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4884"
+           d="m -9.956902,1037.397 0,3.9112 3.933098,0 z"
+           style="display:inline;fill:url(#linearGradient4900-1-2);fill-opacity:1;stroke:none" />
+        <path
+           sodipodi:nodetypes="cccccc"
+           inkscape:connector-curvature="0"
+           id="rect4001"
+           d="m -16.48062,1037.8597 7.009669,0 3.062057,3.0066 0,9.9546 -10.071726,0 z"
+           style="display:inline;fill:none;stroke:url(#linearGradient4908-2-2);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+    </g>
+    <g
+       id="g7371"
+       mask="url(#mask7379)">
+      <g
+         transform="translate(-20,-1.2913233e-7)"
+         id="g7056-7"
+         style="display:inline;fill:#ffffff;stroke:#ffffff;filter:url(#filter7367);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none">
+        <path
+           transform="translate(-12.551145,0)"
+           sodipodi:nodetypes="ccssscscsssszcc"
+           inkscape:connector-curvature="0"
+           id="path7582-8"
+           d="m 38.106543,1040.5982 0,-1.1582 c 0,0 -0.257386,-0.6113 -0.997369,-0.032 -0.739983,0.5791 -1.608659,1.5121 -1.737352,1.7695 -0.128693,0.2574 -0.675637,0.7078 0.06435,1.4156 0.739983,0.7079 1.544313,1.4478 1.544313,1.4478 0,0 1.126061,1.0617 1.126061,0.064 0,-0.9975 0,-1.3192 0,-1.3192 0.994736,-0.046 1.2338,0.2586 1.484999,0.5012 0.25151,0.2428 0.591496,1.4331 0.887246,1.5242 0.295748,0.091 0.454997,-1.5926 0.454997,-1.911 0,-0.3185 -0.127248,-0.9056 -0.523248,-1.4333 -0.213698,-0.2846 -0.732779,-0.6955 -1.114743,-0.8006 -0.381965,-0.1053 -1.189251,-0.068 -1.189251,-0.068 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           transform="translate(-12.551145,0)"
+           sodipodi:nodetypes="ccssscc"
+           inkscape:connector-curvature="0"
+           id="path7602-2-3-0"
+           d="m 37.645884,1040.3848 0,-0.4343 c 0,0 0.08043,-0.2735 -0.160866,-0.177 -0.241299,0.097 -0.70781,0.4826 -0.75607,0.5631 -0.04826,0.08 -0.546944,0.4343 -0.434338,0.5952 0.112606,0.1609 1.061715,0.048 1.061715,0.048 z"
+           style="opacity:0.85714285000000001;fill:#ffffff;fill-opacity:1;stroke:#ffffff;display:inline;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+        <g
+           style="stroke:#ffffff;stroke-opacity:1;display:inline;fill:#ffffff;stroke-width:2.74726762;stroke-miterlimit:4;stroke-dasharray:none"
+           id="g7604-6-2"
+           transform="matrix(-0.72799606,0,0,-0.72799606,41.57279,1805.7535)">
+          <path
+             sodipodi:nodetypes="ccssscsscsssszcc"
+             inkscape:connector-curvature="0"
+             id="path7582-7-0"
+             d="m 23.585155,1039.3249 0,-1.591 c 0,0 -0.353553,-0.8397 -1.370019,-0.044 -1.016466,0.7955 -2.209709,2.0772 -2.386486,2.4307 -0.176776,0.3536 -0.928077,0.9723 0.08839,1.9446 1.016466,0.9722 2.121321,1.9887 2.121321,1.9887 0,0 0.404271,0.3812 0.799458,0.5707 0.37782,0.1811 0.747338,0.1871 0.747338,-0.4827 0,-1.37 0,-1.812 0,-1.812 1.366404,-0.063 1.727345,0.3446 2.039845,0.6884 0.3125,0.3437 0.8125,1.9687 1.21875,2.0937 0.40625,0.125 0.625,-2.1875 0.625,-2.625 0,-0.4375 -0.09375,-1.3125 -0.71875,-1.9687 -0.625,-0.6563 -1.006571,-0.9555 -1.53125,-1.0998 -0.524679,-0.1444 -1.633595,-0.094 -1.633595,-0.094 z"
+             style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.74726762;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+          <path
+             sodipodi:nodetypes="ccssscc"
+             inkscape:connector-curvature="0"
+             id="path7602-2-8"
+             d="m 23.069359,1042.9731 0,0.5966 c 0,0 0.110485,0.3757 -0.220971,0.2431 -0.331456,-0.1326 -0.972272,-0.6629 -1.038563,-0.7734 -0.06629,-0.1105 -0.751301,-0.5966 -0.596622,-0.8176 0.15468,-0.221 1.458408,-0.066 1.458408,-0.066 z"
+             style="opacity:0.85714285000000001;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.74726762;stroke-miterlimit:4;stroke-dasharray:none" />
+        </g>
+      </g>
+    </g>
+    <g
+       id="g7056"
+       transform="translate(-20,0)">
+      <path
+         style="display:inline;opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none"
+         d="m 24.969739,1040.5411 0,-0.4343 c 0,0 0.08043,-0.2735 -0.160866,-0.177 -0.241299,0.097 -0.70781,0.4826 -0.75607,0.5631 -0.04826,0.08 -0.546944,0.4343 -0.434338,0.5952 0.112606,0.1609 1.061715,0.048 1.061715,0.048 z"
+         id="path7602-2-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccssscc" />
+      <path
+         style="fill:url(#linearGradient4203);fill-opacity:1;fill-rule:evenodd;stroke:#a86d11;stroke-width:0.9;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 24.310388,1039.863 c 0.833712,0 1.209697,10e-5 1.209697,10e-5 0,0 -0.05339,1.0038 0.28125,1.0038 1.472051,0 3.592632,0.059 2.010802,3.949 -1.178012,-0.4009 -0.264087,-2.3606 -2.269694,-1.9742 l 0,1.0587 -1.229705,2e-4 c -1.032511,-1.2396 -1.654513,-1.9855 -1.654513,-1.9855 0.984366,-1.3448 0.996095,-1.3023 1.652163,-2.0521 z"
+         id="path4195"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccscccccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient4203-0);fill-opacity:1;fill-rule:evenodd;stroke:#a86d11;stroke-width:0.89999998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 25.693267,1049.8453 c -0.833712,0 -1.209697,-10e-5 -1.209697,-10e-5 0,0 0.05339,-1.0038 -0.28125,-1.0038 -1.472051,0 -3.592632,-0.059 -2.010802,-3.949 1.178012,0.4009 0.264087,2.3606 2.269694,1.9742 l 0,-1.0587 1.229705,-2e-4 c 1.032511,1.2396 1.654513,1.9855 1.654513,1.9855 -0.984366,1.3448 -0.996095,1.3023 -1.652163,2.0521 z"
+         id="path4195-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccscccccc" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/remove.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/remove.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="remove_exc.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4852-7">
+      <stop
+         style="stop-color:#707070;stop-opacity:1"
+         offset="0"
+         id="stop4854-4" />
+      <stop
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         offset="1"
+         id="stop4856-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4844-4">
+      <stop
+         style="stop-color:#414141;stop-opacity:1;"
+         offset="0"
+         id="stop4846-8" />
+      <stop
+         style="stop-color:#535353;stop-opacity:1;"
+         offset="1"
+         id="stop4848-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="matrix(0.99104673,0,0,1.0377289,-0.03213967,-39.635801)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4047"
+       xlink:href="#linearGradient4852-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="matrix(0.99104673,0,0,1.0377289,-0.03213967,-39.635801)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4049"
+       xlink:href="#linearGradient4844-4"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999998"
+     inkscape:cx="5.5301136"
+     inkscape:cy="7.9227098"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="963"
+     inkscape:window-y="622"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4047);fill-opacity:1;stroke:url(#linearGradient4049);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       d="m 13.267004,1038.2068 c -0.463993,-0.4858 -1.211033,-0.4858 -1.675002,-10e-5 l -3.0849275,3.2304 -3.0849031,-3.2303 c -0.4639226,-0.4858 -1.2110333,-0.4858 -1.6750018,0 l -0.8523552,0.8927 c -0.4639479,0.4856 -0.463936,1.2678 3.62e-5,1.7537 l 3.0848535,3.2303 -3.084858,3.2302 c -0.4640179,0.4858 -0.4640062,1.268 -1.34e-5,1.7538 l 0.852401,0.8927 c 0.4639431,0.4858 1.2109842,0.4858 1.6750016,0 l 3.084908,-3.2302 3.1063417,3.2526 c 0.463945,0.4859 1.210985,0.4859 1.675003,0 l 0.852355,-0.8925 c 0.463969,-0.4859 0.459308,-1.2632 -3.6e-5,-1.7539 l -3.106344,-3.2527 3.084908,-3.2302 c 0.46399,-0.4859 0.463978,-1.2681 3.4e-5,-1.7538 z"
+       id="rect4043"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccccssccsccsccss" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/removeall.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/removeall.svg
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="removea_exc.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4119">
+      <stop
+         id="stop4121"
+         offset="0"
+         style="stop-color:#2b2b2b;stop-opacity:1;" />
+      <stop
+         id="stop4123"
+         offset="1"
+         style="stop-color:#686861;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4113"
+       inkscape:collect="always">
+      <stop
+         id="stop4115"
+         offset="0"
+         style="stop-color:#d8d8d8;stop-opacity:1" />
+      <stop
+         id="stop4117"
+         offset="1"
+         style="stop-color:#d8d8d8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4852-7">
+      <stop
+         style="stop-color:#707070;stop-opacity:1"
+         offset="0"
+         id="stop4854-4" />
+      <stop
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         offset="1"
+         id="stop4856-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4844-4">
+      <stop
+         style="stop-color:#313131;stop-opacity:1;"
+         offset="0"
+         id="stop4846-8" />
+      <stop
+         style="stop-color:#696969;stop-opacity:1;"
+         offset="1"
+         id="stop4848-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="matrix(0.85131056,0,0,0.85131056,3.1105797,157.79848)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4047"
+       xlink:href="#linearGradient4852-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="matrix(0.85131056,0,0,0.85131056,3.1105797,157.79848)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4049"
+       xlink:href="#linearGradient4844-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4113"
+       id="linearGradient4109"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.85131056,0,0,0.85131056,-0.812566,152.8602)"
+       x1="4.7528968"
+       y1="1051.0466"
+       x2="4.7528968"
+       y2="1038.5814" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4119"
+       id="linearGradient4111"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.85131056,0,0,0.85131056,-0.812566,152.8602)"
+       x1="8.6566515"
+       y1="1050.7386"
+       x2="8.6566515"
+       y2="1037.7" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="9.4041766"
+     inkscape:cy="9.0380727"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="199"
+     inkscape:window-y="506"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4109);fill-opacity:1;stroke:url(#linearGradient4111);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       d="m 10.611417,1037.0786 c -0.39857,-0.3986 -1.040279,-0.3986 -1.438829,-10e-5 l -2.649957,2.65 -2.6499362,-2.6499 c -0.3985102,-0.3986 -1.0402794,-0.3986 -1.4388289,0 l -0.7321744,0.7322 c -0.3985317,0.3984 -0.3985216,1.0401 3.12e-5,1.4388 l 2.6498934,2.65 -2.6498973,2.6498 c -0.398592,0.3986 -0.3985819,1.0403 -1.14e-5,1.4389 l 0.7322136,0.7322 c 0.3985277,0.3985 1.0402371,0.3985 1.4388286,0 l 2.6499404,-2.6499 2.668352,2.6683 c 0.398529,0.3986 1.040238,0.3986 1.43883,0 l 0.732174,-0.7321 c 0.39855,-0.3986 0.394547,-1.0363 -3.2e-5,-1.4389 l -2.668352,-2.6683 2.649939,-2.6499 c 0.398568,-0.3987 0.398558,-1.0404 2.9e-5,-1.4389 z"
+       id="rect4043-2-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccccssccsccsccss" />
+    <path
+       style="fill:url(#linearGradient4047);fill-opacity:1;stroke:url(#linearGradient4049);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       d="m 14.534563,1042.0169 c -0.39857,-0.3986 -1.040279,-0.3986 -1.438829,-10e-5 l -2.649957,2.65 -2.6499365,-2.6499 c -0.3985102,-0.3986 -1.0402794,-0.3986 -1.4388289,0 l -0.7321744,0.7322 c -0.3985317,0.3984 -0.3985216,1.0401 3.12e-5,1.4388 l 2.6498934,2.65 -2.6498973,2.6498 c -0.398592,0.3986 -0.3985819,1.0403 -1.14e-5,1.4389 l 0.7322136,0.7322 c 0.3985277,0.3985 1.0402371,0.3985 1.4388286,0 l 2.6499407,-2.6499 2.668352,2.6683 c 0.398529,0.3986 1.040238,0.3986 1.43883,0 l 0.732174,-0.7321 c 0.39855,-0.3986 0.394547,-1.0363 -3.2e-5,-1.4389 l -2.668352,-2.6683 2.649939,-2.6499 c 0.398568,-0.3987 0.398558,-1.0404 2.9e-5,-1.4389 z"
+       id="rect4043-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccccssccsccsccss" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/step_current.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/step_current.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="step_current.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#ffffee;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#ffecad;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#ba7f0d;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#a2660b;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="11.0625"
+       y1="1038.5497"
+       x2="11.0625"
+       y2="1049.912"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="4.5"
+       y1="1042.047"
+       x2="4.5"
+       y2="1046.4902"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="-0.57568266"
+     inkscape:cy="2.7852926"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="275"
+     inkscape:window-y="180"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 8.5,1038.8622 0,3 -5.78125,0 c -0.6678671,0 -1.21875,0.5509 -1.21875,1.2188 l 0,2.5625 c 0,0.6678 0.5508829,1.2187 1.21875,1.2187 l 5.78125,0 0,3 1,0 5.5,-5.5 -5.5,-5.5 -1,0 z"
+       id="rect3968"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/step_done.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/step_done.svg
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="step_done.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(18,-3.000037)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062"
+       xlink:href="#linearGradient4910-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2"
+       xlink:href="#linearGradient4994-4"
+       inkscape:collect="always"
+       gradientTransform="translate(18,-3.000037)" />
+    <linearGradient
+       id="linearGradient4994-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883"
+       id="linearGradient4889"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="-5.6436176"
+     inkscape:cy="1.709725"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="379"
+     inkscape:window-y="250"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 2,1038.3622 0.03125,12 11.96875,0 -0.03125,-12 z m 1,1 9.96875,0 0.03125,10 -9.96875,0 z"
+       id="rect3997-9-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 3,1039.3622 9.96875,0 0.03125,10 -9.96875,0 z"
+       id="rect3997-9-1-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient5062);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 0,8 -2,0 0,-10 z"
+       id="rect4853-82-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 8,0 0,-2 -10,0 z"
+       id="rect4853-82-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:none;stroke:#334e6f;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 3.9687503,1044.3309 2.5000001,2.5313 5.5000006,-5.4375"
+       id="path4065"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/stop.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/stop.svg
@@ -1,0 +1,4572 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="ch_cancel.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4774">
+      <stop
+         style="stop-color:#c01020;stop-opacity:1"
+         offset="0"
+         id="stop4776" />
+      <stop
+         id="stop4782"
+         offset="0.5"
+         style="stop-color:#b83838;stop-opacity:1" />
+      <stop
+         style="stop-color:#c85848;stop-opacity:1"
+         offset="1"
+         id="stop4778" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4760">
+      <stop
+         id="stop4762"
+         offset="0"
+         style="stop-color:#e85050;stop-opacity:1" />
+      <stop
+         style="stop-color:#e83038;stop-opacity:1"
+         offset="0.49362174"
+         id="stop4764" />
+      <stop
+         id="stop4772"
+         offset="0.63784295"
+         style="stop-color:#e82030;stop-opacity:1" />
+      <stop
+         id="stop4766"
+         offset="1"
+         style="stop-color:#e83840;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4750">
+      <stop
+         id="stop4752"
+         offset="0"
+         style="stop-color:#f8b0a8;stop-opacity:1" />
+      <stop
+         style="stop-color:#f07878;stop-opacity:1"
+         offset="0.5"
+         id="stop4754" />
+      <stop
+         id="stop4756"
+         offset="1"
+         style="stop-color:#f8a8a8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6642">
+      <stop
+         style="stop-color:#e83038;stop-opacity:1;"
+         offset="0"
+         id="stop6644" />
+      <stop
+         style="stop-color:#af131a;stop-opacity:1;"
+         offset="1"
+         id="stop6646" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13858" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13860" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13850">
+      <stop
+         id="stop13852"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13854"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13834">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13836" />
+      <stop
+         style="stop-color:#807e66;stop-opacity:0;"
+         offset="1"
+         id="stop13838" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799">
+      <stop
+         style="stop-color:#b9772f;stop-opacity:1"
+         offset="0"
+         id="stop13801" />
+      <stop
+         id="stop13809"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop13807"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop13811" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop13803" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090" />
+      <stop
+         id="stop12096"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001" />
+      <stop
+         id="stop12007"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971" />
+      <stop
+         id="stop11979"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689" />
+      <stop
+         id="stop11695"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150" />
+      <stop
+         id="stop11152"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11128">
+      <stop
+         style="stop-color:#e4d09d;stop-opacity:1"
+         offset="0"
+         id="stop11130" />
+      <stop
+         id="stop11136"
+         offset="0.27413794"
+         style="stop-color:#f6ecb2;stop-opacity:1" />
+      <stop
+         style="stop-color:#b58a68;stop-opacity:1"
+         offset="1"
+         id="stop11132" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856">
+      <stop
+         id="stop10858"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860" />
+      <stop
+         id="stop10862"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800" />
+      <stop
+         id="stop10806"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10748">
+      <stop
+         id="stop10750"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754" />
+      <stop
+         id="stop10756"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450" />
+      <stop
+         id="stop10458"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442" />
+      <stop
+         id="stop10521"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10432">
+      <stop
+         id="stop10434"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436" />
+      <stop
+         id="stop10438"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10414">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416" />
+      <stop
+         id="stop10422"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10396">
+      <stop
+         style="stop-color:#1b3e79;stop-opacity:1;"
+         offset="0"
+         id="stop10398" />
+      <stop
+         id="stop10404"
+         offset="0.5"
+         style="stop-color:#728fbf;stop-opacity:1" />
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="1"
+         id="stop10400" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10157">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159" />
+      <stop
+         id="stop10165"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9914"
+       inkscape:collect="always">
+      <stop
+         id="stop9916"
+         offset="0"
+         style="stop-color:#4a6fa4;stop-opacity:1" />
+      <stop
+         id="stop9918"
+         offset="1"
+         style="stop-color:#4e86ca;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9908"
+       inkscape:collect="always">
+      <stop
+         id="stop9910"
+         offset="0"
+         style="stop-color:#525f72;stop-opacity:1" />
+      <stop
+         id="stop9912"
+         offset="1"
+         style="stop-color:#9e884e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9605">
+      <stop
+         style="stop-color:#2a5bbf;stop-opacity:1;"
+         offset="0"
+         id="stop9607" />
+      <stop
+         style="stop-color:#2a5bbf;stop-opacity:0;"
+         offset="1"
+         id="stop9609" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9510">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9512" />
+      <stop
+         id="stop9514"
+         offset="0.35636142"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9516" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334" />
+      <stop
+         id="stop9340"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9324">
+      <stop
+         id="stop9326"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.30000001"
+         id="stop9328" />
+      <stop
+         id="stop9330"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9312">
+      <stop
+         style="stop-color:#cf6c00;stop-opacity:1"
+         offset="0"
+         id="stop9314" />
+      <stop
+         id="stop9322"
+         offset="0.36339331"
+         style="stop-color:#f5db48;stop-opacity:0.24200913" />
+      <stop
+         style="stop-color:#c36000;stop-opacity:1"
+         offset="1"
+         id="stop9316" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9299">
+      <stop
+         style="stop-color:#929baa;stop-opacity:1"
+         offset="0"
+         id="stop9301" />
+      <stop
+         style="stop-color:#cac3a5;stop-opacity:1"
+         offset="1"
+         id="stop9303" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9291">
+      <stop
+         style="stop-color:#e9f8ff;stop-opacity:1;"
+         offset="0"
+         id="stop9293" />
+      <stop
+         style="stop-color:#f5f6f9;stop-opacity:1"
+         offset="1"
+         id="stop9295" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8661"
+       inkscape:collect="always">
+      <stop
+         id="stop8663"
+         offset="0"
+         style="stop-color:#c6e7f9;stop-opacity:1" />
+      <stop
+         id="stop8665"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8653">
+      <stop
+         style="stop-color:#676656;stop-opacity:1;"
+         offset="0"
+         id="stop8655" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop8657" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9">
+      <stop
+         id="stop7561-3-3-4-48"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1" />
+      <stop
+         id="stop7565-8-8-3-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6" />
+      <stop
+         id="stop7114-9-0-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4320">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4322" />
+      <stop
+         id="stop4324"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4326" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4329">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4331" />
+      <stop
+         id="stop4333"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4335" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8">
+      <stop
+         id="stop7561-3-3-4-48-7"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7" />
+      <stop
+         id="stop7565-8-8-3-2-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7" />
+      <stop
+         id="stop7114-9-0-1-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3256">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3258" />
+      <stop
+         id="stop3260"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3262" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3265">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3267" />
+      <stop
+         id="stop3269"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3271" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-2">
+      <stop
+         id="stop7561-3-3-4-48-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-76" />
+      <stop
+         id="stop7565-8-8-3-2-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-22">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-8" />
+      <stop
+         id="stop7114-9-0-1-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3506">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3508" />
+      <stop
+         id="stop3510"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3512" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3515">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3517" />
+      <stop
+         id="stop3519"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3521" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1">
+      <stop
+         id="stop7561-3-3-4-48-7-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3" />
+      <stop
+         id="stop7565-8-8-3-2-0-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9" />
+      <stop
+         id="stop7114-9-0-1-4-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4133">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4135" />
+      <stop
+         id="stop4137"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4139" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4142">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4144" />
+      <stop
+         id="stop4146"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4148" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1" />
+      <stop
+         id="stop7114-9-0-1-4-6-2"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4356" />
+      <stop
+         id="stop4358"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4360" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4365" />
+      <stop
+         id="stop4367"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4369" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-5">
+      <stop
+         id="stop7561-3-3-4-48-7-4-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-0" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-3"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4356-1" />
+      <stop
+         id="stop4358-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4360-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4365-6" />
+      <stop
+         id="stop4367-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4369-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-5">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-7" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-0" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5692" />
+      <stop
+         id="stop5694"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5696" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5701" />
+      <stop
+         id="stop5703"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5705" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-9">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-2"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-0" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-5"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-2" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-16"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5692-0" />
+      <stop
+         id="stop5694-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5696-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5701-6" />
+      <stop
+         id="stop5703-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5705-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-2" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-8" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6127" />
+      <stop
+         id="stop6129"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6131" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6136" />
+      <stop
+         id="stop6138"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6140" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6127-4" />
+      <stop
+         id="stop6129-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6131-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6136-6" />
+      <stop
+         id="stop6138-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6140-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-92">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-6" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-55"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-72">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-5" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6293">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6295" />
+      <stop
+         id="stop6297"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6299" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6302">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6304" />
+      <stop
+         id="stop6306"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6308" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6321">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6323" />
+      <stop
+         id="stop6325"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6327" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6330">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6332" />
+      <stop
+         id="stop6334"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6336" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-3-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-2-2" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-3-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-8-5" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-4-5"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-0-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6349">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6351" />
+      <stop
+         id="stop6353"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6355" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6358">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6360" />
+      <stop
+         id="stop6362"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6364" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8-0"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4-7" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0-7"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6940">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6942" />
+      <stop
+         id="stop6944"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6946" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6949">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6951" />
+      <stop
+         id="stop6953"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6955" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6-1">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8-0-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4-7-3" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8-6-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9-4-8" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0-7-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4-1-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7106">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7108" />
+      <stop
+         id="stop7110"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7112" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7115">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7117" />
+      <stop
+         id="stop7119"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7121" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7686-9"
+       id="linearGradient7692-4"
+       x1="1303.0625"
+       y1="610.34235"
+       x2="1303.0625"
+       y2="723.85583"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7686-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7688-7" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7690-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-140)"
+       y2="723.85583"
+       x2="1303.0625"
+       y1="610.34235"
+       x1="1303.0625"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7755-5"
+       xlink:href="#linearGradient7686-9-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7686-9-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7688-7-1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7690-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2"
+       id="linearGradient8159-0"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-9"
+       id="linearGradient8143-2"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-9">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-4" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,2.6171875e-6)"
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8180-3"
+       xlink:href="#linearGradient8153-2-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-8">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-7" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,2.6171875e-6)"
+       y2="283.2832"
+       x2="657.71722"
+       y1="283.2832"
+       x1="617.06256"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8182"
+       xlink:href="#linearGradient8137-9-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-9-5">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-4-2" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-6"
+       id="linearGradient8291-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-6">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-6" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-1">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-4" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-4">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-78" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-93">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-9" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8498"
+       id="linearGradient8504"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8498">
+      <stop
+         style="stop-color:#d9f4ff;stop-opacity:1"
+         offset="0"
+         id="stop8500" />
+      <stop
+         style="stop-color:#f9fcff;stop-opacity:1"
+         offset="1"
+         id="stop8502" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8659"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8661"
+       id="linearGradient8681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137"
+       id="linearGradient8683"
+       gradientUnits="userSpaceOnUse"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2"
+       id="linearGradient8685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337"
+       id="linearGradient8687"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8689"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8691"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8693"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8695"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8697"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-93"
+       id="linearGradient8699"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-4"
+       id="linearGradient8701"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-1"
+       id="linearGradient8703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375262)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291"
+       id="linearGradient9297"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299"
+       id="linearGradient9305"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332-9"
+       id="linearGradient9338-8"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient9332-9">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334-5" />
+      <stop
+         id="stop9340-2"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9324-7"
+       id="linearGradient9318"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient9324-7">
+      <stop
+         id="stop9326-0"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.30000001"
+         id="stop9328-1" />
+      <stop
+         id="stop9330-5"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291-8"
+       id="linearGradient9297-1"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9291-8">
+      <stop
+         style="stop-color:#e9f8ff;stop-opacity:1;"
+         offset="0"
+         id="stop9293-7" />
+      <stop
+         style="stop-color:#f5f6f9;stop-opacity:1"
+         offset="1"
+         id="stop9295-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299-1"
+       id="linearGradient9305-8"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9299-1">
+      <stop
+         style="stop-color:#929baa;stop-opacity:1"
+         offset="0"
+         id="stop9301-6" />
+      <stop
+         style="stop-color:#cac3a5;stop-opacity:1"
+         offset="1"
+         id="stop9303-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332-6">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334-52" />
+      <stop
+         id="stop9340-23"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9312-9">
+      <stop
+         style="stop-color:#cf6c00;stop-opacity:1"
+         offset="0"
+         id="stop9314-5" />
+      <stop
+         id="stop9322-0"
+         offset="0.36339331"
+         style="stop-color:#f5db48;stop-opacity:0.24200913" />
+      <stop
+         style="stop-color:#c36000;stop-opacity:1"
+         offset="1"
+         id="stop9316-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       y2="472.63525"
+       x2="556.25635"
+       y1="472.63525"
+       x1="526.85181"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9415-5"
+       xlink:href="#linearGradient9510-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9510-3">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9512-4" />
+      <stop
+         id="stop9514-9"
+         offset="0.35636142"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9516-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8661-5"
+       inkscape:collect="always">
+      <stop
+         id="stop8663-3"
+         offset="0"
+         style="stop-color:#c6e7f9;stop-opacity:1" />
+      <stop
+         id="stop8665-5"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-6">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-1" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-0">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-9" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-2">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-7" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-2"
+       id="linearGradient8697-5"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8653-2">
+      <stop
+         style="stop-color:#676656;stop-opacity:1;"
+         offset="0"
+         id="stop8655-9" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop8657-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-4-4">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-78-0" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-0-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-1-3"
+       id="linearGradient8703-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375262)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-1-3">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-4-2" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-2-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9605"
+       id="linearGradient9962"
+       gradientUnits="userSpaceOnUse"
+       x1="213.82529"
+       y1="441.62799"
+       x2="227.09628"
+       y2="454.31174" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332-6"
+       id="linearGradient9964"
+       gradientUnits="userSpaceOnUse"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9312-9"
+       id="linearGradient9966"
+       gradientUnits="userSpaceOnUse"
+       x1="526.4375"
+       y1="448.46484"
+       x2="556.9375"
+       y2="448.46484" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9510-3"
+       id="linearGradient9968"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8661-5"
+       id="linearGradient9970"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-6"
+       id="linearGradient9972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0)"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-0"
+       id="linearGradient9974"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-2"
+       id="linearGradient9976"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0.34375)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9908"
+       id="linearGradient9978"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="306.07397"
+       x2="641.07611"
+       y2="281.43512" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-2"
+       id="linearGradient9980"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-4-4"
+       id="linearGradient9982"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9914"
+       id="linearGradient9984"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0.34375262)"
+       x1="636.09375"
+       y1="279.41037"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332"
+       id="linearGradient9997"
+       gradientUnits="userSpaceOnUse"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9312"
+       id="linearGradient9999"
+       gradientUnits="userSpaceOnUse"
+       x1="526.4375"
+       y1="448.46484"
+       x2="556.9375"
+       y2="448.46484" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9510"
+       id="linearGradient10001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291-8"
+       id="linearGradient10003"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299-1"
+       id="linearGradient10005"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-5"
+       id="linearGradient10163-8"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10157-5">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-7" />
+      <stop
+         id="stop10165-2"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-3"
+       id="linearGradient10155-1"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-3">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-0" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-6"
+       id="linearGradient10155-5"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-6">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-5" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2"
+       id="linearGradient10163-2"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10157-2">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8" />
+      <stop
+         id="stop10165-3"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39"
+       id="linearGradient10155-7"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10149-6-5">
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="0"
+         id="stop10151-5-7" />
+      <stop
+         id="stop10394"
+         offset="0.5"
+         style="stop-color:#b9c7df;stop-opacity:1" />
+      <stop
+         style="stop-color:#567ebc;stop-opacity:1"
+         offset="1"
+         id="stop10153-8-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-4"
+       id="linearGradient10454-7"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10448-4">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-4" />
+      <stop
+         id="stop10458-7"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-9"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-1" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-2"
+       id="linearGradient10446-9"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10440-2">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-4" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9"
+       id="linearGradient10454-9"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10448-9">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3" />
+      <stop
+         id="stop10458-8"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1"
+       id="linearGradient10446-7"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10440-1">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43" />
+      <stop
+         id="stop10521-1"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10546-3"
+       xlink:href="#linearGradient10448-9-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-7">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5" />
+      <stop
+         id="stop10458-8-0"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4-1"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2-9" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10548-3"
+       xlink:href="#linearGradient10440-1-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-1-0">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-2" />
+      <stop
+         id="stop10521-1-2"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10546-8"
+       xlink:href="#linearGradient10448-9-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-6">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-8" />
+      <stop
+         id="stop10458-8-7"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4-7"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2-1" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10548-1"
+       xlink:href="#linearGradient10440-1-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-1-3">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-0" />
+      <stop
+         id="stop10521-1-4"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-9-7-0">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6" />
+      <stop
+         id="stop10456-4-1-5"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-0-0">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-2-0" />
+      <stop
+         id="stop10521-1-2-5"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-4-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0"
+       id="linearGradient10770"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-0-0"
+       id="linearGradient10772"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       x1="334.375"
+       y1="529.06494"
+       x2="334.375"
+       y2="518.67365" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748"
+       id="linearGradient10774"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-3"
+       id="linearGradient10776"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       x1="334.375"
+       y1="532.30212"
+       x2="334.375"
+       y2="515.73615" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448"
+       id="linearGradient10778"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440"
+       id="linearGradient10780"
+       gradientUnits="userSpaceOnUse"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414"
+       id="linearGradient10782"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432"
+       id="linearGradient10784"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157"
+       id="linearGradient10786"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10396"
+       id="linearGradient10788"
+       gradientUnits="userSpaceOnUse"
+       x1="302.3125"
+       y1="532.98718"
+       x2="302.3125"
+       y2="514.67456" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2"
+       id="linearGradient10790"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39"
+       id="linearGradient10792"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-6-5"
+       id="linearGradient10794"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.88388349,2.6171875e-6)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="511.38498" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-8"
+       id="linearGradient10804-7"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10798-8">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-2" />
+      <stop
+         id="stop10806-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1"
+       id="linearGradient10804-8"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10798-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5" />
+      <stop
+         id="stop10806-6"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2" />
+      <stop
+         id="stop10806-6-8"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10835-2"
+       xlink:href="#linearGradient10856-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6">
+      <stop
+         id="stop10858-0"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7" />
+      <stop
+         id="stop10862-3"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8"
+       id="radialGradient11144-4"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)" />
+    <linearGradient
+       id="linearGradient11146-8">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7" />
+      <stop
+         id="stop11152-8"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-7"
+       id="radialGradient11144-2"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)" />
+    <linearGradient
+       id="linearGradient11146-7">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9" />
+      <stop
+         id="stop11152-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11169-6"
+       xlink:href="#linearGradient11146-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-8-7">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8" />
+      <stop
+         id="stop11152-8-8"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11063-6"
+       xlink:href="#linearGradient10856-6-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-3">
+      <stop
+         id="stop10858-0-7"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9" />
+      <stop
+         id="stop10862-3-3"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1" />
+      <stop
+         id="stop10806-6-8-5"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-4"
+       id="radialGradient11268-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-4">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4" />
+      <stop
+         id="stop11152-9"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-3"
+       id="radialGradient11270-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-8-3">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5" />
+      <stop
+         id="stop11152-8-4"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-7-5"
+       id="radialGradient11272-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-154.64572)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-7-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6" />
+      <stop
+         id="stop11152-6-7"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-7-5"
+       id="radialGradient11274-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-154.64572)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-8-7-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3" />
+      <stop
+         id="stop11152-8-8-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11298-3"
+       xlink:href="#linearGradient10856-6-3-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-3-0">
+      <stop
+         id="stop10858-0-7-6"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1" />
+      <stop
+         id="stop10862-3-3-8"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10880-5-3-4"
+       xlink:href="#linearGradient10798-1-9-3-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8" />
+      <stop
+         id="stop10806-6-8-5-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390"
+       xlink:href="#linearGradient10798-1-9-3-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-4-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-7" />
+      <stop
+         id="stop11152-9-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-4">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-5" />
+      <stop
+         id="stop11152-8-4-9"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-3">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-4" />
+      <stop
+         id="stop11152-6-7-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-6">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-1" />
+      <stop
+         id="stop11152-8-8-6-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-1">
+      <stop
+         id="stop10858-0-7-6-1"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-7" />
+      <stop
+         id="stop10862-3-3-8-4"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-0"
+       xlink:href="#linearGradient10798-1-9-3-7-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2" />
+      <stop
+         id="stop10806-6-8-5-3-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11520-3"
+       xlink:href="#linearGradient10798-1-9-3-7-1-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-6" />
+      <stop
+         id="stop10806-6-8-5-3-2-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11520-8"
+       xlink:href="#linearGradient10798-1-9-3-7-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5" />
+      <stop
+         id="stop10806-6-8-5-3-2-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-2"
+       id="radialGradient11685-7"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-1"
+       id="linearGradient11693-0"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-1">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-9" />
+      <stop
+         id="stop11695-3"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11888-8"
+       id="linearGradient11894-2"
+       x1="342.37973"
+       y1="457.29816"
+       x2="358.60471"
+       y2="444.57022"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11888-8">
+      <stop
+         style="stop-color:#a7c8ec;stop-opacity:1"
+         offset="0"
+         id="stop11890-4" />
+      <stop
+         style="stop-color:#b4def6;stop-opacity:1"
+         offset="1"
+         id="stop11892-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11888-4"
+       id="linearGradient11894-5"
+       x1="342.37973"
+       y1="457.29816"
+       x2="358.60471"
+       y2="444.57022"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11888-4">
+      <stop
+         style="stop-color:#a7c8ec;stop-opacity:1"
+         offset="0"
+         id="stop11890-8" />
+      <stop
+         style="stop-color:#b4def6;stop-opacity:1"
+         offset="1"
+         id="stop11892-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-3" />
+      <stop
+         id="stop11979-8"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-7"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-1" />
+      <stop
+         id="stop12096-1"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-7">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-9" />
+      <stop
+         id="stop12007-1"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-7"
+       id="radialGradient11685-5"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-94" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-9"
+       id="linearGradient11693-2"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-9">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-1" />
+      <stop
+         id="stop11695-2"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-8"
+       id="radialGradient11685-3"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-8"
+       id="linearGradient11693-26"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-8">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-6" />
+      <stop
+         id="stop11695-6"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2-2">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-3-7" />
+      <stop
+         id="stop11979-8-6"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-7-6"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-6-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2-1">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-1-8" />
+      <stop
+         id="stop12096-1-8"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-2-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-7-2">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-9-2" />
+      <stop
+         id="stop12007-1-3"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-2-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8" />
+      <stop
+         id="stop10806-6-8-5-3-2-95"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-9">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-7" />
+      <stop
+         id="stop11979-0"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-6"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-7" />
+      <stop
+         id="stop12096-6"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-1" />
+      <stop
+         id="stop12007-4"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5-2" />
+      <stop
+         id="stop10806-6-8-5-3-2-3-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-3"
+       id="radialGradient11685-2"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-91" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-02" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-2"
+       id="linearGradient11693-3"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-2">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-3" />
+      <stop
+         id="stop11695-9"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-10" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-9"
+       id="radialGradient12723-3"
+       cx="433.36786"
+       cy="424.34106"
+       fx="433.36786"
+       fy="424.34106"
+       r="12.027534"
+       gradientTransform="matrix(1.1614831,2.1855961e-7,-2.811228e-7,1.4939602,-69.981471,-211.63828)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-9">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-7" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-5">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-6" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-9" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-5"
+       id="radialGradient12739-4"
+       cx="433.5452"
+       cy="420.74988"
+       fx="433.5452"
+       fy="420.74988"
+       r="12.952347"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1"
+       id="linearGradient12904-2"
+       x1="420.88995"
+       y1="455.88452"
+       x2="440.35345"
+       y2="417.26108"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11146-4-0">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-1" />
+      <stop
+         id="stop11152-9-9"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-2" />
+      <stop
+         id="stop11152-8-4-3"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-8" />
+      <stop
+         id="stop11152-6-7-5"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-9">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-19" />
+      <stop
+         id="stop11152-8-8-6-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-5">
+      <stop
+         id="stop10858-0-7-6-9"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-9" />
+      <stop
+         id="stop10862-3-3-8-6"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-9"
+       xlink:href="#linearGradient10798-1-9-3-7-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20" />
+      <stop
+         id="stop10806-6-8-5-3-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13197-7"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4" />
+      <stop
+         id="stop10806-6-8-5-3-9-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-4"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13197-3"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6" />
+      <stop
+         id="stop10806-6-8-5-3-9-24"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13468-0"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-9-6"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13333-0-1"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-5">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2-1"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2-3" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13551"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient13850-2">
+      <stop
+         id="stop13852-4"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13854-7"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856-0">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13858-8" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13860-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799-7">
+      <stop
+         style="stop-color:#b9772f;stop-opacity:1"
+         offset="0"
+         id="stop13801-4" />
+      <stop
+         id="stop13809-4"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop13807-7"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop13811-8" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop13803-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1-8">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3-6" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4-9" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="455.88452"
+       x1="420.88995"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13011-8"
+       xlink:href="#linearGradient12862-1-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11969-9-0">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-7-1" />
+      <stop
+         id="stop11979-0-0"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-6-1"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7-6">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-7-9" />
+      <stop
+         id="stop12096-6-2"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-1-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9-8">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-1-9" />
+      <stop
+         id="stop12007-4-6"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-3-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5-2-6" />
+      <stop
+         id="stop10806-6-8-5-3-2-3-3-7"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2-2-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687-2-2">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-3-7" />
+      <stop
+         id="stop11695-9-8"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-10-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13468-0-8"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-9-6-5"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13551-0"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-5-8">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2-1-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2-3-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5029"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-4" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-1"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5029-2"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5-8-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-5-8-5">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3-1-1-7" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2-1-2-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2-3-4-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-9-6-5-6-8"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2-6-7-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-9">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-8" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-4"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6001-2"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-2">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-8-7" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-4-1"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-6-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6001-4"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-7">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-8-72" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-4-16"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-6-0" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6038-4-1"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-7-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-9-7-0">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-8-72-8" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-4-16-4"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-6-0-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-7">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-7" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-3"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13468-0-8-4"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-8" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-9" />
+    </linearGradient>
+    <linearGradient
+       y2="462.11539"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3929-5"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-8-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-3-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-9-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6642"
+       id="linearGradient6648"
+       x1="8.2203207"
+       y1="1043.3812"
+       x2="8.2203207"
+       y2="1049.0878"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="translate(0.397748,0.19882835)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4729"
+       id="linearGradient4735"
+       x1="7.5007138"
+       y1="1040.3939"
+       x2="7.5007138"
+       y2="1048.3102"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4729">
+      <stop
+         style="stop-color:#f8b0a8;stop-opacity:1"
+         offset="0"
+         id="stop4731" />
+      <stop
+         id="stop4737"
+         offset="0.5"
+         style="stop-color:#f07878;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8a8a8;stop-opacity:1"
+         offset="1"
+         id="stop4733" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6642-7"
+       id="linearGradient6648-1"
+       x1="8.2203207"
+       y1="1043.3812"
+       x2="8.2203207"
+       y2="1049.0878"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient6642-7">
+      <stop
+         id="stop4758"
+         offset="0"
+         style="stop-color:#cb2129;stop-opacity:1;" />
+      <stop
+         style="stop-color:#bd1a21;stop-opacity:1;"
+         offset="0.75"
+         id="stop4770" />
+      <stop
+         style="stop-color:#af131a;stop-opacity:1;"
+         offset="1"
+         id="stop6646-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0.397748,0.19882835)"
+       y2="1048.1158"
+       x2="8.2203207"
+       y1="1041.1198"
+       x1="8.2203207"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4783"
+       xlink:href="#linearGradient4760"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4750"
+       id="linearGradient4748"
+       x1="18.277163"
+       y1="4.5243545"
+       x2="18.277163"
+       y2="12.6786"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-10,1036.3622)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4774"
+       id="linearGradient4780"
+       x1="15.820688"
+       y1="1049.7999"
+       x2="15.820688"
+       y2="1039.7346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-10,0)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="12.963467"
+     inkscape:cy="7.0594162"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="851"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3958" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;color:#000000;fill:url(#linearGradient4783);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4780);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans"
+       id="rect6562"
+       width="10.011972"
+       height="9.9912109"
+       x="3.4962158"
+       y="1039.864"
+       rx="1.3052979"
+       ry="1.3052979" />
+    <rect
+       style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;color:#000000;fill:none;stroke:url(#linearGradient4735);stroke-width:1;stroke-miterlimit:4;stroke-opacity:0.69158876;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans"
+       id="rect6562-9"
+       width="8.0096645"
+       height="8.0024414"
+       x="4.4926262"
+       y="1040.8654"
+       rx="0.30935922"
+       ry="0.30935922" />
+    <rect
+       style="fill:none;stroke:url(#linearGradient4748)"
+       id="rect4740"
+       width="8.0100994"
+       height="8.0082979"
+       x="4.4903278"
+       y="1040.8599"
+       rx="0.30935922"
+       ry="0.30935922" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/synced.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/synced.svg
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="synced.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1;"
+         offset="0"
+         id="stop4885" />
+      <stop
+         style="stop-color:#aa6f10;stop-opacity:1"
+         offset="1"
+         id="stop4887" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5103">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105" />
+      <stop
+         style="stop-color:#fce69e;stop-opacity:1"
+         offset="1"
+         id="stop5107" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5103"
+       id="linearGradient5109"
+       x1="11.906143"
+       y1="1042.3622"
+       x2="11.906143"
+       y2="1047.2684"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1,2.9999502)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883"
+       id="linearGradient4889"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1052.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-7"
+       id="linearGradient4889-1"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1052.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,15.987978,-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-7">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1;"
+         offset="0"
+         id="stop4885-4" />
+      <stop
+         style="stop-color:#aa6f10;stop-opacity:1"
+         offset="1"
+         id="stop4887-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5103-4">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105-8" />
+      <stop
+         style="stop-color:#fce69e;stop-opacity:1"
+         offset="1"
+         id="stop5107-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.2684"
+       x2="11.906143"
+       y1="1042.3622"
+       x1="11.906143"
+       gradientTransform="matrix(-1,0,0,1,16.987978,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4911"
+       xlink:href="#linearGradient5103-4"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.999999"
+     inkscape:cx="16.638127"
+     inkscape:cy="5.0891236"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="1124"
+     inkscape:window-y="592"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient5109);fill-opacity:1;stroke:none;display:inline"
+       d="m 4,1047.3622 0,1 7,0 0,3 3.999893,-3.5 -3.999893,-3.5 0,3 z"
+       id="path4108-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="fill:url(#linearGradient4889);fill-opacity:1;stroke:none;display:inline"
+       d="m 10,1043.3622 0,3 -5,0 -1,0 c -0.99185,0.9918 -0.986324,2.0137 0,3 l 1,0 5,0 0,3 c 0,0.6519 0.740915,0.6375 1.5,0 l 4.9375,-4.5 -4.9375,-4.5 c -0.760225,-0.7602 -1.5,-0.5203 -1.5,0 z m 1,1 4,3.5 -4,3.5 0,-3 -6.4375,0 c -0.276214,-0.2099 -0.277444,-0.7282 0,-1 l 6.4375,0 z"
+       id="path4108-1-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccc" />
+    <path
+       style="fill:url(#linearGradient4911);fill-opacity:1;stroke:none;display:inline"
+       d="m 11.987978,1040.3622 0,1 -7.0000023,0 0,3 -3.99989299,-3.5 3.99989299,-3.5 0,3 z"
+       id="path4108-1-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="fill:url(#linearGradient4889-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 5.9879757,1036.3622 0,3 5.0000023,0 1,0 c 0.99185,0.9918 0.986324,2.0137 0,3 l -1,0 -5.0000023,0 0,3 c 0,0.6519 -0.740915,0.6375 -1.5,0 l -4.93749974,-4.5 4.93749974,-4.5 c 0.760225,-0.7602 1.5,-0.5203 1.5,0 z m -1,1 -3.99999999,3.5 3.99999999,3.5 0,-3 6.4375023,0 c 0.276214,-0.2099 0.277444,-0.7282 0,-1 l -6.4375023,0 z"
+       id="path4108-1-6-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/thin_close_view.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/thin_close_view.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="thin_close_view.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="-16.486217"
+     inkscape:cy="-6.5503762"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4794"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="182"
+     inkscape:window-y="338"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="layer1-4"
+       inkscape:label="Layer 1"
+       transform="matrix(1,0,0,0.99372502,-3.0082434,5.559686)">
+      <g
+         transform="matrix(0.97551468,0,0,0.97551468,9.2809852,25.497327)"
+         id="g4794"
+         style="display:inline">
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#000000;fill-opacity:1;stroke:none;display:inline"
+           d="m -5.4050871,1041.337 0,0.6448 2.9471622,2.9657 -2.9471622,2.9658 0,0.6447 1.633753,0 2.4666466,-2.4499 2.4346123,2.4499 1.6657873,0 0,-0.6125 -2.9791966,-2.998 2.9791966,-2.998 0,-0.6125 -1.6657873,0 -2.4346123,2.45 -2.4666466,-2.45 -1.633753,0 z"
+           id="rect6001" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/thin_hide_toolbar.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/thin_hide_toolbar.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="thin_hide_toolbar.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="10.785537"
+     inkscape:cy="4.4004394"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="959"
+     inkscape:window-y="465"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:#ffffff;stroke:#005514;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline;fill-opacity:1"
+       d="m 1.546796,1045.1254 1.9666408,0 0,5.0602 3.9995727,0 0,-5.0602 2.0771262,0 0,-1.0165 -4.0327184,-4.0327 -3.9995727,3.9996 z"
+       id="path3981"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/thin_max_view.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/thin_max_view.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="thin_max_view.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="14.904804"
+     inkscape:cy="6.018814"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="959"
+     inkscape:window-y="465"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g4769"
+       transform="translate(-9.5017474,3.8281246e-7)">
+      <rect
+         y="1039.8309"
+         x="10.90625"
+         height="9.28125"
+         width="8.1875"
+         id="rect3979"
+         style="fill:#ffffff;fill-opacity:1;stroke:#787878;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         transform="translate(0,1036.3622)"
+         inkscape:connector-curvature="0"
+         id="path4767"
+         d="m 10.9375,5.46875 8.125,0"
+         style="fill:none;stroke:#787878;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/thin_min_view.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/thin_min_view.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="thin_min_view.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="14.993192"
+     inkscape:cy="6.018814"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4769"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="1080"
+     inkscape:window-y="486"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g4769"
+       transform="translate(-9.5017474,3.8281246e-7)">
+      <rect
+         y="1039.8309"
+         x="10.90625"
+         height="3.0499132"
+         width="8.1875"
+         id="rect3979"
+         style="fill:#ffffff;fill-opacity:1;stroke:#787878;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/thin_restore_view.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/thin_restore_view.svg
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="thin_restore_view.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="2.2098598"
+     inkscape:cy="8.0947072"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4794"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="622"
+     inkscape:window-y="413"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="layer1-4"
+       inkscape:label="Layer 1"
+       transform="matrix(1,0,0,0.99372502,-3.0082434,5.559686)">
+      <g
+         transform="matrix(0.97551468,0,0,0.97551468,9.2809852,25.497327)"
+         id="g4794"
+         style="display:inline">
+        <rect
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.92549819;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4141"
+           width="4.1003995"
+           height="2.0631461"
+           x="-1.3046875"
+           y="1042.3685"
+           ry="0"
+           rx="0" />
+        <rect
+           style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.92549819;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4141-6"
+           width="4.9653277"
+           height="2.8045893"
+           x="-3.6431966"
+           y="1045.0442"
+           ry="0"
+           rx="0" />
+        <g
+           transform="matrix(1.0250999,0,0,1.031573,-8.4817307,-32.901454)"
+           style="fill:#3f5f3f;fill-opacity:1;display:inline"
+           id="layer1-6"
+           inkscape:label="Layer 1">
+          <g
+             transform="translate(17.6875,0)"
+             id="g4908"
+             style="fill:#3f5f3f;fill-opacity:1">
+            <g
+               transform="translate(18.156683,-1.59099)"
+               id="g4948"
+               style="fill:#3f5f3f;fill-opacity:1;display:inline">
+              <path
+                 id="path4951-1"
+                 style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#3f5f3f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.25;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+                 d="m -29.844183,1041.9532 0,5 6,0 0,-5 z m 0.994582,2.0165 4.005418,-0.017 0,2 -4,0 z"
+                 inkscape:connector-curvature="0"
+                 sodipodi:nodetypes="cccccccccc" />
+              <path
+                 id="path4951"
+                 style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#3f5f3f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.25;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+                 d="m -31.844183,1044.9532 0,5 6,0 0,-5 z m 1,2 4,0 0,2 -4,0 z"
+                 inkscape:connector-curvature="0"
+                 sodipodi:nodetypes="cccccccccc" />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/thin_show_toolbar.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/thin_show_toolbar.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="thin_show_toolbar.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="8.0277958"
+     inkscape:cy="6.4576495"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="959"
+     inkscape:window-y="465"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:#ffffff;stroke:#005514;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline;fill-opacity:1"
+       d="m 1.546796,1044.9596 1.9666408,0 0,-5.0602 3.9995727,0 0,5.0602 2.0771262,0 0,1.0165 -4.0327184,4.0327 -3.9995727,-3.9996 z"
+       id="path3981"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/thin_view_menu.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/thin_view_menu.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="thin_view_menu.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="15.08158"
+     inkscape:cy="6.018814"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4769"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="25"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g4769"
+       transform="translate(-9.5017474,3.8281246e-7)">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#3f5f3f;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+         d="m 11.048543,1039.9436 8.04334,0 0,1.9888 -4.065864,4.0658 -4.02167,-4.11 z"
+         id="path3980"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/trash.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/trash.svg
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   viewBox="0 0 16 16"
+   width="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="trash.svg"
+   style="fill:#000000">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6168"
+       id="radialGradient6174"
+       cx="10.152482"
+       cy="1045.8538"
+       fx="10.152482"
+       fy="1045.8538"
+       r="5.0078058"
+       gradientTransform="matrix(-0.04400863,-1.6558063,1.1452248,-0.03043823,-1162.7367,54.412022)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient6168">
+      <stop
+         style="stop-color:#fff891;stop-opacity:1;"
+         offset="0"
+         id="stop6170" />
+      <stop
+         style="stop-color:#4090ce;stop-opacity:1;"
+         offset="1"
+         id="stop6172" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(26.490719,-1036.4924)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient6176"
+       id="linearGradient6182"
+       x1="3.0355341"
+       y1="1045.7552"
+       x2="7.8229179"
+       y2="1037.4633"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient6176">
+      <stop
+         style="stop-color:#166b9b;stop-opacity:1;"
+         offset="0"
+         id="stop6178" />
+      <stop
+         style="stop-color:#169b6e;stop-opacity:1;"
+         offset="1"
+         id="stop6180" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6176"
+       id="linearGradient6198"
+       gradientUnits="userSpaceOnUse"
+       x1="19.58931"
+       y1="1048.307"
+       x2="19.58931"
+       y2="1039.0699" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6176"
+       id="linearGradient6200"
+       gradientUnits="userSpaceOnUse"
+       x1="22.736761"
+       y1="1046.0887"
+       x2="22.736761"
+       y2="1038.9832" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6168"
+       id="radialGradient6343"
+       cx="8.0400419"
+       cy="1038.7124"
+       fx="8.0400419"
+       fy="1038.7124"
+       r="6.0875001"
+       gradientTransform="matrix(0.96462225,1.3001557e-8,0,0.36634733,26.778462,-378.30949)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#515658"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1440"
+     inkscape:window-height="852"
+     id="namedview8"
+     showgrid="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:zoom="23.147693"
+     inkscape:cx="12.67061"
+     inkscape:cy="6.3370634"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4140" />
+  </sodipodi:namedview>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="old"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <rect
+       style="display:inline;fill:#166b9b;fill-opacity:1;stroke:none"
+       id="rect6283"
+       width="3.8750002"
+       height="3.8750002"
+       x="32.596558"
+       y="-0.13019475" />
+    <path
+       id="path5339-5"
+       style="display:inline;fill:url(#radialGradient6174);fill-opacity:1;stroke:url(#linearGradient6182);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 30.026253,2.9209222 c 0,0 0,5.7561004 0,9.5900998 0,1.189 1.635185,1.9888 2.96101,1.9888 1.757376,4e-4 2.13047,0 3.093592,0 1.325826,0 2.96101,-0.7998 2.96101,-1.9887 0,-3.8339994 0,-9.5901998 0,-9.5901998"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csccsc" />
+    <g
+       style="display:inline;fill:#000000"
+       id="g6194"
+       transform="translate(13.487183,-1036.4924)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5361"
+         d="m 19.531251,1051.0185 0,-11.1683"
+         style="fill:none;stroke:url(#linearGradient6198);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5361-0"
+         d="m 22.562501,1051.0185 0,-11.1683"
+         style="display:inline;fill:none;stroke:url(#linearGradient6200);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <path
+       style="display:inline;fill:url(#radialGradient6343);fill-opacity:1;stroke:#166b9b;stroke-width:0.80000001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 30.034059,1.2982222 c -0.657875,0 -1.1875,0.5296 -1.1875,1.1875 l 0,0.6562 11.375,0 0,-0.6562 c 0,-0.6579 -0.529625,-1.1875 -1.1875,-1.1875 l -9,0 z"
+       id="rect6322"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="new"
+     style="display:inline">
+    <path
+       d="m 3.5,13.5 c 0,0.864286 1.4250001,2 2.25,2 l 4.5,0 c 0.824999,0 2.25,-1.135714 2.25,-2 l 0,-9 -9,0 z"
+       id="path4144"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ssssccs"
+       style="fill:#b8d0ea;fill-opacity:1;stroke:#6883a7;stroke-width:1;stroke-opacity:1" />
+    <path
+       d="M 14,2 11,2 10.4,1 5.6,1 5,2 2,2 2,2.9996667 14,3 Z"
+       id="path4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc"
+       style="fill:#6883a7;fill-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#6883a7;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 6.5,4 0,11"
+       id="path5058"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#6883a7;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 9.5,4 0,11"
+       id="path5058-1"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/up_nav.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/up_nav.svg
@@ -1,0 +1,242 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="up_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3973"
+       inkscape:collect="always">
+      <stop
+         id="stop3975"
+         offset="0"
+         style="stop-color:#f8d078;stop-opacity:1" />
+      <stop
+         id="stop3977"
+         offset="1"
+         style="stop-color:#f8f0c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3967"
+       inkscape:collect="always">
+      <stop
+         id="stop3969"
+         offset="0"
+         style="stop-color:#c48a4e;stop-opacity:1;" />
+      <stop
+         id="stop3971"
+         offset="1"
+         style="stop-color:#ad6c24;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955">
+      <stop
+         id="stop3957"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961" />
+      <stop
+         id="stop3963"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3949">
+      <stop
+         style="stop-color:#9e6627;stop-opacity:1"
+         offset="0"
+         id="stop3951" />
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="1"
+         id="stop3953" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-61.366562,-4.4425559)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955"
+       id="linearGradient3945"
+       gradientUnits="userSpaceOnUse"
+       x1="523.00781"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294"
+       gradientTransform="translate(-60.558598,-4.4691418)" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973"
+       id="linearGradient4933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-60.558598,-5.8879418)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949"
+       id="linearGradient4935"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-60.558598,-5.8879418)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       id="linearGradient5148">
+      <stop
+         style="stop-color:#166b9f;stop-opacity:1"
+         offset="0"
+         id="stop5150" />
+      <stop
+         style="stop-color:#e6f9cc;stop-opacity:1;"
+         offset="1"
+         id="stop5152" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5148"
+       id="linearGradient9162"
+       x1="28.901876"
+       y1="1042.0194"
+       x2="18.31155"
+       y2="1042.0194"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="7.5096396"
+     inkscape:cy="4.8192667"
+     inkscape:document-units="px"
+     inkscape:current-layer="g7604-8"
+     showgrid="true"
+     inkscape:window-width="964"
+     inkscape:window-height="940"
+     inkscape:window-x="1234"
+     inkscape:window-y="421"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3947" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-129.51159,939.94639)"
+       style="display:inline"
+       id="g13862">
+      <g
+         transform="matrix(1.1835826,0,0,1.1835826,-75.612218,-78.069702)"
+         id="g13813">
+        <rect
+           style="fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient3939);stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+           id="rect13693-3"
+           width="15"
+           height="16.625"
+           x="463.74335"
+           y="362.60709"
+           rx="2.625"
+           ry="2.625" />
+        <path
+           style="fill:url(#linearGradient4933);fill-opacity:1;stroke:url(#linearGradient4935);stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+           d="m 463.24874,368.76025 28.07551,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.92132 c 0,1.45425 -1.17074,2.62799 -2.625,2.625 l -28.07551,-0.0577 c -1.45425,-0.003 -2.625,-1.17075 -2.625,-2.625 l 0,-18.86359 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+           id="rect13693"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3945);stroke-width:3.02792978;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           d="m 462.26171,368.76025 20.09375,0"
+           id="path13797"
+           inkscape:connector-curvature="0" />
+        <g
+           id="g4914"
+           mask="url(#mask4917)" />
+        <g
+           transform="matrix(0,-1.5754342,-1.5754342,0,2121.9777,401.22933)"
+           style="display:inline"
+           id="layer1-9"
+           inkscape:label="Layer 1">
+          <g
+             style="display:inline"
+             id="g7604-8"
+             transform="matrix(-1.6126329,0,0,-1.6126329,46.005373,2723.8623)">
+            <path
+               sodipodi:nodetypes="ccsssscscsssszcc"
+               inkscape:connector-curvature="0"
+               id="path7582-2"
+               d="m 22.661327,1040.1179 0,-1.8566 c 0,0 -0.41258,-0.9799 -1.598748,-0.051 -1.186168,0.9283 -2.578626,2.424 -2.784917,2.8365 -0.206289,0.4127 -1.083079,1.1348 0.103147,2.2693 0.190189,0.1819 0.383029,0.3651 0.572781,0.5446 0.993695,0.9397 1.902701,1.7761 1.902701,1.7761 0,0 1.805038,1.7019 1.805038,0.1027 0,-1.5987 0,-2.1145 0,-2.1145 0.703285,0.019 2.652411,-0.1465 3.127354,0.1495 0.771951,0.4815 1.680072,0.9857 2.359903,3.5016 0.129381,0.4789 0.692227,-1.6976 0.631549,-3.065 -0.06353,-1.4316 -0.643779,-2.3394 -1.344769,-2.992 -0.980677,-0.913 -0.951882,-0.8604 -1.564157,-1.0288 -0.612276,-0.1685 -1.83184,-0.1097 -1.83184,-0.1097 z"
+               style="fill:url(#linearGradient9162);fill-opacity:1;stroke:#1a659c;stroke-width:0.95345461;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/view_menu.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/view_menu.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="view_menu.svg"
+   inkscape:export-filename="C:\Users\jongw\Desktop\view_menu@2x.png"
+   inkscape:export-xdpi="192"
+   inkscape:export-ydpi="192">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#b8b8b8"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.968673"
+     inkscape:cx="7.7830763"
+     inkscape:cy="5.9552658"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:window-width="1707"
+     inkscape:window-height="907"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="false"
+     objecttolerance="10000"
+     inkscape:snap-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,13"
+       orientation="0,4"
+       id="guide817"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:title></dc:title>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Remain BV, W.S. Jongman</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>Eclipse Foundation</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <cc:license
+           rdf:resource="https://www.eclipse.org/legal/epl-2.0/" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <circle
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#747474;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4790"
+       cx="10.499991"
+       cy="1040.8622"
+       r="1.5" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#747474;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4790-4"
+       cx="10.499983"
+       cy="1044.8622"
+       r="1.5" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#747474;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4790-4-7"
+       cx="10.499983"
+       cy="1048.8622"
+       r="1.5" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/clear.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/clear.svg
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="clear.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="divider-stroke-7">
+      <stop
+         style="stop-color:#ac9575;stop-opacity:1;"
+         offset="0"
+         id="divider-stroke-stop0" />
+      <stop
+         style="stop-color:#f4efe9;stop-opacity:1"
+         offset="1"
+         id="divider-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="eraser-stroke-5">
+      <stop
+         style="stop-color:#9a8d73;stop-opacity:1;"
+         offset="0"
+         id="eraser-stroke-stop0" />
+      <stop
+         style="stop-color:#c0b194;stop-opacity:1"
+         offset="1"
+         id="eraser-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="lightarea-bg-6">
+      <stop
+         style="stop-color:#f5ede6;stop-opacity:1;"
+         offset="0"
+         id="lightarea-bg-stop0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="lightarea-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="darkarea-bg-3">
+      <stop
+         style="stop-color:#ccbba3;stop-opacity:1;"
+         offset="0"
+         id="darkarea-bg-stop0" />
+      <stop
+         style="stop-color:#f2ebe4;stop-opacity:1"
+         offset="1"
+         id="darkarea-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#darkarea-bg-3"
+       id="darkarea-bg"
+       x1="7.8634343"
+       y1="1047.5792"
+       x2="4.2270188"
+       y2="1046.548"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#lightarea-bg-6"
+       id="lightarea-bg"
+       x1="9.6854334"
+       y1="1043.3263"
+       x2="9.6854334"
+       y2="1039.8574"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#eraser-stroke-5"
+       id="eraser-stroke"
+       x1="-15.131505"
+       y1="13.523434"
+       x2="-10.560841"
+       y2="2.5190842"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98966812,0,0,1.0004489,19.863103,1036.3587)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#divider-stroke-7"
+       id="divider-stroke"
+       x1="-13.833534"
+       y1="1043.8658"
+       x2="-9.9898014"
+       y2="1043.8658"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,-4.708816,0)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="7.8217953"
+     inkscape:cy="10.12089"
+     inkscape:document-units="px"
+     inkscape:current-layer="g6616"
+     showgrid="true"
+     inkscape:window-width="1350"
+     inkscape:window-height="936"
+     inkscape:window-x="990"
+     inkscape:window-y="365"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4000" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g6616">
+      <path
+         style="fill:none;stroke:#9a8d73;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 9.0194025,1049.8598 6.0104105,0"
+         id="line"
+         inkscape:connector-curvature="0">
+        <title
+           id="title3217">line</title>
+      </path>
+      <path
+         style="fill:url(#lightarea-bg);fill-opacity:1;stroke:none;display:inline"
+         d="m 4.747933,1043.8557 1.748611,-3.9562 c 0.22097,-0.4861 0.762754,-1.0077 1.425262,-1.0386 l 3.590776,0 c 0.618718,-0.033 1.193243,0.442 1.016466,1.0165 l -2.016145,3.9783 z"
+         id="lightarea"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc">
+        <title
+           id="title3225">lightarea</title>
+      </path>
+      <path
+         style="fill:url(#darkarea-bg);fill-opacity:1;stroke:none;display:inline"
+         d="m 3.49134,1049.8653 c -0.845557,0 -1.109408,-0.4396 -1.016466,-0.9502 l 2.273059,-5.0594 5.76497,0 -2.698303,5.4091 c -0.173238,0.3219 -0.540186,0.6005 -0.809823,0.6005 z"
+         id="darkarea"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc">
+        <desc
+           id="desc3223">darkarea</desc>
+        <title
+           id="title3221">darkarea</title>
+      </path>
+      <path
+         style="fill:none;stroke:url(#divider-stroke);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+         d="m 10.650797,1043.8658 -6.01041,0"
+         id="divider"
+         inkscape:connector-curvature="0">
+        <title
+           id="title3219">divider</title>
+      </path>
+      <path
+         style="display:inline;fill:none;stroke:url(#eraser-stroke);stroke-width:0.99504387px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m 7.8943041,1038.8597 c -0.6556632,0.031 -1.1730339,0.5454 -1.3917209,1.0318 l -1.7319191,3.9705 -2.2576805,5.0648 c -0.091979,0.5108 0.1837745,0.9379 1.0205952,0.9379 l 3.4638385,0 c 0.2668512,0 0.6326572,-0.272 0.8041053,-0.594 l 2.6597334,-5.4087 2.010263,-4.0019 c 0.17495,-0.5747 -0.40827,-1.0334 -1.020595,-1.0004 l -3.5566199,0 z"
+         id="eraser"
+         inkscape:connector-curvature="0">
+        <title
+           id="title3215">eraser</title>
+      </path>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/clear_co.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/clear_co.svg
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="clear.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="divider-stroke-7">
+      <stop
+         style="stop-color:#ac9575;stop-opacity:1;"
+         offset="0"
+         id="divider-stroke-stop0" />
+      <stop
+         style="stop-color:#f4efe9;stop-opacity:1"
+         offset="1"
+         id="divider-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="eraser-stroke-5">
+      <stop
+         style="stop-color:#9a8d73;stop-opacity:1;"
+         offset="0"
+         id="eraser-stroke-stop0" />
+      <stop
+         style="stop-color:#c0b194;stop-opacity:1"
+         offset="1"
+         id="eraser-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="lightarea-bg-6">
+      <stop
+         style="stop-color:#f5ede6;stop-opacity:1;"
+         offset="0"
+         id="lightarea-bg-stop0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="lightarea-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="darkarea-bg-3">
+      <stop
+         style="stop-color:#ccbba3;stop-opacity:1;"
+         offset="0"
+         id="darkarea-bg-stop0" />
+      <stop
+         style="stop-color:#f2ebe4;stop-opacity:1"
+         offset="1"
+         id="darkarea-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#darkarea-bg-3"
+       id="darkarea-bg"
+       x1="7.8634343"
+       y1="1047.5792"
+       x2="4.2270188"
+       y2="1046.548"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#lightarea-bg-6"
+       id="lightarea-bg"
+       x1="9.6854334"
+       y1="1043.3263"
+       x2="9.6854334"
+       y2="1039.8574"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#eraser-stroke-5"
+       id="eraser-stroke"
+       x1="-15.131505"
+       y1="13.523434"
+       x2="-10.560841"
+       y2="2.5190842"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98966812,0,0,1.0004489,19.863103,1036.3587)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#divider-stroke-7"
+       id="divider-stroke"
+       x1="-13.833534"
+       y1="1043.8658"
+       x2="-9.9898014"
+       y2="1043.8658"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,-4.708816,0)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="7.8217953"
+     inkscape:cy="10.12089"
+     inkscape:document-units="px"
+     inkscape:current-layer="g6616"
+     showgrid="true"
+     inkscape:window-width="1350"
+     inkscape:window-height="936"
+     inkscape:window-x="990"
+     inkscape:window-y="365"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4000" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g6616">
+      <path
+         style="fill:none;stroke:#9a8d73;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 9.0194025,1049.8598 6.0104105,0"
+         id="line"
+         inkscape:connector-curvature="0">
+        <title
+           id="title3217">line</title>
+      </path>
+      <path
+         style="fill:url(#lightarea-bg);fill-opacity:1;stroke:none;display:inline"
+         d="m 4.747933,1043.8557 1.748611,-3.9562 c 0.22097,-0.4861 0.762754,-1.0077 1.425262,-1.0386 l 3.590776,0 c 0.618718,-0.033 1.193243,0.442 1.016466,1.0165 l -2.016145,3.9783 z"
+         id="lightarea"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc">
+        <title
+           id="title3225">lightarea</title>
+      </path>
+      <path
+         style="fill:url(#darkarea-bg);fill-opacity:1;stroke:none;display:inline"
+         d="m 3.49134,1049.8653 c -0.845557,0 -1.109408,-0.4396 -1.016466,-0.9502 l 2.273059,-5.0594 5.76497,0 -2.698303,5.4091 c -0.173238,0.3219 -0.540186,0.6005 -0.809823,0.6005 z"
+         id="darkarea"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc">
+        <desc
+           id="desc3223">darkarea</desc>
+        <title
+           id="title3221">darkarea</title>
+      </path>
+      <path
+         style="fill:none;stroke:url(#divider-stroke);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+         d="m 10.650797,1043.8658 -6.01041,0"
+         id="divider"
+         inkscape:connector-curvature="0">
+        <title
+           id="title3219">divider</title>
+      </path>
+      <path
+         style="display:inline;fill:none;stroke:url(#eraser-stroke);stroke-width:0.99504387px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m 7.8943041,1038.8597 c -0.6556632,0.031 -1.1730339,0.5454 -1.3917209,1.0318 l -1.7319191,3.9705 -2.2576805,5.0648 c -0.091979,0.5108 0.1837745,0.9379 1.0205952,0.9379 l 3.4638385,0 c 0.2668512,0 0.6326572,-0.272 0.8041053,-0.594 l 2.6597334,-5.4087 2.010263,-4.0019 c 0.17495,-0.5747 -0.40827,-1.0334 -1.020595,-1.0004 l -3.5566199,0 z"
+         id="eraser"
+         inkscape:connector-curvature="0">
+        <title
+           id="title3215">eraser</title>
+      </path>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/copy_edit.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/copy_edit.svg
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="copy_edit.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="fold-bg-7">
+      <stop
+         style="stop-color:#d8bc68;stop-opacity:1;"
+         offset="0"
+         id="fold-bg-stop0" />
+      <stop
+         style="stop-color:#fff0c2;stop-opacity:1;"
+         offset="1"
+         id="fold-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="frontpaper-bg-2">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="frontpaper-bg-stop0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="frontpaper-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="frontpaper-stroke-1">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="frontpaper-stroke-stop0" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="frontpaper-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="back-bg-0">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="back-bg-stop0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="back-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="back-stroke-9">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="back-stroke-stop0" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="back-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#back-bg-0"
+       id="linearGradient5568"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7089396,0,0,1.6630222,-8.0201048,-693.2724)"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#back-stroke-9"
+       id="linearGradient5570"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7089396,0,0,1.6630222,-8.0201048,-698.4173)"
+       x1="11.977677"
+       y1="1042.1279"
+       x2="5.926301"
+       y2="1051.2535" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#frontpaper-bg-2"
+       id="linearGradient4279"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6960825,0,0,1.7009614,-4.9210482,-731.7352)"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#frontpaper-stroke-1"
+       id="linearGradient4281"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6960825,0,0,1.7009614,-4.9210482,-736.99747)"
+       x1="11.977677"
+       y1="1042.1279"
+       x2="5.926301"
+       y2="1051.2535" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254833"
+     inkscape:cx="4.3183483"
+     inkscape:cy="7.4077604"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1409"
+     inkscape:window-height="977"
+     inkscape:window-x="622"
+     inkscape:window-y="413"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4250" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:nodetypes="ccccccc"
+       inkscape:connector-curvature="0"
+       id="backpaper"
+       d="m 1.4964779,1037.8555 0,12.013 8.9390701,0 0,-8.5938 -1.8866429,-0.031 c -0.045,0 -0.03125,-3.388 -0.03125,-3.388 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient5568);fill-opacity:1;stroke:url(#linearGradient5570);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate">
+      <title
+         id="title3444">backpaper</title>
+    </path>
+    <path
+       id="page-lines-back"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7795b6;fill-opacity:1;stroke:none;stroke-width:0.99252546;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 2.9988794,1049.3833 5.990228,0 0,-1.0156 -5.990228,0 z m 0,-1.9991 5.990228,0 0,-1.0156 -5.990228,0 z m 0,-1.9969 5.990228,0 0,-1.0156 -5.990228,0 z m 0,-1.9991 5.990228,0 0,-1.0156 -5.990228,0 z m 0,-2.0054 3.6479367,0 0,-1.0155 -3.6479367,0 z"
+       inkscape:connector-curvature="0">
+      <title
+         id="title3384-9">page-lines-back</title>
+    </path>
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4279);fill-opacity:1;stroke:url(#linearGradient4281);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 4.5239373,1038.8424 0,13.0137 9.9557807,0 0.01563,-9.9733 -2.950551,-0.023 0.02422,-3.0176 z"
+       id="frontpaper"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc">
+      <title
+         id="title3291">frontpaper</title>
+    </path>
+    <path
+       id="page-lines"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7795b6;fill-opacity:1;stroke:none;stroke-width:0.99252546;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 6.006692,1050.3755 5.990228,0 0,-1.0156 -5.990228,0 z m 0,-1.9991 5.990228,0 0,-1.0156 -5.990228,0 z m 0,-1.9969 5.990228,0 0,-1.0156 -5.990228,0 z m 0,-1.9991 5.990228,0 0,-1.0156 -5.990228,0 z m 0,-2.0054 3.6479367,0 0,-1.0155 -3.6479367,0 z"
+       inkscape:connector-curvature="0">
+      <title
+         id="title3384">page-lines</title>
+    </path>
+    <path
+       style="fill:#d8bc68;fill-opacity:1;stroke:none"
+       d="m 12.033136,1038.3884 2.941491,3.0035 -2.965778,0 z"
+       id="fold"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc">
+      <title
+         id="title3222">fold</title>
+    </path>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/cut_edit.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/cut_edit.svg
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="cut_edit.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="lefthandle-stroke-3">
+      <stop
+         style="stop-color:#7395b8;stop-opacity:1;"
+         offset="0"
+         id="lefthandle-stroke-stop0" />
+      <stop
+         style="stop-color:#125f9c;stop-opacity:1"
+         offset="1"
+         id="lefthandle-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="righthandle-stroke-6">
+      <stop
+         style="stop-color:#7395b8;stop-opacity:1;"
+         offset="0"
+         id="righthandle-stroke-stop0" />
+      <stop
+         style="stop-color:#125f9c;stop-opacity:1"
+         offset="1"
+         id="righthandle-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#lefthandle-stroke-3"
+       id="lefthandle-stroke"
+       gradientUnits="userSpaceOnUse"
+       x1="-17.093752"
+       y1="9.625"
+       x2="-13.312501"
+       y2="12.4375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#righthandle-stroke-6"
+       id="righthandle-stroke"
+       gradientUnits="userSpaceOnUse"
+       x1="-17.093752"
+       y1="9.625"
+       x2="-13.312501"
+       y2="12.4375"
+       gradientTransform="translate(27.726339,1036.5644)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999999"
+     inkscape:cx="3.7583705"
+     inkscape:cy="7.871566"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4857"
+     showgrid="true"
+     inkscape:window-width="1208"
+     inkscape:window-height="830"
+     inkscape:window-x="689"
+     inkscape:window-y="437"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4857"
+       transform="matrix(0.75134134,0.65047808,-0.62287103,0.78464248,652.4173,219.65493)">
+      <path
+         inkscape:connector-curvature="0"
+         id="leftblade"
+         d="m 6.312499,1045.9559 2.125,-3 2.500001,-5.875 c 0,0 0.71875,1.4063 0.5,2.0313 -0.21875,0.625 -2.531251,6.0312 -2.531251,6.0312 l -2,1.9688 z"
+         style="fill:#79879d;fill-opacity:1;stroke:#4d607b;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none">
+        <title
+           id="title3215">leftblade</title>
+      </path>
+      <path
+         inkscape:connector-curvature="0"
+         id="rightblade"
+         d="m 11.317555,1045.6254 -1.963626,-2.6695 -2.500001,-5.875 c 0,0 -0.71875,1.4063 -0.5,2.0313 0.21875,0.625 2.531251,6.0312 2.531251,6.0312 l 1.838626,1.6383 z"
+         style="display:inline;fill:#79879d;fill-opacity:1;stroke:#4d607b;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="cccsccc">
+        <title
+           id="title3213">rightblade</title>
+      </path>
+      <path
+         transform="matrix(1.3529412,0,0,1.3529412,24.013328,1033.8898)"
+         d="m -10.906251,7.0937495 a 0.265625,0.265625 0 0 1 -0.265625,0.265625 0.265625,0.265625 0 0 1 -0.265625,-0.265625 0.265625,0.265625 0 0 1 0.265625,-0.265625 0.265625,0.265625 0 0 1 0.265625,0.265625 z"
+         sodipodi:ry="0.265625"
+         sodipodi:rx="0.265625"
+         sodipodi:cy="7.0937495"
+         sodipodi:cx="-11.171876"
+         id="pin"
+         style="fill:#4d607b;fill-opacity:1;stroke:none"
+         sodipodi:type="arc">
+        <title
+           id="title3211">pin</title>
+      </path>
+      <path
+         transform="translate(20,1036.706)"
+         d="m -13.187501,10.875 a 2.03125,2.1875 0 0 1 -2.03125,2.1875 2.03125,2.1875 0 0 1 -2.03125,-2.1875 2.03125,2.1875 0 0 1 2.03125,-2.1875 2.03125,2.1875 0 0 1 2.03125,2.1875 z"
+         sodipodi:ry="2.1875"
+         sodipodi:rx="2.03125"
+         sodipodi:cy="10.875"
+         sodipodi:cx="-15.218751"
+         id="lefthandle"
+         style="fill:none;stroke:url(#lefthandle-stroke);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc">
+        <title
+           id="title3207">lefthandle</title>
+      </path>
+      <ellipse
+         id="righthandle"
+         style="display:inline;fill:none;stroke:url(#righthandle-stroke);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         cx="12.507588"
+         cy="1047.4393"
+         rx="2.03125"
+         ry="2.1875">
+        <title
+           id="title3209">righthandle</title>
+      </ellipse>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/delete.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/delete.svg
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="delete.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="x-bg-3">
+      <stop
+         style="stop-color:#df2c33;stop-opacity:1"
+         offset="0"
+         id="x-bg-stop0" />
+      <stop
+         style="stop-color:#f5817d;stop-opacity:1"
+         offset="1"
+         id="x-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="x-stroke-6">
+      <stop
+         style="stop-color:#c51325;stop-opacity:1;"
+         offset="0"
+         id="x-stroke-stop0" />
+      <stop
+         style="stop-color:#ca5d49;stop-opacity:1"
+         offset="1"
+         id="x-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#x-stroke-6"
+       id="x-stroke"
+       x1="8.6566515"
+       y1="1050.7386"
+       x2="8.6566515"
+       y2="1037.7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.962068e-6,-2.1458883e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#x-bg-3"
+       id="x-bg"
+       x1="4.7528968"
+       y1="1051.0466"
+       x2="4.7528968"
+       y2="1038.5814"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.962068e-6,-2.1458883e-5)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999998"
+     inkscape:cx="6.0853136"
+     inkscape:cy="4.9180796"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1509"
+     inkscape:window-height="997"
+     inkscape:window-x="761"
+     inkscape:window-y="339"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#x-bg);fill-opacity:1;stroke:url(#x-stroke);stroke-width:0.98060334;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 13.419292,1038.6553 c -0.468185,-0.4682 -1.221974,-0.4682 -1.690135,-10e-5 l -3.1127968,3.1129 -3.1127723,-3.1128 c -0.4681138,-0.4682 -1.221974,-0.4682 -1.690134,0 l -0.8600555,0.8601 c -0.4681391,0.468 -0.4681272,1.2218 3.66e-5,1.6901 l 3.1127223,3.1128 -3.1127269,3.1127 c -0.4682099,0.4682 -0.468198,1.222 -1.34e-5,1.6902 l 0.8601016,0.8601 c 0.4681344,0.4681 1.2219244,0.4681 1.6901337,0 l 3.1127774,-3.1128 3.1344053,3.1344 c 0.468135,0.4682 1.221925,0.4682 1.690135,0 l 0.860055,-0.86 c 0.46816,-0.4682 0.463458,-1.2173 -3.7e-5,-1.6902 l -3.134406,-3.1344 3.112777,-3.1127 c 0.468181,-0.4683 0.468169,-1.2221 3.4e-5,-1.6902 z"
+       id="x"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccccssccsccsccss">
+      <title
+         id="title3202">x</title>
+    </path>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/delete_edit.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/delete_edit.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="delete_edit.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="x-bg-3">
+      <stop
+         style="stop-color:#df2c33;stop-opacity:1"
+         offset="0"
+         id="x-bg-stop0" />
+      <stop
+         style="stop-color:#f5817d;stop-opacity:1"
+         offset="1"
+         id="x-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="x-stroke-6">
+      <stop
+         style="stop-color:#c51325;stop-opacity:1;"
+         offset="0"
+         id="x-stroke-stop0" />
+      <stop
+         style="stop-color:#ca5d49;stop-opacity:1"
+         offset="1"
+         id="x-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#x-stroke-6"
+       id="x-stroke"
+       x1="8.6566515"
+       y1="1050.7386"
+       x2="8.6566515"
+       y2="1037.7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.962068e-6,-2.1458883e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#x-bg-3"
+       id="x-bg"
+       x1="4.7528968"
+       y1="1051.0466"
+       x2="4.7528968"
+       y2="1038.5814"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.962068e-6,-2.1458883e-5)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999998"
+     inkscape:cx="0.14781323"
+     inkscape:cy="4.8555796"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1509"
+     inkscape:window-height="997"
+     inkscape:window-x="761"
+     inkscape:window-y="339"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#x-bg);fill-opacity:1;stroke:url(#x-stroke);stroke-width:0.98060334;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 13.419292,1038.6553 c -0.468185,-0.4682 -1.221974,-0.4682 -1.690135,-10e-5 l -3.1127968,3.1129 -3.1127723,-3.1128 c -0.4681138,-0.4682 -1.221974,-0.4682 -1.690134,0 l -0.8600555,0.8601 c -0.4681391,0.468 -0.4681272,1.2218 3.66e-5,1.6901 l 3.1127223,3.1128 -3.1127269,3.1127 c -0.4682099,0.4682 -0.468198,1.222 -1.34e-5,1.6902 l 0.8601016,0.8601 c 0.4681344,0.4681 1.2219244,0.4681 1.6901337,0 l 3.1127774,-3.1128 3.1344053,3.1344 c 0.468135,0.4682 1.221925,0.4682 1.690135,0 l 0.860055,-0.86 c 0.46816,-0.4682 0.463458,-1.2173 -3.7e-5,-1.6902 l -3.134406,-3.1344 3.112777,-3.1127 c 0.468181,-0.4683 0.468169,-1.2221 3.4e-5,-1.6902 z"
+       id="x"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccccssccsccsccss">
+      <desc
+         id="desc3203">x</desc>
+      <title
+         id="title3202">x</title>
+    </path>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/editor_area.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/editor_area.svg
@@ -1,0 +1,432 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="editor_area.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient12204">
+      <stop
+         style="stop-color:#f5b9ac;stop-opacity:1"
+         offset="0"
+         id="stop12206" />
+      <stop
+         id="stop12214"
+         offset="0.25"
+         style="stop-color:#f7cec5;stop-opacity:1" />
+      <stop
+         id="stop12212"
+         offset="0.5"
+         style="stop-color:#f7ccc3;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5b9ac;stop-opacity:1"
+         offset="1"
+         id="stop12208" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12144">
+      <stop
+         style="stop-color:#ca9189;stop-opacity:1"
+         offset="0"
+         id="stop12146" />
+      <stop
+         id="stop12154"
+         offset="0.25"
+         style="stop-color:#f5b9ac;stop-opacity:1" />
+      <stop
+         id="stop12152"
+         offset="0.5"
+         style="stop-color:#f5b9ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#bd847e;stop-opacity:1"
+         offset="1"
+         id="stop12148" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082-3">
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1"
+         offset="0"
+         id="stop4084-8" />
+      <stop
+         id="stop4864-7"
+         offset="0.5"
+         style="stop-color:#5a9ccc;stop-opacity:1" />
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1"
+         offset="1"
+         id="stop4086-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4994-4-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-9"
+         offset="0"
+         style="stop-color:#c5dff4;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-5" />
+      <stop
+         style="stop-color:#c5dff4;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4810-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4812-0"
+         offset="0"
+         style="stop-color:#be9a4b;stop-opacity:1" />
+      <stop
+         id="stop4814-4"
+         offset="1"
+         style="stop-color:#877e60;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4082-3"
+       id="linearGradient8878"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.87616643,1.0002456)"
+       x1="8.0137892"
+       y1="1039.876"
+       x2="8.0137892"
+       y2="1041.8765" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-4-5"
+       id="linearGradient8881"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(17,0.9999451)"
+       x1="-11"
+       y1="1042.3622"
+       x2="-11"
+       y2="1044.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4910-4-0"
+       id="linearGradient8884"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(17,-5.0312549)"
+       x1="-13"
+       y1="1047.3622"
+       x2="-15"
+       y2="1047.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4810-5"
+       id="linearGradient8887"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.91881011,1.0357451)"
+       x1="8.0137892"
+       y1="1042.3622"
+       x2="8.0137892"
+       y2="1050.0707" />
+    <linearGradient
+       id="linearGradient4908-52-3-2-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4910-7-2-7-1"
+         offset="0"
+         style="stop-color:#986443;stop-opacity:1" />
+      <stop
+         id="stop4912-6-2-9-49"
+         offset="1"
+         style="stop-color:#994f1b;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       id="filter5428-3"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur5430-8"
+         stdDeviation="0.22207033"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       id="linearGradient5077-5-3">
+      <stop
+         id="stop5079-7-3"
+         offset="0"
+         style="stop-color:#e4cf94;stop-opacity:1" />
+      <stop
+         style="stop-color:#ede0ba;stop-opacity:1"
+         offset="0.32186735"
+         id="stop5087-6-7" />
+      <stop
+         style="stop-color:#c1aa7e;stop-opacity:1"
+         offset="0.64764118"
+         id="stop5085-1-30" />
+      <stop
+         id="stop5081-8-1"
+         offset="1"
+         style="stop-color:#ad8865;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5300-8">
+      <stop
+         id="stop5302-7"
+         offset="0"
+         style="stop-color:#4d4d4d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#727272;stop-opacity:1;"
+         offset="0.29405674"
+         id="stop5308-8" />
+      <stop
+         id="stop5304-9"
+         offset="1"
+         style="stop-color:#4d4d4d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4908-52-3-2-6"
+       id="linearGradient12292"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20,0)"
+       x1="-11.21119"
+       y1="1042.1598"
+       x2="-8.7005796"
+       y2="1044.6704" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5077-5-3"
+       id="linearGradient12294"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4,-1036.3622)"
+       x1="-0.9810437"
+       y1="1047.4242"
+       x2="1.9838035"
+       y2="1050.3188" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5300-8"
+       id="linearGradient12296"
+       gradientUnits="userSpaceOnUse"
+       x1="2.65625"
+       y1="1049.3976"
+       x2="4.0822439"
+       y2="1050.5304" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12144"
+       id="linearGradient12298"
+       gradientUnits="userSpaceOnUse"
+       x1="29.095431"
+       y1="0.03125"
+       x2="32.279569"
+       y2="0.03125"
+       gradientTransform="translate(3.3308581e-7,1037.1136)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12204"
+       id="linearGradient12300"
+       gradientUnits="userSpaceOnUse"
+       x1="29.150082"
+       y1="1.046875"
+       x2="32.162418"
+       y2="1.046875" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7584">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path7586"
+         d="m 1.5076731,1040.8978 13.0019249,0 0,10.9667 -13.0019248,0 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter8356"
+       x="-0.23975421"
+       width="1.4795084"
+       y="-0.24024629"
+       height="1.4804926">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.90851138"
+         id="feGaussianBlur8358" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8"
+     inkscape:cx="-0.40626607"
+     inkscape:cy="7.707515"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-5-8"
+     showgrid="true"
+     inkscape:window-width="1208"
+     inkscape:window-height="913"
+     inkscape:window-x="1083"
+     inkscape:window-y="526"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid8762" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9"
+       d="m 1.5076731,1040.8978 13.0019249,0 0,10.9667 -13.0019248,0 z"
+       style="fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient8887);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4853-82-7"
+       d="m 3,1044.331 0,7.0312 -1,0 0,-8.0312 z"
+       style="fill:url(#linearGradient8884);fill-opacity:1;stroke:none;display:inline" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4853-82-0"
+       d="m 3,1044.3622 10.928078,0 0,-1 -11.928078,0 z"
+       style="fill:url(#linearGradient8881);fill-opacity:1;stroke:none;display:inline" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9-9"
+       d="m 1.503712,1040.8623 13.004333,0 0,2.0053 -13.004333,0 z"
+       style="fill:#58b6e8;fill-opacity:1;stroke:url(#linearGradient8878);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    <g
+       id="g7581"
+       mask="url(#mask7584)">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path5226-6-14-1-5-9-9"
+         d="m 14.945713,1040.3274 -5.5989979,5.572 -3.4954296,1.6602 1.6601595,-3.4924 5.545372,-5.5834 c 0.812805,0.3857 1.414835,1.0349 1.888896,1.8439 z"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;stroke:#ffffff;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;filter:url(#filter8356)" />
+    </g>
+    <g
+       id="g12278"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,726.06628,283.93164)">
+      <g
+         transform="matrix(0.45259182,-0.45259182,0.45259182,0.45259182,-446.0304,573.84462)"
+         inkscape:label="Layer 1"
+         id="layer1-5-8"
+         style="display:inline">
+        <path
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:none;stroke:url(#linearGradient12292);stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 15.685953,1040.5523 -8.7475939,8.7054 -5.461084,2.5938 2.59375,-5.4564 8.6638109,-8.7231 c 1.269887,0.6025 2.210467,1.6169 2.951117,2.8807 z"
+           id="path5226-6-14-1-5-9"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccc" />
+        <path
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffcb72;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 12.75,1037.6747 -8.6875,8.7188 0.9375,0.9062 8.9375,-8.875 c -0.362696,-0.2963 -0.752826,-0.5438 -1.1875,-0.75 z"
+           id="path5424-7"
+           inkscape:connector-curvature="0" />
+        <path
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#e5a856;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 15.3125,1039.956 -8.78125,8.9062 0.40625,0.4063 8.75,-8.7188 c -0.120121,-0.205 -0.24381,-0.4026 -0.375,-0.5937 z"
+           id="path5226-6-14-1-5-2-9"
+           inkscape:connector-curvature="0" />
+        <path
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#fbbc67;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 6.536718,1048.8567 -1.548139,-1.5456 8.939717,-8.8821 c 0.52506,0.4288 0.980135,0.9451 1.380966,1.5292 z"
+           id="path5226-6-14-1-5-2-7-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="opacity:0.5;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;filter:url(#filter5428-3)"
+           d="m 4.984376,1047.2528 8.937501,-8.8281"
+           id="path5426-9"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:url(#linearGradient12294);fill-opacity:1;stroke:none;display:inline"
+           d="M 4.09375,10 2.6875,12.9375 c 0.1928924,0.586348 0.244767,1.257306 1.375,1.28125 L 4.03125,14.28125 6.96875,12.875 C 7.3020356,11.516034 6.7891722,11.737439 5.9815375,11.315162 5.6074141,10.176906 5.9121401,10.42899 4.6833038,10.420015 4.6786211,9.4016554 4.2560993,10.44918 4.09375,10 z"
+           id="path5006-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc"
+           transform="translate(0,1036.3622)" />
+        <path
+           style="fill:url(#linearGradient12296);fill-opacity:1;stroke:none;display:inline"
+           d="m 2.6874999,1049.2997 -1.21875,2.5625 2.5625,-1.2187 0.03125,-0.062 c -0.7244984,-0.1443 -1.1657597,-0.5692 -1.375,-1.2818 z"
+           id="path5006-1-8"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+      </g>
+      <path
+         sodipodi:nodetypes="sccsccs"
+         inkscape:connector-curvature="0"
+         id="path11335"
+         d="m 30.6875,1035.7699 c -0.790527,0 -1.4375,0.166 -1.4375,0.375 l 0,2 c 0,0.209 0.646973,0.375 1.4375,0.375 0.790527,0 1.4375,-0.166 1.4375,-0.375 l 0,-2 c 0,-0.209 -0.646973,-0.375 -1.4375,-0.375 z"
+         style="fill:url(#linearGradient12298);fill-opacity:1;stroke:none" />
+      <path
+         transform="matrix(1.0529667,0,0,1.0529667,-1.5886036,1035.0448)"
+         d="m 32.015625,1.046875 c 0,0.1984773 -0.608613,0.359375 -1.359375,0.359375 -0.750762,0 -1.359375,-0.1608977 -1.359375,-0.359375 0,-0.19847733 0.608613,-0.359375 1.359375,-0.359375 0.750762,0 1.359375,0.16089767 1.359375,0.359375 z"
+         sodipodi:ry="0.359375"
+         sodipodi:rx="1.359375"
+         sodipodi:cy="1.046875"
+         sodipodi:cx="30.65625"
+         id="path11335-9"
+         style="fill:#f5b9ac;fill-opacity:1;stroke:url(#linearGradient12300);stroke-width:0.2935867;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:nodetypes="sccsccs"
+         inkscape:connector-curvature="0"
+         id="path11335-4"
+         d="m 30.687499,1035.7698 c -0.790526,0 -1.437499,0.166 -1.437499,0.375 l 0,1.4807 c 0,0.209 0.646973,0.375 1.437499,0.375 0.790527,0 1.4375,-0.166 1.4375,-0.375 l 0,-1.4807 c 0,-0.209 -0.646973,-0.375 -1.4375,-0.375 z"
+         style="fill:none;stroke:#b6766f;stroke-width:0.30913702;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+      <path
+         sodipodi:nodetypes="cssscsc"
+         inkscape:connector-curvature="0"
+         id="path11335-4-0"
+         d="m 29.09375,1037.7074 0,1.6022 c 0,0.2327 0.713814,0.4063 1.59375,0.4063 0.879938,0 1.59375,-0.1736 1.59375,-0.4063 l 0,-1.6022 c 0,0.2327 -0.713812,0.4062 -1.59375,0.4062 -0.879936,0 -1.59375,-0.1735 -1.59375,-0.4062 z"
+         style="fill:#dedfe2;fill-opacity:1;stroke:#a79a9e;stroke-width:0.34410122;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/export_wiz.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/export_wiz.svg
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="export_wiz.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="provider-bg-6">
+      <stop
+         style="stop-color:#85a2cd;stop-opacity:1;"
+         offset="0"
+         id="stop4923" />
+      <stop
+         style="stop-color:#d3dce9;stop-opacity:1;"
+         offset="1"
+         id="stop4925" />
+    </linearGradient>
+    <linearGradient
+       id="provider-stroke-7">
+      <stop
+         style="stop-color:#4e6b9b;stop-opacity:1"
+         offset="0"
+         id="stop4915" />
+      <stop
+         style="stop-color:#6783b1;stop-opacity:1"
+         offset="1"
+         id="stop4917" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#provider-stroke-7"
+       id="linearGradient4919"
+       x1="1.860189"
+       y1="1051.5892"
+       x2="1.860189"
+       y2="1046.8492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0234842,0,0,1.0234842,-17.402505,-25.185931)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#provider-bg-6"
+       id="linearGradient4927"
+       x1="1.860189"
+       y1="1051.5892"
+       x2="1.860189"
+       y2="1046.8492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0234842,0,0,1.0234842,-17.402505,-25.185931)" />
+    <linearGradient
+       id="arrow-bg-3">
+      <stop
+         style="stop-color:#4e8fbd;stop-opacity:1;"
+         offset="0"
+         id="stop4791" />
+      <stop
+         style="stop-color:#8dacc3;stop-opacity:1"
+         offset="1"
+         id="stop4793" />
+    </linearGradient>
+    <linearGradient
+       y2="1049.5981"
+       x2="-2.2873085"
+       y1="1044.6919"
+       x1="-2.2873085"
+       gradientTransform="matrix(0.72371262,0.72371262,0.72371262,-0.72371262,-745.18023,1799.8892)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3924"
+       xlink:href="#arrow-bg-3"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="0.70729396"
+     inkscape:cy="4.4960559"
+     inkscape:document-units="px"
+     inkscape:current-layer="provider"
+     showgrid="true"
+     inkscape:window-width="1652"
+     inkscape:window-height="1174"
+     inkscape:window-x="786"
+     inkscape:window-y="281"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4039" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="provider"
+       transform="translate(17.6875,0)">
+      <title
+         id="title3210">provider</title>
+      <path
+         style="fill:url(#linearGradient4927);fill-opacity:1;stroke:url(#linearGradient4919);stroke-width:0.71643895;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m -17.306554,1043.8942 0,7.1004 7.132406,0 7.1324058,0 0,-7.1004 -3.0064848,0 0,2.015 0.9275325,0 0,3.0704 -5.0534535,0 -5.053453,0 0,-3.0704 0.927532,0 0,-2.015 z"
+         id="path4143"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccc" />
+    </g>
+    <path
+       style="display:inline;fill:url(#linearGradient3924);fill-opacity:1;stroke:none"
+       d="m 4.4413392,1046.1891 0.6556696,0.6556 6.2848652,-6.2848 1.311339,1.3113 0.335794,-3.5021 -3.5021958,0.3037 1.2313798,1.2315 z"
+       id="arrow"
+       inkscape:connector-curvature="0">
+      <title
+         id="title3208">arrow</title>
+    </path>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/fastview_restore.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/fastview_restore.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="fastview_restore.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="-2.0757757"
+     inkscape:cy="14.750225"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4948"
+     showgrid="true"
+     inkscape:window-width="1652"
+     inkscape:window-height="1174"
+     inkscape:window-x="501"
+     inkscape:window-y="175"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4037" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4908"
+       transform="translate(17.6875,0)">
+      <g
+         style="display:inline"
+         id="g4948"
+         transform="translate(18.156683,-1.59099)">
+        <path
+           sodipodi:nodetypes="cccccccccc"
+           inkscape:connector-curvature="0"
+           d="m -29.844183,1041.9532 0,5 6,0 0,-5 z m 0.994582,2.0165 4.005418,-0.017 0,2 -4,0 z"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#93897e;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.25;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           id="topwindow">
+          <title
+             id="title3197">topwindow</title>
+        </path>
+        <path
+           sodipodi:nodetypes="cccccccccc"
+           inkscape:connector-curvature="0"
+           d="m -31.844183,1044.9532 0,5 6,0 0,-5 z m 1,2 4,0 0,2 -4,0 z"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#93897e;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.25;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           id="bottomwindow">
+          <title
+             id="title3199">bottomwindow</title>
+        </path>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/help_contents.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/help_contents.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="help_contents.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="5.1939192"
+     inkscape:cy="7.2545152"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="false"
+     inkscape:window-width="1011"
+     inkscape:window-height="979"
+     inkscape:window-x="247"
+     inkscape:window-y="365"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <path
+         sodipodi:type="arc"
+         style="fill:#f7fcff;fill-opacity:1;stroke:#286296;stroke-width:1.50000000000000000;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+         id="circle"
+         sodipodi:cx="388.125"
+         sodipodi:cy="468.23718"
+         sodipodi:rx="10.625"
+         sodipodi:ry="10.625"
+         d="m 398.75,468.23718 a 10.625,10.625 0 0 1 -10.625,10.625 10.625,10.625 0 0 1 -10.625,-10.625 10.625,10.625 0 0 1 10.625,-10.625 10.625,10.625 0 0 1 10.625,10.625 z"
+         transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)">
+        <title
+           id="title3199">circle</title>
+      </path>
+      <g
+         style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#286296;fill-opacity:1;stroke:none;font-family:Sans"
+         id="question"
+         transform="matrix(1,0,0,0.8709833,0,136.37376)">
+        <title
+           id="title3197">question</title>
+        <path
+           d="m 17.235772,1058.8666 -2.115234,0 0,-0.2871 c -2e-6,-0.3203 0.06445,-0.6035 0.193359,-0.8496 0.128904,-0.25 0.400388,-0.5664 0.814453,-0.9493 l 0.375,-0.3398 c 0.222653,-0.2031 0.384762,-0.3945 0.486328,-0.5742 0.105465,-0.1797 0.158199,-0.3594 0.158204,-0.5391 -5e-6,-0.2734 -0.09375,-0.4863 -0.28125,-0.6387 -0.187504,-0.1562 -0.449223,-0.2343 -0.785157,-0.2343 -0.316409,0 -0.658205,0.066 -1.02539,0.1992 -0.367189,0.1289 -0.750002,0.3223 -1.148438,0.5801 l 0,-1.8399 c 0.472655,-0.164 0.904295,-0.2851 1.294922,-0.3633 0.390622,-0.078 0.767575,-0.1171 1.130859,-0.1171 0.953121,0 1.679683,0.1953 2.179688,0.5859 0.499994,0.3867 0.749994,0.9531 0.75,1.6992 -6e-6,0.3828 -0.07618,0.7266 -0.228516,1.0313 -0.152349,0.3007 -0.412115,0.625 -0.779297,0.9726 l -0.375,0.334 c -0.265629,0.2422 -0.439457,0.4375 -0.521484,0.5859 -0.08204,0.1446 -0.123051,0.3047 -0.123047,0.4805 l 0,0.2637 m -2.115234,0.8672 2.115234,0 0,2.0859 -2.115234,0 0,-2.0859"
+           style="font-size:12px;font-weight:bold;fill:#286296;-inkscape-font-specification:Sans Bold"
+           id="path5245"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/help_search.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/help_search.svg
@@ -1,0 +1,338 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="help_search.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1054.8198"
+       x2="33.890187"
+       y1="1054.8198"
+       x1="25.367543"
+       id="linearGradient5454"
+       xlink:href="#linearGradient5448"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.66091722,0.66091722,-0.66091722,0.66091722,682.60065,332.67431)" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1051.4068"
+       x2="33.890359"
+       y1="1051.4068"
+       x1="25.367371"
+       id="linearGradient5446"
+       xlink:href="#portal-stroke-3"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.66091722,0.66091722,-0.66091722,0.66091722,682.60065,332.67431)" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1045.9496"
+       x2="33.162997"
+       y1="1045.9496"
+       x1="26.107269"
+       id="linearGradient5434"
+       xlink:href="#handle-stroke-6"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.66091722,0.66091722,-0.66091722,0.66091722,682.60065,332.67431)" />
+    <linearGradient
+       y2="1052.0043"
+       x2="32.842041"
+       y1="1052.0043"
+       x1="26.45211"
+       gradientTransform="matrix(0.66091722,0.66091722,-0.66091722,0.66091722,682.60068,332.67428)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5376"
+       xlink:href="#portal-bg-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1056.9694"
+       x2="33.275511"
+       y1="1056.9694"
+       x1="25.982219"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5374"
+       xlink:href="#beam-stroke-5"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.66091722,0.66091722,-0.66091722,0.66091722,682.60065,332.67431)" />
+    <linearGradient
+       y2="1056.9694"
+       x2="32.471878"
+       y1="1056.9694"
+       x1="26.880592"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5372"
+       xlink:href="#beam-bg-6"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.66091722,0.66091722,-0.66091722,0.66091722,682.60065,332.67431)" />
+    <linearGradient
+       y2="1046.1316"
+       x2="32.176903"
+       y1="1046.1316"
+       x1="27.009878"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5370"
+       xlink:href="#handle-bg-3"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.66091722,0.66091722,-0.66091722,0.66091722,682.60065,332.67431)" />
+    <linearGradient
+       y2="1039.1387"
+       x2="29.714636"
+       y1="1041.3262"
+       x1="29.714636"
+       gradientTransform="matrix(0.66091722,0.66091722,-0.66091722,0.66091722,682.60846,332.6665)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5368"
+       xlink:href="#end-stroke-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="end-stroke-7"
+       inkscape:collect="always">
+      <stop
+         id="end-stroke-stop0"
+         offset="0"
+         style="stop-color:#906f4e;stop-opacity:1" />
+      <stop
+         id="end-stroke-stop1"
+         offset="1"
+         style="stop-color:#dfbd7f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="portal-bg-5">
+      <stop
+         id="portal-bg-stop0"
+         offset="0"
+         style="stop-color:#bbb8bb;stop-opacity:1" />
+      <stop
+         style="stop-color:#ccc8cb;stop-opacity:1"
+         offset="0.25"
+         id="portal-bg-stop1" />
+      <stop
+         style="stop-color:#bdb6bc;stop-opacity:1"
+         offset="0.5"
+         id="portal-bg-stop2" />
+      <stop
+         id="portal-bg-stop3"
+         offset="1"
+         style="stop-color:#9b8c98;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="beam-bg-6">
+      <stop
+         id="beam-bg-stop0"
+         offset="0"
+         style="stop-color:#fef48d;stop-opacity:1" />
+      <stop
+         style="stop-color:#fffffe;stop-opacity:1"
+         offset="0.3251386"
+         id="beam-bg-stop1" />
+      <stop
+         style="stop-color:#fffffe;stop-opacity:1"
+         offset="0.66393197"
+         id="beam-bg-stop2" />
+      <stop
+         id="beam-bg-stop3"
+         offset="1"
+         style="stop-color:#fef48d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="beam-stroke-5"
+       inkscape:collect="always">
+      <stop
+         id="beam-stroke-stop0"
+         offset="0"
+         style="stop-color:#e4a239;stop-opacity:1;" />
+      <stop
+         id="beam-stroke-stop1"
+         offset="1"
+         style="stop-color:#fada7d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="handle-bg-3">
+      <stop
+         style="stop-color:#f4d684;stop-opacity:1"
+         offset="0"
+         id="handle-bg-stop0" />
+      <stop
+         id="handle-bg-stop1"
+         offset="0.25"
+         style="stop-color:#fcf4c6;stop-opacity:1" />
+      <stop
+         id="handle-bg-stop2"
+         offset="0.5"
+         style="stop-color:#fbeebc;stop-opacity:1" />
+      <stop
+         style="stop-color:#eeb960;stop-opacity:1"
+         offset="1"
+         id="handle-bg-stop3" />
+    </linearGradient>
+    <linearGradient
+       id="handle-stroke-6">
+      <stop
+         id="handle-stroke-stop0"
+         offset="0"
+         style="stop-color:#f0a53b;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f2d58f;stop-opacity:1"
+         offset="0.26895422"
+         id="handle-stroke-stop1" />
+      <stop
+         style="stop-color:#efb965;stop-opacity:1"
+         offset="0.60424823"
+         id="handle-stroke-stop2" />
+      <stop
+         id="handle-stroke-stop3"
+         offset="1"
+         style="stop-color:#df9833;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="portal-stroke-3"
+       inkscape:collect="always">
+      <stop
+         id="portal-stroke-stop0"
+         offset="0"
+         style="stop-color:#ad8e5f;stop-opacity:1" />
+      <stop
+         id="portal-stroke-stop1"
+         offset="1"
+         style="stop-color:#8f6e4d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5448"
+       inkscape:collect="always">
+      <stop
+         id="stop5450"
+         offset="0"
+         style="stop-color:#ad8e5f;stop-opacity:1" />
+      <stop
+         id="stop5452"
+         offset="1"
+         style="stop-color:#8f6e4d;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254836"
+     inkscape:cx="2.0999167"
+     inkscape:cy="8.420501"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1358"
+     inkscape:window-height="1119"
+     inkscape:window-x="911"
+     inkscape:window-y="226"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5273" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="end"
+       d="m 14.08007,1038.9534 -2.121338,0.7071 2.828428,2.8285 0.707124,-2.1214 c 0.313851,-0.9388 -0.714952,-1.7228 -1.414214,-1.4142 z"
+       style="display:inline;fill:#e09a36;stroke:url(#linearGradient5368);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1">
+      <title
+         id="title3349">end</title>
+    </path>
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="handle"
+       d="m 11.349638,1039.0957 c 1.914769,-0.25 4.20546,2.2167 4.002335,4.0024 l -5.678931,5.6789 -4.0023349,-4.0023 z"
+       style="fill:url(#linearGradient5370);fill-opacity:1;stroke:url(#linearGradient5434);stroke-width:0.93467808;stroke-opacity:1">
+      <title
+         id="title3347">handle</title>
+    </path>
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="switch"
+       d="m 12.76372,1041.3884 c -0.250135,-0.2369 -0.509005,-0.4521 -0.773396,-0.6408 l -1.591026,1.591 c 0.264193,0.1889 0.523063,0.4041 0.773396,0.6409 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#496da1;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate">
+      <title
+         id="title3345">switch</title>
+    </path>
+    <path
+       sodipodi:nodetypes="sccccs"
+       inkscape:connector-curvature="0"
+       id="rect4221-7-1"
+       d="m 5.9110252,1048.5505 c -1.0224085,-1.0224 -2.2817063,-1.8119 -3.1820117,-1.8119 l -0.3755993,0.3756 c 9.3e-6,1.8006 3.1956518,4.9719 4.971845,4.9718 l 0.3755992,-0.3756 c 4.36e-5,-0.8881 -0.7689448,-2.136 -1.7898332,-3.1599 z"
+       style="display:inline;fill:#ffffc9;fill-opacity:1;stroke:url(#linearGradient5454);stroke-width:0.93467808;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="beam"
+       d="m 4.501298,1045.6994 -8.0140839,8.0141 4.23868551,4.2387 8.01408389,-8.0141 z"
+       style="display:inline;fill:url(#linearGradient5372);fill-opacity:1;stroke:url(#linearGradient5374);stroke-width:0.8224746;stroke-opacity:1">
+      <title
+         id="title3353">beam</title>
+    </path>
+    <path
+       inkscape:connector-curvature="0"
+       id="portal"
+       d="m 5.6237648,1043.8438 -2.8947513,2.8948 c 2.443245,-0.093 5.1304955,2.6631 4.9718449,4.9718 l 2.8947516,-2.8948 c 0.845012,-2.5084 -2.3283495,-5.67 -4.9718452,-4.9718 z"
+       style="display:inline;fill:url(#linearGradient5376);fill-opacity:1;stroke:url(#linearGradient5446);stroke-width:0.935;stroke-linejoin:round;stroke-miterlimit:3;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:nodetypes="ccccc">
+      <title
+         id="title3351">portal</title>
+    </path>
+    <circle
+       r="3.9515381"
+       cy="1041.8074"
+       cx="5.4765129"
+       style="display:inline;fill:#f6fcff;fill-opacity:1;stroke:#4f627e;stroke-width:0.558;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="circle">
+      <title
+         id="title3270">circle</title>
+    </circle>
+    <path
+       inkscape:connector-curvature="0"
+       id="question"
+       style="font-style:normal;font-weight:bold;font-size:12px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#64768f;fill-opacity:1;stroke:none"
+       d="m 6.0041779,1042.5936 -1.2627075,0 0,-0.1493 c -1.2e-6,-0.1665 0.038474,-0.3138 0.1154274,-0.4417 0.07695,-0.13 0.2390151,-0.2945 0.4861948,-0.4936 l 0.2238596,-0.1767 c 0.1329146,-0.1056 0.229687,-0.2051 0.2903178,-0.2985 0.062958,-0.093 0.094438,-0.1869 0.094441,-0.2803 -3e-6,-0.1422 -0.055965,-0.2529 -0.1678946,-0.3321 -0.1119322,-0.081 -0.2681677,-0.1218 -0.4687064,-0.1218 -0.1888831,0 -0.3929213,0.034 -0.6121156,0.1035 -0.2191967,0.067 -0.4477202,0.1676 -0.6855701,0.3017 l 0,-0.9567 c 0.2821555,-0.085 0.5398268,-0.1482 0.773015,-0.1889 0.2331853,-0.04 0.4582107,-0.061 0.6750763,-0.061 0.5689739,0 1.0027015,0.1016 1.3011838,0.3047 0.2984758,0.201 0.4477155,0.4955 0.4477191,0.8835 -3.6e-6,0.199 -0.045476,0.3777 -0.1364146,0.5362 -0.090946,0.1563 -0.2460157,0.3249 -0.4652082,0.5057 l -0.2238595,0.1736 c -0.1585696,0.126 -0.2623377,0.2275 -0.3113045,0.3047 -0.048974,0.075 -0.073456,0.1584 -0.073454,0.2498 l 0,0.1371 m -1.2627075,0.4509 1.2627075,0 0,1.0845 -1.2627075,0 0,-1.0845">
+      <title
+         id="title3255">question</title>
+    </path>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/import_wiz.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/import_wiz.svg
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="import_wiz.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="receiver-bg-6">
+      <stop
+         style="stop-color:#85a2cd;stop-opacity:1;"
+         offset="0"
+         id="stop4923" />
+      <stop
+         style="stop-color:#d3dce9;stop-opacity:1;"
+         offset="1"
+         id="stop4925" />
+    </linearGradient>
+    <linearGradient
+       id="receiver-stroke-7">
+      <stop
+         style="stop-color:#4e6b9b;stop-opacity:1"
+         offset="0"
+         id="stop4915" />
+      <stop
+         style="stop-color:#6783b1;stop-opacity:1"
+         offset="1"
+         id="stop4917" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#receiver-stroke-7"
+       id="linearGradient4919"
+       x1="1.860189"
+       y1="1051.5892"
+       x2="1.860189"
+       y2="1046.8492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0224167,0,0,1.0224167,-17.402778,-24.047507)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#receiver-bg-6"
+       id="linearGradient4927"
+       x1="1.860189"
+       y1="1051.5892"
+       x2="1.860189"
+       y2="1046.8492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0224167,0,0,1.0224167,-17.402778,-24.047507)" />
+    <linearGradient
+       id="arrow-bg-3">
+      <stop
+         style="stop-color:#4e8fbd;stop-opacity:1;"
+         offset="0"
+         id="stop4791" />
+      <stop
+         style="stop-color:#6991ae;stop-opacity:1"
+         offset="1"
+         id="stop4793" />
+    </linearGradient>
+    <linearGradient
+       y2="1049.5981"
+       x2="-2.2873085"
+       y1="1044.6919"
+       x1="-2.2873085"
+       gradientTransform="matrix(0.72295781,-0.72295781,0.72295781,0.72295781,-747.11893,286.63871)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3924"
+       xlink:href="#arrow-bg-3"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="-4.4004976"
+     inkscape:cy="10.211107"
+     inkscape:document-units="px"
+     inkscape:current-layer="receiver"
+     showgrid="true"
+     inkscape:window-width="1652"
+     inkscape:window-height="1174"
+     inkscape:window-x="530"
+     inkscape:window-y="179"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <sodipodi:guide
+       position="0,0"
+       orientation="0,16"
+       id="guide4039" />
+    <sodipodi:guide
+       position="16,0"
+       orientation="-16,0"
+       id="guide4041" />
+    <sodipodi:guide
+       position="16,16"
+       orientation="0,-16"
+       id="guide4043" />
+    <sodipodi:guide
+       position="0,16"
+       orientation="16,0"
+       id="guide4045" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4047" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="receiver"
+       transform="translate(17.6875,0)">
+      <title
+         id="title3214">receiver</title>
+      <path
+         style="fill:url(#linearGradient4927);fill-opacity:1;stroke:url(#linearGradient4919);stroke-width:0.71569169;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m -17.306927,1043.9175 0,7.0931 7.124966,0 7.1249674,0 0,-7.0931 -3.0033491,0 0,2.013 0.9265651,0 0,3.0672 -5.0481834,0 -5.048182,0 0,-3.0672 0.926565,0 0,-2.013 z"
+         id="path4143"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccc" />
+    </g>
+    <path
+       style="fill:url(#linearGradient3924);fill-opacity:1;stroke:none;display:inline"
+       d="m 1.7208163,1039.5526 0.6549857,-0.6549 6.2783105,6.2782 1.3099712,-1.3099 0.3354433,3.4985 -3.4985427,-0.3034 1.2300951,-1.2302 z"
+       id="arrow"
+       inkscape:connector-curvature="0">
+      <title
+         id="title3212">arrow</title>
+    </path>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/new_fastview.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/new_fastview.svg
@@ -1,0 +1,349 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="new_fastview.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="frame-bg-2">
+      <stop
+         style="stop-color:#d5f3ff;stop-opacity:1;"
+         offset="0"
+         id="frame-bg-stop0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="frame-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="frame-stroke-9">
+      <stop
+         style="stop-color:#877e60;stop-opacity:1;"
+         offset="0"
+         id="frame-stroke-stop0" />
+      <stop
+         style="stop-color:#c0a753;stop-opacity:1;"
+         offset="1"
+         id="frame-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="stripe-fill-2-7">
+      <stop
+         style="stop-color:#68b3e1;stop-opacity:1;"
+         offset="0"
+         id="stripe-fill-stop0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stripe-fill-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="header-fill-1">
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1;"
+         offset="0"
+         id="header-fill-stop0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="header-fill-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#frame-stroke-9"
+       id="linearGradient4915"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-16.1875,0)"
+       x1="24.021645"
+       y1="1048.7585"
+       x2="24.021645"
+       y2="1039.4414" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#header-fill-1"
+       id="linearGradient4917"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0181309,0,0,0.9948761,-16.099193,5.6519305)"
+       x1="16.793787"
+       y1="1040.5402"
+       x2="30.714952"
+       y2="1040.5402" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#stripe-fill-2-7"
+       id="linearGradient4919"
+       gradientUnits="userSpaceOnUse"
+       x1="7.4688163"
+       y1="1040.5623"
+       x2="21.389982"
+       y2="1040.5623"
+       gradientTransform="matrix(1.0158646,0,0,1.0160703,-6.588225,-16.417469)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#frame-bg-2"
+       id="linearGradient4936"
+       x1="3.0401695"
+       y1="1043.2539"
+       x2="10.021644"
+       y2="1048.3789"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.5625,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#starinterior-fill-0"
+       id="radialGradient3091-1-9-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,655.80191,583.59074)"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574" />
+    <linearGradient
+       id="starinterior-fill-0">
+      <stop
+         style="stop-color:#e0c576;stop-opacity:1;"
+         offset="0"
+         id="stop4530-0-5-0-5" />
+      <stop
+         style="stop-color:#9e7916;stop-opacity:1"
+         offset="1"
+         id="stop4532-7-9-3-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#starcross-fill-9"
+       id="linearGradient3093-5-2-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,9.777217,1027.2705)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <linearGradient
+       id="starcross-fill-9">
+      <stop
+         id="stop6283-0-2-2-1-2-0-1"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7-6-9-9"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="5.6780771"
+     inkscape:cy="6.9475601"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1290"
+     inkscape:window-height="1001"
+     inkscape:window-x="1160"
+     inkscape:window-y="427"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3080" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4936);fill-opacity:1;stroke:url(#linearGradient4915);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="winframe"
+       width="6.0077248"
+       height="11.035645"
+       x="1.5057945"
+       y="1039.8481">
+      <title
+         id="title3346">winframe</title>
+    </rect>
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4917);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.89999998;marker:none;enable-background:accumulate"
+       id="header"
+       width="7.0192919"
+       height="3.0338135"
+       x="0.99908066"
+       y="1039.3436">
+      <title
+         id="title3348">header</title>
+    </rect>
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4919);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.89999998;marker:none;enable-background:accumulate"
+       id="stripe"
+       width="7.0036669"
+       height="0.98791504"
+       x="0.99908066"
+       y="1040.373">
+      <title
+         id="title3353">stripe</title>
+    </rect>
+    <path
+       style="display:inline;opacity:0.85;fill:#945112;fill-opacity:1;stroke:none"
+       d="m 10.343965,1047.1951 c 0,0 0.0781,0.3441 0.303204,0.59 0.225108,0.2459 0.56093,0.3542 0.56093,0.3542 0,0 -0.342043,0.076 -0.590001,0.3031 -0.247957,0.227 -0.354126,0.5609 -0.354126,0.5609 0,0 -0.06889,-0.3339 -0.303205,-0.5899 -0.234327,-0.2561 -0.56093,-0.3542 -0.56093,-0.3542 0,0 0.350102,-0.084 0.590001,-0.3032 0.239908,-0.2196 0.354127,-0.5609 0.354127,-0.5609 z"
+       id="starshadow4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="czczczczc"
+       inkscape:label="#starshadow4">
+      <title
+         id="title3438">starshadow4</title>
+    </path>
+    <path
+       style="display:inline;opacity:0.85;fill:#945112;fill-opacity:1;stroke:none"
+       d="m 9.308111,1048.961 c 0,0 -0.131805,0.319 -0.0908,0.6427 0.04104,0.3235 0.248295,0.5996 0.248295,0.5996 0,0 -0.316348,-0.1322 -0.642582,-0.09 -0.326253,0.041 -0.599601,0.2483 -0.599601,0.2483 0,0 0.133515,-0.3057 0.09081,-0.6425 -0.0427,-0.3369 -0.248297,-0.5996 -0.248297,-0.5996 0,0 0.326935,0.1309 0.642582,0.09 0.315656,-0.04 0.599602,-0.2483 0.599602,-0.2483 z"
+       id="starshadow3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="czczczczc">
+      <title
+         id="title3436">starshadow3</title>
+    </path>
+    <path
+       style="display:inline;opacity:0.85;fill:#945112;fill-opacity:1;stroke:none"
+       d="m 7.03436,1049.8306 c 0,0 -0.03603,0.2767 0.06387,0.5208 0.09991,0.2441 0.319618,0.4161 0.319618,0.4161 0,0 -0.274729,-0.037 -0.520794,0.064 -0.246065,0.1008 -0.416106,0.3196 -0.416106,0.3196 0,0 0.04012,-0.2667 -0.06387,-0.5208 -0.103986,-0.254 -0.319618,-0.4161 -0.319618,-0.4161 0,0 0.282721,0.034 0.520794,-0.064 0.23807,-0.097 0.416106,-0.3196 0.416106,-0.3196 z"
+       id="starshadow2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="czczczczc">
+      <title
+         id="title3434">starshadow2</title>
+    </path>
+    <path
+       inkscape:transform-center-y="0.625"
+       inkscape:transform-center-x="1.4375"
+       style="display:inline;opacity:0.85;fill:#945112;fill-opacity:1;stroke:none"
+       d="m 4.929806,1050.5922 c 0,0 -0.02929,0.1772 0.02958,0.3364 0.05889,0.1592 0.196418,0.2748 0.196418,0.2748 0,0 -0.175934,-0.03 -0.336408,0.029 -0.16051,0.059 -0.274716,0.1964 -0.274716,0.1964 0,0 0.03168,-0.1707 -0.02962,-0.3364 -0.06129,-0.1657 -0.196419,-0.2747 -0.196419,-0.2747 0,0 0.181112,0.028 0.336412,-0.03 0.155292,-0.057 0.274712,-0.1963 0.274712,-0.1963 z"
+       id="starshadow1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="czczczczc">
+      <title
+         id="title3432">starshadow1</title>
+    </path>
+    <path
+       style="display:inline;opacity:0.85;fill:#945112;fill-opacity:1;stroke:none"
+       d="m 11.694602,1044.4567 c 0,0 -0.05151,0.4757 0.12879,0.8904 0.180313,0.4147 0.563366,0.7016 0.563366,0.7016 0,0 -0.472359,-0.053 -0.890472,0.1287 -0.418126,0.1818 -0.701541,0.5634 -0.701541,0.5634 0,0 0.05889,-0.4588 -0.12879,-0.8905 -0.187682,-0.4317 -0.563367,-0.7015 -0.563367,-0.7015 0,0 0.485949,0.047 0.890474,-0.1288 0.404539,-0.1759 0.70154,-0.5633 0.70154,-0.5633 z"
+       id="starshadow5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="czczczczc">
+      <title
+         id="title3440">starshadow5</title>
+    </path>
+    <path
+       style="display:inline;opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none"
+       d="m 10.568823,1046.9482 c 0,0 0.0781,0.3441 0.303204,0.59 0.225108,0.2459 0.56093,0.3542 0.56093,0.3542 0,0 -0.342043,0.076 -0.590001,0.3031 -0.247957,0.227 -0.354126,0.5609 -0.354126,0.5609 0,0 -0.06889,-0.3339 -0.303205,-0.5899 -0.234327,-0.2561 -0.56093,-0.3542 -0.56093,-0.3542 0,0 0.350102,-0.084 0.590001,-0.3032 0.239908,-0.2196 0.354127,-0.5609 0.354127,-0.5609 z"
+       id="star4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="czczczczc">
+      <title
+         id="title3428">star4</title>
+    </path>
+    <path
+       style="display:inline;opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none"
+       d="m 9.532969,1048.7141 c 0,0 -0.131805,0.319 -0.0908,0.6427 0.04104,0.3235 0.248295,0.5996 0.248295,0.5996 0,0 -0.316348,-0.1322 -0.642582,-0.09 -0.326253,0.041 -0.599601,0.2483 -0.599601,0.2483 0,0 0.133515,-0.3057 0.09081,-0.6425 -0.0427,-0.3369 -0.248297,-0.5996 -0.248297,-0.5996 0,0 0.326935,0.1309 0.642582,0.09 0.315656,-0.04 0.599602,-0.2483 0.599602,-0.2483 z"
+       id="star3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="czczczczc">
+      <title
+         id="title3426">star3</title>
+    </path>
+    <path
+       style="display:inline;opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none"
+       d="m 7.259218,1049.5837 c 0,0 -0.03603,0.2767 0.06387,0.5208 0.09991,0.2441 0.319618,0.4161 0.319618,0.4161 0,0 -0.274729,-0.037 -0.520794,0.064 -0.246065,0.1008 -0.416106,0.3196 -0.416106,0.3196 0,0 0.04012,-0.2667 -0.06387,-0.5208 -0.103986,-0.254 -0.319618,-0.4161 -0.319618,-0.4161 0,0 0.282721,0.034 0.520794,-0.064 0.23807,-0.097 0.416106,-0.3196 0.416106,-0.3196 z"
+       id="star2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="czczczczc">
+      <title
+         id="title3424">star2</title>
+    </path>
+    <path
+       inkscape:transform-center-y="0.625"
+       inkscape:transform-center-x="1.4375"
+       style="display:inline;opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none"
+       d="m 5.154664,1050.3453 c 0,0 -0.02929,0.1772 0.02958,0.3364 0.05889,0.1592 0.196418,0.2748 0.196418,0.2748 0,0 -0.175934,-0.03 -0.336408,0.029 -0.16051,0.059 -0.274716,0.1964 -0.274716,0.1964 0,0 0.03168,-0.1707 -0.02962,-0.3364 -0.06129,-0.1657 -0.196419,-0.2747 -0.196419,-0.2747 0,0 0.181112,0.028 0.336412,-0.03 0.155292,-0.057 0.274712,-0.1963 0.274712,-0.1963 z"
+       id="star1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="czczczczc">
+      <title
+         id="title3422">star1</title>
+    </path>
+    <path
+       style="display:inline;opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none"
+       d="m 11.91946,1044.2098 c 0,0 -0.05151,0.4757 0.12879,0.8904 0.180313,0.4147 0.563366,0.7016 0.563366,0.7016 0,0 -0.472359,-0.053 -0.890472,0.1287 -0.418126,0.1818 -0.701541,0.5634 -0.701541,0.5634 0,0 0.05889,-0.4588 -0.12879,-0.8905 -0.187682,-0.4317 -0.563367,-0.7015 -0.563367,-0.7015 0,0 0.485949,0.047 0.890474,-0.1288 0.404539,-0.1759 0.70154,-0.5633 0.70154,-0.5633 z"
+       id="star5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="czczczczc">
+      <title
+         id="title3430">star5</title>
+    </path>
+    <rect
+       style="display:inline;fill:url(#radialGradient3091-1-9-6);fill-opacity:1;stroke:none;stroke-width:1.03243756;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="starinterior"
+       width="4.5825453"
+       height="4.454073"
+       x="-747.27124"
+       y="-729.45618"
+       transform="matrix(-0.70710678,-0.70710678,0.70710678,-0.70710678,0,0)">
+      <title
+         id="title3334">starinterior</title>
+    </rect>
+    <path
+       sodipodi:nodetypes="ccccccccccccc"
+       inkscape:connector-curvature="0"
+       id="starcross"
+       d="m 12.04871,1038.3943 1.001133,0 0,1.946 1.986639,0 0,1.0167 -1.986639,0 0,2.043 -1.001133,0 0,-2.043 -1.98664,0 0,-1.0167 1.98664,0 z"
+       style="display:inline;fill:url(#linearGradient3093-5-2-7);fill-opacity:1;stroke:none">
+      <title
+         id="title3336">starcross</title>
+    </path>
+    <rect
+       style="display:inline;fill:none;fill-opacity:1;stroke:#a27d18;stroke-width:1.03243756;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="starexterior"
+       width="4.5825453"
+       height="4.454073"
+       x="-747.27124"
+       y="-729.45618"
+       transform="matrix(-0.70710678,-0.70710678,0.70710678,-0.70710678,0,0)">
+      <title
+         id="title3322">starexterior</title>
+    </rect>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/new_wiz.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/new_wiz.svg
@@ -1,0 +1,546 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="new_wiz.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       y2="1050.0707"
+       x2="8.0137892"
+       y1="1042.3622"
+       x1="8.0137892"
+       gradientTransform="translate(0,2.000063)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4046-24"
+       xlink:href="#linearGradient4810-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4810-5">
+      <stop
+         style="stop-color:#be9a4b;stop-opacity:1"
+         offset="0"
+         id="stop4812-0" />
+      <stop
+         style="stop-color:#877e60;stop-opacity:1"
+         offset="1"
+         id="stop4814-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4910-4-0"
+       id="linearGradient5062-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(18,-4.000037)"
+       x1="-13"
+       y1="1047.3622"
+       x2="-15"
+       y2="1047.3622" />
+    <linearGradient
+       id="linearGradient4910-4-0"
+       inkscape:collect="always">
+      <stop
+         id="stop4912-8-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0" />
+      <stop
+         id="stop4914-8-1"
+         offset="1"
+         style="stop-color:#c5dff4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(18,1.999963)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-4-5"
+       id="linearGradient4975-2-1"
+       gradientUnits="userSpaceOnUse"
+       x1="-11"
+       y1="1042.3622"
+       x2="-11"
+       y2="1044.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-4-5">
+      <stop
+         style="stop-color:#c5dff4;stop-opacity:1"
+         offset="0"
+         id="stop4996-5-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4998-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4082-3"
+       id="linearGradient4063-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.0001)"
+       x1="8.0137892"
+       y1="1039.876"
+       x2="8.0137892"
+       y2="1041.8765" />
+    <linearGradient
+       id="linearGradient4082-3">
+      <stop
+         id="stop4084-8"
+         offset="0"
+         style="stop-color:#4476aa;stop-opacity:1" />
+      <stop
+         style="stop-color:#5a9ccc;stop-opacity:1"
+         offset="0.5"
+         id="stop4864-7" />
+      <stop
+         id="stop4086-2"
+         offset="1"
+         style="stop-color:#4476aa;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter7823-3-4-6"
+       x="-0.18344673"
+       width="1.4377165"
+       y="-0.16038014"
+       height="1.382678">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.6188839"
+         id="feGaussianBlur7825-1-3-8" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7272-66-4-5-5-5"
+       id="linearGradient7736-9-7-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       x1="-15.945988"
+       y1="1037.4661"
+       x2="-15.945988"
+       y2="1023.2569" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7540-2-3-8"
+       id="linearGradient7738-6-2-3"
+       gradientUnits="userSpaceOnUse"
+       x1="-22.453552"
+       y1="1030.3411"
+       x2="-10.159802"
+       y2="1030.3411" />
+    <linearGradient
+       id="linearGradient7540-2-3-8">
+      <stop
+         id="stop7542-8-7-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9" />
+      <stop
+         id="stop7548-98-9-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7540-6-33-6-3"
+       id="linearGradient7740-1-3-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       x1="-22.453552"
+       y1="1030.3411"
+       x2="-10.159802"
+       y2="1030.3411" />
+    <linearGradient
+       id="linearGradient7540-6-33-6-3">
+      <stop
+         id="stop7542-4-4-3-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-5-3-8-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-2-9-1-2" />
+      <stop
+         id="stop7548-9-2-0-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask8465">
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 2.005808,1041.3724 0,0.5 0,11.0313 0,0.5 0.5,0 12.9375,0 0.5,0 0,-0.5 0,-11.0313 0,-0.5 -0.5,0 -12.9375,0 -0.5,0 z"
+         id="path8467"
+         inkscape:connector-curvature="0" />
+    </mask>
+    <linearGradient
+       y2="6.9843998"
+       x2="10.007812"
+       y1="5"
+       x1="10"
+       gradientTransform="translate(-15.015625,1046.6356)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6323"
+       xlink:href="#linearGradient5068-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5068-6"
+       inkscape:collect="always">
+      <stop
+         id="stop5070-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop5072-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.3466"
+       x2="12"
+       y1="1043.3622"
+       x1="12"
+       id="linearGradient5084-3"
+       xlink:href="#linearGradient5068-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.3466"
+       x2="15.007812"
+       y1="1043.3622"
+       x1="13"
+       id="linearGradient5086-8"
+       xlink:href="#linearGradient5068-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.3622"
+       x2="10.007812"
+       y1="1042.3622"
+       x1="12"
+       id="linearGradient5082-1"
+       xlink:href="#linearGradient5068-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1041.3466"
+       x2="8.0078125"
+       y1="1041.3622"
+       x1="10"
+       id="linearGradient5078-8"
+       xlink:href="#linearGradient5068-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1038.3466"
+       x2="10.007812"
+       y1="1040.3622"
+       x1="10"
+       id="linearGradient5076-5"
+       xlink:href="#linearGradient5068-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1038.3466"
+       x2="10.007812"
+       y1="1038.3622"
+       x1="12"
+       id="linearGradient5074-2"
+       xlink:href="#linearGradient5068-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.3466"
+       x2="14"
+       y1="1041.3622"
+       x1="14"
+       id="linearGradient5088-1"
+       xlink:href="#linearGradient5068-6"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9-5-7"
+       id="radialGradient3091-1-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574" />
+    <linearGradient
+       id="linearGradient4528-9-5-7">
+      <stop
+         style="stop-color:#e0c576;stop-opacity:1;"
+         offset="0"
+         id="stop4530-0-5-0" />
+      <stop
+         style="stop-color:#9e7916;stop-opacity:1"
+         offset="1"
+         id="stop4532-7-9-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6-6-4"
+       id="linearGradient3093-5-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4">
+      <stop
+         id="stop6283-0-2-2-1-2-0"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7-6-9"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9-5-7-9"
+       id="radialGradient3091-1-9-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574" />
+    <linearGradient
+       id="linearGradient4528-9-5-7-9">
+      <stop
+         style="stop-color:#e0c576;stop-opacity:1;"
+         offset="0"
+         id="stop4530-0-5-0-5" />
+      <stop
+         style="stop-color:#9e7916;stop-opacity:1"
+         offset="1"
+         id="stop4532-7-9-3-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6-6-4-2"
+       id="linearGradient3093-5-2-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2">
+      <stop
+         id="stop6283-0-2-2-1-2-0-1"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7-6-9-9"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="11.512582"
+     inkscape:cy="2.3643883"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid6272"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4908"
+       transform="translate(17.6875,0)">
+      <g
+         transform="translate(-18.599558,-2.010247)"
+         style="display:inline"
+         id="layer1-8"
+         inkscape:label="Layer 1">
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect3997-9"
+           d="m 2.500702,1041.8621 12.927706,0 0,11.033 -12.927706,0 z"
+           style="fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient4046-24);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect4853-82-7"
+           d="m 4,1045.3622 0,7.0312 -1,0 0,-8.0312 z"
+           style="fill:url(#linearGradient5062-4);fill-opacity:1;stroke:none;display:inline" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect4853-82-0"
+           d="m 4,1045.3622 10.928078,0 0,-1 -11.928078,0 z"
+           style="fill:url(#linearGradient4975-2-1);fill-opacity:1;stroke:none;display:inline" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect3997-9-9"
+           d="m 2.500702,1041.8621 12.883511,0 0,2.0053 -12.883511,0 z"
+           style="fill:#58b6e8;fill-opacity:1;stroke:url(#linearGradient4063-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+        <path
+           transform="matrix(0.40514455,0,0,0.40514455,48.017265,625.5691)"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path7813-2"
+           d="m -106.1326,1054.8481 c 15.377466,0 21.179561,-6.8234 21.179561,-24.2257"
+           style="fill:none;stroke:#ffe99f;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;filter:url(#filter7823-3-4-6)" />
+        <path
+           style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+           d="m 12.422762,1049.0556 c 0,0 0.0781,0.3441 0.303204,0.59 0.225108,0.2459 0.56093,0.3542 0.56093,0.3542 0,0 -0.342043,0.076 -0.590001,0.3031 -0.247957,0.227 -0.354126,0.5609 -0.354126,0.5609 0,0 -0.06889,-0.3339 -0.303205,-0.5899 -0.234327,-0.2561 -0.56093,-0.3542 -0.56093,-0.3542 0,0 0.350102,-0.084 0.590001,-0.3032 0.239908,-0.2196 0.354127,-0.5609 0.354127,-0.5609 z"
+           id="rect6501-4-4-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="czczczczc" />
+        <path
+           style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+           d="m 11.386908,1050.8215 c 0,0 -0.131805,0.319 -0.0908,0.6427 0.04104,0.3235 0.248295,0.5996 0.248295,0.5996 0,0 -0.316348,-0.1322 -0.642582,-0.09 -0.326253,0.041 -0.599601,0.2483 -0.599601,0.2483 0,0 0.133515,-0.3057 0.09081,-0.6425 -0.0427,-0.3369 -0.248297,-0.5996 -0.248297,-0.5996 0,0 0.326935,0.1309 0.642582,0.09 0.315656,-0.04 0.599602,-0.2483 0.599602,-0.2483 z"
+           id="rect6501-4-4-1-7"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="czczczczc" />
+        <path
+           style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+           d="m 9.1131569,1051.6911 c 0,0 -0.036027,0.2767 0.063869,0.5208 0.099907,0.2441 0.3196179,0.4161 0.3196179,0.4161 0,0 -0.2747289,-0.037 -0.5207938,0.064 -0.2460648,0.1008 -0.4161058,0.3196 -0.4161058,0.3196 0,0 0.040122,-0.2667 -0.063869,-0.5208 -0.1039866,-0.254 -0.319618,-0.4161 -0.319618,-0.4161 0,0 0.2827212,0.034 0.5207942,-0.064 0.2380696,-0.097 0.4161055,-0.3196 0.4161055,-0.3196 z"
+           id="rect6501-4-4-7-0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="czczczczc" />
+        <path
+           inkscape:transform-center-y="0.625"
+           inkscape:transform-center-x="1.4375"
+           style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+           d="m 7.0086025,1052.4527 c 0,0 -0.029292,0.1772 0.029576,0.3364 0.058888,0.1592 0.1964181,0.2748 0.1964181,0.2748 0,0 -0.175934,-0.03 -0.3364077,0.029 -0.1605102,0.059 -0.2747164,0.1964 -0.2747164,0.1964 0,0 0.031682,-0.1707 -0.029616,-0.3364 -0.06129,-0.1657 -0.1964182,-0.2747 -0.1964182,-0.2747 0,0 0.1811118,0.028 0.3364118,-0.03 0.1552919,-0.057 0.2747123,-0.1963 0.2747123,-0.1963 z"
+           id="rect6501-4-4-93-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="czczczczc" />
+        <path
+           style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+           d="m 13.773399,1046.3172 c 0,0 -0.05151,0.4757 0.12879,0.8904 0.180313,0.4147 0.563366,0.7016 0.563366,0.7016 0,0 -0.472359,-0.053 -0.890472,0.1287 -0.418126,0.1818 -0.701541,0.5634 -0.701541,0.5634 0,0 0.05889,-0.4588 -0.12879,-0.8905 -0.187682,-0.4317 -0.563367,-0.7015 -0.563367,-0.7015 0,0 0.485949,0.047 0.890474,-0.1288 0.404539,-0.1759 0.70154,-0.5633 0.70154,-0.5633 z"
+           id="rect6501-4-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="czczczczc" />
+        <g
+           style="display:inline"
+           id="g6432"
+           transform="translate(15.96379,-8.280374)">
+          <g
+             style="display:inline"
+             id="g4514"
+             transform="translate(-5.536708,-5.6240351)">
+            <g
+               id="g4522"
+               transform="translate(-9.9375,0)">
+              <rect
+                 style="fill:url(#radialGradient3091-1-9-6);fill-opacity:1;stroke:#a27d18;stroke-width:1.03243756;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+                 id="rect3910"
+                 width="4.5825453"
+                 height="4.454073"
+                 x="-758.82336"
+                 y="-740.41083"
+                 transform="matrix(-0.70710678,-0.70710678,0.70710678,-0.70710678,0,0)" />
+              <path
+                 sodipodi:nodetypes="ccccccccccccc"
+                 inkscape:connector-curvature="0"
+                 id="path5581-5-5"
+                 d="m 12.471186,1054.309 1.001133,0 0,1.946 1.986639,0 0,1.0167 -1.986639,0 0,2.043 -1.001133,0 0,-2.043 -1.98664,0 0,-1.0167 1.98664,0 z"
+                 style="fill:url(#linearGradient3093-5-2-7);fill-opacity:1;stroke:none;display:inline" />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/paste_edit.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/paste_edit.svg
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="paste_edit.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="clasp-stroke-6">
+      <stop
+         style="stop-color:#607396;stop-opacity:1;"
+         offset="0"
+         id="clasp-stroke-stop0" />
+      <stop
+         style="stop-color:#a7afbc;stop-opacity:1;"
+         offset="1"
+         id="clasp-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="clasp-bg-7">
+      <stop
+         style="stop-color:#8194b4;stop-opacity:1;"
+         offset="0"
+         id="clasp-bg-stop0" />
+      <stop
+         style="stop-color:#cdd4e0;stop-opacity:1;"
+         offset="1"
+         id="clasp-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="clipboard-bg-3">
+      <stop
+         style="stop-color:#f2c671;stop-opacity:1;"
+         offset="0"
+         id="clipboard-bg-stop0" />
+      <stop
+         style="stop-color:#f3e2bf;stop-opacity:1"
+         offset="1"
+         id="clipboard-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="paper-bg-5">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="paper-bg-stop0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="paper-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="paper-stroke-3">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="paper-stroke-stop0" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="paper-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="paper-lines-2">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="paper-lines-stop0" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:0;"
+         offset="1"
+         id="paper-lines-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="paper-fold-bg-6">
+      <stop
+         style="stop-color:#d8bc68;stop-opacity:1;"
+         offset="0"
+         id="paper-fold-stop0" />
+      <stop
+         style="stop-color:#fff0c2;stop-opacity:1;"
+         offset="1"
+         id="paper-fold-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#paper-lines-2"
+       id="paper-lines"
+       gradientTransform="scale(0.98560841,1.0146017)"
+       x1="12.793009"
+       y1="1032.0781"
+       x2="8.1463385"
+       y2="1032.0781"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#paper-stroke-3"
+       id="paper-stroke"
+       gradientTransform="scale(0.89262372,1.1202929)"
+       x1="15.995771"
+       y1="931.12573"
+       x2="8.210084"
+       y2="937.90405"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#paper-bg-5"
+       id="paper-bg"
+       gradientTransform="scale(0.89262372,1.1202929)"
+       x1="15.995771"
+       y1="931.12573"
+       x2="8.210084"
+       y2="937.90405"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#clipboard-bg-3"
+       id="clipboard-bg"
+       gradientTransform="scale(0.95989664,1.0417788)"
+       x1="6.19349"
+       y1="1009.338"
+       x2="6.19349"
+       y2="1003.3985"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#clasp-stroke-6"
+       id="clasp-stroke"
+       gradientTransform="scale(1.4438315,0.69260158)"
+       x1="5.5867453"
+       y1="1502.386"
+       x2="5.5867453"
+       y2="1498.0094"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#clasp-bg-7"
+       id="clasp-bg"
+       gradientTransform="scale(1.4438315,0.69260158)"
+       x1="5.5867453"
+       y1="1502.386"
+       x2="5.5867453"
+       y2="1498.0094"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="-1.625299"
+     inkscape:cy="5.4280558"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1335"
+     inkscape:window-height="996"
+     inkscape:window-x="1052"
+     inkscape:window-y="430"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4172" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4908"
+       transform="translate(16.803617,1.1490485)" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#clipboard-bg);fill-opacity:1;fill-rule:nonzero;stroke:#af8456;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="clipboard"
+       width="10.98879"
+       height="12.011471"
+       x="2.4875708"
+       y="1039.8506"
+       ry="1.2056092">
+      <title
+         id="title3254">clipboard</title>
+    </rect>
+    <path
+       style="display:inline;fill:url(#clasp-bg);fill-opacity:1;stroke:url(#clasp-stroke);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.6872685,1037.8674 -1.9237704,3.0156 3.2735126,0 3.2735103,0 -1.923769,-3.0156 -1.3497413,0 z"
+       id="clasp"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc">
+      <title
+         id="title3256">clasp</title>
+    </path>
+    <path
+       sodipodi:nodetypes="ccccccc"
+       inkscape:connector-curvature="0"
+       id="paper"
+       d="m 7.5294306,1042.8539 0.022097,9.0235 6.9629104,0 -0.0221,-7.0161 -1.972619,0 0.0023,-2.0089 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#paper-bg);fill-opacity:1;stroke:url(#paper-stroke);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate">
+      <title
+         id="title3321">paper</title>
+    </path>
+    <path
+       style="display:inline;fill:url(#paper-fold-bg-6);fill-opacity:1;stroke:none"
+       d="m 13.021488,1042.3689 2.01799,2.0018 -2.031854,0 z"
+       id="paper-fold"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc">
+      <title
+         id="title3399">paper-fold</title>
+    </path>
+    <path
+       id="paper-lines"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#paper-lines);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.51251632;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 8.1401475,1049.3676 0,-0.3002 0,-0.7009 4.8577025,0 0,1.0011 -4.8577025,0 z m 0,-2.0108 0,-0.3002 0,-0.7009 4.8577025,0 0,1.0011 -4.8577025,0 z m 0.1767768,-1.9887 0,-0.3002 0,-0.7009 2.6921877,0 0,1.0011 -2.6921877,0 z">
+      <title
+         id="title3402"
+         style="fill-opacity:1.0;fill:url(#paper-lines-2)">paper-lines</title>
+    </path>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/pin_editor.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/pin_editor.svg
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   sodipodi:docname="pin_editor.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4925">
+      <stop
+         style="stop-color:#679fb0;stop-opacity:1;"
+         offset="0"
+         id="stop4927" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4929" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4905">
+      <stop
+         style="stop-color:#3c7a16;stop-opacity:1;"
+         offset="0"
+         id="stop4907" />
+      <stop
+         style="stop-color:#72b649;stop-opacity:1;"
+         offset="1"
+         id="stop4909" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4929">
+      <stop
+         style="stop-color:#d5f3ff;stop-opacity:1;"
+         offset="0"
+         id="stop4931" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4934" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4900">
+      <stop
+         style="stop-color:#877e60;stop-opacity:1;"
+         offset="0"
+         id="stop4902" />
+      <stop
+         style="stop-color:#c0a753;stop-opacity:1;"
+         offset="1"
+         id="stop4904" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4881">
+      <stop
+         style="stop-color:#68b3e1;stop-opacity:1;"
+         offset="0"
+         id="stop4883" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4885" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4839">
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1;"
+         offset="0"
+         id="stop4841" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4843" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4900"
+       id="linearGradient4915"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0699894,0,0,1.0815179,-17.413438,-84.328211)"
+       x1="24.021645"
+       y1="1048.7585"
+       x2="24.021645"
+       y2="1039.4414" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4839"
+       id="linearGradient4917"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0706979,0,0,0.99096776,-16.933753,9.7313634)"
+       x1="16.793787"
+       y1="1040.5402"
+       x2="34.512348"
+       y2="1040.4956" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4881"
+       id="linearGradient4919"
+       gradientUnits="userSpaceOnUse"
+       x1="7.4688163"
+       y1="1040.5623"
+       x2="25.11368"
+       y2="1040.5837"
+       gradientTransform="matrix(1.0740861,0,0,1.0300159,-6.9746824,-30.931308)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4929"
+       id="linearGradient4936"
+       x1="3.0401695"
+       y1="1043.2539"
+       x2="10.021644"
+       y2="1048.3789"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0699894,0,0,1.0815179,0.50888551,-84.328211)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4905"
+       id="linearGradient4921"
+       gradientUnits="userSpaceOnUse"
+       x1="18.139078"
+       y1="1059.4176"
+       x2="18.139078"
+       y2="1057.1572" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4925"
+       id="radialGradient4931"
+       cx="9.5247316"
+       cy="9.6384525"
+       fx="9.5247316"
+       fy="9.6384525"
+       r="1.8125"
+       gradientTransform="matrix(0.91319129,-0.76247039,1.7639714,2.1126635,-16.631902,1032.4401)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="9.9657862"
+     inkscape:cy="9.3912619"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4039"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g1"
+       inkscape:label="window"
+       style="display:inline">
+      <rect
+         y="1039.8638"
+         x="1.5014815"
+         height="11.997034"
+         width="13.997037"
+         id="rect4898"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4936);fill-opacity:1;stroke:url(#linearGradient4915);stroke-width:1.00297;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4917);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.899998;marker:none;enable-background:accumulate"
+         id="rect4069"
+         width="14.999999"
+         height="3"
+         x="1.0000004"
+         y="1039.3622" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4919);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.899998;marker:none;enable-background:accumulate"
+         id="rect4069-8"
+         width="14.999999"
+         height="1.0014741"
+         x="1.0000004"
+         y="1040.3636" />
+    </g>
+    <path
+       style="fill:url(#radialGradient4931);fill-opacity:1;stroke:none"
+       d="m 9.4397234,1049.2211 -0.7435345,-4.3869 4.3125001,2.2306 z"
+       id="path4923"
+       inkscape:connector-curvature="0"
+       inkscape:label="Shadow" />
+    <g
+       id="g4915"
+       transform="matrix(0.60837194,0.60837194,-0.60837194,0.60837194,644.94323,386.71487)"
+       inkscape:label="Pin">
+      <rect
+         ry="0"
+         y="1060.6265"
+         x="17.456699"
+         height="3.2261746"
+         width="0.9722718"
+         id="rect4913"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.9;marker:none;enable-background:accumulate" />
+      <g
+         id="g4900">
+        <path
+           sodipodi:nodetypes="sssssssss"
+           inkscape:connector-curvature="0"
+           id="rect4897"
+           d="m 17.54509,1054.9697 h 0.537498 c 0.734509,0 1.22834,0.5978 1.325829,1.3258 l 0.390574,2.9167 c 0.120235,0.8979 -0.729293,1.6352 -1.635185,1.6352 h -0.662913 c -0.905892,0 -1.744197,-0.7359 -1.635185,-1.6352 l 0.353553,-2.9167 c 0.08839,-0.7292 0.59132,-1.3258 1.325829,-1.3258 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4921);fill-opacity:1;fill-rule:nonzero;stroke:#007236;stroke-width:0.9;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+        <ellipse
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#72b649;fill-opacity:1;stroke:#007236;stroke-width:0.9;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="path4127"
+           transform="matrix(0.84972771,0,0,0.84972771,-2.0265541,1040.3142)"
+           cx="23.422913"
+           cy="17.59099"
+           rx="3.2261746"
+           ry="1.7235727" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/print_edit.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/print_edit.svg
@@ -1,0 +1,321 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="print_edit.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       gradientTransform="translate(-20.991187,-0.01685309)"
+       gradientUnits="userSpaceOnUse"
+       y2="1050.3622"
+       x2="24"
+       y1="1051.3622"
+       x1="24"
+       id="printer-footer-stroke"
+       xlink:href="#printer-footer-stroke-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="printer-footer-stroke-5"
+       inkscape:collect="always">
+      <stop
+         id="printer-footer-stroke-stop0"
+         offset="0"
+         style="stop-color:#5978ab;stop-opacity:1;" />
+      <stop
+         id="printer-footer-stroke-stop1"
+         offset="1"
+         style="stop-color:#5373a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-20.920874,-0.00122809)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.6714"
+       x2="29.391129"
+       y1="1049.8108"
+       x1="29.453629"
+       id="printer-body-fill"
+       xlink:href="#printer-body-fill-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="printer-body-fill-5"
+       inkscape:collect="always">
+      <stop
+         id="printer-body-fill-stop0"
+         offset="0"
+         style="stop-color:#8daad3;stop-opacity:1" />
+      <stop
+         id="printer-body-fill-stop1"
+         offset="1"
+         style="stop-color:#f3f5f6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-20.920874,-0.00122809)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.6865"
+       x2="23.289864"
+       y1="1050.5165"
+       x1="23.289864"
+       id="printer-body-stroke"
+       xlink:href="#printer-body-stroke-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="printer-body-stroke-7"
+       inkscape:collect="always">
+      <stop
+         id="printer-body-stroke-stop0"
+         offset="0"
+         style="stop-color:#607fb0;stop-opacity:1" />
+      <stop
+         id="printer-body-stroke-stop1"
+         offset="1"
+         style="stop-color:#7593c1;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0.02388337,-1.02277)"
+       gradientUnits="userSpaceOnUse"
+       y2="1039.9095"
+       x2="9.0883884"
+       y1="1040.9814"
+       x1="8.3314562"
+       id="paper-fold"
+       xlink:href="#paper-fold-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="paper-fold-2"
+       inkscape:collect="always">
+      <stop
+         id="paper-fold-stop0"
+         offset="0"
+         style="stop-color:#e4cf9d;stop-opacity:1" />
+      <stop
+         id="paper-fold-stop1"
+         offset="1"
+         style="stop-color:#d0ab5b;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.7139977,0,0,1,-0.00123099,-3.9882538)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.8571"
+       x2="14"
+       y1="1047.8571"
+       x1="7.0070496"
+       id="paper-lines"
+       xlink:href="#paper-lines-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="paper-lines-6">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="paper-lines-stop0" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="paper-lines-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#body-shadow-right-1"
+       id="body-shadow-right"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.016466,0,0,0.24869905,-11.113476,782.85244)"
+       x1="6"
+       y1="1045.4012"
+       x2="7"
+       y2="1045.4012" />
+    <linearGradient
+       inkscape:collect="always"
+       id="body-shadow-right-1">
+      <stop
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0"
+         id="body-shadow-right-stop0" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="1"
+         id="body-shadow-right-stop1" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.4012"
+       x2="7"
+       y1="1045.4012"
+       x1="6"
+       gradientTransform="matrix(-1.9722718,0,0,0.24869905,25.807689,782.85244)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6209"
+       xlink:href="#body-shadow-right-1"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-0.9982137,-0.01689991)"
+       inkscape:collect="always"
+       xlink:href="#paper-bg-3"
+       id="paper-bg"
+       x1="3.9972825"
+       y1="1041.8641"
+       x2="13.002603"
+       y2="1041.8641"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="paper-bg-3"
+       inkscape:collect="always">
+      <stop
+         id="paper-bg-stop0"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1;" />
+      <stop
+         id="paper-bg-stop1"
+         offset="1"
+         style="stop-color:#dce7f8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.9982137,-1.0559999)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.4012"
+       x2="10.544736"
+       y1="1038.5779"
+       x1="10.544736"
+       id="paper-stroke"
+       xlink:href="#paper-stroke-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="paper-stroke-6"
+       inkscape:collect="always">
+      <stop
+         id="paper-stroke-stop0"
+         offset="0"
+         style="stop-color:#c7b571;stop-opacity:1" />
+      <stop
+         id="paper-stroke-stop1"
+         offset="1"
+         style="stop-color:#788dae;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="7.1411525"
+     inkscape:cy="7.6897506"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1397"
+     inkscape:window-height="1174"
+     inkscape:window-x="975"
+     inkscape:window-y="243"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5105" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="display:inline;fill:#89a8d6;fill-opacity:1;stroke:url(#printer-footer-stroke);stroke-opacity:1"
+       id="printer-footer"
+       width="12.001725"
+       height="3.5034955"
+       x="1.5043809"
+       y="1048.3453"
+       rx="0.86178637"
+       ry="0.86178637">
+      <title
+         id="title3315">printer-footer</title>
+    </rect>
+    <rect
+       style="fill:url(#printer-body-fill);fill-opacity:1;stroke:url(#printer-body-stroke);stroke-opacity:1"
+       id="printer-body"
+       width="13.98806"
+       height="7.0093994"
+       x="0.51012605"
+       y="1042.8629"
+       rx="0.39777759"
+       ry="0.39777759">
+      <title
+         id="title3313">printer-body</title>
+    </rect>
+    <path
+       style="display:inline;fill:url(#paper-bg);fill-opacity:1;stroke:url(#paper-stroke);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 3.4990688,1037.8478 4.9432633,0 3.0620569,2.0122 0,5.9867 -8.0053202,0 z"
+       id="paper-base"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc"
+       inkscape:label="paper-base">
+      <title
+         id="title3307">paper-base</title>
+    </path>
+    <path
+       style="fill:url(#paper-fold);fill-opacity:1;stroke:none"
+       d="m 8.0005054,1037.4182 0,2.961 3.9774756,0 z"
+       id="paper-fold"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc">
+      <title
+         id="title3311">paper-fold</title>
+    </path>
+    <path
+       id="paper-lines"
+       style="display:inline;fill:url(#paper-lines);fill-opacity:1;stroke:none"
+       d="m 5.0017863,1043.3635 4.99295,0 0,1.0104 -4.99295,0 z m 0,-2.0104 4.99295,0 0,1.0104 -4.99295,0 z"
+       inkscape:connector-curvature="0">
+      <title
+         id="title3309">paper-lines</title>
+    </path>
+    <path
+       style="display:inline;opacity:0.36500005;fill:url(#body-shadow-right);fill-opacity:1;stroke:none"
+       d="m 0.98532027,1042.3453 2.01646603,0 0,0.9948 -2.01646603,0 z"
+       id="body-shadow-left"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc">
+      <title
+         id="title3319">body-shadow-left</title>
+    </path>
+    <path
+       style="display:inline;opacity:0.23000004;fill:url(#linearGradient6209);fill-opacity:1.0;stroke:none"
+       d="m 13.974058,1042.3453 -1.972272,0 0,0.9948 1.972272,0 z"
+       id="body-shadow-right"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc">
+      <title
+         id="title3317">body-shadow-right</title>
+    </path>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/redo_edit.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/redo_edit.svg
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   sodipodi:docname="redo_edit.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="arrow-bg">
+      <stop
+         id="arrow-bg-stop0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="arrow-bg-stop1"
+         offset="1"
+         style="stop-color:#ffd25d;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="arrow-stroke-3">
+      <stop
+         id="arrow-stroke-stop0"
+         offset="0"
+         style="stop-color:#ad7212;stop-opacity:1;" />
+      <stop
+         id="arrow-stroke-stop1"
+         offset="1"
+         style="stop-color:#a17124;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#arrow-bg"
+       id="radialGradient11"
+       cx="23.632435"
+       cy="1043.5266"
+       fx="23.632435"
+       fy="1043.5266"
+       r="4.6733794"
+       gradientTransform="matrix(2.3492025,0,0,0.9655141,-31.900682,35.645304)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="arrow-stroke-6-7">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="arrow-stroke-stop0-3" />
+      <stop
+         style="stop-color:#996c22;stop-opacity:1"
+         offset="1"
+         id="arrow-stroke-stop1-5" />
+    </linearGradient>
+    <radialGradient
+       r="4.6733794"
+       fy="1043.6658"
+       fx="23.61665"
+       cy="1043.6658"
+       cx="23.61665"
+       gradientTransform="matrix(2.3370403,0,0,0.99262129,-32.199663,6.908994)"
+       gradientUnits="userSpaceOnUse"
+       id="arrow-bg-3"
+       xlink:href="#arrow-bg"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1039.2389"
+       x2="22.668835"
+       y1="1043.5796"
+       x1="22.668835"
+       gradientTransform="matrix(0.99482282,0,0,1.0280754,-0.79185985,-30.004701)"
+       gradientUnits="userSpaceOnUse"
+       id="arrow-stroke-5"
+       xlink:href="#arrow-stroke-6-7"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="26.803134"
+     inkscape:cx="7.6110502"
+     inkscape:cy="7.3498867"
+     inkscape:document-units="px"
+     inkscape:current-layer="g7604-8"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3763"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(-1.6126329,0,0,-1.6126329,45.067873,2723.8623)"
+       id="g7604-8"
+       style="display:inline">
+      <path
+         style="display:inline;fill:url(#arrow-bg-3);fill-opacity:1;stroke:url(#arrow-stroke-5);stroke-width:0.620104;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 18.335135,1040.5602 4.357039,3.9515 c 0,0 -0.021,-1.3944 -0.021,-2.2463 1.441121,-0.092 1.860491,-0.049 2.56576,0.6514 0.887176,0.8812 0.753766,2.4466 1.157913,2.5751 0.404148,0.1285 0.621765,-2.2489 0.621765,-2.6987 0,-0.4498 -0.173888,-1.955 -0.715029,-2.7001 -0.292025,-0.4021 -1.00136,-0.9824 -1.523322,-1.1307 -0.521964,-0.1485 -2.107087,-0.4407 -2.107087,-0.4407 l 0.01271,-1.7079 c -0.784087,0.6848 -4.34875,3.7464 -4.34875,3.7464 z"
+         id="redo-arrow"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccsssszccc">
+        <title
+           id="title3225">redo-arrow</title>
+      </path>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/save_edit.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/save_edit.svg
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="save_edit.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="io-slider-fill-0">
+      <stop
+         style="stop-color:#e4cf9d;stop-opacity:1;"
+         offset="0"
+         id="io-slider-fill-stop0" />
+      <stop
+         id="io-slider-fill-stop1"
+         offset="0.38282764"
+         style="stop-color:#b5cef2;stop-opacity:1" />
+      <stop
+         id="io-slider-fill-stop2"
+         offset="0.62501514"
+         style="stop-color:#97b2d9;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8f8fc;stop-opacity:1"
+         offset="1"
+         id="io-slider-fill-stop3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="base-fill-9">
+      <stop
+         style="stop-color:#b7c9e3;stop-opacity:1;"
+         offset="0"
+         id="base-fill-stop0" />
+      <stop
+         style="stop-color:#f3f5f6;stop-opacity:1"
+         offset="1"
+         id="base-fill-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="label-fill-7">
+      <stop
+         style="stop-color:#e4cf9d;stop-opacity:1;"
+         offset="0"
+         id="label-fill-stop0" />
+      <stop
+         id="label-fill-stop1"
+         offset="0.16666377"
+         style="stop-color:#dce9f2;stop-opacity:1" />
+      <stop
+         style="stop-color:#fefdfa;stop-opacity:1"
+         offset="1"
+         id="label-fill-stop2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="base-stroke-3">
+      <stop
+         style="stop-color:#8a9b9e;stop-opacity:1"
+         offset="0"
+         id="base-stroke-stop0" />
+      <stop
+         style="stop-color:#5b7aaa;stop-opacity:1"
+         offset="1"
+         id="base-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#base-stroke-3"
+       id="base-stroke-inst"
+       x1="29.586615"
+       y1="1037.9237"
+       x2="29.586615"
+       y2="1052.0179"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,1.7382813e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#base-fill-9"
+       id="base-fill-inst"
+       x1="32.663635"
+       y1="1051.8007"
+       x2="32.663635"
+       y2="1038.272"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,1.7382813e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#io-slider-fill-0"
+       id="io-slider-fill-inst"
+       x1="24.101135"
+       y1="1042.035"
+       x2="24.101135"
+       y2="1038.3345"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.997089,9.0087328)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#label-fill-7"
+       id="label-fill-inst"
+       x1="24.101135"
+       y1="1036.6213"
+       x2="24.101135"
+       y2="1043.1295"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-16.992359,2080.6648)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#label-stroke-3"
+       id="label-stroke-inst"
+       x1="20.52261"
+       y1="1044.1688"
+       x2="24.423742"
+       y2="1040.4579"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-13.413833,-0.1253)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="label-stroke-3">
+      <stop
+         style="stop-color:#8a9b9e;stop-opacity:1"
+         offset="0"
+         id="label-stroke-stop0" />
+      <stop
+         style="stop-color:#b1bdbf;stop-opacity:1"
+         offset="1"
+         id="label-stroke-stop1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="4.734375"
+     inkscape:cy="5.703125"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1458"
+     inkscape:window-height="1033"
+     inkscape:window-x="444"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3952"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="fill:url(#base-fill-inst);fill-opacity:1;stroke:url(#base-stroke-inst);stroke-opacity:1"
+       id="disk-base"
+       width="14.007257"
+       height="14"
+       x="1.4963722"
+       y="1037.8622"
+       rx="0.8125"
+       ry="0.8125" />
+    <path
+       style="display:inline;fill:url(#io-slider-fill-inst);fill-opacity:1;stroke:#5b7aaa;stroke-opacity:1"
+       d="m 6.311783,1046.871 4.380896,0 c 0.450125,0 0.8125,0.3624 0.8125,0.8125 l 0,4.1273 -6.005896,0 0,-4.1273 c 0,-0.4501 0.362375,-0.8125 0.8125,-0.8125 z"
+       id="io-slider"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssccss" />
+    <rect
+       style="display:inline;fill:#5b7aaa;fill-opacity:1;stroke:none"
+       id="io-slider-slot"
+       width="1"
+       height="2.90625"
+       x="9"
+       y="1047.9248" />
+    <path
+       style="display:inline;fill:url(#label-fill-inst);fill-opacity:1;stroke:url(#label-stroke-inst);stroke-opacity:1"
+       d="m 5.3165135,1044.8465 6.3751585,0 c 0.450124,0 0.812499,-0.3624 0.812499,-0.8125 l 0,-6.1713 -8.0001575,0 0,6.1713 c 0,0.4501 0.362375,0.8125 0.8125,0.8125 z"
+       id="label-base"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssccss" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 11,1039.3623 0,0.9999 -5,0 0,-0.9999 z m 0,2 0,0.9998 -5.000002,0 0,-0.9998 z"
+       style="display:inline;opacity:0.35;fill:#a6b4b6;fill-opacity:1;stroke:none"
+       id="label-lines" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/saveall_edit.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/saveall_edit.svg
@@ -1,0 +1,448 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="saveall_edit.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="base-bg-0">
+      <stop
+         style="stop-color:#b7c9e3;stop-opacity:1;"
+         offset="0"
+         id="base-bg-stop0" />
+      <stop
+         style="stop-color:#f3f5f6;stop-opacity:1"
+         offset="1"
+         id="base-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="label-fill-back-2">
+      <stop
+         id="label-fill-back-stop0"
+         offset="0"
+         style="stop-color:#e4cf9d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#dce9f2;stop-opacity:1"
+         offset="0.40000713"
+         id="label-fill-back-stop1" />
+      <stop
+         id="label-fill-back-stop2"
+         offset="1"
+         style="stop-color:#fefdfa;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="label-stroke-back-9"
+       inkscape:collect="always">
+      <stop
+         id="label-stroke-back-stop0"
+         offset="0"
+         style="stop-color:#8a9b9e;stop-opacity:1" />
+      <stop
+         id="label-stroke-back-stop1"
+         offset="1"
+         style="stop-color:#b1bdbf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="base-stroke-back-6"
+       inkscape:collect="always">
+      <stop
+         id="base-stroke-back-stop0"
+         offset="0"
+         style="stop-color:#8a9b9e;stop-opacity:1" />
+      <stop
+         id="base-stroke-back-stop1"
+         offset="1"
+         style="stop-color:#5b7aaa;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="base-bg-back-3"
+       inkscape:collect="always">
+      <stop
+         id="base-bg-back-stop0"
+         offset="0"
+         style="stop-color:#b7c9e3;stop-opacity:1;" />
+      <stop
+         id="base-bg-back-stop1"
+         offset="1"
+         style="stop-color:#f3f5f6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="label-fill-mid-5">
+      <stop
+         id="label-fill-mid-stop0"
+         offset="0"
+         style="stop-color:#e4cf9d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#dce9f2;stop-opacity:1"
+         offset="0.40000713"
+         id="label-fill-mid-stop1" />
+      <stop
+         id="label-fill-mid-stop2"
+         offset="1"
+         style="stop-color:#fefdfa;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="label-stroke-mid-6"
+       inkscape:collect="always">
+      <stop
+         id="label-stroke-mid-stop0"
+         offset="0"
+         style="stop-color:#8a9b9e;stop-opacity:1" />
+      <stop
+         id="label-stroke-mid-stop1"
+         offset="1"
+         style="stop-color:#b1bdbf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="base-bg-mid-3"
+       inkscape:collect="always">
+      <stop
+         id="base-bg-mid-stop0"
+         offset="0"
+         style="stop-color:#b7c9e3;stop-opacity:1;" />
+      <stop
+         id="base-bg-mid-stop1"
+         offset="1"
+         style="stop-color:#f3f5f6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="base-stroke-mid-4"
+       inkscape:collect="always">
+      <stop
+         id="base-stroke-mid-stop0"
+         offset="0"
+         style="stop-color:#8a9b9e;stop-opacity:1" />
+      <stop
+         id="base-stroke-mid-stop1"
+         offset="1"
+         style="stop-color:#5b7aaa;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="base-stroke-5">
+      <stop
+         style="stop-color:#8a9b9e;stop-opacity:1"
+         offset="0"
+         id="base-stroke-stop0" />
+      <stop
+         style="stop-color:#5b7aaa;stop-opacity:1"
+         offset="1"
+         id="base-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="label-fill-7">
+      <stop
+         style="stop-color:#e4cf9d;stop-opacity:1;"
+         offset="0"
+         id="label-fill-stop0" />
+      <stop
+         id="label-fill-stop1"
+         offset="0.40000713"
+         style="stop-color:#dce9f2;stop-opacity:1" />
+      <stop
+         style="stop-color:#fefdfa;stop-opacity:1"
+         offset="1"
+         id="label-fill-stop2" />
+    </linearGradient>
+    <linearGradient
+       id="io-slider-fill-0">
+      <stop
+         style="stop-color:#e4cf9d;stop-opacity:1;"
+         offset="0"
+         id="io-slider-fill-stop0" />
+      <stop
+         id="io-slider-fill-stop1"
+         offset="0.28500253"
+         style="stop-color:#b5cef2;stop-opacity:1" />
+      <stop
+         id="io-slider-fill-stop2"
+         offset="0.47500423"
+         style="stop-color:#97b2d9;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8f8fc;stop-opacity:1"
+         offset="1"
+         id="io-slider-fill-stop3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#label-fill-7"
+       id="label-fill-inst"
+       x1="24.076765"
+       y1="1039.2804"
+       x2="24.101135"
+       y2="1043.1295"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-14.0418,2084.6703)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#label-stroke-3"
+       id="label-stroke-inst"
+       x1="20.49824"
+       y1="1041.5098"
+       x2="24.423742"
+       y2="1040.4579"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-10.463274,3.8801626)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="label-stroke-3">
+      <stop
+         style="stop-color:#8a9b9e;stop-opacity:1"
+         offset="0"
+         id="label-stroke-stop0" />
+      <stop
+         style="stop-color:#b1bdbf;stop-opacity:1"
+         offset="1"
+         id="label-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#io-slider-fill-0"
+       id="io-slider-fill-inst"
+       x1="24.101135"
+       y1="1042.035"
+       x2="24.101135"
+       y2="1039.4751"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-13.068628,9.0809824)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#base-bg-0"
+       id="base-fill-inst"
+       x1="32.663635"
+       y1="1051.8007"
+       x2="32.663635"
+       y2="1038.272"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-18.176393,3.8396626)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#base-stroke-5"
+       id="base-stroke-inst"
+       x1="29.586615"
+       y1="1037.9237"
+       x2="29.586615"
+       y2="1052.0179"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-18.176393,3.8396626)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#label-fill-mid-5"
+       id="label-fill-inst-1"
+       x1="24.076765"
+       y1="1039.2804"
+       x2="24.101135"
+       y2="1043.1295"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99789677,0,0,-1.0001,-15.985606,2082.7493)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#label-stroke-mid-6"
+       id="label-stroke-inst-8"
+       x1="20.49824"
+       y1="1041.5098"
+       x2="24.423742"
+       y2="1040.4579"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99789677,0,0,1.0001,-12.414606,1.7510028)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#base-bg-mid-3"
+       id="base-fill-inst-0"
+       x1="32.663635"
+       y1="1051.8007"
+       x2="32.663635"
+       y2="1038.272"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99789677,0,0,1.0001,-20.111503,1.7104987)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#base-stroke-mid-4"
+       id="base-stroke-inst-1"
+       x1="29.586615"
+       y1="1037.9237"
+       x2="29.586615"
+       y2="1052.0179"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99789677,0,0,1.0001,-20.111503,1.7104987)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#base-bg-back-3"
+       id="base-fill-inst-0-0"
+       x1="32.663635"
+       y1="1051.8007"
+       x2="32.663635"
+       y2="1038.272"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99789677,0,0,1.0001,-22.095878,-0.28950011)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#base-stroke-back-6"
+       id="base-stroke-inst-1-5"
+       x1="29.586615"
+       y1="1037.9237"
+       x2="29.586615"
+       y2="1052.0179"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99789677,0,0,1.0001,-22.095878,-0.28950011)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#label-fill-back-2"
+       id="label-fill-inst-1-7"
+       x1="24.076765"
+       y1="1039.2804"
+       x2="24.101135"
+       y2="1043.1295"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99789677,0,0,-1.0001,-17.969981,2080.7493)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#label-stroke-back-9"
+       id="label-stroke-inst-8-9"
+       x1="20.49824"
+       y1="1041.5098"
+       x2="24.423742"
+       y2="1040.4579"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99789677,0,0,1.0001,-14.398981,-0.24900011)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="6.3539382"
+     inkscape:cy="11.653079"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1532"
+     inkscape:window-height="1142"
+     inkscape:window-x="1011"
+     inkscape:window-y="329"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4165" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       ry="0.8125813"
+       rx="0.81079113"
+       y="1037.8534"
+       x="1.5162416"
+       height="10.008326"
+       width="10.008686"
+       id="disk-back"
+       style="display:inline;fill:url(#base-fill-inst-0-0);fill-opacity:1;stroke:url(#base-stroke-inst-1-5);stroke-width:0.99899781;stroke-opacity:1">
+      <title
+         id="title3675">disk-back</title>
+    </rect>
+    <path
+       sodipodi:nodetypes="sssccss"
+       inkscape:connector-curvature="0"
+       id="label-back"
+       d="m 4.3140202,1041.8419 4.3771973,0 c 0.4491765,0 0.8076745,-0.3624 0.8107895,-0.8126 l 0,-3.1863 -5.9987779,0 0,3.1863 c 0,0.4502 0.3616129,0.8126 0.8107911,0.8126 z"
+       style="display:inline;fill:url(#label-fill-inst-1-7);fill-opacity:1.0;stroke:url(#label-stroke-inst-8-9);stroke-width:0.99899781;stroke-opacity:1"
+       inkscape:label="#label-back">
+      <title
+         id="title3679"
+         style="fill-opacity:1.0">label-back</title>
+    </path>
+    <rect
+       ry="0.8125813"
+       rx="0.81079113"
+       y="1039.8534"
+       x="3.5006166"
+       height="10.008326"
+       width="10.008686"
+       id="disk-mid"
+       style="display:inline;fill:url(#base-fill-inst-0);fill-opacity:1.0;stroke:url(#base-stroke-inst-1);stroke-width:0.99899781;stroke-opacity:1">
+      <title
+         id="title3677"
+         style="fill-opacity:1.0">disk-mid</title>
+    </rect>
+    <path
+       sodipodi:nodetypes="sssccss"
+       inkscape:connector-curvature="0"
+       id="label-mid"
+       d="m 6.2983952,1043.8419 4.3771968,0 c 0.449177,0 0.807675,-0.3624 0.81079,-0.8126 l 0,-3.1863 -5.9987779,0 0,3.1863 c 0,0.4502 0.3616129,0.8126 0.8107911,0.8126 z"
+       style="display:inline;fill:url(#label-fill-inst-1);fill-opacity:1.0;stroke:url(#label-stroke-inst-8);stroke-width:0.99899781;stroke-opacity:1">
+      <title
+         id="title3681"
+         style="fill-opacity:1.0">label-mid</title>
+    </path>
+    <rect
+       ry="0.8125"
+       rx="0.8125"
+       y="1041.8787"
+       x="5.4854927"
+       height="10.007324"
+       width="10.029781"
+       id="disk-base"
+       style="display:inline;fill:url(#base-fill-inst);fill-opacity:1.0;stroke:url(#base-stroke-inst);stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="sssccss"
+       inkscape:connector-curvature="0"
+       id="io-slider"
+       d="m 9.2733891,1047.8879 2.4032069,0 c 0.450126,0 0.812501,0.3624 0.812501,0.8125 l 0,3.1826 -4.0116349,0 0,-3.1826 c 0,-0.4501 0.345802,-0.8125 0.795927,-0.8125 z"
+       style="display:inline;fill:url(#io-slider-fill-inst);fill-opacity:1;stroke:#5b7aaa;stroke-opacity:1" />
+    <rect
+       y="1049.3669"
+       x="10.447958"
+       height="2.042556"
+       width="0.82322329"
+       id="io-slider-slot"
+       style="display:inline;fill:#5b7aaa;fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="sssccss"
+       inkscape:connector-curvature="0"
+       id="label-base"
+       d="m 8.2891681,1045.8667 4.3864229,0 c 0.450123,0 0.809377,-0.3624 0.812498,-0.8125 l 0,-3.186 -6.0114209,0 0,3.186 c 0,0.4501 0.362375,0.8125 0.8125,0.8125 z"
+       style="display:inline;fill:url(#label-fill-inst);fill-opacity:1;stroke:url(#label-stroke-inst);stroke-opacity:1" />
+    <path
+       id="label-lines"
+       style="display:inline;opacity:0.35;fill:#a6b4b6;fill-opacity:1;stroke:none"
+       d="m 11.983919,1042.8938 0,0.495 -3.0002169,0 0,-0.495 z m 0,0.99 0,0.495 -3.0002179,0 0,-0.495 z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/saveas_edit.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/saveas_edit.svg
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="saveas_edit.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       gradientTransform="translate(0.5625,1037.034)"
+       inkscape:collect="always"
+       xlink:href="#dot1-bg-3"
+       id="dot1-bg"
+       x1="9.125"
+       y1="13.625"
+       x2="7.8546576"
+       y2="14.895342"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="dot1-bg-3">
+      <stop
+         style="stop-color:#83adf0;stop-opacity:1;"
+         offset="0"
+         id="dot1-bg-stop0" />
+      <stop
+         style="stop-color:#224377;stop-opacity:1;"
+         offset="1"
+         id="dot1-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(3.53125,1037.034)"
+       y2="14.895342"
+       x2="7.8546576"
+       y1="13.625"
+       x1="9.125"
+       gradientUnits="userSpaceOnUse"
+       id="dot2-bg"
+       xlink:href="#dot2-bg-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="dot2-bg-6">
+      <stop
+         style="stop-color:#83adf0;stop-opacity:1;"
+         offset="0"
+         id="dot2-bg-stop0" />
+      <stop
+         style="stop-color:#224377;stop-opacity:1;"
+         offset="1"
+         id="dot2-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       y2="14.895342"
+       x2="7.8546576"
+       y1="13.625"
+       x1="9.125"
+       gradientTransform="translate(6.53125,1037.034)"
+       gradientUnits="userSpaceOnUse"
+       id="dot3-bg"
+       xlink:href="#dot3-bg-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="dot3-bg-7">
+      <stop
+         style="stop-color:#83adf0;stop-opacity:1;"
+         offset="0"
+         id="dot3-bg-stop0" />
+      <stop
+         style="stop-color:#224377;stop-opacity:1;"
+         offset="1"
+         id="dot3-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="base-bg-5"
+       inkscape:collect="always">
+      <stop
+         id="base-bg-stop0"
+         offset="0"
+         style="stop-color:#b7c9e3;stop-opacity:1;" />
+      <stop
+         id="base-bg-stop1"
+         offset="1"
+         style="stop-color:#f3f5f6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="base-stroke-3"
+       inkscape:collect="always">
+      <stop
+         id="base-stroke-stop0"
+         offset="0"
+         style="stop-color:#8a9b9e;stop-opacity:1" />
+      <stop
+         id="base-stroke-stop1"
+         offset="1"
+         style="stop-color:#5b7aaa;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#label-fill-7"
+       id="label-fill-inst"
+       x1="24.101135"
+       y1="1038.2776"
+       x2="24.101135"
+       y2="1043.1295"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-18.021769,2080.6501)" />
+    <linearGradient
+       id="label-fill-7">
+      <stop
+         style="stop-color:#e4cf9d;stop-opacity:1;"
+         offset="0"
+         id="label-fill-stop0" />
+      <stop
+         id="label-fill-stop1"
+         offset="0.21472463"
+         style="stop-color:#dce9f2;stop-opacity:1" />
+      <stop
+         style="stop-color:#fefdfa;stop-opacity:1"
+         offset="1"
+         id="label-fill-stop2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#label-stroke-3"
+       id="label-stroke-inst"
+       x1="20.52261"
+       y1="1042.5127"
+       x2="24.423742"
+       y2="1040.4579"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-14.443243,-0.140149)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="label-stroke-3">
+      <stop
+         style="stop-color:#8a9b9e;stop-opacity:1"
+         offset="0"
+         id="label-stroke-stop0" />
+      <stop
+         style="stop-color:#b1bdbf;stop-opacity:1"
+         offset="1"
+         id="label-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#io-slider-fill-0"
+       id="io-slider-fill-inst"
+       x1="24.101135"
+       y1="1042.035"
+       x2="24.101135"
+       y2="1039.4751"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-17.048597,5.9666501)" />
+    <linearGradient
+       id="io-slider-fill-0">
+      <stop
+         style="stop-color:#e4cf9d;stop-opacity:1;"
+         offset="0"
+         id="io-slider-fill-stop0" />
+      <stop
+         id="io-slider-fill-stop1"
+         offset="0.28500253"
+         style="stop-color:#b5cef2;stop-opacity:1" />
+      <stop
+         id="io-slider-fill-stop2"
+         offset="0.47500423"
+         style="stop-color:#97b2d9;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8f8fc;stop-opacity:1"
+         offset="1"
+         id="io-slider-fill-stop3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#base-bg-5"
+       id="base-fill-inst"
+       x1="32.663635"
+       y1="1051.8007"
+       x2="32.663635"
+       y2="1038.272"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-22.156362,-0.1805772)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#base-stroke-3"
+       id="base-stroke-inst"
+       x1="29.586615"
+       y1="1037.9237"
+       x2="29.586615"
+       y2="1052.0179"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-22.156362,-0.1805772)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="64"
+     inkscape:cx="11.136254"
+     inkscape:cy="3.2777773"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1549"
+     inkscape:window-height="1011"
+     inkscape:window-x="973"
+     inkscape:window-y="333"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4005" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g6052"
+       transform="matrix(0.79947032,0,0,0.79947032,-0.3432694,207.40429)" />
+    <rect
+       style="opacity:0.97330592;color:#000000;fill:url(#dot1-bg);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.80000001;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="dot1"
+       width="2"
+       height="2.0000174"
+       x="8"
+       y="1050.3622"
+       ry="0.46875">
+      <title
+         id="title3247">dot1</title>
+    </rect>
+    <rect
+       style="opacity:0.97330592;color:#000000;fill:url(#dot2-bg);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.80000001;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="dot2"
+       width="2"
+       height="2.0000174"
+       x="11"
+       y="1050.3622"
+       ry="0.46875">
+      <title
+         id="title3249">dot2</title>
+    </rect>
+    <rect
+       style="opacity:0.97330592;color:#000000;fill:url(#dot3-bg);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.80000001;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="dot3"
+       width="2"
+       height="2.0000174"
+       x="14"
+       y="1050.3622"
+       ry="0.46875">
+      <title
+         id="title3251">dot3</title>
+    </rect>
+    <rect
+       ry="0.8125"
+       rx="0.8125"
+       y="1037.8584"
+       x="1.5055251"
+       height="10.972677"
+       width="10.957859"
+       id="disk-base"
+       style="display:inline;fill:url(#base-fill-inst);fill-opacity:1;stroke:url(#base-stroke-inst);stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="sssccss"
+       inkscape:connector-curvature="0"
+       id="io-slider"
+       d="m 5.2934214,1044.8621 3.3865267,0 c 0.450125,0 0.8125,0.3624 0.8125,0.8125 l 0,3.0942 -4.9949539,0 0,-3.0942 c 0,-0.4501 0.3458022,-0.8125 0.7959272,-0.8125 z"
+       style="display:inline;fill:url(#io-slider-fill-inst);fill-opacity:1;stroke:#5b7aaa;stroke-opacity:1" />
+    <rect
+       y="1046.0317"
+       x="6.976222"
+       height="2.2875197"
+       width="1"
+       id="io-slider-slot"
+       style="display:inline;fill:#5b7aaa;fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="sssccss"
+       inkscape:connector-curvature="0"
+       id="label-base"
+       d="m 4.2871034,1042.863 5.3586936,0 c 0.450123,0 0.812498,-0.3624 0.812498,-0.8125 l 0,-4.2025 -6.9836916,0 0,4.2025 c 0,0.4501 0.362375,0.8125 0.8125,0.8125 z"
+       style="display:inline;fill:url(#label-fill-inst);fill-opacity:1;stroke:url(#label-stroke-inst);stroke-opacity:1" />
+    <path
+       id="label-lines"
+       style="display:inline;opacity:0.35;fill:#a6b4b6;fill-opacity:1;stroke:none"
+       d="m 8.976222,1038.3531 0,0.9999 -4.0166807,0 0,-0.9999 z m 0,2 0,0.9999 -4.0166827,0 0,-0.9999 z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect3423"
+       width="0.375"
+       height="0.0625"
+       x="51.375"
+       y="1033.1122"
+       rx="0.8125"
+       ry="0.0625" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/tricks.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/tricks.svg
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="tricks.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6-6-4-2-8"
+       id="linearGradient3093-5-2-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3319227,0,0,2.3173471,2.7136817,1026.2511)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8">
+      <stop
+         id="stop6283-0-2-2-1-2-0-1-6"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7-6-9-9-1"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9-5-7-9-7"
+       id="radialGradient3091-1-9-6-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5999835,-7.6194038e-6,7.307521e-6,1.5344919,469.64026,399.62587)"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574" />
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7">
+      <stop
+         style="stop-color:#e0c576;stop-opacity:1;"
+         offset="0"
+         id="stop4530-0-5-0-5-8" />
+      <stop
+         style="stop-color:#9e7916;stop-opacity:1"
+         offset="1"
+         id="stop4532-7-9-3-3-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6-6-4-2-8"
+       id="linearGradient3093-5-2-7-0-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3319227,0,0,2.3173471,0.713682,1032.2511)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9-5-7-9-7"
+       id="radialGradient3091-1-9-6-4-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5999835,-7.6194038e-6,7.307521e-6,1.5344919,466.79533,393.96068)"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5531"
+       x="-0.44375949"
+       width="1.887519"
+       y="-0.44424077"
+       height="1.8884815">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.83048467"
+         id="feGaussianBlur5533" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.180449"
+     inkscape:cx="10.644739"
+     inkscape:cy="-2.0000313"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <image
+       y="1036.272"
+       x="21.054579"
+       id="image4657"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAAZiS0dEAKoA
+wQDg87MiRwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wFCQ0UH7e+//0AAADsSURBVDjL
+Y2DAAnZNV/vPQC4Aaf739/1/sgzZOlH5/9ZJymADQDQIE615XZf8/79fzkPwZygGskHiRBuytEnq
+Pwj/eb74/zIgvaxRCqx51cEHTEQbMq9S7P/vu83/QTQQ/APiP0AD/hEdgCB6ZokwSDMLSPPfv3//
+gzDQkCckhf7qQw9YQDYDwX8Qnr3gGMgQZqJDH6gYZAATEP+cvfAY2AAGvvz/ZIU+0BBNsGYoBvIl
+iAp9ZADUJIlmCBfO0MfmTaAGRjADyRAMRaDQxxXIMAOAtBhQ822QAeziJeTnGZyuIBYAXcJDkQEw
+QwAXy/ppHcLvJQAAAABJRU5ErkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16.000017"
+       width="16" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#394e75;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9.368794,1043.1191 6.369165,6.9799"
+       id="path4268-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.50000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 9.4101707,1043.1648 0.4715283,0.4656"
+       id="path4268-6-3"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="display:inline;fill:url(#radialGradient3091-1-9-6-4);fill-opacity:1;stroke:#a27d18;stroke-width:1.03244627;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3910"
+       width="3.9614904"
+       height="3.8504293"
+       x="-743.27991"
+       y="-735.46869"
+       transform="matrix(-0.70916057,-0.70504701,0.70916057,-0.70504701,0,0)" />
+    <path
+       sodipodi:nodetypes="ccccccccccccc"
+       inkscape:connector-curvature="0"
+       id="path5581-5-5"
+       d="m 4.9968591,1037.3622 1.0062828,0 0,2 1.9968581,0 0,0.9593 -1.9968581,0 0,2.0407 -1.0062828,0 0,-2.0407 -1.9968591,0 0,-0.9593 1.9968591,0 z"
+       style="display:inline;fill:url(#linearGradient3093-5-2-7-0);fill-opacity:1;stroke:none" />
+    <rect
+       style="display:inline;fill:url(#radialGradient3091-1-9-6-4-3);fill-opacity:1;stroke:#a27d18;stroke-width:1.03244627;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3910-7"
+       width="3.9614904"
+       height="3.8504293"
+       x="-746.12482"
+       y="-741.13385"
+       transform="matrix(-0.70916057,-0.70504701,0.70916057,-0.70504701,0,0)" />
+    <path
+       sodipodi:nodetypes="ccccccccccccc"
+       inkscape:connector-curvature="0"
+       id="path5581-5-5-9"
+       d="m 3,1043.3622 1.003142,0 0,2 1.996858,0 0,1 -1.996858,0 0,2 -1.003142,0 0,-2 -2,0 0,-1 2,0 z"
+       style="display:inline;fill:url(#linearGradient3093-5-2-7-0-6);fill-opacity:1;stroke:none" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.939;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter5531)"
+       d="m 8.8828125,1040.5508 a 2.0002,2.0002 0 0 0 -1.3710937,3.4433 l 0.4707031,0.4668 a 2.0005,2.0005 0 0 0 2.8105471,-2.8476 l -0.470703,-0.4649 a 2.0002,2.0002 0 0 0 -1.4394535,-0.5976 z"
+       id="path4268-6-3-5"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/etool16/undo_edit.svg
+++ b/bundles/org.eclipse.ui/icons/full/etool16/undo_edit.svg
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   sodipodi:docname="undo_edit.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="arrow-stroke-6-7">
+      <stop
+         style="stop-color:#ad7212;stop-opacity:1;"
+         offset="0"
+         id="arrow-stroke-stop0" />
+      <stop
+         style="stop-color:#996c22;stop-opacity:1"
+         offset="1"
+         id="arrow-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="arrow-bg-3-5">
+      <stop
+         id="arrow-bg-stop0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="arrow-bg-stop1"
+         offset="1"
+         style="stop-color:#ffd25d;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       r="4.6733794"
+       fy="1043.6658"
+       fx="23.61665"
+       cy="1043.6658"
+       cx="23.61665"
+       gradientTransform="matrix(3.7687879,0,0,-1.6007454,-79.994106,2712.7325)"
+       gradientUnits="userSpaceOnUse"
+       id="arrow-bg"
+       xlink:href="#arrow-bg-3-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1039.2389"
+       x2="22.668835"
+       y1="1043.5796"
+       x1="22.668835"
+       gradientTransform="matrix(1.604284,0,0,-1.6579203,-29.344853,2772.2612)"
+       gradientUnits="userSpaceOnUse"
+       id="arrow-stroke"
+       xlink:href="#arrow-stroke-6-7"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="26.803133"
+     inkscape:cx="9.3645769"
+     inkscape:cy="7.834905"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3020"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="display:inline;fill:url(#arrow-bg);fill-opacity:1;stroke:url(#arrow-stroke);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 1.4999698,1045.8207 7.0263049,-6.3724 c 0,0 -0.033867,2.2486 -0.033867,3.6226 2.3239983,0.1492 3.0002883,0.079 4.1376283,-1.0505 1.430689,-1.4212 1.215549,-3.9455 1.86729,-4.1528 0.651741,-0.2072 1.002677,3.6267 1.002677,4.352 0,0.7254 -0.280417,3.1527 -1.153079,4.3545 -0.470928,0.6484 -1.614825,1.584 -2.456559,1.8233 -0.841735,0.2394 -3.397957,0.7106 -3.397957,0.7106 l 0.020499,2.7542 c -1.2644448,-1.1042 -7.0129378,-6.0415 -7.0129372,-6.0415 z"
+       id="undo-arrow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsssszccc">
+      <title
+         id="title3225">undo-arrow</title>
+    </path>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/eview16/bkmrk_nav.svg
+++ b/bundles/org.eclipse.ui/icons/full/eview16/bkmrk_nav.svg
@@ -1,0 +1,991 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="bkmrk_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5641">
+      <stop
+         style="stop-color:#1e6cbe;stop-opacity:1;"
+         offset="0"
+         id="stop5643" />
+      <stop
+         style="stop-color:#104276;stop-opacity:1;"
+         offset="1"
+         id="stop5645" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5411">
+      <stop
+         style="stop-color:#72828e;stop-opacity:1;"
+         offset="0"
+         id="stop5413" />
+      <stop
+         style="stop-color:#003358;stop-opacity:1;"
+         offset="1"
+         id="stop5415" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5630">
+      <stop
+         style="stop-color:#d8bc68;stop-opacity:1;"
+         offset="0"
+         id="stop5632" />
+      <stop
+         style="stop-color:#fff0c2;stop-opacity:1;"
+         offset="1"
+         id="stop5634" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-8">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-5">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-5" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-4-1">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6799-4-3">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="stop6801-4-0" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-8-8">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0-7" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-6">
+      <stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974-71" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-4-1-2">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6799-4-3-3">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="stop6801-4-0-8" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-5-7">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-8-9">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0-5" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-5-7">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-5-6" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-8-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-7">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-0" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-33" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-5-2-6">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-3-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-9-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-8-8-8">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0-7-9" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5-3-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-0">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-1" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-6"
+       id="linearGradient5572"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972"
+       id="linearGradient4283"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1146582"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972"
+       id="linearGradient4288"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1146582"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972"
+       id="linearGradient4321"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1146582"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-4-1"
+       id="linearGradient4382"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6238641,0,0,1.6285353,-5.817902,-657.26294)"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3"
+       id="linearGradient4384"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6238641,0,0,1.6285353,-5.817902,-662.30115)"
+       x1="11.977677"
+       y1="1042.1279"
+       x2="5.926301"
+       y2="1051.2535" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9"
+       id="linearGradient4390"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-8-8"
+       id="linearGradient4392"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96301391,0,0,0.30750995,-1.0449584,-1044.537)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2"
+       id="linearGradient4394"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-5">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-3" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-8-8-0">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0-7-7" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5-3-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-0">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-8" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-4-1-4"
+       id="linearGradient4382-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6960825,0,0,1.7009614,-4.9210482,-731.7352)"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       id="linearGradient4972-4-1-4">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3-7"
+       id="linearGradient4384-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6960825,0,0,1.7009614,-4.9210482,-736.99747)"
+       x1="11.977677"
+       y1="1042.1279"
+       x2="5.926301"
+       y2="1051.2535" />
+    <linearGradient
+       id="linearGradient6799-4-3-7">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="stop6801-4-0-9" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-4-1-9"
+       id="linearGradient4382-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6960825,0,0,1.7009614,-6.197689,-731.7678)"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       id="linearGradient4972-4-1-9">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-8" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3-9"
+       id="linearGradient4384-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6960825,0,0,1.7009614,-6.197689,-737.03007)"
+       x1="11.977677"
+       y1="1042.1279"
+       x2="5.926301"
+       y2="1051.2535" />
+    <linearGradient
+       id="linearGradient6799-4-3-9">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="stop6801-4-0-7" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-74" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-1"
+       id="linearGradient4394-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3892048,0,0,0.27549241,-31.899058,-1052.4756)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-1">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-2" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-8-8-07"
+       id="linearGradient4392-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0464198,0,0,0.30750995,-29.951794,-1049.0796)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-8-8-07">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0-7-0" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5-3-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-4"
+       id="linearGradient4390-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3930703,0,0,0.26192631,-31.957849,1053.1869)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-4">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-26" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-4-1-5"
+       id="linearGradient4382-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.623864,0.69032316,0,1.6285353,32.3374,-665.37304)"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       id="linearGradient4972-4-1-5">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-97" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-60" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3-0"
+       id="linearGradient4384-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.623864,0.69032316,0,1.6285353,32.3374,-670.41122)"
+       x1="11.977677"
+       y1="1042.1279"
+       x2="5.926301"
+       y2="1051.2535" />
+    <linearGradient
+       id="linearGradient6799-4-3-0">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="stop6801-4-0-90" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5411"
+       id="radialGradient5417"
+       cx="13.94572"
+       cy="1045.8255"
+       fx="13.94572"
+       fy="1045.8255"
+       r="10.779004"
+       gradientTransform="matrix(1,0,0,0.98529514,0,15.378714)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5411"
+       id="radialGradient5419"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8121447,-1.9541983,0.96980008,0.27977302,-1035.1855,788.68965)"
+       cx="16.494715"
+       cy="1050.2904"
+       fx="16.494715"
+       fy="1050.2904"
+       r="10.779004" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9"
+       id="linearGradient5426"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-8-8"
+       id="linearGradient5428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96301391,0,0,0.30750995,-1.0449584,-1044.537)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2"
+       id="linearGradient5430"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6"
+       id="linearGradient5430-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-6">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-35" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-9" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5475"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-9"
+       id="linearGradient5426-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-9">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-80" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-66"
+       id="linearGradient5430-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-66">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-23" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-8" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5475-9"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-6-9">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-35-8" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-9-1" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5525"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-9-2"
+       id="linearGradient5426-4-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-9-2">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-80-0" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-6-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-66-1"
+       id="linearGradient5430-1-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-66-1">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-23-1" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-8-6" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5525-6"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6-9-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-6-9-6">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-35-8-5" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-9-1-1" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5592"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6-9-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5641"
+       id="linearGradient5647"
+       x1="30.45603"
+       y1="1028.9988"
+       x2="30.45603"
+       y2="1033.8717"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-12.948786,22.935422)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5641-4"
+       id="linearGradient5647-2"
+       x1="30.45603"
+       y1="1028.9988"
+       x2="30.45603"
+       y2="1033.8717"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-12.948786,22.935422)" />
+    <linearGradient
+       id="linearGradient5641-4">
+      <stop
+         style="stop-color:#1e6cbe;stop-opacity:1;"
+         offset="0"
+         id="stop5643-1" />
+      <stop
+         style="stop-color:#104276;stop-opacity:1;"
+         offset="1"
+         id="stop5645-2" />
+    </linearGradient>
+    <linearGradient
+       y2="1033.8717"
+       x2="30.45603"
+       y1="1028.9988"
+       x1="30.45603"
+       gradientTransform="matrix(0.71554797,0.15002359,0,0.70580829,-11.070338,316.74005)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5664"
+       xlink:href="#linearGradient5641-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9"
+       id="linearGradient5695"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2"
+       id="linearGradient5697"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6"
+       id="linearGradient5699"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="10.917562"
+     inkscape:cy="13.077131"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="954"
+     inkscape:window-y="323"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4250" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4328"
+       transform="matrix(0.7269685,0.15452131,0,0.7269685,-1.9135076,281.00893)">
+      <path
+         id="rect6795-0-1"
+         style="color:#000000;fill:url(#radialGradient5419);fill-opacity:1;stroke:none;stroke-width:1.05102229;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="m 24.629424,1051.8747 c 0,0 -3.992044,0.5682 -11.390548,4.8211 0,-5.4647 0,-15.2237 0,-15.2237 0,0 0.0075,-4.3255 0.0075,-3.2598 0,1.0657 0.44242,-0.08 3.322649,-1.5295 2.880227,-1.4497 8.094855,-2.1898 8.094855,-2.1898 0,0 0.674765,13.1244 -0.03446,17.3817 z m -21.2774334,-11.0351 -0.185274,15.8319 c 0,0 3.5446198,-1.0065 10.1139074,0.015 0,-4.9305 0,-13.7353 0,-13.7353 0,0 -0.0067,-3.8997 -0.0067,-2.9382 0,0.9615 -0.392834,0.097 -2.95025,-0.1158 -2.5574137,-0.2119 -6.9716755,0.9414 -6.9716755,0.9414 z"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccscccccccsccc" />
+      <path
+         sodipodi:nodetypes="cccczzc"
+         inkscape:connector-curvature="0"
+         id="rect6795"
+         d="m 3.3995322,1038.9031 -0.1746117,14.8143 c 0,0 3.3406326,-0.9469 9.5318685,0 0,-4.6135 0,-12.8522 0,-12.8522 0,0 -0.0063,-3.649 -0.0063,-2.7493 0,0.8997 -0.370227,0.091 -2.7804682,-0.1036 -2.4102412,-0.1947 -6.5704696,0.8908 -6.5704696,0.8908 z"
+         style="color:#000000;fill:url(#linearGradient4382);fill-opacity:1;stroke:url(#linearGradient4384);stroke-width:1.00627029;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <g
+         id="g5421"
+         transform="translate(0.30396211,0.05697596)">
+        <g
+           id="g5494">
+          <rect
+             style="color:#000000;fill:none;stroke:url(#linearGradient5695);stroke-width:0.57948124;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="rect6891-5-7-3-9"
+             width="5.0426011"
+             height="0.20836112"
+             x="5.1543803"
+             y="1047.5212" />
+          <rect
+             transform="scale(1,-1)"
+             style="color:#000000;fill:none;stroke:url(#linearGradient5697);stroke-width:0.59347337;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="rect6891-5-7-3-9-8"
+             width="5.0286093"
+             height="0.21915288"
+             x="5.1861606"
+             y="-1045.4623" />
+          <rect
+             transform="scale(1,-1)"
+             style="color:#000000;fill:none;stroke:url(#linearGradient5699);stroke-width:0.59347337;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="rect6891-5-7-3-9-8-5"
+             width="5.0286093"
+             height="0.21915288"
+             x="5.1861606"
+             y="-1043.0914" />
+        </g>
+      </g>
+      <path
+         sodipodi:nodetypes="cccczzc"
+         inkscape:connector-curvature="0"
+         id="rect6795-9"
+         d="m 23.119966,1034.7114 0.174612,14.74 c 0,0 -3.340632,0.4733 -9.531868,4.0522 0,-4.6135 0,-12.8522 0,-12.8522 0,0 0.0063,-3.6517 0.0063,-2.752 0,0.8997 0.370226,-0.066 2.780467,-1.2856 2.410241,-1.2194 6.570469,-1.9024 6.570469,-1.9024 z"
+         style="color:#000000;fill:url(#linearGradient4382-9);fill-opacity:1;stroke:url(#linearGradient4384-0);stroke-width:1.00627029;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    </g>
+    <g
+       style="display:inline"
+       id="g5494-1"
+       transform="matrix(-0.7269685,0.15452131,0,0.7269685,16.858502,281.15492)">
+      <rect
+         style="color:#000000;fill:none;stroke:url(#linearGradient5426-4-0);stroke-width:0.57948124;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect6891-5-7-3-9-9"
+         width="5.0426011"
+         height="0.20836112"
+         x="5.1543803"
+         y="1047.5212" />
+      <rect
+         transform="scale(1,-1)"
+         style="color:#000000;fill:none;stroke:url(#linearGradient5430-1-7);stroke-width:0.59347337;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect6891-5-7-3-9-8-3"
+         width="5.0286093"
+         height="0.21915288"
+         x="5.1861606"
+         y="-1045.4623" />
+      <rect
+         transform="scale(1,-1)"
+         style="color:#000000;fill:none;stroke:url(#linearGradient5592);stroke-width:0.59347337;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="rect6891-5-7-3-9-8-5-2"
+         width="5.0286093"
+         height="0.21915288"
+         x="5.1861606"
+         y="-1043.0914" />
+    </g>
+    <path
+       style="fill:#71baff;fill-opacity:1;stroke:url(#linearGradient5664);stroke-width:0.97756845px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+       d="m 8.4740656,1038.0944 c 0,0 0.826498,-1.0382 1.8269964,-1.1241 1.000497,-0.085 2.305493,-0.045 2.305493,-0.045 l 0,14.4475 -2.087994,-2.2428 -0.9569985,2.7578 c 0,0 -1.0004969,-0.944 -1.0439973,-1.7595 -0.043498,-0.8151 -0.043498,-12.0333 -0.043498,-12.0333 z"
+       id="path5639"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csccccscc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/eview16/default_persp.svg
+++ b/bundles/org.eclipse.ui/icons/full/eview16/default_persp.svg
@@ -1,0 +1,363 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="default_persp.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient8661"
+       inkscape:collect="always">
+      <stop
+         id="stop8663"
+         offset="0"
+         style="stop-color:#c6e7f9;stop-opacity:1" />
+      <stop
+         id="stop8665"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8653">
+      <stop
+         style="stop-color:#676656;stop-opacity:1;"
+         offset="0"
+         id="stop8655" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop8657" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-1">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-4" />
+      <stop
+         style="stop-color:#bbcdeb;stop-opacity:0"
+         offset="1"
+         id="stop8341-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-4">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-78" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-93">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-9" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8661"
+       id="linearGradient8681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137"
+       id="linearGradient8683"
+       gradientUnits="userSpaceOnUse"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2"
+       id="linearGradient8685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337"
+       id="linearGradient8687"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8689"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8691"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064"
+       gradientTransform="translate(0,-0.78395737)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8693"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064"
+       gradientTransform="translate(0,-0.78395737)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8695"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064"
+       gradientTransform="translate(0,-0.78395737)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8697"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-93"
+       id="linearGradient8699"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99437637,0,0,1.000597,3.6856765,-0.1625023)"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-4"
+       id="linearGradient8701"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-1"
+       id="linearGradient8703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375262)"
+       x1="610.59406"
+       y1="269.33588"
+       x2="643.06262"
+       y2="269.33588" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="6.2307292"
+     inkscape:cy="8.2561974"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8667"
+     showgrid="true"
+     inkscape:window-width="1189"
+     inkscape:window-height="819"
+     inkscape:window-x="1089"
+     inkscape:window-y="526"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3032" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g8667"
+       transform="matrix(0.27903303,0,0,0.27903303,-169.06377,963.86005)">
+      <rect
+         ry="2.5632601"
+         rx="2.5632601"
+         y="268.004"
+         x="613.83698"
+         height="41"
+         width="40.880188"
+         id="rect8093"
+         style="fill:url(#linearGradient8681);fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="sssccss"
+         inkscape:connector-curvature="0"
+         id="rect8093-5"
+         d="m 619.40542,268.004 33.14428,0 c 1.42005,0 2.56326,1.14321 2.56326,2.56326 l 0,5.87348 -38.2708,0 0,-5.87348 c 0,-1.42005 1.14322,-2.56326 2.56326,-2.56326 z"
+         style="fill:#4e86ca;fill-opacity:1;stroke:url(#linearGradient8683);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="rect8093-5-9"
+         d="m 619.40625,269 c -0.88334,0 -1.5625,0.67915 -1.5625,1.5625 l 0,4.875 37,0 0,-4.875 c 0,-0.88335 -0.67915,-1.5625 -1.5625,-1.5625 z"
+         style="fill:url(#linearGradient8685);fill-opacity:1;stroke:none"
+         sodipodi:nodetypes="ssccsss" />
+      <path
+         inkscape:connector-curvature="0"
+         id="rect8093-5-9-8"
+         d="m 619.40625,269.34375 c -0.88334,0 -1.5625,0.67915 -1.5625,1.5625 l 0,4.875 37,0 0,-4.875 c 0,-0.88335 -0.67915,-1.5625 -1.5625,-1.5625 z"
+         style="fill:url(#linearGradient8687);fill-opacity:1;stroke:none"
+         sodipodi:nodetypes="ssccsss" />
+      <g
+         style="stroke:url(#linearGradient8697);stroke-opacity:1"
+         id="g8643">
+        <rect
+           id="rect8645"
+           style="fill:none;stroke:url(#linearGradient8689);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           width="39.491531"
+           height="39.768036"
+           x="614.69171"
+           y="268.67596"
+           rx="2.5632601"
+           ry="2.5632601" />
+        <path
+           id="path8647"
+           style="fill:none;stroke:url(#linearGradient8691);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           d="m 613.49908,293.76572 15.68842,0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path8649"
+           style="fill:none;stroke:url(#linearGradient8693);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           d="m 629.3125,290.45322 26.3125,0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path8651"
+           style="fill:none;stroke:url(#linearGradient8695);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           d="m 629.1875,275.20322 0,32.84375"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+      </g>
+      <path
+         sodipodi:nodetypes="sssccss"
+         inkscape:connector-curvature="0"
+         id="rect8093-5-8"
+         d="m 616.37736,268.00148 36.02007,0 c 1.41207,0 2.54885,1.14389 2.54885,2.56479 l 0,5.87699 -41.11776,0 0,-5.87699 c 0,-1.4209 1.13679,-2.56479 2.54884,-2.56479 z"
+         style="fill:#4e86ca;fill-opacity:1;stroke:url(#linearGradient8699);stroke-width:1.99496365;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssccsss"
+         inkscape:connector-curvature="0"
+         id="rect8093-5-9-6"
+         d="m 616.33433,269 c -0.88334,0 -1.5625,0.67915 -1.5625,1.5625 l 0,4.875 39.18804,0 0,-4.875 c 0,-0.88335 -0.67915,-1.5625 -1.5625,-1.5625 z"
+         style="fill:url(#linearGradient8701);fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="ssccsss"
+         inkscape:connector-curvature="0"
+         id="rect8093-5-9-8-0"
+         d="m 615.93658,269.34375 c -0.88334,0 -1.57051,0.67919 -1.5625,1.5625 l 0,4.875 39.60789,0 0,-4.875 c 0,-0.88335 -0.67915,-1.5625 -1.5625,-1.5625 z"
+         style="fill:url(#linearGradient8703);fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       transform="translate(-20.000002,2.6171874e-6)"
+       style="stroke:#694337;stroke-opacity:1;display:inline"
+       id="g11029" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/eview16/defaultview_misc.svg
+++ b/bundles/org.eclipse.ui/icons/full/eview16/defaultview_misc.svg
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="defaultview_misc.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4157">
+      <stop
+         style="stop-color:#58b6e8;stop-opacity:1;"
+         offset="0"
+         id="stop4159" />
+      <stop
+         style="stop-color:#58b6e8;stop-opacity:0;"
+         offset="1"
+         id="stop4161" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082-3">
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1"
+         offset="0"
+         id="stop4084-8" />
+      <stop
+         id="stop4864-7"
+         offset="0.5"
+         style="stop-color:#5a9ccc;stop-opacity:1" />
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1"
+         offset="1"
+         id="stop4086-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4994-4-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-9"
+         offset="0"
+         style="stop-color:#c5dff4;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-5" />
+      <stop
+         style="stop-color:#c5dff4;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4810-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4812-0"
+         offset="0"
+         style="stop-color:#be9a4b;stop-opacity:1" />
+      <stop
+         id="stop4814-4"
+         offset="1"
+         style="stop-color:#877e60;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4082-3"
+       id="linearGradient8878"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.87616643,1.0002456)"
+       x1="8.0137892"
+       y1="1039.876"
+       x2="8.0137892"
+       y2="1041.8765" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-4-5"
+       id="linearGradient8881"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(17,0.9999451)"
+       x1="-11"
+       y1="1042.3622"
+       x2="-11"
+       y2="1044.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4910-4-0"
+       id="linearGradient8884"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(17,-5.0312549)"
+       x1="-13"
+       y1="1047.3622"
+       x2="-15"
+       y2="1047.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4810-5"
+       id="linearGradient8887"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.91881011,1.0357451)"
+       x1="8.0137892"
+       y1="1042.3622"
+       x2="8.0137892"
+       y2="1050.0707" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4157"
+       id="linearGradient4163"
+       x1="1.003712"
+       y1="1041.865"
+       x2="13.052239"
+       y2="1041.865"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="7.1971697"
+     inkscape:cy="11.64645"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4166"
+     showgrid="true"
+     inkscape:window-width="1208"
+     inkscape:window-height="913"
+     inkscape:window-x="1276"
+     inkscape:window-y="379"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid8762" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4166"
+       transform="translate(1,-2)">
+      <path
+         style="display:inline;fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient8887);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 1.5076731,1040.8978 11.0019249,0 0,10.9667 -11.0019248,0 z"
+         id="rect3997-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient8884);fill-opacity:1;stroke:none"
+         d="m 3,1044.331 0,7.0312 -1,0 0,-8.0312 z"
+         id="rect4853-82-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient8881);fill-opacity:1;stroke:none"
+         d="m 3,1044.3622 8.990578,0 0,-1 -9.990578,0 z"
+         id="rect4853-82-0"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient4163);fill-opacity:1;stroke:url(#linearGradient8878);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 1.503712,1040.8623 11.048527,0 0,2.0053 -11.048527,0 z"
+         id="rect3997-9-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <image
+       y="1051.4872"
+       x="1.3190871e-10"
+       id="image4163"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAASBJREFU OI3FkztOw0AURc+bNzO2YkoaloCEaCnS0yKqsAX2QIPoEVKKSOwA9kGBREVBwwLYAIbEAR6FPbEt BylSCm4zH9135s5PzIxt5LaqBnzqHEyuDecxUdAILoIGcBHzGaIRXMDEg1NebsbSA/zsHXF2sk9U Rx6EUVCKzFEEx05UikwZBSEPwunlwzCBe3vk/vYJxNcraVYn0Aw0YhoQCZgGEB0CLo5fOZzMNtr3 8905MO4DknbjRoyVVrew+B6w/lTXu+rNq9gSBcTqFiA9FZG+twf4qPJ6QprCxkwX1EDKRT4EvM9r qneNMymNO8CyyoaAMiWgY06SZkrABMrFGsDnsk1g1hZ001hzNvPlmjOovjzTqymbqb0F+fff+Asq 4kbXACvQQAAAAABJRU5ErkJggg== "
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/eview16/filenav_nav.svg
+++ b/bundles/org.eclipse.ui/icons/full/eview16/filenav_nav.svg
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="filenav_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5991"
+       inkscape:collect="always">
+      <stop
+         id="stop5993"
+         offset="0"
+         style="stop-color:#9c6a3e;stop-opacity:1;" />
+      <stop
+         id="stop5995"
+         offset="1"
+         style="stop-color:#c48d4f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5981">
+      <stop
+         style="stop-color:#9c6a3e;stop-opacity:1;"
+         offset="0"
+         id="stop5983" />
+      <stop
+         style="stop-color:#c48d4f;stop-opacity:1"
+         offset="1"
+         id="stop5985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5973">
+      <stop
+         id="stop5975"
+         offset="0"
+         style="stop-color:#ffffc7;stop-opacity:1" />
+      <stop
+         style="stop-color:#fff1a8;stop-opacity:1"
+         offset="0.55546904"
+         id="stop5977" />
+      <stop
+         id="stop5979"
+         offset="1"
+         style="stop-color:#ffd379;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5965">
+      <stop
+         id="stop5967"
+         offset="0"
+         style="stop-color:#ffffc7;stop-opacity:1" />
+      <stop
+         style="stop-color:#fff1a8;stop-opacity:1"
+         offset="0.55546904"
+         id="stop5969" />
+      <stop
+         id="stop5971"
+         offset="1"
+         style="stop-color:#ffd379;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5965"
+       id="linearGradient5897"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.50533162,0,0,-0.41430567,-0.83251169,1485.2614)"
+       x1="-17.950155"
+       y1="1064.4285"
+       x2="-17.950155"
+       y2="1056.4362" />
+    <linearGradient
+       y2="1056.3333"
+       x2="-17.950155"
+       y1="1064.538"
+       x1="-17.950155"
+       gradientTransform="matrix(-0.50533162,0,0,-0.41430567,-6.6559892,1479.2214)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5926"
+       xlink:href="#linearGradient5973"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5981"
+       id="linearGradient5987"
+       x1="27.119074"
+       y1="1043.2889"
+       x2="27.119074"
+       y2="1038.8683"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-21.016465,5.0823298)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5991"
+       id="linearGradient5989"
+       x1="22.577229"
+       y1="1041.0941"
+       x2="22.577229"
+       y2="1037.0269"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-21.856155,1.016466)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627418"
+     inkscape:cx="-1.1641998"
+     inkscape:cy="8.5000841"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="1229"
+     inkscape:window-y="423"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5126" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g8391"
+       transform="translate(0.92807761,0)">
+      <path
+         id="path4887-8-4-7-4"
+         style="fill:url(#linearGradient5926);fill-opacity:1;stroke:url(#linearGradient5989);stroke-width:0.72602755;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         d="m 4.8035208,1038.452 c 0,0 0.990421,-0.074 0.990421,0.6682 l 0,2.9207 -5.26811702,-0.011 0,-2.1262 0,-1.0528 c 0,-0.6447 0.29721,-1.0949 1.10178102,-1.0813 l 0.452249,0 c 1.074957,0 1.827519,-0.1549 1.827519,0.6733 z"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccscccc" />
+      <g
+         transform="translate(0.00695065,-0.9965488)"
+         inkscape:label="Layer 1"
+         id="layer1-8-0"
+         style="display:inline">
+        <path
+           style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline"
+           d="m 2.1438445,1043.3787 1.0000146,0 0,4.039 -1.0000146,0 z"
+           id="rect4035-1-1-5-2-4"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline"
+           d="m 2.1438445,1046.5061 3.0000003,0 0,0.9999 -3.0000003,0 z"
+           id="rect4035-1-1-5-2-2-1-5"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cccccscccc"
+       inkscape:connector-curvature="0"
+       d="m 10.626998,1044.492 c 0,0 0.990422,-0.074 0.990422,0.6682 l 0,2.9207 -5.2681169,-0.011 0,-2.1262 0,-1.0528 c 0,-0.6447 0.297209,-1.0949 1.10178,-1.0813 l 0.45225,0 c 1.0749569,0 1.8275183,-0.1549 1.8275183,0.6733 z"
+       style="fill:url(#linearGradient5897);fill-opacity:1;stroke:url(#linearGradient5987);stroke-width:0.72602755;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path4887-8-4-7" />
+    <path
+       style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline"
+       d="m 13.039882,1045.4099 3.000001,0 0,0.9999 -3.000001,0 z"
+       id="rect4035-1-1-5-2-2-1-5-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline"
+       d="m 8.1785233,1039.4436 7.6845827,0 0,0.9999 -7.6845827,0 z"
+       id="rect4035-1-1-5-2-2-1-5-0-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/eview16/new_persp.svg
+++ b/bundles/org.eclipse.ui/icons/full/eview16/new_persp.svg
@@ -1,0 +1,755 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="new_persp.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient8661"
+       inkscape:collect="always">
+      <stop
+         id="stop8663"
+         offset="0"
+         style="stop-color:#c6e7f9;stop-opacity:1" />
+      <stop
+         id="stop8665"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8653">
+      <stop
+         style="stop-color:#676656;stop-opacity:1;"
+         offset="0"
+         id="stop8655" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop8657" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-1">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-4" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-4">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-78" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-93">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-9" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8661"
+       id="linearGradient8681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137"
+       id="linearGradient8683"
+       gradientUnits="userSpaceOnUse"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2"
+       id="linearGradient8685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337"
+       id="linearGradient8687"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8689"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8691"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064"
+       gradientTransform="translate(0,-0.95029984)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8693"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064"
+       gradientTransform="translate(0,-0.95029984)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8695"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064"
+       gradientTransform="translate(-0.79191653,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8697"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-93"
+       id="linearGradient8699"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-4"
+       id="linearGradient8701"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-1"
+       id="linearGradient8703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375262)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       id="linearGradient7540-2-3-8">
+      <stop
+         id="stop7542-8-7-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9" />
+      <stop
+         id="stop7548-98-9-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-6-33-6-3">
+      <stop
+         id="stop7542-4-4-3-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-5-3-8-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-2-9-1-2" />
+      <stop
+         id="stop7548-9-2-0-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7540-2-3-8"
+       id="linearGradient4786"
+       gradientUnits="userSpaceOnUse"
+       x1="-22.453552"
+       y1="1030.3411"
+       x2="-10.159802"
+       y2="1030.3411" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7540-6-33-6-3"
+       id="linearGradient4788"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       x1="-22.453552"
+       y1="1030.3411"
+       x2="-10.159802"
+       y2="1030.3411" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7272-66-4-5-5-5"
+       id="linearGradient4790"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       x1="-15.945988"
+       y1="1037.4661"
+       x2="-15.945988"
+       y2="1023.2569" />
+    <linearGradient
+       y2="6.9843998"
+       x2="10.007812"
+       y1="5"
+       x1="10"
+       gradientTransform="translate(-15.015625,1046.6356)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6323-7"
+       xlink:href="#linearGradient5068-6-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5068-6-9"
+       inkscape:collect="always">
+      <stop
+         id="stop5070-8-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop5072-3-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.3466"
+       x2="12"
+       y1="1043.3622"
+       x1="12"
+       id="linearGradient5084-3-3"
+       xlink:href="#linearGradient5068-6-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.3466"
+       x2="15.007812"
+       y1="1043.3622"
+       x1="13"
+       id="linearGradient5086-8-0"
+       xlink:href="#linearGradient5068-6-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.3622"
+       x2="10.007812"
+       y1="1042.3622"
+       x1="12"
+       id="linearGradient5082-1-0"
+       xlink:href="#linearGradient5068-6-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1041.3466"
+       x2="8.0078125"
+       y1="1041.3622"
+       x1="10"
+       id="linearGradient5078-8-2"
+       xlink:href="#linearGradient5068-6-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1038.3466"
+       x2="10.007812"
+       y1="1040.3622"
+       x1="10"
+       id="linearGradient5076-5-2"
+       xlink:href="#linearGradient5068-6-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1038.3466"
+       x2="10.007812"
+       y1="1038.3622"
+       x1="12"
+       id="linearGradient5074-2-1"
+       xlink:href="#linearGradient5068-6-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.3466"
+       x2="14"
+       y1="1041.3622"
+       x1="14"
+       id="linearGradient5088-1-4"
+       xlink:href="#linearGradient5068-6-9"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9-5-7-9"
+       id="radialGradient3091-1-9-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574" />
+    <linearGradient
+       id="linearGradient4528-9-5-7-9">
+      <stop
+         style="stop-color:#e0c576;stop-opacity:1;"
+         offset="0"
+         id="stop4530-0-5-0-5" />
+      <stop
+         style="stop-color:#9e7916;stop-opacity:1"
+         offset="1"
+         id="stop4532-7-9-3-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6-6-4-2"
+       id="linearGradient3093-5-2-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2">
+      <stop
+         id="stop6283-0-2-2-1-2-0-1"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7-6-9-9"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5068-6-9-4"
+       inkscape:collect="always">
+      <stop
+         id="stop5070-8-0-4"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop5072-3-6-1"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1038.3466"
+       x2="10.007812"
+       y1="1038.3622"
+       x1="12"
+       id="linearGradient5074-2-1-3"
+       xlink:href="#linearGradient5068-6-9-4"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9-5-7-9-7"
+       id="radialGradient3091-1-9-6-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574" />
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7">
+      <stop
+         style="stop-color:#e0c576;stop-opacity:1;"
+         offset="0"
+         id="stop4530-0-5-0-5-8" />
+      <stop
+         style="stop-color:#9e7916;stop-opacity:1"
+         offset="1"
+         id="stop4532-7-9-3-3-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6-6-4-2-8"
+       id="linearGradient3093-5-2-7-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8">
+      <stop
+         id="stop6283-0-2-2-1-2-0-1-6"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7-6-9-9-1"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32.000001"
+     inkscape:cx="5.3906248"
+     inkscape:cy="8.9218746"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4759"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g8667"
+       transform="matrix(0.27903303,0,0,0.27903303,-169.81507,964.92071)">
+      <rect
+         ry="2.5632601"
+         rx="2.5632601"
+         y="268.004"
+         x="613.83698"
+         height="41"
+         width="40.880188"
+         id="rect8093"
+         style="fill:url(#linearGradient8681);fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="sssccss"
+         inkscape:connector-curvature="0"
+         id="rect8093-5"
+         d="m 619.40542,268.004 33.14428,0 c 1.42005,0 2.56326,1.14321 2.56326,2.56326 l 0,5.87348 -38.2708,0 0,-5.87348 c 0,-1.42005 1.14322,-2.56326 2.56326,-2.56326 z"
+         style="fill:#4e86ca;fill-opacity:1;stroke:url(#linearGradient8683);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="rect8093-5-9"
+         d="m 619.40625,269 c -0.88334,0 -1.5625,0.67915 -1.5625,1.5625 l 0,4.875 37,0 0,-4.875 c 0,-0.88335 -0.67915,-1.5625 -1.5625,-1.5625 z"
+         style="fill:url(#linearGradient8685);fill-opacity:1;stroke:none"
+         sodipodi:nodetypes="ssccsss" />
+      <path
+         inkscape:connector-curvature="0"
+         id="rect8093-5-9-8"
+         d="m 619.40625,269.34375 c -0.88334,0 -1.5625,0.67915 -1.5625,1.5625 l 0,4.875 37,0 0,-4.875 c 0,-0.88335 -0.67915,-1.5625 -1.5625,-1.5625 z"
+         style="fill:url(#linearGradient8687);fill-opacity:1;stroke:none"
+         sodipodi:nodetypes="ssccsss" />
+      <g
+         style="stroke:url(#linearGradient8697);stroke-opacity:1"
+         id="g8643">
+        <rect
+           id="rect8645"
+           style="fill:none;stroke:url(#linearGradient8689);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+           width="39.49477"
+           height="39.416187"
+           x="614.36371"
+           y="268.63754"
+           rx="2.5632601"
+           ry="2.5632601" />
+        <path
+           id="path8647"
+           style="fill:none;stroke:url(#linearGradient8691);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           d="m 613.49908,293.59938 15.68842,0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path8649"
+           style="fill:none;stroke:url(#linearGradient8693);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           d="m 629.3125,290.28688 26.3125,0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           id="path8651"
+           style="fill:none;stroke:url(#linearGradient8695);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           d="m 628.39558,275.98718 0,32.84375"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+      </g>
+      <path
+         sodipodi:nodetypes="sssccss"
+         inkscape:connector-curvature="0"
+         id="rect8093-5-8"
+         d="m 616.15672,268.004 36.22378,0 c 1.42005,0 2.56326,1.14321 2.56326,2.56326 l 0,5.87348 -41.3503,0 0,-5.87348 c 0,-1.42005 1.14322,-2.56326 2.56326,-2.56326 z"
+         style="fill:#4e86ca;fill-opacity:1;stroke:url(#linearGradient8699);stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         sodipodi:nodetypes="ssccsss"
+         inkscape:connector-curvature="0"
+         id="rect8093-5-9-6"
+         d="m 616.33433,269 c -0.88334,0 -1.5625,0.67915 -1.5625,1.5625 l 0,4.875 39.18804,0 0,-4.875 c 0,-0.88335 -0.67915,-1.5625 -1.5625,-1.5625 z"
+         style="fill:url(#linearGradient8701);fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="ssccsss"
+         inkscape:connector-curvature="0"
+         id="rect8093-5-9-8-0"
+         d="m 615.93658,269.34375 c -0.88334,0 -1.57051,0.67919 -1.5625,1.5625 l 0,4.875 39.60789,0 0,-4.875 c 0,-0.88335 -0.67915,-1.5625 -1.5625,-1.5625 z"
+         style="fill:url(#linearGradient8703);fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="g4761"
+       transform="matrix(0.90974503,0,0,0.90974503,0.94380764,95.200178)">
+      <g
+         transform="translate(0.25,-0.5)"
+         id="g3921">
+        <g
+           id="g4145-3"
+           style="opacity:0.48945151;fill:#945112;fill-opacity:1;display:inline"
+           transform="translate(-12.498262,-0.47405)">
+          <path
+             sodipodi:nodetypes="czczczczc"
+             inkscape:connector-curvature="0"
+             id="rect6501-4-4-6-9"
+             d="m 22.854803,1047.125 c 0,0 0.0781,0.3441 0.303204,0.59 0.225108,0.2459 0.56093,0.3542 0.56093,0.3542 0,0 -0.342043,0.076 -0.590001,0.3031 -0.247957,0.227 -0.354126,0.5609 -0.354126,0.5609 0,0 -0.06889,-0.3339 -0.303205,-0.5899 -0.234327,-0.2561 -0.56093,-0.3542 -0.56093,-0.3542 0,0 0.350102,-0.084 0.590001,-0.3032 0.239908,-0.2196 0.354127,-0.5609 0.354127,-0.5609 z"
+             style="opacity:0.85;fill:#945112;fill-opacity:1;stroke:none;display:inline" />
+          <path
+             sodipodi:nodetypes="czczczczc"
+             inkscape:connector-curvature="0"
+             id="rect6501-4-4-1-7-0"
+             d="m 21.818949,1048.8909 c 0,0 -0.131805,0.319 -0.0908,0.6427 0.04104,0.3235 0.248295,0.5996 0.248295,0.5996 0,0 -0.316348,-0.1322 -0.642582,-0.09 -0.326253,0.041 -0.599601,0.2483 -0.599601,0.2483 0,0 0.133515,-0.3057 0.09081,-0.6425 -0.0427,-0.3369 -0.248297,-0.5996 -0.248297,-0.5996 0,0 0.326935,0.1309 0.642582,0.09 0.315656,-0.04 0.599602,-0.2483 0.599602,-0.2483 z"
+             style="opacity:0.85;fill:#945112;fill-opacity:1;stroke:none;display:inline" />
+          <path
+             sodipodi:nodetypes="czczczczc"
+             inkscape:connector-curvature="0"
+             id="rect6501-4-4-7-0-7"
+             d="m 19.545198,1049.7605 c 0,0 -0.03603,0.2767 0.06387,0.5208 0.09991,0.2441 0.319618,0.4161 0.319618,0.4161 0,0 -0.274729,-0.037 -0.520794,0.064 -0.246065,0.1008 -0.416106,0.3196 -0.416106,0.3196 0,0 0.04012,-0.2667 -0.06387,-0.5208 -0.103986,-0.254 -0.319618,-0.4161 -0.319618,-0.4161 0,0 0.282721,0.034 0.520794,-0.064 0.23807,-0.097 0.416106,-0.3196 0.416106,-0.3196 z"
+             style="opacity:0.85;fill:#945112;fill-opacity:1;stroke:none;display:inline" />
+          <path
+             sodipodi:nodetypes="czczczczc"
+             inkscape:connector-curvature="0"
+             id="rect6501-4-4-93-5-1"
+             d="m 17.440644,1050.5221 c 0,0 -0.02929,0.1772 0.02958,0.3364 0.05889,0.1592 0.196418,0.2748 0.196418,0.2748 0,0 -0.175934,-0.03 -0.336408,0.029 -0.16051,0.059 -0.274716,0.1964 -0.274716,0.1964 0,0 0.03168,-0.1707 -0.02962,-0.3364 -0.06129,-0.1657 -0.196419,-0.2747 -0.196419,-0.2747 0,0 0.181112,0.028 0.336412,-0.03 0.155292,-0.057 0.274712,-0.1963 0.274712,-0.1963 z"
+             style="opacity:0.85;fill:#945112;fill-opacity:1;stroke:none;display:inline"
+             inkscape:transform-center-x="1.4375"
+             inkscape:transform-center-y="0.625" />
+          <path
+             sodipodi:nodetypes="czczczczc"
+             inkscape:connector-curvature="0"
+             id="rect6501-4-5-9"
+             d="m 24.20544,1044.3866 c 0,0 -0.05151,0.4757 0.12879,0.8904 0.180313,0.4147 0.563366,0.7016 0.563366,0.7016 0,0 -0.472359,-0.053 -0.890472,0.1287 -0.418126,0.1818 -0.701541,0.5634 -0.701541,0.5634 0,0 0.05889,-0.4588 -0.12879,-0.8905 -0.187682,-0.4317 -0.563367,-0.7015 -0.563367,-0.7015 0,0 0.485949,0.047 0.890474,-0.1288 0.404539,-0.1759 0.70154,-0.5633 0.70154,-0.5633 z"
+             style="opacity:0.85;fill:#945112;fill-opacity:1;stroke:none;display:inline" />
+        </g>
+        <g
+           transform="translate(-12.273403,-0.72095)"
+           style="display:inline"
+           id="g4145">
+          <path
+             style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+             d="m 22.854803,1047.125 c 0,0 0.0781,0.3441 0.303204,0.59 0.225108,0.2459 0.56093,0.3542 0.56093,0.3542 0,0 -0.342043,0.076 -0.590001,0.3031 -0.247957,0.227 -0.354126,0.5609 -0.354126,0.5609 0,0 -0.06889,-0.3339 -0.303205,-0.5899 -0.234327,-0.2561 -0.56093,-0.3542 -0.56093,-0.3542 0,0 0.350102,-0.084 0.590001,-0.3032 0.239908,-0.2196 0.354127,-0.5609 0.354127,-0.5609 z"
+             id="rect6501-4-4-6"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="czczczczc" />
+          <path
+             style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+             d="m 21.818949,1048.8909 c 0,0 -0.131805,0.319 -0.0908,0.6427 0.04104,0.3235 0.248295,0.5996 0.248295,0.5996 0,0 -0.316348,-0.1322 -0.642582,-0.09 -0.326253,0.041 -0.599601,0.2483 -0.599601,0.2483 0,0 0.133515,-0.3057 0.09081,-0.6425 -0.0427,-0.3369 -0.248297,-0.5996 -0.248297,-0.5996 0,0 0.326935,0.1309 0.642582,0.09 0.315656,-0.04 0.599602,-0.2483 0.599602,-0.2483 z"
+             id="rect6501-4-4-1-7"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="czczczczc" />
+          <path
+             style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+             d="m 19.545198,1049.7605 c 0,0 -0.03603,0.2767 0.06387,0.5208 0.09991,0.2441 0.319618,0.4161 0.319618,0.4161 0,0 -0.274729,-0.037 -0.520794,0.064 -0.246065,0.1008 -0.416106,0.3196 -0.416106,0.3196 0,0 0.04012,-0.2667 -0.06387,-0.5208 -0.103986,-0.254 -0.319618,-0.4161 -0.319618,-0.4161 0,0 0.282721,0.034 0.520794,-0.064 0.23807,-0.097 0.416106,-0.3196 0.416106,-0.3196 z"
+             id="rect6501-4-4-7-0"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="czczczczc" />
+          <path
+             inkscape:transform-center-y="0.625"
+             inkscape:transform-center-x="1.4375"
+             style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+             d="m 17.440644,1050.5221 c 0,0 -0.02929,0.1772 0.02958,0.3364 0.05889,0.1592 0.196418,0.2748 0.196418,0.2748 0,0 -0.175934,-0.03 -0.336408,0.029 -0.16051,0.059 -0.274716,0.1964 -0.274716,0.1964 0,0 0.03168,-0.1707 -0.02962,-0.3364 -0.06129,-0.1657 -0.196419,-0.2747 -0.196419,-0.2747 0,0 0.181112,0.028 0.336412,-0.03 0.155292,-0.057 0.274712,-0.1963 0.274712,-0.1963 z"
+             id="rect6501-4-4-93-5"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="czczczczc" />
+          <path
+             style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+             d="m 24.20544,1044.3866 c 0,0 -0.05151,0.4757 0.12879,0.8904 0.180313,0.4147 0.563366,0.7016 0.563366,0.7016 0,0 -0.472359,-0.053 -0.890472,0.1287 -0.418126,0.1818 -0.701541,0.5634 -0.701541,0.5634 0,0 0.05889,-0.4588 -0.12879,-0.8905 -0.187682,-0.4317 -0.563367,-0.7015 -0.563367,-0.7015 0,0 0.485949,0.047 0.890474,-0.1288 0.404539,-0.1759 0.70154,-0.5633 0.70154,-0.5633 z"
+             id="rect6501-4-5"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="czczczczc" />
+        </g>
+        <g
+           style="display:inline"
+           id="g6432"
+           transform="matrix(1.0992091,0,0,1.0992091,14.12881,-115.43836)">
+          <g
+             style="display:inline"
+             id="g4514"
+             transform="translate(-5.536708,-5.6240351)">
+            <g
+               id="g4522"
+               transform="translate(-9.9375,0)">
+              <rect
+                 style="fill:url(#radialGradient3091-1-9-6-4);fill-opacity:1;stroke:#a27d18;stroke-width:1.03243756;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+                 id="rect3910"
+                 width="4.5825453"
+                 height="4.454073"
+                 x="-758.82336"
+                 y="-740.41083"
+                 transform="matrix(-0.70710678,-0.70710678,0.70710678,-0.70710678,0,0)" />
+              <path
+                 sodipodi:nodetypes="ccccccccccccc"
+                 inkscape:connector-curvature="0"
+                 id="path5581-5-5"
+                 d="m 12.471186,1054.309 1.001133,0 0,1.946 1.986639,0 0,1.0167 -1.986639,0 0,2.043 -1.001133,0 0,-2.043 -1.98664,0 0,-1.0167 1.98664,0 z"
+                 style="fill:url(#linearGradient3093-5-2-7-0);fill-opacity:1;stroke:none;display:inline" />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/eview16/outline_co.svg
+++ b/bundles/org.eclipse.ui/icons/full/eview16/outline_co.svg
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="outline_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient8292">
+      <stop
+         style="stop-color:#71baff;stop-opacity:1;"
+         offset="0"
+         id="stop8294" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop8296" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082-3">
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1"
+         offset="0"
+         id="stop4084-8" />
+      <stop
+         id="stop4864-7"
+         offset="0.5"
+         style="stop-color:#5a9ccc;stop-opacity:1" />
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1"
+         offset="1"
+         id="stop4086-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8292"
+       id="linearGradient8298"
+       x1="4.0797281"
+       y1="1043.2366"
+       x2="4.0797281"
+       y2="1039.6121"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.04419417,-1.11019)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8292-9"
+       id="linearGradient8298-2"
+       x1="4.0797281"
+       y1="1043.2366"
+       x2="4.0797281"
+       y2="1039.6121"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.04419417,-19.04769)" />
+    <linearGradient
+       id="linearGradient8292-9">
+      <stop
+         style="stop-color:#71baff;stop-opacity:1;"
+         offset="0"
+         id="stop8294-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop8296-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1039.6121"
+       x2="4.0797281"
+       y1="1043.2366"
+       x1="4.0797281"
+       gradientTransform="translate(0.04419417,7.9496395)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8315"
+       xlink:href="#linearGradient8292-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8292-2"
+       id="linearGradient8298-1"
+       x1="4.0797281"
+       y1="1043.2366"
+       x2="4.0797281"
+       y2="1039.6121"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.04419417,-1.11019)" />
+    <linearGradient
+       id="linearGradient8292-2">
+      <stop
+         style="stop-color:#71baff;stop-opacity:1;"
+         offset="0"
+         id="stop8294-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop8296-3" />
+    </linearGradient>
+    <linearGradient
+       y2="1039.6121"
+       x2="4.0797281"
+       y1="1043.2366"
+       x1="4.0797281"
+       gradientTransform="matrix(0.9884064,0,0,1.0281702,7.0646362,-24.388494)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8415"
+       xlink:href="#linearGradient8292-2"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="19.282433"
+     inkscape:cy="3.1651779"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1208"
+     inkscape:window-height="913"
+     inkscape:window-x="980"
+     inkscape:window-y="435"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid8762" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4174"
+       transform="translate(1.0450352,-0.94370265)">
+      <rect
+         y="1037.817"
+         x="1.4584078"
+         height="4.9938965"
+         width="4.9988432"
+         id="rect7504"
+         style="fill:url(#linearGradient8298);fill-opacity:1;stroke:#1469ab;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         y="1046.8143"
+         x="1.4584078"
+         height="4.9938965"
+         width="5.0144682"
+         id="rect7504-6"
+         style="display:inline;fill:url(#linearGradient8315);fill-opacity:1;stroke:#1469ab;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <g
+         transform="matrix(1.0111624,0,0,1,-0.22277643,17.911612)"
+         id="g8372">
+        <path
+           style="fill:none;stroke:#10558a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 8.0801553,-13.4375 5.9388007,0"
+           id="path8334"
+           inkscape:connector-curvature="0"
+           transform="translate(0,1036.3622)"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;stroke:#c1e8ff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 8.0801553,1021.9082 5.9388007,0"
+           id="path8334-0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+      </g>
+      <g
+         transform="matrix(1.0074416,0,0,1,-0.1927118,26.927223)"
+         id="g8372-7"
+         style="display:inline">
+        <path
+           style="fill:none;stroke:#10558a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 8.0801553,-13.4375 5.9388007,0"
+           id="path8334-4"
+           inkscape:connector-curvature="0"
+           transform="translate(0,1036.3622)"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;stroke:#c1e8ff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 8.0801553,1021.9082 5.9388007,0"
+           id="path8334-0-2"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+      </g>
+      <rect
+         y="1043.8054"
+         x="8.4624538"
+         height="1.9858042"
+         width="2.022001"
+         id="rect7504-2"
+         style="display:inline;fill:url(#linearGradient8415);fill-opacity:1;stroke:#1469ab;stroke-width:1.00809228;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <g
+         transform="matrix(1.0320805,0,0,1,3.6122231,21.884139)"
+         id="g8372-7-1"
+         style="display:inline">
+        <path
+           style="fill:none;stroke:#10558a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 8.0801553,-13.4375 1.9482227,0"
+           id="path8334-4-7"
+           inkscape:connector-curvature="0"
+           transform="translate(0,1036.3622)"
+           sodipodi:nodetypes="cc" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/eview16/problems_view.svg
+++ b/bundles/org.eclipse.ui/icons/full/eview16/problems_view.svg
@@ -1,0 +1,360 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="problems_view.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3840">
+      <stop
+         style="stop-color:#5c6884;stop-opacity:1;"
+         offset="0"
+         id="stop3842" />
+      <stop
+         style="stop-color:#a09860;stop-opacity:1;"
+         offset="1"
+         id="stop3844" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5105">
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1;"
+         offset="0"
+         id="stop5107" />
+      <stop
+         style="stop-color:#8693ae;stop-opacity:1"
+         offset="1"
+         id="stop5109" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5255">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1"
+         offset="0"
+         id="stop5257" />
+      <stop
+         style="stop-color:#d2e9f7;stop-opacity:1;"
+         offset="1"
+         id="stop5259" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4903-7-7-52">
+      <stop
+         id="stop4905-2-3-9"
+         offset="0"
+         style="stop-color:#ffe69f;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffcb2f;stop-opacity:1"
+         offset="0.41477016"
+         id="stop4911-4-9-2" />
+      <stop
+         id="stop4907-3-6-1"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3852"
+       id="linearGradient3858"
+       x1="385.98376"
+       y1="462.57028"
+       x2="385.98376"
+       y2="471.69949"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3852">
+      <stop
+         style="stop-color:#ff4949;stop-opacity:1"
+         offset="0"
+         id="stop3854" />
+      <stop
+         style="stop-color:#cb3e44;stop-opacity:1"
+         offset="1"
+         id="stop3856" />
+    </linearGradient>
+    <linearGradient
+       y2="471.69949"
+       x2="385.98376"
+       y1="462.57028"
+       x1="385.98376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3077"
+       xlink:href="#linearGradient3852"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="471.69949"
+       x2="385.98376"
+       y1="462.57028"
+       x1="385.98376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3077-2"
+       xlink:href="#linearGradient3852-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3852-1">
+      <stop
+         style="stop-color:#ff4949;stop-opacity:1"
+         offset="0"
+         id="stop3854-7" />
+      <stop
+         style="stop-color:#cb3e44;stop-opacity:1"
+         offset="1"
+         id="stop3856-4" />
+    </linearGradient>
+    <linearGradient
+       y2="471.69949"
+       x2="385.98376"
+       y1="462.57028"
+       x1="385.98376"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3048"
+       xlink:href="#linearGradient3852-1"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.20238482,0,0,0.2001287,962.33652,-73.387252)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4903-7-7-52"
+       id="linearGradient3027"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.38251092,0.43284103,-0.38251092,0.43284103,3.5071013,-622.17083)"
+       x1="733.18365"
+       y1="727.80212"
+       x2="738.31683"
+       y2="732.9353" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5255"
+       id="linearGradient3807"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3823084,0,0,0.98071248,-6.1929306,20.044209)"
+       x1="22.878796"
+       y1="1037.2108"
+       x2="22.878796"
+       y2="1051.027" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5105"
+       id="linearGradient3809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3823084,0,0,0.98071248,20.427518,20.044209)"
+       x1="9.1708698"
+       y1="1036.9434"
+       x2="9.1708698"
+       y2="1051.6799" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3840"
+       id="linearGradient3846"
+       x1="1035.5981"
+       y1="28.695572"
+       x2="1035.5981"
+       y2="21.128925"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94939611,0,0,1,52.335761,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5105"
+       id="linearGradient3809-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3823085,0,0,0.98071249,20.427518,20.044243)"
+       x1="9.1708698"
+       y1="1036.9434"
+       x2="9.1708698"
+       y2="1051.6799" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32.000001"
+     inkscape:cx="3.4296369"
+     inkscape:cy="1.2330866"
+     inkscape:document-units="px"
+     inkscape:current-layer="g20348"
+     showgrid="true"
+     inkscape:window-width="1054"
+     inkscape:window-height="943"
+     inkscape:window-x="1506"
+     inkscape:window-y="496"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4233" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g3854">
+      <g
+         transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)"
+         id="g8472"
+         style="display:inline">
+        <g
+           id="g8421"
+           transform="translate(15.600543,0)" />
+        <g
+           transform="matrix(0,1,1,0,-1019.4029,1019.4029)"
+           id="g10285">
+          <g
+             transform="matrix(0.93769259,0,0,0.87333542,0.96774196,131.10119)"
+             id="g3797">
+            <path
+               sodipodi:nodetypes="ccczcc"
+               inkscape:connector-curvature="0"
+               id="rect4172-1"
+               d="m 16.096979,1035.5285 15.961689,0 0,16.5683 c -1.062971,-0.5903 -2.773231,-4.1408 -6.924462,-2.3593 -4.15123,1.7815 -7.453027,3.3668 -9.037227,-0.9619 z"
+               style="fill:url(#linearGradient3807);fill-opacity:1;stroke:url(#linearGradient3809);stroke-width:1.18227136;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+            <rect
+               transform="matrix(0,1,1,0,0,0)"
+               y="16.693478"
+               x="1036.2134"
+               height="14.832721"
+               width="1.2250586"
+               id="rect3852"
+               style="fill:#d0f0f8;fill-opacity:1;stroke:none" />
+            <path
+               style="fill:#adc1e1;fill-opacity:1;stroke:#a8bcde;stroke-width:1.18227136;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 24.072394,1036.214 0,14.4407"
+               id="path18345"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+            <path
+               sodipodi:nodetypes="cc"
+               style="fill:#adc1e1;fill-opacity:1;stroke:#a8bcde;stroke-width:1.18227136;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 16.661877,1046.6502 15.957858,0"
+               id="path18347"
+               inkscape:connector-curvature="0" />
+            <rect
+               style="fill:url(#linearGradient3846);fill-opacity:1;stroke:none"
+               id="rect21127"
+               width="1.2696832"
+               height="17.151628"
+               x="1034.9858"
+               y="15.551206"
+               transform="matrix(0,1,1,0,0,0)"
+               ry="0" />
+            <rect
+               transform="scale(1,-1)"
+               style="fill:#5c6884;fill-opacity:1;stroke:none;display:inline"
+               id="rect21127-6"
+               width="1.2099167"
+               height="17.228739"
+               x="31.455427"
+               y="-1052.2151"
+               ry="0" />
+            <path
+               sodipodi:nodetypes="ccczcc"
+               inkscape:connector-curvature="0"
+               id="rect4172-1-8"
+               d="m 16.09698,1035.5285 15.961689,0 0,16.5683 c -1.062971,-0.5903 -2.773232,-4.1408 -6.924462,-2.3593 -4.15123,1.7815 -7.453027,3.3668 -9.037227,-0.9619 z"
+               style="display:inline;fill:none;fill-opacity:1;stroke:url(#linearGradient3809-4);stroke-width:1.18227136;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          </g>
+          <rect
+             style="fill:none;stroke:none"
+             id="rect4942"
+             width="1.4184428"
+             height="1.069887"
+             x="22.741739"
+             y="1042.6464" />
+          <rect
+             style="fill:none;stroke:none;display:inline"
+             id="rect4942-1"
+             width="1.4184427"
+             height="1.069887"
+             x="22.741737"
+             y="1044.7861" />
+          <g
+             transform="matrix(0.8824479,0,0,0.82626422,3.9709262,181.04934)"
+             id="g20348">
+            <rect
+               y="1043.4609"
+               x="25.572638"
+               height="1.0125971"
+               width="1.4224106"
+               id="rect4942-1-7"
+               style="fill:none;stroke:none;display:inline" />
+            <path
+               style="color:#000000;font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:#c4781a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+               d="M 6.0136719,10.267578 5.4707031,9.7338436 4.9316406,10.289062 c -0.3479375,0.347988 -1.4298024,1.666016 -1.4298024,1.666016 0,0.854295 -0.00391,1.552734 -0.00391,1.552734 1.3596609,-0.0334 2.6684352,-0.036 4.0196462,-0.02148 0,0 -0.00781,-0.698439 -0.00781,-1.552734 0,0 -1.1480994,-1.318028 -1.4960925,-1.66602 z"
+               transform="matrix(0,1.2948486,1.2124082,0,13.085015,1033.4996)"
+               id="rect4880"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cccccccc" />
+          </g>
+          <g
+             inkscape:label="Layer 1"
+             id="layer1-8"
+             style="display:inline;fill:#d34a50;fill-opacity:1;stroke:#a81d24;stroke-opacity:1"
+             transform="matrix(0,1.0698871,1.0698871,0,-1093.1782,1054.4736)">
+            <g
+               transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
+               style="display:inline;fill:#d34a50;fill-opacity:1;stroke:#a81d24;stroke-opacity:1"
+               id="g11331-3-1-1">
+              <g
+                 id="g13408-8"
+                 style="fill:#d34a50;fill-opacity:1;stroke:#a81d24;stroke-opacity:1" />
+            </g>
+            <g
+               transform="matrix(-1,0,0,1,16.12959,8.0140628)"
+               style="display:inline;fill:#d34a50;fill-opacity:1;stroke:#a81d24;stroke-opacity:1"
+               id="g6124-3">
+              <g
+                 transform="scale(-1,1)"
+                 style="font-size:13.58917427000000089px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#d34a50;fill-opacity:1;stroke:#a81d24;font-family:Sans;stroke-opacity:1"
+                 id="text6430" />
+              <g
+                 transform="scale(-1,1)"
+                 style="font-size:13.58917427000000089px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#d34a50;fill-opacity:1;stroke:#a81d24;display:inline;font-family:Sans;stroke-opacity:1"
+                 id="g6438" />
+            </g>
+          </g>
+          <ellipse
+             style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient3048);fill-opacity:1;stroke:#c91d24;stroke-width:1.05468071;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path10796-2-6-2-1"
+             transform="matrix(0,1,1,0,0,0)"
+             cy="20.32045"
+             cx="1040.8871"
+             rx="2.1503391"
+             ry="2.1263676" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/eview16/prop_ps.svg
+++ b/bundles/org.eclipse.ui/icons/full/eview16/prop_ps.svg
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="prop_ps.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient7491">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7493" />
+      <stop
+         style="stop-color:#a0b0cc;stop-opacity:1;"
+         offset="1"
+         id="stop7495" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7254">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7254"
+       id="linearGradient7260"
+       x1="15.000595"
+       y1="2"
+       x2="-8"
+       y2="1.375"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.03125,1035.7997)" />
+    <linearGradient
+       id="linearGradient7254-6">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-5" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.93721973,0,0,1,1036.3976,-3.562483)"
+       y2="2"
+       x2="-3.2642515"
+       y1="2"
+       x1="15.000595"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7277"
+       xlink:href="#linearGradient7254-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7254-62">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-0" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-16.03125,1037.7997)"
+       y2="2"
+       x2="-17.187742"
+       y1="2"
+       x1="15.000595"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7328"
+       xlink:href="#linearGradient7254-62"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7254-6-4">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-5-4" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-7-4" />
+    </linearGradient>
+    <linearGradient
+       y2="2"
+       x2="-28.335314"
+       y1="2"
+       x1="15.000595"
+       gradientTransform="matrix(0.93721973,0,0,1,1036.3977,-16.624983)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7362"
+       xlink:href="#linearGradient7254-6-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7491"
+       id="linearGradient7497"
+       x1="1.9445436"
+       y1="3.0732041"
+       x2="14.142135"
+       y2="3.0732041"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99637681,0,0,1,0.01998962,1035.7997)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="10.07852"
+     inkscape:cy="11.787627"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="1384"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4046" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7499"
+       width="14.142136"
+       height="13.169864"
+       x="0.9410218"
+       y="1037.3481" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415-2"
+       width="1.125"
+       height="12.09375"
+       x="-1042.5184"
+       y="1.96875"
+       transform="matrix(0,-1,1,0,0,0)" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415"
+       width="1.125"
+       height="12.9375"
+       x="5.09375"
+       y="1037.4247" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient7362);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244-4-4"
+       width="13.0625"
+       height="1"
+       x="1037.3934"
+       y="-15.0625"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient7277);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244-4"
+       width="13.0625"
+       height="1"
+       x="1037.3934"
+       y="-2"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <rect
+       style="opacity:0.67558528;color:#000000;fill:url(#linearGradient7497);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7489"
+       width="12.153398"
+       height="1.1932427"
+       x="1.9574878"
+       y="1038.2762" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient7260);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244"
+       width="13.9375"
+       height="1"
+       x="1.03125"
+       y="1037.3622" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient7328);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244-7"
+       width="13.9375"
+       height="1"
+       x="-14.96875"
+       y="1039.3622"
+       transform="scale(-1,1)" />
+    <rect
+       style="color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244-4-4-8"
+       width="14.0625"
+       height="1"
+       x="1.03125"
+       y="1049.4247" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415-2-4"
+       width="1.125"
+       height="12.125"
+       x="-1044.7281"
+       y="1.9375"
+       transform="matrix(0,-1,1,0,0,0)" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415-2-4-3"
+       width="1.125"
+       height="12.09375"
+       x="-1047.0262"
+       y="1.96875"
+       transform="matrix(0,-1,1,0,0,0)" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415-2-4-3-9"
+       width="1.125"
+       height="12.0625"
+       x="-1049.3685"
+       y="2"
+       transform="matrix(0,-1,1,0,0,0)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/eview16/tasks_tsk.svg
+++ b/bundles/org.eclipse.ui/icons/full/eview16/tasks_tsk.svg
@@ -1,0 +1,328 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="tasks_tsk.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4176">
+      <stop
+         style="stop-color:#abb5cb;stop-opacity:1"
+         offset="0"
+         id="stop4178" />
+      <stop
+         style="stop-color:#67789d;stop-opacity:1"
+         offset="1"
+         id="stop4180" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4845">
+      <stop
+         style="stop-color:#afb8cd;stop-opacity:1;"
+         offset="0"
+         id="stop4847" />
+      <stop
+         style="stop-color:#8192b5;stop-opacity:1"
+         offset="1"
+         id="stop4849" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4784">
+      <stop
+         style="stop-color:#b68e69;stop-opacity:1"
+         offset="0"
+         id="stop4786" />
+      <stop
+         id="stop4792"
+         offset="0.94238818"
+         style="stop-color:#d5ae7d;stop-opacity:1" />
+      <stop
+         style="stop-color:#c69863;stop-opacity:1"
+         offset="1"
+         id="stop4788" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4784"
+       id="linearGradient4790"
+       x1="-17.3125"
+       y1="1050.9445"
+       x2="-17.34375"
+       y2="1039.0842"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(22.985216,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4845"
+       id="linearGradient4851"
+       x1="-12.921875"
+       y1="1037.3231"
+       x2="-12.921875"
+       y2="1040.3914"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(22.985216,0)" />
+    <linearGradient
+       gradientTransform="translate(-4,-2)"
+       gradientUnits="userSpaceOnUse"
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       id="linearGradient5000-6"
+       xlink:href="#linearGradient4994-7"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-4,-2)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.1633"
+       x2="10.500542"
+       y1="1038.5779"
+       x1="10.544736"
+       id="linearGradient4908"
+       xlink:href="#linearGradient4902"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.72293526,0,0,1,-13.883505,-5.141466)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.857"
+       x2="14"
+       y1="1047.857"
+       x1="7.0070496"
+       id="linearGradient4871"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.57546531,0,0,1,-12.850176,-5.141466)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.857"
+       x2="14"
+       y1="1045.857"
+       x1="7.0070496"
+       id="linearGradient4869"
+       xlink:href="#linearGradient4861"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.82571734,0,0,1,-14.603704,-5.141466)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.857"
+       x2="11"
+       y1="1043.857"
+       x1="7.0070496"
+       id="linearGradient4867"
+       xlink:href="#linearGradient4877"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4861"
+       inkscape:collect="always">
+      <stop
+         id="stop4863"
+         offset="0"
+         style="stop-color:#68789c;stop-opacity:1" />
+      <stop
+         id="stop4865"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877">
+      <stop
+         style="stop-color:#66769a;stop-opacity:1"
+         offset="0"
+         id="stop4879" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop4881" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4902"
+       inkscape:collect="always">
+      <stop
+         id="stop4904"
+         offset="0"
+         style="stop-color:#c7b571;stop-opacity:1;" />
+      <stop
+         id="stop4906"
+         offset="1"
+         style="stop-color:#8794ad;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4994-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-7"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1;" />
+      <stop
+         id="stop4998-4"
+         offset="1"
+         style="stop-color:#dce7f7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5147">
+      <stop
+         style="stop-color:#647499;stop-opacity:1"
+         offset="0"
+         id="stop5149" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop5151" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter11154"
+       x="-0.10200531"
+       width="1.2040106"
+       y="-0.1500768"
+       height="1.3001536">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.34001774"
+         id="feGaussianBlur11156" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4176"
+       id="linearGradient4182"
+       x1="10.015625"
+       y1="0.13492173"
+       x2="10.015625"
+       y2="1.6036717"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999999"
+     inkscape:cx="3.0215099"
+     inkscape:cy="8.5706121"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-3"
+     showgrid="true"
+     inkscape:window-width="1498"
+     inkscape:window-height="1078"
+     inkscape:window-x="899"
+     inkscape:window-y="219"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="fill:#d4b07b;fill-opacity:1;stroke:url(#linearGradient4790);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect3997"
+       width="11.009807"
+       height="11.993408"
+       x="4.5066614"
+       y="1038.8688"
+       rx="1.21875"
+       ry="1.21875" />
+    <path
+       style="fill:url(#linearGradient4851);fill-opacity:1;stroke:none"
+       d="m 6.0008411,1040.3466 1.53125,-1.3672 0.9375,-2.1172 1.5,0 1.4999999,0 0.953125,2.1172 1.546875,1.3672"
+       id="path4794"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <g
+       style="display:inline"
+       id="layer1-3"
+       inkscape:label="Layer 1"
+       transform="translate(4.1753807,4.1676048)">
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="rect4001-3"
+         d="m 1.4972825,1036.1745 8.8855065,0 0.02997,3.7358 0,5.7983 -8.9154755,0 z"
+         style="display:inline;fill:url(#linearGradient5000-6);fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4001"
+         d="m 10.331915,1036.1797 0.0092,3.7303 0,5.7984 -9.0313039,-0.022 0.015596,-9.5017"
+         style="fill:none;stroke:url(#linearGradient4908);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1038.2103"
+         x="-8.8178616"
+         height="1.0103934"
+         width="3.2970483"
+         id="rect4001-1"
+         style="display:inline;fill:url(#linearGradient4867);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+      <rect
+         y="1040.2103"
+         x="-8.8178616"
+         height="1.0103934"
+         width="4.0242004"
+         id="rect4001-1-7"
+         style="display:inline;fill:url(#linearGradient4869);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+      <rect
+         y="1042.2103"
+         x="-8.8178616"
+         height="1.0103934"
+         width="5.0554504"
+         id="rect4001-1-7-4"
+         style="display:inline;fill:url(#linearGradient4871);fill-opacity:1;stroke:none"
+         transform="scale(-1,1)" />
+    </g>
+    <path
+       d="M 8.328125 0.013671875 C 8.189912 0.056671875 8.072509 0.16192188 8.015625 0.29492188 L 7.140625 2.2949219 L 6.1757812 3.1582031 C 5.9563322 3.3776031 6.013878 3.4828937 5.984375 3.9960938 C 6.18979 3.9960938 6.4687177 3.9963937 6.7304688 3.9960938 L 7.859375 2.9824219 C 7.910975 2.9394219 7.953775 2.8853719 7.984375 2.8261719 L 8.796875 1.0136719 L 9.984375 1.0136719 L 11.140625 1.0136719 L 11.953125 2.8261719 C 11.983725 2.8861719 12.026525 2.9394219 12.078125 2.9824219 L 13.251953 4.0136719 C 13.365471 4.0136719 13.724689 3.9934219 13.96875 3.9824219 C 13.96875 3.7695219 14.05019 3.4075719 13.84375 3.2011719 L 12.828125 2.2929688 L 11.921875 0.29296875 C 11.842135 0.12896875 11.666632 0.018071875 11.484375 0.013671875 L 9.984375 0.013671875 L 8.484375 0.013671875 C 8.432715 0.003671875 8.37978 0.003671875 8.328125 0.013671875 z "
+       transform="translate(0,1036.3622)"
+       id="path4794-5"
+       style="fill:url(#linearGradient4182);fill-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4065-9"
+       d="m 2.7977158,1045.1747 2.4999999,2.5313 5.5000013,-5.4375"
+       style="display:inline;fill:none;stroke:#ffffff;stroke-width:1.79999995;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter11154)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4065"
+       d="m 1.5164659,1045.4246 2.4999999,2.5313 5.500001,-5.4375"
+       style="display:inline;fill:none;stroke:#0073ff;stroke-width:1.79999995;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/activity.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/activity.svg
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="activity.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11290">
+      <stop
+         style="stop-color:#567ead;stop-opacity:1"
+         offset="0"
+         id="stop11292" />
+      <stop
+         style="stop-color:#35679d;stop-opacity:1"
+         offset="1"
+         id="stop11294" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient8230"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient8232"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient8238"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       id="linearGradient8222-2">
+      <stop
+         id="stop8224-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e4f173;stop-opacity:1;"
+         offset="0.47270355"
+         id="stop8226-8" />
+      <stop
+         id="stop8228-1"
+         offset="1"
+         style="stop-color:#f4f4cb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="460.75397"
+       x2="387.91077"
+       y1="477.56372"
+       x1="388.07498"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8109"
+       xlink:href="#linearGradient8222-2"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="4.1959862"
+     inkscape:cy="9.4897506"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-71"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="153"
+     inkscape:window-y="42"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="stroke:url(#linearGradient8238);stroke-opacity:1;display:inline"
+       id="layer1-71"
+       inkscape:label="Layer 1"
+       transform="matrix(1.447537,0,0,1.447537,-3.3953682,-463.26381)">
+      <g
+         id="g11331-3-1-1"
+         style="stroke:url(#linearGradient8232);stroke-opacity:1;display:inline"
+         transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)">
+        <g
+           style="fill:#737986;fill-opacity:1;stroke:url(#linearGradient8230);stroke-opacity:1"
+           id="g13408-8" />
+      </g>
+      <path
+         transform="matrix(0.20842624,0,0,0.20842624,-72.670931,943.93239)"
+         d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10796-2-6-2-7"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient8109);fill-opacity:1;stroke:#71ac4b;stroke-width:3.31449938;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/activity_category.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/activity_category.svg
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="activity_category.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11290">
+      <stop
+         style="stop-color:#567ead;stop-opacity:1"
+         offset="0"
+         id="stop11292" />
+      <stop
+         style="stop-color:#35679d;stop-opacity:1"
+         offset="1"
+         id="stop11294" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient8230"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient8232"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient8238"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       id="linearGradient8222-2">
+      <stop
+         id="stop8224-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e4f173;stop-opacity:1;"
+         offset="0.47270355"
+         id="stop8226-8" />
+      <stop
+         id="stop8228-1"
+         offset="1"
+         style="stop-color:#f4f4cb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="460.75397"
+       x2="387.91077"
+       y1="477.56372"
+       x1="388.07498"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8109"
+       xlink:href="#linearGradient8222-2"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.19631748,0,0,0.19369052,-65.902232,953.2307)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-61.366562,1.4453859)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       id="linearGradient3967"
+       inkscape:collect="always">
+      <stop
+         id="stop3969"
+         offset="0"
+         style="stop-color:#c48a4e;stop-opacity:1;" />
+      <stop
+         id="stop3971"
+         offset="1"
+         style="stop-color:#ad6c24;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973"
+       id="linearGradient4933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-60.558598,0)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       id="linearGradient3973"
+       inkscape:collect="always">
+      <stop
+         id="stop3975"
+         offset="0"
+         style="stop-color:#f8d078;stop-opacity:1" />
+      <stop
+         id="stop3977"
+         offset="1"
+         style="stop-color:#f8f0c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949"
+       id="linearGradient4935"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-60.558598,0)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3949">
+      <stop
+         style="stop-color:#9e6627;stop-opacity:1"
+         offset="0"
+         id="stop3951" />
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="1"
+         id="stop3953" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955">
+      <stop
+         id="stop3957"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961" />
+      <stop
+         id="stop3963"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="373.2294"
+       x2="543.91406"
+       y1="373.2294"
+       x1="523.00781"
+       gradientTransform="translate(-60.558598,1.4188)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9459"
+       xlink:href="#linearGradient3955"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient7357"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient4178"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="4.158123"
+     inkscape:cy="11.390849"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-71"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="536"
+     inkscape:window-y="483"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="stroke:url(#linearGradient8238);stroke-opacity:1;display:inline"
+       id="layer1-71"
+       inkscape:label="Layer 1"
+       transform="matrix(1.447537,0,0,1.447537,-3.3953682,-463.26381)">
+      <g
+         id="g11331-3-1-1"
+         style="stroke:url(#linearGradient8232);stroke-opacity:1;display:inline"
+         transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)">
+        <g
+           style="fill:#737986;fill-opacity:1;stroke:url(#linearGradient8230);stroke-opacity:1"
+           id="g13408-8" />
+      </g>
+      <g
+         style="stroke:url(#linearGradient7357);display:inline"
+         transform="matrix(0.22815212,0,0,0.22815212,-101.00478,953.54114)"
+         id="g13813">
+        <g
+           id="g4173"
+           style="stroke:url(#linearGradient4178)"
+           transform="translate(-3.1225528,-2.6021273)">
+          <rect
+             ry="2.625"
+             rx="2.625"
+             y="368.49503"
+             x="463.74335"
+             height="16.625"
+             width="15"
+             id="rect13693-3"
+             style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient3939);stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="sssssssss"
+             inkscape:connector-curvature="0"
+             id="rect13693"
+             d="m 463.24874,374.64819 31.13385,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,19.0178 c 0,1.45425 -1.17076,2.63221 -2.625,2.625 l -31.13385,-0.15421 c -1.45423,-0.007 -2.625,-1.17075 -2.625,-2.625 l 0,-18.86359 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+             style="fill:url(#linearGradient4933);fill-opacity:1;stroke:url(#linearGradient4935);stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path13797"
+             d="m 462.26171,374.64819 20.09375,0"
+             style="fill:none;stroke:url(#linearGradient9459);stroke-width:3.02792978;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+      </g>
+      <ellipse
+         id="path10796-2-6-2-7"
+         style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient8109);fill-opacity:1;stroke:#71ac4b;stroke-width:0.69391578;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         cx="10.293494"
+         cy="1043.9237"
+         rx="2.0858731"
+         ry="2.0579617" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/add_obj.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/add_obj.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="add_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5591-4">
+      <stop
+         style="stop-color:#e0e566;stop-opacity:1;"
+         offset="0"
+         id="stop5593-0" />
+      <stop
+         style="stop-color:#82c448;stop-opacity:1;"
+         offset="1"
+         id="stop5595-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5583-2">
+      <stop
+         style="stop-color:#426e4a;stop-opacity:1;"
+         offset="0"
+         id="stop5585-3" />
+      <stop
+         style="stop-color:#669f71;stop-opacity:1;"
+         offset="1"
+         id="stop5587-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.9375158,0,0,2.0245922,3.5980621,1028.9745)"
+       y2="9.1435204"
+       x2="2.03125"
+       y1="6.9396911"
+       x1="2.03125"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5618"
+       xlink:href="#linearGradient5591-4"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.9375158,0,0,2.0245922,3.5980621,1028.9745)"
+       y2="4.671875"
+       x2="2.03125"
+       y1="9.1435204"
+       x1="2.03125"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5620"
+       xlink:href="#linearGradient5583-2"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32.000001"
+     inkscape:cx="9.0872213"
+     inkscape:cy="7.1700733"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="25"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3971" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient5618);fill-opacity:1;stroke:url(#linearGradient5620);stroke-width:0.89473408;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       d="m 5.4144832,1038.7811 3.9961264,0 0,3.9228 3.8750314,0 0,4.1756 -4.0566734,0 0,4.1127 -3.8144844,0 0,-4.1127 -3.9961262,0 0,-4.1123 3.935579,0 z"
+       id="path5581"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/blank.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/blank.svg
@@ -1,0 +1,4466 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="blank.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5591">
+      <stop
+         style="stop-color:#e0e566;stop-opacity:1;"
+         offset="0"
+         id="stop5593" />
+      <stop
+         style="stop-color:#b0b456;stop-opacity:1;"
+         offset="1"
+         id="stop5595" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5583">
+      <stop
+         style="stop-color:#426e4a;stop-opacity:1;"
+         offset="0"
+         id="stop5585" />
+      <stop
+         style="stop-color:#669f71;stop-opacity:1;"
+         offset="1"
+         id="stop5587" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5328">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5330" />
+      <stop
+         style="stop-color:#464646;stop-opacity:1;"
+         offset="1"
+         id="stop5332" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5209">
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="0"
+         id="stop5211" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:1;"
+         offset="1"
+         id="stop5213" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4961">
+      <stop
+         style="stop-color:#df9a39;stop-opacity:1;"
+         offset="0"
+         id="stop4963" />
+      <stop
+         style="stop-color:#b55829;stop-opacity:1;"
+         offset="1"
+         id="stop4965" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4938">
+      <stop
+         style="stop-color:#8bc7d7;stop-opacity:1;"
+         offset="0"
+         id="stop4940" />
+      <stop
+         style="stop-color:#17477c;stop-opacity:1;"
+         offset="1"
+         id="stop4942" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4928">
+      <stop
+         style="stop-color:#4dac81;stop-opacity:1;"
+         offset="0"
+         id="stop4930" />
+      <stop
+         style="stop-color:#058048;stop-opacity:1;"
+         offset="1"
+         id="stop4932" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4918">
+      <stop
+         style="stop-color:#d48a4b;stop-opacity:1;"
+         offset="0"
+         id="stop4920" />
+      <stop
+         style="stop-color:#b1623a;stop-opacity:1;"
+         offset="1"
+         id="stop4922" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4907">
+      <stop
+         style="stop-color:#b86c44;stop-opacity:1;"
+         offset="0"
+         id="stop4909" />
+      <stop
+         style="stop-color:#8f4017;stop-opacity:1;"
+         offset="1"
+         id="stop4911" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4789">
+      <stop
+         style="stop-color:#4e8fbd;stop-opacity:1;"
+         offset="0"
+         id="stop4791" />
+      <stop
+         style="stop-color:#30495a;stop-opacity:1;"
+         offset="1"
+         id="stop4793" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4781">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4783" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4785" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4773">
+      <stop
+         style="stop-color:#8e4694;stop-opacity:1;"
+         offset="0"
+         id="stop4775" />
+      <stop
+         style="stop-color:#bc7bc1;stop-opacity:1;"
+         offset="1"
+         id="stop4777" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4763">
+      <stop
+         style="stop-color:#77a29d;stop-opacity:1;"
+         offset="0"
+         id="stop4765" />
+      <stop
+         style="stop-color:#1b867b;stop-opacity:1;"
+         offset="1"
+         id="stop4767" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13858" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13860" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13850">
+      <stop
+         id="stop13852"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13854"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13834">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13836" />
+      <stop
+         style="stop-color:#807e66;stop-opacity:0;"
+         offset="1"
+         id="stop13838" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799">
+      <stop
+         style="stop-color:#b9772f;stop-opacity:1"
+         offset="0"
+         id="stop13801" />
+      <stop
+         id="stop13809"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop13807"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop13811" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop13803" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090" />
+      <stop
+         id="stop12096"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001" />
+      <stop
+         id="stop12007"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971" />
+      <stop
+         id="stop11979"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689" />
+      <stop
+         id="stop11695"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150" />
+      <stop
+         id="stop11152"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11128">
+      <stop
+         style="stop-color:#e4d09d;stop-opacity:1"
+         offset="0"
+         id="stop11130" />
+      <stop
+         id="stop11136"
+         offset="0.27413794"
+         style="stop-color:#f6ecb2;stop-opacity:1" />
+      <stop
+         style="stop-color:#b58a68;stop-opacity:1"
+         offset="1"
+         id="stop11132" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856">
+      <stop
+         id="stop10858"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860" />
+      <stop
+         id="stop10862"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800" />
+      <stop
+         id="stop10806"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10748">
+      <stop
+         id="stop10750"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754" />
+      <stop
+         id="stop10756"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450" />
+      <stop
+         id="stop10458"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442" />
+      <stop
+         id="stop10521"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10432">
+      <stop
+         id="stop10434"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436" />
+      <stop
+         id="stop10438"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10414">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416" />
+      <stop
+         id="stop10422"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10396">
+      <stop
+         style="stop-color:#1b3e79;stop-opacity:1;"
+         offset="0"
+         id="stop10398" />
+      <stop
+         id="stop10404"
+         offset="0.5"
+         style="stop-color:#728fbf;stop-opacity:1" />
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="1"
+         id="stop10400" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10157">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159" />
+      <stop
+         id="stop10165"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9914"
+       inkscape:collect="always">
+      <stop
+         id="stop9916"
+         offset="0"
+         style="stop-color:#4a6fa4;stop-opacity:1" />
+      <stop
+         id="stop9918"
+         offset="1"
+         style="stop-color:#4e86ca;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9908"
+       inkscape:collect="always">
+      <stop
+         id="stop9910"
+         offset="0"
+         style="stop-color:#525f72;stop-opacity:1" />
+      <stop
+         id="stop9912"
+         offset="1"
+         style="stop-color:#9e884e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9605">
+      <stop
+         style="stop-color:#2a5bbf;stop-opacity:1;"
+         offset="0"
+         id="stop9607" />
+      <stop
+         style="stop-color:#2a5bbf;stop-opacity:0;"
+         offset="1"
+         id="stop9609" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9510">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9512" />
+      <stop
+         id="stop9514"
+         offset="0.35636142"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9516" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334" />
+      <stop
+         id="stop9340"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9324">
+      <stop
+         id="stop9326"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.30000001"
+         id="stop9328" />
+      <stop
+         id="stop9330"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9312">
+      <stop
+         style="stop-color:#cf6c00;stop-opacity:1"
+         offset="0"
+         id="stop9314" />
+      <stop
+         id="stop9322"
+         offset="0.36339331"
+         style="stop-color:#f5db48;stop-opacity:0.24200913" />
+      <stop
+         style="stop-color:#c36000;stop-opacity:1"
+         offset="1"
+         id="stop9316" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9299">
+      <stop
+         style="stop-color:#929baa;stop-opacity:1"
+         offset="0"
+         id="stop9301" />
+      <stop
+         style="stop-color:#cac3a5;stop-opacity:1"
+         offset="1"
+         id="stop9303" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9291">
+      <stop
+         style="stop-color:#e9f8ff;stop-opacity:1;"
+         offset="0"
+         id="stop9293" />
+      <stop
+         style="stop-color:#f5f6f9;stop-opacity:1"
+         offset="1"
+         id="stop9295" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8661"
+       inkscape:collect="always">
+      <stop
+         id="stop8663"
+         offset="0"
+         style="stop-color:#c6e7f9;stop-opacity:1" />
+      <stop
+         id="stop8665"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8653">
+      <stop
+         style="stop-color:#676656;stop-opacity:1;"
+         offset="0"
+         id="stop8655" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop8657" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9">
+      <stop
+         id="stop7561-3-3-4-48"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1" />
+      <stop
+         id="stop7565-8-8-3-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6" />
+      <stop
+         id="stop7114-9-0-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4320">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4322" />
+      <stop
+         id="stop4324"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4326" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4329">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4331" />
+      <stop
+         id="stop4333"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4335" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8">
+      <stop
+         id="stop7561-3-3-4-48-7"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7" />
+      <stop
+         id="stop7565-8-8-3-2-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7" />
+      <stop
+         id="stop7114-9-0-1-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3256">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3258" />
+      <stop
+         id="stop3260"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3262" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3265">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3267" />
+      <stop
+         id="stop3269"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3271" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-2">
+      <stop
+         id="stop7561-3-3-4-48-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-76" />
+      <stop
+         id="stop7565-8-8-3-2-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-22">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-8" />
+      <stop
+         id="stop7114-9-0-1-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3506">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3508" />
+      <stop
+         id="stop3510"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3512" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3515">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3517" />
+      <stop
+         id="stop3519"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3521" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1">
+      <stop
+         id="stop7561-3-3-4-48-7-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3" />
+      <stop
+         id="stop7565-8-8-3-2-0-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9" />
+      <stop
+         id="stop7114-9-0-1-4-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4133">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4135" />
+      <stop
+         id="stop4137"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4139" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4142">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4144" />
+      <stop
+         id="stop4146"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4148" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1" />
+      <stop
+         id="stop7114-9-0-1-4-6-2"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4356" />
+      <stop
+         id="stop4358"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4360" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4365" />
+      <stop
+         id="stop4367"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4369" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-5">
+      <stop
+         id="stop7561-3-3-4-48-7-4-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-0" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-3"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4354-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4356-1" />
+      <stop
+         id="stop4358-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4360-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4363-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop4365-6" />
+      <stop
+         id="stop4367-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4369-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-5">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-7" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-7"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-0" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5692" />
+      <stop
+         id="stop5694"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5696" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5701" />
+      <stop
+         id="stop5703"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5705" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-9">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-2"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-0" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-5"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-2" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-16"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5690-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5692-0" />
+      <stop
+         id="stop5694-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5696-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5699-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop5701-6" />
+      <stop
+         id="stop5703-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5705-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-2" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-8" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-4"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6127" />
+      <stop
+         id="stop6129"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6131" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6136" />
+      <stop
+         id="stop6138"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6140" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6125-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6127-4" />
+      <stop
+         id="stop6129-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6131-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6134-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6136-6" />
+      <stop
+         id="stop6138-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6140-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-92">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-4"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-6" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-55"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-72">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-5" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-6"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6293">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6295" />
+      <stop
+         id="stop6297"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6299" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6302">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6304" />
+      <stop
+         id="stop6306"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6308" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6321">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6323" />
+      <stop
+         id="stop6325"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6327" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6330">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6332" />
+      <stop
+         id="stop6334"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6336" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-6-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-3-3"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-2-2" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-3-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-7-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-8-5" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-4-5"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-0-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6349">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6351" />
+      <stop
+         id="stop6353"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6355" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6358">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6360" />
+      <stop
+         id="stop6362"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6364" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8-0"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4-7" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8-6"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9-4" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0-7"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6940">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6942" />
+      <stop
+         id="stop6944"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6946" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6949">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop6951" />
+      <stop
+         id="stop6953"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop6955" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7559-9-3-0-9-8-1-4-62-9-6-1">
+      <stop
+         id="stop7561-3-3-4-48-7-4-3-5-8-0-8"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0.5"
+         id="stop7563-1-3-0-1-7-3-4-1-4-7-3" />
+      <stop
+         id="stop7565-8-8-3-2-0-3-0-1-8-6-8"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49599999;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7102-3-8-5-2-2-1-0-5-3-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7104-0-1-6-7-9-1-4-9-4-8" />
+      <stop
+         id="stop7114-9-0-1-4-6-2-3-0-7-1"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7106-25-7-1-2-9-0-8-4-1-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7106">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7108" />
+      <stop
+         id="stop7110"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7112" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7115">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop7117" />
+      <stop
+         id="stop7119"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7121" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7686-9"
+       id="linearGradient7692-4"
+       x1="1303.0625"
+       y1="610.34235"
+       x2="1303.0625"
+       y2="723.85583"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7686-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7688-7" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7690-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-140)"
+       y2="723.85583"
+       x2="1303.0625"
+       y1="610.34235"
+       x1="1303.0625"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7755-5"
+       xlink:href="#linearGradient7686-9-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7686-9-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7688-7-1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7690-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2"
+       id="linearGradient8159-0"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-9"
+       id="linearGradient8143-2"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-9">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-4" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,2.6171875e-6)"
+       y2="272.22238"
+       x2="658.34216"
+       y1="272.22238"
+       x1="616.34216"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8180-3"
+       xlink:href="#linearGradient8153-2-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-8">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-7" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,2.6171875e-6)"
+       y2="283.2832"
+       x2="657.71722"
+       y1="283.2832"
+       x1="617.06256"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8182"
+       xlink:href="#linearGradient8137-9-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-9-5">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-4-2" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-6"
+       id="linearGradient8291-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-6">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-6" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-1">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-4" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-4">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-78" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-93">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-9" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8498"
+       id="linearGradient8504"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8498">
+      <stop
+         style="stop-color:#d9f4ff;stop-opacity:1"
+         offset="0"
+         id="stop8500" />
+      <stop
+         style="stop-color:#f9fcff;stop-opacity:1"
+         offset="1"
+         id="stop8502" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8659"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8661"
+       id="linearGradient8681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137"
+       id="linearGradient8683"
+       gradientUnits="userSpaceOnUse"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2"
+       id="linearGradient8685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337"
+       id="linearGradient8687"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8689"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8691"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8693"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8695"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653"
+       id="linearGradient8697"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-93"
+       id="linearGradient8699"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-4"
+       id="linearGradient8701"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-1"
+       id="linearGradient8703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375262)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291"
+       id="linearGradient9297"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299"
+       id="linearGradient9305"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332-9"
+       id="linearGradient9338-8"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient9332-9">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334-5" />
+      <stop
+         id="stop9340-2"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9324-7"
+       id="linearGradient9318"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient9324-7">
+      <stop
+         id="stop9326-0"
+         offset="0"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e2ca69;stop-opacity:1"
+         offset="0.30000001"
+         id="stop9328-1" />
+      <stop
+         id="stop9330-5"
+         offset="1"
+         style="stop-color:#c07c32;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291-8"
+       id="linearGradient9297-1"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9291-8">
+      <stop
+         style="stop-color:#e9f8ff;stop-opacity:1;"
+         offset="0"
+         id="stop9293-7" />
+      <stop
+         style="stop-color:#f5f6f9;stop-opacity:1"
+         offset="1"
+         id="stop9295-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299-1"
+       id="linearGradient9305-8"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient9299-1">
+      <stop
+         style="stop-color:#929baa;stop-opacity:1"
+         offset="0"
+         id="stop9301-6" />
+      <stop
+         style="stop-color:#cac3a5;stop-opacity:1"
+         offset="1"
+         id="stop9303-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9332-6">
+      <stop
+         style="stop-color:#f5b517;stop-opacity:1"
+         offset="0"
+         id="stop9334-52" />
+      <stop
+         id="stop9340-23"
+         offset="0.33703175"
+         style="stop-color:#fcf79e;stop-opacity:1" />
+      <stop
+         style="stop-color:#f5ae19;stop-opacity:1"
+         offset="1"
+         id="stop9336-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9312-9">
+      <stop
+         style="stop-color:#cf6c00;stop-opacity:1"
+         offset="0"
+         id="stop9314-5" />
+      <stop
+         id="stop9322-0"
+         offset="0.36339331"
+         style="stop-color:#f5db48;stop-opacity:0.24200913" />
+      <stop
+         style="stop-color:#c36000;stop-opacity:1"
+         offset="1"
+         id="stop9316-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       y2="472.63525"
+       x2="556.25635"
+       y1="472.63525"
+       x1="526.85181"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9415-5"
+       xlink:href="#linearGradient9510-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9510-3">
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="0"
+         id="stop9512-4" />
+      <stop
+         id="stop9514-9"
+         offset="0.35636142"
+         style="stop-color:#e2ca69;stop-opacity:1" />
+      <stop
+         style="stop-color:#c07c32;stop-opacity:1;"
+         offset="1"
+         id="stop9516-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8661-5"
+       inkscape:collect="always">
+      <stop
+         id="stop8663-3"
+         offset="0"
+         style="stop-color:#c6e7f9;stop-opacity:1" />
+      <stop
+         id="stop8665-5"
+         offset="1"
+         style="stop-color:#f9fcff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8137-6">
+      <stop
+         style="stop-color:#326097;stop-opacity:1"
+         offset="0"
+         id="stop8139-1" />
+      <stop
+         style="stop-color:#2e73c5;stop-opacity:1"
+         offset="1"
+         id="stop8141-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-0">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-9" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-2">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-7" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-2"
+       id="linearGradient8697-5"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8653-2">
+      <stop
+         style="stop-color:#676656;stop-opacity:1;"
+         offset="0"
+         id="stop8655-9" />
+      <stop
+         style="stop-color:#9e884e;stop-opacity:1"
+         offset="1"
+         id="stop8657-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8153-2-4-4">
+      <stop
+         style="stop-color:#75b1e3;stop-opacity:1;"
+         offset="0"
+         id="stop8155-7-78-0" />
+      <stop
+         style="stop-color:#c1def7;stop-opacity:1"
+         offset="1"
+         id="stop8157-7-0-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-1-3"
+       id="linearGradient8703-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.34375262)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8337-1-3">
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:1;"
+         offset="0"
+         id="stop8339-4-2" />
+      <stop
+         style="stop-color:#4e86ca;stop-opacity:0;"
+         offset="1"
+         id="stop8341-2-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9605"
+       id="linearGradient9962"
+       gradientUnits="userSpaceOnUse"
+       x1="213.82529"
+       y1="441.62799"
+       x2="227.09628"
+       y2="454.31174" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332-6"
+       id="linearGradient9964"
+       gradientUnits="userSpaceOnUse"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9312-9"
+       id="linearGradient9966"
+       gradientUnits="userSpaceOnUse"
+       x1="526.4375"
+       y1="448.46484"
+       x2="556.9375"
+       y2="448.46484" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9510-3"
+       id="linearGradient9968"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8661-5"
+       id="linearGradient9970"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       x1="636.99469"
+       y1="277.45544"
+       x2="636.99469"
+       y2="308.57455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8137-6"
+       id="linearGradient9972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0)"
+       x1="617.06256"
+       y1="283.2832"
+       x2="657.71722"
+       y2="283.2832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-0"
+       id="linearGradient9974"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,3e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8337-2"
+       id="linearGradient9976"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0.34375)"
+       x1="636.09375"
+       y1="275.53125"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9908"
+       id="linearGradient9978"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="306.07397"
+       x2="641.07611"
+       y2="281.43512" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8653-2"
+       id="linearGradient9980"
+       gradientUnits="userSpaceOnUse"
+       x1="641.07611"
+       y1="308.68875"
+       x2="641.07611"
+       y2="276.3064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8153-2-4-4"
+       id="linearGradient9982"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,2.6171875e-6)"
+       x1="616.34216"
+       y1="272.22238"
+       x2="658.34216"
+       y2="272.22238" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9914"
+       id="linearGradient9984"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.506824,0.34375262)"
+       x1="636.09375"
+       y1="279.41037"
+       x2="636.09375"
+       y2="269.33588" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9332"
+       id="linearGradient9997"
+       gradientUnits="userSpaceOnUse"
+       x1="528.36798"
+       y1="460.34375"
+       x2="555.01776"
+       y2="460.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9312"
+       id="linearGradient9999"
+       gradientUnits="userSpaceOnUse"
+       x1="526.4375"
+       y1="448.46484"
+       x2="556.9375"
+       y2="448.46484" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9510"
+       id="linearGradient10001"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.5942995e-8,2.6171875e-6)"
+       x1="526.85181"
+       y1="472.63525"
+       x2="556.25635"
+       y2="472.63525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9291-8"
+       id="linearGradient10003"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       x1="548.41693"
+       y1="488.59351"
+       x2="548.41693"
+       y2="463.98975" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9299-1"
+       id="linearGradient10005"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-7.3828125e-6)"
+       x1="567.47571"
+       y1="489.69833"
+       x2="567.47571"
+       y2="463.04114" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-5"
+       id="linearGradient10163-8"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10157-5">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-7" />
+      <stop
+         id="stop10165-2"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-3"
+       id="linearGradient10155-1"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-3">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-0" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-6"
+       id="linearGradient10155-5"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-6">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-5" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2"
+       id="linearGradient10163-2"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10157-2">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8" />
+      <stop
+         id="stop10165-3"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39"
+       id="linearGradient10155-7"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10149-6-5">
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="0"
+         id="stop10151-5-7" />
+      <stop
+         id="stop10394"
+         offset="0.5"
+         style="stop-color:#b9c7df;stop-opacity:1" />
+      <stop
+         style="stop-color:#567ebc;stop-opacity:1"
+         offset="1"
+         id="stop10153-8-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-4"
+       id="linearGradient10454-7"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10448-4">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-4" />
+      <stop
+         id="stop10458-7"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-9"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-1" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-2"
+       id="linearGradient10446-9"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10440-2">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-4" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9"
+       id="linearGradient10454-9"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10448-9">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3" />
+      <stop
+         id="stop10458-8"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1"
+       id="linearGradient10446-7"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10440-1">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43" />
+      <stop
+         id="stop10521-1"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10546-3"
+       xlink:href="#linearGradient10448-9-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-7">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5" />
+      <stop
+         id="stop10458-8-0"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4-1"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2-9" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10548-3"
+       xlink:href="#linearGradient10440-1-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-1-0">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-2" />
+      <stop
+         id="stop10521-1-2"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="511.66458"
+       x2="324.1601"
+       y1="535.52948"
+       x1="324.1601"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10546-8"
+       xlink:href="#linearGradient10448-9-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10448-9-6">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-8" />
+      <stop
+         id="stop10458-8-7"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-4-7"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-2-1" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       y2="512.36218"
+       x2="334.375"
+       y1="535.36218"
+       x1="334.375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10548-1"
+       xlink:href="#linearGradient10440-1-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10440-1-3">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-0" />
+      <stop
+         id="stop10521-1-4"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-9-7-0">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6" />
+      <stop
+         id="stop10456-4-1-5"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-0-0">
+      <stop
+         style="stop-color:#ae7603;stop-opacity:1;"
+         offset="0"
+         id="stop10442-43-2-0" />
+      <stop
+         id="stop10521-1-2-5"
+         offset="0.5"
+         style="stop-color:#e8d8a3;stop-opacity:1" />
+      <stop
+         style="stop-color:#bb9221;stop-opacity:1"
+         offset="1"
+         id="stop10444-3-4-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0"
+       id="linearGradient10770"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-0-0"
+       id="linearGradient10772"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.875,2.6171875e-6)"
+       x1="334.375"
+       y1="529.06494"
+       x2="334.375"
+       y2="518.67365" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748"
+       id="linearGradient10774"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440-1-3"
+       id="linearGradient10776"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(7.4375,2.6171875e-6)"
+       x1="334.375"
+       y1="532.30212"
+       x2="334.375"
+       y2="515.73615" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448"
+       id="linearGradient10778"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10440"
+       id="linearGradient10780"
+       gradientUnits="userSpaceOnUse"
+       x1="334.375"
+       y1="535.36218"
+       x2="334.375"
+       y2="512.36218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414"
+       id="linearGradient10782"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432"
+       id="linearGradient10784"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157"
+       id="linearGradient10786"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10396"
+       id="linearGradient10788"
+       gradientUnits="userSpaceOnUse"
+       x1="302.3125"
+       y1="532.98718"
+       x2="302.3125"
+       y2="514.67456" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2"
+       id="linearGradient10790"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39"
+       id="linearGradient10792"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.6171875e-6)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-6-5"
+       id="linearGradient10794"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.88388349,2.6171875e-6)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="511.38498" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-8"
+       id="linearGradient10804-7"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10798-8">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-2" />
+      <stop
+         id="stop10806-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1"
+       id="linearGradient10804-8"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient10798-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5" />
+      <stop
+         id="stop10806-6"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2" />
+      <stop
+         id="stop10806-6-8"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10835-2"
+       xlink:href="#linearGradient10856-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6">
+      <stop
+         id="stop10858-0"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7" />
+      <stop
+         id="stop10862-3"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8"
+       id="radialGradient11144-4"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)" />
+    <linearGradient
+       id="linearGradient11146-8">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7" />
+      <stop
+         id="stop11152-8"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-7"
+       id="radialGradient11144-2"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)" />
+    <linearGradient
+       id="linearGradient11146-7">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9" />
+      <stop
+         id="stop11152-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       r="6.1875"
+       fy="442.57816"
+       fx="387.59717"
+       cy="442.57816"
+       cx="387.59717"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11169-6"
+       xlink:href="#linearGradient11146-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-8-7">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8" />
+      <stop
+         id="stop11152-8-8"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11063-6"
+       xlink:href="#linearGradient10856-6-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-3">
+      <stop
+         id="stop10858-0-7"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9" />
+      <stop
+         id="stop10862-3-3"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1" />
+      <stop
+         id="stop10806-6-8-5"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-4"
+       id="radialGradient11268-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-165.52072)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-4">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4" />
+      <stop
+         id="stop11152-9"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-3"
+       id="radialGradient11270-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-165.52072)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-8-3">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5" />
+      <stop
+         id="stop11152-8-4"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-7-5"
+       id="radialGradient11272-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-219.20821,-154.64572)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-7-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6" />
+      <stop
+         id="stop11152-6-7"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11146-8-7-5"
+       id="radialGradient11274-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5657869,-2.9706834e-6,2.6069523e-6,1.3740716,-208.33321,-154.64572)"
+       cx="387.59717"
+       cy="442.57816"
+       fx="387.59717"
+       fy="442.57816"
+       r="6.1875" />
+    <linearGradient
+       id="linearGradient11146-8-7-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3" />
+      <stop
+         id="stop11152-8-8-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11298-3"
+       xlink:href="#linearGradient10856-6-3-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10856-6-3-0">
+      <stop
+         id="stop10858-0-7-6"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1" />
+      <stop
+         id="stop10862-3-3-8"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10880-5-3-4"
+       xlink:href="#linearGradient10798-1-9-3-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8" />
+      <stop
+         id="stop10806-6-8-5-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390"
+       xlink:href="#linearGradient10798-1-9-3-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11146-4-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-7" />
+      <stop
+         id="stop11152-9-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-4">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-5" />
+      <stop
+         id="stop11152-8-4-9"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-3">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-4" />
+      <stop
+         id="stop11152-6-7-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-6">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-1" />
+      <stop
+         id="stop11152-8-8-6-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-1">
+      <stop
+         id="stop10858-0-7-6-1"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-7" />
+      <stop
+         id="stop10862-3-3-8-4"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-0"
+       xlink:href="#linearGradient10798-1-9-3-7-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2" />
+      <stop
+         id="stop10806-6-8-5-3-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11520-3"
+       xlink:href="#linearGradient10798-1-9-3-7-1-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-6" />
+      <stop
+         id="stop10806-6-8-5-3-2-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11520-8"
+       xlink:href="#linearGradient10798-1-9-3-7-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5" />
+      <stop
+         id="stop10806-6-8-5-3-2-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-2"
+       id="radialGradient11685-7"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-1"
+       id="linearGradient11693-0"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-1">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-9" />
+      <stop
+         id="stop11695-3"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11888-8"
+       id="linearGradient11894-2"
+       x1="342.37973"
+       y1="457.29816"
+       x2="358.60471"
+       y2="444.57022"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11888-8">
+      <stop
+         style="stop-color:#a7c8ec;stop-opacity:1"
+         offset="0"
+         id="stop11890-4" />
+      <stop
+         style="stop-color:#b4def6;stop-opacity:1"
+         offset="1"
+         id="stop11892-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11888-4"
+       id="linearGradient11894-5"
+       x1="342.37973"
+       y1="457.29816"
+       x2="358.60471"
+       y2="444.57022"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11888-4">
+      <stop
+         style="stop-color:#a7c8ec;stop-opacity:1"
+         offset="0"
+         id="stop11890-8" />
+      <stop
+         style="stop-color:#b4def6;stop-opacity:1"
+         offset="1"
+         id="stop11892-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-3" />
+      <stop
+         id="stop11979-8"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-7"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-1" />
+      <stop
+         id="stop12096-1"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-7">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-9" />
+      <stop
+         id="stop12007-1"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-7"
+       id="radialGradient11685-5"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-94" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-9"
+       id="linearGradient11693-2"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-9">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-1" />
+      <stop
+         id="stop11695-2"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-8"
+       id="radialGradient11685-3"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-8"
+       id="linearGradient11693-26"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-8">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-6" />
+      <stop
+         id="stop11695-6"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-2-2">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-3-7" />
+      <stop
+         id="stop11979-8-6"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-7-6"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-6-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-2-1">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-1-8" />
+      <stop
+         id="stop12096-1-8"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-2-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-7-2">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-9-2" />
+      <stop
+         id="stop12007-1-3"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-2-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8" />
+      <stop
+         id="stop10806-6-8-5-3-2-95"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11969-9">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-7" />
+      <stop
+         id="stop11979-0"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-6"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-7" />
+      <stop
+         id="stop12096-6"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-1" />
+      <stop
+         id="stop12007-4"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5-2" />
+      <stop
+         id="stop10806-6-8-5-3-2-3-3"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11679-3"
+       id="radialGradient11685-2"
+       cx="385.7438"
+       cy="465.42303"
+       fx="385.7438"
+       fy="465.42303"
+       r="11.849554"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11679-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.72146118"
+         offset="0"
+         id="stop11681-91" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop11683-02" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11687-2"
+       id="linearGradient11693-3"
+       x1="390.76602"
+       y1="458.54279"
+       x2="390.76602"
+       y2="478.80402"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11687-2">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-3" />
+      <stop
+         id="stop11695-9"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-10" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-9"
+       id="radialGradient12723-3"
+       cx="433.36786"
+       cy="424.34106"
+       fx="433.36786"
+       fy="424.34106"
+       r="12.027534"
+       gradientTransform="matrix(1.1614831,2.1855961e-7,-2.811228e-7,1.4939602,-69.981471,-211.63828)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-9">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-7" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12717-5">
+      <stop
+         style="stop-color:#e4f1d8;stop-opacity:1"
+         offset="0"
+         id="stop12719-6" />
+      <stop
+         style="stop-color:#8ebc7b;stop-opacity:1"
+         offset="1"
+         id="stop12721-9" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12717-5"
+       id="radialGradient12739-4"
+       cx="433.5452"
+       cy="420.74988"
+       fx="433.5452"
+       fy="420.74988"
+       r="12.952347"
+       gradientTransform="matrix(1,0,0,1.2797889,0,-120.61151)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12862-1"
+       id="linearGradient12904-2"
+       x1="420.88995"
+       y1="455.88452"
+       x2="440.35345"
+       y2="417.26108"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient11146-4-0">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-1" />
+      <stop
+         id="stop11152-9-9"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-2" />
+      <stop
+         id="stop11152-8-4-3"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-5">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-8" />
+      <stop
+         id="stop11152-6-7-5"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-9">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-19" />
+      <stop
+         id="stop11152-8-8-6-2"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-5">
+      <stop
+         id="stop10858-0-7-6-9"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-9" />
+      <stop
+         id="stop10862-3-3-8-6"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-9"
+       xlink:href="#linearGradient10798-1-9-3-7-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20" />
+      <stop
+         id="stop10806-6-8-5-3-9"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13197-7"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4" />
+      <stop
+         id="stop10806-6-8-5-3-9-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-4"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13197-3"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6" />
+      <stop
+         id="stop10806-6-8-5-3-9-24"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13333-0-1"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-5">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2-1"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13850-2">
+      <stop
+         id="stop13852-4"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13854-7"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13856-0">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13858-8" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13860-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13799-7">
+      <stop
+         style="stop-color:#b9772f;stop-opacity:1"
+         offset="0"
+         id="stop13801-4" />
+      <stop
+         id="stop13809-4"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop13807-7"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop13811-8" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop13803-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12862-1-8">
+      <stop
+         style="stop-color:#2d493b;stop-opacity:1;"
+         offset="0"
+         id="stop12864-3-6" />
+      <stop
+         style="stop-color:#296c79;stop-opacity:1"
+         offset="1"
+         id="stop12866-4-9" />
+    </linearGradient>
+    <linearGradient
+       y2="417.26108"
+       x2="440.35345"
+       y1="455.88452"
+       x1="420.88995"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13011-8"
+       xlink:href="#linearGradient12862-1-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient11969-9-0">
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1;"
+         offset="0"
+         id="stop11971-7-1" />
+      <stop
+         id="stop11979-0-0"
+         offset="0.29546595"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         id="stop11977-6-1"
+         offset="0.57727957"
+         style="stop-color:#6f93c7;stop-opacity:0;" />
+      <stop
+         style="stop-color:#6f93c7;stop-opacity:1"
+         offset="1"
+         id="stop11973-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12088-7-6">
+      <stop
+         style="stop-color:#84a7d5;stop-opacity:1;"
+         offset="0"
+         id="stop12090-7-9" />
+      <stop
+         id="stop12096-6-2"
+         offset="0.5"
+         style="stop-color:#a9cded;stop-opacity:1" />
+      <stop
+         style="stop-color:#95b8e0;stop-opacity:1"
+         offset="1"
+         id="stop12092-1-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11999-9-8">
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="0"
+         id="stop12001-1-9" />
+      <stop
+         id="stop12007-4-6"
+         offset="0.5"
+         style="stop-color:#f8decd;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8b098;stop-opacity:1"
+         offset="1"
+         id="stop12003-3-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-1-2-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-5-2-6" />
+      <stop
+         id="stop10806-6-8-5-3-2-3-3-7"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-2-2-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11687-2-2">
+      <stop
+         style="stop-color:#bdb692;stop-opacity:1;"
+         offset="0"
+         id="stop11689-3-7" />
+      <stop
+         id="stop11695-9-8"
+         offset="0.5"
+         style="stop-color:#869097;stop-opacity:1" />
+      <stop
+         style="stop-color:#c3cace;stop-opacity:1"
+         offset="1"
+         id="stop11691-10-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-4-4">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-4-72" />
+      <stop
+         id="stop11152-9-0"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-2">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-5-9" />
+      <stop
+         id="stop11152-8-4-35"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-30">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-9-6-9" />
+      <stop
+         id="stop11152-6-7-6"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-7">
+      <stop
+         style="stop-color:#faefba;stop-opacity:1"
+         offset="0"
+         id="stop11150-7-8-3-8" />
+      <stop
+         id="stop11152-8-8-6-3"
+         offset="1"
+         style="stop-color:#9e6542;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10856-6-3-0-0">
+      <stop
+         id="stop10858-0-7-6-0"
+         offset="0"
+         style="stop-color:#7d75ac;stop-opacity:1" />
+      <stop
+         style="stop-color:#574a96;stop-opacity:1"
+         offset="0.5"
+         id="stop10860-7-9-1-0" />
+      <stop
+         id="stop10862-3-3-8-2"
+         offset="1"
+         style="stop-color:#9f99c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11390-1"
+       xlink:href="#linearGradient10798-1-9-3-7-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-7">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-4" />
+      <stop
+         id="stop10806-6-8-5-3-1"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4918-5">
+      <stop
+         style="stop-color:#d48a4b;stop-opacity:1;"
+         offset="0"
+         id="stop4920-9" />
+      <stop
+         style="stop-color:#b1623a;stop-opacity:1;"
+         offset="1"
+         id="stop4922-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4907-9">
+      <stop
+         style="stop-color:#b86c44;stop-opacity:1;"
+         offset="0"
+         id="stop4909-5" />
+      <stop
+         style="stop-color:#8f4017;stop-opacity:1;"
+         offset="1"
+         id="stop4911-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4928-4">
+      <stop
+         style="stop-color:#4dac81;stop-opacity:1;"
+         offset="0"
+         id="stop4930-9" />
+      <stop
+         style="stop-color:#058048;stop-opacity:1;"
+         offset="1"
+         id="stop4932-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4938-8">
+      <stop
+         style="stop-color:#8bc7d7;stop-opacity:1;"
+         offset="0"
+         id="stop4940-4" />
+      <stop
+         style="stop-color:#17477c;stop-opacity:1;"
+         offset="1"
+         id="stop4942-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4961-6"
+       id="linearGradient4983-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4.625,0)"
+       x1="15.073242"
+       y1="1040.0764"
+       x2="18.744612"
+       y2="1049.2014" />
+    <linearGradient
+       id="linearGradient4961-6">
+      <stop
+         style="stop-color:#df9a39;stop-opacity:1;"
+         offset="0"
+         id="stop4963-0" />
+      <stop
+         style="stop-color:#b55829;stop-opacity:1;"
+         offset="1"
+         id="stop4965-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5328-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5330-9" />
+      <stop
+         style="stop-color:#464646;stop-opacity:1;"
+         offset="1"
+         id="stop5332-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5209-0">
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="0"
+         id="stop5211-9" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:1;"
+         offset="1"
+         id="stop5213-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5397">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5399" />
+      <stop
+         style="stop-color:#464646;stop-opacity:1;"
+         offset="1"
+         id="stop5401" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5404">
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="0"
+         id="stop5406" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:1;"
+         offset="1"
+         id="stop5408" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5411">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5413" />
+      <stop
+         style="stop-color:#464646;stop-opacity:1;"
+         offset="1"
+         id="stop5415" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5418">
+      <stop
+         style="stop-color:#5c5c5c;stop-opacity:1;"
+         offset="0"
+         id="stop5420" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:1;"
+         offset="1"
+         id="stop5422" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5583"
+       id="linearGradient5589"
+       x1="2.03125"
+       y1="9.1435204"
+       x2="2.03125"
+       y2="4.671875"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5591"
+       id="linearGradient5597"
+       x1="2.03125"
+       y1="7.8880248"
+       x2="2.03125"
+       y2="9.1435204"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5591-4"
+       id="linearGradient5597-1"
+       x1="2.03125"
+       y1="7.8880248"
+       x2="2.03125"
+       y2="9.1435204"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5591-4">
+      <stop
+         style="stop-color:#e0e566;stop-opacity:1;"
+         offset="0"
+         id="stop5593-0" />
+      <stop
+         style="stop-color:#82c448;stop-opacity:1;"
+         offset="1"
+         id="stop5595-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5583-2"
+       id="linearGradient5589-8"
+       x1="2.03125"
+       y1="9.1435204"
+       x2="2.03125"
+       y2="4.671875"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5583-2">
+      <stop
+         style="stop-color:#426e4a;stop-opacity:1;"
+         offset="0"
+         id="stop5585-3" />
+      <stop
+         style="stop-color:#669f71;stop-opacity:1;"
+         offset="1"
+         id="stop5587-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.9375158,0,0,2.0245922,3.5980621,1028.9745)"
+       y2="9.1435204"
+       x2="2.03125"
+       y1="6.9396911"
+       x1="2.03125"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5618"
+       xlink:href="#linearGradient5591-4"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.9375158,0,0,2.0245922,3.5980621,1028.9745)"
+       y2="4.671875"
+       x2="2.03125"
+       y1="9.1435204"
+       x1="2.03125"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5620"
+       xlink:href="#linearGradient5583-2"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32.000001"
+     inkscape:cx="9.0872213"
+     inkscape:cy="7.1700733"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="677"
+     inkscape:window-y="178"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3971" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)" />
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/change_obj.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/change_obj.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="change_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4817-9"
+       id="linearGradient4002-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(5.1921478,1050.4872)"
+       x1="11.436646"
+       y1="9.6309509"
+       x2="14.526019"
+       y2="15.130951" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4817-9">
+      <stop
+         style="stop-color:#7695b8;stop-opacity:1"
+         offset="0"
+         id="stop4819-5" />
+      <stop
+         style="stop-color:#8daac8;stop-opacity:1"
+         offset="1"
+         id="stop4821-6" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="8.5921205"
+     inkscape:cy="7.7872055"
+     inkscape:document-units="px"
+     inkscape:current-layer="g3997"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="441"
+     inkscape:window-y="664"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g3997"
+       transform="matrix(1.5278295,0,0,1.5278295,-16.980814,-578.75806)">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4005"
+         d="m 13.191294,1066.0121 3.491339,-7.0379 3.535534,7.0379 -2.010835,0 -2.496971,-5.0271"
+         style="fill:url(#linearGradient4002-1);fill-opacity:1;stroke:#095799;stroke-width:0.65452331;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <rect
+         y="1065.5039"
+         x="12.417285"
+         height="0.99438477"
+         width="4.5827146"
+         id="rect4009"
+         style="fill:#095799;fill-opacity:1;stroke:none" />
+      <rect
+         y="1065.5039"
+         x="16.243729"
+         height="0.99438477"
+         width="4.5872188"
+         id="rect4009-1"
+         style="fill:#095799;fill-opacity:1;stroke:none;display:inline" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/delete_obj.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/delete_obj.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="delete_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4852">
+      <stop
+         style="stop-color:#df2c33;stop-opacity:1"
+         offset="0"
+         id="stop4854" />
+      <stop
+         style="stop-color:#f5817d;stop-opacity:1"
+         offset="1"
+         id="stop4856" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4844">
+      <stop
+         style="stop-color:#c51325;stop-opacity:1;"
+         offset="0"
+         id="stop4846" />
+      <stop
+         style="stop-color:#ca5d49;stop-opacity:1"
+         offset="1"
+         id="stop4848" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4844"
+       id="linearGradient4850"
+       x1="8.6566515"
+       y1="1050.7386"
+       x2="8.6566515"
+       y2="1037.7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.962068e-6,-2.1458883e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4852"
+       id="linearGradient4858"
+       x1="4.7528968"
+       y1="1051.0466"
+       x2="4.7528968"
+       y2="1038.5814"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.962068e-6,-2.1458883e-5)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9999996"
+     inkscape:cx="-16.40091"
+     inkscape:cy="-0.10638011"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="150"
+     inkscape:window-y="150"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4858);fill-opacity:1;stroke:url(#linearGradient4850);stroke-width:0.98060334;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 13.419292,1038.6553 c -0.468185,-0.4682 -1.221974,-0.4682 -1.690135,-10e-5 l -3.1127968,3.1129 -3.1127723,-3.1128 c -0.4681138,-0.4682 -1.221974,-0.4682 -1.690134,0 l -0.8600555,0.8601 c -0.4681391,0.468 -0.4681272,1.2218 3.66e-5,1.6901 l 3.1127223,3.1128 -3.1127269,3.1127 c -0.4682099,0.4682 -0.468198,1.222 -1.34e-5,1.6902 l 0.8601016,0.8601 c 0.4681344,0.4681 1.2219244,0.4681 1.6901337,0 l 3.1127774,-3.1128 3.1344053,3.1344 c 0.468135,0.4682 1.221925,0.4682 1.690135,0 l 0.860055,-0.86 c 0.46816,-0.4682 0.463458,-1.2173 -3.7e-5,-1.6902 l -3.134406,-3.1344 3.112777,-3.1127 c 0.468181,-0.4683 0.468169,-1.2221 3.4e-5,-1.6902 z"
+       id="rect4043"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccccssccsccsccss" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/elements_obj.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/elements_obj.svg
@@ -1,0 +1,315 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="elements_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient28634"
+       osb:paint="gradient">
+      <stop
+         style="stop-color:#c1d9ee;stop-opacity:1;"
+         offset="0"
+         id="stop28636" />
+      <stop
+         id="stop28642"
+         offset="0.5"
+         style="stop-color:#6eaddd;stop-opacity:1" />
+      <stop
+         style="stop-color:#40689d;stop-opacity:1"
+         offset="1"
+         id="stop28638" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(37.991756,0.976947)"
+       gradientUnits="userSpaceOnUse"
+       y2="1038.8951"
+       x2="-4.991955"
+       y1="1038.8951"
+       x1="-16.963362"
+       id="linearGradient8293-6"
+       xlink:href="#linearGradient8287-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1050.0707"
+       x2="8.0137892"
+       y1="1042.3622"
+       x1="8.0137892"
+       gradientTransform="translate(17.072947,-0.95605802)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8887-0"
+       xlink:href="#linearGradient4810-5-87"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-13"
+       gradientTransform="translate(35.999999,-7.0301587)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8884-0"
+       xlink:href="#linearGradient4910-4-0-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="translate(35.071922,-0.9989587)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8881-0"
+       xlink:href="#linearGradient4994-4-5-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.8765"
+       x2="8.0137892"
+       y1="1039.876"
+       x1="8.0137892"
+       gradientTransform="translate(17.115591,-0.991558)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8878-5"
+       xlink:href="#linearGradient4082-3-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4810-5-87">
+      <stop
+         style="stop-color:#a79c68;stop-opacity:1"
+         offset="0"
+         id="stop4812-0-1" />
+      <stop
+         style="stop-color:#687692;stop-opacity:1"
+         offset="1"
+         id="stop4814-4-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4910-4-0-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4912-8-5-7"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0" />
+      <stop
+         id="stop4914-8-1-8"
+         offset="1"
+         style="stop-color:#c5dff4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-4-5-3">
+      <stop
+         style="stop-color:#c5dff4;stop-opacity:1"
+         offset="0"
+         id="stop4996-5-9-7" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4998-5-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082-3-1">
+      <stop
+         id="stop4084-8-1"
+         offset="0"
+         style="stop-color:#4476aa;stop-opacity:1" />
+      <stop
+         style="stop-color:#5a9ccc;stop-opacity:1"
+         offset="0.5"
+         id="stop4864-7-00" />
+      <stop
+         id="stop4086-2-0"
+         offset="1"
+         style="stop-color:#4476aa;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8287-6"
+       inkscape:collect="always">
+      <stop
+         id="stop8289-6"
+         offset="0"
+         style="stop-color:#288dcb;stop-opacity:1" />
+      <stop
+         id="stop8291-34"
+         offset="1"
+         style="stop-color:#d3e5f4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient28634"
+       id="linearGradient28640"
+       x1="6.8443742"
+       y1="2.8245051"
+       x2="10.132697"
+       y2="6.1128283"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient28634-6"
+       osb:paint="gradient">
+      <stop
+         style="stop-color:#c1d9ee;stop-opacity:1;"
+         offset="0"
+         id="stop28636-4" />
+      <stop
+         id="stop28642-9"
+         offset="0.5"
+         style="stop-color:#6eaddd;stop-opacity:1" />
+      <stop
+         style="stop-color:#40689d;stop-opacity:1"
+         offset="1"
+         id="stop28638-5" />
+    </linearGradient>
+    <linearGradient
+       y2="6.1128283"
+       x2="10.132697"
+       y1="2.8245051"
+       x1="6.8443742"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient28660"
+       xlink:href="#linearGradient28634-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient28634-6-8"
+       osb:paint="gradient">
+      <stop
+         style="stop-color:#c1d9ee;stop-opacity:1;"
+         offset="0"
+         id="stop28636-4-5" />
+      <stop
+         id="stop28642-9-4"
+         offset="0.5"
+         style="stop-color:#6eaddd;stop-opacity:1" />
+      <stop
+         style="stop-color:#40689d;stop-opacity:1"
+         offset="1"
+         id="stop28638-5-4" />
+    </linearGradient>
+    <linearGradient
+       y2="6.1128283"
+       x2="10.132697"
+       y1="2.8245051"
+       x1="6.8443742"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient28697"
+       xlink:href="#linearGradient28634-6-8"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999999"
+     inkscape:cx="2.3953492"
+     inkscape:cy="12.174401"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-4"
+     showgrid="true"
+     inkscape:window-width="1208"
+     inkscape:window-height="913"
+     inkscape:window-x="168"
+     inkscape:window-y="92"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid8762" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="layer1-4"
+       inkscape:label="Layer 1"
+       transform="translate(-19.001354,-2.0072)">
+      <path
+         style="fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient8887-0);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 20.49694,1038.9049 14.004414,0 0,14.0292 -14.004414,0 z"
+         id="rect3997-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:url(#linearGradient8884-0);fill-opacity:1;stroke:none;display:inline"
+         d="m 22,1042.3622 0,10 -1,0 0,-11 z"
+         id="rect4853-82-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:url(#linearGradient8881-0);fill-opacity:1;stroke:none;display:inline"
+         d="m 22,1042.3622 12,0 0,-1 -13,0 z"
+         id="rect4853-82-0"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:url(#linearGradient8293-6);fill-opacity:1;stroke:url(#linearGradient8878-5);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 20.500887,1038.8694 13.998914,0 0,2.0053 -13.998914,0 z"
+         id="rect3997-9-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <path
+       sodipodi:type="arc"
+       style="fill:url(#linearGradient28640);fill-opacity:1.0;stroke:#2b568d;stroke-width:0.93798536000000021;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path4035-4-5-4"
+       sodipodi:cx="8.531251"
+       sodipodi:cy="4.499999"
+       sodipodi:rx="2.8125002"
+       sodipodi:ry="2.8125002"
+       d="M 11.343751,4.499999 A 2.8125002,2.8125002 0 0 1 8.531251,7.3124993 2.8125002,2.8125002 0 0 1 5.7187507,4.499999 2.8125002,2.8125002 0 0 1 8.531251,1.6874988 a 2.8125002,2.8125002 0 0 1 2.8125,2.8125002 z"
+       transform="matrix(0.60821276,0,0,0.60821276,0.8371643,1044.6443)" />
+    <path
+       sodipodi:type="arc"
+       style="fill:url(#linearGradient28660);fill-opacity:1;stroke:#2b568d;stroke-width:0.93798536;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path4035-4-5-4-6"
+       sodipodi:cx="8.531251"
+       sodipodi:cy="4.499999"
+       sodipodi:rx="2.8125002"
+       sodipodi:ry="2.8125002"
+       d="M 11.343751,4.499999 A 2.8125002,2.8125002 0 0 1 8.531251,7.3124993 2.8125002,2.8125002 0 0 1 5.7187507,4.499999 2.8125002,2.8125002 0 0 1 8.531251,1.6874988 a 2.8125002,2.8125002 0 0 1 2.8125,2.8125002 z"
+       transform="matrix(0.60821276,0,0,0.60821276,6.8371643,1044.6443)" />
+    <path
+       sodipodi:type="arc"
+       style="fill:url(#linearGradient28697);fill-opacity:1;stroke:#2b568d;stroke-width:0.93798536;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path4035-4-5-4-6-6"
+       sodipodi:cx="8.531251"
+       sodipodi:cy="4.499999"
+       sodipodi:rx="2.8125002"
+       sodipodi:ry="2.8125002"
+       d="M 11.343751,4.499999 A 2.8125002,2.8125002 0 0 1 8.531251,7.3124993 2.8125002,2.8125002 0 0 1 5.7187507,4.499999 2.8125002,2.8125002 0 0 1 8.531251,1.6874988 a 2.8125002,2.8125002 0 0 1 2.8125,2.8125002 z"
+       transform="matrix(0.60821276,0,0,0.60821276,3.8094366,1039.6167)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/error_tsk.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/error_tsk.svg
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="error_tsk.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1"
+       id="linearGradient8163-2"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="470.63007"
+       x2="388.63736"
+       y2="465.52719"
+       gradientTransform="matrix(0.55009867,0,0,0.51533101,-196.69116,815.62527)" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1">
+      <stop
+         style="stop-color:#e17673;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8"
+         offset="0.5"
+         style="stop-color:#d04046;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e17673;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="6.8406528"
+     inkscape:cy="1.3839809"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4095"
+     showgrid="true"
+     inkscape:window-width="1168"
+     inkscape:window-height="959"
+     inkscape:window-x="1148"
+     inkscape:window-y="613"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4099" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <ellipse
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path4251"
+         cx="16.705399"
+         cy="1056.8037"
+         rx="6.4965439"
+         ry="6.518641" />
+      <g
+         id="g4181"
+         transform="matrix(1.0023865,0,0,1.0126954,-0.11825605,-13.601798)">
+        <ellipse
+           id="path10796-2-6-0"
+           style="display:inline;fill:url(#linearGradient8163-2);fill-opacity:1;stroke:#c93e35;stroke-width:0.99394739;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           cx="16.815882"
+           cy="1056.9225"
+           rx="4.9682899"
+           ry="4.9240961" />
+        <g
+           transform="matrix(1.1880342,0,0,1.1860465,14.354445,-196.67175)"
+           id="g5025">
+          <g
+             transform="matrix(1.0905016,0,0,1.0905016,0.12760593,-95.828442)"
+             id="g4095">
+            <path
+               sodipodi:nodetypes="ccscccccccccccccccccc"
+               inkscape:connector-curvature="0"
+               id="path5021"
+               transform="matrix(0.77187105,0,0,0.77316463,-4.647127,1051.0563)"
+               d="M 6.2265625,3.6953125 C 5.9177427,3.7062384 5.125,4.3515625 5.125,4.3515625 c 0,0 0.2885111,0.2731764 0.78125,0.6796875 0.4927389,0.4065111 0.9552143,0.9554552 1.0625,1.4375 C 7.068619,6.9173537 7.1051563,7.3329889 7.15625,7.75 L 4.2010947,10.96967 5.0906092,11.868663 7.4375,9.375 c 0.2792655,0.4616799 0.5966442,0.914462 0.8125,1.28125 0.2533102,0.354 0.6860498,0.734189 1.40625,1.09375 1.285897,0.641907 1.105068,0.565316 1.105068,0.565316 l 0.965609,-0.791649 c 0,0 -0.202967,-0.247189 -1.508177,-0.898667 C 9.6433969,10.337868 9.4953002,10.118107 9.34375,9.90625 8.8239337,9.3154094 8.6327445,8.816423 8.5,8.1875 L 11.629711,4.6423859 10.681163,3.8870243 8.28125,6.5 C 8.263796,6.4030643 8.2724218,6.3194727 8.25,6.21875 8.0333974,5.2456067 7.3191341,4.5264873 6.71875,4.03125 6.4464909,3.8171333 6.4806949,3.8796991 6.2265625,3.6953125 Z"
+               style="fill:#ffffff;fill-opacity:1" />
+          </g>
+        </g>
+        <ellipse
+           id="path10796-2-6-0-3"
+           style="display:inline;fill:none;fill-opacity:1;stroke:#c93e35;stroke-width:0.99394739;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           cx="16.815882"
+           cy="1056.9225"
+           rx="4.9682899"
+           ry="4.9240961" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/file_obj.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/file_obj.svg
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="file_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5135-7"
+       id="linearGradient4873-1"
+       x1="7.0070496"
+       y1="1051.8571"
+       x2="12.016466"
+       y2="1051.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       id="linearGradient5135-7"
+       inkscape:collect="always">
+      <stop
+         id="stop5137-4"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5139-0"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5141-4"
+       id="linearGradient4875-9"
+       x1="7.0070496"
+       y1="1049.8571"
+       x2="14"
+       y2="1049.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       id="linearGradient5141-4"
+       inkscape:collect="always">
+      <stop
+         id="stop5143-8"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5145-8"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5147-4"
+       id="linearGradient4871-2"
+       x1="7.0070496"
+       y1="1047.8571"
+       x2="14"
+       y2="1047.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       id="linearGradient5147-4"
+       inkscape:collect="always">
+      <stop
+         id="stop5149-5"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5151-5"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861-1"
+       id="linearGradient4869-17"
+       x1="7.0070496"
+       y1="1045.8571"
+       x2="14"
+       y2="1045.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861-1">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4863-1" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop4865-52" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877-6"
+       id="linearGradient4867-7"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       id="linearGradient4877-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4879-1"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4881-4"
+         offset="1"
+         style="stop-color:#5e76a3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient4908-2"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-1.044194)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902-3">
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1"
+         offset="0"
+         id="stop4904-2" />
+      <stop
+         style="stop-color:#8392b0;stop-opacity:1"
+         offset="1"
+         id="stop4906-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894-6"
+       id="linearGradient4900-1"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.022097,-1.044194)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4894-6">
+      <stop
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0"
+         id="stop4896-8" />
+      <stop
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1"
+         id="stop4898-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-6">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996-1" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998-89" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101"
+       xlink:href="#linearGradient4994-6"
+       inkscape:collect="always"
+       gradientTransform="translate(-1.977903,-1.044194)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313709"
+     inkscape:cx="39.563403"
+     inkscape:cy="1.2514114"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1440"
+     inkscape:window-height="900"
+     inkscape:window-x="81"
+     inkscape:window-y="29"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4101);fill-opacity:1;stroke:none;display:inline"
+       d="m 3.5193795,1037.8597 7.0096695,0 3.062057,3.0066 0,9.9546 -10.0717265,0 z"
+       id="rect4001-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:url(#linearGradient4900-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 9.998718,1037.397 0,3.9112 3.977478,0 z"
+       id="path4884"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:url(#linearGradient4908-2);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+       d="m 3.5193795,1037.8597 7.0096695,0 3.062057,3.0066 0,9.9546 -10.0717265,0 z"
+       id="rect4001"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <rect
+       style="fill:url(#linearGradient4867-7);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1"
+       width="3.9929504"
+       height="1.0103934"
+       x="5.0291462"
+       y="1040.3074" />
+    <rect
+       style="fill:url(#linearGradient4869-17);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7"
+       width="6.9929504"
+       height="1.0103934"
+       x="5.0291462"
+       y="1042.3074" />
+    <rect
+       style="fill:url(#linearGradient4871-2);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4"
+       width="6.9929504"
+       height="1.0103934"
+       x="5.0291462"
+       y="1044.3074" />
+    <rect
+       style="fill:url(#linearGradient4875-9);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4-0"
+       width="6.9929504"
+       height="1.0103934"
+       x="5.0291462"
+       y="1046.3074" />
+    <rect
+       style="fill:url(#linearGradient4873-1);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4-0-9"
+       width="5.0094166"
+       height="1.0103934"
+       x="5.0291462"
+       y="1048.3074" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/fldr_obj.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/fldr_obj.svg
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="fldr_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3973"
+       inkscape:collect="always">
+      <stop
+         id="stop3975"
+         offset="0"
+         style="stop-color:#f8d078;stop-opacity:1" />
+      <stop
+         id="stop3977"
+         offset="1"
+         style="stop-color:#f8f0c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3967"
+       inkscape:collect="always">
+      <stop
+         id="stop3969"
+         offset="0"
+         style="stop-color:#c48a4e;stop-opacity:1;" />
+      <stop
+         id="stop3971"
+         offset="1"
+         style="stop-color:#ad6c24;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955">
+      <stop
+         id="stop3957"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.10921973"
+         id="stop3959" />
+      <stop
+         style="stop-color:#fdf7eb;stop-opacity:1"
+         offset="0.27304932"
+         id="stop3961" />
+      <stop
+         id="stop3963"
+         offset="0.5638296"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3949">
+      <stop
+         style="stop-color:#9e6627;stop-opacity:1"
+         offset="0"
+         id="stop3951" />
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="1"
+         id="stop3953" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-61.366562,1.4453859)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955"
+       id="linearGradient3945"
+       gradientUnits="userSpaceOnUse"
+       x1="523.00781"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294"
+       gradientTransform="translate(-60.558598,1.4188)" />
+    <linearGradient
+       id="linearGradient3973-7"
+       inkscape:collect="always">
+      <stop
+         id="stop3975-4"
+         offset="0"
+         style="stop-color:#f8d078;stop-opacity:1" />
+      <stop
+         id="stop3977-0"
+         offset="1"
+         style="stop-color:#f8f0c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="381.57214"
+       x2="538.83301"
+       y1="397.56107"
+       x1="537.94318"
+       gradientTransform="matrix(1,0,0,1.4165687,344.32442,-1.0061522e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4776"
+       xlink:href="#linearGradient3973-7"
+       inkscape:collect="always" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter4929"
+       x="-0.13757156"
+       width="1.2751431"
+       y="-0.37744917"
+       height="1.7548983">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="3.5620748"
+         id="feGaussianBlur4931" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973"
+       id="linearGradient4933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-60.558598,0)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949"
+       id="linearGradient4935"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-60.558598,0)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="5.9167846"
+     inkscape:cy="3.9382328"
+     inkscape:document-units="px"
+     inkscape:current-layer="g13813"
+     showgrid="true"
+     inkscape:window-width="1598"
+     inkscape:window-height="1221"
+     inkscape:window-x="805"
+     inkscape:window-y="137"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3947" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-129.51159,939.94639)"
+       style="display:inline"
+       id="g13862">
+      <g
+         transform="matrix(1.1835826,0,0,1.1835826,-75.612218,-78.069702)"
+         id="g13813">
+        <rect
+           style="fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient3939);stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+           id="rect13693-3"
+           width="15"
+           height="16.625"
+           x="463.74335"
+           y="368.49503"
+           rx="2.625"
+           ry="2.625" />
+        <path
+           style="fill:url(#linearGradient4933);fill-opacity:1;stroke:url(#linearGradient4935);stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 463.24874,374.64819 28.07551,0 c 1.45425,0 2.625,-0.30124 2.625,1.15301 l 0,12.76575 c 0,1.45425 -1.22088,2.24642 -2.625,2.625 l -28.07551,7.56983 c -1.40411,0.37858 -2.625,-1.17075 -2.625,-2.625 l 0,-21.37109 c 0,0 1.17075,-0.1175 2.625,-0.1175 z"
+           id="rect13693"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ssssssscs" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3945);stroke-width:3.02792978;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 462.26171,374.64819 18.01958,-0.0669"
+           id="path13797"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <g
+           id="g4914"
+           mask="url(#mask4917)">
+          <rect
+             transform="matrix(1,0,-0.70828043,0.70593118,4.9445873e-7,0)"
+             ry="3.7184925"
+             rx="2.625"
+             y="542.8974"
+             x="860.68469"
+             height="22.649353"
+             width="24.877882"
+             id="rect13693-2-2"
+             style="opacity:0.5;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2.38039374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;filter:url(#filter4929)" />
+        </g>
+        <rect
+           style="fill:url(#linearGradient4776);fill-opacity:1;stroke:#9e6627;stroke-width:4.3245993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+           id="rect13693-2"
+           width="30.475229"
+           height="21.377747"
+           x="860.68469"
+           y="543.56671"
+           rx="2.625"
+           ry="3.7184927"
+           transform="matrix(1,0,-0.70828042,0.70593119,0,0)" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/font.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/font.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="font.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999999"
+     inkscape:cx="10.170642"
+     inkscape:cy="4.1953582"
+     inkscape:document-units="px"
+     inkscape:current-layer="text7319"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="1069"
+     inkscape:window-y="696"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path4719"
+       d="m 14.464118,1049.2149 c -0.423701,0 -0.784673,-0.1086 -1.082887,-0.3248 -0.327307,-0.2449 -0.501742,-0.5743 -0.523298,-0.9886 -0.483034,0.8661 -1.115289,1.2992 -1.89675,1.2992 -0.706167,0 -1.268019,-0.2164 -1.685572,-0.6495 -0.417843,-0.4426 -0.637261,-1.0217 -0.658246,-1.7372 -0.02899,-0.9886 0.302696,-1.8784 0.995072,-2.6693 0.692364,-0.7909 1.523441,-1.1863 2.493226,-1.1863 0.932125,0 1.447444,0.3954 1.545972,1.1863 l 0.28047,-1.031 1.610026,0 c -0.239065,0.8381 -0.473417,1.676 -0.703042,2.5139 -0.322726,1.1959 -0.477998,2.0008 -0.465847,2.4151 0.01269,0.4331 0.174396,0.6497 0.485117,0.6497 m -1.655353,-4.4347 c -0.01354,-0.4613 -0.227442,-0.692 -0.641712,-0.692 -0.583757,0 -1.095142,0.5413 -1.534151,1.6241 -0.386941,0.9322 -0.570468,1.7372 -0.550585,2.4151 0.01905,0.6497 0.282794,0.9745 0.791232,0.9745 0.508425,0 0.980339,-0.6026 1.41577,-1.8078 0.365073,-1.0356 0.538211,-1.8737 0.519446,-2.5139"
+       style="font-size:11.05178356px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#236298;fill-opacity:1;stroke:#236298;stroke-width:0.31768805;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:AustralianFlyingCorpsStencil;-inkscape-font-specification:AustralianFlyingCorpsStencil"
+       sodipodi:nodetypes="cccscssscccccccsccscc" />
+    <g
+       transform="scale(0.93822513,1.0658423)"
+       style="font-size:10.25895119px;font-style:normal;font-weight:bold;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#236298;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:DejaVu Serif Bold Italic"
+       id="text7319">
+      <path
+         d="m 0.49347803,984.61603 0.11521283,-0.60612 0.61112894,0 4.1526711,-6.8727 1.1972116,0 1.4827391,6.8727 0.711314,0 -0.1152129,0.60612 -3.5014682,0 0.1152129,-0.60612 0.731351,0 -0.315583,-1.52782 -2.8101912,0 -0.9267119,1.52782 0.8916471,0 -0.1152128,0.60612 -2.22410857,0 m 2.73505237,-2.74006 2.3192844,0 -0.5961011,-2.86029 -1.7231833,2.86029"
+         style="font-style:italic;font-variant:normal;font-stretch:normal;fill:#236298;font-family:DejaVu Serif;-inkscape-font-specification:DejaVu Serif Bold Italic"
+         id="path7303" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/generic_element.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/generic_element.svg
@@ -1,0 +1,312 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="generic_element.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient8222">
+      <stop
+         id="stop8224"
+         offset="0"
+         style="stop-color:#6b9ac3;stop-opacity:1" />
+      <stop
+         style="stop-color:#1c65a2;stop-opacity:1"
+         offset="0.47270355"
+         id="stop8226" />
+      <stop
+         id="stop8228"
+         offset="1"
+         style="stop-color:#98b9d5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8169">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop8171" />
+      <stop
+         id="stop8177"
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop8173" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8161">
+      <stop
+         style="stop-color:#6a9ac2;stop-opacity:1;"
+         offset="0"
+         id="stop8163" />
+      <stop
+         style="stop-color:#1c65a2;stop-opacity:1"
+         offset="1"
+         id="stop8165" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11290">
+      <stop
+         style="stop-color:#567ead;stop-opacity:1"
+         offset="0"
+         id="stop11292" />
+      <stop
+         style="stop-color:#35679d;stop-opacity:1"
+         offset="1"
+         id="stop11294" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter11520"
+       x="-0.24"
+       width="1.48"
+       y="-0.24"
+       height="1.48">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.63130821"
+         id="feGaussianBlur11522" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8161"
+       id="linearGradient8167"
+       x1="390.80499"
+       y1="458.06378"
+       x2="390.80499"
+       y2="478.99371"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45742408,0,0,0.46433392,-171.53139,825.09565)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8169"
+       id="linearGradient8175"
+       x1="14.673837"
+       y1="1037.2446"
+       x2="14.555945"
+       y2="1044.6091"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8169"
+       id="linearGradient8189"
+       gradientUnits="userSpaceOnUse"
+       x1="7.2564602"
+       y1="1041.0063"
+       x2="17.787801"
+       y2="1041.0063" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8169"
+       id="linearGradient8191"
+       gradientUnits="userSpaceOnUse"
+       x1="7.2564602"
+       y1="1041.0063"
+       x2="17.787801"
+       y2="1041.0063" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8169"
+       id="linearGradient8193"
+       gradientUnits="userSpaceOnUse"
+       x1="7.2564602"
+       y1="1041.0063"
+       x2="17.787801"
+       y2="1041.0063" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8169"
+       id="linearGradient8195"
+       gradientUnits="userSpaceOnUse"
+       x1="7.2564602"
+       y1="1041.0063"
+       x2="17.787801"
+       y2="1041.0063" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8169"
+       id="linearGradient8197"
+       gradientUnits="userSpaceOnUse"
+       x1="7.2564602"
+       y1="1041.0063"
+       x2="17.787801"
+       y2="1041.0063" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient8230"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient8232"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8222"
+       id="linearGradient8234"
+       gradientUnits="userSpaceOnUse"
+       x1="388.07498"
+       y1="477.56372"
+       x2="387.91077"
+       y2="460.75397" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient8236"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient8238"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.656854"
+     inkscape:cx="-5.8860414"
+     inkscape:cy="1.4162793"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4184"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="846"
+     inkscape:window-y="387"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4184"
+       transform="matrix(0.91261684,0,0,0.90294467,2.5146594,103.03176)"
+       style="stroke-width:1.10160321;stroke-miterlimit:4;stroke-dasharray:none">
+      <g
+         transform="matrix(1.447537,0,0,1.447537,-6.107679,-464.44227)"
+         inkscape:label="Layer 1"
+         id="layer1-71"
+         style="display:inline;stroke:url(#linearGradient8238);stroke-opacity:1;stroke-width:0.76101903;stroke-miterlimit:4;stroke-dasharray:none">
+        <g
+           transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
+           style="display:inline;stroke:url(#linearGradient8232);stroke-opacity:1;stroke-width:2.7273439;stroke-miterlimit:4;stroke-dasharray:none"
+           id="g11331-3-1-1">
+          <g
+             id="g13408-8"
+             style="fill:#737986;fill-opacity:1;stroke:url(#linearGradient8230);stroke-opacity:1;stroke-width:2.7273439;stroke-miterlimit:4;stroke-dasharray:none" />
+        </g>
+        <circle
+           style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient8234);fill-opacity:1;stroke:url(#linearGradient8236);stroke-width:2.56161;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path10796-2-6-2-7"
+           transform="matrix(0.29708622,0,0,0.29708622,-106.92943,901.89947)"
+           cx="388.125"
+           cy="468.23718"
+           r="10.625" />
+      </g>
+      <g
+         transform="matrix(1.1796625,0,0,1.1796625,-10.75332,-185.58326)"
+         inkscape:label="Layer 1"
+         id="layer1-71-3"
+         style="display:inline;opacity:0.25;fill:none;stroke:url(#linearGradient8175);stroke-opacity:1;filter:url(#filter11520);stroke-width:0.93382913;stroke-miterlimit:4;stroke-dasharray:none">
+        <g
+           transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
+           style="display:inline;fill:none;stroke:url(#linearGradient8191);stroke-opacity:1;stroke-width:3.34666161;stroke-miterlimit:4;stroke-dasharray:none"
+           id="g11331-3-1-1-0">
+          <g
+             id="g13408-8-8"
+             style="fill:none;stroke:url(#linearGradient8189);stroke-opacity:1;stroke-width:3.34666161;stroke-miterlimit:4;stroke-dasharray:none" />
+        </g>
+        <g
+           style="fill:none;stroke:url(#linearGradient8197);stroke-opacity:1;stroke-width:1.03900708;stroke-miterlimit:4;stroke-dasharray:none"
+           id="g5050-1"
+           transform="matrix(0.89877071,0,0,0.89877071,20.827721,106.0773)">
+          <g
+             transform="matrix(0.78959805,0,0,0.78959805,-14.954585,196.9502)"
+             id="g6940-5-9"
+             style="display:inline;fill:none;stroke:url(#linearGradient8195);stroke-opacity:1;stroke-width:1.31586835;stroke-miterlimit:4;stroke-dasharray:none">
+            <circle
+               style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:none;stroke:url(#linearGradient8193);stroke-width:3.14329335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               id="path10796-2-6-2-7-2"
+               transform="matrix(0.41862728,0,0,0.41862728,-152.85471,871.97034)"
+               cx="388.125"
+               cy="468.23718"
+               r="10.625" />
+          </g>
+        </g>
+      </g>
+      <ellipse
+         id="path10796-2-6-2-7-1"
+         style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:none;stroke:url(#linearGradient8167);stroke-width:1.18055916;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         cx="6.0063357"
+         cy="1042.5139"
+         rx="4.8601308"
+         ry="4.933548" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/generic_elements.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/generic_elements.svg
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="generic_elements.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4894">
+      <stop
+         id="stop4896"
+         offset="0"
+         style="stop-color:#b4d1e5;stop-opacity:1" />
+      <stop
+         style="stop-color:#5395be;stop-opacity:1"
+         offset="0.5"
+         id="stop4898" />
+      <stop
+         id="stop4900"
+         offset="1"
+         style="stop-color:#91bcd7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="6.8716693"
+       x2="8.7378912"
+       y1="2.1550355"
+       x1="8.7378912"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4871"
+       xlink:href="#linearGradient4894"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4894-7">
+      <stop
+         id="stop4896-4"
+         offset="0"
+         style="stop-color:#b4d1e5;stop-opacity:1" />
+      <stop
+         style="stop-color:#5395be;stop-opacity:1"
+         offset="0.5"
+         id="stop4898-0" />
+      <stop
+         id="stop4900-9"
+         offset="1"
+         style="stop-color:#91bcd7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="6.8716693"
+       x2="8.7378912"
+       y1="2.1550355"
+       x1="8.7378912"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4064"
+       xlink:href="#linearGradient4894-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4894-8">
+      <stop
+         id="stop4896-2"
+         offset="0"
+         style="stop-color:#b4d1e5;stop-opacity:1" />
+      <stop
+         style="stop-color:#5395be;stop-opacity:1"
+         offset="0.5"
+         id="stop4898-4" />
+      <stop
+         id="stop4900-5"
+         offset="1"
+         style="stop-color:#91bcd7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="6.8716693"
+       x2="8.7378912"
+       y1="2.1550355"
+       x1="8.7378912"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4064-5"
+       xlink:href="#linearGradient4894-8"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9999995"
+     inkscape:cx="6.2127369"
+     inkscape:cy="2.2035889"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="88"
+     inkscape:window-y="106"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:type="arc"
+       style="fill:url(#linearGradient4871);fill-opacity:1;stroke:#264e72;stroke-width:0.93798536;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path4035-4-5"
+       sodipodi:cx="8.531251"
+       sodipodi:cy="4.499999"
+       sodipodi:rx="2.8125002"
+       sodipodi:ry="2.8125002"
+       d="m 11.343751,4.499999 c 0,1.553301 -1.259199,2.8125003 -2.8125,2.8125003 -1.553301,0 -2.8125003,-1.2591993 -2.8125003,-2.8125003 0,-1.5533009 1.2591993,-2.8125002 2.8125003,-2.8125002 1.553301,0 2.8125,1.2591993 2.8125,2.8125002 z"
+       transform="matrix(1.0661147,0,0,1.0661147,-4.59529,1043.0648)" />
+    <path
+       sodipodi:type="arc"
+       style="fill:url(#linearGradient4064);fill-opacity:1;stroke:#264e72;stroke-width:0.93798536;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path4035-4-5-4"
+       sodipodi:cx="8.531251"
+       sodipodi:cy="4.499999"
+       sodipodi:rx="2.8125002"
+       sodipodi:ry="2.8125002"
+       d="m 11.343751,4.499999 c 0,1.553301 -1.259199,2.8125003 -2.8125,2.8125003 -1.553301,0 -2.8125003,-1.2591993 -2.8125003,-2.8125003 0,-1.5533009 1.2591993,-2.8125002 2.8125003,-2.8125002 1.553301,0 2.8125,1.2591993 2.8125,2.8125002 z"
+       transform="matrix(1.0661147,0,0,1.0661147,-0.595291,1036.0648)" />
+    <path
+       sodipodi:type="arc"
+       style="fill:url(#linearGradient4064-5);fill-opacity:1;stroke:#264e72;stroke-width:0.93798536;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path4035-4-5-1"
+       sodipodi:cx="8.531251"
+       sodipodi:cy="4.499999"
+       sodipodi:rx="2.8125002"
+       sodipodi:ry="2.8125002"
+       d="m 11.343751,4.499999 c 0,1.553301 -1.259199,2.8125003 -2.8125,2.8125003 -1.553301,0 -2.8125003,-1.2591993 -2.8125003,-2.8125003 0,-1.5533009 1.2591993,-2.8125002 2.8125003,-2.8125002 1.553301,0 2.8125,1.2591993 2.8125,2.8125002 z"
+       transform="matrix(1.0661147,0,0,1.0661147,3.40471,1043.0648)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/info_tsk.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/info_tsk.svg
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="info_tsk.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4172">
+      <stop
+         id="stop4174"
+         offset="0"
+         style="stop-color:#2857bd;stop-opacity:1;" />
+      <stop
+         id="stop4176"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4890">
+      <stop
+         style="stop-color:#2857bd;stop-opacity:1;"
+         offset="0"
+         id="stop4892" />
+      <stop
+         style="stop-color:#3d5384;stop-opacity:1;"
+         offset="1"
+         id="stop4894" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4996-4">
+      <stop
+         style="stop-color:#02468c;stop-opacity:1"
+         offset="0"
+         id="stop4998-5" />
+      <stop
+         style="stop-color:#0e62a4;stop-opacity:1"
+         offset="1"
+         id="stop5000-5" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.7347"
+       x2="13.903196"
+       y1="1062.1353"
+       x1="13.903196"
+       gradientTransform="translate(38.469436,55.035191)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5028"
+       xlink:href="#linearGradient4996-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4890"
+       id="linearGradient4896"
+       x1="14.256123"
+       y1="1056.5471"
+       x2="18.340696"
+       y2="1056.5471"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4890"
+       id="linearGradient4898"
+       gradientUnits="userSpaceOnUse"
+       x1="16.307018"
+       y1="1055.0179"
+       x2="16.307018"
+       y2="1060.6793" />
+    <linearGradient
+       gradientTransform="translate(-1.7374361e-7,-6.62e-6)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4172"
+       id="linearGradient4898-1"
+       gradientUnits="userSpaceOnUse"
+       x1="16.368029"
+       y1="1056.7682"
+       x2="17.425541"
+       y2="1056.7682" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254832"
+     inkscape:cx="9.0523079"
+     inkscape:cy="7.627334"
+     inkscape:document-units="px"
+     inkscape:current-layer="text4140-1-8"
+     showgrid="true"
+     inkscape:window-width="1280"
+     inkscape:window-height="1053"
+     inkscape:window-x="1206"
+     inkscape:window-y="327"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4099" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <g
+         style="font-size:15.07241725999999993px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient4896);fill-opacity:1;stroke:none;display:inline;font-family:Kozuka Mincho Pr6N H;-inkscape-font-specification:Kozuka Mincho Pr6N H Heavy"
+         id="text4140-1-8"
+         transform="matrix(1.0865583,0,0,1,-1.7201207,-0.04419418)">
+        <path
+           d="m 16.245657,1050.9177 c -0.355456,0.01 -0.65062,0.1291 -0.885494,0.3674 -0.234876,0.2383 -0.35671,0.5529 -0.365501,0.9439 0.0088,0.3981 0.130625,0.7172 0.365502,0.9571 0.234873,0.2399 0.530037,0.363 0.885493,0.3692 0.362672,-0.01 0.662232,-0.1293 0.898681,-0.3692 0.236442,-0.2399 0.358903,-0.559 0.367386,-0.9571 -0.0057,-0.3778 -0.122466,-0.6886 -0.35043,-0.9326 -0.227971,-0.244 -0.533183,-0.3702 -0.915637,-0.3787 z m 0.94955,3.3912 c -1.039986,0.4346 -2.019679,0.6808 -2.939084,0.7386 l 0,0.6029 c 0.435838,-0.02 0.70965,0.039 0.821436,0.1771 0.111784,0.1381 0.159513,0.476 0.143187,1.0136 l 0,3.4515 c 0.01539,0.5401 -0.03423,0.888 -0.148838,1.0438 -0.114613,0.1557 -0.386541,0.2248 -0.815785,0.2072 l 0,0.633 4.084573,0 0,-0.633 c -0.386544,0.017 -0.634608,-0.051 -0.744192,-0.2054 -0.109591,-0.1541 -0.157947,-0.4977 -0.145069,-1.0305 l 0,-5.8631 z"
+           style="fill:url(#linearGradient4898);fill-opacity:1"
+           id="path5058"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 16.245657,1050.9177 c -0.355456,0.01 -0.65062,0.1291 -0.885494,0.3674 -0.234876,0.2383 -0.35671,0.5529 -0.365501,0.9439 0.0088,0.3981 0.130625,0.7172 0.365502,0.9571 0.234873,0.2399 0.530037,0.363 0.885493,0.3692 0.362672,-0.01 0.662232,-0.1293 0.898681,-0.3692 0.236442,-0.2399 0.358903,-0.559 0.367386,-0.9571 -0.0057,-0.3778 -0.122466,-0.6886 -0.35043,-0.9326 -0.227971,-0.244 -0.533183,-0.3702 -0.915637,-0.3787 z m 0.94955,3.3912 c -1.039986,0.4346 -2.019679,0.6808 -2.939084,0.7386 l 0,0.6029 c 0.435838,-0.02 0.70965,0.039 0.821436,0.1771 0.111784,0.1381 0.159513,0.476 0.143187,1.0136 l 0,3.4515 c 0.01539,0.5401 -0.03423,0.888 -0.148838,1.0438 -0.114613,0.1557 -0.386541,0.2248 -0.815785,0.2072 l 0,0.633 4.084573,0 0,-0.633 c -0.386544,0.017 -0.634608,-0.051 -0.744192,-0.2054 -0.109591,-0.1541 -0.157947,-0.4977 -0.145069,-1.0305 l 0,-5.8631 z"
+           style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:15.07241726px;line-height:125%;font-family:'Kozuka Mincho Pr6N H';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:url(#linearGradient4898-1);fill-opacity:1;stroke:none"
+           id="path5058-4"
+           inkscape:connector-curvature="0" />
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-size:15.07241726px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient5028);fill-opacity:1;stroke:none;display:inline;font-family:Kozuka Mincho Pr6N H;-inkscape-font-specification:Kozuka Mincho Pr6N H Heavy"
+         x="50.288464"
+         y="1117.2119"
+         id="text4140-1-8-1"
+         sodipodi:linespacing="125%"><tspan
+           sodipodi:role="line"
+           id="tspan4142-7-8-7"
+           x="50.288464"
+           y="1117.2119"
+           style="fill:url(#linearGradient5028);fill-opacity:1">Kozuka Mincho Pr6N H</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/keygroups_obj.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/keygroups_obj.svg
@@ -1,0 +1,1079 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="keygroups_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3869">
+      <stop
+         style="stop-color:#7090b0;stop-opacity:1;"
+         offset="0"
+         id="stop3871" />
+      <stop
+         style="stop-color:#5d4886;stop-opacity:1;"
+         offset="1"
+         id="stop3873" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3861">
+      <stop
+         style="stop-color:#4b87ac;stop-opacity:1;"
+         offset="0"
+         id="stop3863" />
+      <stop
+         style="stop-color:#4b87ac;stop-opacity:0;"
+         offset="1"
+         id="stop3865" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3853">
+      <stop
+         style="stop-color:#698ba5;stop-opacity:1"
+         offset="0"
+         id="stop3855" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3857" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10359">
+      <stop
+         style="stop-color:#4a77a8;stop-opacity:1;"
+         offset="0"
+         id="stop10361" />
+      <stop
+         style="stop-color:#2266a0;stop-opacity:1"
+         offset="1"
+         id="stop10363" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10593">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop10595" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop10597" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9610">
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1"
+         offset="0"
+         id="stop9612" />
+      <stop
+         id="stop9614"
+         offset="1"
+         style="stop-color:#9a9990;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient15990"
+       inkscape:collect="always">
+      <stop
+         id="stop15992"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1" />
+      <stop
+         id="stop15994"
+         offset="1"
+         style="stop-color:#e0eaf8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9610"
+       id="linearGradient9568"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-6.074384,3.9704772)"
+       x1="8.0137892"
+       y1="1035.9741"
+       x2="8.0137892"
+       y2="1051.0103" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15990"
+       id="linearGradient9571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8474583,0,0,0.67963192,9.9008257,358.14455)"
+       x1="-3.1651151"
+       y1="1030.4418"
+       x2="-3.1651151"
+       y2="1041.0583" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10593"
+       id="linearGradient10599"
+       x1="10"
+       y1="10"
+       x2="10"
+       y2="5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.8153447,1050.371)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10653-6">
+      <stop
+         style="stop-color:#130d08;stop-opacity:1"
+         offset="0"
+         id="stop10655-1" />
+      <stop
+         style="stop-color:#654628;stop-opacity:0;"
+         offset="1"
+         id="stop10657-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.3622"
+       x2="14"
+       y1="1041.3622"
+       x1="14"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10676"
+       xlink:href="#linearGradient10653-6"
+       inkscape:collect="always"
+       gradientTransform="matrix(1,0,0,-1,-20.299911,2088.3986)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351"
+       id="linearGradient10357"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-19.268661,0.67417473)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10359"
+       id="linearGradient10365"
+       x1="9"
+       y1="1043.8622"
+       x2="14"
+       y2="1043.8622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-19.268661,-1.3258253)" />
+    <linearGradient
+       gradientTransform="translate(-19.268661,0.67417473)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient10359-9"
+       id="linearGradient10365-7"
+       x1="9"
+       y1="1043.8622"
+       x2="14"
+       y2="1043.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10359-9">
+      <stop
+         style="stop-color:#4a77a8;stop-opacity:1;"
+         offset="0"
+         id="stop10361-8" />
+      <stop
+         style="stop-color:#2266a0;stop-opacity:1"
+         offset="1"
+         id="stop10363-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-19.268661,10.674175)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10490"
+       xlink:href="#linearGradient10351-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9610-6">
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1"
+         offset="0"
+         id="stop9612-8" />
+      <stop
+         id="stop9614-2"
+         offset="1"
+         style="stop-color:#9a9990;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.0103"
+       x2="8.0137892"
+       y1="1035.9741"
+       x1="8.0137892"
+       gradientTransform="translate(-8.9053941,21.029495)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9594"
+       xlink:href="#linearGradient9610-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10359-8">
+      <stop
+         style="stop-color:#4a77a8;stop-opacity:1;"
+         offset="0"
+         id="stop10361-2" />
+      <stop
+         style="stop-color:#2266a0;stop-opacity:1"
+         offset="1"
+         id="stop10363-3" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.8622"
+       x2="14"
+       y1="1043.8622"
+       x1="9"
+       gradientTransform="translate(-7.1250006,11.937509)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9628"
+       xlink:href="#linearGradient10359-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2-3">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6-3" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9-7" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-3.0000004,22.062509)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9662"
+       xlink:href="#linearGradient10351-2-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2-3-1">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6-3-8" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9-7-7" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-3.0000004,24.0625)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9696"
+       xlink:href="#linearGradient10351-2-3-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2-3-1-1">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6-3-8-2" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9-7-7-1" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-3.0000004,25.9375)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9730"
+       xlink:href="#linearGradient10351-2-3-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2-3-1-1-5">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6-3-8-2-7" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9-7-7-1-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-3.0000004,28.0625)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9764"
+       xlink:href="#linearGradient10351-2-3-1-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15990"
+       id="linearGradient9793"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8474583,0,0,0.67963192,9.9008257,358.14455)"
+       x1="-3.1651151"
+       y1="1030.4418"
+       x2="-3.1651151"
+       y2="1041.0583" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9610-6"
+       id="linearGradient9795"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-8.9053941,21.029495)"
+       x1="8.0137892"
+       y1="1035.9741"
+       x2="8.0137892"
+       y2="1051.0103" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10593"
+       id="linearGradient9797"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.8153447,1050.371)"
+       x1="10"
+       y1="10"
+       x2="10"
+       y2="5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10359-8"
+       id="linearGradient9799"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-7.1250006,11.937509)"
+       x1="9"
+       y1="1043.8622"
+       x2="14"
+       y2="1043.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351-2-3"
+       id="linearGradient9801"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.0000004,22.062509)"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351-2-3-1"
+       id="linearGradient9803"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.0000004,24.0625)"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351-2-3-1-1"
+       id="linearGradient9805"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.0000004,25.9375)"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351-2-3-1-1-5"
+       id="linearGradient9807"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.0000004,28.0625)"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3853"
+       id="radialGradient3859"
+       cx="9.166254"
+       cy="2.788337"
+       fx="9.166254"
+       fy="2.788337"
+       r="3.3394759"
+       gradientTransform="matrix(-1.8167088,-4.120454e-8,3.3433294e-8,-1.4740744,26.981502,5.6508693)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3869"
+       id="linearGradient3875"
+       x1="7.8512411"
+       y1="2.6097209"
+       x2="7.8512411"
+       y2="6.3611164"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3853-6"
+       id="radialGradient3859-5"
+       cx="9.166254"
+       cy="2.788337"
+       fx="9.166254"
+       fy="2.788337"
+       r="3.3394759"
+       gradientTransform="matrix(-1.8167088,-4.120454e-8,3.3433294e-8,-1.4740744,26.981502,5.6508693)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3853-6">
+      <stop
+         style="stop-color:#698ba5;stop-opacity:1"
+         offset="0"
+         id="stop3855-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3857-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3869-7"
+       id="linearGradient3875-5"
+       x1="7.8512411"
+       y1="2.6097209"
+       x2="7.8512411"
+       y2="6.3611164"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3869-7">
+      <stop
+         style="stop-color:#7090b0;stop-opacity:1;"
+         offset="0"
+         id="stop3871-2" />
+      <stop
+         style="stop-color:#5d4886;stop-opacity:1;"
+         offset="1"
+         id="stop3873-2" />
+    </linearGradient>
+    <radialGradient
+       r="3.3394759"
+       fy="2.788337"
+       fx="9.166254"
+       cy="2.788337"
+       cx="9.166254"
+       gradientTransform="matrix(-1.8167088,-4.120454e-8,3.3433294e-8,-1.4740744,26.981502,1042.0131)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3919"
+       xlink:href="#linearGradient3853-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(0,1036.3622)"
+       y2="6.3611164"
+       x2="7.8512411"
+       y1="2.6097209"
+       x1="7.8512411"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3921"
+       xlink:href="#linearGradient3869-7"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3853"
+       id="radialGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.6467056,-3.734872e-8,3.0304688e-8,-1.3361341,25.191739,1041.8786)"
+       cx="9.166254"
+       cy="2.788337"
+       fx="9.166254"
+       fy="2.788337"
+       r="3.3394759" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3869"
+       id="linearGradient3979"
+       gradientUnits="userSpaceOnUse"
+       x1="7.8512411"
+       y1="2.6097209"
+       x2="7.8512411"
+       y2="6.3611164"
+       gradientTransform="matrix(0.90642244,0,0,0.90642244,0.73509994,1036.7566)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3853-4"
+       id="radialGradient3977-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.6467056,-3.734872e-8,3.0304688e-8,-1.3361341,25.191739,1041.8786)"
+       cx="9.166254"
+       cy="2.788337"
+       fx="9.166254"
+       fy="2.788337"
+       r="3.3394759" />
+    <linearGradient
+       id="linearGradient3853-4">
+      <stop
+         style="stop-color:#698ba5;stop-opacity:1"
+         offset="0"
+         id="stop3855-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3857-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3869-5"
+       id="linearGradient3979-3"
+       gradientUnits="userSpaceOnUse"
+       x1="7.8512411"
+       y1="2.6097209"
+       x2="7.8512411"
+       y2="6.3611164"
+       gradientTransform="matrix(0.90642244,0,0,0.90642244,0.73509994,1036.7566)" />
+    <linearGradient
+       id="linearGradient3869-5">
+      <stop
+         style="stop-color:#7090b0;stop-opacity:1;"
+         offset="0"
+         id="stop3871-6" />
+      <stop
+         style="stop-color:#5d4886;stop-opacity:1;"
+         offset="1"
+         id="stop3873-6" />
+    </linearGradient>
+    <radialGradient
+       r="3.3394759"
+       fy="2.788337"
+       fx="9.166254"
+       cy="2.788337"
+       cx="9.166254"
+       gradientTransform="matrix(-1.6467056,-3.734872e-8,3.0304688e-8,-1.3361341,20.285489,1049.066)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4000"
+       xlink:href="#linearGradient3853-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="6.3611164"
+       x2="7.8512411"
+       y1="2.6097209"
+       x1="7.8512411"
+       gradientTransform="matrix(0.90642244,0,0,0.90642244,-4.1711503,1043.944)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4002"
+       xlink:href="#linearGradient3869-5"
+       inkscape:collect="always" />
+    <radialGradient
+       r="3.3394759"
+       fy="2.788337"
+       fx="9.166254"
+       cy="2.788337"
+       cx="9.166254"
+       gradientTransform="matrix(-1.6467056,-3.734872e-8,3.0304688e-8,-1.3361341,20.285489,1049.066)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4000-6"
+       xlink:href="#linearGradient3853-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3853-4-3">
+      <stop
+         style="stop-color:#698ba5;stop-opacity:1"
+         offset="0"
+         id="stop3855-0-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3857-2-9" />
+    </linearGradient>
+    <linearGradient
+       y2="6.3611164"
+       x2="7.8512411"
+       y1="2.6097209"
+       x1="7.8512411"
+       gradientTransform="matrix(0.90642244,0,0,0.90642244,-4.1711503,1043.944)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4002-4"
+       xlink:href="#linearGradient3869-5-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3869-5-6">
+      <stop
+         style="stop-color:#7090b0;stop-opacity:1;"
+         offset="0"
+         id="stop3871-6-4" />
+      <stop
+         style="stop-color:#5d4886;stop-opacity:1;"
+         offset="1"
+         id="stop3873-6-6" />
+    </linearGradient>
+    <radialGradient
+       r="3.3394759"
+       fy="2.788337"
+       fx="9.166254"
+       cy="2.788337"
+       cx="9.166254"
+       gradientTransform="matrix(-1.6467056,-3.734872e-8,3.0304688e-8,-1.3361341,20.285489,1049.0659)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4050"
+       xlink:href="#linearGradient3853-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="6.3611164"
+       x2="7.8512411"
+       y1="2.6097209"
+       x1="7.8512411"
+       gradientTransform="matrix(0.90642244,0,0,0.90642244,-4.1711503,1043.9439)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4052"
+       xlink:href="#linearGradient3869-5-6"
+       inkscape:collect="always" />
+    <radialGradient
+       r="3.3394759"
+       fy="2.788337"
+       fx="9.166254"
+       cy="2.788337"
+       cx="9.166254"
+       gradientTransform="matrix(-1.6467056,-3.734872e-8,3.0304688e-8,-1.3361341,20.285489,1049.066)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4000-3"
+       xlink:href="#linearGradient3853-4-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3853-4-1">
+      <stop
+         style="stop-color:#698ba5;stop-opacity:1"
+         offset="0"
+         id="stop3855-0-1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3857-2-5" />
+    </linearGradient>
+    <linearGradient
+       y2="6.3611164"
+       x2="7.8512411"
+       y1="2.6097209"
+       x1="7.8512411"
+       gradientTransform="matrix(0.90642244,0,0,0.90642244,-4.1711503,1043.944)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4002-45"
+       xlink:href="#linearGradient3869-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3869-5-8">
+      <stop
+         style="stop-color:#7090b0;stop-opacity:1;"
+         offset="0"
+         id="stop3871-6-9" />
+      <stop
+         style="stop-color:#5d4886;stop-opacity:1;"
+         offset="1"
+         id="stop3873-6-1" />
+    </linearGradient>
+    <radialGradient
+       r="3.3394759"
+       fy="2.788337"
+       fx="9.166254"
+       cy="2.788337"
+       cx="9.166254"
+       gradientTransform="matrix(-1.6467056,-3.734872e-8,3.0304688e-8,-1.3361341,25.36782,1049.0659)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4169"
+       xlink:href="#linearGradient3853-4-1"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="6.3611164"
+       x2="7.8512411"
+       y1="2.6097209"
+       x1="7.8512411"
+       gradientTransform="matrix(0.90642244,0,0,0.90642244,0.91118001,1043.9439)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4171"
+       xlink:href="#linearGradient3869-5-8"
+       inkscape:collect="always" />
+    <radialGradient
+       r="3.3394759"
+       fy="2.788337"
+       fx="9.166254"
+       cy="2.788337"
+       cx="9.166254"
+       gradientTransform="matrix(-1.6467056,-3.734872e-8,3.0304688e-8,-1.3361341,25.36782,1049.0659)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4169-7"
+       xlink:href="#linearGradient3853-4-1-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3853-4-1-7">
+      <stop
+         style="stop-color:#698ba5;stop-opacity:1"
+         offset="0"
+         id="stop3855-0-1-2" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3857-2-5-3" />
+    </linearGradient>
+    <linearGradient
+       y2="6.3611164"
+       x2="7.8512411"
+       y1="2.6097209"
+       x1="7.8512411"
+       gradientTransform="matrix(0.90642244,0,0,0.90642244,0.91118001,1043.9439)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4171-2"
+       xlink:href="#linearGradient3869-5-8-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3869-5-8-4">
+      <stop
+         style="stop-color:#7090b0;stop-opacity:1;"
+         offset="0"
+         id="stop3871-6-9-2" />
+      <stop
+         style="stop-color:#5d4886;stop-opacity:1;"
+         offset="1"
+         id="stop3873-6-1-7" />
+    </linearGradient>
+    <radialGradient
+       r="3.3394759"
+       fy="2.788337"
+       fx="9.166254"
+       cy="2.788337"
+       cx="9.166254"
+       gradientTransform="matrix(-1.6467056,-3.734872e-8,3.0304688e-8,-1.3361341,30.405956,1049.0658)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4219"
+       xlink:href="#linearGradient3853-4-1-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="6.3611164"
+       x2="7.8512411"
+       y1="2.6097209"
+       x1="7.8512411"
+       gradientTransform="matrix(0.90642244,0,0,0.90642244,5.9493161,1043.9438)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4221"
+       xlink:href="#linearGradient3869-5-8-4"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3853-5"
+       id="radialGradient3977-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.5977219,-3.8373858e-8,2.9403229e-8,-1.372808,24.819678,1041.9483)"
+       cx="9.166254"
+       cy="2.788337"
+       fx="9.166254"
+       fy="2.788337"
+       r="3.3394759" />
+    <linearGradient
+       id="linearGradient3853-5">
+      <stop
+         style="stop-color:#acbcc8;stop-opacity:1;"
+         offset="0"
+         id="stop3855-09" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3857-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3869-3"
+       id="linearGradient3979-6"
+       gradientUnits="userSpaceOnUse"
+       x1="7.8512411"
+       y1="2.6097209"
+       x2="7.8512411"
+       y2="6.3611164"
+       gradientTransform="matrix(0.87945953,0,0,0.93130168,1.0905381,1036.6857)" />
+    <linearGradient
+       id="linearGradient3869-3">
+      <stop
+         style="stop-color:#7090b0;stop-opacity:1;"
+         offset="0"
+         id="stop3871-8" />
+      <stop
+         style="stop-color:#5d4886;stop-opacity:1;"
+         offset="1"
+         id="stop3873-7" />
+    </linearGradient>
+    <radialGradient
+       r="3.3394759"
+       fy="2.788337"
+       fx="9.166254"
+       cy="2.788337"
+       cx="9.166254"
+       gradientTransform="matrix(-1.6339615,-3.8142251e-8,3.0070156e-8,-1.3645223,20.245213,1048.9593)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4000-9"
+       xlink:href="#linearGradient3853-4-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3853-4-9">
+      <stop
+         style="stop-color:#b0bcc5;stop-opacity:1;"
+         offset="0"
+         id="stop3855-0-6" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3857-2-2" />
+    </linearGradient>
+    <linearGradient
+       y2="6.3611164"
+       x2="7.8512411"
+       y1="2.6097209"
+       x1="7.8512411"
+       gradientTransform="matrix(0.89940753,0,0,0.92568078,-4.0221531,1043.7284)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4002-3"
+       xlink:href="#linearGradient3869-5-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3869-5-7">
+      <stop
+         style="stop-color:#7090b0;stop-opacity:1;"
+         offset="0"
+         id="stop3871-6-97" />
+      <stop
+         style="stop-color:#5d4886;stop-opacity:1;"
+         offset="1"
+         id="stop3873-6-5" />
+    </linearGradient>
+    <radialGradient
+       r="3.3394759"
+       fy="2.788337"
+       fx="9.166254"
+       cy="2.788337"
+       cx="9.166254"
+       gradientTransform="matrix(-1.6339615,-3.8142251e-8,3.0070156e-8,-1.3645223,25.288212,1048.9592)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4169-78"
+       xlink:href="#linearGradient3853-4-1-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3853-4-1-8">
+      <stop
+         style="stop-color:#a6b8c5;stop-opacity:1;"
+         offset="0"
+         id="stop3855-0-1-3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3857-2-5-6" />
+    </linearGradient>
+    <linearGradient
+       y2="6.3611164"
+       x2="7.8512411"
+       y1="2.6097209"
+       x1="7.8512411"
+       gradientTransform="matrix(0.89940753,0,0,0.92568078,1.0208444,1043.7283)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4171-5"
+       xlink:href="#linearGradient3869-5-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3869-5-8-7">
+      <stop
+         style="stop-color:#7090b0;stop-opacity:1;"
+         offset="0"
+         id="stop3871-6-9-9" />
+      <stop
+         style="stop-color:#5d4886;stop-opacity:1;"
+         offset="1"
+         id="stop3873-6-1-71" />
+    </linearGradient>
+    <radialGradient
+       r="3.3394759"
+       fy="2.788337"
+       fx="9.166254"
+       cy="2.788337"
+       cx="9.166254"
+       gradientTransform="matrix(-1.6467056,-3.734872e-8,3.0304688e-8,-1.3361341,30.405956,1049.0658)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4219-2"
+       xlink:href="#linearGradient3853-4-1-7-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3853-4-1-7-6">
+      <stop
+         style="stop-color:#a9becf;stop-opacity:1;"
+         offset="0"
+         id="stop3855-0-1-2-3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3857-2-5-3-1" />
+    </linearGradient>
+    <linearGradient
+       y2="6.3611164"
+       x2="7.8512411"
+       y1="2.6097209"
+       x1="7.8512411"
+       gradientTransform="matrix(0.90642244,0,0,0.90642244,5.9493161,1043.9438)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4221-1"
+       xlink:href="#linearGradient3869-5-8-4-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3869-5-8-4-5">
+      <stop
+         style="stop-color:#7090b0;stop-opacity:1;"
+         offset="0"
+         id="stop3871-6-9-2-2" />
+      <stop
+         style="stop-color:#5d4886;stop-opacity:1;"
+         offset="1"
+         id="stop3873-6-1-7-6" />
+    </linearGradient>
+    <radialGradient
+       r="3.3394759"
+       fy="2.788337"
+       fx="9.166254"
+       cy="2.788337"
+       cx="9.166254"
+       gradientTransform="matrix(-1.6339615,-3.8142251e-8,3.0070156e-8,-1.3645223,30.287357,1048.9591)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4303"
+       xlink:href="#linearGradient3853-4-1-7-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="6.3611164"
+       x2="7.8512411"
+       y1="2.6097209"
+       x1="7.8512411"
+       gradientTransform="matrix(0.89940753,0,0,0.92568078,6.0199898,1043.7282)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4305"
+       xlink:href="#linearGradient3869-5-8-4-5"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254832"
+     inkscape:cx="7.0421623"
+     inkscape:cy="7.4951033"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4250"
+     showgrid="true"
+     inkscape:window-width="1449"
+     inkscape:window-height="924"
+     inkscape:window-x="933"
+     inkscape:window-y="330"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g4250"
+       transform="translate(0,1.1932427)">
+      <rect
+         ry="0.93130189"
+         y="1037.6545"
+         x="5.5019417"
+         height="5.0212893"
+         width="4.9944077"
+         id="rect3083"
+         style="fill:url(#radialGradient3977-7);fill-opacity:1;stroke:url(#linearGradient3979-6);stroke-width:0.99844122;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         ry="0.92568088"
+         y="1044.6915"
+         x="0.48931003"
+         height="4.9910431"
+         width="4.9761353"
+         id="rect3083-6"
+         style="display:inline;fill:url(#radialGradient4000-9);fill-opacity:1;stroke:url(#linearGradient4002-3);stroke-width:1.00664937;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         ry="0.92568088"
+         y="1044.6915"
+         x="5.5323081"
+         height="4.9910431"
+         width="4.9761353"
+         id="rect3083-6-3"
+         style="display:inline;fill:url(#radialGradient4169-78);fill-opacity:1;stroke:url(#linearGradient4171-5);stroke-width:1.00664937;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         ry="0.92568088"
+         y="1044.6915"
+         x="10.531453"
+         height="4.9910431"
+         width="4.9761353"
+         id="rect3083-6-3-2"
+         style="display:inline;fill:url(#radialGradient4303);fill-opacity:1;stroke:url(#linearGradient4305);stroke-width:1.00664937;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/layout_co.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/layout_co.svg
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="layout_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient28634"
+       osb:paint="gradient">
+      <stop
+         style="stop-color:#c1d9ee;stop-opacity:1;"
+         offset="0"
+         id="stop28636" />
+      <stop
+         id="stop28642"
+         offset="0.5"
+         style="stop-color:#6eaddd;stop-opacity:1" />
+      <stop
+         style="stop-color:#40689d;stop-opacity:1"
+         offset="1"
+         id="stop28638" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(37.991756,2.976947)"
+       gradientUnits="userSpaceOnUse"
+       y2="1038.8951"
+       x2="-4.991955"
+       y1="1038.8951"
+       x1="-16.963362"
+       id="linearGradient8293-6"
+       xlink:href="#linearGradient8287-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1053.3254"
+       x2="8.0137892"
+       y1="1049.3254"
+       x1="7.9284072"
+       gradientTransform="translate(17.072947,-0.956058)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8887-0"
+       xlink:href="#linearGradient4810-5-87"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-13"
+       gradientTransform="matrix(1,0,0,2.1113755,37.016465,-1184.4129)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8884-0"
+       xlink:href="#linearGradient4910-4-0-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.8765"
+       x2="8.0137892"
+       y1="1039.876"
+       x1="8.0137892"
+       gradientTransform="translate(17.115591,1.008442)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8878-5"
+       xlink:href="#linearGradient4082-3-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4810-5-87">
+      <stop
+         style="stop-color:#9d7c2f;stop-opacity:1"
+         offset="0"
+         id="stop4812-0-1" />
+      <stop
+         style="stop-color:#6b623f;stop-opacity:1"
+         offset="1"
+         id="stop4814-4-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4910-4-0-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4912-8-5-7"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0" />
+      <stop
+         id="stop4914-8-1-8"
+         offset="1"
+         style="stop-color:#c5dff4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082-3-1">
+      <stop
+         id="stop4084-8-1"
+         offset="0"
+         style="stop-color:#4476aa;stop-opacity:1" />
+      <stop
+         style="stop-color:#5a9ccc;stop-opacity:1"
+         offset="0.5"
+         id="stop4864-7-00" />
+      <stop
+         id="stop4086-2-0"
+         offset="1"
+         style="stop-color:#4476aa;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8287-6"
+       inkscape:collect="always">
+      <stop
+         id="stop8289-6"
+         offset="0"
+         style="stop-color:#6eb6e2;stop-opacity:1;" />
+      <stop
+         id="stop8291-34"
+         offset="1"
+         style="stop-color:#d3e5f4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient28634-6"
+       osb:paint="gradient">
+      <stop
+         style="stop-color:#c1d9ee;stop-opacity:1;"
+         offset="0"
+         id="stop28636-4" />
+      <stop
+         id="stop28642-9"
+         offset="0.5"
+         style="stop-color:#6eaddd;stop-opacity:1" />
+      <stop
+         style="stop-color:#40689d;stop-opacity:1"
+         offset="1"
+         id="stop28638-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient28634-6-8"
+       osb:paint="gradient">
+      <stop
+         style="stop-color:#c1d9ee;stop-opacity:1;"
+         offset="0"
+         id="stop28636-4-5" />
+      <stop
+         id="stop28642-9-4"
+         offset="0.5"
+         style="stop-color:#6eaddd;stop-opacity:1" />
+      <stop
+         style="stop-color:#40689d;stop-opacity:1"
+         offset="1"
+         id="stop28638-5-4" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509662"
+     inkscape:cx="6.1496285"
+     inkscape:cy="5.4075215"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-4"
+     showgrid="true"
+     inkscape:window-width="1668"
+     inkscape:window-height="1010"
+     inkscape:window-x="690"
+     inkscape:window-y="394"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid8762" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="layer1-4"
+       inkscape:label="Layer 1"
+       transform="translate(-19.001354,-2.0072)">
+      <path
+         style="display:inline;fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient8887-0);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 21.513406,1040.9049 10.99737,0 0,10.9667 -10.99737,0 z"
+         id="rect3997-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient8884-0);fill-opacity:1;stroke:none"
+         d="m 23.01782,1046.0433 -0.0014,5.3245 -1,0 0.0014,-7.4359 z"
+         id="rect4853-82-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient8293-6);fill-opacity:1;stroke:url(#linearGradient8878-5);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 21.499277,1040.8694 11.02044,0 0,2.0053 -11.02044,0 z"
+         id="rect3997-9-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <rect
+         style="opacity:1;fill:#d5f3ff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4179"
+         width="9.9989319"
+         height="1.016466"
+         x="22.006559"
+         y="1043.365"
+         ry="0" />
+      <path
+         style="fill:none;stroke:#757575;stroke-width:1.00184608px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 24.497563,1043.3675 0,8.0075"
+         id="path17673"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <image
+         y="1033.6945"
+         x="-0.46692258"
+         id="image4176"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAYJJREFU
+OI2lky+OVEEQh79fVffrHTAQBCcAgUKhMBAusA6QoLgBOAwJjuBICAYFl1g0GFZyAy5A2Nl9r6sQ
+b2aXyUMxrTqdqq+/1B9lJvsc2ysbKNvLrYdvEgrphqkSvkJuYAMqA/iK9AqqBPDj7V3tAOL6HR4d
+3qRRWLXK5cFpLbnilUsHzG8F2jBx+PLb0qD8/Mrnd9+xAhONUgYmG7BSSatQGmJAbqQNS8CzGx+5
+9+KYsAmLwtGH1zx4+pwgAZEGHnPsl1e3geNdQIwOwLVazit7tYFCSBACT0DBOrU0WPe5nY0EzQEO
+oDlJCjILwojpH11Y9wEBhoiNqm1HJA3LjVfCydiWgNNxzip+MVhDSaJrVokN0GE8uzA4H6ST0wYG
+3gUbg0DUMgfZ9rtIfnVfGpxNoAArOUOAg4D0JBHFoGfgZoxjWQLGqTIZmIS2Xg5SUhCWYGZkBr//
+KqK2y/Tk8f1UjKQ7iSE61h2Z0/uIqTJZR4LS4f2nI+0A/vfsvY1/AEi3hpqHbHAAAAAAAElFTkSu
+QmCC
+"
+         style="image-rendering:optimizeSpeed"
+         preserveAspectRatio="none"
+         height="16"
+         width="16" />
+      <rect
+         style="display:inline;opacity:1;fill:#d5f3ff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4179-7"
+         width="7.9980602"
+         height="1.0164661"
+         x="1043.3582"
+         y="-23.014256"
+         ry="0"
+         transform="matrix(0,1,-1,0,0,0)" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/menu.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/menu.svg
@@ -1,0 +1,524 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="menu.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10359">
+      <stop
+         style="stop-color:#4a77a8;stop-opacity:1;"
+         offset="0"
+         id="stop10361" />
+      <stop
+         style="stop-color:#2266a0;stop-opacity:1"
+         offset="1"
+         id="stop10363" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10593">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop10595" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop10597" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9610">
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1"
+         offset="0"
+         id="stop9612" />
+      <stop
+         id="stop9614"
+         offset="1"
+         style="stop-color:#9a9990;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient15990"
+       inkscape:collect="always">
+      <stop
+         id="stop15992"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1" />
+      <stop
+         id="stop15994"
+         offset="1"
+         style="stop-color:#e0eaf8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9610"
+       id="linearGradient9568"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-6.074384,3.9704772)"
+       x1="8.0137892"
+       y1="1035.9741"
+       x2="8.0137892"
+       y2="1051.0103" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15990"
+       id="linearGradient9571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8474583,0,0,0.67963192,9.9008257,358.14455)"
+       x1="-3.1651151"
+       y1="1030.4418"
+       x2="-3.1651151"
+       y2="1041.0583" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10593"
+       id="linearGradient10599"
+       x1="10"
+       y1="10"
+       x2="10"
+       y2="5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.8153447,1050.371)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10653-6">
+      <stop
+         style="stop-color:#130d08;stop-opacity:1"
+         offset="0"
+         id="stop10655-1" />
+      <stop
+         style="stop-color:#654628;stop-opacity:0;"
+         offset="1"
+         id="stop10657-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.3622"
+       x2="14"
+       y1="1041.3622"
+       x1="14"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10676"
+       xlink:href="#linearGradient10653-6"
+       inkscape:collect="always"
+       gradientTransform="matrix(1,0,0,-1,-20.299911,2088.3986)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351"
+       id="linearGradient10357"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-19.268661,0.67417473)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10359"
+       id="linearGradient10365"
+       x1="9"
+       y1="1043.8622"
+       x2="14"
+       y2="1043.8622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-19.268661,-1.3258253)" />
+    <linearGradient
+       gradientTransform="translate(-19.268661,0.67417473)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient10359-9"
+       id="linearGradient10365-7"
+       x1="9"
+       y1="1043.8622"
+       x2="14"
+       y2="1043.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10359-9">
+      <stop
+         style="stop-color:#4a77a8;stop-opacity:1;"
+         offset="0"
+         id="stop10361-8" />
+      <stop
+         style="stop-color:#2266a0;stop-opacity:1"
+         offset="1"
+         id="stop10363-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-19.268661,10.674175)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10490"
+       xlink:href="#linearGradient10351-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9610-6">
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1"
+         offset="0"
+         id="stop9612-8" />
+      <stop
+         id="stop9614-2"
+         offset="1"
+         style="stop-color:#9a9990;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.0103"
+       x2="8.0137892"
+       y1="1035.9741"
+       x1="8.0137892"
+       gradientTransform="translate(-8.9053941,21.029495)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9594"
+       xlink:href="#linearGradient9610-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10359-8">
+      <stop
+         style="stop-color:#4a77a8;stop-opacity:1;"
+         offset="0"
+         id="stop10361-2" />
+      <stop
+         style="stop-color:#2266a0;stop-opacity:1"
+         offset="1"
+         id="stop10363-3" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.8622"
+       x2="14"
+       y1="1043.8622"
+       x1="9"
+       gradientTransform="translate(-7.1250006,11.937509)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9628"
+       xlink:href="#linearGradient10359-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2-3">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6-3" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9-7" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-3.0000004,22.062509)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9662"
+       xlink:href="#linearGradient10351-2-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2-3-1">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6-3-8" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9-7-7" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-3.0000004,24.0625)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9696"
+       xlink:href="#linearGradient10351-2-3-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2-3-1-1">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6-3-8-2" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9-7-7-1" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-3.0000004,25.9375)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9730"
+       xlink:href="#linearGradient10351-2-3-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2-3-1-1-5">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6-3-8-2-7" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9-7-7-1-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-3.0000004,28.0625)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9764"
+       xlink:href="#linearGradient10351-2-3-1-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15990"
+       id="linearGradient9793"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8474583,0,0,0.67963192,9.9008257,358.14455)"
+       x1="-3.1651151"
+       y1="1030.4418"
+       x2="-3.1651151"
+       y2="1041.0583" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9610-6"
+       id="linearGradient9795"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-8.8391028,21.029495)"
+       x1="8.0137892"
+       y1="1035.9741"
+       x2="8.0137892"
+       y2="1051.0103" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10593"
+       id="linearGradient9797"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.7450322,1050.371)"
+       x1="10"
+       y1="10"
+       x2="10"
+       y2="5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10359-8"
+       id="linearGradient9799"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.95526974,0,0,1,-6.5349282,11.992197)"
+       x1="9"
+       y1="1043.8622"
+       x2="14"
+       y2="1043.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351-2-3"
+       id="linearGradient9801"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.9375004,22.000009)"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351-2-3-1"
+       id="linearGradient9803"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.9375004,24.015625)"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351-2-3-1-1"
+       id="linearGradient9805"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.9375004,26)"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351-2-3-1-1-5"
+       id="linearGradient9807"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.9531254,28)"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254831"
+     inkscape:cx="6.4323094"
+     inkscape:cy="13.110358"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="1016"
+     inkscape:window-y="571"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4209"
+       width="5.9662137"
+       height="3.8669906"
+       x="3.5797284"
+       y="1036.9385" />
+    <g
+       id="g9783"
+       transform="translate(2.9375001,-17.000001)">
+      <rect
+         y="1058.2614"
+         x="0.93990028"
+         height="9.1253662"
+         width="8.2161407"
+         id="rect3997-9-2-7"
+         style="display:inline;fill:url(#linearGradient9793);fill-opacity:1;stroke:none" />
+      <rect
+         ry="0"
+         rx="0"
+         y="1057.8822"
+         x="0.59143734"
+         height="9.967041"
+         width="8.980629"
+         id="rect3997-9"
+         style="display:inline;fill:none;stroke:url(#linearGradient9795);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="rect18863-4-5"
+         d="m 0.08198279,1053.371 0,4.9984 1.00000001,0 4.9745387,0 1,0 0,-1 0,-3.9984 -5.9745387,0 z m 1.00000001,1 4.9745387,0 0,2.9984 -4.9745387,0 z"
+         style="display:inline;fill:url(#linearGradient9797);fill-opacity:1;stroke:none" />
+      <rect
+         style="display:inline;fill:url(#linearGradient9799);fill-opacity:1;stroke:none"
+         id="rect18863-4-8-1-4-71"
+         width="3.0032198"
+         height="1"
+         x="2.0625005"
+         y="1055.3544" />
+      <rect
+         style="display:inline;fill:url(#linearGradient9801);fill-opacity:1;stroke:none"
+         id="rect18863-4-2-4"
+         width="6"
+         height="1.0000174"
+         x="2.0625007"
+         y="1059.3622" />
+      <rect
+         style="display:inline;fill:url(#linearGradient9803);fill-opacity:1;stroke:none"
+         id="rect18863-4-2-4-3"
+         width="6"
+         height="1.0000174"
+         x="2.0625007"
+         y="1061.3778" />
+      <rect
+         style="display:inline;fill:url(#linearGradient9805);fill-opacity:1;stroke:none"
+         id="rect18863-4-2-4-3-7"
+         width="6"
+         height="1.0000174"
+         x="2.0625007"
+         y="1063.3622" />
+      <rect
+         style="display:inline;fill:url(#linearGradient9807);fill-opacity:1;stroke:none"
+         id="rect18863-4-2-4-3-7-2"
+         width="6"
+         height="1.0000174"
+         x="2.0468757"
+         y="1065.3622" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/separator.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/separator.svg
@@ -1,0 +1,491 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="separator.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10359">
+      <stop
+         style="stop-color:#4a77a8;stop-opacity:1;"
+         offset="0"
+         id="stop10361" />
+      <stop
+         style="stop-color:#2266a0;stop-opacity:1"
+         offset="1"
+         id="stop10363" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10593">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop10595" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop10597" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9610">
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1"
+         offset="0"
+         id="stop9612" />
+      <stop
+         id="stop9614"
+         offset="1"
+         style="stop-color:#9a9990;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient15990"
+       inkscape:collect="always">
+      <stop
+         id="stop15992"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1" />
+      <stop
+         id="stop15994"
+         offset="1"
+         style="stop-color:#e0eaf8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9610"
+       id="linearGradient9568"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-6.074384,3.9704772)"
+       x1="8.0137892"
+       y1="1035.9741"
+       x2="8.0137892"
+       y2="1051.0103" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15990"
+       id="linearGradient9571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8474583,0,0,0.67963192,9.9008257,358.14455)"
+       x1="-3.1651151"
+       y1="1030.4418"
+       x2="-3.1651151"
+       y2="1041.0583" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10593"
+       id="linearGradient10599"
+       x1="10"
+       y1="10"
+       x2="10"
+       y2="5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.8153447,1050.371)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10653-6">
+      <stop
+         style="stop-color:#130d08;stop-opacity:1"
+         offset="0"
+         id="stop10655-1" />
+      <stop
+         style="stop-color:#654628;stop-opacity:0;"
+         offset="1"
+         id="stop10657-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.3622"
+       x2="14"
+       y1="1041.3622"
+       x1="14"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10676"
+       xlink:href="#linearGradient10653-6"
+       inkscape:collect="always"
+       gradientTransform="matrix(1,0,0,-1,-20.299911,2088.3986)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351"
+       id="linearGradient10357"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-19.268661,0.67417473)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10359"
+       id="linearGradient10365"
+       x1="9"
+       y1="1043.8622"
+       x2="14"
+       y2="1043.8622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-19.268661,-1.3258253)" />
+    <linearGradient
+       gradientTransform="translate(-19.268661,0.67417473)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient10359-9"
+       id="linearGradient10365-7"
+       x1="9"
+       y1="1043.8622"
+       x2="14"
+       y2="1043.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10359-9">
+      <stop
+         style="stop-color:#4a77a8;stop-opacity:1;"
+         offset="0"
+         id="stop10361-8" />
+      <stop
+         style="stop-color:#2266a0;stop-opacity:1"
+         offset="1"
+         id="stop10363-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-19.268661,10.674175)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10490"
+       xlink:href="#linearGradient10351-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9610-6">
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1"
+         offset="0"
+         id="stop9612-8" />
+      <stop
+         id="stop9614-2"
+         offset="1"
+         style="stop-color:#9a9990;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.0103"
+       x2="8.0137892"
+       y1="1035.9741"
+       x1="8.0137892"
+       gradientTransform="translate(-8.9053941,21.029495)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9594"
+       xlink:href="#linearGradient9610-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10359-8">
+      <stop
+         style="stop-color:#4a77a8;stop-opacity:1;"
+         offset="0"
+         id="stop10361-2" />
+      <stop
+         style="stop-color:#2266a0;stop-opacity:1"
+         offset="1"
+         id="stop10363-3" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.8622"
+       x2="14"
+       y1="1043.8622"
+       x1="9"
+       gradientTransform="translate(-7.1250006,11.937509)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9628"
+       xlink:href="#linearGradient10359-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2-3">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6-3" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9-7" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-3.0000004,22.062509)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9662"
+       xlink:href="#linearGradient10351-2-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2-3-1">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6-3-8" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9-7-7" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-3.0000004,24.0625)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9696"
+       xlink:href="#linearGradient10351-2-3-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2-3-1-1">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6-3-8-2" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9-7-7-1" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-3.0000004,25.9375)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9730"
+       xlink:href="#linearGradient10351-2-3-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2-3-1-1-5">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6-3-8-2-7" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9-7-7-1-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-3.0000004,28.0625)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9764"
+       xlink:href="#linearGradient10351-2-3-1-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15990"
+       id="linearGradient9793"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8474583,0,0,0.67963192,9.9008257,358.14455)"
+       x1="-3.1651151"
+       y1="1030.4418"
+       x2="-3.1651151"
+       y2="1041.0583" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9610-6"
+       id="linearGradient9795"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-8.9053941,21.029495)"
+       x1="8.0137892"
+       y1="1035.9741"
+       x2="8.0137892"
+       y2="1051.0103" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10593"
+       id="linearGradient9797"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.8153447,1050.371)"
+       x1="10"
+       y1="10"
+       x2="10"
+       y2="5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10359-8"
+       id="linearGradient9799"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-7.1250006,11.937509)"
+       x1="9"
+       y1="1043.8622"
+       x2="14"
+       y2="1043.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351-2-3"
+       id="linearGradient9801"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.0000004,22.062509)"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351-2-3-1"
+       id="linearGradient9803"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.0000004,24.0625)"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351-2-3-1-1"
+       id="linearGradient9805"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.0000004,25.9375)"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351-2-3-1-1-5"
+       id="linearGradient9807"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.0000004,28.0625)"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.999999"
+     inkscape:cx="4.7686866"
+     inkscape:cy="5.4107473"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="636"
+     inkscape:window-y="140"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0,-1,1,0,-1036.0341,1052.3419)"
+       style="display:inline"
+       id="g6750">
+      <g
+         transform="translate(-0.34374998,0)"
+         id="g6722-9-8"
+         style="stroke:#47698f;stroke-opacity:1;display:inline">
+        <path
+           style="fill:none;stroke:#7795b6;stroke-width:0.95709282px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 11.891049,1040.6825 3.36478,3.3649 -3.304962,3.305"
+           id="path6702-4-8-8"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:#47698f;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 12.15625,1040.5497 3.515625,3.5156 -3.453125,3.4532"
+           id="path6702-1-1"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="matrix(-1,0,0,1,16.428128,0)"
+         id="g6722-9-8-8"
+         style="stroke:#47698f;stroke-opacity:1;display:inline">
+        <path
+           style="fill:none;stroke:#7795b6;stroke-width:0.95709282px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 11.891049,1040.6825 3.36478,3.3649 -3.304962,3.305"
+           id="path6702-4-8-8-5"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:#47698f;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 12.15625,1040.5497 3.515625,3.5156 -3.453125,3.4532"
+           id="path6702-1-1-1"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/signed_no_tbl.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/signed_no_tbl.svg
@@ -1,0 +1,336 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="signed_no_tbl.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4810">
+      <stop
+         id="stop4812"
+         offset="0"
+         style="stop-color:#886b2d;stop-opacity:1;" />
+      <stop
+         id="stop4814"
+         offset="1"
+         style="stop-color:#bc9617;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8" />
+      <stop
+         style="stop-color:#d1eeff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4994-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5"
+         offset="0"
+         style="stop-color:#d1eeff;stop-opacity:1" />
+      <stop
+         id="stop4998-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4810"
+       id="linearGradient6101"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.0000784)"
+       x1="8.0137892"
+       y1="1036.6622"
+       x2="8.0137892"
+       y2="1050.0707" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4910-4"
+       id="linearGradient6103"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20.03125,-4.0000216)"
+       x1="-13"
+       y1="1047.3622"
+       x2="-15"
+       y2="1047.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-4"
+       id="linearGradient6105"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.82102273,0,0,1,17.284091,-4.0000216)"
+       x1="-11"
+       y1="1042.3622"
+       x2="-11"
+       y2="1044.3622" />
+    <linearGradient
+       y2="1043.8571"
+       x2="11"
+       y1="1043.8571"
+       x1="7.0070496"
+       gradientTransform="translate(2.0918142,-0.60984125)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9203-3"
+       xlink:href="#linearGradient4877-6-4-2-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877-6-4-2-5">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4879-1-3-9-9" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop4881-4-4-6-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1.0753482,-4.6757052)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.8571"
+       x2="14"
+       y1="1045.8571"
+       x1="7.0070496"
+       id="linearGradient4869-17-7-2-5"
+       xlink:href="#linearGradient4861-1-9-7-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4861-1-9-7-3"
+       inkscape:collect="always">
+      <stop
+         id="stop4863-1-0-5-5"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4865-52-3-4-4"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5147-4-0-5-8">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop5149-5-8-0-9" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop5151-5-4-6-0" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.8571"
+       x2="14"
+       y1="1047.8571"
+       x1="7.0070496"
+       gradientTransform="translate(1.0753482,-2.5543849)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9273"
+       xlink:href="#linearGradient5147-4-0-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9334-5">
+      <stop
+         style="stop-color:#f3f0bc;stop-opacity:1;"
+         offset="0"
+         id="stop9337-0" />
+      <stop
+         id="stop9366-9"
+         offset="1"
+         style="stop-color:#f6db85;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9368-7">
+      <stop
+         style="stop-color:#c3a867;stop-opacity:1;"
+         offset="0"
+         id="stop9370-5" />
+      <stop
+         style="stop-color:#866f36;stop-opacity:1;"
+         offset="1"
+         id="stop9372-0" />
+    </linearGradient>
+    <radialGradient
+       r="2.7359223"
+       fy="-8.3656569"
+       fx="5.8667765"
+       cy="-8.3656569"
+       cx="5.8667765"
+       gradientTransform="matrix(3.8020701,0,0,0.71327892,-16.439119,-2.0966268)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient9405"
+       xlink:href="#linearGradient9334-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-5.5260382"
+       x2="6.2367058"
+       y1="-8.063673"
+       x1="5.8667765"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9407"
+       xlink:href="#linearGradient9368-7"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="19.851601"
+     inkscape:cy="-0.37337038"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="250"
+     inkscape:window-y="203"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid6094"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g6096"
+       transform="matrix(0,-1,1,0,-1036.3625,1053.3635)">
+      <rect
+         y="1037.9558"
+         x="4.4700499"
+         height="13.908081"
+         width="10.03028"
+         id="rect3997-9"
+         style="fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient6101);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-7"
+         d="m 6.03125,1039.3622 0,12 -1,0 0,-13 z"
+         style="fill:url(#linearGradient6103);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-0"
+         d="m 5.7897727,1039.3622 8.2102273,0 0,-1 -9.03125,0 z"
+         style="fill:url(#linearGradient6105);fill-opacity:1;stroke:none;display:inline" />
+      <g
+         transform="matrix(0,-1,-1,0,1052.6565,1058.4595)"
+         style="display:inline;opacity:0.60493827"
+         id="g9242">
+        <rect
+           style="fill:url(#linearGradient9203-3);fill-opacity:1;stroke:none;display:inline"
+           id="rect4001-1-3"
+           width="3.9929504"
+           height="1.0103934"
+           x="9.0988646"
+           y="1042.7418" />
+        <rect
+           style="fill:url(#linearGradient4869-17-7-2-5);fill-opacity:1;stroke:none;display:inline"
+           id="rect4001-1-7-6"
+           width="6.9929504"
+           height="1.0103934"
+           x="8.0823984"
+           y="1040.6759" />
+        <rect
+           style="fill:url(#linearGradient9273);fill-opacity:1;stroke:none;display:inline"
+           id="rect4001-1-7-4-3"
+           width="5.4461541"
+           height="1.010376"
+           x="8.0823984"
+           y="1044.7972" />
+      </g>
+      <g
+         style="display:inline"
+         id="g9376"
+         transform="matrix(0,1,-1,0,1042.7023,1022.3087)">
+        <path
+           sodipodi:nodetypes="cccccccccc"
+           inkscape:connector-curvature="0"
+           d="m 19.538267,1031.4597 0,3.5797 -1.458408,1.2816 0,-4.7729 1.59099,-0.088 m 0,0 1.590991,0.088 0,4.773 -1.458408,-1.2817 0,-3.5797"
+           style="fill:#da76a3;fill-opacity:1;stroke:#da76a3;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           id="path9345-4" />
+        <path
+           transform="matrix(0.99059914,0,0,1.2070442,13.898978,1040.7488)"
+           d="m 8.3526988,-7.3124266 c 0,0.9396991 -1.1129853,1.7014758 -2.4859223,1.7014758 -1.372937,0 -2.4859224,-0.7617767 -2.4859224,-1.7014758 0,-0.9396991 1.1129854,-1.7014757 2.4859224,-1.7014757 1.372937,0 2.4859223,0.7617766 2.4859223,1.7014757 z"
+           sodipodi:ry="1.7014757"
+           sodipodi:rx="2.4859223"
+           sodipodi:cy="-7.3124266"
+           sodipodi:cx="5.8667765"
+           id="path9314"
+           style="fill:url(#radialGradient9405);fill-opacity:1;stroke:url(#linearGradient9407);stroke-width:0.5;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:type="arc" />
+      </g>
+      <g
+         id="g6146"
+         transform="translate(0,-0.57452426)"
+         style="stroke:#8694ae;stroke-opacity:1">
+        <path
+           id="path6107-3-5-5"
+           style="fill:#ffffff;fill-opacity:1;stroke:none;display:inline"
+           d="m 4.8415918,1046.8695 c 0,0 0.043276,0.044 0.562586,0.4879 0.51931,0.4433 1.5146531,1.2858 2.423445,1.2858 0.9087919,0 1.3848259,-1.0199 1.6444809,-1.4854 0.2596549,-0.4655 0.7356883,-1.4854 1.6444803,-1.4854 0.908793,0 1.904135,0.8425 2.423445,1.2859 0.519309,0.4438 0.562586,0.4878 0.562586,0.4878 l 0.865517,0 0,-3.0494 -0.865517,0 c 0,0 -0.04328,-0.044 -0.562586,-0.4878 -0.51931,-0.4434 -1.514652,-1.2859 -2.423445,-1.2859 -0.908792,0 -1.3848254,1.0199 -1.6444803,1.4854 -0.259655,0.4655 -0.735689,1.4854 -1.6444809,1.4854 -0.9087919,0 -1.904136,-0.8425 -2.423445,-1.2858 -0.51931,-0.4439 -0.562586,-0.4879 -0.562586,-0.4879 l -0.8655164,0 0,3.0494 z"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccsssccccccsssccccc" />
+        <path
+           sodipodi:nodetypes="cccscsccc"
+           inkscape:connector-curvature="0"
+           d="m 14.992426,1044.3625 -0.868803,0 c 0,0 -0.04344,-0.044 -0.564721,-0.4874 -0.521282,-0.4431 -1.520402,-1.2849 -2.432645,-1.2849 -0.912242,0 -1.3900841,1.0191 -1.6507247,1.4842 -0.2606401,0.4651 -0.7384812,1.4842 -1.6507234,1.4842 -0.9122423,0 -1.9113643,-0.8418 -2.4326455,-1.2848 -0.5212811,-0.4431 -0.564722,-0.4875 -0.564722,-0.4875 l -0.8688017,0"
+           style="fill:none;stroke:#8694ae;stroke-width:0.99265999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           id="path6107-3" />
+        <path
+           sodipodi:nodetypes="cccscsccc"
+           inkscape:connector-curvature="0"
+           d="m 14.992836,1047.412 -0.867127,0 c 0,0 -0.04336,-0.044 -0.563632,-0.4876 -0.520277,-0.4432 -1.517471,-1.2852 -2.427955,-1.2852 -0.910483,0 -1.3874026,1.0194 -1.6475407,1.4846 -0.2601381,0.4652 -0.7370577,1.4846 -1.6475403,1.4846 -0.9104833,0 -1.9076786,-0.842 -2.4279545,-1.2851 -0.5202762,-0.4433 -0.5636328,-0.4877 -0.5636328,-0.4877 l -0.8671265,0"
+           style="fill:none;stroke:#8694ae;stroke-width:0.99183947px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           id="path6107-3-5" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/signed_unkn_tbl.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/signed_unkn_tbl.svg
@@ -1,0 +1,384 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="signed_unkn_tbl.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient6208">
+      <stop
+         style="stop-color:#41217e;stop-opacity:1;"
+         offset="0"
+         id="stop6210" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="stop6212" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4810">
+      <stop
+         id="stop4812"
+         offset="0"
+         style="stop-color:#886b2d;stop-opacity:1;" />
+      <stop
+         id="stop4814"
+         offset="1"
+         style="stop-color:#bc9617;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8" />
+      <stop
+         style="stop-color:#d1eeff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4994-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5"
+         offset="0"
+         style="stop-color:#d1eeff;stop-opacity:1" />
+      <stop
+         id="stop4998-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4810"
+       id="linearGradient6101"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.985216,1.9063284)"
+       x1="8.0137892"
+       y1="1036.6622"
+       x2="8.0137892"
+       y2="1050.0707" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4910-4"
+       id="linearGradient6103"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(21.016466,-4.0937716)"
+       x1="-13"
+       y1="1047.3622"
+       x2="-15"
+       y2="1047.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-4"
+       id="linearGradient6105"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.82102273,0,0,1,18.269307,-4.0937716)"
+       x1="-11"
+       y1="1042.3622"
+       x2="-11"
+       y2="1044.3622" />
+    <linearGradient
+       id="linearGradient9334-5">
+      <stop
+         style="stop-color:#f3f0bc;stop-opacity:1;"
+         offset="0"
+         id="stop9337-0" />
+      <stop
+         id="stop9366-9"
+         offset="1"
+         style="stop-color:#eba023;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9368-7">
+      <stop
+         style="stop-color:#c3a867;stop-opacity:1;"
+         offset="0"
+         id="stop9370-5" />
+      <stop
+         style="stop-color:#866f36;stop-opacity:1;"
+         offset="1"
+         id="stop9372-0" />
+    </linearGradient>
+    <radialGradient
+       r="2.7359223"
+       fy="-8.3656569"
+       fx="5.8667765"
+       cy="-8.3656569"
+       cx="5.8667765"
+       gradientTransform="matrix(3.7663274,0,0,0.86095918,-2.4942699,1037.2329)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient9405"
+       xlink:href="#linearGradient9334-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-5.5260382"
+       x2="6.2367058"
+       y1="-8.063673"
+       x1="5.8667765"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9407"
+       xlink:href="#linearGradient9368-7"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.99059914,0,0,1.2070442,13.790307,1039.7636)" />
+    <filter
+       inkscape:collect="always"
+       id="filter6204">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.24680834"
+         id="feGaussianBlur6206" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6208"
+       id="linearGradient6214"
+       x1="29.690636"
+       y1="980.18774"
+       x2="33.581092"
+       y2="980.18772"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.12887916,-1.0479454)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6208"
+       id="linearGradient6222"
+       x1="28.95174"
+       y1="985.64532"
+       x2="31.371033"
+       y2="985.64532"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.12887916,-1.0479454)" />
+    <linearGradient
+       y2="1043.8571"
+       x2="11"
+       y1="1043.8571"
+       x1="7.0070496"
+       gradientTransform="translate(2.0918142,-0.65403543)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9203-3-2"
+       xlink:href="#linearGradient4877-6-4-2-5-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877-6-4-2-5-7">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4879-1-3-9-9-2" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop4881-4-4-6-5-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0.98695985,-4.6978023)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.8571"
+       x2="14"
+       y1="1045.8571"
+       x1="7.0070496"
+       id="linearGradient4869-17-7-2-5-0"
+       xlink:href="#linearGradient4861-1-9-7-3-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4861-1-9-7-3-2"
+       inkscape:collect="always">
+      <stop
+         id="stop4863-1-0-5-5-0"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4865-52-3-4-4-9"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5147-4-0-5-8-6">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop5149-5-8-0-9-8" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop5151-5-4-6-0-0" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.8571"
+       x2="14"
+       y1="1047.8571"
+       x1="7.0070496"
+       gradientTransform="translate(1.1637366,-2.7311616)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4146"
+       xlink:href="#linearGradient5147-4-0-5-8-6"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="63.999997"
+     inkscape:cx="4.1293766"
+     inkscape:cy="12.805568"
+     inkscape:document-units="px"
+     inkscape:current-layer="text4892"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="978"
+     inkscape:window-y="113"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid6094"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g6096"
+       transform="matrix(0,-1,1,0,-1036.3625,1053.3635)">
+      <rect
+         y="1037.8621"
+         x="5.455266"
+         height="13.908081"
+         width="10.03028"
+         id="rect3997-9"
+         style="display:inline;fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient6101);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-7"
+         d="m 7.016466,1039.2684 0,12 -1,0 0,-13 z"
+         style="display:inline;fill:url(#linearGradient6103);fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-0"
+         d="m 6.7749887,1039.2684 8.2102273,0 0,-1 -9.03125,0 z"
+         style="display:inline;fill:url(#linearGradient6105);fill-opacity:1;stroke:none" />
+      <g
+         style="display:inline"
+         id="g9376"
+         transform="matrix(0,0.86269695,-1,0,1042.5476,1024.8382)">
+        <path
+           sodipodi:nodetypes="cccccccccc"
+           inkscape:connector-curvature="0"
+           d="m 19.512358,1030.4695 0,3.5871 -1.393288,1.2842 0,-4.7827 1.51995,-0.088 m 0,0 1.519951,0.088 0,4.7828 -1.393288,-1.2843 0,-3.5871"
+           style="display:inline;fill:#f4006e;fill-opacity:1;stroke:#f4006e;stroke-width:0.48878345;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path9345-4" />
+        <ellipse
+           id="path9314"
+           style="display:inline;fill:url(#radialGradient9405);fill-opacity:1;stroke:url(#linearGradient9407);stroke-width:0.54673964;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           cx="19.601931"
+           cy="1030.9371"
+           rx="2.4625525"
+           ry="2.0537565" />
+        <g
+           transform="matrix(0.84319949,0,0,0.94014067,2.8723743,113.52269)"
+           style="font-size:13.07725716px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+           id="text4892">
+          <g
+             id="g6172"
+             style="fill:#ffffff;fill-opacity:1;filter:url(#filter6204)"
+             transform="matrix(1.0899808,0,0,1.0899808,-3.0796315,-89.217585)">
+            <path
+               sodipodi:nodetypes="cscssssscssscscc"
+               inkscape:connector-curvature="0"
+               id="path4897-4"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:13.07725716px;line-height:125%;font-family:'URW Bookman L';letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none"
+               d="m 31.63734,983.30664 0,-0.10461 c 0,-0.66694 0.156928,-0.85003 1.072335,-1.25542 1.150798,-0.49694 1.752353,-1.3208 1.752353,-2.40622 0,-1.54311 -1.333883,-2.4716 -3.583169,-2.4716 -2.026973,0 -3.570091,1.04618 -3.570091,2.4193 0,0.75848 0.43155,1.21618 1.137721,1.21618 0.627708,0 1.085413,-0.41847 1.085413,-0.99387 0,-0.13077 -0.05231,-0.36616 -0.09154,-0.47078 -0.104618,-0.24847 -0.104618,-0.24847 -0.104618,-0.34001 0,-0.36616 0.627709,-0.6931 1.33388,-0.6931 0.863098,0 1.412344,0.53617 1.412344,1.37312 0,0.52309 -0.209237,0.9154 -0.640786,1.26849 -0.967716,0.75848 -1.137721,1.07234 -1.137721,2.02697 0,0.19616 0,0.27463 0.02615,0.43155 l 1.307726,0" />
+            <path
+               sodipodi:nodetypes="csssc"
+               inkscape:connector-curvature="0"
+               id="path4897-6-1"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:13.07725716px;line-height:125%;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L Bold';letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none"
+               d="m 31.035783,984.43571 c -0.653862,0 -1.203107,0.53617 -1.203107,1.17695 0,0.6931 0.536168,1.24234 1.203107,1.24234 0.66694,0 1.216185,-0.54924 1.216185,-1.21618 0,-0.66694 -0.536168,-1.20311 -1.216185,-1.20311" />
+          </g>
+          <g
+             transform="matrix(-1.374711,0,0,1.0636706,42.669105,-132.49838)"
+             style="display:inline;opacity:0.60493828"
+             id="g9242-2">
+            <rect
+               style="display:inline;fill:url(#linearGradient9203-3-2);fill-opacity:1;stroke:none"
+               id="rect4001-1-3"
+               width="3.9929504"
+               height="1.0103934"
+               x="9.0988646"
+               y="1042.6976" />
+            <rect
+               style="display:inline;fill:url(#linearGradient4869-17-7-2-5-0);fill-opacity:1;stroke:none"
+               id="rect4001-1-7-6-8"
+               width="5.0926008"
+               height="1.010376"
+               x="7.99401"
+               y="1040.6538" />
+            <rect
+               style="display:inline;fill:url(#linearGradient4146);fill-opacity:1;stroke:none"
+               id="rect4001-1-7-4-3"
+               width="4.9379215"
+               height="1.010376"
+               x="8.1707869"
+               y="1044.6205" />
+          </g>
+          <path
+             d="m 30.627525,982.25869 0,-0.10461 c 0,-0.66694 0.156928,-0.85003 1.072335,-1.25542 1.150798,-0.49694 1.752353,-1.3208 1.752353,-2.40622 0,-1.54311 -1.333883,-2.4716 -3.583169,-2.4716 -2.026973,0 -3.570091,1.04618 -3.570091,2.4193 0,0.75848 0.43155,1.21618 1.137721,1.21618 0.627708,0 1.085413,-0.41847 1.085413,-0.99387 0,-0.13077 -0.05231,-0.36616 -0.09154,-0.47078 -0.104618,-0.24847 -0.104618,-0.24847 -0.104618,-0.34001 0,-0.36616 0.627709,-0.6931 1.33388,-0.6931 0.863098,0 1.412344,0.53617 1.412344,1.37312 0,0.52309 -0.209237,0.9154 -0.640786,1.26849 -0.967716,0.75848 -1.137721,1.07234 -1.137721,2.02697 0,0.19616 0,0.27463 0.02615,0.43155 l 1.307726,0"
+             style="font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L Bold';fill:url(#linearGradient6214);fill-opacity:1;stroke:none"
+             id="path4897"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cscssssscssscscc" />
+          <path
+             d="m 30.025968,983.38776 c -0.653862,0 -1.203107,0.53617 -1.203107,1.17695 0,0.6931 0.536168,1.24234 1.203107,1.24234 0.66694,0 1.216185,-0.54924 1.216185,-1.21618 0,-0.66694 -0.536168,-1.20311 -1.216185,-1.20311"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:13.07725716px;line-height:125%;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L Bold';letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient6222);fill-opacity:1;stroke:none"
+             id="path4897-6"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="csssc" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/signed_yes_tbl.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/signed_yes_tbl.svg
@@ -1,0 +1,313 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="signed_yes_tbl.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4810">
+      <stop
+         id="stop4812"
+         offset="0"
+         style="stop-color:#886b2d;stop-opacity:1;" />
+      <stop
+         id="stop4814"
+         offset="1"
+         style="stop-color:#bc9617;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8" />
+      <stop
+         style="stop-color:#d1eeff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4994-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5"
+         offset="0"
+         style="stop-color:#d1eeff;stop-opacity:1" />
+      <stop
+         id="stop4998-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4810"
+       id="linearGradient6101"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.0000784)"
+       x1="8.0137892"
+       y1="1036.6622"
+       x2="8.0137892"
+       y2="1050.0707" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4910-4"
+       id="linearGradient6103"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20.03125,-4.0000216)"
+       x1="-13"
+       y1="1047.3622"
+       x2="-15"
+       y2="1047.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-4"
+       id="linearGradient6105"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.82102273,0,0,1,17.284091,-4.0000216)"
+       x1="-11"
+       y1="1042.3622"
+       x2="-11"
+       y2="1044.3622" />
+    <linearGradient
+       y2="1043.8571"
+       x2="11"
+       y1="1043.8571"
+       x1="7.0070496"
+       gradientTransform="translate(2.0918142,-0.65403543)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9203-3"
+       xlink:href="#linearGradient4877-6-4-2-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877-6-4-2-5">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4879-1-3-9-9" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop4881-4-4-6-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0.98695985,-4.6978023)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.8571"
+       x2="14"
+       y1="1045.8571"
+       x1="7.0070496"
+       id="linearGradient4869-17-7-2-5"
+       xlink:href="#linearGradient4861-1-9-7-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4861-1-9-7-3"
+       inkscape:collect="always">
+      <stop
+         id="stop4863-1-0-5-5"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4865-52-3-4-4"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5147-4-0-5-8">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop5149-5-8-0-9" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop5151-5-4-6-0" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.8571"
+       x2="14"
+       y1="1047.8571"
+       x1="7.0070496"
+       gradientTransform="translate(1.1637366,-2.7311616)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9273"
+       xlink:href="#linearGradient5147-4-0-5-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9334-5">
+      <stop
+         style="stop-color:#f3f0bc;stop-opacity:1;"
+         offset="0"
+         id="stop9337-0" />
+      <stop
+         id="stop9366-9"
+         offset="1"
+         style="stop-color:#eba023;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9368-7">
+      <stop
+         style="stop-color:#c3a867;stop-opacity:1;"
+         offset="0"
+         id="stop9370-5" />
+      <stop
+         style="stop-color:#866f36;stop-opacity:1;"
+         offset="1"
+         id="stop9372-0" />
+    </linearGradient>
+    <radialGradient
+       r="2.7359223"
+       fy="-8.3656569"
+       fx="5.8667765"
+       cy="-8.3656569"
+       cx="5.8667765"
+       gradientTransform="matrix(3.8020701,0,0,0.71327892,-16.439119,-2.0966268)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient9405"
+       xlink:href="#linearGradient9334-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-5.5260382"
+       x2="6.2367058"
+       y1="-8.063673"
+       x1="5.8667765"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9407"
+       xlink:href="#linearGradient9368-7"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254832"
+     inkscape:cx="12.437581"
+     inkscape:cy="5.4419504"
+     inkscape:document-units="px"
+     inkscape:current-layer="g9376"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="150"
+     inkscape:window-y="150"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid6094"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g6096"
+       transform="matrix(0,-1,1,0,-1036.3625,1053.3635)">
+      <rect
+         y="1037.9558"
+         x="4.4700499"
+         height="13.908081"
+         width="10.03028"
+         id="rect3997-9"
+         style="fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient6101);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-7"
+         d="m 6.03125,1039.3622 0,12 -1,0 0,-13 z"
+         style="fill:url(#linearGradient6103);fill-opacity:1;stroke:none;display:inline" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4853-82-0"
+         d="m 5.7897727,1039.3622 8.2102273,0 0,-1 -9.03125,0 z"
+         style="fill:url(#linearGradient6105);fill-opacity:1;stroke:none;display:inline" />
+      <g
+         transform="matrix(0,-1,-1,0,1052.6565,1058.4595)"
+         style="display:inline;opacity:0.60493827"
+         id="g9242">
+        <rect
+           style="fill:url(#linearGradient9203-3);fill-opacity:1;stroke:none;display:inline"
+           id="rect4001-1-3"
+           width="3.9929504"
+           height="1.0103934"
+           x="9.0988646"
+           y="1042.6976" />
+        <rect
+           style="fill:url(#linearGradient4869-17-7-2-5);fill-opacity:1;stroke:none;display:inline"
+           id="rect4001-1-7-6"
+           width="5.0926008"
+           height="1.010376"
+           x="7.99401"
+           y="1040.6538" />
+        <rect
+           style="fill:url(#linearGradient9273);fill-opacity:1;stroke:none;display:inline"
+           id="rect4001-1-7-4-3"
+           width="4.9379215"
+           height="1.010376"
+           x="8.1707869"
+           y="1044.6205" />
+      </g>
+      <g
+         style="display:inline"
+         id="g9376"
+         transform="matrix(0,0.86269695,-1,0,1042.5476,1024.8382)">
+        <path
+           sodipodi:nodetypes="cccccccccc"
+           inkscape:connector-curvature="0"
+           d="m 19.621029,1031.4547 0,3.5871 -1.393288,1.2842 0,-4.7827 1.51995,-0.088 m 0,0 1.519951,0.088 0,4.7828 -1.393288,-1.2843 0,-3.5871"
+           style="fill:#f4006e;fill-opacity:1;stroke:#f4006e;stroke-width:0.48878345;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           id="path9345-4" />
+        <path
+           transform="matrix(0.99059914,0,0,1.2070442,13.898978,1040.7488)"
+           d="m 8.3526988,-7.3124266 c 0,0.9396991 -1.1129853,1.7014758 -2.4859223,1.7014758 -1.372937,0 -2.4859224,-0.7617767 -2.4859224,-1.7014758 0,-0.9396991 1.1129854,-1.7014757 2.4859224,-1.7014757 1.372937,0 2.4859223,0.7617766 2.4859223,1.7014757 z"
+           sodipodi:ry="1.7014757"
+           sodipodi:rx="2.4859223"
+           sodipodi:cy="-7.3124266"
+           sodipodi:cx="5.8667765"
+           id="path9314"
+           style="fill:url(#radialGradient9405);fill-opacity:1;stroke:url(#linearGradient9407);stroke-width:0.5;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:type="arc" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/submenu.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/submenu.svg
@@ -1,0 +1,575 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="submenu.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4253"
+       inkscape:collect="always">
+      <stop
+         id="stop4255"
+         offset="0"
+         style="stop-color:#26528a;stop-opacity:1" />
+      <stop
+         id="stop4257"
+         offset="1"
+         style="stop-color:#6579a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4247">
+      <stop
+         id="stop4249"
+         offset="0"
+         style="stop-color:#b4903d;stop-opacity:1" />
+      <stop
+         style="stop-color:#7f774e;stop-opacity:1"
+         offset="1"
+         id="stop4251" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10359">
+      <stop
+         style="stop-color:#4a77a8;stop-opacity:1;"
+         offset="0"
+         id="stop10361" />
+      <stop
+         style="stop-color:#2266a0;stop-opacity:1"
+         offset="1"
+         id="stop10363" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10593">
+      <stop
+         style="stop-color:#1b639e;stop-opacity:1;"
+         offset="0"
+         id="stop10595" />
+      <stop
+         style="stop-color:#6f8db9;stop-opacity:1"
+         offset="1"
+         id="stop10597" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9610">
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1"
+         offset="0"
+         id="stop9612" />
+      <stop
+         id="stop9614"
+         offset="1"
+         style="stop-color:#9a9990;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient15990"
+       inkscape:collect="always">
+      <stop
+         id="stop15992"
+         offset="0"
+         style="stop-color:#f9fafc;stop-opacity:1" />
+      <stop
+         id="stop15994"
+         offset="1"
+         style="stop-color:#e0eaf8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9610"
+       id="linearGradient9568"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-6.074384,3.9704772)"
+       x1="8.0137892"
+       y1="1035.9741"
+       x2="8.0137892"
+       y2="1051.0103" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15990"
+       id="linearGradient9571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8474583,0,0,0.67963192,9.9008257,358.14455)"
+       x1="-3.1651151"
+       y1="1030.4418"
+       x2="-3.1651151"
+       y2="1041.0583" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10593"
+       id="linearGradient10599"
+       x1="10"
+       y1="10"
+       x2="10"
+       y2="5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.8153447,1050.371)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10653-6">
+      <stop
+         style="stop-color:#130d08;stop-opacity:1"
+         offset="0"
+         id="stop10655-1" />
+      <stop
+         style="stop-color:#654628;stop-opacity:0;"
+         offset="1"
+         id="stop10657-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.3622"
+       x2="14"
+       y1="1041.3622"
+       x1="14"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10676"
+       xlink:href="#linearGradient10653-6"
+       inkscape:collect="always"
+       gradientTransform="matrix(1,0,0,-1,-20.299911,2088.3986)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351"
+       id="linearGradient10357"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-19.268661,0.67417473)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10359"
+       id="linearGradient10365"
+       x1="9"
+       y1="1043.8622"
+       x2="14"
+       y2="1043.8622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-19.268661,-1.3258253)" />
+    <linearGradient
+       gradientTransform="translate(-19.268661,0.67417473)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient10359-9"
+       id="linearGradient10365-7"
+       x1="9"
+       y1="1043.8622"
+       x2="14"
+       y2="1043.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10359-9">
+      <stop
+         style="stop-color:#4a77a8;stop-opacity:1;"
+         offset="0"
+         id="stop10361-8" />
+      <stop
+         style="stop-color:#2266a0;stop-opacity:1"
+         offset="1"
+         id="stop10363-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-19.268661,10.674175)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10490"
+       xlink:href="#linearGradient10351-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient9610-6">
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1"
+         offset="0"
+         id="stop9612-8" />
+      <stop
+         id="stop9614-2"
+         offset="1"
+         style="stop-color:#9a9990;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.0103"
+       x2="8.0137892"
+       y1="1035.9741"
+       x1="8.0137892"
+       gradientTransform="translate(-8.9053941,21.029495)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9594"
+       xlink:href="#linearGradient9610-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10359-8">
+      <stop
+         style="stop-color:#4a77a8;stop-opacity:1;"
+         offset="0"
+         id="stop10361-2" />
+      <stop
+         style="stop-color:#2266a0;stop-opacity:1"
+         offset="1"
+         id="stop10363-3" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.8622"
+       x2="14"
+       y1="1043.8622"
+       x1="9"
+       gradientTransform="translate(-7.1250006,11.937509)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9628"
+       xlink:href="#linearGradient10359-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2-3">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6-3" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9-7" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-3.0000004,22.062509)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9662"
+       xlink:href="#linearGradient10351-2-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2-3-1">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6-3-8" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9-7-7" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-3.0000004,24.0625)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9696"
+       xlink:href="#linearGradient10351-2-3-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2-3-1-1">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6-3-8-2" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9-7-7-1" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-3.0000004,25.9375)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9730"
+       xlink:href="#linearGradient10351-2-3-1-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10351-2-3-1-1-5">
+      <stop
+         style="stop-color:#849abe;stop-opacity:1;"
+         offset="0"
+         id="stop10353-6-3-8-2-7" />
+      <stop
+         style="stop-color:#677da9;stop-opacity:1"
+         offset="1"
+         id="stop10355-9-7-7-1-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.8622"
+       x2="11"
+       y1="1037.8622"
+       x1="5"
+       gradientTransform="translate(-3.0000004,28.0625)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9764"
+       xlink:href="#linearGradient10351-2-3-1-1-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15990"
+       id="linearGradient9793"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8474583,0,0,0.76458255,9.9008257,269.47716)"
+       x1="-3.1651151"
+       y1="1030.4418"
+       x2="-3.1651151"
+       y2="1041.0583" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4247"
+       id="linearGradient9795"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-8.8741441,21.029495)"
+       x1="8.0137892"
+       y1="1035.9741"
+       x2="8.0137892"
+       y2="1051.0103" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10593"
+       id="linearGradient9797"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.8153447,1050.371)"
+       x1="10"
+       y1="10"
+       x2="10"
+       y2="5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10359-8"
+       id="linearGradient9799"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-7.1250006,11.937509)"
+       x1="9"
+       y1="1043.8622"
+       x2="14"
+       y2="1043.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351-2-3"
+       id="linearGradient9801"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.9375004,22.015634)"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351-2-3-1"
+       id="linearGradient9803"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.9375004,23.984375)"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351-2-3-1-1"
+       id="linearGradient9805"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.9375004,25.984375)"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10351-2-3-1-1-5"
+       id="linearGradient9807"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.9375004,27.984375)"
+       x1="5"
+       y1="1037.8622"
+       x2="11"
+       y2="1037.8622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4253"
+       id="linearGradient3060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-3.8153447,1050.371)"
+       x1="10"
+       y1="10"
+       x2="10"
+       y2="5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10359-8"
+       id="linearGradient3062"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96134224,0,0,1,-6.7218381,11.992752)"
+       x1="9"
+       y1="1043.8622"
+       x2="14"
+       y2="1043.8622" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="1.9977672"
+     inkscape:cy="11.216296"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1284"
+     inkscape:window-height="898"
+     inkscape:window-x="866"
+     inkscape:window-y="544"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g9783"
+       transform="translate(2.9375001,-17.000001)">
+      <g
+         id="g4222"
+         transform="translate(1.0000001,0)">
+        <rect
+           style="display:inline;fill:url(#linearGradient9793);fill-opacity:1;stroke:none"
+           id="rect3997-9-2-7"
+           width="8.2786407"
+           height="10.406616"
+           x="0.93990028"
+           y="1057.1051" />
+        <rect
+           style="display:inline;fill:none;stroke:url(#linearGradient9795);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect3997-9"
+           width="9.027504"
+           height="10.967041"
+           x="0.55639607"
+           y="1056.8822"
+           rx="0"
+           ry="0" />
+        <rect
+           y="1053.9872"
+           x="-1.4375"
+           height="3.7500002"
+           width="5.9062505"
+           id="rect4210"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <g
+           transform="translate(-1.8750001,0)"
+           id="g3056">
+          <path
+             sodipodi:nodetypes="cccccccccccccc"
+             inkscape:connector-curvature="0"
+             id="rect18863-4-5"
+             d="m -0.05082971,1053.371 0.01104854,4.9892 1.00000001,0 4.99797616,0 1,0 0,-1 -0.011049,-3.9892 -5.9979762,0 z m 1.00000001,1 4.9979762,0 0.011049,2.9892 -4.99797616,0 z"
+             style="display:inline;fill:url(#linearGradient3060);fill-opacity:1;stroke:none" />
+          <rect
+             style="display:inline;fill:url(#linearGradient3062);fill-opacity:1;stroke:none"
+             id="rect18863-4-8-1-4-71"
+             width="3.022311"
+             height="1"
+             x="1.9302431"
+             y="1055.355" />
+        </g>
+        <rect
+           y="1059.3778"
+           x="2.0625007"
+           height="1.0000174"
+           width="6"
+           id="rect18863-4-2-4"
+           style="display:inline;fill:url(#linearGradient9801);fill-opacity:1;stroke:none" />
+        <rect
+           y="1061.3466"
+           x="2.0625007"
+           height="1.0000174"
+           width="6"
+           id="rect18863-4-2-4-3"
+           style="display:inline;fill:url(#linearGradient9803);fill-opacity:1;stroke:none" />
+        <rect
+           y="1063.3466"
+           x="2.0625007"
+           height="1.0000174"
+           width="6"
+           id="rect18863-4-2-4-3-7"
+           style="display:inline;fill:url(#linearGradient9805);fill-opacity:1;stroke:none" />
+        <rect
+           y="1065.3466"
+           x="2.0625007"
+           height="1.0000174"
+           width="6"
+           id="rect18863-4-2-4-3-7-2"
+           style="display:inline;fill:url(#linearGradient9807);fill-opacity:1;stroke:none" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/theme_category.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/theme_category.svg
@@ -1,0 +1,420 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg25490"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="theme_category.svg">
+  <defs
+     id="defs25492">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient8238"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11290">
+      <stop
+         style="stop-color:#567ead;stop-opacity:1"
+         offset="0"
+         id="stop11292" />
+      <stop
+         style="stop-color:#35679d;stop-opacity:1"
+         offset="1"
+         id="stop11294" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient25512"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient25520"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient7357"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       y2="373.2294"
+       x2="543.91406"
+       y1="373.2294"
+       x1="523.00781"
+       gradientTransform="translate(-60.558598,1.4188)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9459"
+       xlink:href="#linearGradient3955"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3955">
+      <stop
+         id="stop3957"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961" />
+      <stop
+         id="stop3963"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient25569"
+       xlink:href="#linearGradient11290"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient25571"
+       xlink:href="#linearGradient11290"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290-0"
+       id="linearGradient7357-5"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11290-0">
+      <stop
+         style="stop-color:#567ead;stop-opacity:1"
+         offset="0"
+         id="stop11292-3" />
+      <stop
+         style="stop-color:#35679d;stop-opacity:1"
+         offset="1"
+         id="stop11294-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967-5"
+       id="linearGradient3939-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-61.366562,1.4453859)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       id="linearGradient3967-5"
+       inkscape:collect="always">
+      <stop
+         id="stop3969-3"
+         offset="0"
+         style="stop-color:#c48a4e;stop-opacity:1;" />
+      <stop
+         id="stop3971-6"
+         offset="1"
+         style="stop-color:#ad6c24;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973-6"
+       id="linearGradient4933-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-60.558598,0)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       id="linearGradient3973-6"
+       inkscape:collect="always">
+      <stop
+         id="stop3975-0"
+         offset="0"
+         style="stop-color:#f8d078;stop-opacity:1" />
+      <stop
+         id="stop3977-3"
+         offset="1"
+         style="stop-color:#f8f0c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949-4"
+       id="linearGradient4935-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-60.558598,0)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3949-4">
+      <stop
+         style="stop-color:#9e6627;stop-opacity:1"
+         offset="0"
+         id="stop3951-7" />
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="1"
+         id="stop3953-6" />
+    </linearGradient>
+    <linearGradient
+       y2="373.2294"
+       x2="543.91406"
+       y1="373.2294"
+       x1="523.00781"
+       gradientTransform="translate(-60.558598,1.4188)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient25567-7"
+       xlink:href="#linearGradient3955-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3955-1">
+      <stop
+         id="stop3957-4"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959-2" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961-1" />
+      <stop
+         id="stop3963-4"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965-5"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="373.2294"
+       x2="543.91406"
+       y1="373.2294"
+       x1="523.00781"
+       gradientTransform="translate(-60.558598,1.4188)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient26656"
+       xlink:href="#linearGradient3955-1"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="-2.6737023"
+     inkscape:cy="3.8243177"
+     inkscape:document-units="px"
+     inkscape:current-layer="text3909-7-7-1"
+     showgrid="true"
+     inkscape:snap-global="false"
+     inkscape:window-width="1429"
+     inkscape:window-height="852"
+     inkscape:window-x="921"
+     inkscape:window-y="529"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid26727"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata25495">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="translate(324.0078,-599.7683)"
+       style="stroke:url(#linearGradient8238);stroke-opacity:1;display:inline"
+       id="layer1-2"
+       inkscape:label="Layer 1">
+      <g
+         id="g11331-3-1-1-7"
+         style="stroke:url(#linearGradient25569);display:inline"
+         transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)">
+        <g
+           style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+           id="g13408-8-9" />
+      </g>
+      <g
+         id="g6124-3"
+         style="stroke:url(#linearGradient25571);display:inline"
+         transform="matrix(-1,0,0,1,16.12959,8.0140628)">
+        <g
+           id="text6430"
+           style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+           transform="scale(-1,1)" />
+        <g
+           id="g6438"
+           style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
+           transform="scale(-1,1)">
+          <g
+             style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#236298;fill-opacity:1;stroke:#236298;stroke-width:0.24860173;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:Sans"
+             id="layer1-9"
+             inkscape:label="Layer 1"
+             transform="matrix(1.2778996,0,0.03747938,1.2778996,-58.56426,-297.79529)">
+            <g
+               transform="translate(20,0)"
+               id="text3909-7-7-1"
+               style="font-size:11.05178356px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#236298;fill-opacity:1;stroke:#236298;stroke-width:0.24860173;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:AustralianFlyingCorpsStencil;-inkscape-font-specification:AustralianFlyingCorpsStencil">
+              <g
+                 style="display:inline;stroke:url(#linearGradient7357-5);stroke-opacity:1"
+                 transform="matrix(0.25843864,0,-0.00757972,0.25843864,-399.68854,1413.0296)"
+                 id="g13813">
+                <rect
+                   style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient3939-2);stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+                   id="rect13693-3"
+                   width="15"
+                   height="16.625"
+                   x="463.74335"
+                   y="368.49503"
+                   rx="2.625"
+                   ry="2.625" />
+                <path
+                   style="fill:url(#linearGradient4933-1);fill-opacity:1;stroke:url(#linearGradient4935-8);stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+                   d="m 463.24874,374.64819 31.13385,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,19.0178 c 0,1.45425 -1.17076,2.63221 -2.625,2.625 l -31.13385,-0.15421 c -1.45423,-0.007 -2.625,-1.17075 -2.625,-2.625 l 0,-18.86359 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+                   id="rect13693"
+                   inkscape:connector-curvature="0"
+                   sodipodi:nodetypes="sssssssss" />
+                <path
+                   style="fill:none;stroke:url(#linearGradient26656);stroke-width:3.02792978;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+                   d="m 462.26171,374.64819 20.09375,0"
+                   id="path13797"
+                   inkscape:connector-curvature="0" />
+              </g>
+              <g
+                 id="g26785"
+                 transform="matrix(1.2478876,0,0,1.2478876,70.80818,-374.53547)"
+                 style="stroke:#727272;stroke-width:0.50166959;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none">
+                <rect
+                   ry="0"
+                   transform="matrix(1,0,-0.02931629,0.99957019,0,0)"
+                   y="1513.1359"
+                   x="-237.82529"
+                   height="1.9921261"
+                   width="1.9912698"
+                   id="rect26729"
+                   style="fill:#ffff00;fill-opacity:1;stroke:#727272;stroke-width:0.50177741;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+                <rect
+                   transform="matrix(1,0,-0.02931629,0.99957019,0,0)"
+                   ry="0"
+                   y="1513.1359"
+                   x="-235.67682"
+                   height="1.9921261"
+                   width="1.9912698"
+                   id="rect26729-5"
+                   style="font-size:11.05178356px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#0f3081;fill-opacity:1;stroke:#727272;stroke-width:0.50177741;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:AustralianFlyingCorpsStencil;-inkscape-font-specification:AustralianFlyingCorpsStencil" />
+                <rect
+                   transform="matrix(1,0,-0.02931629,0.99957019,0,0)"
+                   ry="0"
+                   y="1515.3027"
+                   x="-235.67682"
+                   height="1.9921261"
+                   width="1.9912698"
+                   id="rect26729-5-7"
+                   style="font-size:11.05178356px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#4e845f;fill-opacity:1;stroke:#727272;stroke-width:0.50177741;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:AustralianFlyingCorpsStencil;-inkscape-font-specification:AustralianFlyingCorpsStencil" />
+                <rect
+                   transform="matrix(1,0,-0.02931629,0.99957019,0,0)"
+                   ry="0"
+                   y="1515.3027"
+                   x="-237.82529"
+                   height="1.9921261"
+                   width="1.9912698"
+                   id="rect26729-5-7-8"
+                   style="font-size:11.05178356px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ff6900;fill-opacity:1;stroke:#727272;stroke-width:0.50177747;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:AustralianFlyingCorpsStencil;-inkscape-font-specification:AustralianFlyingCorpsStencil" />
+              </g>
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path4719-5"
+                 d="m -14.204503,1046.9093 c -0.33156,0 -0.61154,-0.085 -0.83994,-0.2542 -0.25051,-0.1916 -0.37945,-0.4494 -0.38681,-0.7736 -0.39787,0.6778 -0.90257,1.0167 -1.5141,1.0167 -0.55259,0 -0.98729,-0.1694 -1.30411,-0.5083 -0.31682,-0.3463 -0.47523,-0.7995 -0.47522,-1.3594 -10e-6,-0.7736 0.27997,-1.4699 0.83993,-2.0888 0.55996,-0.6189 1.21938,-0.9283 1.97827,-0.9283 0.72941,0 1.12359,0.3094 1.18254,0.9283 l 0.24314,-0.8068 1.25991,0 c -0.20631,0.6558 -0.40893,1.3115 -0.60785,1.9672 -0.27999,0.9358 -0.41998,1.5657 -0.41997,1.8899 -10e-6,0.3389 0.12156,0.5084 0.36471,0.5084 m -1.19359,-3.4703 c -10e-6,-0.361 -0.1621,-0.5415 -0.48628,-0.5415 -0.45681,0 -0.86941,0.4236 -1.2378,1.2709 -0.32419,0.7295 -0.48628,1.3594 -0.48628,1.8899 0,0.5084 0.19893,0.7626 0.5968,0.7626 0.39785,0 0.78098,-0.4716 1.14938,-1.4147 0.30944,-0.8104 0.46417,-1.4662 0.46418,-1.9672"
+                 style="font-size:11.05178356000000051px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:AustralianFlyingCorpsStencil;-inkscape-font-specification:AustralianFlyingCorpsStencil"
+                 sodipodi:nodetypes="cccscssscccccccsccscc"
+                 transform="matrix(1.2513217,0,0,1.2513217,-255.28349,210.11538)" />
+              <path
+                 style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+                 d="M 14.375,11 13,9.875 c -0.625,0 -2.5625,1.5625 -2.5625,1.5625 -0.3125,0.3125 -0.0625,3.375 -0.0625,3.375 L 11.5625,15.5 c 0.25,0 1.5625,-1.6875 1.5625,-1.6875 z"
+                 id="path49323"
+                 inkscape:connector-curvature="0"
+                 transform="matrix(0.78253409,0,-0.02295086,0.78253409,-284.5419,1507.0916)" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path4719"
+                 d="m -273.38253,1519.48 c -0.33156,0 -0.61154,-0.085 -0.83994,-0.2542 -0.25051,-0.1916 -0.37945,-0.4494 -0.38681,-0.7736 -0.39787,0.6778 -0.90257,1.0167 -1.51409,1.0167 -0.5526,0 -0.9873,-0.1694 -1.30411,-0.5083 -0.31682,-0.3463 -0.47523,-0.7995 -0.47523,-1.3594 0,-0.7736 0.27998,-1.4699 0.83994,-2.0888 0.55995,-0.6189 1.21937,-0.9283 1.97826,-0.9283 0.72942,0 1.1236,0.3094 1.18255,0.9283 l 0.24314,-0.8068 1.2599,0 c -0.20631,0.6558 -0.40893,1.3115 -0.60785,1.9672 -0.27999,0.9358 -0.41997,1.5657 -0.41997,1.8899 -1e-5,0.3389 0.12156,0.5084 0.36471,0.5084 m -1.19359,-3.4703 c -10e-6,-0.361 -0.1621,-0.5415 -0.48628,-0.5415 -0.45681,0 -0.86941,0.4236 -1.2378,1.2709 -0.32419,0.7295 -0.48628,1.3594 -0.48628,1.8899 0,0.5084 0.19893,0.7626 0.5968,0.7626 0.39786,0 0.78098,-0.4716 1.14938,-1.4147 0.30945,-0.8104 0.46417,-1.4662 0.46418,-1.9672"
+                 style="font-size:11.05178356px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#236298;fill-opacity:1;stroke:#236298;stroke-width:0.24860173;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:AustralianFlyingCorpsStencil;-inkscape-font-specification:AustralianFlyingCorpsStencil"
+                 sodipodi:nodetypes="cccscssscccccccsccscc" />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/toolbar.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/toolbar.svg
@@ -1,0 +1,367 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="toolbar.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient17711">
+      <stop
+         style="stop-color:#7f85aa;stop-opacity:1"
+         offset="0"
+         id="stop17713" />
+      <stop
+         id="stop17715"
+         offset="0.5"
+         style="stop-color:#8086aa;stop-opacity:1" />
+      <stop
+         style="stop-color:#7c82a6;stop-opacity:1"
+         offset="1"
+         id="stop17717" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17705">
+      <stop
+         style="stop-color:#cbcef1;stop-opacity:1"
+         offset="0"
+         id="stop17707" />
+      <stop
+         style="stop-color:#e9ebf6;stop-opacity:1"
+         offset="1"
+         id="stop17709" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient28634"
+       osb:paint="gradient">
+      <stop
+         style="stop-color:#c1d9ee;stop-opacity:1;"
+         offset="0"
+         id="stop28636" />
+      <stop
+         id="stop28642"
+         offset="0.5"
+         style="stop-color:#6eaddd;stop-opacity:1" />
+      <stop
+         style="stop-color:#40689d;stop-opacity:1"
+         offset="1"
+         id="stop28638" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(37.991756,2.976947)"
+       gradientUnits="userSpaceOnUse"
+       y2="1038.8951"
+       x2="-4.991955"
+       y1="1038.8951"
+       x1="-16.963362"
+       id="linearGradient8293-6"
+       xlink:href="#linearGradient8287-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1053.3254"
+       x2="8.0137892"
+       y1="1049.3254"
+       x1="7.9284072"
+       gradientTransform="translate(17.072947,-0.956058)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8887-0"
+       xlink:href="#linearGradient4810-5-87"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-13"
+       gradientTransform="translate(35.999999,-7.0301587)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8884-0"
+       xlink:href="#linearGradient4910-4-0-6"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="translate(35.073276,6.0082413)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8881-0"
+       xlink:href="#linearGradient4994-4-5-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.8765"
+       x2="8.0137892"
+       y1="1039.876"
+       x1="8.0137892"
+       gradientTransform="translate(17.115591,1.008442)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8878-5"
+       xlink:href="#linearGradient4082-3-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4810-5-87">
+      <stop
+         style="stop-color:#9d7c2f;stop-opacity:1"
+         offset="0"
+         id="stop4812-0-1" />
+      <stop
+         style="stop-color:#6b623f;stop-opacity:1"
+         offset="1"
+         id="stop4814-4-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4910-4-0-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4912-8-5-7"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0" />
+      <stop
+         id="stop4914-8-1-8"
+         offset="1"
+         style="stop-color:#c5dff4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-4-5-3">
+      <stop
+         style="stop-color:#c5dff4;stop-opacity:1"
+         offset="0"
+         id="stop4996-5-9-7" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4998-5-0-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082-3-1">
+      <stop
+         id="stop4084-8-1"
+         offset="0"
+         style="stop-color:#4476aa;stop-opacity:1" />
+      <stop
+         style="stop-color:#5a9ccc;stop-opacity:1"
+         offset="0.5"
+         id="stop4864-7-00" />
+      <stop
+         id="stop4086-2-0"
+         offset="1"
+         style="stop-color:#4476aa;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8287-6"
+       inkscape:collect="always">
+      <stop
+         id="stop8289-6"
+         offset="0"
+         style="stop-color:#6eb6e2;stop-opacity:1;" />
+      <stop
+         id="stop8291-34"
+         offset="1"
+         style="stop-color:#d3e5f4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient28634-6"
+       osb:paint="gradient">
+      <stop
+         style="stop-color:#c1d9ee;stop-opacity:1;"
+         offset="0"
+         id="stop28636-4" />
+      <stop
+         id="stop28642-9"
+         offset="0.5"
+         style="stop-color:#6eaddd;stop-opacity:1" />
+      <stop
+         style="stop-color:#40689d;stop-opacity:1"
+         offset="1"
+         id="stop28638-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient28634-6-8"
+       osb:paint="gradient">
+      <stop
+         style="stop-color:#c1d9ee;stop-opacity:1;"
+         offset="0"
+         id="stop28636-4-5" />
+      <stop
+         id="stop28642-9-4"
+         offset="0.5"
+         style="stop-color:#6eaddd;stop-opacity:1" />
+      <stop
+         style="stop-color:#40689d;stop-opacity:1"
+         offset="1"
+         id="stop28638-5-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1039.3925"
+       x2="-4.9904022"
+       y1="1042.3925"
+       x1="-4.9904022"
+       gradientTransform="translate(37.991756,4.9769)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient17672"
+       xlink:href="#linearGradient17705"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.361"
+       x2="7.8857632"
+       y1="1039.876"
+       x1="8.0137892"
+       gradientTransform="translate(17.115591,3.0084)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient17674"
+       xlink:href="#linearGradient17711"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="-1.4270902"
+     inkscape:cy="11.37913"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1208"
+     inkscape:window-height="913"
+     inkscape:window-x="168"
+     inkscape:window-y="92"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid8762" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="layer1-4"
+       inkscape:label="Layer 1"
+       transform="translate(-18.979257,-3.0034088)">
+      <path
+         style="display:inline;fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient8887-0);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 20.49694,1040.9049 14.004414,0 0,12.0292 -14.004414,0 z"
+         id="rect3997-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient8884-0);fill-opacity:1;stroke:none"
+         d="m 22.001354,1049.3694 -0.0014,2.9928 -1,0 0.0014,-3.9928 z"
+         id="rect4853-82-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient8881-0);fill-opacity:1;stroke:none"
+         d="m 22.001354,1049.3694 12,0 0,-1 -13,0 z"
+         id="rect4853-82-0"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient17672);fill-opacity:1;stroke:url(#linearGradient17674);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 20.500887,1042.8694 13.998914,0 0,5.033 -13.998914,0 z"
+         id="rect3997-9-9-4"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient8293-6);fill-opacity:1;stroke:url(#linearGradient8878-5);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 20.500887,1040.8694 13.998914,0 0,2.0053 -13.998914,0 z"
+         id="rect3997-9-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <rect
+         style="fill:#2b568d;fill-opacity:1;stroke:none"
+         id="rect17719"
+         width="1"
+         height="1"
+         x="23.001354"
+         y="1044.3694" />
+      <rect
+         style="display:inline;fill:#687692;fill-opacity:1;stroke:none"
+         id="rect17719-3"
+         width="1"
+         height="1"
+         x="25.001354"
+         y="1044.3694" />
+      <rect
+         style="display:inline;fill:#2b568d;fill-opacity:1;stroke:none"
+         id="rect17719-3-0"
+         width="1"
+         height="1"
+         x="27.001354"
+         y="1044.3694" />
+      <rect
+         style="display:inline;fill:#687692;fill-opacity:1;stroke:none"
+         id="rect17719-3-0-2"
+         width="1"
+         height="1"
+         x="29.001354"
+         y="1044.3694" />
+      <rect
+         style="display:inline;fill:#bec3df;fill-opacity:1;stroke:none"
+         id="rect17719-5"
+         width="1"
+         height="1"
+         x="24.001354"
+         y="1045.3694" />
+      <rect
+         style="display:inline;fill:#bec3df;fill-opacity:1;stroke:none"
+         id="rect17719-3-3"
+         width="1"
+         height="1"
+         x="26.001354"
+         y="1045.3694" />
+      <rect
+         style="display:inline;fill:#bec3df;fill-opacity:1;stroke:none"
+         id="rect17719-3-0-6"
+         width="1"
+         height="1"
+         x="28.001354"
+         y="1045.3694" />
+      <rect
+         style="display:inline;fill:#bec3df;fill-opacity:1;stroke:none"
+         id="rect17719-3-0-2-3"
+         width="1"
+         height="1"
+         x="30.001354"
+         y="1045.3694" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/warn_tsk.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/warn_tsk.svg
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="warn_tsk.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5091">
+      <stop
+         style="stop-color:#c6852e;stop-opacity:1"
+         offset="0"
+         id="stop5093" />
+      <stop
+         style="stop-color:#e1a555;stop-opacity:1"
+         offset="1"
+         id="stop5095" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5081">
+      <stop
+         style="stop-color:#ffe296;stop-opacity:1"
+         offset="0"
+         id="stop5083" />
+      <stop
+         id="stop5089"
+         offset="0.5"
+         style="stop-color:#f8d880;stop-opacity:1" />
+      <stop
+         style="stop-color:#fffcd3;stop-opacity:1"
+         offset="1"
+         id="stop5085" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5081"
+       id="linearGradient4198"
+       gradientUnits="userSpaceOnUse"
+       x1="3.3833356"
+       y1="7.0159616"
+       x2="3.3833356"
+       y2="0.98171616"
+       gradientTransform="matrix(1.0686937,0,0,1.0924875,15.427671,1043.3065)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5091"
+       id="linearGradient4200"
+       gradientUnits="userSpaceOnUse"
+       x1="6.3885393"
+       y1="7.2369323"
+       x2="6.3885393"
+       y2="0.39338252"
+       gradientTransform="matrix(1.0686937,0,0,1.0924875,15.427671,1043.3065)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="0.71005768"
+     inkscape:cy="8.7906593"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4193"
+     showgrid="true"
+     inkscape:window-width="1638"
+     inkscape:window-height="1174"
+     inkscape:window-x="398"
+     inkscape:window-y="172"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4202"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8472"
+       transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)">
+      <g
+         id="g4193"
+         transform="matrix(1.4166388,0,0,1.4166388,-3.2411359,-441.17622)">
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0"
+           id="path4292-2"
+           d="m 17.77336,1043.2949 -2.548759,5.4323 c -0.873093,1.4312 -0.277787,3.7716 1.350634,3.7972 l 1.845867,0 1.890117,0 1.845867,0 c 1.628421,-0.024 2.223727,-2.4133 1.350634,-3.8444 l -2.619561,-5.3851 c -0.423981,-0.7773 -2.745708,-0.6522 -3.114799,0 z"
+           style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.93301046;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0"
+           id="path4292"
+           d="m 18.433373,1044.2966 -2.170784,4.4724 c -0.64766,1.1199 -0.206062,2.5932 1.0019,2.6133 l 1.369264,0 1.402088,0 1.369264,0 c 1.207962,-0.019 1.64956,-1.4935 1.0019,-2.6133 l -2.170784,-4.4724 c -0.314508,-0.6082 -1.529057,-0.5104 -1.802848,0 z"
+           style="fill:url(#linearGradient4198);fill-opacity:1;stroke:url(#linearGradient4200);stroke-width:0.76273859;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           transform="matrix(1.125929,0,0,1.125929,15.445014,1043.3905)"
+           d="m 4.109375,5.484375 a 0.625,0.625 0 0 1 -0.625,0.625 0.625,0.625 0 0 1 -0.625,-0.625 0.625,0.625 0 0 1 0.625,-0.625 0.625,0.625 0 0 1 0.625,0.625 z"
+           sodipodi:ry="0.625"
+           sodipodi:rx="0.625"
+           sodipodi:cy="5.484375"
+           sodipodi:cx="3.484375"
+           id="path4253"
+           style="fill:#502800;fill-opacity:1;stroke:none"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="ccsccc"
+           inkscape:connector-curvature="0"
+           id="path4253-7"
+           d="m 18.48263,1046.4854 0.09137,0.8464 c 0,0.3887 0.464638,0.7037 0.801057,0.7037 0.336419,0 0.75099,-0.315 0.75099,-0.7037 l 0.06091,-0.8464 c -0.34003,-1.1674 -1.417226,-0.9954 -1.704327,0 z"
+           style="fill:#502800;fill-opacity:1;stroke:none;display:inline" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/obj16/workingsets.svg
+++ b/bundles/org.eclipse.ui/icons/full/obj16/workingsets.svg
@@ -1,0 +1,394 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="workingsets.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4489">
+      <stop
+         id="stop4491"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0"
+         id="stop4493" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop4495" />
+      <stop
+         id="stop4497"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop4499"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4410"
+       inkscape:collect="always">
+      <stop
+         id="stop4412"
+         offset="0"
+         style="stop-color:#394e6c;stop-opacity:1" />
+      <stop
+         id="stop4414"
+         offset="1"
+         style="stop-color:#17325d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955-1">
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="0"
+         id="stop3957-5" />
+      <stop
+         id="stop3959-27"
+         offset="0"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop3961-61"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop3963-4" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop3965-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955-1-7">
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="0"
+         id="stop3957-5-4" />
+      <stop
+         id="stop3959-27-7"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop3961-61-6"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop3963-4-2" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop3965-2-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967-7-6"
+       id="linearGradient11228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3229028,0,0,0.33094668,-163.85051,916.49701)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3967-7-6">
+      <stop
+         style="stop-color:#c48a4e;stop-opacity:1;"
+         offset="0"
+         id="stop3969-4-9" />
+      <stop
+         style="stop-color:#ad6c24;stop-opacity:1"
+         offset="1"
+         id="stop3971-0-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955-1"
+       id="linearGradient11220"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33025865,0,0,0.37663939,-167.52788,899.63769)"
+       x1="525.6676"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973-4-2"
+       id="linearGradient11223"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31452219,0,0,0.31371764,-159.16354,922.56876)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3973-4-2">
+      <stop
+         style="stop-color:#f8d078;stop-opacity:1"
+         offset="0"
+         id="stop3975-8-0" />
+      <stop
+         style="stop-color:#f8f0c8;stop-opacity:1"
+         offset="1"
+         id="stop3977-8-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949-45-0"
+       id="linearGradient11225"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31452219,0,0,0.31371764,-159.16354,922.56876)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       id="linearGradient3949-45-0"
+       inkscape:collect="always">
+      <stop
+         id="stop3951-5-9"
+         offset="0"
+         style="stop-color:#9e6627;stop-opacity:1" />
+      <stop
+         id="stop3953-1-7"
+         offset="1"
+         style="stop-color:#c38536;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973-4-2"
+       id="linearGradient11239"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31618113,0,0,0.31519571,-164.70896,925.22497)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949-45-0"
+       id="linearGradient11241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31618113,0,0,0.31519571,-164.70896,925.22497)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4489"
+       id="linearGradient11236"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33025865,0,0,0.37083744,-172.21908,905.95512)"
+       x1="525.6676"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967-7-6"
+       id="linearGradient11244"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33025865,0,0,0.33025865,-172.37268,920.9139)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <radialGradient
+       gradientTransform="matrix(1.0222222,0,0,1.0222222,-8.3495761,-1068.3786)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4410"
+       id="radialGradient4345-0-1"
+       cx="-5.9998393"
+       cy="17.116383"
+       fx="-5.9998393"
+       fy="17.116383"
+       r="0.99436891"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       gradientTransform="matrix(1.0222222,0,0,1.0222222,8.6670209,-1068.3786)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4410"
+       id="radialGradient4345-0-1-2"
+       cx="-5.9998393"
+       cy="17.116383"
+       fx="-5.9998393"
+       fy="17.116383"
+       r="0.99436891"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       gradientTransform="matrix(1.0222222,0,0,1.0222222,-8.3495761,1021.3916)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4410"
+       id="radialGradient4345-0-1-4"
+       cx="-5.9998393"
+       cy="17.116383"
+       fx="-5.9998393"
+       fy="17.116383"
+       r="0.99436891"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       gradientTransform="matrix(1.0222222,0,0,1.0222222,8.6670209,1021.3916)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4410"
+       id="radialGradient4345-0-1-2-5"
+       cx="-5.9998393"
+       cy="17.116383"
+       fx="-5.9998393"
+       fy="17.116383"
+       r="0.99436891"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313709"
+     inkscape:cx="32.454376"
+     inkscape:cy="-4.935734"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1414"
+     inkscape:window-height="946"
+     inkscape:window-x="1046"
+     inkscape:window-y="403"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3939" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g11349"
+       transform="matrix(0.89017036,0,0,0.89017036,0.83301922,114.20596)">
+      <g
+         id="g4479"
+         transform="matrix(1.0018477,0,0,0.99989099,-0.15194004,0.88596001)">
+        <g
+           id="g4501"
+           transform="translate(0.99293744,0)">
+          <path
+             style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient11228);stroke-width:1.11195588;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m 7.4732015,1037.971 1.64818,0 c 0.4695812,0 0.8476202,0.3874 0.8476202,0.8687 l 0,3.7644 c 0,0.4812 -0.378039,0.8687 -0.8476202,0.8687 l -1.64818,0 c -0.4695817,0 -0.8476199,-0.3875 -0.8476199,-0.8687 l 0,-3.7644 c 0,-0.4813 0.3780382,-0.8687 0.8476199,-0.8687 z"
+             id="rect13693-3-6"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="sssssssss" />
+          <path
+             style="display:inline;fill:url(#linearGradient11223);fill-opacity:1;stroke:url(#linearGradient11225);stroke-width:1.12210238;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="m 8.2342241,1040.214 5.4167849,0 c 0.457394,0 0.825621,0.3674 0.825621,0.8236 l 0,5.0704 c 0,0.4563 -0.368224,0.8241 -0.825621,0.8235 l -7.3214871,-0.01 c -0.457397,-6e-4 -0.8256208,-0.3672 -0.8256208,-0.8235 l 0,-5.0642 c 0,-0.4561 0.3541512,-0.8244 0.8256208,-0.8235 z"
+             id="rect13693-7"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cssssssssc" />
+          <path
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient11220);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             d="m 6.0761719,1039.6406 0,1.1405 5.6972661,0 0,-1.1405 -5.6972661,0 z"
+             id="path13797-0"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g4484"
+         transform="translate(1.0531692,0)">
+        <path
+           sodipodi:nodetypes="sssssssss"
+           inkscape:connector-curvature="0"
+           id="rect13693-3"
+           d="m 2.8538607,1042.1354 1.5453036,0 c 0.480278,0 0.866929,0.3866 0.866929,0.8669 l 0,3.7566 c 0,0.4802 -0.386651,0.8669 -0.866929,0.8669 l -1.5453036,0 c -0.480279,0 -0.866929,-0.3867 -0.866929,-0.8669 l 0,-3.7566 c 0,-0.4803 0.38665,-0.8669 0.866929,-0.8669 z"
+           style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient11244);stroke-width:1.12338042;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cssssssssc"
+           inkscape:connector-curvature="0"
+           id="rect13693"
+           d="m 3.5717244,1044.3725 5.3954399,0 c 0.4598064,0 0.829976,0.3691 0.829976,0.8275 l 0,4.1464 c 0,0.4584 -0.3701668,0.828 -0.829976,0.8274 l -7.3101884,-0.01 c -0.4598095,-6e-4 -0.8299754,-0.3689 -0.8299754,-0.8274 l 0,-4.14 c 0,-0.4583 0.3560191,-0.8283 0.8299754,-0.8274 z"
+           style="display:inline;fill:url(#linearGradient11239);fill-opacity:1;stroke:url(#linearGradient11241);stroke-width:1.12770486;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient11236);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           d="m 1.3838017,1043.8018 0,1.1229 5.6992188,0 0,-1.1229 -5.6992188,0 z"
+           id="path13797"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <path
+       sodipodi:type="arc"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       id="path11406"
+       sodipodi:cx="-18.605747"
+       sodipodi:cy="-7.0472617"
+       sodipodi:rx="0.044194173"
+       sodipodi:ry="0.022097087"
+       d="m -18.561553,-7.0472617 a 0.04419417,0.02209709 0 0 1 -0.04419,0.022097 0.04419417,0.02209709 0 0 1 -0.04419,-0.022097 0.04419417,0.02209709 0 0 1 0.04419,-0.022097 0.04419417,0.02209709 0 0 1 0.04419,0.022097 z"
+       transform="translate(0,1036.3622)" />
+    <circle
+       r="1.016466"
+       cy="-1051.3678"
+       cx="-15.013075"
+       style="display:inline;fill:url(#radialGradient4345-0-1);fill-opacity:1;stroke:none"
+       id="path11408-0-3-8-9-3"
+       transform="scale(-1,-1)" />
+    <circle
+       r="1.016466"
+       cy="-1051.3678"
+       cx="2.0035217"
+       style="display:inline;fill:url(#radialGradient4345-0-1-2);fill-opacity:1;stroke:none"
+       id="path11408-0-3-8-9-3-6"
+       transform="scale(1,-1)" />
+    <circle
+       r="1.016466"
+       cy="1038.4025"
+       cx="-15.013075"
+       style="display:inline;fill:url(#radialGradient4345-0-1-4);fill-opacity:1;stroke:none"
+       id="path11408-0-3-8-9-3-5"
+       transform="scale(-1,1)" />
+    <circle
+       r="1.016466"
+       cy="1038.4025"
+       cx="2.0035217"
+       style="display:inline;fill:url(#radialGradient4345-0-1-2-5);fill-opacity:1;stroke:none"
+       id="path11408-0-3-8-9-3-6-7" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/ovr16/error_ovr.svg
+++ b/bundles/org.eclipse.ui/icons/full/ovr16/error_ovr.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="7"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="error_ovr.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="256"
+     inkscape:cx="3.8095711"
+     inkscape:cy="2.2892427"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4171"
+     showgrid="true"
+     inkscape:window-width="1236"
+     inkscape:window-height="1004"
+     inkscape:window-x="828"
+     inkscape:window-y="425"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1044.3622)">
+    <rect
+       style="fill:#d8424f;fill-opacity:1;stroke:none;display:inline"
+       id="rect4244"
+       width="7"
+       height="8"
+       x="-1.1130133e-007"
+       y="1044.3622" />
+    <g
+       id="g4171">
+      <path
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 2,1 0.96143694,0.98353403 1,2 1,3 2,3 3,3 3,2 3,1 Z"
+         transform="translate(0,1044.3622)"
+         id="rect4137"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 5.0022321,1045.3622 1.0385631,-0.016 -0.038563,1.0165 0,1 -1,0 -1,0 0,-1 0,-1 z"
+         id="rect4137-2"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 2,1051.3667 -1.00084097,0 L 1,1050.3667 l 0,-1 1,0 1,0 0,1 0,1 z"
+         id="rect4137-0"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 5.0022321,1051.3667 1.000841,4e-4 -8.41e-4,-1.0009 0,-1 -1,0 -1,0 0,1 0,1 z"
+         id="rect4137-2-5"
+         sodipodi:nodetypes="ccccccccc" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4141"
+         width="1"
+         height="2"
+         x="3"
+         y="1047.3622" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/ovr16/lock_ovr.svg
+++ b/bundles/org.eclipse.ui/icons/full/ovr16/lock_ovr.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="8"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="lock_ovr.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313709"
+     inkscape:cx="-11.027069"
+     inkscape:cy="-14.272935"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8472"
+     showgrid="true"
+     inkscape:window-width="980"
+     inkscape:window-height="1174"
+     inkscape:window-x="201"
+     inkscape:window-y="161"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4164"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1044.3622)">
+    <g
+       style="display:inline"
+       id="g8472"
+       transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)">
+      <path
+         style="fill:#888888;fill-opacity:1;stroke:none"
+         d="m 19.869741,1043.4798 c -1.778161,0 -3.209662,1.4315 -3.209662,3.2097 l 0,5.3494 7.48921,0 0,-5.3494 c 0,-1.7782 -1.431501,-3.2097 -3.209661,-3.2097 l -1.069887,0 z"
+         id="rect4177"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#000000;fill-opacity:1;stroke:none"
+         id="path4966"
+         sodipodi:cx="4.5"
+         sodipodi:cy="3.03125"
+         sodipodi:rx="1.5"
+         sodipodi:ry="1.5"
+         d="m 6,3.03125 c 0,0.8284271 -0.6715729,1.5 -1.5,1.5 -0.8284271,0 -1.5,-0.6715729 -1.5,-1.5 0,-0.8284271 0.6715729,-1.5 1.5,-1.5 0.8284271,0 1.5,0.6715729 1.5,1.5 z"
+         transform="matrix(1.2147676,0,0,1.2147676,14.93823,1043.0406)" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none"
+         d="m 19.869741,1047.7593 -1.069888,3.2097 3.209661,0 -1.069886,-3.2097 z"
+         id="rect4968"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/ovr16/pinned_ovr.svg
+++ b/bundles/org.eclipse.ui/icons/full/ovr16/pinned_ovr.svg
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="8"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="pinned_ovr.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       y2="1041.6436"
+       x2="22"
+       y1="1041.6436"
+       x1="19.624538"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5269"
+       xlink:href="#linearGradient4981"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="8.296731"
+       x2="22.095001"
+       y1="7.609231"
+       x1="18.909349"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5267"
+       xlink:href="#linearGradient4981"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1046.688"
+       x2="21.123072"
+       y1="1045.577"
+       x1="21.123072"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5265"
+       xlink:href="#linearGradient4973"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4973"
+       inkscape:collect="always">
+      <stop
+         id="stop4975"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop4977"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4981">
+      <stop
+         id="stop4983"
+         offset="0"
+         style="stop-color:#359b58;stop-opacity:1" />
+      <stop
+         style="stop-color:#72b649;stop-opacity:1"
+         offset="0.39414415"
+         id="stop4991" />
+      <stop
+         style="stop-color:#72b649;stop-opacity:1"
+         offset="0.5"
+         id="stop4989" />
+      <stop
+         id="stop4985"
+         offset="1"
+         style="stop-color:#359b58;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0698871,0,0,1.0698871,-42.751471,-52.694709)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4344"
+       id="linearGradient4350"
+       x1="745.86108"
+       y1="725.74878"
+       x2="747.35107"
+       y2="727.13776"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4344">
+      <stop
+         style="stop-color:#00953e;stop-opacity:1;"
+         offset="0"
+         id="stop4346" />
+      <stop
+         style="stop-color:#00612e;stop-opacity:1"
+         offset="1"
+         id="stop4348" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4981"
+       id="linearGradient5269-6"
+       gradientUnits="userSpaceOnUse"
+       x1="19.624538"
+       y1="1041.6436"
+       x2="22"
+       y2="1041.6436"
+       gradientTransform="matrix(0.78040928,0.7836369,-0.78040928,0.7836369,817.10982,214.47174)" />
+    <linearGradient
+       gradientTransform="matrix(1.0698871,0,0,1.0698871,7.0310959,-67.450446)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4336"
+       id="linearGradient4342"
+       x1="9.9039965"
+       y1="1038.8525"
+       x2="11.543543"
+       y2="1044.9678"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4336">
+      <stop
+         style="stop-color:#00953e;stop-opacity:1;"
+         offset="0"
+         id="stop4338" />
+      <stop
+         style="stop-color:#005227;stop-opacity:1"
+         offset="1"
+         id="stop4340" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#d8d8d8"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="26.489053"
+     inkscape:cx="4"
+     inkscape:cy="4"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8472"
+     showgrid="true"
+     inkscape:window-width="1440"
+     inkscape:window-height="852"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4164"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1044.3622)">
+    <g
+       style="display:inline"
+       id="g8472"
+       transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)">
+      <path
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.06988704px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 15.590192,1052.0389 0,-4.2796 3.209661,-3.2096 3.209661,0 1.069887,1.0699 0,3.2096 -3.209661,3.2097 z"
+         id="path4285"
+         inkscape:connector-curvature="0" />
+      <g
+         transform="matrix(1.0144223,0,0,1.0144223,12.025291,-22.647573)"
+         style="display:inline"
+         id="layer1-3"
+         inkscape:label="Layer 1">
+        <g
+           id="g5014"
+           transform="translate(-3.6239221,22.097086)">
+          <g
+             id="g5001"
+             transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,734.42008,290.38128)">
+            <path
+               sodipodi:nodetypes="ccccc"
+               inkscape:connector-curvature="0"
+               id="rect4944"
+               d="m 20.492187,1045.1591 0.921876,0 0,2.4062 c -0.376231,0.2965 -0.615362,0.1856 -0.921876,0 z"
+               style="fill:#a5adba;fill-opacity:1;stroke:#17325d;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+            <g
+               id="g5057">
+              <path
+                 inkscape:connector-curvature="0"
+                 style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient5265);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate"
+                 d="m 20.40625,1044.9062 a 0.250025,0.250025 0 0 0 -0.125,0.125 0.250025,0.250025 0 0 0 -0.03125,0.125 l 0,2.4063 a 0.250025,0.250025 0 0 0 0,0.062 0.250025,0.250025 0 0 0 0.125,0.1562 c 0.159025,0.096 0.31691,0.1983 0.53125,0.2188 0.21434,0.021 0.436009,-0.076 0.65625,-0.25 a 0.250025,0.250025 0 0 0 0.09375,-0.125 0.250025,0.250025 0 0 0 0,-0.062 l 0,-2.4063 a 0.250025,0.250025 0 0 0 0,-0.031 0.250025,0.250025 0 0 0 -0.03125,-0.094 0.250025,0.250025 0 0 0 -0.15625,-0.125 0.250025,0.250025 0 0 0 -0.0625,0 l -0.90625,0 a 0.250025,0.250025 0 0 0 -0.09375,0 z"
+                 id="path4971" />
+              <path
+                 style="display:inline;fill:url(#linearGradient5267);fill-opacity:1;stroke:#00953e;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+                 d="M 20.9375,6.125 C 19.686416,6.1463072 18.732332,7.2495515 18.53125,8 c 0,0.595432 1.068685,1.09375 2.40625,1.09375 C 22.275065,9.09375 23.375,8.595432 23.375,8 23.179528,7.2704899 22.188584,6.1036928 20.9375,6.125 Z"
+                 transform="translate(0,1036.3622)"
+                 id="path4884-8"
+                 inkscape:connector-curvature="0"
+                 sodipodi:nodetypes="zcscz" />
+              <path
+                 style="fill:url(#linearGradient5269);fill-opacity:1;stroke:#00953e;stroke-width:0.83458644;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+                 d="m 20.929746,1040.0249 c -0.533598,0 -0.994941,0.084 -1.356203,0.2348 l 0,2.7676 c 0.361262,0.1504 0.822605,0.2348 1.356203,0.2348 0.487606,0 0.928812,-0.081 1.277961,-0.2087 l 0,-2.8198 c -0.349149,-0.128 -0.790355,-0.2087 -1.277961,-0.2087 z"
+                 id="rect4923"
+                 inkscape:connector-curvature="0"
+                 sodipodi:nodetypes="sccsccs" />
+              <ellipse
+                 style="fill:#7db551;fill-opacity:1;stroke:#00953e;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+                 id="path4884"
+                 transform="matrix(0.90924832,0,0,0.90924832,2.1288433,1036.5222)"
+                 cx="20.703125"
+                 cy="3.1406245"
+                 rx="2.421875"
+                 ry="1.078125" />
+            </g>
+          </g>
+        </g>
+      </g>
+      <image
+         y="1043.4797"
+         x="25.219175"
+         id="image4249"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAABHNCSVQICAgIfAhkiAAAAKxJREFU
+GJVdj6EKwmAYRc8vBsGgILIuqBgEGf5o0rJiNVl8ifkEvsCCoGWgwWg3+QS2sWBYNi4YBNs1qGPz
+wE3ncvk+JJEP24lsuNDxupYkjCRyyKxG+F6Dqip0mgNKBbmb4nsNgkvK07zYRLdsQWY14mDHAMS1
+hOB0h2Gd8k/aXou4ltB/tAkuKdpHAAZJ8s8zMe/Khgsx7+rL52hJctxlVspLSeC4S/1RePsNTiB+
+7prF+oIAAAAASUVORK5CYII=
+"
+         style="image-rendering:optimizeSpeed"
+         preserveAspectRatio="none"
+         height="8.5590963"
+         width="8.5590963" />
+      <path
+         style="display:inline;fill:#17325d;fill-opacity:1;stroke:#17325d;stroke-width:0.53494352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 17.791495,1049.0967 0.7409,0.7408 -2.822408,2.8629 c -0.540665,-0.064 -0.643723,-0.3454 -0.7409,-0.7409 z"
+         id="rect4944-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient5269-6);fill-opacity:1;stroke:url(#linearGradient4342);stroke-width:0.89291328;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 21.798494,1045.8747 c -0.416424,-0.418 -0.842016,-0.7137 -1.241633,-0.8786 l -3.450333,3.4418 c 0.164559,0.4008 0.458728,0.8286 0.875153,1.2467 0.380533,0.3821 0.788067,0.6645 1.160205,0.8379 l 3.491068,-3.4826 c -0.172585,-0.3739 -0.453928,-0.7829 -0.83446,-1.1652 z"
+         id="rect4923-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sccsccs" />
+      <ellipse
+         ry="0.95290297"
+         rx="2.1405795"
+         cy="724.29584"
+         cx="755.40894"
+         style="display:inline;fill:#7db551;fill-opacity:1;stroke:url(#linearGradient4350);stroke-width:0.97279334;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path4884-9"
+         transform="matrix(0.70757429,0.70663896,-0.70757429,0.70663896,0,0)" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/ovr16/running_ovr.svg
+++ b/bundles/org.eclipse.ui/icons/full/ovr16/running_ovr.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="7"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="running_ovr.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1-3">
+      <stop
+         id="stop10800-5-2-1-8-2-8-1-7-3-7-4"
+         offset="0"
+         style="stop-color:#4f9e55;stop-opacity:1" />
+      <stop
+         style="stop-color:#3c8d49;stop-opacity:1;"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-95-0-5-4-8-0" />
+      <stop
+         id="stop10802-1-5-3-0-2-0-9-8-4-3-8"
+         offset="1"
+         style="stop-color:#a4e173;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8163-2-7"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1-3"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="4.0500421"
+     inkscape:cy="-8.429114"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8472"
+     showgrid="true"
+     inkscape:window-width="980"
+     inkscape:window-height="1174"
+     inkscape:window-x="75"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4164" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1044.3622)">
+    <g
+       style="display:inline"
+       id="g8472"
+       transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)">
+      <g
+         transform="matrix(0.48581594,0,0,0.48581594,15.384272,540.91024)"
+         style="display:inline"
+         id="layer1-5"
+         inkscape:label="Layer 1">
+        <g
+           transform="translate(-8.2201163,-12.904699)"
+           id="g8159"
+           style="display:inline">
+          <path
+             transform="matrix(0.62300696,0,0,0.62300696,-225.45273,765.59692)"
+             d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+             sodipodi:ry="10.625"
+             sodipodi:rx="10.625"
+             sodipodi:cy="468.23718"
+             sodipodi:cx="388.125"
+             id="path10796-2-6-0"
+             style="fill:url(#linearGradient8163-2-7);fill-opacity:1;stroke:#14733c;stroke-width:3.49078488;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+             sodipodi:type="arc" />
+          <path
+             style="fill:#ffffff;fill-opacity:1;stroke:none;display:inline"
+             d="m 14.233999,1052.5785 5.673194,4.8544 -5.614707,4.7374 z"
+             id="path8117"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cccc" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/ovr16/warning_ovr.svg
+++ b/bundles/org.eclipse.ui/icons/full/ovr16/warning_ovr.svg
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="7"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="New document 1">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5081"
+       id="linearGradient5087"
+       x1="3.3833356"
+       y1="7.0159616"
+       x2="3.3833356"
+       y2="0.98171616"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5081">
+      <stop
+         style="stop-color:#ffe296;stop-opacity:1"
+         offset="0"
+         id="stop5083" />
+      <stop
+         id="stop5089"
+         offset="0.5"
+         style="stop-color:#f8d880;stop-opacity:1" />
+      <stop
+         style="stop-color:#fffcd3;stop-opacity:1"
+         offset="1"
+         id="stop5085" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5091"
+       id="linearGradient5097"
+       x1="6.3885393"
+       y1="7.2369323"
+       x2="6.3885393"
+       y2="0.39338252"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5091">
+      <stop
+         style="stop-color:#c6852e;stop-opacity:1"
+         offset="0"
+         id="stop5093" />
+      <stop
+         style="stop-color:#e1a555;stop-opacity:1"
+         offset="1"
+         id="stop5095" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(3.8209032e-8,1044.3622)"
+       y2="0.98171616"
+       x2="3.3833356"
+       y1="7.0159616"
+       x1="3.3833356"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4230"
+       xlink:href="#linearGradient5081"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(3.8209032e-8,1044.3622)"
+       y2="0.39338252"
+       x2="6.3885393"
+       y1="7.2369323"
+       x1="6.3885393"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4232"
+       xlink:href="#linearGradient5091"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.678384"
+     inkscape:cx="-0.70863259"
+     inkscape:cy="2.3717404"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="945"
+     inkscape:window-height="1125"
+     inkscape:window-x="75"
+     inkscape:window-y="75"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3024"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1044.3622)">
+    <path
+       style="fill:url(#linearGradient4230);fill-opacity:1;stroke:url(#linearGradient4232);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+       d="m 2.8125,1045.2684 -2.03124996,4.0938 c -0.60602934,1.0251 -0.19281594,2.4817 0.93749996,2.5 l 1.28125,0 1,0 1.28125,0 c 1.1303165,-0.018 1.5435294,-1.475 0.9375,-2.5 l -2.03125,-4.0938 c -0.2942923,-0.5567 -1.1188077,-0.4672 -1.375,0 z"
+       id="path4292"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       sodipodi:type="arc"
+       style="fill:#502800;fill-opacity:1;stroke:none;display:inline"
+       id="path4253"
+       sodipodi:cx="3.484375"
+       sodipodi:cy="5.484375"
+       sodipodi:rx="0.625"
+       sodipodi:ry="0.625"
+       d="m 4.109375,5.484375 a 0.625,0.625 0 1 1 -1.25,0 0.625,0.625 0 1 1 1.25,0 z"
+       transform="matrix(1.0523812,0,0,1.0523812,-0.16689048,1044.2631)" />
+    <path
+       style="fill:#502800;fill-opacity:1;stroke:none;display:inline"
+       d="m 3.5142345,1046.253 c -0.3537485,0 -0.6547532,0.3148 -0.6547532,0.7235 l 0.085402,1.3916 c 0,0.3633 0.2549073,0.6577 0.5693508,0.6577 0.3144435,0 0.5693489,-0.2944 0.5693489,-0.6577 l 0.056931,-1.3916 c 0,-0.4087 -0.2725362,-0.7235 -0.6262867,-0.7235 z"
+       id="path4253-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccsccs" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/bottom.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/bottom.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer2" />
+  <g
+     id="layer1"
+     style="fill:#000000;fill-opacity:1">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 3.1750003,2.6458336 H 4.497917 V 3.704167 h 0.79375 V 4.2333333 L 3.8364586,5.5562503 2.3812503,4.2333333 V 3.704167 h 0.79375 z"
+       id="path5516" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/bottom_mask.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/bottom_mask.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1"
+     style="fill:#000000;fill-opacity:1">
+    <path
+       style="fill:#000000;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="M 0,0 H 8.4666659 V 8.4666659 H 0 Z"
+       id="path1237" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/bottom_source.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/bottom_source.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer2"
+     style="fill:#ffffff;fill-opacity:1">
+    <path
+       style="fill:#ffffff;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="M 0,0 H 8.4666659 V 8.4666659 H 0 Z"
+       id="path856" />
+  </g>
+  <g
+     id="layer1"
+     style="fill:#000000;fill-opacity:1">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 3.1750003,2.6458336 H 4.497917 V 3.704167 h 0.79375 V 4.2333333 L 3.8364586,5.5562503 2.3812503,4.2333333 V 3.704167 h 0.79375 z"
+       id="path5516" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/invalid.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/invalid.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer2" />
+  <g
+     id="layer1"
+     style="stroke:#000000;stroke-opacity:1;fill:none;fill-opacity:1">
+    <circle
+       id="path110"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.529127;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       cy="3.7041664"
+       cx="3.7041664"
+       r="2.1166863" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal;fill-opacity:1"
+       d="M 2.1166665,2.1166665 5.2916662,5.2916662"
+       id="path4379" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/invalid_mask.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/invalid_mask.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1"
+     style="fill:#000000;fill-opacity:1">
+    <path
+       style="fill:#000000;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="M 0,0 H 8.4666659 V 8.4666659 H 0 Z"
+       id="path1237" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/invalid_source.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/invalid_source.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer2"
+     style="fill:#ffffff;fill-opacity:1">
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 0,0 H 8.4666659 V 8.4666659 H 0 Z"
+       id="path856" />
+  </g>
+  <g
+     id="layer1"
+     style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1">
+    <circle
+       id="path110"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.529127;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       cy="3.7041664"
+       cx="3.7041664"
+       r="2.1166863" />
+    <path
+       style="fill:#ffffff;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal;fill-opacity:1"
+       d="M 2.1166665,2.1166665 5.2916662,5.2916662"
+       id="path4379" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/left.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/left.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer3" />
+  <g
+     id="layer1"
+     style="fill:#000000;fill-opacity:1;stroke:none">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 5.8208338,3.1750003 V 4.497917 H 4.7625004 v 0.79375 H 4.2333341 L 2.9104171,3.8364586 4.2333341,2.3812503 h 0.5291663 v 0.79375 z"
+       id="path5516" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/left_mask.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/left_mask.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1"
+     style="fill:#000000;fill-opacity:1">
+    <path
+       style="fill:#000000;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="M 0,0 H 8.4666659 V 8.4666659 H 0 Z"
+       id="path1237" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/left_source.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/left_source.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer3"
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 0,0 H 8.4666659 V 8.4666659 H 0 Z"
+       id="path856" />
+  </g>
+  <g
+     id="layer1">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 5.8208338,3.1750003 V 4.497917 H 4.7625004 v 0.79375 H 4.2333341 L 2.9104171,3.8364586 4.2333341,2.3812503 h 0.5291663 v 0.79375 z"
+       id="path5516" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/offscreen.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/offscreen.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.299861px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 1.5874999,1.8520832 V 6.3499995 H 6.0854162 V 1.8520832 Z"
+       id="path6338" />
+    <path
+       style="fill:#ffffff;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="M 1.8520832,2.1166665 H 5.8208328 V 6.0854161 H 1.8520832 Z"
+       id="path6885" />
+    <path
+       style="fill:#000000;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="m 2.1166665,2.3812498 h 3.439583 v 3.439583 h -3.439583 z"
+       id="path7184" />
+    <path
+       style="fill:#ffffff;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="M 2.3812498,2.6458331 H 3.7041663 V 3.9687497 H 2.3812498 Z"
+       id="path7516" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 3.9687497,2.6458331 H 5.2916662 V 3.9687497 H 3.9687497 Z"
+       id="path7516-7" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 2.3812498,4.2333329 H 3.7041663 V 5.5562495 H 2.3812498 Z"
+       id="path7516-5" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 3.9687496,4.233333 H 5.2916661 V 5.5562496 H 3.9687496 Z"
+       id="path7516-3" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/offscreen_mask.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/offscreen_mask.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1"
+     style="fill:#000000;fill-opacity:1">
+    <path
+       style="fill:#000000;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="M 0,0 H 8.4666659 V 8.4666659 H 0 Z"
+       id="path1237" />
+  </g>
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 1.8520832,2.1166665 V 6.0854161 H 5.8208328 V 2.1166665 Z"
+     id="path856" />
+  <path
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 2.1166665,2.3812498 h 3.439583 v 3.439583 h -3.439583 z"
+     id="path1526" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 2.3812498,2.6458331 H 3.7041663 V 3.9687496 H 2.3812498 Z"
+     id="path2237" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 3.9687496,2.6458331 H 5.2916661 V 3.9687496 H 3.9687496 Z"
+     id="path2237-3" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 2.3812498,4.233333 H 3.7041663 V 5.5562494 H 2.3812498 Z"
+     id="path2237-6" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 3.9687496,4.233333 H 5.2916661 V 5.5562494 H 3.9687496 Z"
+     id="path2237-7" />
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/offscreen_source.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/offscreen_source.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer2">
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 0,0 H 8.4666664 V 8.4666659 H 0 Z"
+       id="path856" />
+  </g>
+  <path
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 1.5874999,1.8520832 4.4979162,0 V 6.3499994 H 1.5874999 Z"
+     id="path1063" />
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/right.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/right.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer2" />
+  <g
+     id="layer1">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 2.6458336,5.2916669 V 3.9687502 H 3.704167 v -0.79375 h 0.5291663 l 1.322917,1.4552084 -1.322917,1.4552083 H 3.704167 v -0.79375 z"
+       id="path5516" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/right_mask.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/right_mask.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1"
+     style="fill:#000000;fill-opacity:1">
+    <path
+       style="fill:#000000;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="M 0,0 H 8.4666659 V 8.4666659 H 0 Z"
+       id="path1237" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/right_source.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/right_source.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer2">
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 0,0 H 8.4666659 V 8.4666659 H 0 Z"
+       id="path856" />
+  </g>
+  <g
+     id="layer1"
+     style="fill:#000000;fill-opacity:1">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 2.6458336,5.2916669 V 3.9687502 H 3.704167 v -0.79375 h 0.5291663 l 1.322917,1.4552084 -1.322917,1.4552083 H 3.704167 v -0.79375 z"
+       id="path5516" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/stack.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/stack.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer2" />
+  <path
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 2.9104164,1.8520832 H 4.233333 v 0.7937499 h 2.1166664 v 2.1166665 h -3.439583 z"
+     id="path937" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 3.1749997,2.1166665 h 0.79375 V 2.9104164 H 6.0854161 V 4.4979163 H 3.1749997 Z"
+     id="path1375" />
+  <path
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 2.3812498,2.3812498 H 3.7041664 V 3.1749997 H 5.8208328 V 5.2916662 H 2.3812498 Z"
+     id="path937-3" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 2.6458331,2.6458331 h 0.79375 V 3.439583 H 5.5562495 V 5.0270829 H 2.6458331 Z"
+     id="path1375-6" />
+  <path
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 1.8520832,2.9104164 H 3.1749998 V 3.7041663 H 5.2916662 V 5.8208328 H 1.8520832 Z"
+     id="path937-7" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 2.1166665,3.1749997 h 0.79375 V 3.9687496 H 5.0270829 V 5.5562495 H 2.1166665 Z"
+     id="path1375-5" />
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/stack_mask.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/stack_mask.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1">
+    <path
+       id="rect110"
+       style="stroke-width:0.486237"
+       d="M 0,0 H 8.4666662 V 8.4666662 H 0 Z" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 2.1166665,3.1749997 h 0.7937499 v 0.5291666 l 1.8520832,0 V 5.2916662 H 2.1166665 Z"
+       id="path2950" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 2.6458331,2.6458331 H 3.439583 V 3.1749997 H 5.2916662 V 4.7624996 H 5.0270829 V 3.439583 H 3.1749997 V 2.9104164 H 2.6458331 Z"
+       id="path3230" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 3.1749997,2.1166665 H 3.9687496 V 2.6458331 H 5.8208328 V 4.233333 H 5.5562495 V 2.9104164 H 3.7041663 V 2.3812498 H 3.1749997 Z"
+       id="path3230-5" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/stack_source.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/stack_source.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer2">
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 0,0 H 8.4666659 V 8.4666659 H 0 Z"
+       id="path856" />
+  </g>
+  <g
+     id="layer1">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 1.8520832,2.9104164 H 2.3812498 V 2.3812498 H 2.9104164 V 1.8520832 H 4.233333 v 0.5291666 h 1.8520831 l 0,2.1166665 H 5.5562495 V 5.0270829 H 5.0270829 V 5.5562495 H 1.8520832 Z"
+       id="path2950" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/tofastview.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/tofastview.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer2" />
+  <g
+     id="layer1">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.073351;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.3812498,5.8208328 h 3.7041663 l 4e-7,0.2645833 H 2.3812498 Z"
+       id="path140-3" />
+    <g
+       id="g7156">
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.103734;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 2.3812498,2.3812498 h 3.7041663 l 4e-7,0.5291666 H 2.3812498 Z"
+         id="path140" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.073351;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 2.6458331,2.3812498 v 3.7041663 l -0.2645833,4e-7 V 2.3812498 Z"
+         id="path140-3-6" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.073351;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 3.439583,2.3812498 v 3.7041663 l -0.2645833,4e-7 V 2.3812498 Z"
+         id="path140-3-6-7" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.073351;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 6.0854161,2.3812498 v 3.7041663 l -0.2645833,4e-7 V 2.3812498 Z"
+         id="path140-3-6-7-5" />
+    </g>
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 4.7624996,3.1749997 v 0.7937499 h 0.7937499 v 0.79375 H 4.7624996 V 5.5562495 L 3.439583,4.3656246 Z"
+       id="path146" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/tofastview_mask.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/tofastview_mask.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1"
+     style="fill:#000000;fill-opacity:1">
+    <path
+       style="fill:#000000;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="M 0,0 H 8.4666659 V 8.4666659 H 0 Z"
+       id="path1237" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/tofastview_source.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/tofastview_source.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer2">
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 0,0 H 8.4666659 V 8.4666659 H 0 Z"
+       id="path856" />
+  </g>
+  <g
+     id="layer1">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.073351;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.3812498,5.8208328 h 3.7041663 l 4e-7,0.2645833 H 2.3812498 Z"
+       id="path140-3" />
+    <g
+       id="g7156">
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.103734;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 2.3812498,2.3812498 h 3.7041663 l 4e-7,0.5291666 H 2.3812498 Z"
+         id="path140" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.073351;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 2.6458331,2.3812498 v 3.7041663 l -0.2645833,4e-7 V 2.3812498 Z"
+         id="path140-3-6" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.073351;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 3.439583,2.3812498 v 3.7041663 l -0.2645833,4e-7 V 2.3812498 Z"
+         id="path140-3-6-7" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.073351;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 6.0854161,2.3812498 v 3.7041663 l -0.2645833,4e-7 V 2.3812498 Z"
+         id="path140-3-6-7-5" />
+    </g>
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 4.7624996,3.1749997 v 0.7937499 h 0.7937499 v 0.79375 H 4.7624996 V 5.5562495 L 3.439583,4.3656246 Z"
+       id="path146" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/top.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/top.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer2" />
+  <g
+     id="layer1">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 3.9687502,5.8208338 H 5.2916669 V 4.7625004 h 0.79375 V 4.2333341 L 4.6302085,2.9104171 3.1750002,4.2333341 v 0.5291663 h 0.79375 z"
+       id="path5516" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/top_mask.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/top_mask.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1"
+     style="fill:#000000;fill-opacity:1">
+    <path
+       style="fill:#000000;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="M 0,0 H 8.4666659 V 8.4666659 H 0 Z"
+       id="path1237" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pointer/top_source.svg
+++ b/bundles/org.eclipse.ui/icons/full/pointer/top_source.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666659 8.4666659"
+   version="1.1"
+   id="svg5"
+   shape-rendering="crispEdges"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer2">
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 0,0 H 8.4666659 V 8.4666659 H 0 Z"
+       id="path856" />
+  </g>
+  <g
+     id="layer1">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 3.9687502,5.8208338 H 5.2916669 V 4.7625004 h 0.79375 V 4.2333341 L 4.6302085,2.9104171 3.1750002,4.2333341 v 0.5291663 h 0.79375 z"
+       id="path5516" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pref/export_wiz.svg
+++ b/bundles/org.eclipse.ui/icons/full/pref/export_wiz.svg
@@ -1,0 +1,1119 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="export_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4432">
+      <stop
+         style="stop-color:#ced8e7;stop-opacity:1;"
+         offset="0"
+         id="stop4434" />
+      <stop
+         style="stop-color:#b7c5e0;stop-opacity:1"
+         offset="1"
+         id="stop4436" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4420">
+      <stop
+         style="stop-color:#5b7aaa;stop-opacity:1"
+         offset="0"
+         id="stop4422" />
+      <stop
+         style="stop-color:#96aaca;stop-opacity:1"
+         offset="1"
+         id="stop4424" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4541">
+      <stop
+         style="stop-color:#a1adb2;stop-opacity:1"
+         offset="0"
+         id="stop4543" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient5885"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2">
+      <stop
+         id="stop11150-4-72-3-9-7"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10507">
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="0"
+         id="stop10509" />
+      <stop
+         id="stop10511"
+         offset="0.18181793"
+         style="stop-color:#9e7058;stop-opacity:1" />
+      <stop
+         id="stop10513"
+         offset="0.36363617"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10515"
+         offset="0.49999985"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10517"
+         offset="0.63636351"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e7058;stop-opacity:1"
+         offset="0.81818175"
+         id="stop10519" />
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="1"
+         id="stop10522" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4456"
+       id="linearGradient4462"
+       x1="63.734764"
+       y1="1039.3618"
+       x2="61.727211"
+       y2="1006.3618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,-0.72750163,1,733.40264,2.0004)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4456">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.659"
+         offset="0"
+         id="stop4458" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.369"
+         offset="1"
+         id="stop4460" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4606"
+       x="-0.062976152"
+       width="1.1259522"
+       y="-0.10879012"
+       height="1.2175802">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.5412116"
+         id="feGaussianBlur4608" />
+    </filter>
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2-8">
+      <stop
+         id="stop11150-4-72-3-9-7-2"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad6e48;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4368">
+      <stop
+         id="stop4370"
+         offset="0"
+         style="stop-color:#9c7561;stop-opacity:1" />
+      <stop
+         style="stop-color:#966d59;stop-opacity:1"
+         offset="0.18181793"
+         id="stop4372" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.36363617"
+         id="stop4374" />
+      <stop
+         style="stop-color:#794f40;stop-opacity:1"
+         offset="0.49999985"
+         id="stop4376" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.63636351"
+         id="stop4378" />
+      <stop
+         id="stop4380"
+         offset="0.81818175"
+         style="stop-color:#966d59;stop-opacity:1" />
+      <stop
+         id="stop4382"
+         offset="1"
+         style="stop-color:#99705c;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       height="1.2013515"
+       y="-0.10067577"
+       width="1.2017672"
+       x="-0.1"
+       id="filter4285-9-8"
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur4287-9-5"
+         stdDeviation="0.10000000000000001"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4496"
+       id="linearGradient4494"
+       x1="8"
+       y1="1013.3622"
+       x2="19"
+       y2="1024.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88619287,0,0,0.87964908,22.674808,110.55825)" />
+    <linearGradient
+       id="linearGradient4496"
+       inkscape:collect="always">
+      <stop
+         id="stop4498"
+         offset="0"
+         style="stop-color:#6885b2;stop-opacity:1" />
+      <stop
+         style="stop-color:#5777a7;stop-opacity:1"
+         offset="0.54585904"
+         id="stop4512" />
+      <stop
+         style="stop-color:#355286;stop-opacity:1"
+         offset="0.63636416"
+         id="stop4500" />
+      <stop
+         id="stop4502"
+         offset="1"
+         style="stop-color:#2c4a81;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4504"
+       id="linearGradient4510"
+       x1="3.2928932"
+       y1="1020.7158"
+       x2="20"
+       y2="1020.7158"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88619287,0,0,0.87964908,22.674808,110.55825)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4504">
+      <stop
+         style="stop-color:#b0c1db;stop-opacity:1"
+         offset="0"
+         id="stop4506" />
+      <stop
+         style="stop-color:#8299c2;stop-opacity:1"
+         offset="1"
+         id="stop4508" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4420"
+       id="linearGradient4426"
+       x1="68.572693"
+       y1="1016.118"
+       x2="67.579018"
+       y2="1015.3881"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99967036,0.02567416,-0.02567416,0.99967036,-14.525917,-1.4292246)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4432"
+       id="linearGradient4438"
+       x1="8"
+       y1="1019.3622"
+       x2="52"
+       y2="1039.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9893617,0,0,0.97823962,0.31914907,22.399103)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4506"
+       x="-0.092571429"
+       width="1.1851429"
+       y="-0.0324"
+       height="1.0648">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.27"
+         id="feGaussianBlur4508" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4524"
+       x="-0.029837838"
+       width="1.0596757"
+       y="-0.12266667"
+       height="1.2453333">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.46"
+         id="feGaussianBlur4526" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4566"
+       x="-0.08775"
+       width="1.1755"
+       y="-0.1404"
+       height="1.2808">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.2925"
+         id="feGaussianBlur4568" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4588"
+       x="-0.042439024"
+       width="1.084878"
+       y="-0.10235294"
+       height="1.2047059">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.725"
+         id="feGaussianBlur4590" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4661"
+       x="-0.14766911"
+       width="1.2953382"
+       y="-0.11646623"
+       height="1.2329325">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.36234727"
+         id="feGaussianBlur4663" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#a5a5a5"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="26.213333"
+     inkscape:cx="40.276938"
+     inkscape:cy="29.125507"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline">
+    <image
+       y="0"
+       x="75"
+       id="image4415"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAACXBIWXMAAAsTAAALEwEAmpwYAAAK
+TWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQ
+WaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec
+5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28A
+AgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0
+ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaO
+WJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHi
+wmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryM
+AgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0l
+YqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHi
+NLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYA
+QH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6c
+wR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBie
+whi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1c
+QPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqO
+Y4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hM
+WEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgoh
+JZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSU
+Eko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/p
+dLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Y
+b1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7O
+UndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsb
+di97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W
+7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83
+MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxr
+PGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW
+2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1
+U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd
+8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H0
+8PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+H
+vqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsG
+Lww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjg
+R2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4
+qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWY
+EpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1Ir
+eZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/Pb
+FWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYj
+i1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVk
+Ve9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0Ibw
+Da0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vz
+DoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+y
+CW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawt
+o22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtd
+UV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3r
+O9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0
+/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv95
+63Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+
+UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMA
+APn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAAPMElEQVR42uxce4wd1Xn/fefMfe7du3d3bS+Y
+NaxZP8DGYIhpISEFIqQmFVKBKC1Vowi1f1QKVVUJNVLTqtCqUitCSqNWSZqUghCVYhGVhwglIhHh
+VUhCWqCBpBgHO2t7vV7v+3HvPM736x8z996513ftxY81rDPS7MzcmTNz5nd+3+/7znfOrOBXS8fl
+3m8dtCTyJHtIdAMoeL+CpQWgDIACibIqu0gU0ufPebDu//YhS6JLibwqC1R2KZHtdO05C9Y/PTZa
+UEWRZJaABdkNMne8MucUWF9/8rBRIkeym4QVAUgUQZYAyInKnzNgfeOpsW4liwIYEkDMprIAWVnm
+PVY9WA88PVZQImYSAMYUKhDoFkD4Pu4lqxWkh757JEuiTDKjCigBkiDRTbKoCqgSynjrki0ZX3tO
+gPXIs+NWyTKJfB2gBCwBWCGRVU1+O5fB+vfvjXeRKJE0yiablPAA9FDp1cE5GbBWhWbtfu5oJmFT
+FgDY+rKeEfSR70+fViVYj/7gaJcSJYEYgu1m44lIH8lTBupDDdZ/vDhhVNFLMCsE2sEQiRmlhJCn
+55kfSrAef2kir0SPSCNmagNKPBH0USHHwvghBOvx5/cMkRiKnKs45U4XKZzyeucUkdOdzmnFOX38
+zt/ddWu63BMvT5YJdAnZEQYBPDGnR6NWHKzHn98zBOAOAFcAqAAYAjBEAk4VqsTUzCKqfojZuSpm
+5qs4OjGD7ryHrZsvqtTv851XJ40SvSSyXNq1e8ZIn54mjVpxsG65fvO+x5/fsw/A3QAwMR/hlyOH
+kfEspueqCMIIwBhGx/PwgxA1P8Ch/SO4fNvFCCMdAoCnfziVIdEnoFkKBBFYY6SPhIBn5l3MSpjc
+LddvfgjAlQCmy0UPV10puGDDGqwfqGDjYAH9lX54noExgumjE4jCCIdGxxE5HXrmR1MFEaw5bl0F
+Yg0qcobjRrNSGnXL9ZtfV+VGOPe61i7AZUMZ3HDtFlx71WYUSuuRy3iYnZ5FdWERxhpADKLIYd/I
+wR0nNA8rfSJyxq1kxcACgNtu3DL9mZsuudIT+ebEpEU5SxSLPdg4fBF2XbsL1UUfxlgYYzE2Po3I
+KeYXqhuOC5SRsqyQo1pRsOrLzR8f/uLgOtw7dnRm/uiRCfR3zSGfz+Lq666BzWRgrAdjDKJI4QdR
+ean7WCNFY1pTv6sOLACz2y9+6VnS+519B2ex5/8mYXQCQ8ODGL50G5ikUiamZlGt+ts7Vtwgaw26
+z3A9hURGlQVVFs9SnJUD8Fsv/ejtS+/Le8To0QUUpnxICdiy4xIcHDmAqbHDqNV8RB16tSKwVqTC
+0+n1CNEYGI9EhnHnW846s0SC4G8e+MInizlz5//8/AAm5vw3jNj7qpMTkIUZ7Lj6Koi1mJtfRK0W
+XNtePmOlInJqno+AKJGNHLsix0rk2K/KMokiiUynjMxZAesvvv7iUH9P7sH3RsYR0ZveODhw18eu
+3v4PhXzuD6KFudkSAmy+bAfm5xcROW0HqixycoJOwjpFPnIsRxH7nWOZRCFh0QdTs3q7c48tLixW
+DozPY8P5a+6+9vLhtwHgox/Z9kxvpfxpDfy31lcK6K70wQ+ij6YEPfd+BZ2EOEU+itgTOfaqssQl
+hro+cGD97YOv3F/MYOebe0Zx/sCa3Z/82GWPps//2s6tb23ffNGnrTHP9JSKiCIXV1RgPSs9y32O
+U2Qjx+7Iab8qSwQyp1p3u5JA/dU3XrplXW/+H9985yBy+eJPr9kx/PlKuejXhbruBXvLJX/r8IYn
+9rx3aLbqhzeOT84+s2Xj+giArV9DJiuaWyUkciyGym5V5OMMKY+5rlG2/fcPClh//tUXhwZ6C/85
+OjaZn5wLZ7Zt2vCHl28ZPMBUZrNR4aTyW4c3/PfB0YlXSsW8Hdqwbi79UumXVcKGjqXIsVtjTybN
++54+sFYsdOgpZR6LQr+yb3QGm4YuuOe6ncNv6TJc/8037XrNWulVPfacEpkwYtEpMuSZf4eOYN31
+lefuF5GdThXqFE4VzunrTnWmfqza3KryoW/93Wf2LfWQe7758oM9RbvzlTdGMLC2f/fNv3H5bi4D
+KRGIZ6VMAE98/9Vdo0cmdyUnjDUmI2IsSfhBOOAH4UC67LbNm7526ebNe884WAR2grgBrdS84Tj3
++QGAjmB98Wsv3rGuN3/H2+8eRKHQ9dav79h493Irl/WkBMCSwOiRqV0T03N/tNyyVb9WWhFmqSoA
+wZ997hqICERitykiMAKIAM45fO+He/HUC+8sefMv/PPzO9f25O8fn5jGzKKbvXLbhX+6acPa2eWY
+n2cla4wUk+Ep63k2BwCP3ve5OFqUZn7GJPtB4PDsf72LB558deXM0CWBoAAIgghhGMWA1YETwcEj
+M1ishkuK4pce+XFfEEYPGkSVd/ZPYHho8O4bPrJpWTolIpLxpKwKiSKWIkXOiDScUS2I4Acu1Xhx
+OD96ZB7VarSymqUpNQ3CCPMLtWbFjMCIYH7RjxuXBNvUlWT24aff+ldqtPOFn+zF2jW9u2/7xBW7
+uUwVznpScg7dkWMhHkluSR3DDxxm530YkeZqBFNTNfAMKr1ZilnOKUSkLrTJ2uyQicR5yU5Ve2PP
++N+vX9N169xCFYPn9Y/83m9e8RXPyrICYAGKkXLQKYvslPmURnI0Va/mhe4MgtXZDFPMEqlXDQid
+g3OEiec1IZ7f1Mqs2QX/jw+Nz99ZzBn0lArhpz5+6XfP6+teV/U1HJsKDvsh3RJOxaqy2xozQPC4
+wPpBhKofwjMGhbyXNJxAyYaErJwZ1jUraTFJ/szN+5iaq8ImtE9MrgUsa+TWvnIuO7dQxY1XXzx6
+Xn8pUGKrUqIw4sHO/TcWVVGyRrpE4B2PHJMzVfx871FQgQsv6EE+5yEKFSQROYXTs8QsQdP0GvsC
+/HTvOCDE/GJQn8YDANhzoJo9OOE+O9CTuWvLhWv+pLsrt0BgI5QYmwx3d+pBJGmRrAisNVI40bv+
+22M/hnPEVZesx8bBCmZm/ZhV8XjjyoPVEHhJRYcNbRC8+e5YMuNEoUlfYe+haobxuB4OT+uXVfnl
+TQV+3hr5fT/kvyzUNGiNvmM21Z/iWekCTjyM9er/xuHcxRt6YYw0nIwqETm2SMgKMivFqBSrjAhU
+FST++tF7b78HAN4brRkSfe1a886B2lcH12af2z/m/ywlTlaVZaTSJMZIxohk9Tj299nfvulhVX1Y
+Cdz/4LefbbSlAE5jYY+cwrkVZ1bcrUyDlPZAWu+FNj1UL4BMJ1aMHGkCRbKg8QR8aQtAu0/WicXz
+qerM0pVnVjPOkhavWF+pTVHfP1Yrk8jyhPlt9pDIdYjUixCYkxpFFgEZm55Tnk3NkmPiq5hlsYsm
+iZEjfkHJrhO0vKdkBTw2HZQMuRdO5v0kiTdcwio9e2ClzDAVOkAQx1iqECMGQPn4QLFIssNwFQVU
+8ayUQNjWJFWSC27oZXPfQE0rYePpjk4Za1aSBQEAz4j1RD1CoYJ4TXJbCkKRbAmoNKdHpnNdjuI0
+NVmnM1h1AUlq2Sr08fmssZu/9ND3ryMJ1hNsCeNIoLsrX7LWZkA2dCUhqc0YyXrW5PI5rxupBFx7
+og4p/JK+fGuisD4/NGGXc2wIfCknlXLGX0dqByBikKj1+7A5mxmAU4lCJ0HgTLAYmZpT0RNqljQ8
+jjTNMdGJmh/evndk/HYmb1sHKQYu+Q1sAaEexJ6uJS3uDc1K7l/KSl/BhgPNujTBSLMHTbBIQiOV
+IFTxjYhVip44n5Wy+2a/KwaskMvitk9sTz20ztMlAGFKZMgmVdv6OjG0bbnd1LPbl+3DA0lKOQaq
+3RvmM9KTFbeWkgKrkbKuN3CDoapEFKlUlSAoNT8ytdnAztdZdUIzbPQLE6HPZTxcPNiPy7euT7US
+W1q6sSOp10yFHkh3oVKtjFSrI3U+XaZ+TDSnZNdXl/QLNTHDnIc+z7iwpV5t5h7zQiIlqqHKPAEG
+zixMVDNH5kNbbZ9cuARYmg7eGwFqVzGL6dlqTH0STM0jr/+mGgNoklSOJP3IRi4s2YdIXC6Juuum
+RGUjDdSegjEiEAgipwidIowUQeQaHjHSpjfMetLrJaSgtDI8MYhQKTWCC6oSBs5MTVa9A+OLmaOh
+E7f8tHLiAo5J0aDpUcBWM2xqAJupnHT6pBGCJErYcAZsEV4k18QBcGpNSjJpFKdN82tqVrO7kzXo
+M8Jsm7UrgEiJKiFOiarv7Oicb0fGFrIj86GpqS4d8XlLuPxUR7qpG83hI7aBxIYOgICYJjDNl0UL
+gDED0YjZ6n3M9hyVpBoLIo0AtMX86vtOk7AH8Kz0GrCU0r+AQFUpM0qZDZwZWQjt/sladv/EojcZ
+quiJnI+3lJepa9eh8TlUaz6MmBgkrbdqMoHW1Y/jlyDjWMxYk6RyDKw1sSlZgTUmyeEnghzF2YIo
+itMsIgbWxNdZI7BiYG28FQiCyKEWONTCCH4QwQ/jYz+MWoJSa9Br4hnwESFVJRYczViosr8a2fdm
+/My+icXs2GJkfF2mhz4us5564Weo+WGzdw80WlNdrG0uZQZ1861rjCQvHR8DJtmPO+sxEyJXF2Zt
+lG2WiUGqb0kiiBz8UBGEEYLIIQg12TqEkcNCtdbiSAlZdJRfhmr2Bc78Yi7M7J2oZUfmfW/R6fuL
+Y44B67WX38j95SOvZZwSDz/5E+CYkdpmVNj++0oMdC53UcJ3lFFH84tA7buLkffulJ/dNxNkpiN3
+clX12oAyAHKb1vfck896g33lwhprJOdZyWczXpdnTdEIPMTzl4wIbCIpNpEbk3bPzRSM8dITZNmC
++RLgtx23lmnVDHaQkHK5PLvosodrzh6YC7OHZoPMVOAkmRt3cq3acULY3GJkSKwlYZQUp+gj4TU+
+OauLcpJHqncn6ueZ+jwNpOQytk8JUWryqdqxn69R0Qg9mtv0dXHPQtue1fnaZhlSO5/XDtenPPOy
+R3dE0APAMJ5T2XcqcyIynilAVsd3jceAtVBzXYDkkw7/KQElgFgrBaySxbTOD3AWQAngKTOqziqR
+1fO1bDuzKognYpwyUMkMmFXDqhawaoErAMjFpnfqn3asNlY1wApCNQKpnA5GrVZWNZkl6CXQDzk9
+MwE9KzlZhf8GwURO8wDOP11AAUDGShGrcDEANp7Or6oyRrIiYlYjWP8/ABVzRoT3Sqt3AAAAAElF
+TkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66"
+       width="75" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4426);stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 21.369661,1023.8 13.432176,-16.6606"
+       id="path4418"
+       inkscape:connector-curvature="0" />
+    <path
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient4462);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4606)"
+       d="m 47.000294,1007.3622 -12.319149,16.9335 -12.416197,17.0669 16.933329,0 17.066666,0 12.416197,-17.0669 0.09676,-0.133 12.2221,-16.8001 -17.066666,0 -16.933329,0 z"
+       id="rect10961-8-3-6-1"
+       inkscape:connector-curvature="0"
+       transform="matrix(1.2008267,0,0.09173299,0.36603268,-108.57532,660.98864)"
+       inkscape:transform-center-x="4.4580006"
+       inkscape:transform-center-y="0.53407962" />
+    <path
+       style="display:inline;fill:url(#linearGradient4494);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4510);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 26.662676,1001.5215 13.292893,0 0,13.1948 z"
+       id="path4478"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4285-9-8)"
+       id="path4252-6-0"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="0.49178758"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="-3.0800218"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.9823895,-2.1047 -1.6734053,-2.5419 2.1987064,2.0209 2.4513363,-1.6427 -2.0383649,2.1623 1.7419712,2.4882 -2.2030799,-2.0431 z"
+       transform="matrix(-0.68431401,1.2284231,-1.0636666,-0.87657521,1143.5516,1913.5172)"
+       inkscape:transform-center-x="0.16252253"
+       inkscape:transform-center-y="0.33382692" />
+    <path
+       style="fill:url(#linearGradient4438);fill-opacity:1;fill-rule:evenodd;stroke:#3d5b8a;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.7500001,1018.1127 0,22.4995 46.4999999,0 0,-22.4995 -11,-4e-4 0,7.9997 3.085106,4e-4 -3.19e-4,6.9996 -31.584946,4e-4 3.19e-4,-6.9997 2.99984,-9e-4 0,-7.9997 z"
+       id="path4430"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#edf2f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4506)"
+       d="m 15.342812,1019.5906 -7.0000002,0 0,20"
+       id="path4480"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#eef1f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4524)"
+       d="m 11.162866,1034.8767 36,0 0,-9"
+       id="path4510"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="opacity:0.98000004;fill:none;fill-rule:evenodd;stroke:#eef1f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4566)"
+       d="m 43.900881,1024.6827 0,-5 8,0"
+       id="path4528"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#5d7aad;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4588)"
+       d="m 10.260003,1038.6222 41,0 0,-17"
+       id="path4570"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4661)"
+       id="path4252-6-0-1"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="1.0287941"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="3.1299058"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.5012045,-2.162 -1.1922203,-2.4846 2.095707,1.5226 2.5543357,-1.1444 -1.4929874,2.1437 1.1965937,2.5068 -2.164271,-1.4559 z"
+       transform="matrix(-0.3564605,0.66452158,-0.554066,-0.47418772,601.0265,1514.0687)"
+       inkscape:transform-center-x="0.084658908"
+       inkscape:transform-center-y="0.18052959" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/pref/import_wiz.svg
+++ b/bundles/org.eclipse.ui/icons/full/pref/import_wiz.svg
@@ -1,0 +1,1119 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="import_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4432">
+      <stop
+         style="stop-color:#ced8e7;stop-opacity:1;"
+         offset="0"
+         id="stop4434" />
+      <stop
+         style="stop-color:#b7c5e0;stop-opacity:1"
+         offset="1"
+         id="stop4436" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4420">
+      <stop
+         style="stop-color:#5b7aaa;stop-opacity:1"
+         offset="0"
+         id="stop4422" />
+      <stop
+         style="stop-color:#96aaca;stop-opacity:1"
+         offset="1"
+         id="stop4424" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4541">
+      <stop
+         style="stop-color:#a1adb2;stop-opacity:1"
+         offset="0"
+         id="stop4543" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient5885"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2">
+      <stop
+         id="stop11150-4-72-3-9-7"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10507">
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="0"
+         id="stop10509" />
+      <stop
+         id="stop10511"
+         offset="0.18181793"
+         style="stop-color:#9e7058;stop-opacity:1" />
+      <stop
+         id="stop10513"
+         offset="0.36363617"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10515"
+         offset="0.49999985"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10517"
+         offset="0.63636351"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e7058;stop-opacity:1"
+         offset="0.81818175"
+         id="stop10519" />
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="1"
+         id="stop10522" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4456"
+       id="linearGradient4462"
+       x1="63.734764"
+       y1="1039.3618"
+       x2="61.727211"
+       y2="1006.3618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,-0.72750163,1,733.40264,2.0004)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4456">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.659"
+         offset="0"
+         id="stop4458" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.369"
+         offset="1"
+         id="stop4460" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4606"
+       x="-0.062976152"
+       width="1.1259522"
+       y="-0.10879012"
+       height="1.2175802">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.5412116"
+         id="feGaussianBlur4608" />
+    </filter>
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2-8">
+      <stop
+         id="stop11150-4-72-3-9-7-2"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad6e48;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4368">
+      <stop
+         id="stop4370"
+         offset="0"
+         style="stop-color:#9c7561;stop-opacity:1" />
+      <stop
+         style="stop-color:#966d59;stop-opacity:1"
+         offset="0.18181793"
+         id="stop4372" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.36363617"
+         id="stop4374" />
+      <stop
+         style="stop-color:#794f40;stop-opacity:1"
+         offset="0.49999985"
+         id="stop4376" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.63636351"
+         id="stop4378" />
+      <stop
+         id="stop4380"
+         offset="0.81818175"
+         style="stop-color:#966d59;stop-opacity:1" />
+      <stop
+         id="stop4382"
+         offset="1"
+         style="stop-color:#99705c;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       height="1.2013515"
+       y="-0.10067577"
+       width="1.2017672"
+       x="-0.1"
+       id="filter4285-9-8"
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur4287-9-5"
+         stdDeviation="0.10000000000000001"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4496"
+       id="linearGradient4494"
+       x1="8"
+       y1="1013.3622"
+       x2="19"
+       y2="1024.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88619287,0,0,-0.87964908,19.219239,1914.8255)" />
+    <linearGradient
+       id="linearGradient4496"
+       inkscape:collect="always">
+      <stop
+         id="stop4498"
+         offset="0"
+         style="stop-color:#6885b2;stop-opacity:1" />
+      <stop
+         style="stop-color:#5777a7;stop-opacity:1"
+         offset="0.54585904"
+         id="stop4512" />
+      <stop
+         style="stop-color:#355286;stop-opacity:1"
+         offset="0.63636416"
+         id="stop4500" />
+      <stop
+         id="stop4502"
+         offset="1"
+         style="stop-color:#2c4a81;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4504"
+       id="linearGradient4510"
+       x1="3.2928932"
+       y1="1020.7158"
+       x2="20"
+       y2="1020.7158"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88619287,0,0,-0.87964908,19.219239,1914.8255)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4504">
+      <stop
+         style="stop-color:#b0c1db;stop-opacity:1"
+         offset="0"
+         id="stop4506" />
+      <stop
+         style="stop-color:#8299c2;stop-opacity:1"
+         offset="1"
+         id="stop4508" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4420"
+       id="linearGradient4426"
+       x1="68.572693"
+       y1="1016.118"
+       x2="67.579018"
+       y2="1015.3881"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99587969,-0.09068428,-0.09068428,-0.99587969,47.64461,2028.4309)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4432"
+       id="linearGradient4438"
+       x1="8"
+       y1="1019.3622"
+       x2="52"
+       y2="1039.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9893617,0,0,0.97823962,0.31914907,22.399103)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4506"
+       x="-0.092571429"
+       width="1.1851429"
+       y="-0.0324"
+       height="1.0648">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.27"
+         id="feGaussianBlur4508" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4524"
+       x="-0.029837838"
+       width="1.0596757"
+       y="-0.12266667"
+       height="1.2453333">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.46"
+         id="feGaussianBlur4526" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4566"
+       x="-0.08775"
+       width="1.1755"
+       y="-0.1404"
+       height="1.2808">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.2925"
+         id="feGaussianBlur4568" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4588"
+       x="-0.042439024"
+       width="1.084878"
+       y="-0.10235294"
+       height="1.2047059">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.725"
+         id="feGaussianBlur4590" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4661"
+       x="-0.14766911"
+       width="1.2953382"
+       y="-0.11646623"
+       height="1.2329325">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.36234727"
+         id="feGaussianBlur4663" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#a5a5a5"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.106667"
+     inkscape:cx="75"
+     inkscape:cy="20.792472"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <image
+       y="0"
+       x="75"
+       id="image4762"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAACXBIWXMAAAsTAAALEwEAmpwYAAAK
+TWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQ
+WaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec
+5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28A
+AgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0
+ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaO
+WJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHi
+wmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryM
+AgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0l
+YqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHi
+NLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYA
+QH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6c
+wR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBie
+whi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1c
+QPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqO
+Y4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hM
+WEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgoh
+JZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSU
+Eko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/p
+dLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Y
+b1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7O
+UndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsb
+di97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W
+7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83
+MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxr
+PGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW
+2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1
+U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd
+8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H0
+8PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+H
+vqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsG
+Lww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjg
+R2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4
+qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWY
+EpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1Ir
+eZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/Pb
+FWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYj
+i1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVk
+Ve9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0Ibw
+Da0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vz
+DoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+y
+CW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawt
+o22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtd
+UV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3r
+O9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0
+/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv95
+63Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+
+UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMA
+APn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAAPF0lEQVR42uxbbYwd1Xl+3jNz537s7t0PYxaM
+AYNJQ0pluQntD9K0JKoqFalBoq3USLSlUtVW/ZOiSP2VCKP+qJRWilAqtaJNQ1MqUZGWgCgqhcQk
+AWSIYxuDjYm/7669Xtv7vfdjZs55n/6YmXtn7+56be+uDUtGGs3MvTPnnnnO8z7vxzlX8PNtye3r
+z5zxSJRI9pPoA1D2fw7LAoAKAMokqqrsIVHOf/+xB+sb3z3rkehRoqTKMpU9SgRL3fuxBeubz42V
+VVEhGRDwQPaBLF7qmY8VWP/0wjmjRJFkHwlPBCBRAdkLQFZ6/mMD1pMvjvcpWRHAkAASNlUFCOQy
+29jwYH3rpfGyEgmTADChUJlAnwDCK2hrw4L11MvnAxJVkgVhAhISoPogqOQ/+9iC9fQrFzwlqyRK
+XWCICAYABOTVtb2hwPqPVy/0kOgVwCzAQ+AbQT8VPlfR/oYA6z93XyykbAoAoIs5vhEMkVemTxsS
+rGdfu9ijRK9ADLtUSABfRIZIrhqojzRY//3jCaOKQYLBUmItiekNKSHk2vzmRxKs770+UVKiX6Qd
+M3UruS+CISrkyn3eBgLr+TcmqwR6hFwSBgF8MWujUR9ZsP5nz6RRYpBc3vUL4BsjQ7pGGtW9mbVo
+JLbuYZK/u15AvfTWVAGQzYKlqwGpRnmeJ0MQyHr1Y9XMaoXxH9ab8b/VW/FZkqMi8tZadvB/354q
+Exi4pEgLxBMMrIfprRos0hoRXwFgrh49MT45J0q55dTZ2W+SfEhERteic/+3d7pKsmclb+Z7MkTC
+J7muUnBVZijiKxl6ADA5F37h/HRr+tDxc5icrf/Kk987+ARJb7Ude/Wn0wMAelYcbSNVuUbae9Wa
+JVJ0APALt5UO+Z7/4NS8rb918DSo9qFd//zmv1xtu7v3z5jv75u+AVhY0l1q84xUjFn5vg+NwItU
+4s/t7N8z0Ff51ZmGvrPvcA3Dg8Ejjz35xrevtK3XDswYAEMCFFbsuEHgGfStMz5CoqDKsiora+IN
+RfqiL/3WzSdKpdL9XqF04MCR0UsCRp4eIGt/RY7sJkd3k6O7nda+IoLNkJWBEoHnGRlYU1gIUSJw
+yooq+53jJue4SZX9JHpIVNbUzZITlb/+h/eC+Xpzt4ubO3fevRXjU9FTj//ZZ/+kc09tF2C+DHgD
+gJcjt0IZv/ni682Rvt4bHlUCSoAklIBq59z3ZBNJXxVQEskRUGXXMfuei753CnGOBetYUGXBKXwl
+QS5KxPNx3DrkbbsP3vLKW2dftFFz5y9/aivGp6Ondv3p1kcBsxvwdiZW5iMBKwNMsf+DCdTGQ1T7
+Nm9ZDizPSBWCsipxpWA5R88qCs5p4ByCRfevAJZZD7Ae+vyOM7/92S1f9IPygf3vj2B4IHjk2e9P
+ngQKO5O4spjuZQAlAEXs/2AOtfFwJUEvXqmgkxCnKFnLfus4qMpecvngdt0j+KW2L35ux8jv/PqW
+B/2gcmD/+yO4OGUHnv/RxRSkDDAfgMH+Dy6gNj6H2ZBwTpfuqMDzPem/3N93isA69lmnm1TZy8tw
+GtcNLAB44L4dtb/78t3Ydusm7Ds8gnMXZvHi66dTsJKffufoKGrjs6ijiNGxSYSRW7Ktgm8GVpIN
+AmIdK5HjkFNWlSh+6HLD5U2gtqunFOx89Eufwh23bca+98ehbgw/2DsCADhx5jTGJycQ+xVMTNfR
+arbQiuxioDzpFVk+8CTgxY59seUmJSrg+rzXkiP1lSd2PyIi25wqjADWKqLYwqlCnSZH7RxV+dQz
+f/v7p7rCg22AdzIzu2bo4R//6xCmZ6bxwK/djt6eKubqLZyrFzEbAkcOHYWow203DeKT2+9sC7wR
+BJ4ng8+9sufesfOT96bgZCmhMcYURMRj7gsCuPuu7S/ffsvWcVKXdgC6hENYQeD9ZUbqj4eqF+93
+bguMAKqKas8oaucEs/NLZiCvATjVNQ6PJc37AAooFwP85e99Bv/+0nsAiugrl3BmxoMVwchIDbNz
+8ygWfIQ5ZolAfE+qBDB2fureiem5P79cFkxMTb1z+y1bx9c9kSaJgd4iHn7gdlA3w/PqILcjigez
+lwBJvLrnGF744QfLWfj9SVjgt8OEUgB8/t6bMN+IMD7vEBQtZqcUp0+dgbMOVKIVWuzYHt1z4Fhw
+KPClF4CXH+ln//6PEnOQNrsg6bm1ipdfP4pvvbDn2lUdhESjeSPAAVSKEZQF1JslWOegSogAtbFp
+zDeiSxRtZVsiiVksBRw8ehLnpyYxGQ3DGQfDSRw5fAzz9bDN/TCyKBUqt/qeO2qMVFQJEp7ve22x
+tqqp1xSISCJQApwZm0Ozaa9ticapIrYOgAenDtYp6s065puEdQojgpm5ZjK4JJYvjZj2/pPD53B8
+tIVzrSpCRhg5eRwH3t6PZn0eN229GUExgDEGrcii4Pu/VPB1ryrEWvZaRdGIeBmh6o0Ys/MhjEhn
+N4ILFxtYzzLNkmCFkcV8I4Qx5zAzvwnN0KLgT8EzhHP92aQALj0dwFMAtwHA24fGcGxkCidniKOn
+RnHi8BHMTk0CVKg6jJwawfCWm+AbD2FoYYzscA591rGs7HJCXebX3rOBvtZgOVX4Xg3N8DNoxYpm
+aFFv9sO5SYSxhUmW6rS1a6nRjC2+WvDjp/e8N46jtTn89OhF7N13GBNjZ+D5PozxQSroEo965vQI
+CtvvQBhZCMw2p6ws99phZNEMY/jGoFzy04ETKJcPatcNLHWKMxeGoCzA2hai2EFEMDVbxNTcDLyU
+9pkz6Abrg1qjevwsfnC8Vnvz4nR038H3a3j33Z+h4BTDNyZlckLSsCNhlzpFWG+gFVp4nnfXch2e
+nGniyPGLoAJbhvtQKvqwsYJMJMLpdWBWxniRZAagfS7Ae8cvAMJE4NPYJNt+NtIsE+jZd+jE42Fk
+74utwx233YRbt2xGFDvENtHDOHbpMb1OP0tCB8HwYGF4bDJe5Pr/9bmfwDni03dvwSe2DWFmNkxY
+5fT6gKUpWG0hkJw+QHDw2DgSL6VQdqaDj442AwIDIPDpX7zjMSUeW6rEogSYBIKedVpVRUDA+8Qt
++hueKffNNez25Tq8590knLvz1kEYI20no0pYx/ZAX2Nm5RiVE3QjifmQePzZr//BruyZ42ebBSbz
+epe1KVlRRXt5ou9Jz8lz3kHVCEq+0f3ODz/4m99R1e8ogW98+7uvtMdSAKeJsFuncO6aM4tJ6TBn
+ekkgkJxrV05wcqxlSPQTXDknIzxVVpErkxgjBSMS6FV4MrJTs7JpKnZ9zDDntfNumtol6oJBAIWV
+lhWQLGuyAF+6prL6rsrji4BMTM8pr6dm5eMYybFM0oQz6dTp8VaVRMAV69vs5xIlE9+TCgTmStdv
+SJrEuqwSev3Ayplhyiq0NQugKghg5HxYVrJnBTPxlRwAkZtLpIAqAnhGTI+SAqY2lR47ern4vDMG
+neqBI2HTUCSdT/R8UZ9QqCDZkXhuBaFIjwRU0s9TdUnP6SiaX3/iLyO+neETdAl98r0RMQCqK5hd
+hWRfLoDzoM4XZ0viXCBGBuCSpdWiGQWTBIkKaDuOa9fjJdPFDNsMKFXCObYFvrcoA9VCeCOpi4DI
+vDI1a4ftej8BWCexVYlDZ6KmNS2nSe8uqVnS9jgLTZIkrPJrf/E3z3yNSNiQvRSRmmj7POUAOxWN
+tSsudsS9rVlp+72BDJW9eLjTlw4YzAGHDlgkoVYlio2EsZMwVhOvXKLJ2X0n70r0qlwM8NAX7sn9
+aMbTZQDJralObpDFJccM0Pz9yN+6uEZ5z/ZhMLUCp4u9Yakg/YG4zZQcWGn7nQFuM1SVEltFSwkC
+ErasadZj08xYtaIZimCB0BcLPu7cugk7PrklN0pcMNLtE8m9Zi75bZu1dG5l2mPm2pAlnsmuiXzF
+k21TdE6hqRkWfQz5xsUL+tU+bw8slRIr0YoV84Q0I2fqk83C+bnIa3Svl1sGLG0vc2oDBqCnEmB6
+tplQn8yi8LQsy/YcHkkYk5ROJM0jTWrK2TlEkufSqDszJSoXPJMvwRgRCATWKWKniK0isq6tWVY7
+3jDwZdBPSUFZyPDUeq1SWgTrqhJHzkxPNv2RC43CxdiJu/xKqRIEFwCWmWPmUcCFZtjRALZDDeTL
+J+0QJFXCNPxgru7NlJHZfZKafuc605cEWJdjVne6UzAYMEK/beadcpJVoklIXYlW5MzYbOiPjNeD
+0fnYNFNHf2Vl5W6QAOm8VCriC3WrIwxiOsB0XjZnkpJ6ovYkAds55oIaVc5ks/AlC0AXmF8KnHOa
+hj1AwZNNBqxmXQcQE2gqZUYps5EzI/XYOz3ZCmoTDX8iVtGVnI+/nJfJtOvshTk0WyGMmASkrGOK
+dLYnu05egsmMDIxn0lKOgeeZxJQ8gWcMRADnUkG2SbXA2qTMImLgmeQ+zwi83LVAEFmHVuTQii3C
+yCKMk+swtguCUs9g0CSLui0hTSUajmY8Vqk1rXdiJiycmmgE4w1rwstNsy7JrJd+fASNVtTJ7pGL
+a1yibdkoZ3rDNNI3Jtk9kwJlAJOeJ8l6wgTrMmFO+G8k/0wCVnYkicg6hHEyNRdZhyjW9JiUeerN
+1gJHSkjDUWqxmlORMyfm4sLxiVYwMh/6DXeFyegisPa+8U7xq0/vLTglnnp+L7q9eX5yrvvzdV6l
+eEWbEqGjjDmaE5F6xxrWPz4VBidnosK0dVfXVb8LKAOgeNeW/l0CDN8wULmhFPi9viclI+IHvtfr
++6YMopCRIJUUL5Ubk3fPCxZ1eF6pK6xCLrpaDH7Xdfckal4zuISEVKvV2YYLzrWcNzoXB2dno8JU
+5MTqEn1b1Yw0AMzUbQnEoHaKd1VVljUvymkdKUsnspld5mZ7ScL3TMWIVJQKly0Fyq+Vyp7hpZYR
+JZmFdv3WSkuO1n1Geq5h0/pUexpxCFe5yFUA8Y2U9UNkomu6MEQE/Uj+s7cqoNLVL+X1XMh/XcGq
+t1wPIKU0OlkVUAKI50kZG2RbAFYzdB6AXoCrZlTGKtkgrFqKWQNIFmKsGqh0BcyGYdUCsFqRKwMo
+JqYnq/7HwkZjVRusKFYjkIG1YNRGZVWHWYJBApsga/MfGN+TomBjsQoAjHVaAnDzWgGVZvwVbMDN
+ALhjLf9VVTASSDKZseG2/x8AeW7Aj7mVvz8AAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66"
+       width="75" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4426);stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 16.736,1003.0392 14.488067,15.7511"
+       id="path4418"
+       inkscape:connector-curvature="0" />
+    <path
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient4462);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4606)"
+       d="m 47.000294,1007.3622 -12.319149,16.9335 -12.416197,17.0669 16.933329,0 17.066666,0 12.416197,-17.0669 0.09676,-0.133 12.2221,-16.8001 -17.066666,0 -16.933329,0 z"
+       id="rect10961-8-3-6-1"
+       inkscape:connector-curvature="0"
+       transform="matrix(1.2008267,0,0.09173299,0.36603268,-108.57532,660.98864)"
+       inkscape:transform-center-x="4.4580006"
+       inkscape:transform-center-y="0.53407962" />
+    <path
+       style="display:inline;fill:url(#linearGradient4494);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4510);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 23.207107,1023.8622 13.292893,0 0,-13.1948 z"
+       id="path4478"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4285-9-8)"
+       id="path4252-6-0"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="0.49178758"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="-3.0800218"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.9823895,-2.1047 -1.6734053,-2.5419 2.1987064,2.0209 2.4513363,-1.6427 -2.0383649,2.1623 1.7419712,2.4882 -2.2030799,-2.0431 z"
+       transform="matrix(-0.68431401,-1.2284231,-1.0636666,0.87657521,1139.9713,112.35675)"
+       inkscape:transform-center-x="0.16252253"
+       inkscape:transform-center-y="-0.33383187" />
+    <path
+       style="fill:url(#linearGradient4438);fill-opacity:1;fill-rule:evenodd;stroke:#3d5b8a;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.7500001,1018.1127 0,22.4995 46.4999999,0 0,-22.4995 -11,-4e-4 0,7.9997 3.085106,4e-4 -3.19e-4,6.9996 -31.584946,4e-4 3.19e-4,-6.9997 2.99984,-9e-4 0,-7.9997 z"
+       id="path4430"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#edf2f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4506)"
+       d="m 15.342812,1019.5906 -7.0000002,0 0,20"
+       id="path4480"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#eef1f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4524)"
+       d="m 11.162866,1034.8767 36,0 0,-9"
+       id="path4510"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="opacity:0.98000004;fill:none;fill-rule:evenodd;stroke:#eef1f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4566)"
+       d="m 43.900881,1024.6827 0,-5 8,0"
+       id="path4528"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#5d7aad;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4588)"
+       d="m 10.260003,1038.6222 41,0 0,-17"
+       id="path4570"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4661)"
+       id="path4252-6-0-1"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="1.0287941"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="3.1299058"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.5012045,-2.162 -1.1922203,-2.4846 2.095707,1.5226 2.5543357,-1.1444 -1.4929874,2.1437 1.1965937,2.5068 -2.164271,-1.4559 z"
+       transform="matrix(-0.3564605,-0.66452158,-0.554066,0.47418772,596.13721,512.95467)"
+       inkscape:transform-center-x="0.084658908"
+       inkscape:transform-center-y="-0.18053454" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/progress/errorstate.svg
+++ b/bundles/org.eclipse.ui/icons/full/progress/errorstate.svg
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="20"
+   height="20"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="errorstate.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1-1"
+       id="linearGradient4116-4"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="470.63007"
+       x2="388.63736"
+       y2="465.52719" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1-1">
+      <stop
+         style="stop-color:#e17673;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7-3" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8-2"
+         offset="0.5"
+         style="stop-color:#d04046;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e17673;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3-1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4"
+     inkscape:cx="25.883401"
+     inkscape:cy="-11.147202"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="225"
+     inkscape:window-y="203"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4118"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1032.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <g
+         style="display:inline"
+         id="g4110"
+         transform="matrix(1.2028965,0,0,1.2028965,-1.5237048,-216.61998)">
+        <path
+           transform="matrix(0.50645089,0,0,0.50645089,-180.12602,820.2612)"
+           d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+           sodipodi:ry="10.625"
+           sodipodi:rx="10.625"
+           sodipodi:cy="468.23718"
+           sodipodi:cx="388.125"
+           id="path10796-2-6-0"
+           style="fill:url(#linearGradient4116-4);fill-opacity:1;stroke:#c93e35;stroke-width:1.97452509;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+           sodipodi:type="arc" />
+        <g
+           transform="matrix(0.85394764,0,0,0.8525189,15.059954,156.13336)"
+           id="g5025">
+          <g
+             transform="matrix(1.0905016,0,0,1.0905016,-0.09572826,-95.681285)"
+             id="g4095">
+            <path
+               sodipodi:nodetypes="ccscccccccccccccccccc"
+               inkscape:connector-curvature="0"
+               id="path5021"
+               transform="matrix(0.77187105,0,0,0.77316463,-4.647127,1051.0563)"
+               d="M 6.2265625,3.6953125 C 5.9177427,3.7062384 5.125,4.3515625 5.125,4.3515625 c 0,0 0.2885111,0.2731764 0.78125,0.6796875 0.4927389,0.4065111 0.9552143,0.9554552 1.0625,1.4375 C 7.068619,6.9173537 7.1051563,7.3329889 7.15625,7.75 L 4.2010947,10.96967 5.0906092,11.868663 7.4375,9.375 c 0.2792655,0.4616799 0.5966442,0.914462 0.8125,1.28125 0.2533102,0.354 0.6860498,0.734189 1.40625,1.09375 1.285897,0.641907 1.105068,0.565316 1.105068,0.565316 l 0.965609,-0.791649 c 0,0 -0.202967,-0.247189 -1.508177,-0.898667 C 9.6433969,10.337868 9.4953002,10.118107 9.34375,9.90625 8.8239337,9.3154094 8.6327445,8.816423 8.5,8.1875 L 11.629711,4.6423859 10.681163,3.8870243 8.28125,6.5 C 8.263796,6.4030643 8.2724218,6.3194727 8.25,6.21875 8.0333974,5.2456067 7.3191341,4.5264873 6.71875,4.03125 6.4464909,3.8171333 6.4806949,3.8796991 6.2265625,3.6953125 z"
+               style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/progress/lockedstate.svg
+++ b/bundles/org.eclipse.ui/icons/full/progress/lockedstate.svg
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="20"
+   height="20"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="lockedstate.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5156">
+      <stop
+         style="stop-color:#fdf3cb;stop-opacity:1;"
+         offset="0"
+         id="stop5158" />
+      <stop
+         id="stop5166"
+         offset="0.48612955"
+         style="stop-color:#fdf3cb;stop-opacity:1" />
+      <stop
+         id="stop5164"
+         offset="0.56520796"
+         style="stop-color:#a77e1c;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#a77e1c;stop-opacity:0.5"
+         offset="1"
+         id="stop5160" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5001">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5003" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop5005" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4886">
+      <stop
+         style="stop-color:#dec26f;stop-opacity:1"
+         offset="0"
+         id="stop4888" />
+      <stop
+         style="stop-color:#fce69e;stop-opacity:1"
+         offset="1"
+         id="stop4890" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4870">
+      <stop
+         style="stop-color:#fdf3cb;stop-opacity:1"
+         offset="0"
+         id="stop4872" />
+      <stop
+         style="stop-color:#fce69e;stop-opacity:1"
+         offset="1"
+         id="stop4874" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4862">
+      <stop
+         style="stop-color:#c79c2f;stop-opacity:1"
+         offset="0"
+         id="stop4864" />
+      <stop
+         style="stop-color:#b7912c;stop-opacity:1"
+         offset="1"
+         id="stop4866" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4862"
+       id="linearGradient4868"
+       x1="30.0625"
+       y1="1034.6094"
+       x2="30.0625"
+       y2="1040.7631"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4870"
+       id="linearGradient4876"
+       x1="25.65625"
+       y1="1035.1342"
+       x2="25.65625"
+       y2="1040.8594"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4886"
+       id="linearGradient4892"
+       x1="32.325939"
+       y1="1049.9935"
+       x2="32.325939"
+       y2="1040.7358"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5001"
+       id="linearGradient5007"
+       x1="29.435884"
+       y1="1041.4501"
+       x2="29.435884"
+       y2="1039.0558"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4878">
+      <stop
+         style="stop-color:#a77e1c;stop-opacity:1"
+         offset="0"
+         id="stop4880" />
+      <stop
+         style="stop-color:#c19e38;stop-opacity:1"
+         offset="1"
+         id="stop4882" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-20,2.1382813e-5)"
+       y2="1040.7803"
+       x2="29.263437"
+       y1="1049.9935"
+       x1="29.263437"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5103"
+       xlink:href="#linearGradient4878"
+       inkscape:collect="always" />
+    <filter
+       inkscape:collect="always"
+       id="filter5152">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.32374297"
+         id="feGaussianBlur5154" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5156"
+       id="linearGradient5162"
+       x1="26.334742"
+       y1="1041.0375"
+       x2="32.558262"
+       y2="1049.7878"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999998"
+     inkscape:cx="4.2960564"
+     inkscape:cy="10.236278"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="379"
+     inkscape:window-y="250"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1032.3622)">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4876);fill-opacity:1;stroke:url(#linearGradient4868);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 9.5,1034.625 c -2.758584,0 -5,2.2414 -5,5 l 0,2.9375 c 0,2.7586 2.241416,5.0313 5,5.0313 2.758584,0 5.03125,-2.2727 5.03125,-5.0313 l 0,-2.9375 c 0,-2.7586 -2.272666,-5 -5.03125,-5 z m 0,2 c 1.685179,0 3.03125,1.3148 3.03125,3 l 0,2.9375 c 0,1.6852 -1.346071,3.0313 -3.03125,3.0313 -1.685179,0 -3,-1.3461 -3,-3.0313 l 0,-2.9375 c 0,-1.6852 1.314821,-3 3,-3 z"
+       id="rect4838-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ssssssssssssss" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.5;color:#000000;fill:url(#linearGradient5007);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 9.5,1034.1122 c -3.029423,0 -5.5,2.4706 -5.5,5.5 l 0,2.9375 c 0,3.0294 2.466794,5.5313 5.5,5.5313 3.033206,0 5.53125,-2.4981 5.53125,-5.5313 l 0,-2.9375 c 0,-3.0332 -2.501827,-5.5 -5.53125,-5.5 z m 0,3 c 1.425108,0 2.53125,1.0811 2.53125,2.5 l 0,2.9375 c 0,1.4189 -1.112334,2.5313 -2.53125,2.5313 -1.418916,0 -2.5,-1.1062 -2.5,-2.5313 l 0,-2.9375 c 0,-1.4251 1.074892,-2.5 2.5,-2.5 z"
+       id="path4994"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="fill:url(#linearGradient4892);fill-opacity:1;stroke:none"
+       id="rect4838"
+       width="11.998713"
+       height="8.9936171"
+       x="3.5134373"
+       y="1040.8717"
+       rx="1.1048543"
+       ry="1.1048543" />
+    <rect
+       style="fill:none;stroke:url(#linearGradient5162);stroke-width:0.87896538;stroke-opacity:1;display:inline;filter:url(#filter5152)"
+       id="rect4838-4"
+       width="10.729074"
+       height="7.770525"
+       x="4.1482563"
+       y="1041.4833"
+       rx="0.62204111"
+       ry="0.60104567" />
+    <rect
+       style="opacity:0.25;fill:#a77e1c;fill-opacity:1;stroke:none"
+       id="rect4894"
+       width="11.031251"
+       height="1"
+       x="3.9971676"
+       y="1044.4247" />
+    <rect
+       style="opacity:0.25;fill:#a77e1c;fill-opacity:1;stroke:none;display:inline"
+       id="rect4894-7"
+       width="11.031251"
+       height="1"
+       x="3.9971676"
+       y="1046.4247" />
+    <rect
+       style="opacity:0.25;fill:#a77e1c;fill-opacity:1;stroke:none;display:inline"
+       id="rect4894-7-4"
+       width="11.031251"
+       height="1"
+       x="3.9971676"
+       y="1048.4247" />
+    <path
+       sodipodi:type="arc"
+       style="fill:#785b13;fill-opacity:1;stroke:none"
+       id="path4066"
+       sodipodi:cx="9.4796505"
+       sodipodi:cy="12.531184"
+       sodipodi:rx="1.016466"
+       sodipodi:ry="1.016466"
+       d="m 10.496117,12.531184 c 0,0.561379 -0.455088,1.016466 -1.0164665,1.016466 -0.5613787,0 -1.016466,-0.455087 -1.016466,-1.016466 0,-0.561378 0.4550873,-1.016466 1.016466,-1.016466 0.5613785,0 1.0164665,0.455088 1.0164665,1.016466 z"
+       transform="translate(0,1032.3622)" />
+    <rect
+       style="fill:#785b13;fill-opacity:1;stroke:none"
+       id="rect4836"
+       width="1.0606602"
+       height="2.8063302"
+       x="8.9493217"
+       y="1045.5342" />
+    <rect
+       style="fill:none;stroke:url(#linearGradient5103);stroke-opacity:1;display:inline"
+       id="rect4838-12"
+       width="11.998713"
+       height="8.9936171"
+       x="3.5134373"
+       y="1040.8717"
+       rx="1.1048543"
+       ry="1.1048543" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/progress/progress_error.svg
+++ b/bundles/org.eclipse.ui/icons/full/progress/progress_error.svg
@@ -1,0 +1,448 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="progress_error.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-2-6-3"
+       id="linearGradient3825-4-6-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-2-6-3">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-2-4-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-0-0-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-4-9-3"
+       id="linearGradient3827-6-7-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-4-9-3">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-8-8-5" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-4-3-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-3-6-8"
+       id="linearGradient3829-8-2-9"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       id="linearGradient3797-3-6-8">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-3-9-0" />
+      <stop
+         id="stop3805-5-3-6"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-7-0-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-2-4"
+       id="linearGradient3825-4-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-2-4">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-2-40" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-0-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-4-0"
+       id="linearGradient3827-6-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-4-0">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-8-7" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-4-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-3-61"
+       id="linearGradient3829-8-7"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       id="linearGradient3797-3-61">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-3-91" />
+      <stop
+         id="stop3805-5-9"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-7-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-3"
+       id="linearGradient3825-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-3">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-8" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-06" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-7"
+       id="linearGradient3827-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-7">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-1" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-2"
+       id="linearGradient3829-3"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071"
+       gradientTransform="matrix(1.1129032,0,0,1,-0.6602823,1036.3622)" />
+    <linearGradient
+       id="linearGradient3797-2">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-6" />
+      <stop
+         id="stop3805-4"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1">
+      <stop
+         id="stop10800-5-2-1-8-2-8-1-7-3-7"
+         offset="0"
+         style="stop-color:#e17673;stop-opacity:1;" />
+      <stop
+         style="stop-color:#d04046;stop-opacity:1;"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-95-0-5-4-8" />
+      <stop
+         id="stop10802-1-5-3-0-2-0-9-8-4-3"
+         offset="1"
+         style="stop-color:#e17673;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="465.52719"
+       x2="388.63736"
+       y1="470.63007"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8163-2"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1"
+       inkscape:collect="always" />
+    <filter
+       inkscape:collect="always"
+       id="filter6101">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.33997253"
+         id="feGaussianBlur6103" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="7.8083738"
+     inkscape:cy="4.2468998"
+     inkscape:document-units="px"
+     inkscape:current-layer="g3819"
+     showgrid="true"
+     inkscape:window-width="1056"
+     inkscape:window-height="796"
+     inkscape:window-x="75"
+     inkscape:window-y="75"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g3969">
+      <g
+         transform="translate(-3.8839286,-13.973215)"
+         id="g3819-3-3">
+        <rect
+           style="fill:url(#linearGradient3825-4-6-0);fill-opacity:1;stroke:none"
+           id="rect3809-0-6"
+           width="9.687501"
+           height="5.8928571"
+           x="5.6696429"
+           y="1051.0229" />
+        <rect
+           style="fill:none;stroke:url(#linearGradient3827-6-7-7);stroke-width:0.89767581;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           id="rect3017-4-4"
+           width="10.15411"
+           height="6.1183953"
+           x="5.4006238"
+           y="1050.8164" />
+        <rect
+           style="fill:url(#linearGradient3829-8-2-9);fill-opacity:1;stroke:none"
+           id="rect3795-5-3"
+           width="8.1696424"
+           height="5.2232132"
+           x="5.8482141"
+           y="14.883928"
+           transform="translate(0,1036.3622)" />
+        <path
+           style="fill:none;stroke:#4ea54c;stroke-width:1.0107801px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 14.553572,1051.257 0,5.2908"
+           id="path3807-8-4"
+           inkscape:connector-curvature="0" />
+      </g>
+      <rect
+         style="opacity:0.62139917;fill:#ffffff;fill-opacity:1;stroke:#cbe8f3;stroke-width:0.86707354;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="rect4166-7"
+         width="9.3186407"
+         height="5.3454266"
+         x="2.3496084"
+         y="1037.6135" />
+      <g
+         transform="translate(-1.9196429,-11.919643)"
+         id="g3819-3">
+        <rect
+           style="fill:url(#linearGradient3825-4-8);fill-opacity:1;stroke:none"
+           id="rect3809-0"
+           width="9.687501"
+           height="5.8928571"
+           x="5.6696429"
+           y="1051.0229" />
+        <rect
+           style="fill:none;stroke:url(#linearGradient3827-6-4);stroke-width:0.89767581;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           id="rect3017-4"
+           width="10.15411"
+           height="6.1183953"
+           x="5.4006238"
+           y="1050.8164" />
+        <rect
+           style="fill:url(#linearGradient3829-8-7);fill-opacity:1;stroke:none"
+           id="rect3795-5"
+           width="8.2589283"
+           height="5.2232132"
+           x="5.8482141"
+           y="14.883928"
+           transform="translate(0,1036.3622)" />
+        <path
+           style="fill:none;stroke:#4ea54c;stroke-width:1.0107801px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 14.598215,1051.257 0,5.2908"
+           id="path3807-8"
+           inkscape:connector-curvature="0" />
+      </g>
+      <rect
+         style="opacity:0.62139917;fill:#ffffff;fill-opacity:1;stroke:#cbe8f3;stroke-width:0.87074792;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="rect4166"
+         width="9.4042521"
+         height="5.3417521"
+         x="4.2264457"
+         y="1039.6689" />
+      <g
+         transform="translate(1.4285714e-8,-10)"
+         id="g3819">
+        <rect
+           style="fill:url(#linearGradient3825-6);fill-opacity:1;stroke:none"
+           id="rect3809"
+           width="9.687501"
+           height="5.8928571"
+           x="5.6696429"
+           y="1051.0229" />
+        <rect
+           style="fill:none;stroke:url(#linearGradient3827-9);stroke-width:0.89767581;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           id="rect3017"
+           width="10.15411"
+           height="6.1183953"
+           x="5.4006238"
+           y="1050.8164" />
+        <rect
+           style="fill:url(#linearGradient3829-3);fill-opacity:1;stroke:none"
+           id="rect3795"
+           width="9.2410707"
+           height="5.2232132"
+           x="5.8482141"
+           y="1051.2461" />
+      </g>
+      <path
+         sodipodi:type="arc"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;filter:url(#filter6101)"
+         id="path5329"
+         sodipodi:cx="10.9375"
+         sodipodi:cy="10.642858"
+         sodipodi:rx="4.4196429"
+         sodipodi:ry="4.4196429"
+         d="m 15.357143,10.642858 c 0,2.440901 -1.978742,4.419642 -4.419643,4.419642 -2.4409014,0 -4.4196429,-1.978741 -4.4196429,-4.419642 0,-2.4409018 1.9787415,-4.4196434 4.4196429,-4.4196434 2.440901,0 4.419643,1.9787416 4.419643,4.4196434 z"
+         transform="matrix(1.1161616,0,0,1.1161616,-0.7571248,1035.9072)" />
+      <g
+         style="display:inline"
+         id="layer1-2"
+         inkscape:label="Layer 1"
+         transform="matrix(0.70395181,0,0,0.70395181,5.9991493,312.7126)">
+        <g
+           transform="translate(-8.2201163,-12.904699)"
+           id="g8159"
+           style="display:inline">
+          <path
+             transform="matrix(0.50645089,0,0,0.50645089,-180.12602,820.2612)"
+             d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+             sodipodi:ry="10.625"
+             sodipodi:rx="10.625"
+             sodipodi:cy="468.23718"
+             sodipodi:cx="388.125"
+             id="path10796-2-6-0"
+             style="fill:url(#linearGradient8163-2);fill-opacity:1;stroke:#c93e35;stroke-width:1.97452509;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+             sodipodi:type="arc" />
+          <g
+             transform="matrix(1.1880342,0,0,1.1860465,14.354445,-196.67175)"
+             id="g5025">
+            <g
+               transform="matrix(1.0905016,0,0,1.0905016,-0.09572826,-95.681285)"
+               id="g4095">
+              <path
+                 sodipodi:nodetypes="ccscccccccccccccccccc"
+                 inkscape:connector-curvature="0"
+                 id="path5021"
+                 transform="matrix(0.77187105,0,0,0.77316463,-4.647127,1051.0563)"
+                 d="M 6.2265625,3.6953125 C 5.9177427,3.7062384 5.125,4.3515625 5.125,4.3515625 c 0,0 0.2885111,0.2731764 0.78125,0.6796875 0.4927389,0.4065111 0.9552143,0.9554552 1.0625,1.4375 C 7.068619,6.9173537 7.1051563,7.3329889 7.15625,7.75 L 4.2010947,10.96967 5.0906092,11.868663 7.4375,9.375 c 0.2792655,0.4616799 0.5966442,0.914462 0.8125,1.28125 0.2533102,0.354 0.6860498,0.734189 1.40625,1.09375 1.285897,0.641907 1.105068,0.565316 1.105068,0.565316 l 0.965609,-0.791649 c 0,0 -0.202967,-0.247189 -1.508177,-0.898667 C 9.6433969,10.337868 9.4953002,10.118107 9.34375,9.90625 8.8239337,9.3154094 8.6327445,8.816423 8.5,8.1875 L 11.629711,4.6423859 10.681163,3.8870243 8.28125,6.5 C 8.263796,6.4030643 8.2724218,6.3194727 8.25,6.21875 8.0333974,5.2456067 7.3191341,4.5264873 6.71875,4.03125 6.4464909,3.8171333 6.4806949,3.8796991 6.2265625,3.6953125 z"
+                 style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/progress/progress_none.svg
+++ b/bundles/org.eclipse.ui/icons/full/progress/progress_none.svg
@@ -1,0 +1,602 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="progress_none.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3811">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3797">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799" />
+      <stop
+         id="stop3805"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3787">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787"
+       id="linearGradient3793"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797"
+       id="linearGradient3803"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811"
+       id="linearGradient3817"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811"
+       id="linearGradient3825"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787"
+       id="linearGradient3827"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797"
+       id="linearGradient3829"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-2"
+       id="linearGradient3825-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-2">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-2" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-4"
+       id="linearGradient3827-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-4">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-8" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-3"
+       id="linearGradient3829-8"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       id="linearGradient3797-3">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-3" />
+      <stop
+         id="stop3805-5"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-2-6"
+       id="linearGradient3825-4-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-2-6">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-2-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-0-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-4-9"
+       id="linearGradient3827-6-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-4-9">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-8-8" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-4-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-3-6"
+       id="linearGradient3829-8-2"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       id="linearGradient3797-3-6">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-3-9" />
+      <stop
+         id="stop3805-5-3"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-7-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-2-6-3"
+       id="linearGradient3825-4-6-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-2-6-3">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-2-4-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-0-0-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-4-9-3"
+       id="linearGradient3827-6-7-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-4-9-3">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-8-8-5" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-4-3-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-3-6-8"
+       id="linearGradient3829-8-2-9"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       id="linearGradient3797-3-6-8">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-3-9-0" />
+      <stop
+         id="stop3805-5-3-6"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-7-0-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-2-4"
+       id="linearGradient3825-4-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-2-4">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-2-40" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-0-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-4-0"
+       id="linearGradient3827-6-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-4-0">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-8-7" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-4-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-3-61"
+       id="linearGradient3829-8-7"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       id="linearGradient3797-3-61">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-3-91" />
+      <stop
+         id="stop3805-5-9"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-7-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-3"
+       id="linearGradient3825-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-3">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-8" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-06" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-7"
+       id="linearGradient3827-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-7">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-1" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-2"
+       id="linearGradient3829-3"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       id="linearGradient3797-2">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-6" />
+      <stop
+         id="stop3805-4"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-9" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="7.8083738"
+     inkscape:cy="4.2468998"
+     inkscape:document-units="px"
+     inkscape:current-layer="g3969"
+     showgrid="true"
+     inkscape:window-width="1056"
+     inkscape:window-height="796"
+     inkscape:window-x="863"
+     inkscape:window-y="447"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g3969">
+      <g
+         transform="translate(-3.8839286,-11.964286)"
+         id="g3819-3-3">
+        <rect
+           style="fill:url(#linearGradient3825-4-6-0);fill-opacity:1;stroke:none"
+           id="rect3809-0-6"
+           width="9.687501"
+           height="5.8928571"
+           x="5.6696429"
+           y="1051.0229" />
+        <rect
+           style="fill:none;stroke:url(#linearGradient3827-6-7-7);stroke-width:0.89767581;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           id="rect3017-4-4"
+           width="10.15411"
+           height="6.1183953"
+           x="5.4006238"
+           y="1050.8164" />
+        <rect
+           style="fill:url(#linearGradient3829-8-2-9);fill-opacity:1;stroke:none"
+           id="rect3795-5-3"
+           width="5.1785712"
+           height="5.2232137"
+           x="5.8482141"
+           y="14.883928"
+           transform="translate(0,1036.3622)" />
+        <path
+           style="fill:none;stroke:#4ea54c;stroke-width:1.0107801px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 11.026786,1051.257 0,5.2908"
+           id="path3807-8-4"
+           inkscape:connector-curvature="0" />
+      </g>
+      <rect
+         style="opacity:0.62139917;fill:#ffffff;fill-opacity:1;stroke:#cbe8f3;stroke-width:0.8596682;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="rect4166-7"
+         width="9.1474743"
+         height="5.3528318"
+         x="2.3459058"
+         y="1039.7081" />
+      <g
+         transform="translate(-1.9196429,-9.9107144)"
+         id="g3819-3">
+        <rect
+           style="fill:url(#linearGradient3825-4-8);fill-opacity:1;stroke:none"
+           id="rect3809-0"
+           width="9.687501"
+           height="5.8928571"
+           x="5.6696429"
+           y="1051.0229" />
+        <rect
+           style="fill:none;stroke:url(#linearGradient3827-6-4);stroke-width:0.89767581;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           id="rect3017-4"
+           width="10.15411"
+           height="6.1183953"
+           x="5.4006238"
+           y="1050.8164" />
+        <rect
+           style="fill:url(#linearGradient3829-8-7);fill-opacity:1;stroke:none"
+           id="rect3795-5"
+           width="5.1785712"
+           height="5.2232137"
+           x="5.8482141"
+           y="14.883928"
+           transform="translate(0,1036.3622)" />
+        <path
+           style="fill:none;stroke:#4ea54c;stroke-width:1.0107801px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 11.026786,1051.257 0,5.2908"
+           id="path3807-8"
+           inkscape:connector-curvature="0" />
+      </g>
+      <rect
+         style="opacity:0.62139917;fill:#ffffff;fill-opacity:1;stroke:#cbe8f3;stroke-width:0.8596682;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="rect4166"
+         width="9.1474743"
+         height="5.3528318"
+         x="4.2209058"
+         y="1041.7617" />
+      <g
+         transform="translate(0,-7.9910715)"
+         id="g3819">
+        <rect
+           style="fill:url(#linearGradient3825-6);fill-opacity:1;stroke:none"
+           id="rect3809"
+           width="9.687501"
+           height="5.8928571"
+           x="5.6696429"
+           y="1051.0229" />
+        <rect
+           style="fill:none;stroke:url(#linearGradient3827-9);stroke-width:0.89767581;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           id="rect3017"
+           width="10.15411"
+           height="6.1183953"
+           x="5.4006238"
+           y="1050.8164" />
+        <rect
+           style="fill:url(#linearGradient3829-3);fill-opacity:1;stroke:none"
+           id="rect3795"
+           width="5.1785712"
+           height="5.2232137"
+           x="5.8482141"
+           y="14.883928"
+           transform="translate(0,1036.3622)" />
+        <path
+           style="fill:none;stroke:#4ea54c;stroke-width:1.0107801px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 11.026786,1051.257 0,5.2908"
+           id="path3807"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/progress/progress_ok.svg
+++ b/bundles/org.eclipse.ui/icons/full/progress/progress_ok.svg
@@ -1,0 +1,481 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="progress_ok.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3811">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3797">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799" />
+      <stop
+         id="stop3805"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3787">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3811-2">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-2" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3787-4">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-8" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3797-3">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-3" />
+      <stop
+         id="stop3805-5"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3811-2-6">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-2-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-0-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3787-4-9">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-8-8" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-4-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3797-3-6">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-3-9" />
+      <stop
+         id="stop3805-5-3"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-7-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-2-6-3"
+       id="linearGradient3825-4-6-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-2-6-3">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-2-4-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-0-0-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-4-9-3"
+       id="linearGradient3827-6-7-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-4-9-3">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-8-8-5" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-4-3-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-3-6-8"
+       id="linearGradient3829-8-2-9"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       id="linearGradient3797-3-6-8">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-3-9-0" />
+      <stop
+         id="stop3805-5-3-6"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-7-0-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-2-4"
+       id="linearGradient3825-4-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-2-4">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-2-40" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-0-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-4-0"
+       id="linearGradient3827-6-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-4-0">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-8-7" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-4-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-3-61"
+       id="linearGradient3829-8-7"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       id="linearGradient3797-3-61">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-3-91" />
+      <stop
+         id="stop3805-5-9"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-7-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-3"
+       id="linearGradient3825-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-3">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-8" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-06" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-7"
+       id="linearGradient3827-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-7">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-1" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-2"
+       id="linearGradient3829-3"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071"
+       gradientTransform="matrix(1.1182796,0,0,1,-0.69172431,1036.3622)" />
+    <linearGradient
+       id="linearGradient3797-2">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-6" />
+      <stop
+         id="stop3805-4"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-9" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="7.8083738"
+     inkscape:cy="4.2468998"
+     inkscape:document-units="px"
+     inkscape:current-layer="g3819"
+     showgrid="true"
+     inkscape:window-width="1056"
+     inkscape:window-height="796"
+     inkscape:window-x="863"
+     inkscape:window-y="447"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g3969">
+      <g
+         transform="translate(-3.8839286,-11.964286)"
+         id="g3819-3-3">
+        <rect
+           style="fill:url(#linearGradient3825-4-6-0);fill-opacity:1;stroke:none"
+           id="rect3809-0-6"
+           width="9.687501"
+           height="5.8928571"
+           x="5.6696429"
+           y="1051.0229" />
+        <rect
+           style="fill:none;stroke:url(#linearGradient3827-6-7-7);stroke-width:0.89767581;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           id="rect3017-4-4"
+           width="10.15411"
+           height="6.1183953"
+           x="5.4006238"
+           y="1050.8164" />
+        <rect
+           style="fill:url(#linearGradient3829-8-2-9);fill-opacity:1;stroke:none"
+           id="rect3795-5-3"
+           width="8.1696424"
+           height="5.2232132"
+           x="5.8482141"
+           y="14.883928"
+           transform="translate(0,1036.3622)" />
+        <path
+           style="fill:none;stroke:#4ea54c;stroke-width:1.0107801px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 14.553572,1051.257 0,5.2908"
+           id="path3807-8-4"
+           inkscape:connector-curvature="0" />
+      </g>
+      <rect
+         style="opacity:0.62139917;fill:#ffffff;fill-opacity:1;stroke:#cbe8f3;stroke-width:0.86707354;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="rect4166-7"
+         width="9.3186407"
+         height="5.3454266"
+         x="2.3496084"
+         y="1039.6224" />
+      <g
+         transform="translate(-1.9196429,-9.9107144)"
+         id="g3819-3">
+        <rect
+           style="fill:url(#linearGradient3825-4-8);fill-opacity:1;stroke:none"
+           id="rect3809-0"
+           width="9.687501"
+           height="5.8928571"
+           x="5.6696429"
+           y="1051.0229" />
+        <rect
+           style="fill:none;stroke:url(#linearGradient3827-6-4);stroke-width:0.89767581;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           id="rect3017-4"
+           width="10.15411"
+           height="6.1183953"
+           x="5.4006238"
+           y="1050.8164" />
+        <rect
+           style="fill:url(#linearGradient3829-8-7);fill-opacity:1;stroke:none"
+           id="rect3795-5"
+           width="8.2589283"
+           height="5.2232132"
+           x="5.8482141"
+           y="14.883928"
+           transform="translate(0,1036.3622)" />
+        <path
+           style="fill:none;stroke:#4ea54c;stroke-width:1.0107801px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 14.598215,1051.257 0,5.2908"
+           id="path3807-8"
+           inkscape:connector-curvature="0" />
+      </g>
+      <rect
+         style="opacity:0.62139917;fill:#ffffff;fill-opacity:1;stroke:#cbe8f3;stroke-width:0.87074792;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="rect4166"
+         width="9.4042521"
+         height="5.3417521"
+         x="4.2264457"
+         y="1041.6779" />
+      <g
+         transform="translate(0,-7.9910715)"
+         id="g3819">
+        <rect
+           style="fill:url(#linearGradient3825-6);fill-opacity:1;stroke:none"
+           id="rect3809"
+           width="9.687501"
+           height="5.8928571"
+           x="5.6696429"
+           y="1051.0229" />
+        <rect
+           style="fill:none;stroke:url(#linearGradient3827-9);stroke-width:0.89767581;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           id="rect3017"
+           width="10.15411"
+           height="6.1183953"
+           x="5.4006238"
+           y="1050.8164" />
+        <rect
+           style="fill:url(#linearGradient3829-3);fill-opacity:1;stroke:none"
+           id="rect3795"
+           width="9.2857132"
+           height="5.2232132"
+           x="5.8482141"
+           y="1051.2461" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/progress/progress_task.svg
+++ b/bundles/org.eclipse.ui/icons/full/progress/progress_task.svg
@@ -1,0 +1,527 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="progress_task.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3811">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3797">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799" />
+      <stop
+         id="stop3805"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3787">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787"
+       id="linearGradient3793"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797"
+       id="linearGradient3803"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811"
+       id="linearGradient3817"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811"
+       id="linearGradient3825"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787"
+       id="linearGradient3827"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797"
+       id="linearGradient3829"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-2"
+       id="linearGradient3825-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-2">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-2" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-4"
+       id="linearGradient3827-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-4">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-8" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-3"
+       id="linearGradient3829-8"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       id="linearGradient3797-3">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-3" />
+      <stop
+         id="stop3805-5"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-2-6"
+       id="linearGradient3825-4-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-2-6">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-2-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-0-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-4-9"
+       id="linearGradient3827-6-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-4-9">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-8-8" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-4-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-3-6"
+       id="linearGradient3829-8-2"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       id="linearGradient3797-3-6">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-3-9" />
+      <stop
+         id="stop3805-5-3"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-7-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-2-6-3"
+       id="linearGradient3825-4-6-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-2-6-3">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-2-4-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-0-0-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-4-9-3"
+       id="linearGradient3827-6-7-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-4-9-3">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-8-8-5" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-4-3-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-3-6-8"
+       id="linearGradient3829-8-2-9"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       id="linearGradient3797-3-6-8">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-3-9-0" />
+      <stop
+         id="stop3805-5-3-6"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-7-0-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-2-4"
+       id="linearGradient3825-4-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-2-4">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-2-40" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-0-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-4-0"
+       id="linearGradient3827-6-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-4-0">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-8-7" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-4-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-3-61"
+       id="linearGradient3829-8-7"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       id="linearGradient3797-3-61">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-3-91" />
+      <stop
+         id="stop3805-5-9"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-7-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-3"
+       id="linearGradient3825-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-3">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-8" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-06" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-7"
+       id="linearGradient3827-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-7">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-1" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-2"
+       id="linearGradient3829-3"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       id="linearGradient3797-2">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-6" />
+      <stop
+         id="stop3805-4"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-9" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="44.8"
+     inkscape:cx="7.9018613"
+     inkscape:cy="8.6908022"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1528"
+     inkscape:window-height="961"
+     inkscape:window-x="863"
+     inkscape:window-y="447"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g3969"
+       transform="translate(0,-1.0044643)">
+      <g
+         transform="translate(0,-7.9910715)"
+         id="g3819">
+        <rect
+           style="fill:url(#linearGradient3825-6);fill-opacity:1;stroke:none"
+           id="rect3809"
+           width="9.687501"
+           height="5.8928571"
+           x="5.6696429"
+           y="1051.0229" />
+        <rect
+           style="fill:none;stroke:url(#linearGradient3827-9);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3017"
+           width="12.988933"
+           height="6.0290875"
+           x="2.5211596"
+           y="1050.8611" />
+        <rect
+           style="fill:url(#linearGradient3829-3);fill-opacity:1;stroke:none"
+           id="rect3795"
+           width="6.0714278"
+           height="5.0669632"
+           x="2.96875"
+           y="14.973214"
+           transform="translate(0,1036.3622)" />
+        <path
+           style="fill:none;stroke:#4ea54c;stroke-width:0.98704726px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 9.4866074,1051.3463 0,5.0452"
+           id="path3807"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/progress/pview.svg
+++ b/bundles/org.eclipse.ui/icons/full/progress/pview.svg
@@ -1,0 +1,384 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="pview.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient14965">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop14967" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop14969" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient14957">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop14959" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop14961" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811-3"
+       id="linearGradient3825-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0483092,0,0,1.1478261,-0.46109385,1033.8876)"
+       x1="10.267857"
+       y1="15.620537"
+       x2="10.267857"
+       y2="20.042208" />
+    <linearGradient
+       id="linearGradient3811-3">
+      <stop
+         style="stop-color:#cbe8f3;stop-opacity:1;"
+         offset="0"
+         id="stop3813-8" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop3815-06" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787-7"
+       id="linearGradient3827-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98720513,0,0,1.0077357,0.0679531,1044.3021)"
+       x1="9.8428583"
+       y1="7.6656647"
+       x2="9.8428583"
+       y2="15.080358" />
+    <linearGradient
+       id="linearGradient3787-7">
+      <stop
+         style="stop-color:#a3937d;stop-opacity:1;"
+         offset="0"
+         id="stop3789-1" />
+      <stop
+         style="stop-color:#2a5e90;stop-opacity:1;"
+         offset="1"
+         id="stop3791-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3797-2"
+       id="linearGradient3829-3"
+       gradientUnits="userSpaceOnUse"
+       x1="8.0803566"
+       y1="17.936087"
+       x2="8.0803566"
+       y2="14.813071" />
+    <linearGradient
+       id="linearGradient3797-2">
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="0"
+         id="stop3799-6" />
+      <stop
+         id="stop3805-4"
+         offset="0.42753732"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#59ac57;stop-opacity:1;"
+         offset="1"
+         id="stop3801-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1">
+      <stop
+         id="stop10800-5-2-1-8-2-8-1-7-3-7"
+         offset="0"
+         style="stop-color:#e17673;stop-opacity:1;" />
+      <stop
+         style="stop-color:#d04046;stop-opacity:1;"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-95-0-5-4-8" />
+      <stop
+         id="stop10802-1-5-3-0-2-0-9-8-4-3"
+         offset="1"
+         style="stop-color:#e17673;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1-4">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7-37" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8-8"
+         offset="0.5"
+         style="stop-color:#3c8d49;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4e173;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-0-5-5">
+      <stop
+         id="stop7594-8-9-0"
+         offset="0"
+         style="stop-color:#b08319;stop-opacity:1" />
+      <stop
+         id="stop7596-5-6-6"
+         offset="1"
+         style="stop-color:#9a680f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9276"
+       inkscape:collect="always">
+      <stop
+         id="stop9278"
+         offset="0"
+         style="stop-color:#9dd560;stop-opacity:1" />
+      <stop
+         id="stop9280"
+         offset="1"
+         style="stop-color:#499851;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9321"
+       inkscape:collect="always">
+      <stop
+         id="stop9323"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop9325"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9329">
+      <stop
+         id="stop9331"
+         offset="0"
+         style="stop-color:#f8d060;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8e898;stop-opacity:1"
+         offset="0.5"
+         id="stop9337" />
+      <stop
+         id="stop9333"
+         offset="1"
+         style="stop-color:#f8f8e8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1-4"
+       id="linearGradient14169"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9276"
+       id="linearGradient14178"
+       gradientUnits="userSpaceOnUse"
+       x1="16.965528"
+       y1="1054.6906"
+       x2="15.633883"
+       y2="1056.2894"
+       gradientTransform="matrix(0.39976481,0,0,0.39976481,5.3283725,624.86839)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9321"
+       id="radialGradient14183"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.77257883,-1.3315319e-7,1.3315322e-7,0.772579,89.457223,108.43693)"
+       cx="390.43927"
+       cy="472.6676"
+       fx="390.43927"
+       fy="472.6676"
+       r="10.625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14965"
+       id="linearGradient14973"
+       x1="10.640893"
+       y1="10.601437"
+       x2="14.25831"
+       y2="15.284449"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14965"
+       id="linearGradient14981"
+       gradientUnits="userSpaceOnUse"
+       x1="10.640893"
+       y1="10.601437"
+       x2="14.25831"
+       y2="15.284449" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1-4"
+       id="linearGradient14983"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="478.18777"
+       x2="388.63736"
+       y2="457.95499" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9276"
+       id="linearGradient14985"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.39976481,0,0,0.39976481,5.3283725,624.86839)"
+       x1="16.965528"
+       y1="1054.6906"
+       x2="15.633883"
+       y2="1056.2894" />
+    <filter
+       inkscape:collect="always"
+       id="filter3817">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.15706387"
+         id="feGaussianBlur3819" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="11.128103"
+     inkscape:cy="6.2863069"
+     inkscape:document-units="px"
+     inkscape:current-layer="g14975"
+     showgrid="true"
+     inkscape:window-width="1056"
+     inkscape:window-height="796"
+     inkscape:window-x="863"
+     inkscape:window-y="447"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g3969">
+      <g
+         transform="translate(-0.06313449,-9.8851075)"
+         id="g3819">
+        <rect
+           style="fill:url(#linearGradient3825-6);fill-opacity:1;stroke:none"
+           id="rect3809"
+           width="9.687501"
+           height="5.8928571"
+           x="5.6696429"
+           y="1051.0229" />
+        <rect
+           style="fill:none;stroke:url(#linearGradient3827-9);stroke-width:0.89767581;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           id="rect3017"
+           width="13.055895"
+           height="6.1184082"
+           x="2.4988382"
+           y="1050.8164" />
+        <rect
+           style="fill:url(#linearGradient3829-3);fill-opacity:1;stroke:none"
+           id="rect3795"
+           width="6.1160707"
+           height="5.2232132"
+           x="2.9464285"
+           y="14.883928"
+           transform="translate(0,1036.3622)" />
+        <path
+           style="fill:none;stroke:#4ea54c;stroke-width:1.0107801px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 9.5535717,1051.257 0,5.2908"
+           id="path3807"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="g14975"
+         transform="matrix(1.2210526,0,0,1.2210526,-2.1292952,-230.36387)">
+        <path
+           transform="matrix(1.1386602,0,0,1.1034706,-2.2282159,1033.4277)"
+           d="m 14.931318,12.480249 a 2.762136,2.762136 0 1 1 -5.5242722,0 2.762136,2.762136 0 1 1 5.5242722,0 z"
+           sodipodi:ry="2.762136"
+           sodipodi:rx="2.762136"
+           sodipodi:cy="12.480249"
+           sodipodi:cx="12.169182"
+           id="path14185"
+           style="fill:url(#linearGradient14981);fill-opacity:1;stroke:none;filter:url(#filter3817)"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:type="arc"
+           style="fill:url(#linearGradient14983);fill-opacity:1;stroke:none;display:inline"
+           id="path10796-2-6-0"
+           sodipodi:cx="388.125"
+           sodipodi:cy="468.23718"
+           sodipodi:rx="10.625"
+           sodipodi:ry="10.625"
+           d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+           transform="matrix(0.24905626,0,0,0.24905626,-84.799696,930.9271)" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path8117"
+           d="m 10.940808,1045.5207 2.423575,2.0738 -2.398589,2.0238 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient14985);stroke-width:0.2582669;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:type="arc"
+           style="fill:none;stroke:#14733c;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+           id="path10796-2-6-0-5"
+           sodipodi:cx="388.125"
+           sodipodi:cy="468.23718"
+           sodipodi:rx="10.625"
+           sodipodi:ry="10.625"
+           d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+           transform="matrix(0.24905626,0,0,0.24905626,-84.799696,930.9271)" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/progress/sleeping.svg
+++ b/bundles/org.eclipse.ui/icons/full/progress/sleeping.svg
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="20"
+   height="20"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="sleeping.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.678384"
+     inkscape:cx="10.804398"
+     inkscape:cy="8.9401374"
+     inkscape:document-units="px"
+     inkscape:current-layer="text2996"
+     showgrid="false"
+     inkscape:window-width="855"
+     inkscape:window-height="756"
+     inkscape:window-x="1127"
+     inkscape:window-y="559"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1032.3622)">
+    <g
+       transform="scale(0.96516945,1.0360875)"
+       style="font-size:10.94554329px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#005596;fill-opacity:1;stroke:none;font-family:Sans"
+       id="text2996">
+      <path
+         d="m 0.45558062,1002.0839 6.70735198,0 0,1.2453 -4.2809474,5.1788 4.403871,0 0,1.5553 -6.95319916,0 0,-1.2453 4.28094736,-5.1788 -4.15802378,0 0,-1.5553"
+         style="font-weight:bold;fill:#005596;-inkscape-font-specification:Sans Bold"
+         id="path3041" />
+      <path
+         d="m 7.9396227,1004.0774 5.2215803,0 0,1.3362 -3.153257,3.2815 3.153257,0 0,1.3682 -5.3551928,0 0,-1.3361 3.1532578,-3.2816 -3.0196453,0 0,-1.3682"
+         style="font-weight:bold;fill:#005596;-inkscape-font-specification:Sans Bold"
+         id="path3043"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 14.768161,1004.0774 5.22158,0 0,1.3362 -3.153257,3.2815 3.153257,0 0,1.3682 -5.355193,0 0,-1.3361 3.153257,-3.2816 -3.019644,0 0,-1.3682"
+         style="font-weight:bold;fill:#005596;-inkscape-font-specification:Sans Bold"
+         id="path3045" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/progress/waiting.svg
+++ b/bundles/org.eclipse.ui/icons/full/progress/waiting.svg
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="20"
+   height="20"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="waiting.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13831">
+      <stop
+         style="stop-color:#055797;stop-opacity:1;"
+         offset="0"
+         id="stop13833" />
+      <stop
+         style="stop-color:#184785;stop-opacity:1"
+         offset="1"
+         id="stop13835" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13755">
+      <stop
+         style="stop-color:#f1fdfc;stop-opacity:1"
+         offset="0"
+         id="stop13757" />
+      <stop
+         id="stop13765"
+         offset="0.45454547"
+         style="stop-color:#dbeff9;stop-opacity:1" />
+      <stop
+         id="stop13763"
+         offset="0.54545456"
+         style="stop-color:#cee4f0;stop-opacity:1" />
+      <stop
+         style="stop-color:#def1fa;stop-opacity:1"
+         offset="1"
+         id="stop13759" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13755"
+       id="linearGradient8584"
+       gradientUnits="userSpaceOnUse"
+       x1="28.004765"
+       y1="-5.6084509"
+       x2="28.004765"
+       y2="1.6087028" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13831"
+       id="linearGradient8586"
+       gradientUnits="userSpaceOnUse"
+       x1="30.033665"
+       y1="-6.1109905"
+       x2="30.033665"
+       y2="1.9089624" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="11.499646"
+     inkscape:cy="10.549205"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="1183"
+     inkscape:window-height="955"
+     inkscape:window-x="976"
+     inkscape:window-y="546"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4092"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1032.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <g
+         id="g8579"
+         transform="matrix(1.0304739,0,0,1.0304739,-36.147172,-25.214481)">
+        <path
+           transform="matrix(1.247029,0,0,1.247029,20.641113,1050.8233)"
+           d="m 31.413783,-2 c 0,2.98994957 -2.423833,5.4137826 -5.413783,5.4137826 -2.98995,0 -5.413783,-2.42383303 -5.413783,-5.4137826 0,-2.9899496 2.423833,-5.4137826 5.413783,-5.4137826 2.98995,0 5.413783,2.423833 5.413783,5.4137826 z"
+           sodipodi:ry="5.4137826"
+           sodipodi:rx="5.4137826"
+           sodipodi:cy="-2"
+           sodipodi:cx="26"
+           id="path13745"
+           style="fill:url(#linearGradient8584);fill-opacity:1;stroke:url(#linearGradient8586);stroke-width:0.80190599;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path13811"
+           d="m 53.094196,1048.3597 0,-4.5945"
+           style="fill:none;stroke:#1f4a83;stroke-width:0.80000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path13811-9"
+           d="m 53.094196,1048.3597 2.607457,3.6255"
+           style="fill:none;stroke:#1f4a83;stroke-width:0.80000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:type="arc"
+           style="fill:#125385;fill-opacity:1;stroke:#105285;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           id="path8563"
+           sodipodi:cx="1.0606602"
+           sodipodi:cy="-3.458333"
+           sodipodi:rx="0.39016506"
+           sodipodi:ry="0.42904606"
+           d="m 1.4508253,-3.458333 c 0,0.2369556 -0.1746828,0.429046 -0.3901651,0.429046 -0.21548217,0 -0.39016502,-0.1920904 -0.39016502,-0.429046 0,-0.2369556 0.17468285,-0.4290461 0.39016502,-0.4290461 0.2154823,0 0.3901651,0.1920905 0.3901651,0.4290461 z"
+           transform="matrix(0.7191532,0,0,0.7191532,49.14706,1047.6173)" />
+        <path
+           sodipodi:type="arc"
+           style="fill:#125385;fill-opacity:1;stroke:#105285;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           id="path8563-6"
+           sodipodi:cx="1.0606602"
+           sodipodi:cy="-3.458333"
+           sodipodi:rx="0.39016506"
+           sodipodi:ry="0.42904606"
+           d="m 1.4508253,-3.458333 c 0,0.2369556 -0.1746828,0.429046 -0.3901651,0.429046 -0.21548217,0 -0.39016502,-0.1920904 -0.39016502,-0.429046 0,-0.2369556 0.17468285,-0.4290461 0.39016502,-0.4290461 0.2154823,0 0.3901651,0.1920905 0.3901651,0.4290461 z"
+           transform="matrix(0.7191532,0,0,0.7191532,47.89706,1051.6173)" />
+        <path
+           sodipodi:type="arc"
+           style="fill:#125385;fill-opacity:1;stroke:#105285;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           id="path8563-6-3"
+           sodipodi:cx="1.0606602"
+           sodipodi:cy="-3.458333"
+           sodipodi:rx="0.39016506"
+           sodipodi:ry="0.42904606"
+           d="m 1.4508253,-3.458333 c 0,0.2369556 -0.1746828,0.429046 -0.3901651,0.429046 -0.21548217,0 -0.39016502,-0.1920904 -0.39016502,-0.429046 0,-0.2369556 0.17468285,-0.4290461 0.39016502,-0.4290461 0.2154823,0 0.3901651,0.1920905 0.3901651,0.4290461 z"
+           transform="matrix(0.7191532,0,0,0.7191532,49.49173,1054.087)" />
+        <path
+           sodipodi:type="arc"
+           style="fill:#125385;fill-opacity:1;stroke:#105285;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           id="path8563-6-3-6"
+           sodipodi:cx="1.0606602"
+           sodipodi:cy="-3.458333"
+           sodipodi:rx="0.39016506"
+           sodipodi:ry="0.42904606"
+           d="m 1.4508253,-3.458333 c 0,0.2369556 -0.1746828,0.429046 -0.3901651,0.429046 -0.21548217,0 -0.39016502,-0.1920904 -0.39016502,-0.429046 0,-0.2369556 0.17468285,-0.4290461 0.39016502,-0.4290461 0.2154823,0 0.3901651,0.1920905 0.3901651,0.4290461 z"
+           transform="matrix(0.7191532,0,0,0.7191532,52.27206,1055.7423)" />
+        <path
+           sodipodi:type="arc"
+           style="fill:#125385;fill-opacity:1;stroke:#105285;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           id="path8563-6-3-6-8"
+           sodipodi:cx="1.0606602"
+           sodipodi:cy="-3.458333"
+           sodipodi:rx="0.39016506"
+           sodipodi:ry="0.42904606"
+           d="m 1.4508253,-3.458333 c 0,0.2369556 -0.1746828,0.429046 -0.3901651,0.429046 -0.21548217,0 -0.39016502,-0.1920904 -0.39016502,-0.429046 0,-0.2369556 0.17468285,-0.4290461 0.39016502,-0.4290461 0.2154823,0 0.3901651,0.1920905 0.3901651,0.4290461 z"
+           transform="matrix(0.7191532,0,0,0.7191532,55.630817,1047.6106)" />
+        <path
+           sodipodi:type="arc"
+           style="fill:#125385;fill-opacity:1;stroke:#105285;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           id="path8563-6-3-6-8-6"
+           sodipodi:cx="1.0606602"
+           sodipodi:cy="-3.458333"
+           sodipodi:rx="0.39016506"
+           sodipodi:ry="0.42904606"
+           d="m 1.4508253,-3.458333 c 0,0.2369556 -0.1746828,0.429046 -0.3901651,0.429046 -0.21548217,0 -0.39016502,-0.1920904 -0.39016502,-0.429046 0,-0.2369556 0.17468285,-0.4290461 0.39016502,-0.4290461 0.2154823,0 0.3901651,0.1920905 0.3901651,0.4290461 z"
+           transform="matrix(0.7191532,0,0,0.7191532,56.868254,1051.2345)" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/wizban/export_wiz.svg
+++ b/bundles/org.eclipse.ui/icons/full/wizban/export_wiz.svg
@@ -1,0 +1,1119 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="export_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4432">
+      <stop
+         style="stop-color:#ced8e7;stop-opacity:1;"
+         offset="0"
+         id="stop4434" />
+      <stop
+         style="stop-color:#b7c5e0;stop-opacity:1"
+         offset="1"
+         id="stop4436" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4420">
+      <stop
+         style="stop-color:#5b7aaa;stop-opacity:1"
+         offset="0"
+         id="stop4422" />
+      <stop
+         style="stop-color:#96aaca;stop-opacity:1"
+         offset="1"
+         id="stop4424" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4541">
+      <stop
+         style="stop-color:#a1adb2;stop-opacity:1"
+         offset="0"
+         id="stop4543" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient5885"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2">
+      <stop
+         id="stop11150-4-72-3-9-7"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10507">
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="0"
+         id="stop10509" />
+      <stop
+         id="stop10511"
+         offset="0.18181793"
+         style="stop-color:#9e7058;stop-opacity:1" />
+      <stop
+         id="stop10513"
+         offset="0.36363617"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10515"
+         offset="0.49999985"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10517"
+         offset="0.63636351"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e7058;stop-opacity:1"
+         offset="0.81818175"
+         id="stop10519" />
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="1"
+         id="stop10522" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4456"
+       id="linearGradient4462"
+       x1="63.734764"
+       y1="1039.3618"
+       x2="61.727211"
+       y2="1006.3618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,-0.72750163,1,733.40264,2.0004)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4456">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.659"
+         offset="0"
+         id="stop4458" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.369"
+         offset="1"
+         id="stop4460" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4606"
+       x="-0.062976152"
+       width="1.1259522"
+       y="-0.10879012"
+       height="1.2175802">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.5412116"
+         id="feGaussianBlur4608" />
+    </filter>
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2-8">
+      <stop
+         id="stop11150-4-72-3-9-7-2"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad6e48;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4368">
+      <stop
+         id="stop4370"
+         offset="0"
+         style="stop-color:#9c7561;stop-opacity:1" />
+      <stop
+         style="stop-color:#966d59;stop-opacity:1"
+         offset="0.18181793"
+         id="stop4372" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.36363617"
+         id="stop4374" />
+      <stop
+         style="stop-color:#794f40;stop-opacity:1"
+         offset="0.49999985"
+         id="stop4376" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.63636351"
+         id="stop4378" />
+      <stop
+         id="stop4380"
+         offset="0.81818175"
+         style="stop-color:#966d59;stop-opacity:1" />
+      <stop
+         id="stop4382"
+         offset="1"
+         style="stop-color:#99705c;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       height="1.2013515"
+       y="-0.10067577"
+       width="1.2017672"
+       x="-0.1"
+       id="filter4285-9-8"
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur4287-9-5"
+         stdDeviation="0.10000000000000001"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4496"
+       id="linearGradient4494"
+       x1="8"
+       y1="1013.3622"
+       x2="19"
+       y2="1024.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88619287,0,0,0.87964908,22.674808,110.55825)" />
+    <linearGradient
+       id="linearGradient4496"
+       inkscape:collect="always">
+      <stop
+         id="stop4498"
+         offset="0"
+         style="stop-color:#6885b2;stop-opacity:1" />
+      <stop
+         style="stop-color:#5777a7;stop-opacity:1"
+         offset="0.54585904"
+         id="stop4512" />
+      <stop
+         style="stop-color:#355286;stop-opacity:1"
+         offset="0.63636416"
+         id="stop4500" />
+      <stop
+         id="stop4502"
+         offset="1"
+         style="stop-color:#2c4a81;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4504"
+       id="linearGradient4510"
+       x1="3.2928932"
+       y1="1020.7158"
+       x2="20"
+       y2="1020.7158"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88619287,0,0,0.87964908,22.674808,110.55825)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4504">
+      <stop
+         style="stop-color:#b0c1db;stop-opacity:1"
+         offset="0"
+         id="stop4506" />
+      <stop
+         style="stop-color:#8299c2;stop-opacity:1"
+         offset="1"
+         id="stop4508" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4420"
+       id="linearGradient4426"
+       x1="68.572693"
+       y1="1016.118"
+       x2="67.579018"
+       y2="1015.3881"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99967036,0.02567416,-0.02567416,0.99967036,-14.525917,-1.4292246)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4432"
+       id="linearGradient4438"
+       x1="8"
+       y1="1019.3622"
+       x2="52"
+       y2="1039.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9893617,0,0,0.97823962,0.31914907,22.399103)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4506"
+       x="-0.092571429"
+       width="1.1851429"
+       y="-0.0324"
+       height="1.0648">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.27"
+         id="feGaussianBlur4508" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4524"
+       x="-0.029837838"
+       width="1.0596757"
+       y="-0.12266667"
+       height="1.2453333">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.46"
+         id="feGaussianBlur4526" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4566"
+       x="-0.08775"
+       width="1.1755"
+       y="-0.1404"
+       height="1.2808">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.2925"
+         id="feGaussianBlur4568" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4588"
+       x="-0.042439024"
+       width="1.084878"
+       y="-0.10235294"
+       height="1.2047059">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.725"
+         id="feGaussianBlur4590" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4661"
+       x="-0.14766911"
+       width="1.2953382"
+       y="-0.11646623"
+       height="1.2329325">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.36234727"
+         id="feGaussianBlur4663" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#a5a5a5"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="26.213333"
+     inkscape:cx="40.276938"
+     inkscape:cy="29.125507"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline">
+    <image
+       y="0"
+       x="75"
+       id="image4415"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAACXBIWXMAAAsTAAALEwEAmpwYAAAK
+TWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQ
+WaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec
+5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28A
+AgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0
+ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaO
+WJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHi
+wmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryM
+AgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0l
+YqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHi
+NLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYA
+QH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6c
+wR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBie
+whi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1c
+QPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqO
+Y4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hM
+WEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgoh
+JZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSU
+Eko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/p
+dLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Y
+b1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7O
+UndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsb
+di97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W
+7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83
+MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxr
+PGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW
+2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1
+U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd
+8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H0
+8PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+H
+vqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsG
+Lww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjg
+R2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4
+qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWY
+EpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1Ir
+eZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/Pb
+FWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYj
+i1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVk
+Ve9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0Ibw
+Da0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vz
+DoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+y
+CW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawt
+o22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtd
+UV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3r
+O9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0
+/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv95
+63Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+
+UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMA
+APn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAAPMElEQVR42uxce4wd1Xn/fefMfe7du3d3bS+Y
+NaxZP8DGYIhpISEFIqQmFVKBKC1Vowi1f1QKVVUJNVLTqtCqUitCSqNWSZqUghCVYhGVhwglIhHh
+VUhCWqCBpBgHO2t7vV7v+3HvPM736x8z996513ftxY81rDPS7MzcmTNz5nd+3+/7znfOrOBXS8fl
+3m8dtCTyJHtIdAMoeL+CpQWgDIACibIqu0gU0ufPebDu//YhS6JLibwqC1R2KZHtdO05C9Y/PTZa
+UEWRZJaABdkNMne8MucUWF9/8rBRIkeym4QVAUgUQZYAyInKnzNgfeOpsW4liwIYEkDMprIAWVnm
+PVY9WA88PVZQImYSAMYUKhDoFkD4Pu4lqxWkh757JEuiTDKjCigBkiDRTbKoCqgSynjrki0ZX3tO
+gPXIs+NWyTKJfB2gBCwBWCGRVU1+O5fB+vfvjXeRKJE0yiablPAA9FDp1cE5GbBWhWbtfu5oJmFT
+FgDY+rKeEfSR70+fViVYj/7gaJcSJYEYgu1m44lIH8lTBupDDdZ/vDhhVNFLMCsE2sEQiRmlhJCn
+55kfSrAef2kir0SPSCNmagNKPBH0USHHwvghBOvx5/cMkRiKnKs45U4XKZzyeucUkdOdzmnFOX38
+zt/ddWu63BMvT5YJdAnZEQYBPDGnR6NWHKzHn98zBOAOAFcAqAAYAjBEAk4VqsTUzCKqfojZuSpm
+5qs4OjGD7ryHrZsvqtTv851XJ40SvSSyXNq1e8ZIn54mjVpxsG65fvO+x5/fsw/A3QAwMR/hlyOH
+kfEspueqCMIIwBhGx/PwgxA1P8Ch/SO4fNvFCCMdAoCnfziVIdEnoFkKBBFYY6SPhIBn5l3MSpjc
+LddvfgjAlQCmy0UPV10puGDDGqwfqGDjYAH9lX54noExgumjE4jCCIdGxxE5HXrmR1MFEaw5bl0F
+Yg0qcobjRrNSGnXL9ZtfV+VGOPe61i7AZUMZ3HDtFlx71WYUSuuRy3iYnZ5FdWERxhpADKLIYd/I
+wR0nNA8rfSJyxq1kxcACgNtu3DL9mZsuudIT+ebEpEU5SxSLPdg4fBF2XbsL1UUfxlgYYzE2Po3I
+KeYXqhuOC5SRsqyQo1pRsOrLzR8f/uLgOtw7dnRm/uiRCfR3zSGfz+Lq666BzWRgrAdjDKJI4QdR
+ean7WCNFY1pTv6sOLACz2y9+6VnS+519B2ex5/8mYXQCQ8ODGL50G5ikUiamZlGt+ts7Vtwgaw26
+z3A9hURGlQVVFs9SnJUD8Fsv/ejtS+/Le8To0QUUpnxICdiy4xIcHDmAqbHDqNV8RB16tSKwVqTC
+0+n1CNEYGI9EhnHnW846s0SC4G8e+MInizlz5//8/AAm5vw3jNj7qpMTkIUZ7Lj6Koi1mJtfRK0W
+XNtePmOlInJqno+AKJGNHLsix0rk2K/KMokiiUynjMxZAesvvv7iUH9P7sH3RsYR0ZveODhw18eu
+3v4PhXzuD6KFudkSAmy+bAfm5xcROW0HqixycoJOwjpFPnIsRxH7nWOZRCFh0QdTs3q7c48tLixW
+DozPY8P5a+6+9vLhtwHgox/Z9kxvpfxpDfy31lcK6K70wQ+ij6YEPfd+BZ2EOEU+itgTOfaqssQl
+hro+cGD97YOv3F/MYOebe0Zx/sCa3Z/82GWPps//2s6tb23ffNGnrTHP9JSKiCIXV1RgPSs9y32O
+U2Qjx+7Iab8qSwQyp1p3u5JA/dU3XrplXW/+H9985yBy+eJPr9kx/PlKuejXhbruBXvLJX/r8IYn
+9rx3aLbqhzeOT84+s2Xj+giArV9DJiuaWyUkciyGym5V5OMMKY+5rlG2/fcPClh//tUXhwZ6C/85
+OjaZn5wLZ7Zt2vCHl28ZPMBUZrNR4aTyW4c3/PfB0YlXSsW8Hdqwbi79UumXVcKGjqXIsVtjTybN
++54+sFYsdOgpZR6LQr+yb3QGm4YuuOe6ncNv6TJc/8037XrNWulVPfacEpkwYtEpMuSZf4eOYN31
+lefuF5GdThXqFE4VzunrTnWmfqza3KryoW/93Wf2LfWQe7758oM9RbvzlTdGMLC2f/fNv3H5bi4D
+KRGIZ6VMAE98/9Vdo0cmdyUnjDUmI2IsSfhBOOAH4UC67LbNm7526ebNe884WAR2grgBrdS84Tj3
++QGAjmB98Wsv3rGuN3/H2+8eRKHQ9dav79h493Irl/WkBMCSwOiRqV0T03N/tNyyVb9WWhFmqSoA
+wZ997hqICERitykiMAKIAM45fO+He/HUC+8sefMv/PPzO9f25O8fn5jGzKKbvXLbhX+6acPa2eWY
+n2cla4wUk+Ep63k2BwCP3ve5OFqUZn7GJPtB4PDsf72LB558deXM0CWBoAAIgghhGMWA1YETwcEj
+M1ishkuK4pce+XFfEEYPGkSVd/ZPYHho8O4bPrJpWTolIpLxpKwKiSKWIkXOiDScUS2I4Acu1Xhx
+OD96ZB7VarSymqUpNQ3CCPMLtWbFjMCIYH7RjxuXBNvUlWT24aff+ldqtPOFn+zF2jW9u2/7xBW7
+uUwVznpScg7dkWMhHkluSR3DDxxm530YkeZqBFNTNfAMKr1ZilnOKUSkLrTJ2uyQicR5yU5Ve2PP
++N+vX9N169xCFYPn9Y/83m9e8RXPyrICYAGKkXLQKYvslPmURnI0Va/mhe4MgtXZDFPMEqlXDQid
+g3OEiec1IZ7f1Mqs2QX/jw+Nz99ZzBn0lArhpz5+6XfP6+teV/U1HJsKDvsh3RJOxaqy2xozQPC4
+wPpBhKofwjMGhbyXNJxAyYaErJwZ1jUraTFJ/szN+5iaq8ImtE9MrgUsa+TWvnIuO7dQxY1XXzx6
+Xn8pUGKrUqIw4sHO/TcWVVGyRrpE4B2PHJMzVfx871FQgQsv6EE+5yEKFSQROYXTs8QsQdP0GvsC
+/HTvOCDE/GJQn8YDANhzoJo9OOE+O9CTuWvLhWv+pLsrt0BgI5QYmwx3d+pBJGmRrAisNVI40bv+
+22M/hnPEVZesx8bBCmZm/ZhV8XjjyoPVEHhJRYcNbRC8+e5YMuNEoUlfYe+haobxuB4OT+uXVfnl
+TQV+3hr5fT/kvyzUNGiNvmM21Z/iWekCTjyM9er/xuHcxRt6YYw0nIwqETm2SMgKMivFqBSrjAhU
+FST++tF7b78HAN4brRkSfe1a886B2lcH12af2z/m/ywlTlaVZaTSJMZIxohk9Tj299nfvulhVX1Y
+Cdz/4LefbbSlAE5jYY+cwrkVZ1bcrUyDlPZAWu+FNj1UL4BMJ1aMHGkCRbKg8QR8aQtAu0/WicXz
+qerM0pVnVjPOkhavWF+pTVHfP1Yrk8jyhPlt9pDIdYjUixCYkxpFFgEZm55Tnk3NkmPiq5hlsYsm
+iZEjfkHJrhO0vKdkBTw2HZQMuRdO5v0kiTdcwio9e2ClzDAVOkAQx1iqECMGQPn4QLFIssNwFQVU
+8ayUQNjWJFWSC27oZXPfQE0rYePpjk4Za1aSBQEAz4j1RD1CoYJ4TXJbCkKRbAmoNKdHpnNdjuI0
+NVmnM1h1AUlq2Sr08fmssZu/9ND3ryMJ1hNsCeNIoLsrX7LWZkA2dCUhqc0YyXrW5PI5rxupBFx7
+og4p/JK+fGuisD4/NGGXc2wIfCknlXLGX0dqByBikKj1+7A5mxmAU4lCJ0HgTLAYmZpT0RNqljQ8
+jjTNMdGJmh/evndk/HYmb1sHKQYu+Q1sAaEexJ6uJS3uDc1K7l/KSl/BhgPNujTBSLMHTbBIQiOV
+IFTxjYhVip44n5Wy+2a/KwaskMvitk9sTz20ztMlAGFKZMgmVdv6OjG0bbnd1LPbl+3DA0lKOQaq
+3RvmM9KTFbeWkgKrkbKuN3CDoapEFKlUlSAoNT8ytdnAztdZdUIzbPQLE6HPZTxcPNiPy7euT7US
+W1q6sSOp10yFHkh3oVKtjFSrI3U+XaZ+TDSnZNdXl/QLNTHDnIc+z7iwpV5t5h7zQiIlqqHKPAEG
+zixMVDNH5kNbbZ9cuARYmg7eGwFqVzGL6dlqTH0STM0jr/+mGgNoklSOJP3IRi4s2YdIXC6Juuum
+RGUjDdSegjEiEAgipwidIowUQeQaHjHSpjfMetLrJaSgtDI8MYhQKTWCC6oSBs5MTVa9A+OLmaOh
+E7f8tHLiAo5J0aDpUcBWM2xqAJupnHT6pBGCJErYcAZsEV4k18QBcGpNSjJpFKdN82tqVrO7kzXo
+M8Jsm7UrgEiJKiFOiarv7Oicb0fGFrIj86GpqS4d8XlLuPxUR7qpG83hI7aBxIYOgICYJjDNl0UL
+gDED0YjZ6n3M9hyVpBoLIo0AtMX86vtOk7AH8Kz0GrCU0r+AQFUpM0qZDZwZWQjt/sladv/EojcZ
+quiJnI+3lJepa9eh8TlUaz6MmBgkrbdqMoHW1Y/jlyDjWMxYk6RyDKw1sSlZgTUmyeEnghzF2YIo
+itMsIgbWxNdZI7BiYG28FQiCyKEWONTCCH4QwQ/jYz+MWoJSa9Br4hnwESFVJRYczViosr8a2fdm
+/My+icXs2GJkfF2mhz4us5564Weo+WGzdw80WlNdrG0uZQZ1861rjCQvHR8DJtmPO+sxEyJXF2Zt
+lG2WiUGqb0kiiBz8UBGEEYLIIQg12TqEkcNCtdbiSAlZdJRfhmr2Bc78Yi7M7J2oZUfmfW/R6fuL
+Y44B67WX38j95SOvZZwSDz/5E+CYkdpmVNj++0oMdC53UcJ3lFFH84tA7buLkffulJ/dNxNkpiN3
+clX12oAyAHKb1vfck896g33lwhprJOdZyWczXpdnTdEIPMTzl4wIbCIpNpEbk3bPzRSM8dITZNmC
++RLgtx23lmnVDHaQkHK5PLvosodrzh6YC7OHZoPMVOAkmRt3cq3acULY3GJkSKwlYZQUp+gj4TU+
+OauLcpJHqncn6ueZ+jwNpOQytk8JUWryqdqxn69R0Qg9mtv0dXHPQtue1fnaZhlSO5/XDtenPPOy
+R3dE0APAMJ5T2XcqcyIynilAVsd3jceAtVBzXYDkkw7/KQElgFgrBaySxbTOD3AWQAngKTOqziqR
+1fO1bDuzKognYpwyUMkMmFXDqhawaoErAMjFpnfqn3asNlY1wApCNQKpnA5GrVZWNZkl6CXQDzk9
+MwE9KzlZhf8GwURO8wDOP11AAUDGShGrcDEANp7Or6oyRrIiYlYjWP8/ABVzRoT3Sqt3AAAAAElF
+TkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66"
+       width="75" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4426);stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 21.369661,1023.8 13.432176,-16.6606"
+       id="path4418"
+       inkscape:connector-curvature="0" />
+    <path
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient4462);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4606)"
+       d="m 47.000294,1007.3622 -12.319149,16.9335 -12.416197,17.0669 16.933329,0 17.066666,0 12.416197,-17.0669 0.09676,-0.133 12.2221,-16.8001 -17.066666,0 -16.933329,0 z"
+       id="rect10961-8-3-6-1"
+       inkscape:connector-curvature="0"
+       transform="matrix(1.2008267,0,0.09173299,0.36603268,-108.57532,660.98864)"
+       inkscape:transform-center-x="4.4580006"
+       inkscape:transform-center-y="0.53407962" />
+    <path
+       style="display:inline;fill:url(#linearGradient4494);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4510);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 26.662676,1001.5215 13.292893,0 0,13.1948 z"
+       id="path4478"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4285-9-8)"
+       id="path4252-6-0"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="0.49178758"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="-3.0800218"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.9823895,-2.1047 -1.6734053,-2.5419 2.1987064,2.0209 2.4513363,-1.6427 -2.0383649,2.1623 1.7419712,2.4882 -2.2030799,-2.0431 z"
+       transform="matrix(-0.68431401,1.2284231,-1.0636666,-0.87657521,1143.5516,1913.5172)"
+       inkscape:transform-center-x="0.16252253"
+       inkscape:transform-center-y="0.33382692" />
+    <path
+       style="fill:url(#linearGradient4438);fill-opacity:1;fill-rule:evenodd;stroke:#3d5b8a;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.7500001,1018.1127 0,22.4995 46.4999999,0 0,-22.4995 -11,-4e-4 0,7.9997 3.085106,4e-4 -3.19e-4,6.9996 -31.584946,4e-4 3.19e-4,-6.9997 2.99984,-9e-4 0,-7.9997 z"
+       id="path4430"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#edf2f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4506)"
+       d="m 15.342812,1019.5906 -7.0000002,0 0,20"
+       id="path4480"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#eef1f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4524)"
+       d="m 11.162866,1034.8767 36,0 0,-9"
+       id="path4510"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="opacity:0.98000004;fill:none;fill-rule:evenodd;stroke:#eef1f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4566)"
+       d="m 43.900881,1024.6827 0,-5 8,0"
+       id="path4528"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#5d7aad;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4588)"
+       d="m 10.260003,1038.6222 41,0 0,-17"
+       id="path4570"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4661)"
+       id="path4252-6-0-1"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="1.0287941"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="3.1299058"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.5012045,-2.162 -1.1922203,-2.4846 2.095707,1.5226 2.5543357,-1.1444 -1.4929874,2.1437 1.1965937,2.5068 -2.164271,-1.4559 z"
+       transform="matrix(-0.3564605,0.66452158,-0.554066,-0.47418772,601.0265,1514.0687)"
+       inkscape:transform-center-x="0.084658908"
+       inkscape:transform-center-y="0.18052959" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/wizban/exportdir_wiz.svg
+++ b/bundles/org.eclipse.ui/icons/full/wizban/exportdir_wiz.svg
@@ -1,0 +1,1132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="exportdir_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4541">
+      <stop
+         style="stop-color:#a1adb2;stop-opacity:1"
+         offset="0"
+         id="stop4543" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient5885"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894"
+       id="linearGradient4884"
+       x1="11.927121"
+       y1="67.148781"
+       x2="1.0141196"
+       y2="30.177986"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0044289,0,0,1.0089329,10.981389,-7.447563)" />
+    <linearGradient
+       id="linearGradient4894"
+       inkscape:collect="always">
+      <stop
+         id="stop4896"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1" />
+      <stop
+         style="stop-color:#f3da70;stop-opacity:1;"
+         offset="0.30296871"
+         id="stop5248" />
+      <stop
+         style="stop-color:#f5e499;stop-opacity:1"
+         offset="0.72222227"
+         id="stop5246" />
+      <stop
+         id="stop4898"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5252"
+       id="linearGradient5258"
+       x1="5"
+       y1="64"
+       x2="5"
+       y2="32"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0067606,0,0,1.0132311,10.880208,-7.5854333)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5252">
+      <stop
+         style="stop-color:#5f443c;stop-opacity:1"
+         offset="0"
+         id="stop5254" />
+      <stop
+         style="stop-color:#765d54;stop-opacity:1"
+         offset="1"
+         id="stop5256" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4199"
+       id="linearGradient4205"
+       x1="12"
+       y1="26"
+       x2="29"
+       y2="21"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4358218,0,0,1.270043,-3.499458,-7.3507277)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4199">
+      <stop
+         style="stop-color:#765d54;stop-opacity:1;"
+         offset="0"
+         id="stop4201" />
+      <stop
+         id="stop4207"
+         offset="0.49346113"
+         style="stop-color:#c5b7ae;stop-opacity:1" />
+      <stop
+         style="stop-color:#765d54;stop-opacity:1"
+         offset="1"
+         id="stop4203" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4944"
+       id="linearGradient4936"
+       gradientUnits="userSpaceOnUse"
+       x1="72.098145"
+       y1="86.551781"
+       x2="49.569252"
+       y2="40.099323"
+       gradientTransform="matrix(1,0,0,1.0179005,6.5979291,-9.4754449)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0"
+         id="stop4908" />
+      <stop
+         id="stop4948"
+         offset="0.28205132"
+         style="stop-color:#d3b573;stop-opacity:1" />
+      <stop
+         id="stop4946"
+         offset="0.8623212"
+         style="stop-color:#fde29e;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop4910" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4950"
+       id="linearGradient4956-9"
+       x1="60.342896"
+       y1="74.470169"
+       x2="60.805737"
+       y2="44.682102"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0179005,6.5979291,-9.4754449)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4950">
+      <stop
+         style="stop-color:#6a5148;stop-opacity:1;"
+         offset="0"
+         id="stop4952" />
+      <stop
+         style="stop-color:#978379;stop-opacity:1"
+         offset="1"
+         id="stop4954" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2">
+      <stop
+         id="stop11150-4-72-3-9-7"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10507">
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="0"
+         id="stop10509" />
+      <stop
+         id="stop10511"
+         offset="0.18181793"
+         style="stop-color:#9e7058;stop-opacity:1" />
+      <stop
+         id="stop10513"
+         offset="0.36363617"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10515"
+         offset="0.49999985"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10517"
+         offset="0.63636351"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e7058;stop-opacity:1"
+         offset="0.81818175"
+         id="stop10519" />
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="1"
+         id="stop10522" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5309"
+       x="-0.4128"
+       width="1.8256"
+       y="-0.688"
+       height="2.376">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.58"
+         id="feGaussianBlur5311" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4456"
+       id="linearGradient4462"
+       x1="63.734764"
+       y1="1039.3618"
+       x2="61.727211"
+       y2="1006.3618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,-0.72750163,1,733.40264,2.0004)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4456">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.659"
+         offset="0"
+         id="stop4458" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.369"
+         offset="1"
+         id="stop4460" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4606"
+       x="-0.062976152"
+       width="1.1259522"
+       y="-0.10879012"
+       height="1.2175802">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.5412116"
+         id="feGaussianBlur4608" />
+    </filter>
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2-8">
+      <stop
+         id="stop11150-4-72-3-9-7-2"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad6e48;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4368">
+      <stop
+         id="stop4370"
+         offset="0"
+         style="stop-color:#9c7561;stop-opacity:1" />
+      <stop
+         style="stop-color:#966d59;stop-opacity:1"
+         offset="0.18181793"
+         id="stop4372" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.36363617"
+         id="stop4374" />
+      <stop
+         style="stop-color:#794f40;stop-opacity:1"
+         offset="0.49999985"
+         id="stop4376" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.63636351"
+         id="stop4378" />
+      <stop
+         id="stop4380"
+         offset="0.81818175"
+         style="stop-color:#966d59;stop-opacity:1" />
+      <stop
+         id="stop4382"
+         offset="1"
+         style="stop-color:#99705c;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       height="1.2013515"
+       y="-0.10067577"
+       width="1.2017672"
+       x="-0.1"
+       id="filter4285-9-8"
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur4287-9-5"
+         stdDeviation="0.10000000000000001"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4496"
+       id="linearGradient4494"
+       x1="8"
+       y1="1013.3622"
+       x2="19"
+       y2="1024.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88619287,0,0,0.87964908,-2.820998,140.94171)" />
+    <linearGradient
+       id="linearGradient4496"
+       inkscape:collect="always">
+      <stop
+         id="stop4498"
+         offset="0"
+         style="stop-color:#6885b2;stop-opacity:1" />
+      <stop
+         style="stop-color:#5777a7;stop-opacity:1"
+         offset="0.54585904"
+         id="stop4512" />
+      <stop
+         style="stop-color:#355286;stop-opacity:1"
+         offset="0.63636416"
+         id="stop4500" />
+      <stop
+         id="stop4502"
+         offset="1"
+         style="stop-color:#2c4a81;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4504"
+       id="linearGradient4510"
+       x1="3.2928932"
+       y1="1020.7158"
+       x2="20"
+       y2="1020.7158"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88619287,0,0,0.87964908,-2.820998,140.94171)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4504">
+      <stop
+         style="stop-color:#b0c1db;stop-opacity:1"
+         offset="0"
+         id="stop4506" />
+      <stop
+         style="stop-color:#8299c2;stop-opacity:1"
+         offset="1"
+         id="stop4508" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#3e3e3e"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.648485"
+     inkscape:cx="81.933837"
+     inkscape:cy="31.944909"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <image
+       y="-1.5258789e-05"
+       x="75"
+       id="image4446"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAACXBIWXMAAAsTAAALEwEAmpwYAAAK
+TWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQ
+WaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec
+5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28A
+AgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0
+ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaO
+WJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHi
+wmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryM
+AgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0l
+YqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHi
+NLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYA
+QH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6c
+wR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBie
+whi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1c
+QPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqO
+Y4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hM
+WEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgoh
+JZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSU
+Eko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/p
+dLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Y
+b1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7O
+UndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsb
+di97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W
+7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83
+MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxr
+PGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW
+2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1
+U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd
+8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H0
+8PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+H
+vqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsG
+Lww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjg
+R2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4
+qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWY
+EpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1Ir
+eZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/Pb
+FWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYj
+i1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVk
+Ve9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0Ibw
+Da0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vz
+DoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+y
+CW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawt
+o22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtd
+UV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3r
+O9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0
+/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv95
+63Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+
+UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMA
+APn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAAMvUlEQVR42uybe4xc113HP+femd2dfXvXdvyO
+Hcd23k7i2EmapI0VGgpVo7iuECQg2j+SQEEISkBCQgqgIqQqCBCVwEioUaGUCESqEkWCtJiEunHz
+8gM78QPHr117H1579jUz955zfj/+uHfGs95dZx3P2rN2j3R17tx77plzP/M9v/M7v3PG8NM0ZfrG
+P/eGqjSpaocqbUAu81MsEwBlgZwq7SLaokqu+v51D+sv/vVUqEqLKE0imlPRFlEapip73cL661dO
+50RoVtUGhRDVNlQbL/bMdQXrb7/fF4jSqKptqoTGgCrNqLYC5uOev25g/d2r/W2i2mwgUAUSNbUb
+aDAzrGPWYG17vrsTeAH4MtB5GVXlgb967sWhP/okD//9a/05URIlAZpIKKfQZsDoJdRlZhHW9rX3
+/dKjGx7/fdrmLZ+mlIIKqh4AUYcARhVD8hpj506y89U/4fgHr//xpQB76T8GGlRpV9WsCIiCqqJK
+m6o2i4CIIprkPs1Vk7JXDNa257u/3L3kjm9t/Z3/ruJiUXWgAupQFUBmVF9cHOGVbz7J6Lnee557
+cWj3xcr+4+uDoai2q9JUBpTCMqCdqjSIpNcuEVYwS8J64VNP/CkgqB/Fx/14O4S4YcSPIlJENULV
+zujINuV45ItfB/jWxb70Oz8YbAHmG2i6QBKZIKDLMLVLMNMUzIaqlqx+aOWimzbi4wHE5UFjUHtZ
+x+JVd3P7g0/dve357kld8eXtZ7Lf/a/BbmNoN2bSO2UCQ5epgX3O1MiQ/3bVpV+946Gv4AuHEBcj
+3qHeTciTcz/hmvMW7x3e2+SQ8nmSO29T88wL257vPi+aMJcdfv2BBggmmxQTBIStOYwxNC07aO78
+m+1XFZazcndb17IXbtn0JSTOoxqzdNUq1OURGyMuxtsYcRaxMd7FaW4n3LcuwtoI6yJcmlsb4SrX
+Y7yPWb72fuYtXPXCpbbz8K4fEsE9VxVWHAm51iXc99nfwo1/hPhxxI6kv3qWMMwSNrZcPQcrGQE5
+cXAP0dXuhnEk2FhAFdSDuLpyRlUF5zzOerj6sDzOSuISiAOtM1hecNYSlWw9wBLCIJs4lTZfd9Mc
+FY+3ETbylz30XzYsG3nGRguJg1lnqirDcjbGxo7Gq66skuDKNkvqD1YmAGcj4shffVjWCs4riibT
+mYukwmie17+/DWtLGGNmc2o6KS1cEcLez+6aSVkJ2rf3Ln/5a7MYdfh4Ze1//4esXr+V+x7/g0uq
+VtHUBVAkyif+nCgqgoig4hEv+HgYHw0j4vHe453HOY/oxMmekWFM9Q8rRYw9BcD/vPUDfNhxaBZD
+NJq+1fSwxkfzHD38Pl/8uT8HwI+fAF9Civ3pqBUhpf6qUSyq3JvpvC0AstUXw/SYUVrAiZ6jSUyo
+66vfKXNVJaOqGcBkasVKo6GLKuvoofdZfdcWWjuXUjr2L/jhQ3Vn3w4c+l9cZuFrhYb1gXrtvtBO
+1LAbyrSw4rjEwX07eeyXX8IO/gSX/7DuQJ3oOUahOE6++zf+SXWiQGsPS6fvhgf3vUXXkru4Yfl6
+xvf/ZRrLqicvXzlw+ANcZsl/jjc/2o/O0mhYHfGcTlkH9r3NA1/4M6Ke11BXqDtQZ86eoVgqMNz9
+m9+eVddhQjecQlkfHd5HQ66bm255mPEPv1lfoAAR4eCRA0jYsWe8ZXpV1RSW+mhKZe157002/PzX
+KZ18te66nxfhzNBZzp4botC+5R9m3Skt/0YaD01S1pHD+4mtsmz5Wuzx79YZKMV75djJo0jYsSc/
+79k9qHJluuEUNmvf3ne5/eFnkaGddaUqEcV5oVAsMjg0QKn1sVeuyHSnqh9OUNbpUz2c6R/g8bUb
+sf3/XleGyjqPiPJ/x46gprE/P//5HeiVhlWlrHd+spO1G3+RTGE/ro5UFVuP98J4sUTfQD9xywPf
+vmIT6QmuQ6qs3p5T9Jzo4eEtP4Md3l43oJwXrE3miidO9WDCpkG/4g/f6lDXVlmETV3G2VWWL1aU
+9cH+D1m65iFa9QS2TlQlokSRw4sSW8fg0ABB+4PbOxrtgnSlugJqKlaiuJrBkmI/qGN4eJR9+w7w
+C1/9dezwO3XieEKxZPFeEVFOnupFJIzaVzx9xGTdorKStBLlqDyXLlib2ImJMzVrjXpUHD/e8R5t
+81Ywv/kcdrg+VFUsOayVRF2x5fTAaXILPr23qbmrFZXWKSChIKom9krkhUBMDZWFeobzefbuPczn
+n/5d4vyBugEVxz7xq0Q5PdAPhK5r1dM9YaALJ4LSVE3GeqHkQVATOTHFkSgzWENYjrff3k9r+3zW
+rVtJqb/nqne9KPaUSh4vUoHVP9hHy8KH+xoaOzoqltwoilFVrEBRFAHjnZjxsTg8daaQPT0SZ8Zr
+BqtULLF71xEe3fJrFPvevGpG3PvE4YytVLx0EcEJ9A0M4l3E/JVbixkjN2ASUakaq2jRq3EKsRVz
+dtwGveeK2Z6hYnYo9sbVdDR8682deC+sXdWClmSWVaMpnOS8AkUTA+5FK+DKivJe6OvvpXPxI6Wm
+lsXtZf8UpaQQi5oxK6av6ILe4VLm+GAh2zduw2LqTdTOdRARfvTGO2y4bw2mUNsIqFYBqgzt5aFe
+wKuikoCqQKoG5TWZMJ/Ng8QsWvtUY2C0S5WCqimKmiErprfkgpOjcXj8TCHbc7aYzYtO9iAuC9a7
+O/aYf3vxC81HP3iP5uZG7t1wc83ngFpZsADhPCSpbFJLAE2lKJeCcl4ZGuqnbeEmGnI3oFDwanqt
+BD2xD46P2+D4uVL25MB4diD2xmktd/69u2NPI7AM2HDq0I4nfvTy154ulSKMMZgAjDEEaT6Tz4Ex
+mMBgDJjAEKR5peyFnz+m7vKBMRiSHGNY8+A3bHP3+n4r5riV4ETJhceGo8yxwUL29FgcFqWs2FrB
+enfHngBYDtxpTLAew235gSMrx4Z652NM1lTVmqwNAsaE50/TAiYtZkxYeaTq3vmy6SU158+rW55+
+mFC27AukFxU0k22LGjtv7XMS9EQ+6BmLM8fPlrKnhqPMiPOoJI5VbWGlwJozjY3zsk25RarawBRT
+BVUFEzapCVrONyBxicu+jQnCVgwNUl5JS/dzKppMNdMRrlJ3MqZXXkirX5Cq+1LVHpVKvSJILEFU
+sEGhZMPYi2p5T+lMYGW+98bhXcDdUw7DIkn/9zLh/L0+j2rhx5//9Kovlb+g+ktV1DjRDhEaVfVc
+2tAEYNoYA9kgNKXyptfJdiit05TnHCBGknPSMnpB2aoNtee/U6a8r59AJBlgM7ALWDk07hjJj6Cq
+OCdY57HOEVuPTVd3i4UinW3NLF+yYLrhKyNKJ3rx5c0wNM3MsZR58jNr8t974/AWYHtbU7Yz7lpA
+X89p8udGKUUxhVJMKYqJYsvY2Dinjp/k3vXrWLSweyr/JyfQ9nHdOwxoCAxZ0bkFKwB48jNrdnvR
+zYjLd2Yc625dzc233ERrWwvZTEBgDDaKGeg9nUaQE+VdAKpNoX0mdjATmlbmYKrs79q6ee1u52Sz
+jeK8H+1n6Q3Kxk23c9dda+hsC5HoWDLqBAGiSSCtPEiI6jyFGXWrTGiajDHBnIYF8NTnbtvtvWy2
+EflsNEpXC9x04yIe3LicUjQPE4YEQYikcWyFjKh2McPN+MZgMqFpYY6mSb/wV564a3d7S+PPjo41
+jXRlI25d0kBz5yqW3biCIAgxQYgqeC+GBNSMZwGZ0OQSL/EagQWw9bF1+1cvm/cr3sl4YaxIYISb
+b1uHCZLiXgQRzV6Kn2YMJgxNjjmcprMd8aY7Psq3t5jf2/1h/5gp9NLW2UzXwhvwzuG9VNusGaVs
+aHKGuauqaWEZYyy8NLh6+Yo3b1rW9dyhj6IRd+4wt927HhMGiJdJo+FFVcXcV9XFlMVIYdvRYiRn
+71izaPuCea1bz51tGGmKx1iyYmU6k585rGwmyFXN3q4tWKMFFxjoKAvjycdu77vn1qXPulI0unLx
+fMJMFuv8jFWVCea+qi7SDekAAk32VHYBmcfuv/nghtuXPpMNg9HFixbiZ9gNs5lgTo+AF4U1XvIt
+YJpIIh0TXIPHP7X24KY7lz/jvY46kevGVk0Jqxj5EGgFrSjqwgc+98gtB+9ff+MzIjo6I1t1jahq
+UjyrGPluURpFtEuETDleJOXY0YS4TxIa8VOGaJIlk8Zs2KWoSf6PDKKS/hd58v+Tpw3RVIVbRNIQ
+zQVt+SQhmgvbMJN4VkVZpdjngMak613+lu9rTVUVWLGVwGA6p+t6lyzXZA6Y4xpLQdoZ5yl0Y2qz
+NJYJTeNc99anhOW8NAGLawUqndo0cw2mAFhlargynQ1Mw1yNV31c+v8BAIuWGmXp92jwAAAAAElF
+TkSuQmCC
+"
+       style="display:inline;image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66.000015"
+       width="75" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <path
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient4462);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4606)"
+       d="m 47.000294,1007.3622 -12.319149,16.9335 -12.416197,17.0669 16.933329,0 17.066666,0 12.416197,-17.0669 0.09676,-0.133 12.2221,-16.8001 -17.066666,0 -16.933329,0 z"
+       id="rect10961-8-3-6-1"
+       inkscape:connector-curvature="0"
+       transform="matrix(1.2008267,0,0.09173299,0.36603268,-105.2607,648.98864)"
+       inkscape:transform-center-x="4.4580006"
+       inkscape:transform-center-y="0.53407962" />
+    <g
+       id="g4451"
+       transform="translate(6,-14.017696)">
+      <g
+         transform="translate(0,986.3622)"
+         id="g5348">
+        <path
+           style="fill:#fffabf;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4205);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 14.403025,25.481913 3.760593,-4.964217 16.536826,0 3.904565,4.964217 z"
+           id="path5250"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <rect
+           style="opacity:1;fill:url(#linearGradient4884);fill-opacity:1;stroke:url(#linearGradient5258);stroke-width:1;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4876"
+           width="41.860409"
+           height="31"
+           x="11.639588"
+           y="25.5"
+           ry="2.0792062" />
+        <ellipse
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5309)"
+           id="path5111"
+           cx="23.691999"
+           cy="8.3080006"
+           rx="7.5"
+           ry="4.5"
+           transform="matrix(1,0,0,0.38855855,-0.99999923,21.926323)" />
+      </g>
+      <rect
+         ry="1.8222821"
+         y="37.009739"
+         x="42.799835"
+         height="27.408155"
+         width="41.81472"
+         id="rect4932"
+         style="opacity:1;fill:url(#linearGradient4936);fill-opacity:1;stroke:url(#linearGradient4956-9);stroke-width:1.06747472;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         transform="matrix(1,0,-0.47943731,0.87757613,0,986.3622)" />
+    </g>
+    <path
+       style="display:inline;fill:url(#linearGradient4494);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4510);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.1668699,1031.905 13.2928931,0 0,13.1948 z"
+       id="path4478"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4285-9-8)"
+       id="path4252-6-0"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="0.49178758"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="-3.0800218"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.9823895,-2.1047 -1.6734053,-2.5419 2.1987064,2.0209 2.4513363,-1.6427 -2.0383649,2.1623 1.7419712,2.4882 -2.2030799,-2.0431 z"
+       transform="matrix(-0.68431401,1.2284231,-1.0636666,-0.87657521,1120.0558,1944.9007)"
+       inkscape:transform-center-x="0.16252253"
+       inkscape:transform-center-y="0.33382692" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/wizban/exportpref_wiz.svg
+++ b/bundles/org.eclipse.ui/icons/full/wizban/exportpref_wiz.svg
@@ -1,0 +1,1112 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="exportpref_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4505"
+       inkscape:collect="always">
+      <stop
+         id="stop4507"
+         offset="0"
+         style="stop-color:#8c9aaf;stop-opacity:1" />
+      <stop
+         id="stop4509"
+         offset="1"
+         style="stop-color:#94a1b5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4354">
+      <stop
+         style="stop-color:#abacbe;stop-opacity:0.91764706"
+         offset="0"
+         id="stop4356" />
+      <stop
+         style="stop-color:#adadbe;stop-opacity:0.89803922"
+         offset="1"
+         id="stop4358" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4324"
+       inkscape:collect="always">
+      <stop
+         id="stop4326"
+         offset="0"
+         style="stop-color:#94a3b0;stop-opacity:1" />
+      <stop
+         id="stop4328"
+         offset="1"
+         style="stop-color:#c0c8d3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5996">
+      <stop
+         style="stop-color:#dce3eb;stop-opacity:1"
+         offset="0"
+         id="stop5998" />
+      <stop
+         style="stop-color:#a2afc0;stop-opacity:1"
+         offset="1"
+         id="stop6000" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5952">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5954" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop5956" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4541">
+      <stop
+         style="stop-color:#a1adb2;stop-opacity:1"
+         offset="0"
+         id="stop4543" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient5885"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2">
+      <stop
+         id="stop11150-4-72-3-9-7"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10507">
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="0"
+         id="stop10509" />
+      <stop
+         id="stop10511"
+         offset="0.18181793"
+         style="stop-color:#9e7058;stop-opacity:1" />
+      <stop
+         id="stop10513"
+         offset="0.36363617"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10515"
+         offset="0.49999985"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10517"
+         offset="0.63636351"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e7058;stop-opacity:1"
+         offset="0.81818175"
+         id="stop10519" />
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="1"
+         id="stop10522" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4456"
+       id="linearGradient4462"
+       x1="63.734764"
+       y1="1039.3618"
+       x2="61.727211"
+       y2="1006.3618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,-0.72750163,1,733.40264,2.0004)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4456">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.659"
+         offset="0"
+         id="stop4458" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.369"
+         offset="1"
+         id="stop4460" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4606"
+       x="-0.062976152"
+       width="1.1259522"
+       y="-0.10879012"
+       height="1.2175802">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.5412116"
+         id="feGaussianBlur4608" />
+    </filter>
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2-8">
+      <stop
+         id="stop11150-4-72-3-9-7-2"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad6e48;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4368">
+      <stop
+         id="stop4370"
+         offset="0"
+         style="stop-color:#9c7561;stop-opacity:1" />
+      <stop
+         style="stop-color:#966d59;stop-opacity:1"
+         offset="0.18181793"
+         id="stop4372" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.36363617"
+         id="stop4374" />
+      <stop
+         style="stop-color:#794f40;stop-opacity:1"
+         offset="0.49999985"
+         id="stop4376" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.63636351"
+         id="stop4378" />
+      <stop
+         id="stop4380"
+         offset="0.81818175"
+         style="stop-color:#966d59;stop-opacity:1" />
+      <stop
+         id="stop4382"
+         offset="1"
+         style="stop-color:#99705c;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       height="1.2013515"
+       y="-0.10067577"
+       width="1.2017672"
+       x="-0.1"
+       id="filter4285-9-8"
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur4287-9-5"
+         stdDeviation="0.10000000000000001"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4496"
+       id="linearGradient4494"
+       x1="8"
+       y1="1013.3622"
+       x2="19"
+       y2="1024.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88619287,0,0,0.87964908,-2.780761,140.89891)" />
+    <linearGradient
+       id="linearGradient4496"
+       inkscape:collect="always">
+      <stop
+         id="stop4498"
+         offset="0"
+         style="stop-color:#6885b2;stop-opacity:1" />
+      <stop
+         style="stop-color:#5777a7;stop-opacity:1"
+         offset="0.54585904"
+         id="stop4512" />
+      <stop
+         style="stop-color:#355286;stop-opacity:1"
+         offset="0.63636416"
+         id="stop4500" />
+      <stop
+         id="stop4502"
+         offset="1"
+         style="stop-color:#2c4a81;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4504"
+       id="linearGradient4510"
+       x1="3.2928932"
+       y1="1020.7158"
+       x2="20"
+       y2="1020.7158"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88619287,0,0,0.87964908,-2.780761,140.89891)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4504">
+      <stop
+         style="stop-color:#b0c1db;stop-opacity:1"
+         offset="0"
+         id="stop4506" />
+      <stop
+         style="stop-color:#8299c2;stop-opacity:1"
+         offset="1"
+         id="stop4508" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5898"
+       id="linearGradient5892"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.15789444,0.33751306,0,-327.66664,1007.8359)"
+       x1="41"
+       y1="1007.8622"
+       x2="59.944244"
+       y2="1007.8496" />
+    <linearGradient
+       id="linearGradient5898"
+       inkscape:collect="always">
+      <stop
+         id="stop5900"
+         offset="0"
+         style="stop-color:#8c9aaf;stop-opacity:1" />
+      <stop
+         id="stop5902"
+         offset="1"
+         style="stop-color:#bbc5d3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5904"
+       id="linearGradient5890"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.2631579,0,0,-1.0587443,147.78945,2070.9292)"
+       x1="41"
+       y1="1007.8622"
+       x2="60.03624"
+       y2="1007.8358" />
+    <linearGradient
+       id="linearGradient5904"
+       inkscape:collect="always">
+      <stop
+         id="stop5906"
+         offset="0"
+         style="stop-color:#e1f6ff;stop-opacity:1" />
+      <stop
+         id="stop5908"
+         offset="1"
+         style="stop-color:#94a3b0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4324"
+       id="linearGradient4547-0"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.6842127,-2.2065442,0,2236.3926,934.30811)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4505"
+       id="linearGradient4547"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1007.6132"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6315788,0,0,2.0086335,-95.894731,-1022.5635)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4238"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.0834671,0,0,2.9600477,-16.445257,-2077.3398)"
+       x1="10.632975"
+       y1="1039.059"
+       x2="10.632975"
+       y2="1051.5835" />
+    <linearGradient
+       id="linearGradient4902"
+       inkscape:collect="always">
+      <stop
+         id="stop4904"
+         offset="0"
+         style="stop-color:#97a3b6;stop-opacity:1" />
+      <stop
+         id="stop4906"
+         offset="1"
+         style="stop-color:#5c6d8a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient6375-6"
+       x1="50.702839"
+       y1="1052.4476"
+       x2="19.083021"
+       y2="1011.338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4450407,0,0,0.75896453,-14.356232,235.9306)" />
+    <linearGradient
+       id="linearGradient4994"
+       inkscape:collect="always">
+      <stop
+         id="stop4996"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop4998"
+         offset="1"
+         style="stop-color:#d2f1ff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5952"
+       id="linearGradient5958"
+       x1="0"
+       y1="33"
+       x2="75"
+       y2="33"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5996"
+       id="linearGradient6002"
+       x1="66"
+       y1="998.36218"
+       x2="116"
+       y2="1002.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-54.000001,-0.00146599)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4354"
+       id="linearGradient5890-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.5789472,0,0,-1.206476,168.7368,2252.8239)"
+       x1="41"
+       y1="1007.8622"
+       x2="60.03624"
+       y2="1007.8358" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#3e3e3e"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16.381579"
+     inkscape:cx="59.959839"
+     inkscape:cy="33"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline">
+    <image
+       y="0"
+       x="75"
+       id="image5797"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAACXBIWXMAAAsTAAALEwEAmpwYAAAK TWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQ WaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec 5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28A AgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0 ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaO WJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHi wmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryM AgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0l YqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHi NLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYA QH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6c wR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBie whi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1c QPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqO Y4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hM WEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgoh JZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSU Eko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/p dLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Y b1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7O UndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsb di97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W 7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83 MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxr PGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW 2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1 U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd 8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H0 8PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+H vqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsG Lww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjg R2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4 qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWY EpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1Ir eZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/Pb FWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYj i1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVk Ve9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0Ibw Da0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vz DoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+y CW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawt o22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtd UV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3r O9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0 /rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv95 63Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+ UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMA APn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAALQklEQVR42uxcW48cRxX+TlX13GdndjbrtdeX hPU6JE5CHIhIFAlCQEKRkJARLwiJBx7Cr+ABHuEFCV4QEoQHQIkAJYpQCCSSiRSkSJHjkMRIjpWL Y+/F9novMzu37q5zeOieme6Z2c32ZseD1ylptrqrq2q7vjrn1HdOdTfhszQ0/fyZBS2CjIiURFAE kDWfwRIDyAGQFcEEs+RFkI1ep9sdoF/8ZVGLIM+CDLNkhSXPgtSwuretZP3quaUsM3IikhJAQ6QI kfR2bW4rsH79wrJiQVpEiiLQRIAIchAp7ETL9O0C1G/+drUoQDm0SQqAFpEygBwEJABEgrpyu0rW b1+8mmVBIEkhEARkBSgSApB2mvYtWL//x7WUCCZExCHpSQsBRRBy0bLbFqw/vHxds8iECDJ9YBAR ygBSIrvre1+B9cdXrudFUCBASZwgGUUoCcPIp+h/X4D17JkVJ5SmFCKGujNGRaiIJLNPw1IiUvq7 Z18+3Xa95251cAlUU/lj32vL5CILwCywYS4CsOyBZB09cvAUABitkUk7iW9SqWBueMjdyMCJDF/G Y8t770QiFaKSJdE6IvB8CwDFlm8e/mgFL4xMDSW8i3wug0q5mNhZyqQciAiabRdddZFgOJ2+JTyH BIOWEAmJgCDSOd6+TrwsyC23YC2D4M+O1GZdWbwOAHA9H8ZoEO0cLQHgZSyEBfVmG4B0JSwYvHSB 6p13Bh2U99fvSGkXLOEueNH2UXA3anX4noVQGlCTIwRr6RoAYHW9itW1aiKwAMBxTACa60W0TQZV USR2XbqqFpcSdCUqLpmdLnogBoBZy9iobQaui5PDxMzc6MBaCCULAC6+fzmxzZqeKqPteqjW6mM3 8ulsERMzI1TD+eNHkM0qFPIG2hgYY6C1gdYaxhgorYNzo6G1hlYaSgc/rRRSUGi4HjwAk+UitFIg paDCHykFRQRSCgQCdY6JoIiAUJKpL0+aXn3pn7i2xqPnWUopaGMwe/gosrlcd7BE1JcrkKJwoMGx V6sjBYVUykE+XwjACH/oHoeLO1GwfkTyKBUfR0oOFikYYzBzaBalcjlR241mG44CnFwOuVzuluNn u5Isow2UIiSeYArZBgE0xhitKAPAvRlgEYzRgW1JzpxBJCCMN54t5OwULBKBEREDgBKBxSyYrkxh slzE5uoGWtV6RFritiVWFhb7ng+IwG7WsNZq9Ji3SIw2DFKGOE0YqBOhFoN9RsuCOsQC7g89BMUO sxgROCIw/XOakMEz6s0WnLSGyWQ70xTvUQTUQVAEFNU/FkARRGl4NuaM9Abbm/6+wVKEjYXXwokR ka5+d9t0r3WG3GP3rudDhMGClG/FYRbHMgx3ieweqCGzYLNRR77oID9RQD6fTyT+jbV1WFIw2Qyy 6dTY1PCd8++BReeslYntwPl0YIkg5Tgo5nMo5jLI5TKJbrK9oWBFoJVCIWHbPV3VtOoy/dE50swg CqIOuzHwHbsxdgPPAuERk1JmARFBGw3a1fLfWwnHSh1EtoxZ7akaEtGuJatjv8cuWZGoxUgla3Ki BOspXPloMVzkqC/vuCv9ZLRXUGu1UF1ZiUX2utGEPhqArWJdA3RhkDZEY1rRXBMNDUDuuc26sbaB XD6NUnkSTsrZVkb6r7jNJpTWMKnU1lHSYeK43baVbBlTHRpFBYDzFy9BhEevhkoBpVIO03eUkEqn E/2za0seGIRMNo1iITs2NdRaQUZts4QFWmtk02mkUw5STjJvicItYEWEtDO+jSWiYCw3xcBrraB2 Y6T/Xww8A4yRG/iAZwVBO9rV8i8h0RordcBN4FkiAqMN6o02rF2H1npAvrfDwHU9CAiNWh3iedsI 36BFl/if6OGAjxkrkcF+CRi9zWIWaGVQq7ZQo9ZAZKGfIsQPeyebnodauHHQv5DFKEOPU2xDGeJO 8rCNC/RtdBBoMOowCjVcq1Zx7NgM8vk8tEn2eNfGWhWO4yA3xpUQAM6+feEmuDsiKOQymD1QDsDS ycBqbjYgJEg7BlPlwtjAyqRTYGmOnjoQQgO/q9VQugo5bneHIDqjOc2heWFBZGN2j9QQALSK7L4k Zw4B3xozWEYhW0p7UxJxrCViE/dEDYFg00LtYvknRCRrnNSBBSmjCoWUP9NzrNEXxt4DNQQUPrh0 LdzdGfCWh/qEndRotgEiuK6HlZX1LSWvf3qHb+vHHe/+1XQwpt+rr7SCUZTLaDst8a63lCwBOLFk WWvh+X6ohv36FKcRQ33LcCZdzx+KlAxyiVhZP9+KAiMDPExiqtcpspbhKOQdzQcG+thaDTlx1MHz fRw+WIExJvHO8JWlG0ilDCZLBThmfE+V/+vfbyJjUnlHyfSgZA6XERa0zPOvXjwH4NQwAmqZYW0n D47bzHjxtUuYmcrjW189kegml6+vAQAco8dKHQ7NVFBb28xrkpmoFvQBZUXgsqAFoqYIeQbAEwDO ADh1o+6jul6FiMC3DN+zcH0fnmfh+Ra+tXBdH8WMwR3lOajdONKhu6HGZ98xVS6isbaZ00qmBk0A rAAuC9UFsCy06TFdb/nqqjn9+In151+9+ASAc8WMc5dbmcbylWVsrFfRbLtotly02i7arodmy8Xi pct48OQcHrrvrl2u/xKshGONwQNKUUFR+K5O8DaBKyCXBTURalimFdfScstXS5ueXrzRcJYMAJx+ /MT6X8+89x2wPVM2qly6dw6razVcvrQAf2UNrheEYa8tLML3vNDQ8y1LSsMJMxSyAQE8AdWs4LrP tOxatdjy1cKmqxduNM3SesupskBi9/ynl/57yjKf0aZVzk6W0PYnsLx0HYuXL+Ldd87i4wUFthYP 3DeP+TsP4NL75xPfpud5YGakE0ZZ9zo9ev9xPHr/vAhQt0zLPtOia9WVCEiL622zYZl4KM/6/pMn 33r6hbef8P3UmYl2rVyuTKBSmMGhSgtvvPEBlNrsugPlYt794tceXklofghEalt6n+zStg22eya6 VMixz1T1hZa8QJKu1D21sNp0FlebZsNnsp9ISn/47S+89dq5yz+4fLX6zMGpdr40XcZG4wjm7/08 Vl8/ByUEFsC16v2754/9UkJiPuxhjn6iR4rSpFRa+lwLlp6WSl/4pVeGyBPMiOTS1zbed/y417Yt wLWGwGPVbHpUrbpmvdZWDZ+JE/mGjz14+L0PF/I/u7Gx9tONtRoZRTh+zwm8efY82rYFtoK2x/XS wdnXrfQetO86pBx3ToMclHKowgLiyPVYGxFwLI/WC3xTRlge9ju8bq+NCA+/PuQePinGpYYH9Onq 3JG307PT6affvbjSaK0tIJfzcXjuOKz1YdnCJgz4O5qydIu/ZryFvdEMvPL3g1Ozf35g/sCPP/y4 Xd1c/hgnTt4NJ52FtQzftwkMFUhryuIWT1tIFteqjZ+crbf4P3NH73jmQKXw3eqGU6XaKu48cQLW Mjx/55FGx6gsjTXOMEKwag1fEVDqYHf6G/ctP3Tv4R/57XZtdjKPbH4C/g7BIoCMuvWlahvJQgnB O3skggoA8/VH5i986eThpxSkNjU5Ad/aHUsVaH98EmEArHrL5gHKhLG6SnTF/OZjd1/48v1Hn2LL Nd/ybWOrhoLVbFsNoABIV6L6Gzz5lXsuPPLgnU8Jo7YjW0X750Mb1AfWFAvSzFJhhpEIn5E+PiIh v9mKZ4kIpR1dEUjIqwAWDl+CjHMcm4Rn9f2vveZZ221YdCWr5dosgHSgevSpn9rYb1LVBcv1WBGo vJXqJRZXApl9ZKvikkWYFGAKtDcvmBtNadqHHwVSvuUMgEN7BVTo2uSwD5MC8Dnaw08WOIpStFUY 5hZP/xsA6bta8JmBWE4AAAAASUVORK5CYII= "
+       style="fill:url(#linearGradient5958);image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66"
+       width="75" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <path
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient4462);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4606)"
+       d="m 47.000294,1007.3622 -12.319149,16.9335 -12.416197,17.0669 16.933329,0 17.066666,0 12.416197,-17.0669 0.09676,-0.133 12.2221,-16.8001 -17.066666,0 -16.933329,0 z"
+       id="rect10961-8-3-6-1"
+       inkscape:connector-curvature="0"
+       transform="matrix(1.3333201,0,0.10185437,0.36603268,-119.37483,656.83554)"
+       inkscape:transform-center-x="4.9498669"
+       inkscape:transform-center-y="0.53407962" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4"
+       d="m 11.999999,1002.3607 50,3e-4 c 0,0 -0.0819,17.5112 0,33.0364 l -50,0 z"
+       style="display:inline;fill:url(#linearGradient6375-6);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-1"
+       d="m 11.499998,997.86459 c 22.26316,0.10612 51.000001,0 51.000001,0 l 0,37.99601 -51.000001,0 z"
+       style="display:inline;fill:none;stroke:url(#linearGradient4238);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-1-6"
+       d="m 11.999999,998.36073 50,6e-5 c 0,0 -0.0819,2.12021 0,3.99991 l -50,0 z"
+       style="display:inline;fill:url(#linearGradient6002);fill-opacity:1;stroke:none" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient4547);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 12,1001.8622 50,0"
+       id="path4539"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient4547-0);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 12.499998,1003.3607 0,32"
+       id="path4539-4"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient5890);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 54.999999,1003.8607 -43.000002,0"
+       id="path4539-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient5892);stroke-width:1.00000012px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 12.5,1001.3622 0,-3"
+       id="path4539-4-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#677792;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 11.999999,1002.8607 50,0"
+       id="path5950"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:0.65100002;fill:none;fill-rule:evenodd;stroke:#c9cdd1;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 27.999999,1035.3607 0,-32"
+       id="path5960"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:0.65100002;fill:none;fill-rule:evenodd;stroke:#c9cdd1;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 12.000001,1009.3607 49.999998,0"
+       id="path5962"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:0.65100002;fill:none;fill-rule:evenodd;stroke:#c9cdd1;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 12.000001,1016.3607 49.999998,0"
+       id="path5962-8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:0.65100002;fill:none;fill-rule:evenodd;stroke:#c9cdd1;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 12.000001,1023.3607 49.999998,0"
+       id="path5962-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:0.65100002;fill:none;fill-rule:evenodd;stroke:#c9cdd1;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 12.000001,1029.3607 49.999998,0"
+       id="path5962-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:0.92299996;fill:none;fill-rule:evenodd;stroke:url(#linearGradient5890-8);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 62.999998,1036.8622 14,1036.8622"
+       id="path4539-6-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:url(#linearGradient4494);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4510);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.2071069,1031.8622 13.2928931,0 0,13.1948 z"
+       id="path4478"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4285-9-8)"
+       id="path4252-6-0"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="0.49178758"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="-3.0800218"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.9823895,-2.1047 -1.6734053,-2.5419 2.1987064,2.0209 2.4513363,-1.6427 -2.0383649,2.1623 1.7419712,2.4882 -2.2030799,-2.0431 z"
+       transform="matrix(-0.68431401,1.2284231,-1.0636666,-0.87657521,1120.0558,1944.9007)"
+       inkscape:transform-center-x="0.16252253"
+       inkscape:transform-center-y="0.33382692" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/wizban/import_wiz.svg
+++ b/bundles/org.eclipse.ui/icons/full/wizban/import_wiz.svg
@@ -1,0 +1,1119 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="import_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4432">
+      <stop
+         style="stop-color:#ced8e7;stop-opacity:1;"
+         offset="0"
+         id="stop4434" />
+      <stop
+         style="stop-color:#b7c5e0;stop-opacity:1"
+         offset="1"
+         id="stop4436" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4420">
+      <stop
+         style="stop-color:#5b7aaa;stop-opacity:1"
+         offset="0"
+         id="stop4422" />
+      <stop
+         style="stop-color:#96aaca;stop-opacity:1"
+         offset="1"
+         id="stop4424" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4541">
+      <stop
+         style="stop-color:#a1adb2;stop-opacity:1"
+         offset="0"
+         id="stop4543" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient5885"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2">
+      <stop
+         id="stop11150-4-72-3-9-7"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10507">
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="0"
+         id="stop10509" />
+      <stop
+         id="stop10511"
+         offset="0.18181793"
+         style="stop-color:#9e7058;stop-opacity:1" />
+      <stop
+         id="stop10513"
+         offset="0.36363617"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10515"
+         offset="0.49999985"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10517"
+         offset="0.63636351"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e7058;stop-opacity:1"
+         offset="0.81818175"
+         id="stop10519" />
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="1"
+         id="stop10522" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4456"
+       id="linearGradient4462"
+       x1="63.734764"
+       y1="1039.3618"
+       x2="61.727211"
+       y2="1006.3618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,-0.72750163,1,733.40264,2.0004)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4456">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.659"
+         offset="0"
+         id="stop4458" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.369"
+         offset="1"
+         id="stop4460" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4606"
+       x="-0.062976152"
+       width="1.1259522"
+       y="-0.10879012"
+       height="1.2175802">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.5412116"
+         id="feGaussianBlur4608" />
+    </filter>
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2-8">
+      <stop
+         id="stop11150-4-72-3-9-7-2"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad6e48;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4368">
+      <stop
+         id="stop4370"
+         offset="0"
+         style="stop-color:#9c7561;stop-opacity:1" />
+      <stop
+         style="stop-color:#966d59;stop-opacity:1"
+         offset="0.18181793"
+         id="stop4372" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.36363617"
+         id="stop4374" />
+      <stop
+         style="stop-color:#794f40;stop-opacity:1"
+         offset="0.49999985"
+         id="stop4376" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.63636351"
+         id="stop4378" />
+      <stop
+         id="stop4380"
+         offset="0.81818175"
+         style="stop-color:#966d59;stop-opacity:1" />
+      <stop
+         id="stop4382"
+         offset="1"
+         style="stop-color:#99705c;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       height="1.2013515"
+       y="-0.10067577"
+       width="1.2017672"
+       x="-0.1"
+       id="filter4285-9-8"
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur4287-9-5"
+         stdDeviation="0.10000000000000001"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4496"
+       id="linearGradient4494"
+       x1="8"
+       y1="1013.3622"
+       x2="19"
+       y2="1024.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88619287,0,0,-0.87964908,19.219239,1914.8255)" />
+    <linearGradient
+       id="linearGradient4496"
+       inkscape:collect="always">
+      <stop
+         id="stop4498"
+         offset="0"
+         style="stop-color:#6885b2;stop-opacity:1" />
+      <stop
+         style="stop-color:#5777a7;stop-opacity:1"
+         offset="0.54585904"
+         id="stop4512" />
+      <stop
+         style="stop-color:#355286;stop-opacity:1"
+         offset="0.63636416"
+         id="stop4500" />
+      <stop
+         id="stop4502"
+         offset="1"
+         style="stop-color:#2c4a81;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4504"
+       id="linearGradient4510"
+       x1="3.2928932"
+       y1="1020.7158"
+       x2="20"
+       y2="1020.7158"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88619287,0,0,-0.87964908,19.219239,1914.8255)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4504">
+      <stop
+         style="stop-color:#b0c1db;stop-opacity:1"
+         offset="0"
+         id="stop4506" />
+      <stop
+         style="stop-color:#8299c2;stop-opacity:1"
+         offset="1"
+         id="stop4508" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4420"
+       id="linearGradient4426"
+       x1="68.572693"
+       y1="1016.118"
+       x2="67.579018"
+       y2="1015.3881"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99587969,-0.09068428,-0.09068428,-0.99587969,47.64461,2028.4309)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4432"
+       id="linearGradient4438"
+       x1="8"
+       y1="1019.3622"
+       x2="52"
+       y2="1039.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9893617,0,0,0.97823962,0.31914907,22.399103)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4506"
+       x="-0.092571429"
+       width="1.1851429"
+       y="-0.0324"
+       height="1.0648">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.27"
+         id="feGaussianBlur4508" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4524"
+       x="-0.029837838"
+       width="1.0596757"
+       y="-0.12266667"
+       height="1.2453333">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.46"
+         id="feGaussianBlur4526" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4566"
+       x="-0.08775"
+       width="1.1755"
+       y="-0.1404"
+       height="1.2808">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.2925"
+         id="feGaussianBlur4568" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4588"
+       x="-0.042439024"
+       width="1.084878"
+       y="-0.10235294"
+       height="1.2047059">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.725"
+         id="feGaussianBlur4590" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4661"
+       x="-0.14766911"
+       width="1.2953382"
+       y="-0.11646623"
+       height="1.2329325">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.36234727"
+         id="feGaussianBlur4663" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#a5a5a5"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.106667"
+     inkscape:cx="75"
+     inkscape:cy="20.792472"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <image
+       y="0"
+       x="75"
+       id="image4762"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAACXBIWXMAAAsTAAALEwEAmpwYAAAK
+TWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQ
+WaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec
+5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28A
+AgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0
+ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaO
+WJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHi
+wmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryM
+AgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0l
+YqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHi
+NLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYA
+QH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6c
+wR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBie
+whi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1c
+QPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqO
+Y4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hM
+WEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgoh
+JZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSU
+Eko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/p
+dLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Y
+b1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7O
+UndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsb
+di97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W
+7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83
+MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxr
+PGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW
+2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1
+U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd
+8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H0
+8PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+H
+vqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsG
+Lww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjg
+R2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4
+qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWY
+EpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1Ir
+eZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/Pb
+FWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYj
+i1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVk
+Ve9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0Ibw
+Da0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vz
+DoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+y
+CW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawt
+o22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtd
+UV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3r
+O9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0
+/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv95
+63Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+
+UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMA
+APn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAAPF0lEQVR42uxbbYwd1Xl+3jNz537s7t0PYxaM
+AYNJQ0pluQntD9K0JKoqFalBoq3USLSlUtVW/ZOiSP2VCKP+qJRWilAqtaJNQ1MqUZGWgCgqhcQk
+AWSIYxuDjYm/7669Xtv7vfdjZs55n/6YmXtn7+56be+uDUtGGs3MvTPnnnnO8z7vxzlX8PNtye3r
+z5zxSJRI9pPoA1D2fw7LAoAKAMokqqrsIVHOf/+xB+sb3z3rkehRoqTKMpU9SgRL3fuxBeubz42V
+VVEhGRDwQPaBLF7qmY8VWP/0wjmjRJFkHwlPBCBRAdkLQFZ6/mMD1pMvjvcpWRHAkAASNlUFCOQy
+29jwYH3rpfGyEgmTADChUJlAnwDCK2hrw4L11MvnAxJVkgVhAhISoPogqOQ/+9iC9fQrFzwlqyRK
+XWCICAYABOTVtb2hwPqPVy/0kOgVwCzAQ+AbQT8VPlfR/oYA6z93XyykbAoAoIs5vhEMkVemTxsS
+rGdfu9ijRK9ADLtUSABfRIZIrhqojzRY//3jCaOKQYLBUmItiekNKSHk2vzmRxKs770+UVKiX6Qd
+M3UruS+CISrkyn3eBgLr+TcmqwR6hFwSBgF8MWujUR9ZsP5nz6RRYpBc3vUL4BsjQ7pGGtW9mbVo
+JLbuYZK/u15AvfTWVAGQzYKlqwGpRnmeJ0MQyHr1Y9XMaoXxH9ab8b/VW/FZkqMi8tZadvB/354q
+Exi4pEgLxBMMrIfprRos0hoRXwFgrh49MT45J0q55dTZ2W+SfEhERteic/+3d7pKsmclb+Z7MkTC
+J7muUnBVZijiKxl6ADA5F37h/HRr+tDxc5icrf/Kk987+ARJb7Ude/Wn0wMAelYcbSNVuUbae9Wa
+JVJ0APALt5UO+Z7/4NS8rb918DSo9qFd//zmv1xtu7v3z5jv75u+AVhY0l1q84xUjFn5vg+NwItU
+4s/t7N8z0Ff51ZmGvrPvcA3Dg8Ejjz35xrevtK3XDswYAEMCFFbsuEHgGfStMz5CoqDKsiora+IN
+RfqiL/3WzSdKpdL9XqF04MCR0UsCRp4eIGt/RY7sJkd3k6O7nda+IoLNkJWBEoHnGRlYU1gIUSJw
+yooq+53jJue4SZX9JHpIVNbUzZITlb/+h/eC+Xpzt4ubO3fevRXjU9FTj//ZZ/+kc09tF2C+DHgD
+gJcjt0IZv/ni682Rvt4bHlUCSoAklIBq59z3ZBNJXxVQEskRUGXXMfuei753CnGOBetYUGXBKXwl
+QS5KxPNx3DrkbbsP3vLKW2dftFFz5y9/aivGp6Ondv3p1kcBsxvwdiZW5iMBKwNMsf+DCdTGQ1T7
+Nm9ZDizPSBWCsipxpWA5R88qCs5p4ByCRfevAJZZD7Ae+vyOM7/92S1f9IPygf3vj2B4IHjk2e9P
+ngQKO5O4spjuZQAlAEXs/2AOtfFwJUEvXqmgkxCnKFnLfus4qMpecvngdt0j+KW2L35ux8jv/PqW
+B/2gcmD/+yO4OGUHnv/RxRSkDDAfgMH+Dy6gNj6H2ZBwTpfuqMDzPem/3N93isA69lmnm1TZy8tw
+GtcNLAB44L4dtb/78t3Ydusm7Ds8gnMXZvHi66dTsJKffufoKGrjs6ijiNGxSYSRW7Ktgm8GVpIN
+AmIdK5HjkFNWlSh+6HLD5U2gtqunFOx89Eufwh23bca+98ehbgw/2DsCADhx5jTGJycQ+xVMTNfR
+arbQiuxioDzpFVk+8CTgxY59seUmJSrg+rzXkiP1lSd2PyIi25wqjADWKqLYwqlCnSZH7RxV+dQz
+f/v7p7rCg22AdzIzu2bo4R//6xCmZ6bxwK/djt6eKubqLZyrFzEbAkcOHYWow203DeKT2+9sC7wR
+BJ4ng8+9sufesfOT96bgZCmhMcYURMRj7gsCuPuu7S/ffsvWcVKXdgC6hENYQeD9ZUbqj4eqF+93
+bguMAKqKas8oaucEs/NLZiCvATjVNQ6PJc37AAooFwP85e99Bv/+0nsAiugrl3BmxoMVwchIDbNz
+8ygWfIQ5ZolAfE+qBDB2fureiem5P79cFkxMTb1z+y1bx9c9kSaJgd4iHn7gdlA3w/PqILcjigez
+lwBJvLrnGF744QfLWfj9SVjgt8OEUgB8/t6bMN+IMD7vEBQtZqcUp0+dgbMOVKIVWuzYHt1z4Fhw
+KPClF4CXH+ln//6PEnOQNrsg6bm1ipdfP4pvvbDn2lUdhESjeSPAAVSKEZQF1JslWOegSogAtbFp
+zDeiSxRtZVsiiVksBRw8ehLnpyYxGQ3DGQfDSRw5fAzz9bDN/TCyKBUqt/qeO2qMVFQJEp7ve22x
+tqqp1xSISCJQApwZm0Ozaa9ticapIrYOgAenDtYp6s065puEdQojgpm5ZjK4JJYvjZj2/pPD53B8
+tIVzrSpCRhg5eRwH3t6PZn0eN229GUExgDEGrcii4Pu/VPB1ryrEWvZaRdGIeBmh6o0Ys/MhjEhn
+N4ILFxtYzzLNkmCFkcV8I4Qx5zAzvwnN0KLgT8EzhHP92aQALj0dwFMAtwHA24fGcGxkCidniKOn
+RnHi8BHMTk0CVKg6jJwawfCWm+AbD2FoYYzscA591rGs7HJCXebX3rOBvtZgOVX4Xg3N8DNoxYpm
+aFFv9sO5SYSxhUmW6rS1a6nRjC2+WvDjp/e8N46jtTn89OhF7N13GBNjZ+D5PozxQSroEo965vQI
+CtvvQBhZCMw2p6ws99phZNEMY/jGoFzy04ETKJcPatcNLHWKMxeGoCzA2hai2EFEMDVbxNTcDLyU
+9pkz6Abrg1qjevwsfnC8Vnvz4nR038H3a3j33Z+h4BTDNyZlckLSsCNhlzpFWG+gFVp4nnfXch2e
+nGniyPGLoAJbhvtQKvqwsYJMJMLpdWBWxniRZAagfS7Ae8cvAMJE4NPYJNt+NtIsE+jZd+jE42Fk
+74utwx233YRbt2xGFDvENtHDOHbpMb1OP0tCB8HwYGF4bDJe5Pr/9bmfwDni03dvwSe2DWFmNkxY
+5fT6gKUpWG0hkJw+QHDw2DgSL6VQdqaDj442AwIDIPDpX7zjMSUeW6rEogSYBIKedVpVRUDA+8Qt
++hueKffNNez25Tq8590knLvz1kEYI20no0pYx/ZAX2Nm5RiVE3QjifmQePzZr//BruyZ42ebBSbz
+epe1KVlRRXt5ou9Jz8lz3kHVCEq+0f3ODz/4m99R1e8ogW98+7uvtMdSAKeJsFuncO6aM4tJ6TBn
+ekkgkJxrV05wcqxlSPQTXDknIzxVVpErkxgjBSMS6FV4MrJTs7JpKnZ9zDDntfNumtol6oJBAIWV
+lhWQLGuyAF+6prL6rsrji4BMTM8pr6dm5eMYybFM0oQz6dTp8VaVRMAV69vs5xIlE9+TCgTmStdv
+SJrEuqwSev3Ayplhyiq0NQugKghg5HxYVrJnBTPxlRwAkZtLpIAqAnhGTI+SAqY2lR47ern4vDMG
+neqBI2HTUCSdT/R8UZ9QqCDZkXhuBaFIjwRU0s9TdUnP6SiaX3/iLyO+neETdAl98r0RMQCqK5hd
+hWRfLoDzoM4XZ0viXCBGBuCSpdWiGQWTBIkKaDuOa9fjJdPFDNsMKFXCObYFvrcoA9VCeCOpi4DI
+vDI1a4ftej8BWCexVYlDZ6KmNS2nSe8uqVnS9jgLTZIkrPJrf/E3z3yNSNiQvRSRmmj7POUAOxWN
+tSsudsS9rVlp+72BDJW9eLjTlw4YzAGHDlgkoVYlio2EsZMwVhOvXKLJ2X0n70r0qlwM8NAX7sn9
+aMbTZQDJralObpDFJccM0Pz9yN+6uEZ5z/ZhMLUCp4u9Yakg/YG4zZQcWGn7nQFuM1SVEltFSwkC
+ErasadZj08xYtaIZimCB0BcLPu7cugk7PrklN0pcMNLtE8m9Zi75bZu1dG5l2mPm2pAlnsmuiXzF
+k21TdE6hqRkWfQz5xsUL+tU+bw8slRIr0YoV84Q0I2fqk83C+bnIa3Svl1sGLG0vc2oDBqCnEmB6
+tplQn8yi8LQsy/YcHkkYk5ROJM0jTWrK2TlEkufSqDszJSoXPJMvwRgRCATWKWKniK0isq6tWVY7
+3jDwZdBPSUFZyPDUeq1SWgTrqhJHzkxPNv2RC43CxdiJu/xKqRIEFwCWmWPmUcCFZtjRALZDDeTL
+J+0QJFXCNPxgru7NlJHZfZKafuc605cEWJdjVne6UzAYMEK/beadcpJVoklIXYlW5MzYbOiPjNeD
+0fnYNFNHf2Vl5W6QAOm8VCriC3WrIwxiOsB0XjZnkpJ6ovYkAds55oIaVc5ks/AlC0AXmF8KnHOa
+hj1AwZNNBqxmXQcQE2gqZUYps5EzI/XYOz3ZCmoTDX8iVtGVnI+/nJfJtOvshTk0WyGMmASkrGOK
+dLYnu05egsmMDIxn0lKOgeeZxJQ8gWcMRADnUkG2SbXA2qTMImLgmeQ+zwi83LVAEFmHVuTQii3C
+yCKMk+swtguCUs9g0CSLui0hTSUajmY8Vqk1rXdiJiycmmgE4w1rwstNsy7JrJd+fASNVtTJ7pGL
+a1yibdkoZ3rDNNI3Jtk9kwJlAJOeJ8l6wgTrMmFO+G8k/0wCVnYkicg6hHEyNRdZhyjW9JiUeerN
+1gJHSkjDUWqxmlORMyfm4sLxiVYwMh/6DXeFyegisPa+8U7xq0/vLTglnnp+L7q9eX5yrvvzdV6l
+eEWbEqGjjDmaE5F6xxrWPz4VBidnosK0dVfXVb8LKAOgeNeW/l0CDN8wULmhFPi9viclI+IHvtfr
++6YMopCRIJUUL5Ubk3fPCxZ1eF6pK6xCLrpaDH7Xdfckal4zuISEVKvV2YYLzrWcNzoXB2dno8JU
+5MTqEn1b1Yw0AMzUbQnEoHaKd1VVljUvymkdKUsnspld5mZ7ScL3TMWIVJQKly0Fyq+Vyp7hpZYR
+JZmFdv3WSkuO1n1Geq5h0/pUexpxCFe5yFUA8Y2U9UNkomu6MEQE/Uj+s7cqoNLVL+X1XMh/XcGq
+t1wPIKU0OlkVUAKI50kZG2RbAFYzdB6AXoCrZlTGKtkgrFqKWQNIFmKsGqh0BcyGYdUCsFqRKwMo
+JqYnq/7HwkZjVRusKFYjkIG1YNRGZVWHWYJBApsga/MfGN+TomBjsQoAjHVaAnDzWgGVZvwVbMDN
+ALhjLf9VVTASSDKZseG2/x8AeW7Aj7mVvz8AAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66"
+       width="75" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4426);stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 16.736,1003.0392 14.488067,15.7511"
+       id="path4418"
+       inkscape:connector-curvature="0" />
+    <path
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient4462);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4606)"
+       d="m 47.000294,1007.3622 -12.319149,16.9335 -12.416197,17.0669 16.933329,0 17.066666,0 12.416197,-17.0669 0.09676,-0.133 12.2221,-16.8001 -17.066666,0 -16.933329,0 z"
+       id="rect10961-8-3-6-1"
+       inkscape:connector-curvature="0"
+       transform="matrix(1.2008267,0,0.09173299,0.36603268,-108.57532,660.98864)"
+       inkscape:transform-center-x="4.4580006"
+       inkscape:transform-center-y="0.53407962" />
+    <path
+       style="display:inline;fill:url(#linearGradient4494);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4510);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 23.207107,1023.8622 13.292893,0 0,-13.1948 z"
+       id="path4478"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4285-9-8)"
+       id="path4252-6-0"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="0.49178758"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="-3.0800218"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.9823895,-2.1047 -1.6734053,-2.5419 2.1987064,2.0209 2.4513363,-1.6427 -2.0383649,2.1623 1.7419712,2.4882 -2.2030799,-2.0431 z"
+       transform="matrix(-0.68431401,-1.2284231,-1.0636666,0.87657521,1139.9713,112.35675)"
+       inkscape:transform-center-x="0.16252253"
+       inkscape:transform-center-y="-0.33383187" />
+    <path
+       style="fill:url(#linearGradient4438);fill-opacity:1;fill-rule:evenodd;stroke:#3d5b8a;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.7500001,1018.1127 0,22.4995 46.4999999,0 0,-22.4995 -11,-4e-4 0,7.9997 3.085106,4e-4 -3.19e-4,6.9996 -31.584946,4e-4 3.19e-4,-6.9997 2.99984,-9e-4 0,-7.9997 z"
+       id="path4430"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#edf2f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4506)"
+       d="m 15.342812,1019.5906 -7.0000002,0 0,20"
+       id="path4480"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#eef1f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4524)"
+       d="m 11.162866,1034.8767 36,0 0,-9"
+       id="path4510"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="opacity:0.98000004;fill:none;fill-rule:evenodd;stroke:#eef1f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4566)"
+       d="m 43.900881,1024.6827 0,-5 8,0"
+       id="path4528"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#5d7aad;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4588)"
+       d="m 10.260003,1038.6222 41,0 0,-17"
+       id="path4570"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4661)"
+       id="path4252-6-0-1"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="1.0287941"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="3.1299058"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.5012045,-2.162 -1.1922203,-2.4846 2.095707,1.5226 2.5543357,-1.1444 -1.4929874,2.1437 1.1965937,2.5068 -2.164271,-1.4559 z"
+       transform="matrix(-0.3564605,-0.66452158,-0.554066,0.47418772,596.13721,512.95467)"
+       inkscape:transform-center-x="0.084658908"
+       inkscape:transform-center-y="-0.18053454" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/wizban/importdir_wiz.svg
+++ b/bundles/org.eclipse.ui/icons/full/wizban/importdir_wiz.svg
@@ -1,0 +1,1133 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="importdir_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4541">
+      <stop
+         style="stop-color:#a1adb2;stop-opacity:1"
+         offset="0"
+         id="stop4543" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient5885"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894"
+       id="linearGradient4884"
+       x1="11.927121"
+       y1="67.148781"
+       x2="1.0141196"
+       y2="30.177986"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0044289,0,0,1.0089329,10.981389,-7.447563)" />
+    <linearGradient
+       id="linearGradient4894"
+       inkscape:collect="always">
+      <stop
+         id="stop4896"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1" />
+      <stop
+         style="stop-color:#f3da70;stop-opacity:1;"
+         offset="0.30296871"
+         id="stop5248" />
+      <stop
+         style="stop-color:#f5e499;stop-opacity:1"
+         offset="0.72222227"
+         id="stop5246" />
+      <stop
+         id="stop4898"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5252"
+       id="linearGradient5258"
+       x1="5"
+       y1="64"
+       x2="5"
+       y2="32"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0067606,0,0,1.0132311,10.880208,-7.5854333)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5252">
+      <stop
+         style="stop-color:#5f443c;stop-opacity:1"
+         offset="0"
+         id="stop5254" />
+      <stop
+         style="stop-color:#765d54;stop-opacity:1"
+         offset="1"
+         id="stop5256" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4199"
+       id="linearGradient4205"
+       x1="12"
+       y1="26"
+       x2="29"
+       y2="21"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4358218,0,0,1.270043,-3.499458,-7.3507277)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4199">
+      <stop
+         style="stop-color:#765d54;stop-opacity:1;"
+         offset="0"
+         id="stop4201" />
+      <stop
+         id="stop4207"
+         offset="0.49346113"
+         style="stop-color:#c5b7ae;stop-opacity:1" />
+      <stop
+         style="stop-color:#765d54;stop-opacity:1"
+         offset="1"
+         id="stop4203" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4944"
+       id="linearGradient4936"
+       gradientUnits="userSpaceOnUse"
+       x1="72.098145"
+       y1="86.551781"
+       x2="49.569252"
+       y2="40.099323"
+       gradientTransform="matrix(1,0,0,1.0179005,6.5979291,-9.4754449)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0"
+         id="stop4908" />
+      <stop
+         id="stop4948"
+         offset="0.28205132"
+         style="stop-color:#d3b573;stop-opacity:1" />
+      <stop
+         id="stop4946"
+         offset="0.8623212"
+         style="stop-color:#fde29e;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop4910" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4950"
+       id="linearGradient4956-9"
+       x1="60.342896"
+       y1="74.470169"
+       x2="60.805737"
+       y2="44.682102"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0179005,6.5979291,-9.4754449)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4950">
+      <stop
+         style="stop-color:#6a5148;stop-opacity:1;"
+         offset="0"
+         id="stop4952" />
+      <stop
+         style="stop-color:#978379;stop-opacity:1"
+         offset="1"
+         id="stop4954" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2">
+      <stop
+         id="stop11150-4-72-3-9-7"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10507">
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="0"
+         id="stop10509" />
+      <stop
+         id="stop10511"
+         offset="0.18181793"
+         style="stop-color:#9e7058;stop-opacity:1" />
+      <stop
+         id="stop10513"
+         offset="0.36363617"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10515"
+         offset="0.49999985"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10517"
+         offset="0.63636351"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e7058;stop-opacity:1"
+         offset="0.81818175"
+         id="stop10519" />
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="1"
+         id="stop10522" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5309"
+       x="-0.4128"
+       width="1.8256"
+       y="-0.688"
+       height="2.376">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.58"
+         id="feGaussianBlur5311" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4456"
+       id="linearGradient4462"
+       x1="63.734764"
+       y1="1039.3618"
+       x2="61.727211"
+       y2="1006.3618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,-0.72750163,1,733.40264,2.0004)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4456">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.659"
+         offset="0"
+         id="stop4458" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.369"
+         offset="1"
+         id="stop4460" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4606"
+       x="-0.062976152"
+       width="1.1259522"
+       y="-0.10879012"
+       height="1.2175802">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.5412116"
+         id="feGaussianBlur4608" />
+    </filter>
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2-8">
+      <stop
+         id="stop11150-4-72-3-9-7-2"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad6e48;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4368">
+      <stop
+         id="stop4370"
+         offset="0"
+         style="stop-color:#9c7561;stop-opacity:1" />
+      <stop
+         style="stop-color:#966d59;stop-opacity:1"
+         offset="0.18181793"
+         id="stop4372" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.36363617"
+         id="stop4374" />
+      <stop
+         style="stop-color:#794f40;stop-opacity:1"
+         offset="0.49999985"
+         id="stop4376" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.63636351"
+         id="stop4378" />
+      <stop
+         id="stop4380"
+         offset="0.81818175"
+         style="stop-color:#966d59;stop-opacity:1" />
+      <stop
+         id="stop4382"
+         offset="1"
+         style="stop-color:#99705c;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       height="1.2013515"
+       y="-0.10067577"
+       width="1.2017672"
+       x="-0.1"
+       id="filter4285-9-8"
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur4287-9-5"
+         stdDeviation="0.10000000000000001"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4496"
+       id="linearGradient4494"
+       x1="8"
+       y1="1013.3622"
+       x2="19"
+       y2="1024.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.88619287,-0.87964908,0,958.46329,1027.5815)" />
+    <linearGradient
+       id="linearGradient4496"
+       inkscape:collect="always">
+      <stop
+         id="stop4498"
+         offset="0"
+         style="stop-color:#6885b2;stop-opacity:1" />
+      <stop
+         style="stop-color:#5777a7;stop-opacity:1"
+         offset="0.54585904"
+         id="stop4512" />
+      <stop
+         style="stop-color:#355286;stop-opacity:1"
+         offset="0.63636416"
+         id="stop4500" />
+      <stop
+         id="stop4502"
+         offset="1"
+         style="stop-color:#2c4a81;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4504"
+       id="linearGradient4510"
+       x1="3.2928932"
+       y1="1020.7158"
+       x2="20"
+       y2="1020.7158"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.88619287,-0.87964908,0,958.46329,1027.5815)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4504">
+      <stop
+         style="stop-color:#b0c1db;stop-opacity:1"
+         offset="0"
+         id="stop4506" />
+      <stop
+         style="stop-color:#8299c2;stop-opacity:1"
+         offset="1"
+         id="stop4508" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#3e3e3e"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.106667"
+     inkscape:cx="75"
+     inkscape:cy="33"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline">
+    <image
+       y="0"
+       x="75"
+       id="image6232"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAACXBIWXMAAAsTAAALEwEAmpwYAAAK
+TWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQ
+WaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec
+5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28A
+AgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0
+ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaO
+WJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHi
+wmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryM
+AgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0l
+YqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHi
+NLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYA
+QH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6c
+wR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBie
+whi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1c
+QPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqO
+Y4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hM
+WEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgoh
+JZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSU
+Eko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/p
+dLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Y
+b1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7O
+UndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsb
+di97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W
+7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83
+MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxr
+PGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW
+2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1
+U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd
+8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H0
+8PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+H
+vqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsG
+Lww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjg
+R2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4
+qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWY
+EpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1Ir
+eZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/Pb
+FWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYj
+i1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVk
+Ve9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0Ibw
+Da0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vz
+DoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+y
+CW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawt
+o22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtd
+UV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3r
+O9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0
+/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv95
+63Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+
+UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMA
+APn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAANRUlEQVR42uyba4xd1XXHf+ucc++dO++HjV8Y
+G2zygNIARkCoghwUSFJFLbQItQ1qK9oqatWoimrRSvnAl1SVUkt86BdI2tKmiVSUKqQ0iRKaCpJC
+wQQwxsaAbezxjD3jsT3Pe+fee87Ze61+uI954BnP056abOnMPvuec/eZ/bv/tfZee+8j/DJdMH39
+306HZjSZWYcZbUA++iWWGYAyQN6MdlVrMSM//fqHHtbj/z4QmtGiRpOq5U2tRY3she790ML6+2cG
+86o0m1nWIMSsDbPcfN/5UMF64tkzgRo5M2szIxQBM5oxawXkYt//0MD6xg+G2tSsWSAwA6pqahfI
+ygLruOJh/eOPhvJqVJUEWFVCeYM2AbFF1HXFwvrnn5zNmtFuZhmxKiSqoNoQmqd/9qGF9e3/Oheq
+WbsZTbNgiAidQNZsaXVfUbC+89NzLWa0CgQzeAhRIHSYEtky6r8iYD39/PlMTU1ZgFnKiQKh22xx
+/umKhPXdF863qNEqSGCzvJBAJCLdZrZsUP+vYX3vf4YDVboMy17IWUvV9LrVELOVeeayYD25p+dm
+4HFg91LryObbScoTvcBXvrR3+PsL+c73XxxuUqNDpDFmmu3JIxG6TZHF93lzJ1kGqO3A/k/+xt90
+3vSpL81xV+0fVY+hYIpHq2MdM6R2fWTwbX7+3T0MD77zwMWA/cdLI+0GLaaGGqgZpjTOMSJqPkq1
++pnW752e68yyr+Vm1boulIJlgH5q132PTgNlmCaYL2FuAnPjaDqKpiOoH8d8AdNJAi0TapnAKojF
+iMX0bNzJ3Q/+Lbl8+1NP7unpvNDDfvjKSPCfL4/0iNAyzy8fhYF0yzJEMF8Klqiq3W1d1+zede+j
+YB5NR/HJEOpGUD+BagnVMmYJZumCju6NO7nl03/aCTw1+3k/2jeaAVkvXHg2oOajwjCUbmR1QC1H
+WY/tuu9RzE/ikwFMi2Dpso8b7/odNl172/1P7um5v/6gH786mhdh3bz/qyBhQOdqKWpRDv6Jv+y5
+WYR6Azqy+Y7dOz/xGVzpKOod5n0tdzNy9Q5TXztP8d7harmfkU+dt3ZuBHjqyT09NwdRS+7Us3dk
+uEhoIlFbMxIEQX7rey23f+P5ywrLO318y847d2/eeSc+Psu6zTfhy0eqUFyCpinqEnyaNMreJWia
+NHLnElwak7qYNI1xrn6eVM9r11QdW6+/o7Nrw7WPLbYxb7zwdKEFLi+sJFY2bLudXff8CenksVoH
+5wEhiHIEUe6yjrms2gvyyo+/3XbZzTCJPd4pqKseayypetQrSexXumoxIzKzCJCFwapoFZYp2NqD
+Zd7jUkdS0WVUgqiRUbXIjIwZ0exx6ILNMIqygK5JZYl5XBKTxLoINlU4zltG1TJeidSqg9K5wqMF
+m2Fpsrx2laUO5+KLmqEZoVcy3lvWe7L1EftCY8cFK6thhroWzdDh0uSCyjJDvJLz3nJeLaOLgLMk
+WC5VvDfUFbCLwDr85gscfvNnIILIssLPRadd99xA+vKn908PfKM5Gqlhx4Hz25/es0qzDoZpfFEz
+PHLoJe59+J/YsO32RXb9hvkKWh7CzDA1zBRVxVTx8TiajKOqqPd4X8udx3mPmiFWQrQ8R5dZRtIB
+0jThldd+jmu64bnVnaK5iBn2HjtA18ab2LDtdiwZR9NxtHiyZioxWhmaqiqpNn4xcVkwVwsW3Ir1
+vHv0EEhYLPV88X9XEZaB+XmVdfCN57nlM1/FknFKR74JPl5Tvi1NE94/8S4ut/MZl7u+OOdczMrA
+mltZJ469hQTN7Lz5tygf+xfMldZYLwDHTrxH6rRY2vzl763+TOk8yjr4+gvc+tnHSEfexBVOrL0e
+04y+0734pp3PuKbri+hqwjLDKkOg6Qcuneo7SpIqWz9yN/Gxb1ahrqlwCPoH+iiXS8RbHvjJqsaG
+F1PWOwf3ccNdj8D4QXSNmV91mlg58v67aHbzc0n7PUOL9VVL9FkfDKSHBvs5M3CSe//wQSpHn1hz
+fsqr0j9winKlTLzlL7616rMO8ynrzddf5CO7HkJH9q0583O+ulhx7MRRNLv5ubTjnqHlLPYsTlnq
+ZyhrZPgcA6f72P3FPybp+9c1Bcp7w3tleGyUSlwhufoPvrXcOqPFCas0Q1kHD7zOths+TzR5mMR0
+7VifGqnzmBrvnzyORR0HXOfSfdXSwp3KuUapUJjg3cOHeeDP/prk3H+vKYeepB6vxvDoKOMTY/h1
+v70isl/U0GG6ql59ZR/dm36FnqYJ4sLaUVWSepxTvBon+vsg0304d80jvRlLOkwNrUdtVlVgdRZi
+KvcmmnrxiQ+SxItbuoOv+auJiQJvH3qPzz38NSpnX147Dt0pSeLwCoVikUJxgvz2R57Lhul6rf/e
+NSiNcxplc4r3KmkSSBKKBd7CklfRpZlhTVlvvP4WbV1buW5rB/HZtdEDejUqsatOJZlxemiQKNc9
+1LH518cMt8GsNvphChJW3XfjFedV0kCknII4FedUvM7afLNoZcVxwsG3jvCp3/wKlaGX1kwoUyo7
+vK+a32Spwvnhc3Rsf+jtKNCrMDCZgtXwKmbOm8SIxAQmqUolUYnH42islAbx0n2Wr4AKv3j1EEoT
+O7a1YYXLryoDJktpw095NfpO9xNm2ko92x4aNnR9ff6xPkNqhpqQOpWiGM5AEx8UxuLozEgpGnPT
+TG9JsLRylkq5jVf3HeaOzz8CE2+tCdMrVRxp1dmgahTLMSNj59n40T86FYpuqANtRD4QK5TNJDVI
+Uw3GJuJwMJGgJd9st/lJeW5FesN9+w7jvPGrN16NFUYvfUBc2z7k1UhTxXnDa23KWw2nxpmhQbK5
+btdzzRcU7Kp61IMRqxCbSUVNSokPBifTcGCkkj1NyLrutvRrlSR4ZoXGWcr+/ce59c47oXQEW8XQ
+xuqhKNV9VGbWCF2mgIHWQHk1vDfiJGV07DxX7XjQB2IbAGdGDDKpUFST4USD02UXnpqIM33D5cy5
+fJO/prst/bpA64qNs44dO8PwcJGPXteMpcUVh2NW73GrkMxogPogpDogxSsNxz5w5gxBmGP99vuz
+ggWGFAzK3mTQaXC64oO+YprpG6lkBiaTqNyWT67rakv3piqtSZwAmaXBeu2lAwK0AFueffxzHb3v
+7Gfb9vWMjRYZHy02Fm1k2uKNTCs0TmVaVvvwQos+Nq1ns1ljosaAcfpOPqWhqHo+OjrElo/9HmGm
+RRUZUZNTToO+RIO+sotOlix/Jgmyk0SadmTiHR0t6d+ZBK0nz0/SHjoymWBxsF576UAIXAV8DLgB
++PjWG7/QNPrCP9B74iwne88hQRVMUMsXX64ukwW1XAIhqOUXLdfrqC+1Vf8gImQyrbbu2vsnvQUD
+3qQ31fBkRcOThSR78uqrf9HR5u5uVss1YZNXB/T91XBhS0uJHKPn+smvawX8opXVBmwGuoEmIL3l
+vj9/49bPfnmgprTpmhDkwvsl5ljIFBGZuXHfZgx7555KW5CPk7KanHUaDMYa9ZVcZmA8zQw5i9JC
++V77+LaxuypxrimOK7/be/aafDnKMdg/RLkckyRN2BJgTQCHgCPUVp86enpaM0251sZeAMBMQgnD
+LjWT+mdVH1M76nGYTW1qjUJpliDI1zfG1v3SVLxWv9cadc24b1pdqlW0szfgmkHqxSUaJF7FzJQo
+IAwEKVW6Mvmc/f5osSWqhEKpEHPq1BmSOCFO3OJh3fZrn1Agrh2MTKQZg2YzJqbt7s2rWV6VST+r
+AVpfBNIqwbrPCQyJMpJTY1K0uivDqq2twpW6M6/BYlqdgEp1elihdkztVtZZz1f7oEZVk61JMvlw
+sdwcSRYSZxw/3k+xWMarUkkcIm7eLm/e3nCs6AIz65puUma0GnPvGJ4rZULJy6Vcy5+WwqCyPRP2
+f7V3aFO+iJHNOCql0/Qe76+BVOLYEQSeKFr60KEdCKeBaoeZL1kvJAlIGErezC45qFwU78iF5b2n
+zudbziYhSTzBwf2H6Dt+hPau9eRy2eqwPnFEkSfKLwHW+KRrwsjbMkEBZKIgL4gYlxZWNqjsyEhp
+73hZW4+N5jj5/tuceO8olckCpsrEeD9Xbd5IJpslThyZjJ+3gReEVSi5wIyOWtPEjG6W+OqKgESB
+5PUSiyqivCOguHek4FpffPsMRw4epDQxQRhlqv1ubYPJ6b5+1m/aRJw4stnF94aI0GFGYMsEVVcV
+0njz5JKkwEo70OLeYjlt/enPDjAyfJ7WrNC6vhMIah2Jr+7CUSUuFkkSR5IuEtZkxbeY0QQmLBPU
+lK+6lFMRkzvUFfamzreqGrs/eSOp86SpJ3VKmnoS53GpJ3E641qSuoXDKsc+VKMVbNmKavgqWblX
+2BbW9bW8jzQ/EEYgWciY1oYj87/oNH2cNqdiZ5U7gXAlQIkgUSh5rqDUgFVJfB7IVU1Plv3SZl1V
+VxysJNVAkM6VUNSVqqopZQldBj3IyrwGHIWSu1yj9VWF5bw2AZtWClQttGnmCkwBcK2s4IvlmUCy
+IhJcibD+bwAbQ2m7eQUFSAAAAABJRU5ErkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66"
+       width="75" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <path
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient4462);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4606)"
+       d="m 47.000294,1007.3622 -12.319149,16.9335 -12.416197,17.0669 16.933329,0 17.066666,0 12.416197,-17.0669 0.09676,-0.133 12.2221,-16.8001 -17.066666,0 -16.933329,0 z"
+       id="rect10961-8-3-6-1"
+       inkscape:connector-curvature="0"
+       transform="matrix(1.2008267,0,0.09173299,0.36603268,-111.57532,655.98864)"
+       inkscape:transform-center-x="4.4580006"
+       inkscape:transform-center-y="0.53407962" />
+    <g
+       id="g4451"
+       transform="translate(-1.786201,-7.0000016)">
+      <g
+         transform="translate(0,986.3622)"
+         id="g5348">
+        <path
+           style="fill:#fffabf;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4205);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 14.403025,25.481913 3.760593,-4.964217 16.536826,0 3.904565,4.964217 z"
+           id="path5250"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <rect
+           style="opacity:1;fill:url(#linearGradient4884);fill-opacity:1;stroke:url(#linearGradient5258);stroke-width:1;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4876"
+           width="41.860409"
+           height="31"
+           x="11.639588"
+           y="25.5"
+           ry="2.0792062" />
+        <ellipse
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5309)"
+           id="path5111"
+           cx="23.691999"
+           cy="8.3080006"
+           rx="7.5"
+           ry="4.5"
+           transform="matrix(1,0,0,0.38855855,-0.99999923,21.926323)" />
+      </g>
+      <rect
+         ry="1.8222821"
+         y="37.009739"
+         x="42.799835"
+         height="27.408155"
+         width="41.81472"
+         id="rect4932"
+         style="opacity:1;fill:url(#linearGradient4936);fill-opacity:1;stroke:url(#linearGradient4956-9);stroke-width:1.06747472;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         transform="matrix(1,0,-0.47943731,0.87757613,0,986.3622)" />
+    </g>
+    <path
+       style="display:inline;fill:url(#linearGradient4494);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4510);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 67.5,1031.5694 0,13.2928 -13.194799,0 z"
+       id="path4478"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4285-9-8)"
+       id="path4252-6-0"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="0.49178758"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="-3.0800218"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.9823895,-2.1047 -1.6734053,-2.5419 2.1987064,2.0209 2.4513363,-1.6427 -2.0383649,2.1623 1.7419712,2.4882 -2.2030799,-2.0431 z"
+       transform="matrix(-1.2284231,-0.68431401,0.87657521,-1.0636666,-845.15504,2148.9138)"
+       inkscape:transform-center-x="0.33382923"
+       inkscape:transform-center-y="-0.1625483" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/wizban/importpref_wiz.svg
+++ b/bundles/org.eclipse.ui/icons/full/wizban/importpref_wiz.svg
@@ -1,0 +1,1192 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="importpref_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4505"
+       inkscape:collect="always">
+      <stop
+         id="stop4507"
+         offset="0"
+         style="stop-color:#8c9aaf;stop-opacity:1" />
+      <stop
+         id="stop4509"
+         offset="1"
+         style="stop-color:#94a1b5;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4354">
+      <stop
+         style="stop-color:#abacbe;stop-opacity:0.91764706"
+         offset="0"
+         id="stop4356" />
+      <stop
+         style="stop-color:#adadbe;stop-opacity:0.89803922"
+         offset="1"
+         id="stop4358" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4324"
+       inkscape:collect="always">
+      <stop
+         id="stop4326"
+         offset="0"
+         style="stop-color:#94a3b0;stop-opacity:1" />
+      <stop
+         id="stop4328"
+         offset="1"
+         style="stop-color:#c0c8d3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5996">
+      <stop
+         style="stop-color:#dce3eb;stop-opacity:1"
+         offset="0"
+         id="stop5998" />
+      <stop
+         style="stop-color:#a2afc0;stop-opacity:1"
+         offset="1"
+         id="stop6000" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4541">
+      <stop
+         style="stop-color:#a1adb2;stop-opacity:1"
+         offset="0"
+         id="stop4543" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient5885"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2">
+      <stop
+         id="stop11150-4-72-3-9-7"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10507">
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="0"
+         id="stop10509" />
+      <stop
+         id="stop10511"
+         offset="0.18181793"
+         style="stop-color:#9e7058;stop-opacity:1" />
+      <stop
+         id="stop10513"
+         offset="0.36363617"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10515"
+         offset="0.49999985"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10517"
+         offset="0.63636351"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e7058;stop-opacity:1"
+         offset="0.81818175"
+         id="stop10519" />
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="1"
+         id="stop10522" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4456"
+       id="linearGradient4462"
+       x1="63.734764"
+       y1="1039.3618"
+       x2="61.727211"
+       y2="1006.3618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,-0.72750163,1,733.40264,2.0004)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4456">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.659"
+         offset="0"
+         id="stop4458" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.369"
+         offset="1"
+         id="stop4460" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4606"
+       x="-0.062976152"
+       width="1.1259522"
+       y="-0.10879012"
+       height="1.2175802">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.5412116"
+         id="feGaussianBlur4608" />
+    </filter>
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2-8">
+      <stop
+         id="stop11150-4-72-3-9-7-2"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad6e48;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4368">
+      <stop
+         id="stop4370"
+         offset="0"
+         style="stop-color:#9c7561;stop-opacity:1" />
+      <stop
+         style="stop-color:#966d59;stop-opacity:1"
+         offset="0.18181793"
+         id="stop4372" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.36363617"
+         id="stop4374" />
+      <stop
+         style="stop-color:#794f40;stop-opacity:1"
+         offset="0.49999985"
+         id="stop4376" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.63636351"
+         id="stop4378" />
+      <stop
+         id="stop4380"
+         offset="0.81818175"
+         style="stop-color:#966d59;stop-opacity:1" />
+      <stop
+         id="stop4382"
+         offset="1"
+         style="stop-color:#99705c;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       height="1.2013515"
+       y="-0.10067577"
+       width="1.2017672"
+       x="-0.1"
+       id="filter4285-9-8"
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur4287-9-5"
+         stdDeviation="0.10000000000000001"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4496"
+       id="linearGradient4494"
+       x1="8"
+       y1="1013.3622"
+       x2="19"
+       y2="1024.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.88619287,-0.87964908,0,950.46325,1024.5815)" />
+    <linearGradient
+       id="linearGradient4496"
+       inkscape:collect="always">
+      <stop
+         id="stop4498"
+         offset="0"
+         style="stop-color:#6885b2;stop-opacity:1" />
+      <stop
+         style="stop-color:#5777a7;stop-opacity:1"
+         offset="0.54585904"
+         id="stop4512" />
+      <stop
+         style="stop-color:#355286;stop-opacity:1"
+         offset="0.63636416"
+         id="stop4500" />
+      <stop
+         id="stop4502"
+         offset="1"
+         style="stop-color:#2c4a81;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4504"
+       id="linearGradient4510"
+       x1="3.2928932"
+       y1="1020.7158"
+       x2="20"
+       y2="1020.7158"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.88619287,-0.87964908,0,950.46325,1024.5815)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4504">
+      <stop
+         style="stop-color:#b0c1db;stop-opacity:1"
+         offset="0"
+         id="stop4506" />
+      <stop
+         style="stop-color:#8299c2;stop-opacity:1"
+         offset="1"
+         id="stop4508" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5898"
+       id="linearGradient5892"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.15789444,0.33751306,0,-333.66664,1009.8359)"
+       x1="41"
+       y1="1007.8622"
+       x2="59.944244"
+       y2="1007.8496" />
+    <linearGradient
+       id="linearGradient5898"
+       inkscape:collect="always">
+      <stop
+         id="stop5900"
+         offset="0"
+         style="stop-color:#8c9aaf;stop-opacity:1" />
+      <stop
+         id="stop5902"
+         offset="1"
+         style="stop-color:#bbc5d3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5904"
+       id="linearGradient5890"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.2631579,0,0,-1.0587443,141.78945,2072.9292)"
+       x1="41"
+       y1="1007.8622"
+       x2="60.03624"
+       y2="1007.8358" />
+    <linearGradient
+       id="linearGradient5904"
+       inkscape:collect="always">
+      <stop
+         id="stop5906"
+         offset="0"
+         style="stop-color:#e1f6ff;stop-opacity:1" />
+      <stop
+         id="stop5908"
+         offset="1"
+         style="stop-color:#94a3b0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4324"
+       id="linearGradient4547-0"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.6842127,-2.2065442,0,2230.3926,936.30811)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4505"
+       id="linearGradient4547"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1007.6132"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6315788,0,0,2.0086335,-101.89473,-1020.5635)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4238"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.0834671,0,0,2.9600477,-22.445255,-2075.3398)"
+       x1="10.632975"
+       y1="1039.059"
+       x2="10.632975"
+       y2="1051.5835" />
+    <linearGradient
+       id="linearGradient4902"
+       inkscape:collect="always">
+      <stop
+         id="stop4904"
+         offset="0"
+         style="stop-color:#97a3b6;stop-opacity:1" />
+      <stop
+         id="stop4906"
+         offset="1"
+         style="stop-color:#5c6d8a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient6375-6"
+       x1="50.702839"
+       y1="1052.4476"
+       x2="19.083021"
+       y2="1011.338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4450407,0,0,0.75896453,-20.35623,237.9306)" />
+    <linearGradient
+       id="linearGradient4994"
+       inkscape:collect="always">
+      <stop
+         id="stop4996"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop4998"
+         offset="1"
+         style="stop-color:#d2f1ff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5996"
+       id="linearGradient6002"
+       x1="66"
+       y1="998.36218"
+       x2="116"
+       y2="1002.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-59.999999,1.998533)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4354"
+       id="linearGradient5890-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.5789472,0,0,-1.206476,162.7368,2254.8239)"
+       x1="41"
+       y1="1007.8622"
+       x2="60.03624"
+       y2="1007.8358" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#3e3e3e"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.978723"
+     inkscape:cx="74.976706"
+     inkscape:cy="19"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline">
+    <image
+       y="0"
+       x="75"
+       id="image4589"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAACXBIWXMAAAsTAAALEwEAmpwYAAAK
+TWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQ
+WaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec
+5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28A
+AgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0
+ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaO
+WJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHi
+wmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryM
+AgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0l
+YqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHi
+NLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYA
+QH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6c
+wR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBie
+whi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1c
+QPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqO
+Y4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hM
+WEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgoh
+JZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSU
+Eko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/p
+dLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Y
+b1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7O
+UndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsb
+di97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W
+7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83
+MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxr
+PGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW
+2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1
+U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd
+8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H0
+8PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+H
+vqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsG
+Lww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjg
+R2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4
+qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWY
+EpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1Ir
+eZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/Pb
+FWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYj
+i1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVk
+Ve9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0Ibw
+Da0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vz
+DoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+y
+CW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawt
+o22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtd
+UV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3r
+O9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0
+/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv95
+63Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+
+UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMA
+APn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAALf0lEQVR42uybW48kyVWAvxORWV336Z6Z3tmZ
+ZfYizBNaI0sIreSnFbBY/ADECxISv4H/gHjhwX5ASEhYsiXAFpYsyxJehEGAENLgla01xqvFu7Mz
+NdP36ktVZeUl4vCQlVVZ1VU9XT19me1xtKojqzIyKuOrc06ccyJS+GWZW/78bztWlaqq3lClBdSC
+X2KZAhQCNVXa3mtDlVr5/EsP6y++/cSq0vBK1XutqdeGVyrz2r60sL76nac176mrakXBotpCdeWk
+a14qWH/53Q3jlRVVbaliRUCVOqpNQJ51/UsD66++t9nyqnUBowrk0tQWqMgp+7j2sP76+5s1r+SS
+BGguQjWFloDoEn1dW1h/849bFVXaqhqK5pDIQbUQ6uXPXlpY33h/23rVtirVGRgiwipQUT1b39cK
+1jf/abuhSlPATPEQAiPcUE+gz9H/tYD1dz/cCUfSVAGYkZzACDdVl7NP1xLWt/5lp+GVpiBGZ6yQ
+QCAiN1X1uUF9rmH9w7/tGu9ZU7Qyz1hLrno3vSKq5/Odc2F9/dv//GYUDT9QWH1RYW1++l/PbCPI
+UW31zT8kuPnkwmDdu7v+x8CqtYbqSgWR5To1owt88ZOWftnjP7JO/s+RAJ0xQuMjLSmdTvWCKqRp
+BtDKVN7dOOKbFwarGGSztsKttfZ48Kct1UqAKkRxghaDGg1IVQFlVKHjYx2f1zEPHVP0OtG14v6m
++9ZxewUy53DO471vnZc0z4X1+MkWAOs3VwmDAGtOD0sV0moFVehHQ1SLQeWjyAedD8wXkEbni7bF
+4AtAWrQZQfJ+0t/4HOV2cHjUJ80yxKwgjVsXB6vzZBuAre0uO3sHBNYu1WkYBiiQpmlJgyYqUlay
+8nstScx0Pd12IlHTdQE6c47Do35+L5UGr751CZIF8MnD5W3j+q01ALZ3u1c+EdQa7YuF9WtfuE8Y
+CKurITYICGyADQKstZPaBtjAYq3FmFFtLdYYKhgy5+kOY+7cXsNagxiDGb3EGIwIYgyCIMWxSG4f
+RzZSZuply88++BE//WiLC7VZxQ3aIODea/ep1eujARrESD5gKer8s3yg+XF61EdxNJpNGs1mDmP0
+Ynw8mtxF8kRSqS7fw4tUToQV2IA7d+9xY3U5d+sgivEK9Wqder3+eQ4QRJVAVQNAToYVBBgjS/tZ
+SP4qadSLXxTxSui9BqqEqgTMZE8XhzsiBIHNbcvSrPI/AHlh2eRwMqeh9xo6T+C1cF+WcUq9stpq
+cWv1Nr29A4aH/VxSpmxLgaWwPWPGZGkGXpHhgO5mMvGwp7zu2em/5IXPtj/mrc9pM/VZ3qbbHaB+
+yge0zhM6pxXnqHh/MpxTevCewXBIbzAgqI6WznRGUpQStCL/MSLqR99uA1K/YLDj9zIzWCn5ZaNz
+o19CdfKl42vG5yb3MomyFK8e56k6pyvOa+iXgHMqWOqVfhSRuoRGu0mj0Viq00F3H+c9UqnQrFev
+TNV2NjuAqXuvzQtL0XivBNbSatRp1as0lhxwfGBwziNA6wphhYHFez23/haqIQqBPZuB17ESXbGB
+L8WTFwZLfW5VbGBzk7D0iHWSTJErZXXxsAo1tGJJ4xQhGo9aTgHAO58DzzLiaHgiUz0h04Uuzn8d
+D8qPB+hxkl2OGrYadbwzbG/sjCY5mannhCQycSYA0n6fjX5vOvlXZBBm3IDZbMNxt0IXug3ltE65
+3utGl6OGO90DfiVZ58baGmEYMk+nhLkfkwwiACr12lyh0IWqe5JEzcmQLlC94uqN7a1LUENVjAjr
+t9usr9+isrKyVKedRxskaYYNAl5dX70ym/X44S/wenjxNktRrLGTrMAZDPzVz4ZchhrmroO1BiNn
+nwyvGpaqov4S1FCBwJpS7uksCY4rzjqoTlaYLlINV8KQXj8my/axszn4mVlvtiRJivOeeBCxs32C
+OdcFjkHJSE8vkemxJTOdmTXK/R724ssw8B4Q+v2Y4TCbZDhnUjiLcLnM5a5DktJN0meCOvZ+FobO
+a6PH4E4dKwyi9OIlS71ycHREu12j3mgel6xnlN3tLl6VG2ttKuHV7RB43Hl0CTbLK5Uw5PZqi3qj
+sTSsg+4BSZohwO3V5pXBqlbCy1FDVc0XJPj8zoagiBBUbVbzCrV68m5vUPmhN4r3uQb5wlUaLQAv
+nSktRNcWS1Zyltu8+hy8qhIaabTD5I5a/45Y/ZNgJf4fr6Ce0ko2pZXz4yHG6Lf3i51S1fFixfIp
+mhfDKRUTEloaNnC/6wx/AFCz7hVVRS1TUuQVNzVpTEEX55R0oZ9Vr9X4yc8+m4n/5Fg8eNKyRKez
+TaezzZyJfiZO1JmY8Hg+nZnjeUv6zATdDx/v0mi333aGV4app2KFinXrk2vmz6w6lhnJvBI7T+JV
+3EIPfjCIaDVr4wVVeYbzWS79fp6WaTSqC2PlhWH0jMHQ4w7YHOATUIXaq8Lrr9/HVJqvRFR4+HST
+N15pElZ1DKscsJdAOVUyrxKDRl4l8Spp7ExvoWQlacprr64RBMHSK8OffraFc54b7QatxuWklYUE
+azbw+gYAewe7NA8zDn2d/f2IaDAgTqoENXNHZQ4sJVMhdZ5BvoRIlnkZDFK7fRjb7b0o7C60WdYa
+2o0agbVLwzJWyFxus9qXloOvAhUER28AW3sRPV4j8oZHDzvgHMM4w0h4q6wRuRSRIDLwSuyRKPWy
+O0jtxkFsN/eicHeYmWTxbDjKwduR+p3JdeAqXIcq0TCiezRkP2mRIjx9usnhYY+VMCBOMqwEd0a3
+l6gyVKSnMMy87CVONgep2TgYBp3dKNyNMhOfLkWjOt7wIWd0tC7bddg9OGBj54jM1JAQ+vsxH3/0
+CVnmUe+JkwwRbaG5FDmVvczLZuLM00FqH+/H9snuINwZpNOQFsJ68B8/lq99633bHwz5+cePMGKW
+Fo9HnS2SNGMwiDg8OLoUUCa0bO51eNK7i7MZ9bDL/33codeLcp9PQ4ZxhlfpepXN1MvTxJlOlNnO
+wdB2dqLK9iCV+CSHPyhBMsA94MtfuP/qe//76RP+7Gt/f+abz7IM5xwrS2ZZz1Luv36fL33p19mI
+1nDWs7v9lB8/+AlH3Yes3n5jvB8sTjJSbz5MnHkUZbZzGAeP94bh9iAxsVOe+TRPWbLuA78HvPuV
+d94efOWdt/91nF8QCaenHjGcYg+9Hn94JpzrQejJnsXsVsvyu6PM3NuK5PYv9oWN/T4/ffDv7Gxs
+4LMU9Z7Do8+489pdAmMZxhlHafifR0nwpDusbBWQ9JSPPJUHvAV8H3gfMPmsZky91VoTEVv4IWKD
+uhhTUxT14EtT8GRT7fFQwlpTE2NqvhxajOKxyTX5Nomibx2nuEfXjGK5os9+HP1OP06++GGnx39/
+8HOePvwE9Yq1Qd7We7Io5fGnj3jzV98iTjIe9poPkkyyPBm8XJA9hvWbX/6NCHhcPrnfy1ZVtVcM
+0DlteyXyxW5jn3twxSC9zweuvnScn5dKaG6qqjgF7yfBK8VOFj8CN1WDFx31DV58fgwMor33kjj+
+o48+2+VHDz4kjYd5hkMMIHjv8d7h8+3dRIdHxLduknmTLf/w3AmzIcBBP6ui1EpOWxuoneVLwsDU
+BBHlfNIl/d7ue3Ec/WmaOe7dbvL7v/1bpJkjTR1p5klTR5K50Wd+fG4YZ+efojkaZEaVG4W7pMpN
+zvicj4AERmrnmIOj0bz1g1pdf+B1Rgq9ztS5zzh7/swz7twBCjfIn9l7LlCFVCF8XjZLLgerP3QN
+kCr5jrHnAiUg1kqNa1KmYEWxs0AT9LklamyrrolUzZOsVcCeBygRJLhGUjUFa5i4GrCSq54895LM
+dZOqMawk9UaQ1fOQqOsqVRPJEtYUbiHn8xhwYGVFuF5SBWAy56vA3fMCBRBaqXMNiwHeknN8sDw0
+UpE80L525f8HANetZkEck85wAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66"
+       width="75" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <path
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient4462);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4606)"
+       d="m 47.000294,1007.3622 -12.319149,16.9335 -12.416197,17.0669 16.933329,0 17.066666,0 12.416197,-17.0669 0.09676,-0.133 12.2221,-16.8001 -17.066666,0 -16.933329,0 z"
+       id="rect10961-8-3-6-1"
+       inkscape:connector-curvature="0"
+       transform="matrix(1.3333201,0,0.10185437,0.36603268,-132.37483,658.98864)"
+       inkscape:transform-center-x="4.9498669"
+       inkscape:transform-center-y="0.53407962" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4"
+       d="m 6.000001,1004.3607 50,3e-4 c 0,0 -0.0819,17.5112 0,33.0364 l -50,0 z"
+       style="display:inline;fill:url(#linearGradient6375-6);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-1"
+       d="m 5.5,999.86459 c 22.26316,0.10612 51.000001,0 51.000001,0 l 0,37.99601 -51.000001,0 z"
+       style="display:inline;fill:none;stroke:url(#linearGradient4238);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-1-6"
+       d="m 6.000001,1000.3607 50,1e-4 c 0,0 -0.0819,2.1202 0,3.9999 l -50,0 z"
+       style="display:inline;fill:url(#linearGradient6002);fill-opacity:1;stroke:none" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient4547);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 6.000002,1003.8622 50,0"
+       id="path4539"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient4547-0);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 6.5,1005.3607 0,32"
+       id="path4539-4"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient5890);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 49.000001,1005.8607 -43.000002,0"
+       id="path4539-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient5892);stroke-width:1.00000012px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 6.500002,1003.3622 0,-3"
+       id="path4539-4-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#677792;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 6.000001,1004.8607 50,0"
+       id="path5950"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:0.65100002;fill:none;fill-rule:evenodd;stroke:#c9cdd1;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 22.000001,1037.3607 0,-32"
+       id="path5960"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:0.65100002;fill:none;fill-rule:evenodd;stroke:#c9cdd1;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.000003,1011.3607 49.999998,0"
+       id="path5962"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:0.65100002;fill:none;fill-rule:evenodd;stroke:#c9cdd1;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.000003,1018.3607 49.999998,0"
+       id="path5962-8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:0.65100002;fill:none;fill-rule:evenodd;stroke:#c9cdd1;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.000003,1025.3607 49.999998,0"
+       id="path5962-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:0.65100002;fill:none;fill-rule:evenodd;stroke:#c9cdd1;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.000003,1031.3607 49.999998,0"
+       id="path5962-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:0.92299996;fill:none;fill-rule:evenodd;stroke:url(#linearGradient5890-8);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 57,1038.8622 -48.999998,0"
+       id="path4539-6-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:url(#linearGradient4494);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4510);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 59.5,1028.5694 0,13.2928 -13.1948,0 z"
+       id="path4478"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4285-9-8)"
+       id="path4252-6-0"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="0.49178758"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="-3.0800218"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.9823895,-2.1047 -1.6734053,-2.5419 2.1987064,2.0209 2.4513363,-1.6427 -2.0383649,2.1623 1.7419712,2.4882 -2.2030799,-2.0431 z"
+       transform="matrix(-0.68431401,1.2284231,-1.0636666,-0.87657521,1164.0558,1942.5172)"
+       inkscape:transform-center-x="0.16252253"
+       inkscape:transform-center-y="0.33382692" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/wizban/new_wiz.svg
+++ b/bundles/org.eclipse.ui/icons/full/wizban/new_wiz.svg
@@ -1,0 +1,1142 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="new_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5904"
+       inkscape:collect="always">
+      <stop
+         id="stop5906"
+         offset="0"
+         style="stop-color:#c5c6c6;stop-opacity:1" />
+      <stop
+         id="stop5908"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5898"
+       inkscape:collect="always">
+      <stop
+         id="stop5900"
+         offset="0"
+         style="stop-color:#c0c1c1;stop-opacity:1" />
+      <stop
+         id="stop5902"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4541">
+      <stop
+         style="stop-color:#a1adb2;stop-opacity:1"
+         offset="0"
+         id="stop4543" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4461">
+      <stop
+         style="stop-color:#d8d8d8;stop-opacity:1"
+         offset="0"
+         id="stop4463" />
+      <stop
+         id="stop4488"
+         offset="0.18565373"
+         style="stop-color:#848484;stop-opacity:1" />
+      <stop
+         id="stop4486"
+         offset="0.36054265"
+         style="stop-color:#848484;stop-opacity:1" />
+      <stop
+         style="stop-color:#b4b4b4;stop-opacity:1"
+         offset="1"
+         id="stop4465" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient6375-6"
+       x1="50.702839"
+       y1="1052.4476"
+       x2="19.083021"
+       y2="1011.338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1849336,0,0,0.66623436,-15.611709,341.57319)" />
+    <linearGradient
+       id="linearGradient4994"
+       inkscape:collect="always">
+      <stop
+         id="stop4996"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop4998"
+         offset="1"
+         style="stop-color:#d2f1ff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4238"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.1864665,0,0,3.1937368,-17.514189,-2315.1195)"
+       x1="10.632975"
+       y1="1039.059"
+       x2="10.632975"
+       y2="1051.5835" />
+    <linearGradient
+       id="linearGradient4902"
+       inkscape:collect="always">
+      <stop
+         id="stop4904"
+         offset="0"
+         style="stop-color:#777777;stop-opacity:0.74901962" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:0.74901962"
+         offset="0.33183977"
+         id="stop4469" />
+      <stop
+         id="stop4906"
+         offset="1"
+         style="stop-color:#939195;stop-opacity:0.93333334" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4461"
+       id="linearGradient4467"
+       x1="60.069771"
+       y1="1001.3622"
+       x2="60.069771"
+       y2="997.19556"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999996,0,0,1.2,-34.999595,-192.27331)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient4547"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3158111,0,0,1.3158111,-47.947849,-311.29488)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient4547-0"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.2632053,-1.2632053,0,1279.6373,963.56996)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient5885"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5904"
+       id="linearGradient5890"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.1052631,0,0,-1.2903226,133.31659,2343.3296)"
+       x1="41"
+       y1="1007.8622"
+       x2="60.03624"
+       y2="1007.8358" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5898"
+       id="linearGradient5892"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.3684211,2.232687,0,-2202.4505,1097.6433)"
+       x1="41"
+       y1="1007.8622"
+       x2="59.944244"
+       y2="1007.8496" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5517"
+       id="linearGradient6406"
+       gradientUnits="userSpaceOnUse"
+       x1="49.217129"
+       y1="1041.0833"
+       x2="75.020309"
+       y2="1023.2908" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4344"
+       x="-0.027383927"
+       width="1.0547678"
+       y="-0.085576579"
+       height="1.1711532">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.57051052"
+         id="feGaussianBlur4346" />
+    </filter>
+    <linearGradient
+       id="linearGradient5517"
+       inkscape:collect="always">
+      <stop
+         id="stop5519"
+         offset="0"
+         style="stop-color:#c5c3d4;stop-opacity:0.72941178" />
+      <stop
+         id="stop5521"
+         offset="1"
+         style="stop-color:#c5c3d4;stop-opacity:0.72941178" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4598"
+       x="-0.1176"
+       width="1.2352"
+       y="-0.1176"
+       height="1.2352">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.078"
+         id="feGaussianBlur4600" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4935"
+       x="-0.039507246"
+       width="1.0790145"
+       y="-0.061124867"
+       height="1.1222497">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.85979805"
+         id="feGaussianBlur4937" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4992"
+       x="-0.04937429"
+       width="1.0987486"
+       y="-0.076390972"
+       height="1.1527819">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.074535"
+         id="feGaussianBlur4994" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5052"
+       x="-0.1056"
+       width="1.2112"
+       y="-0.1056"
+       height="1.2112">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.968"
+         id="feGaussianBlur5054" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#bcbcbc"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="17.060606"
+     inkscape:cx="20.181458"
+     inkscape:cy="33"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:none"
+     sodipodi:insensitive="true">
+    <image
+       transform="translate(0,-986.3622)"
+       y="986.36218"
+       x="0"
+       id="image4427"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAACXBIWXMAAAsTAAALEwEAmpwYAAAK TWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQ WaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec 5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28A AgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0 ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaO WJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHi wmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryM AgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0l YqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHi NLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYA QH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6c wR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBie whi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1c QPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqO Y4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hM WEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgoh JZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSU Eko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/p dLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Y b1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7O UndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsb di97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W 7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83 MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxr PGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW 2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1 U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd 8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H0 8PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+H vqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsG Lww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjg R2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4 qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWY EpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1Ir eZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/Pb FWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYj i1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVk Ve9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0Ibw Da0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vz DoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+y CW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawt o22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtd UV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3r O9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0 /rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv95 63Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+ UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMA APn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAAQ8UlEQVR42uyba4wlR3XHf6equvs+5r073pe9 eFnsNUYLRjZWMMgOJChKCCThCyRWlChSFCUSsvIhXyIlnxBC+RIhRAgkURIJRB6OANsEO44AKQkm CW8sE5u1vbuz3tndec999u2qOvnQPXdmdmfx2Dsz9lq05qr6cafv7d/9n1PnVJ0Sfrptuf3ZP7xg Vamp6rgqo0Dd/RTLJkAJUFdlLEZtqlLfeP26gqWq+4BFEdGduuefP3jeqtKMSi1GrWvUZlTSrd7r riNQdWAa6AHda73fJ74wW4+RhqqmChbVUVSzn/Q/15Oy9gMHgc7LhfWXD10wUclUdVQVKwKqNFAd AeTF/t9dR6o6BNwAtFV1XkR6L+Uen3nk4mhUbQgYLY3YojomkMo27+GuI1UdBg4Arep4Zjv/+Df/ erEelVJJgJYSqiuMCrwk5+euI1UdqmAtA/teTF1/99ilVJUxVU1ES0iUoEYRGhvP8RpS1kZV7QeW KnOcrZz9pu2zj8/ZqDqmSu0yGCLCBJDqy+xLzXWkqoMVsKmqPaCqm7r4z/37XBPYL1DbjAlnDFPC 1iHBa0VZG1V1eAOouQreReDiP35tPqnUlJaQNz+jEaZUuebgzFwnqjpy8fT/vO7Udx+8qTLBaWAf cOC/n2pNAlOCXKEaAWdEpmQbYcH1rqw1VR0EDj7x8J8c77Xmajfe+q7ZWnPfAYVLq53QSRMZCKxc rhqRUlFREd2heN+8ChUlqjpRKeowcPjMU48dmxivN994+z32e1/7+M2qHCq8HjPCof3jyYGjB7KR yzy5M0amQGQnv5t9lYEaBW4C3gC8HjgGnPjyp3/trnf9yh/ayckDPPHYx0eO3v5LedaY6gD9xIob a9jGxKhDVYtOLyKGKSgVpZUPu6LVrc/D1UMK9yryT2tO/MaqPQIcefI/P3PrsdvuSkenT9JZOsfd P/shvv1vHzv6rvv/etkhYgw3OGsWUiez4w2zONF0rZm5fL7di8VOf88tZfrAAw/8tqrevNuQsixj eno6OXTo0Pj+/fvHJiYmRsfHx0ebzeZ4Yovm89/+26kzP/zigQ/8wd+Tjd1Cd+EZXKJ8/Qsfpdvp du794CfPju9//YKqLsbISl7Ebr/Q851enL207Geen80v5UWMMSpRYVMbNx+HqlWFqC8B1uc//3nd TUgiQpqm1Go1Go0GjUZj0/4zT3yKc0/9C3fd+wFufduvQ3oIsSN0554kHT2EtYHZp7/CE4/+BRMH 72y9/Vc/djGpjXcVVkLQ+SIw38/13FI7PDtzaTBzaWnQ7hcadwXWI488smuwkiShVquRZRn1en24 X6vV8P15vv7Z+zl+4m285e0fIB07Bm4MTAZi6C08Qzp6GBEQHSB+kR9/98t895sPx7vf+6fdYyd/ uR1jbEVlKQTO9wc8t9IJpxZW/bnZhWLx0tKg6yP6cmFt6bPm5uZ2TVXOOer1+lBFIyMjhBBQVRqN aW5/54f5weMfZdCa44573ocdeR2mdgM2m0QEfH8e9V0oljh36pt8+z/+idve/jvmplve0RAJYkQD 0I0imTHUnKUeI+qDhqhckwi2hHXp0iV22wyzLGNiYoKJiQnq9TrNZpOxsVEmjr6bn/vde3n+e5/j 0S9+kjfd9Yvcevf9JM0D+N48+fLTXJr5AU9953Emb7yb93/4K4xOHgGCUS0oBSL9EKXlPUvtXrx4 fiGfX2yF/q4EpbuprI3b7Ows+/btY2JigsnJSdrtFs1mk9HRUY6c/E2OvfV+/vdLD9CYPMqxNx/A GEvRu8T3v/VV3v0bn2b/kduBCBRlKyooXlX6UaUToulZi61nJoWXBUtUcarqANkS1n333cctt9yy J8CstSSJwzmHtbY6Tob7933wEzz2V+/j2G3vhNDie994iNvf8ftMHDixDolQtdGVbthEsBgjdWtI xxqmAaz+5PgFiUoSozpVElXc5T59S1iNRoMTJ07sZaR1WSvD40bj9dx692/xzLf+mX3TN9Pqem65 84OE6LuO0AAPsQsaEJsKWCdIYkTrImqdNZmz4mqp2G5fw4ZPlKgkPmgSoyYh4qLqMFjdthkmSbLH YalcFjfHTVdPvvP3ePhT72V86jD3vP8jqEZkMF9gFFwdVp6E0ZuBJBEwiKaAEyGxhtQanDViVCFE khA0DYF0rffbbu64ZW7ovX8F4/lYgVtXW1of4+aT76ffH3Do+D2oBqLJvC5+p0/7AqSHyhCj9DKJ lKCQ8vlMEcgGhY77oJMx6ojqyxvXcq8+WBtNU4cmeed7/gjeI0AgxoBIGpn6mVUG3RoaoD8HtWkE rIhaVVIfNOvlcbQoYiMqK8A1PdirSFmyBaiN++uvGANKCNqbiYSLUM+gWIaYoyAh4kLlh3Y0Rtzq ZAiBBx99lOhq2GEv5TBVDzVsjcGY8tgYgxhTnVvfFzEYIyAGEbnitTb4JEDNCalRrChGwIjiRHDG 4sRgjRA1EAmIBnC1QH1/eY/RW9asWHbr57wqrIVeQFOHc4JNBOci1lmsE6wVrDNY47DOYrBYytaI xagp93Ud2Bo0QRBjNsOqAlUt+ygSiRWoiBcBBCMbPJoGUJ+QHQzgof00jJy43IrXegn1geCDxl2B 5b0nTWo09+/nxMk79tBLlWCk8g8lIMVIBAyqIBoIweOsGh26EQftGUiaULQs2a2x6uSiD+Q+qN81 WEVRkNRGSKwtZyb32GuVqtMKWvnYSqk2FS1tTQRQp4gXN+lgHMISWrup0EgBEmOUQRHI80IHu2aG pbISEuf2FBaVrtaUVXb/CqKIxPKERpxdH2eX1ScFMkgTsBaVdKAqPkbJQ2TgPcVqN/Z21WclzpE4 u+ewhsBk3RRL44zVFb9msAlQMPYmW3kmWHkyMDrto0oRouQ+0O/lsdPLd2bU9KrKSpJXClYFqoJk 0FJdlTnaKmgVEVclh2WObGvo+Fu9BsmjSi8q/cJLr9PX7k74q59shs6VPmuPUZkKlGFNUWUIsa4u MEaw1gBqCV1oPQsTJwEpoppeDNItvLS7ua4utnx7V0MH7z2JsyTWDLvsPYW1EZLAWqGfqYIoa6qe sf1shqSQHoXueaIdzSPTHR+lkxe02l1dbfdivquwgFfMZ5kN6hLAaAmNytFXjr3c6tMWPwBqYAjR TK2GwrQKL8vdvizNr/jlXQ9KrbWVsl4hWJWvsmu9oYKRODRFY6qEwI04rIfVp4ljJ3uxMCtFMMv9 gSwst+PCSif09hCWeUVgraU7ZaxV+iskVml16eCt9jNolOOX42/SGMyKj3ZxUMhCq8f8xSW/cK1j 7tuCZYwhsRb3isDSDeGCIqIYXUv4IghIzLH5M5CW2YWq6YVo5weFmev25cLccrzQ2kFf9apVlh2a YBwqC2JpiibCyvcxZhpqxyEWYBIN0SwU3l7oDczswiovXFj0S3uWSFtrcWs+a49DBytxEyghVlF8 NSI8fhJpnwOXgl8lJtMrhXfn+gN7bqUjZ88v+os7FVdtX1nG4ozscW5YJs1lXBURjSUkKXtCRTFE SDNwGaq1vPDJmf7AnW51zenZhTCzusNOfUtYqkUK8Q0i2VOlssyex1lGYgmDWMIyoQwZemfANZFk tHxjug9FvA/J8/nAPdvu2efOL+izF5f8ym5+P1eCGljI3wdMqhbPPPjgF3HG7KmDXzM5JCIEIJQj DUvfBDsNteb6KH1U+gNZCDE51era5y8uxdNzy341sZoYkRilnIKPpionitXxZe3aee/R3BO2qayl D0H8Y8i+Ae6htd4wMXsFS4EwhFQOlVfHzePgC+icgZFjgNBqFXT7ZgVrXlhqhbnVdjEYydi3cSpL KaGAllAAHV4vax1CIAwCRV5Q2JxBu0++DVjhZghvBLMMgzeXQ8drI5t7A6oE5MvcOLTBpmUv6DJI xyhLSC1Qo9Xq0urEDqlfbXeKmFmdVlPBYHOhGmuAyt1YXdMQ8T5SWC+5Kt1uzmCbyqo9Db0V8CfA /0KtVqPoz+Hzedqye7isS0iStPxhrGCNYttPlfnM+G1lTmjKtUcxCD4ooeiystxmtatFUmuqgX3V yPNmQNXvsLHVqljGR3JB+uVwqvQ6fXq9wbZhZafA/xcMfh6Kew8e3I+1Dt2dHhgRg0tSnHMlJCtl /idAMobYDLQPkqEqBC+EAMEr3gfanQ79nnVZLU6tVddumtOuwK2ZRRWpeYUiqOmKMohI6OQsz62w 0M0ptjPRWsFKTkHtEYgHoHjLkSMTZFlGUQyIwaPXUO5bgqkN3bgxppzkMJQv7WI6p9DGjUg6htSn wNbKxCZaYjTEKNWscSSGHO89xrgRoj9YLSuJ1QqvzW5DhzO2uajpKlJEZdAPZml+1ZxfaGkrxO2n RK58oLStmj8KOg49NzWV3RGDwboawUeC94QY0Fh+9tXgrc/WSPVnSNI6LqmjsSh9oAFjyjRGtIvp ny7DAu2BjKKmjgYqUFIWnIVIjJHV5Tlq9UYJPEpdYtgHZRi2QUiVIRIQGUSkB9KPmG4ezIWVvjl3 aUXmettU01WCUnsG0scAt7rauWN8PMVaISSGGNJhpZyqolVp3GZom6e11rhZ5xBTIOLL0QKpYBkQ 34X6IUhG0CigCb7whAgxBGJQQvDE4IkxEMIA1RrBB0LwTQ1++sreQqIiA4x0VaWnYpcKtec7hT23 0JYXljrSDuHlmYpbf0Cnqv77QDx9ev4jt7/xRqxTnIuoBVTK2ETLgTcuK6jQy/pNqdRtbByOR4lZ H8gDUDeBRvB5OdXlkjpFsUoM5axzDIEYr3QD3W4XUa1Tj/vYpCYZILQxpqfi5jx2Jo/27HLXnl1o m8W8UH8tCwjcZjNyqup/+KMfneL4sYPlpKo1WAvG6tB8ym+2wXuWxrmpYkjWWvEbnkbQoWlBiJEQ ImhZRdNuXcQXA4IvSlhx6zix2+3ijKlrCGsLvoMY28JKC+teiJLMDNSdbQ/s6YW2zHb6kscdGKzZ BOvHz82M/t/TM8dnZy/w0MNfxSUJtSxjZKRJc6ROs1Gj0cyo11NqNUeWJSRJCXTNH63PEJW+xvtI nnvy3DPIPYOBp58X5NWr38vp93P6/T75YEDwnhcbhlpaanH4wNFhQC/WLuCSGYw76yV5vuvt2cWO O7Pak06MccfGtBzAqdMvZNGH231e3OUH/s6DNxw5b8TcgMf1vdLvdlhZzEnSEl6tnpFlCVktJU0d WepIUkuSluBijMNuvigiReHJ8wJfBIoi0O/nDAYFg7xgUBR479EoCBlOshf90jdMjTA2Mq4Y6Rqb zKhLzgRJzuTqnlvt2bNLHbNQhDIA3Y1Eul4OZNM31py94y13fkmjjqiqE2Nqa957/cN1OEioURgU IkUwIr2qjMEkUpYdqqIYMdg0U5yLMaspjWbcFBuxxTKQyx9Udf0dWnYiXo1dLsReKqKbbefu/ErP LA48fgfFdJkfrrZnz54XwOybnGoaY8diVFGVyajqhoUDVd14mWOV+0HXa8eH16ueE0XS1EypImXy Ggkbrm+sQS/voVcku8Pa9AgxxvLchs8KqhpC2UFfuZICVOOme11t0UCsPn9bZZLHjx7WXh6ISl1V o6pMVRMtcb0G4bKCxhf5AZ0zDZFhyjb8bXSr18bFRxsT4jU4V3nprq4FuXJ+YOM2AVhVprjGRVAi iLNS5zW0DWH1B6EOZChTVyv5filb4kxd9mLQYq9hDYpoBJnYCUW9VlW1rixhUmEfsjM1mM5KtlPr kl9VsHyINeDQToECSKw0eA1uBjgmO7iiNTGSioh5LcL6/wEAi8vcDs2J5owAAAAASUVORK5CYII= "
+       style="display:inline;image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66.000015"
+       width="75" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-5"
+       d="m 61.725004,1022.8099 c 8.529212,-0.052 25.587561,-0.1569 25.587561,-0.1569 l -23.336441,15.9551 -29.322882,0.1009 z"
+       style="display:inline;opacity:0.62999998;fill:url(#linearGradient6406);fill-opacity:1;stroke:none;filter:url(#filter4344)"
+       transform="matrix(1.4111948,0,0,0.94753947,-52.76895,62.627469)" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4"
+       d="m 6.000405,1014.361 41,3e-4 c 0,0 -0.06713,15.3717 0,29 l -41,0 z"
+       style="display:inline;fill:url(#linearGradient6375-6);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-1"
+       d="m 5.5,1002.8653 c 18.334725,0.1145 42.000815,0 42.000815,0 l 0,40.9958 -42.000815,0 z"
+       style="fill:none;stroke:url(#linearGradient4238);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-1"
+       d="m 6.000405,1008.3613 41,10e-5 c 0,0 -0.06713,3.1803 0,5.9999 l -41,0 z"
+       style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-1-6"
+       d="m 6.000405,1003.3613 41,10e-5 c 0,0 -0.0671,3.1803 0,5.9999 l -41,0 z"
+       style="display:inline;fill:url(#linearGradient4467);fill-opacity:1;stroke:none" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4547);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 6.000406,1014.8613 25.000411,0"
+       id="path4539"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient4547-0);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 6.500406,1015.3613 0,24.0009"
+       id="path4539-4"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient5890);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 47.000816,1042.8622 -40,0"
+       id="path4539-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient5892);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 47.790338,1041.5381 0,-26.0001"
+       id="path4539-4-6"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.98600003;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.3544805;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5052)"
+       id="path4432-0"
+       sodipodi:sides="4"
+       sodipodi:cx="-1"
+       sodipodi:cy="15"
+       sodipodi:r1="11"
+       sodipodi:r2="5.6760001"
+       sodipodi:arg1="0"
+       sodipodi:arg2="0.76995223"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="1.0408341e-17"
+       d="M 10,15 3.0750498,18.951069 -1,26 -4.951069,19.07505 -12,15 -5.0750498,11.048931 -1,4 2.951069,10.92495 Z"
+       transform="matrix(1.3283377,0,0,1.3284557,44.697031,984.45987)"
+       inkscape:transform-center-x="0.033467784"
+       inkscape:transform-center-y="-0.052892995" />
+    <g
+       transform="matrix(0.92787456,0,0,0.92766861,-334.80763,585.97703)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-width:0.30075619;stroke-opacity:1" />
+    </g>
+    <g
+       id="text6430-2"
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(3.3253216,0,0,3.3245835,49.654056,-2426.2108)" />
+    <g
+       transform="matrix(3.1391206,0,0,3.5217855,49.654056,-2426.2108)"
+       style="font-style:normal;font-weight:normal;font-size:15.56941891px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="text3782-3" />
+    <g
+       id="g11331-3-1-1-00"
+       style="display:inline"
+       transform="matrix(0,-0.14879357,0.14879357,0,3.0151033,1093.2759)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-1" />
+    </g>
+    <g
+       id="g7590-7-0"
+       style="display:inline"
+       transform="matrix(1.122791,0,0,1.122791,51.605476,-118.01412)" />
+    <g
+       id="g7827-7-5"
+       style="display:inline"
+       transform="matrix(0.45489265,0,0,0.45489265,119.65899,561.31682)" />
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,71.714017,852.06346)"
+       style="display:inline"
+       id="g11331-3-1-1-0">
+      <g
+         id="g13408-8-4"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <path
+       sodipodi:type="star"
+       style="opacity:0.98600003;fill:#e9d291;fill-opacity:1;stroke:#ac8b31;stroke-width:1.79671204;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4432"
+       sodipodi:sides="4"
+       sodipodi:cx="-1"
+       sodipodi:cy="15"
+       sodipodi:r1="11"
+       sodipodi:r2="6.5560002"
+       sodipodi:arg1="0"
+       sodipodi:arg2="0.76995223"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="1.0408341e-17"
+       d="M 10,15 3.7068405,19.563638 -1,26 -5.5636379,19.706841 -12,15 -5.7068405,10.436362 -1,4 3.5636379,10.293159 Z"
+       transform="matrix(0.55626583,0,0,0.55687878,43.924959,996.03352)"
+       inkscape:transform-center-x="0.014015736"
+       inkscape:transform-center-y="-0.022175228" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.86199999;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.3544805;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4598)"
+       id="path4432-0-1"
+       sodipodi:sides="4"
+       sodipodi:cx="-1"
+       sodipodi:cy="15"
+       sodipodi:r1="11"
+       sodipodi:r2="5.6760001"
+       sodipodi:arg1="0"
+       sodipodi:arg2="0.76995223"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="1.0408341e-17"
+       d="M 10,15 3.0750498,18.951069 -1,26 -4.951069,19.07505 -12,15 -5.0750498,11.048931 -1,4 2.951069,10.92495 Z"
+       transform="matrix(0.38274531,0,0,0.38279636,43.583182,998.41912)"
+       inkscape:transform-center-x="0.0096437466"
+       inkscape:transform-center-y="-0.015244411" />
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4992)"
+       d="m 3.0297521,1030.4753 c 24.1010089,15.4959 41.9642429,-4.6259 41.2627759,-20.3573 2.42676,-3.2888 6.43449,-1.5958 8.70624,0.1739 6.227563,27.0063 -34.136731,44.8956 -49.9690159,20.1834 z"
+       id="path4604-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       transform="matrix(1.1544061,0,0,1.1615979,-5.0541449,-166.20783)" />
+    <path
+       style="fill:#fceeb7;fill-opacity:0.90588236;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4935)"
+       d="m 1.5572873,1031.7873 c 23.6764757,16.9772 45.2980937,-5.6621 44.5123537,-21.8207 2.42676,-3.2888 5.215898,-1.949 7.487648,-0.1793 3.64476,24.5311 -36.765221,44.7626 -52.0000017,22 z"
+       id="path4604"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       transform="matrix(1.0291775,0,0,1.0303523,-0.04543774,-30.595788)" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.281;fill:#e9d291;fill-opacity:1;stroke:none;stroke-width:6.77052975;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4432-8"
+       sodipodi:sides="4"
+       sodipodi:cx="-1"
+       sodipodi:cy="15"
+       sodipodi:r1="11"
+       sodipodi:r2="6.5560002"
+       sodipodi:arg1="0"
+       sodipodi:arg2="0.76995223"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="1.0408341e-17"
+       d="M 10,15 3.7068405,19.563638 -1,26 -5.5636379,19.706841 -12,15 -5.7068405,10.436362 -1,4 3.5636379,10.293159 Z"
+       transform="matrix(0.20228474,0.0502297,-0.05009323,0.20228895,50.824026,1009.4719)"
+       inkscape:transform-center-x="0.0030931468"
+       inkscape:transform-center-y="-0.009315946" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.281;fill:#e9d291;fill-opacity:1;stroke:none;stroke-width:6.77052975;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4432-8-4"
+       sodipodi:sides="4"
+       sodipodi:cx="-1"
+       sodipodi:cy="15"
+       sodipodi:r1="11"
+       sodipodi:r2="6.5560002"
+       sodipodi:arg1="0"
+       sodipodi:arg2="0.76995223"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="1.0408341e-17"
+       d="M 10,15 3.7068405,19.563638 -1,26 -5.5636379,19.706841 -12,15 -5.7068405,10.436362 -1,4 3.5636379,10.293159 Z"
+       transform="matrix(0.18930304,-0.08721523,0.0873244,0.18922104,49.796096,1015.2371)"
+       inkscape:transform-center-x="-47.000624"
+       inkscape:transform-center-y="-2.8188888" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.281;fill:#e9d291;fill-opacity:1;stroke:none;stroke-width:6.77052975;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4432-8-1"
+       sodipodi:sides="4"
+       sodipodi:cx="-1"
+       sodipodi:cy="15"
+       sodipodi:r1="11"
+       sodipodi:r2="6.5560002"
+       sodipodi:arg1="0"
+       sodipodi:arg2="0.76995223"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="1.0408341e-17"
+       d="M 10,15 3.7068405,19.563638 -1,26 -5.5636379,19.706841 -12,15 -5.7068405,10.436362 -1,4 3.5636379,10.293159 Z"
+       transform="matrix(0.18131473,-0.00415154,0.00426975,0.18127934,49.922906,1020.7708)"
+       inkscape:transform-center-x="-2.9259864"
+       inkscape:transform-center-y="2.2788878" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.281;fill:#e9d291;fill-opacity:1;stroke:none;stroke-width:6.77052975;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4432-8-1-9"
+       sodipodi:sides="4"
+       sodipodi:cx="-1"
+       sodipodi:cy="15"
+       sodipodi:r1="11"
+       sodipodi:r2="6.5560002"
+       sodipodi:arg1="0"
+       sodipodi:arg2="0.76995223"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="1.0408341e-17"
+       d="M 10,15 3.7068405,19.563638 -1,26 -5.5636379,19.706841 -12,15 -5.7068405,10.436362 -1,4 3.5636379,10.293159 Z"
+       transform="matrix(0.18101786,0.01117144,-0.01105067,0.18099257,47.017789,1025.8949)"
+       inkscape:transform-center-x="-2.723135"
+       inkscape:transform-center-y="2.5177633" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.281;fill:#e9d291;fill-opacity:1;stroke:none;stroke-width:6.77052975;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4432-8-1-9-1"
+       sodipodi:sides="4"
+       sodipodi:cx="-1"
+       sodipodi:cy="15"
+       sodipodi:r1="11"
+       sodipodi:r2="6.5560002"
+       sodipodi:arg1="0"
+       sodipodi:arg2="0.76995223"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="1.0408341e-17"
+       d="M 10,15 3.7068405,19.563638 -1,26 -5.5636379,19.706841 -12,15 -5.7068405,10.436362 -1,4 3.5636379,10.293159 Z"
+       transform="matrix(0.14104626,0.00870492,-0.00861051,0.14103159,42.308457,1030.0921)"
+       inkscape:transform-center-x="-2.1218241"
+       inkscape:transform-center-y="1.961868" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.281;fill:#e9d291;fill-opacity:1;stroke:none;stroke-width:6.77052975;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4432-8-1-9-1-6"
+       sodipodi:sides="4"
+       sodipodi:cx="-1"
+       sodipodi:cy="15"
+       sodipodi:r1="11"
+       sodipodi:r2="6.5560002"
+       sodipodi:arg1="0"
+       sodipodi:arg2="0.76995223"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="1.0408341e-17"
+       d="M 10,15 3.7068405,19.563638 -1,26 -5.5636379,19.706841 -12,15 -5.7068405,10.436362 -1,4 3.5636379,10.293159 Z"
+       transform="matrix(0.11972359,0.00738914,-0.00730882,0.11971414,37.724888,1033.1947)"
+       inkscape:transform-center-x="-1.8010575"
+       inkscape:transform-center-y="1.6653616" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.281;fill:#e9d291;fill-opacity:1;stroke:none;stroke-width:6.77052975;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4432-8-1-9-1-6-0"
+       sodipodi:sides="4"
+       sodipodi:cx="-1"
+       sodipodi:cy="15"
+       sodipodi:r1="11"
+       sodipodi:r2="6.5560002"
+       sodipodi:arg1="0"
+       sodipodi:arg2="0.76995223"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="1.0408341e-17"
+       d="M 10,15 3.7068405,19.563638 -1,26 -5.5636379,19.706841 -12,15 -5.7068405,10.436362 -1,4 3.5636379,10.293159 Z"
+       transform="matrix(0.08509345,0.00525214,-0.00519474,0.08509185,34.288425,1036.1446)"
+       inkscape:transform-center-x="-1.2801038"
+       inkscape:transform-center-y="1.183723" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/icons/full/wizban/workset_wiz.svg
+++ b/bundles/org.eclipse.ui/icons/full/wizban/workset_wiz.svg
@@ -1,0 +1,1199 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="workset_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4541">
+      <stop
+         style="stop-color:#a1adb2;stop-opacity:1"
+         offset="0"
+         id="stop4543" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient5885"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894"
+       id="linearGradient4884"
+       x1="11.927121"
+       y1="67.148781"
+       x2="1.0141196"
+       y2="30.177986"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0044289,0,0,1.0089329,10.981389,-7.447563)" />
+    <linearGradient
+       id="linearGradient4894"
+       inkscape:collect="always">
+      <stop
+         id="stop4896"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1" />
+      <stop
+         style="stop-color:#f3da70;stop-opacity:1;"
+         offset="0.30296871"
+         id="stop5248" />
+      <stop
+         style="stop-color:#f5e499;stop-opacity:1"
+         offset="0.72222227"
+         id="stop5246" />
+      <stop
+         id="stop4898"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5252"
+       id="linearGradient5258"
+       x1="5"
+       y1="64"
+       x2="5"
+       y2="32"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0067606,0,0,1.0132311,10.880208,-7.5854333)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5252">
+      <stop
+         style="stop-color:#5f443c;stop-opacity:1"
+         offset="0"
+         id="stop5254" />
+      <stop
+         style="stop-color:#765d54;stop-opacity:1"
+         offset="1"
+         id="stop5256" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4199"
+       id="linearGradient4205"
+       x1="12"
+       y1="26"
+       x2="29"
+       y2="21"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4358218,0,0,1.270043,-3.499458,-7.3507277)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4199">
+      <stop
+         style="stop-color:#765d54;stop-opacity:1;"
+         offset="0"
+         id="stop4201" />
+      <stop
+         id="stop4207"
+         offset="0.49346113"
+         style="stop-color:#c5b7ae;stop-opacity:1" />
+      <stop
+         style="stop-color:#765d54;stop-opacity:1"
+         offset="1"
+         id="stop4203" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4944"
+       id="linearGradient4936"
+       gradientUnits="userSpaceOnUse"
+       x1="72.098145"
+       y1="86.551781"
+       x2="49.569252"
+       y2="40.099323"
+       gradientTransform="matrix(1,0,0,0.98531644,569.22164,1132.3963)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4944">
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0"
+         id="stop4908" />
+      <stop
+         id="stop4948"
+         offset="0.28205132"
+         style="stop-color:#d3b573;stop-opacity:1" />
+      <stop
+         id="stop4946"
+         offset="0.8623212"
+         style="stop-color:#fde29e;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop4910" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4950"
+       id="linearGradient4956-9"
+       x1="60.342896"
+       y1="74.470169"
+       x2="60.805737"
+       y2="44.682102"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.98531644,569.22164,1132.3963)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4950">
+      <stop
+         style="stop-color:#6a5148;stop-opacity:1;"
+         offset="0"
+         id="stop4952" />
+      <stop
+         style="stop-color:#978379;stop-opacity:1"
+         offset="1"
+         id="stop4954" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2">
+      <stop
+         id="stop11150-4-72-3-9-7"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10507">
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="0"
+         id="stop10509" />
+      <stop
+         id="stop10511"
+         offset="0.18181793"
+         style="stop-color:#9e7058;stop-opacity:1" />
+      <stop
+         id="stop10513"
+         offset="0.36363617"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10515"
+         offset="0.49999985"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10517"
+         offset="0.63636351"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e7058;stop-opacity:1"
+         offset="0.81818175"
+         id="stop10519" />
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="1"
+         id="stop10522" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5309"
+       x="-0.4128"
+       width="1.8256"
+       y="-0.688"
+       height="2.376">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.58"
+         id="feGaussianBlur5311" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4456"
+       id="linearGradient4462"
+       x1="63.734764"
+       y1="1039.3618"
+       x2="61.727211"
+       y2="1006.3618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,-0.72750163,1,733.40264,2.0004)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4456">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.659"
+         offset="0"
+         id="stop4458" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.369"
+         offset="1"
+         id="stop4460" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4606"
+       x="-0.062976152"
+       width="1.1259522"
+       y="-0.10879012"
+       height="1.2175802">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.5412116"
+         id="feGaussianBlur4608" />
+    </filter>
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2-8">
+      <stop
+         id="stop11150-4-72-3-9-7-2"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad6e48;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4368">
+      <stop
+         id="stop4370"
+         offset="0"
+         style="stop-color:#9c7561;stop-opacity:1" />
+      <stop
+         style="stop-color:#966d59;stop-opacity:1"
+         offset="0.18181793"
+         id="stop4372" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.36363617"
+         id="stop4374" />
+      <stop
+         style="stop-color:#794f40;stop-opacity:1"
+         offset="0.49999985"
+         id="stop4376" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.63636351"
+         id="stop4378" />
+      <stop
+         id="stop4380"
+         offset="0.81818175"
+         style="stop-color:#966d59;stop-opacity:1" />
+      <stop
+         id="stop4382"
+         offset="1"
+         style="stop-color:#99705c;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4258"
+       id="linearGradient4264"
+       x1="59.220116"
+       y1="1021.2669"
+       x2="62.220116"
+       y2="1025.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3886897,0,0,1.4503941,-31.101763,-489.45648)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4258">
+      <stop
+         style="stop-color:#f4ae5f;stop-opacity:1;"
+         offset="0"
+         id="stop4260" />
+      <stop
+         id="stop4266"
+         offset="0.41542953"
+         style="stop-color:#eec290;stop-opacity:1" />
+      <stop
+         style="stop-color:#c7700e;stop-opacity:1"
+         offset="1"
+         id="stop4262" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6411"
+       id="linearGradient4240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.77149426,0,0,0.80568312,15.334252,176.55293)"
+       x1="52.166088"
+       y1="1020.8994"
+       x2="47.429596"
+       y2="1023.1616" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6411">
+      <stop
+         style="stop-color:#4f605c;stop-opacity:1"
+         offset="0"
+         id="stop6413" />
+      <stop
+         style="stop-color:#dbe2eb;stop-opacity:0"
+         offset="1"
+         id="stop6415" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4238"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.5915714,0,0,2.7261117,16.2534,-1841.3052)"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228" />
+    <linearGradient
+       id="linearGradient4902"
+       inkscape:collect="always">
+      <stop
+         id="stop4904"
+         offset="0"
+         style="stop-color:#c7b571;stop-opacity:1;" />
+      <stop
+         id="stop4906"
+         offset="1"
+         style="stop-color:#9a9a8f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient6375-6"
+       x1="50.702839"
+       y1="1052.4476"
+       x2="22.530088"
+       y2="1014.1386"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.73184633,0,0,0.77618515,17.329085,207.20801)" />
+    <linearGradient
+       id="linearGradient4994"
+       inkscape:collect="always">
+      <stop
+         id="stop4996"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop4998"
+         offset="1"
+         style="stop-color:#dbe2eb;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#bcbcbc"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="12.306011"
+     inkscape:cx="46.875"
+     inkscape:cy="20.25"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline">
+    <image
+       y="-6.8833828e-15"
+       x="75"
+       id="image4431"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAACXBIWXMAAAsTAAALEwEAmpwYAAAK
+TWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQ
+WaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec
+5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28A
+AgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0
+ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaO
+WJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHi
+wmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryM
+AgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0l
+YqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHi
+NLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYA
+QH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6c
+wR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBie
+whi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1c
+QPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqO
+Y4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hM
+WEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgoh
+JZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSU
+Eko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/p
+dLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Y
+b1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7O
+UndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsb
+di97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W
+7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83
+MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxr
+PGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW
+2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1
+U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd
+8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H0
+8PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+H
+vqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsG
+Lww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjg
+R2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4
+qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWY
+EpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1Ir
+eZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/Pb
+FWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYj
+i1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVk
+Ve9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0Ibw
+Da0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vz
+DoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+y
+CW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawt
+o22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtd
+UV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3r
+O9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0
+/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv95
+63Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+
+UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMA
+APn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAAO50lEQVR42uycWWwd13nHf+fMcjdekiIlWbsc
+S0piWS5kp07cIEWCIE5aB0USBEFjJChauEXshyZBYfShQJs+5aEvKRAEiAO0DykC9CGomyBFWsNF
+giyNLS/1InmVrIWiKIrizrvMzDnf14eZe3lJURIlUSLt5gDDmTmz3Jn//L/v/L/vnEPDb8uK5R/+
+dTRQpayqA6rUgUr4W1iWABQBFVX6RbSmSqX3+P97sL71w3OBKjVRyiJaUdGaKPFK564LWKpv3Q46
+tJa3BDsLdtSYO5LVXPDtJ8YqIlRVNVYIUK2jWrrSNevELNkFyaMgfWtzP+PBnoToGdXjv4JwzJjb
+dflZ3/3xeStKSVXrqgTGgCpVVPsAc7VfWTczzOam7lgYPX+/D+v5666IwfJ6s/i3OKBpg8DPanXX
+3ulocMtBiLcBP1U9dbwXsO/9ZLwuqlUDVvPaANV+A7FZ5TOvG1iSZWbebaVVuwfTAcWY7rYxBTAG
+DEV9gdLiOUDWIn3qr8z8W8NDA79z/8fr+97fB8TAv6ueOvHPP62URcmZlNsrBioKdQNGr+GZ1w0s
+VRDVAgTTZUsHqO5+sd0BDbMMwLhK7fAX8cd+wNSRJ+Os3f7Q0F2H1Ytxx0fjp4xh0mgOUnHLOoZq
+b92GB0tUEV0KBkuAWba/BNBFphkMctuHqE/+Gh9uYvbVpyOi0gcH9t+Vbh8K09u3BU++fS5sFN9g
+EIhVr++Z7fqBBV5ZfOllDDLGYDv1y0Fbzq6oio+Gqe48RN/AIHOv/E+pMTF6X7nU/sjBvcndcayx
+tQwZVpYE7wiwRHXR7MwVwOgBzdIDYE99Zmq4C68SlytU/AzjLzzTb6T5wb5Kct+eLX6fWQMrWkef
+1WOGBmbnmsw3WgTWAAZrDEFguv5NOxvGUKvEVMsx5VJEGFoMkGqJ8uRLaBASl2NK0yc49+pre7cd
+/MD9u7emp06Ohc/KtbupjeKzQGTRP83MNVhYaBLHIdbmzZYqeFFEFFHBO8VYw2B/Fe2vEQSGMMwt
+q9IcwyYLaBASBgGVyDDxxvOh37f/vf3V0h31qrw4PW/SdyhYilft+qM79mxdubVbQVIUqqJ7bbvd
+orZwltgEJLbMrBmiFaTQuMjEyNlNm/YOD5VjjeAdC1a+dBx3q52Spg5rl8qITovYlaXGEEcBpTgk
+DAPCwFKdO0FUv42LOx9gNOlncvIiM60pGqbBx1RDDMFaPPMG0FkGgzIyOsncQpNyOcSaHvb5fHFe
+8F4Aw9bhOluG6gz2VwhKMXb73TS3300F2NlqUirHxHHM/Pwszs+s2TNvAJ2Vs+X9B3bkLFtJya8k
+VgszzZm42GrWarXutXEUkrrJdwNYPToLg6osgqeKdgHJ5YWaxW2MwRrFGnupvABq1Rp+k8MYSOfk
+3QGWqGKL0P/Ym6PMNZpUy1HXgUvREnqvZN6TZYq1hq3D/dw2XGdwoEqtEmOtXSJcrbX09dUQ77gw
+xzsfrK7OArCW9+3bnvuk3iCZpaFQJ7AOjCGKQqLQEgQW220hF1kWRzG1Wm01mZd3iBmKdqVAuRwt
+kQsr+apLYsQrxY4WSqUSHt5dDh7g6OtnmZxZoFIOuukZ75U083ivbB2us3/vVgb7KwWQlwLV2e6U
+IAiQG9LsGFVCVQ0Bs/46q3jR9+zezI7bBlG0m+LrJvkUyqWIajkuTO5Ss+uwkmWabNVgKUaUSERD
+VSJVwuU2fENgPf7Y8GeBbwCHr+W6H3/nEXbe81m8vrdrdgP16lKzu1puawUZsVLxetmkvRElcl4j
+EY28EIpqHofqGpvh448N//3wjkPf+MAn/5rb73rw8v0ICiCgHgG8ejCOkfNnuXByDozFoFcMba7m
+w65UfA+1VAm8EHmvsffEIlcGZ03Aevyx4cNxZeAbn/zTf6G+aXcPMA7VrEgTeBQBXapzAsCYDJtd
+gKSFRS/xO1yS22JVZrcyWODFhO2EAee1ItcAzlox61t3//5XqG/ajUob9Q1U3TVc7noC6fzFp2Ya
+NFvJ0tjQGAJr0YKhqmBtrsxrlTxFE0VBrtUuB5Yq4ok0f9dbG0g//tjwx+LKwMcOfeQvkOwiKu3r
++NmcdR0Hjyqj49N5bBiHXbBEQXwuTJ3ksaExluHBKluG6mwaqGKtwYbBqszwlkiHxx8b/jowWOx+
+9O6P/DmBTuBaC6j3iHeId+gl68Vj3mf4Yh1V+2hpjJdqHjRby+E7d1/FP5kVusZW8VnWDqurg/Wd
+r2067J1+675PfQ1xDdQ3uPN3P4lmE6hL8S5DshTvUiRLEZfhsxQp9r1L8VmKcwlZsS4NDJPV9iBa
+7YLhRTqJ0K5S7/VL1ppLnLkxZtFsNwKzslQGAT7wwFfx7XP4dBJoIgLYkCAOCeIK0bUk/sOI4+en
+kIkcFFXluVfOMDO/QKUUdkERVcQrXhTXiQ0Dy7bhOtu29DM0UKNWjYk2ihmmbem2u+oaIO7Gf1Ut
+qppnHcjZcfjOnTgvS7STE1nCmryDwxCFligKiIrk34YxwzQpoiuVHChdA7AkKMKdnjxUtXSJdFiL
+cmuZlQilcjG4RP0aMStc0rsDyhtvn2dqpkEcBz0pGnBecE4YHqyxZ8cQ9VrpqkJ0HcHypEmzq8LX
+hFnqERG8Bl2xWa2UcE4IgkWnnvcA5dKhUokx10G3W2uGPT4LdWvELJ8zS8ilgzHcvnMth2utV2uY
+SRHMaC4drsKsp370XWamxwtTuTIVYuCHx/7mpmY3Ioj/8+i3HwIe6u+pb2x++JHGwBdO3CQFX7SG
+Vyinjr9I3LeLLz/639dy2yKc0ZxtrXHEtVBRVAUVQUQQL0g6i09mEfF4L3jn8N7j/NL40/oVOimy
+cxhpcfzk64yNjy1k1XvGb2K4o1c1waMv/IwPffqbOf0bZ8C3kdZ4YXkJ0h7vscSke2xV2qxYwpUq
+VyXy+siyEhcnL+BK+59wpQML15oZXD1YHZ91mXLyrZcwtsru932CdPwXZOd/yUYrJ06+Rub8QnPH
+X/7bTQ6kr8ysV174Ofc+8Lf4hVOkYz/fcECpKidOvokv73/ClQ8sIDcbrMsw6+zpN8kyz/57Pk/j
+2D+iKhsMKTgzeprMZSS3fe6/bnqKRtPpyzLr9aPPcPD3/oxk7GdIMrnBGJWz6o3jryHxjifT/o+P
+X28vxuqZJemKzBofO8P01BQPfPBLpMe/t+FYJaKMnBuh1W6S7Pzq929N8k8FJLuk+qXnf8meg59C
+Jn6BuOaGA0pEefPEm0i848ls4OPjNzKc7Rp8llzCrPNjI5w/d5qPPvRPpCM/2FhAaR5Xjl+4QDtp
+ke76+vdv9J7XyKylYB17+TkO3PvHRM3XSDeY+blMEFVOj55Co82/doPX76uuD6weZs3PzXHyxAk+
+84m/I5n42cYCyuX5+smZaWZmZ/CbP//ELYkNu7RunVvCrOeOPM32Oz7MUHmOdN5vHKC8kmUeUeXt
+06fQcOCldPsjL6G3EKze9Mz83DyvHnuNP3r42yQXnt5QDj1NPV6EqZlZZhdmCXd86Uf9UbpJdHHk
+jkqxLoYQqCgCiKo6b1zqjUu8Tb0YuWGf9fRvjtA3uJsdQ4ZkYmP4KlWlneRBtYhy9vw5gtKWt/p2
+f2FMJRuWrubKz+1u0wVRnOAya9PAmETVaEtMct3MUnEkScLRV97gwT/5JsmFX28YVrUTR5blQDXb
+bWZmp6nv/fILZetuU1v0QnfBWRxXL2rEC84ricUkqJAQtJ0Yf81mWK4NhO3GbNfBP//cK9T6N7Nv
+T532+MZgVeo8aeKKrnrh9NkRbFhfGNz9mWmQbVpMBdPFlJCqGhElFdUETFu8yUSNm0/D2dkkmF9u
+gp0kx2XLzIKzQ9v39XWY1W41efbIMQ7d/zla53+Fql/3Jc0yms2UzHky51hoNLk4dZGBXZ9+IzSy
+JTSyJbT5EuXbw4HRQWu0YoyGeTbVtBtZMHm+EZ+dboezKwG1Gmb1h1EpAJCF0zz7zDHEVDh0cBfM
+H13v2Jgk9bTarjsLw4tyZvQscWkgGd772QaqWzrnFtbnFNqqZgEQL6bRdMH4VDManW6Hs5lcORdx
+WbBmG65Mz+zzdqvFb555jQ8/+DDMvYyugwMXLTpcnZA5yc2ucOhOlEazzczMBDsPPTpt0a2YHpCU
+lmIaoiZ1aqbaLjg3l4RnJ9vxRDM1iWgPrNcC1nzTWVUGei/93xdP4J1y1/4YzfxNBqbI+Utn/o4U
+83d6RjBLp7dacAVok1MTlCpbdHj3H5RAt6qSAS3FzAlmwakZS3wwspCFI9Pt+NxcO2h4ZdXTNFcE
+yxgGVLEKpn/zrn6AZ4+8yp137sWmo2vOKi2+aqcZ7zTrInkvtEo+PKkXKF8M+c7XQpI4Lk6Os/3A
+F41BBxUaYJpezaRXO5KKHWm68MxMEp+ZTcKZzBtRbjCt3Gj7mirl1kKj3Gw0D/Rv2X+wUi0z+vab
+HD54H2dOjy+Z0L1ku6djr7ePzyyZjLP0mqV+SJc27x1NxOKA3VxQ5qzzPduT0zMEQYnNt39GFRZE
+7ahXM5KJPdP24en5LDo9ncQTibeZ6Brks1qJD6YmprfPz8y9xzt/r3f+jr2H/nDfW8/+R6M18nLt
+Jz8+grE900AMGFvMOC1GuRhLPkjWsvb7dumEzO6o5aLbbeddX0lN1HfRqT3pxJ5JJTjdcOHJmbQ0
+1nJh218vSvR85K5Tn2ttnRyf3Jtl7m6XZru891tFZEhF66paWYmJetkdMMZEXGaG+/LH1m7q+sr3
+vsK9vGDmvNqJVOxo20dn57LSWNPZhhejXX/X9XvL9osZH6sagNtOfUWVcPP2rYlz/qh3ckwVhF4f
+km936ro+RUHoibkEwtBWA2uqHTPpzALzxXXa84Be83RZ51xB8+iq50Xy35PukPDucdWeOkUUzcQ4
+J0ZEyMe1rlEJAdJMrCqDojoUBIE1NkiDULsvKD1gLX6Bwm8UYJnieO5wMHFk+1RJOkiKgFHBFAPW
+tPO/AqTXTy06eTH5BxDTCXJByIVQvujiWpcDd3OEjS2McZPCMGZtZlyEgSmZtZw0s0GKdV7KwPa1
+AgogCkyVd2GxwHvMGs7hiayJjTH23QjW/w0AFN+1w6jP06YAAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66"
+       width="75" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <g
+       id="g5348"
+       transform="translate(-2.9999979,989.3622)">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path5250"
+         d="m 14.403025,25.481913 3.760593,-4.964217 16.536826,0 3.904565,4.964217 z"
+         style="fill:#fffabf;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4205);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         ry="2.0792062"
+         y="25.5"
+         x="11.639588"
+         height="31"
+         width="41.860409"
+         id="rect4876"
+         style="opacity:1;fill:url(#linearGradient4884);fill-opacity:1;stroke:url(#linearGradient5258);stroke-width:1;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <ellipse
+         transform="matrix(1,0,0,0.38855855,-0.99999923,21.926323)"
+         ry="4.5"
+         rx="7.5"
+         cy="8.3080006"
+         cx="23.691999"
+         id="path5111"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5309)" />
+    </g>
+    <path
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient4462);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4606)"
+       d="m 47.000294,1007.3622 -12.319149,16.9335 -12.416197,17.0669 16.933329,0 17.066666,0 12.416197,-17.0669 0.09676,-0.133 12.2221,-16.8001 -17.066666,0 -16.933329,0 z"
+       id="rect10961-8-3-6-1"
+       inkscape:connector-curvature="0"
+       transform="matrix(1.1726491,0,0.08958045,0.36603268,-107.93917,662.83554)"
+       inkscape:transform-center-x="4.3534013"
+       inkscape:transform-center-y="0.53407962" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4"
+       d="m 31.000018,991.3622 17.999871,0 6.932841,8.03088 0.06727,25.96912 -25,0 z"
+       style="display:inline;opacity:1;fill:url(#linearGradient6375-6);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccscccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-1"
+       d="m 30.5,990.8622 18.166055,0 c 0,0 5.462025,1.1448 4.076837,3.78247 -0.04298,0.0826 3.757108,4.49736 3.757108,4.49736 l 0,26.71327 -26,0 z"
+       style="display:inline;fill:none;stroke:url(#linearGradient4238);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-9-0"
+       d="M 48.720832,990.79371 56,998.91863 l 0,8.44357 -10.682628,-7.386 c 1.401069,-2.96183 2.416093,-6.05562 3.403404,-9.18249 z"
+       style="display:inline;fill:url(#linearGradient4240);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       id="path5675-4"
+       d="m 48.361443,990.36893 c 1.570712,2.13227 3.464822,4.86004 2.060951,9.52059 C 53.652846,998.06863 57,999.03448 57,999.03448 c 0,-4.3511 -5.300793,-8.87065 -8.638557,-8.66555 z"
+       style="display:inline;fill:url(#linearGradient4264);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 34,997.3622 13,0"
+       id="path4696-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 34,1013.3622 13,0"
+       id="path4696-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 34,1001.3622 13,0"
+       id="path4696-0-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 33.999999,1005.3622 13,0"
+       id="path4696-0-3"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 34,1008.3622 9,0"
+       id="path4696-0-8"
+       inkscape:connector-curvature="0" />
+    <rect
+       transform="matrix(1,0,-0.49529213,0.86872649,0,0)"
+       style="opacity:1;fill:url(#linearGradient4936);fill-opacity:1;stroke:url(#linearGradient4956-9);stroke-width:1.07289803;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4932"
+       width="41.81472"
+       height="26.530792"
+       x="605.42352"
+       y="1177.3936"
+       ry="1.7639489" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 34,1017.3622 13,0"
+       id="path4696-9-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#bbc5d8;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 34,1020.3622 10,0"
+       id="path4696-9-8"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui/plugin.xml
+++ b/bundles/org.eclipse.ui/plugin.xml
@@ -1444,82 +1444,82 @@
       <image
             commandId="org.eclipse.ui.edit.copy"
             disabledIcon="$nl$/icons/full/dtool16/copy_edit.png"
-            icon="$nl$/icons/full/etool16/copy_edit.png"/>
+            icon="$nl$/icons/full/etool16/copy_edit.svg"/>
       <image
             commandId="org.eclipse.ui.edit.cut"
             disabledIcon="$nl$/icons/full/dtool16/cut_edit.png"
-            icon="$nl$/icons/full/etool16/cut_edit.png"/>
+            icon="$nl$/icons/full/etool16/cut_edit.svg"/>
       <image
             commandId="org.eclipse.ui.edit.delete"
             disabledIcon="$nl$/icons/full/dtool16/delete_edit.png"
-            icon="$nl$/icons/full/etool16/delete_edit.png"/>
+            icon="$nl$/icons/full/etool16/delete_edit.svg"/>
       <image
             commandId="org.eclipse.ui.edit.paste"
             disabledIcon="$nl$/icons/full/dtool16/paste_edit.png"
-            icon="$nl$/icons/full/etool16/paste_edit.png"/>
+            icon="$nl$/icons/full/etool16/paste_edit.svg"/>
       <image
             commandId="org.eclipse.ui.file.print"
             disabledIcon="$nl$/icons/full/dtool16/print_edit.png"
-            icon="$nl$/icons/full/etool16/print_edit.png"/>
+            icon="$nl$/icons/full/etool16/print_edit.svg"/>
       <image
             commandId="org.eclipse.ui.edit.undo"
             disabledIcon="$nl$/icons/full/dtool16/undo_edit.png"
-            icon="$nl$/icons/full/etool16/undo_edit.png"/>
+            icon="$nl$/icons/full/etool16/undo_edit.svg"/>
       <image
             commandId="org.eclipse.ui.edit.redo"
             disabledIcon="$nl$/icons/full/dtool16/redo_edit.png"
-            icon="$nl$/icons/full/etool16/redo_edit.png"/>
+            icon="$nl$/icons/full/etool16/redo_edit.svg"/>
       <image
             commandId="org.eclipse.ui.file.save"
             disabledIcon="$nl$/icons/full/dtool16/save_edit.png"
-            icon="$nl$/icons/full/etool16/save_edit.png"/>
+            icon="$nl$/icons/full/etool16/save_edit.svg"/>
       <image
             commandId="org.eclipse.ui.file.saveAll"
             disabledIcon="$nl$/icons/full/dtool16/saveall_edit.png"
-            icon="$nl$/icons/full/etool16/saveall_edit.png"/>
+            icon="$nl$/icons/full/etool16/saveall_edit.svg"/>
       <image
             commandId="org.eclipse.ui.file.saveAs"
             disabledIcon="$nl$/icons/full/dtool16/saveas_edit.png"
-            icon="$nl$/icons/full/etool16/saveas_edit.png"/>
+            icon="$nl$/icons/full/etool16/saveas_edit.svg"/>
       <image
             commandId="org.eclipse.ui.file.refresh"
             disabledIcon="$nl$/icons/full/dlcl16/refresh_nav.png"
-            icon="$nl$/icons/full/elcl16/refresh_nav.png"/>
+            icon="$nl$/icons/full/elcl16/refresh_nav.svg"/>
       <image
             commandId="org.eclipse.ui.file.export"
             disabledIcon="$nl$/icons/full/dtool16/export_wiz.png"
-            icon="$nl$/icons/full/etool16/export_wiz.png">
+            icon="$nl$/icons/full/etool16/export_wiz.svg">
       </image>
       <image
             commandId="org.eclipse.ui.file.import"
             disabledIcon="$nl$/icons/full/dtool16/import_wiz.png"
-            icon="$nl$/icons/full/etool16/import_wiz.png">
+            icon="$nl$/icons/full/etool16/import_wiz.svg">
       </image>
       <image
             commandId="org.eclipse.ui.navigate.collapseAll"
             disabledIcon="$nl$/icons/full/dlcl16/collapseall.png"
-            icon="$nl$/icons/full/elcl16/collapseall.png">
+            icon="$nl$/icons/full/elcl16/collapseall.svg">
       </image>
       <image
             commandId="org.eclipse.ui.navigate.expandAll"
-            icon="$nl$/icons/full/elcl16/expandall.png">
+            icon="$nl$/icons/full/elcl16/expandall.svg">
       </image>
       <image
             commandId="org.eclipse.ui.newWizard"
             disabledIcon="$nl$/icons/full/dtool16/new_wiz.png"
-            icon="$nl$/icons/full/etool16/new_wiz.png">
+            icon="$nl$/icons/full/etool16/new_wiz.svg">
       </image>
       <image
             commandId="org.eclipse.ui.perspectives.showPerspective"
-            icon="$nl$/icons/full/eview16/new_persp.png">
+            icon="$nl$/icons/full/eview16/new_persp.svg">
       </image>
       <image
             commandId="org.eclipse.ui.help.helpContents"
-            icon="$nl$/icons/full/etool16/help_contents.png">
+            icon="$nl$/icons/full/etool16/help_contents.svg">
       </image>
       <image
             commandId="org.eclipse.ui.help.helpSearch"
-            icon="$nl$/icons/full/etool16/help_search.png">
+            icon="$nl$/icons/full/etool16/help_search.svg">
       </image>
       <image
             commandId="org.eclipse.ui.window.quickAccess"

--- a/bundles/org.eclipse.ui/plugin.xml
+++ b/bundles/org.eclipse.ui/plugin.xml
@@ -1443,61 +1443,47 @@
          point="org.eclipse.ui.commandImages">
       <image
             commandId="org.eclipse.ui.edit.copy"
-            disabledIcon="$nl$/icons/full/dtool16/copy_edit.png"
             icon="$nl$/icons/full/etool16/copy_edit.svg"/>
       <image
             commandId="org.eclipse.ui.edit.cut"
-            disabledIcon="$nl$/icons/full/dtool16/cut_edit.png"
             icon="$nl$/icons/full/etool16/cut_edit.svg"/>
       <image
             commandId="org.eclipse.ui.edit.delete"
-            disabledIcon="$nl$/icons/full/dtool16/delete_edit.png"
             icon="$nl$/icons/full/etool16/delete_edit.svg"/>
       <image
             commandId="org.eclipse.ui.edit.paste"
-            disabledIcon="$nl$/icons/full/dtool16/paste_edit.png"
             icon="$nl$/icons/full/etool16/paste_edit.svg"/>
       <image
             commandId="org.eclipse.ui.file.print"
-            disabledIcon="$nl$/icons/full/dtool16/print_edit.png"
             icon="$nl$/icons/full/etool16/print_edit.svg"/>
       <image
             commandId="org.eclipse.ui.edit.undo"
-            disabledIcon="$nl$/icons/full/dtool16/undo_edit.png"
             icon="$nl$/icons/full/etool16/undo_edit.svg"/>
       <image
             commandId="org.eclipse.ui.edit.redo"
-            disabledIcon="$nl$/icons/full/dtool16/redo_edit.png"
             icon="$nl$/icons/full/etool16/redo_edit.svg"/>
       <image
             commandId="org.eclipse.ui.file.save"
-            disabledIcon="$nl$/icons/full/dtool16/save_edit.png"
             icon="$nl$/icons/full/etool16/save_edit.svg"/>
       <image
             commandId="org.eclipse.ui.file.saveAll"
-            disabledIcon="$nl$/icons/full/dtool16/saveall_edit.png"
             icon="$nl$/icons/full/etool16/saveall_edit.svg"/>
       <image
             commandId="org.eclipse.ui.file.saveAs"
-            disabledIcon="$nl$/icons/full/dtool16/saveas_edit.png"
             icon="$nl$/icons/full/etool16/saveas_edit.svg"/>
       <image
             commandId="org.eclipse.ui.file.refresh"
-            disabledIcon="$nl$/icons/full/dlcl16/refresh_nav.png"
             icon="$nl$/icons/full/elcl16/refresh_nav.svg"/>
       <image
             commandId="org.eclipse.ui.file.export"
-            disabledIcon="$nl$/icons/full/dtool16/export_wiz.png"
             icon="$nl$/icons/full/etool16/export_wiz.svg">
       </image>
       <image
             commandId="org.eclipse.ui.file.import"
-            disabledIcon="$nl$/icons/full/dtool16/import_wiz.png"
             icon="$nl$/icons/full/etool16/import_wiz.svg">
       </image>
       <image
             commandId="org.eclipse.ui.navigate.collapseAll"
-            disabledIcon="$nl$/icons/full/dlcl16/collapseall.png"
             icon="$nl$/icons/full/elcl16/collapseall.svg">
       </image>
       <image
@@ -1506,7 +1492,6 @@
       </image>
       <image
             commandId="org.eclipse.ui.newWizard"
-            disabledIcon="$nl$/icons/full/dtool16/new_wiz.png"
             icon="$nl$/icons/full/etool16/new_wiz.svg">
       </image>
       <image

--- a/bundles/org.eclipse.ui/schema/actionSets.exsd
+++ b/bundles/org.eclipse.ui/schema/actionSets.exsd
@@ -465,7 +465,7 @@ the sub-elements and the way attributes are used):
                style=&quot;toggle&quot;
                state=&quot;false&quot;
                menubarPath=&quot;com.xyz.xyzMenu/group1&quot; 
-               icon=&quot;icons/runXYZ.png&quot;
+               icon=&quot;icons/runXYZ.svg&quot;
                tooltip=&quot;Run XYZ Tool&quot; 
                helpContextId=&quot;com.xyz.run_action_context&quot; 
                class=&quot;com.xyz.actions.RunXYZ&quot; 
@@ -478,7 +478,7 @@ the sub-elements and the way attributes are used):
                style=&quot;push&quot;
                menubarPath=&quot;com.xyz.xyzMenu/group1&quot;
                toolbarPath=&quot;Normal/XYZ&quot;
-               icon=&quot;icons/runABC.png&quot;
+               icon=&quot;icons/runABC.svg&quot;
                tooltip=&quot;Run ABC Tool&quot;
                helpContextId=&quot;com.xyz.run_abc_action_context&quot;
                retarget=&quot;true&quot;
@@ -499,7 +499,7 @@ the sub-elements and the way attributes are used):
                style=&quot;radio&quot;
                state=&quot;true&quot;
                menubarPath=&quot;com.xyz.xyzMenu/option1&quot;
-               icon=&quot;icons/runDEF.png&quot;
+               icon=&quot;icons/runDEF.svg&quot;
                tooltip=&quot;Run DEF Tool&quot;
                class=&quot;com.xyz.actions.RunDEF&quot; 
                helpContextId=&quot;com.xyz.run_def_action_context&quot;&gt;
@@ -510,7 +510,7 @@ the sub-elements and the way attributes are used):
                style=&quot;radio&quot;
                state=&quot;false&quot;
                menubarPath=&quot;com.xyz.xyzMenu/option1&quot;
-               icon=&quot;icons/runGHI.png&quot;
+               icon=&quot;icons/runGHI.svg&quot;
                tooltip=&quot;Run GHI Tool&quot;
                class=&quot;com.xyz.actions.RunGHI&quot; 
                helpContextId=&quot;com.xyz.run_ghi_action_context&quot;&gt;
@@ -521,7 +521,7 @@ the sub-elements and the way attributes are used):
                style=&quot;radio&quot;
                state=&quot;false&quot;
                menubarPath=&quot;com.xyz.xyzMenu/option1&quot;
-               icon=&quot;icons/runJKL.png&quot;
+               icon=&quot;icons/runJKL.svg&quot;
                tooltip=&quot;Run JKL Tool&quot;
                class=&quot;com.xyz.actions.RunJKL&quot; 
                helpContextId=&quot;com.xyz.run_jkl_action_context&quot;&gt;

--- a/bundles/org.eclipse.ui/schema/activitySupport.exsd
+++ b/bundles/org.eclipse.ui/schema/activitySupport.exsd
@@ -257,10 +257,10 @@ The following is an example of binding images to activities and categories:
   &lt;extension point=&quot;org.eclipse.ui.activitySupport&quot;&gt;
     &lt;activityImageBinding
        id=&quot;some.activity.id&quot;
-       icon=&quot;icons/someIcon.png&quot;/&gt;
+       icon=&quot;icons/someIcon.svg&quot;/&gt;
     &lt;categoryImageBinding
        id=&quot;some.category.id&quot;
-       icon=&quot;icons/someIcon.png&quot;/&gt;
+       icon=&quot;icons/someIcon.svg&quot;/&gt;
   &lt;/extension&gt;
 &lt;/pre&gt;
 &lt;/p&gt;

--- a/bundles/org.eclipse.ui/schema/commandImages.exsd
+++ b/bundles/org.eclipse.ui/schema/commandImages.exsd
@@ -131,14 +131,14 @@ Commands placed in menus using the &lt;a href=&quot;org_eclipse_ui_menus.html&qu
  point=&quot;org.eclipse.ui.commandImages&quot;&gt;
  &lt;image
   commandId=&quot;org.eclipse.example.ProfileLast&quot;
-  hoverIcon=&quot;icons/full/etool16/profile.png&quot;
-  disabledIcon=&quot;icons/full/dtool16/profile.png&quot;
-  icon=&quot;icons/full/etool16/profile.png&quot; /&gt;
+  hoverIcon=&quot;icons/full/etool16/profile.svg&quot;
+  disabledIcon=&quot;icons/full/dtool16/profile.svg&quot;
+  icon=&quot;icons/full/etool16/profile.svg&quot; /&gt;
  &lt;image
   commandId=&quot;org.eclipse.example.ProfileLast&quot;
-  hoverIcon=&quot;icons/full/etool16/history.png&quot;
-  disabledIcon=&quot;icons/full/dtool16/history.png&quot;
-  icon=&quot;icons/full/etool16/history.png&quot;
+  hoverIcon=&quot;icons/full/etool16/history.svg&quot;
+  disabledIcon=&quot;icons/full/dtool16/history.svg&quot;
+  icon=&quot;icons/full/etool16/history.svg&quot;
   style=&quot;toolbar&quot; /&gt;
 &lt;/extension&gt;
 &lt;/pre&gt;

--- a/bundles/org.eclipse.ui/schema/decorators.exsd
+++ b/bundles/org.eclipse.ui/schema/decorators.exsd
@@ -238,7 +238,7 @@ supplies an icon and a quadrant to apply that icon.
             label=&quot;XYZ Lightweight Declarative Decorator&quot; 
             state=&quot;false&quot; 
             lightweight=&quot;true&quot; 
-            icon=&quot;icons/full/declarative.png&quot;
+            icon=&quot;icons/full/declarative.svg&quot;
             location=&quot;TOP_LEFT&quot;&gt; 
             &lt;enablement&gt;
                 &lt;objectClass name=&quot;org.eclipse.core.resources.IResource&quot;/&gt; 

--- a/bundles/org.eclipse.ui/schema/editorActions.exsd
+++ b/bundles/org.eclipse.ui/schema/editorActions.exsd
@@ -430,7 +430,7 @@ If multiple extensions contribute ruler actions to the same text editor, the ext
             toolbarPath=&quot;Normal/additions&quot;
             style=&quot;toggle&quot;
             state=&quot;true&quot; 
-            icon=&quot;icons/runXYZ.png&quot;
+            icon=&quot;icons/runXYZ.svg&quot;
             tooltip=&quot;Run XYZ Tool&quot; 
             helpContextId=&quot;com.xyz.run_action_context&quot; 
             class=&quot;com.xyz.actions.RunXYZ&quot;&gt; 
@@ -461,7 +461,7 @@ The following is an other example of an editor action extension:
             label=&quot;&amp;amp;Run XYZ2 Tool&quot; 
             menubarPath=&quot;edit/XYZ2/group1&quot;
             style=&quot;push&quot;
-            icon=&quot;icons/runXYZ2.png&quot;
+            icon=&quot;icons/runXYZ2.svg&quot;
             tooltip=&quot;Run XYZ2 Tool&quot; 
             helpContextId=&quot;com.xyz.run_action_context2&quot; 
             class=&quot;com.xyz.actions.RunXYZ2&quot;&gt; 

--- a/bundles/org.eclipse.ui/schema/editors.exsd
+++ b/bundles/org.eclipse.ui/schema/editors.exsd
@@ -273,7 +273,7 @@ of an internal editor extension definition:
       &lt;editor 
          id=&quot;com.xyz.XMLEditor&quot; 
          name=&quot;Fancy XYZ XML editor&quot; 
-         icon=&quot;./icons/XMLEditor.png&quot;
+         icon=&quot;./icons/XMLEditor.svg&quot;
          extensions=&quot;xml&quot; 
          class=&quot;com.xyz.XMLEditor&quot; 
          contributorClass=&quot;com.xyz.XMLEditorContributor&quot; 

--- a/bundles/org.eclipse.ui/schema/exportWizards.exsd
+++ b/bundles/org.eclipse.ui/schema/exportWizards.exsd
@@ -229,7 +229,7 @@ when the wizard is invoked.
          id=&quot;com.xyz.ExportWizard1&quot; 
          name=&quot;XYZ Web Exporter&quot; 
          class=&quot;com.xyz.exports.ExportWizard1&quot; 
-         icon=&quot;./icons/import1.png&quot;&gt;
+         icon=&quot;./icons/import1.svg&quot;&gt;
          &lt;description&gt; 
             A simple engine that exports Web project 
          &lt;/description&gt; 

--- a/bundles/org.eclipse.ui/schema/importWizards.exsd
+++ b/bundles/org.eclipse.ui/schema/importWizards.exsd
@@ -225,7 +225,7 @@ added to the &quot;Other&quot; category.
          id=&quot;com.xyz.ImportWizard1&quot; 
          name=&quot;XYZ Web Scraper&quot; 
          class=&quot;com.xyz.imports.ImportWizard1&quot; 
-         icon=&quot;./icons/import1.png&quot;&gt;
+         icon=&quot;./icons/import1.svg&quot;&gt;
          &lt;description&gt; 
             A simple engine that searches the Web and imports files 
          &lt;/description&gt; 

--- a/bundles/org.eclipse.ui/schema/internalTweaklets.exsd
+++ b/bundles/org.eclipse.ui/schema/internalTweaklets.exsd
@@ -128,7 +128,7 @@ be associated with the tweaklet.
          description=&quot;Short description of the tweak&quot; 
          definition=&quot;org.eclipse.ui.internal.tweaklets.AbstractXYZTweaklet&quot; 
          implementation=&quot;org.eclipse.ui.internal.tweaklets.ConcreteXYZTweaklet&quot; 
-         icon=&quot;icons/XYZ.png&quot;/&gt;
+         icon=&quot;icons/XYZ.svg&quot;/&gt;
    &lt;/extension&gt; 
 &lt;/pre&gt;
 &lt;/p&gt;

--- a/bundles/org.eclipse.ui/schema/menus.exsd
+++ b/bundles/org.eclipse.ui/schema/menus.exsd
@@ -944,7 +944,7 @@ A basic extension looks like this.
          locationURI=&quot;menu:someorg.somemenu.id?after=additions&quot;&gt;
          &lt;command
                commandId=&quot;someorg.someid.someCommand&quot;
-               icon=&quot;icons/anything.png&quot;
+               icon=&quot;icons/anything.svg&quot;
                id=&quot;someorg.someid.BasicCmdItem&quot;
                label=&quot;Simple Item&quot;
                mnemonic=&quot;S&quot;&gt;

--- a/bundles/org.eclipse.ui/schema/newWizards.exsd
+++ b/bundles/org.eclipse.ui/schema/newWizards.exsd
@@ -303,7 +303,7 @@ Since 3.0
           id=&quot;com.xyz.wizard1&quot; 
           name=&quot;XYZ artifact&quot; 
           category=&quot;com.xyz.XYZ/com.xyz.XYZ.Web&quot; 
-          icon=&quot;./icons/XYZwizard1.png&quot;
+          icon=&quot;./icons/XYZwizard1.svg&quot;
           class=&quot;com.xyz.XYZWizard1&quot;&gt; 
           &lt;description&gt; 
               Create a simple XYZ artifact and set initial content 

--- a/bundles/org.eclipse.ui/schema/perspectives.exsd
+++ b/bundles/org.eclipse.ui/schema/perspectives.exsd
@@ -142,7 +142,7 @@ with this perspective.
             id=&quot;org.eclipse.ui.resourcePerspective&quot; 
             name=&quot;Resource&quot; 
             class=&quot;org.eclipse.ui.internal.ResourcePerspective&quot; 
-            icon=&quot;icons/MyIcon.png&quot;&gt;
+            icon=&quot;icons/MyIcon.svg&quot;&gt;
         &lt;/perspective&gt; 
     &lt;/extension&gt; 
 &lt;/pre&gt;

--- a/bundles/org.eclipse.ui/schema/popupMenus.exsd
+++ b/bundles/org.eclipse.ui/schema/popupMenus.exsd
@@ -459,7 +459,7 @@ within its &lt;samp&gt;selectionChanged&lt;/samp&gt; method.
             label=&quot;&amp;amp;Run XYZ Tool&quot;
             style=&quot;push&quot;
             menubarPath=&quot;com.xyz.xyzMenu/group1&quot; 
-            icon=&quot;icons/runXYZ.png&quot;
+            icon=&quot;icons/runXYZ.svg&quot;
             helpContextId=&quot;com.xyz.run_action_context&quot; 
             class=&quot;com.xyz.actions.XYZToolActionDelegate&quot; 
             enablesFor=&quot;1&quot; /&gt; 
@@ -473,7 +473,7 @@ within its &lt;samp&gt;selectionChanged&lt;/samp&gt; method.
             style=&quot;toggle&quot;
             state=&quot;true&quot;
             menubarPath=&quot;additions&quot; 
-            icon=&quot;icons/showXYZ.png&quot;
+            icon=&quot;icons/showXYZ.svg&quot;
             helpContextId=&quot;com.xyz.show_action_context&quot; 
             class=&quot;com.xyz.actions.XYZShowActionDelegate&quot; /&gt; 
       &lt;/viewerContribution&gt; 
@@ -497,7 +497,7 @@ The following is an example of the filter mechanism. In this case the action wil
          &lt;action
             id=&quot;com.xyz.runXYZ&quot; 
             label=&quot;High Priority Completed Action Tool&quot; 
-            icon=&quot;icons/runXYZ.png&quot;
+            icon=&quot;icons/runXYZ.svg&quot;
             class=&quot;com.xyz.actions.MarkerActionDelegate&quot;&gt; 
          &lt;/action&gt; 
       &lt;/objectContribution&gt; 
@@ -522,7 +522,7 @@ The following is an other example of using the visibility element:
             label=&quot;&amp;amp;Show XYZ&quot;
             style=&quot;push&quot;
             menubarPath=&quot;additions&quot; 
-            icon=&quot;icons/showXYZ.png&quot;
+            icon=&quot;icons/showXYZ.svg&quot;
             helpContextId=&quot;com.xyz.show_action_context&quot; 
             class=&quot;com.xyz.actions.XYZShowActionDelegate&quot;&gt; 
          &lt;/action&gt; 

--- a/bundles/org.eclipse.ui/schema/preferenceTransfer.exsd
+++ b/bundles/org.eclipse.ui/schema/preferenceTransfer.exsd
@@ -242,7 +242,7 @@ default (org.eclipse.core.resources.ProjectScope.SCOPE)
    &lt;extension
          point=&quot;org.eclipse.ui.preferenceTransfer&quot;&gt;
        &lt;transfer
-            icon=&quot;XYZ.png&quot;
+            icon=&quot;XYZ.svg&quot;
             name=&quot;Export All Transfer Test&quot;
             id=&quot;org.eclipse.ui.tests.all&quot;&gt;
             &lt;mapping scope=&quot;instance&quot;/&gt;
@@ -278,7 +278,7 @@ default (org.eclipse.core.resources.ProjectScope.SCOPE)
    &lt;extension
          point=&quot;org.eclipse.ui.preferenceTransfer&quot;&gt;
        &lt;transfer
-            icon=&quot;XYZ.png&quot;
+            icon=&quot;XYZ.svg&quot;
             name=&quot;Export many preferences&quot;
             id=&quot;org.eclipse.ui.tests.all&quot;&gt;
             &lt;mapping scope=&quot;instance&quot;&gt;

--- a/bundles/org.eclipse.ui/schema/viewActions.exsd
+++ b/bundles/org.eclipse.ui/schema/viewActions.exsd
@@ -442,7 +442,7 @@ can be expressed using:
             toolbarPath=&quot;Normal/additions&quot;
             style=&quot;toggle&quot;
             state=&quot;true&quot; 
-            icon=&quot;icons/runXYZ.png&quot;
+            icon=&quot;icons/runXYZ.svg&quot;
             tooltip=&quot;Run XYZ Tool&quot; 
             helpContextId=&quot;com.xyz.run_action_context&quot; 
             class=&quot;com.xyz.actions.RunXYZ&quot;&gt; 
@@ -475,7 +475,7 @@ The following is an other example of a view action extension:
             label=&quot;&amp;amp;Run XYZ2 Tool&quot; 
             menubarPath=&quot;com.xyz.xyzMenu/group1&quot;
             style=&quot;push&quot;
-            icon=&quot;icons/runXYZ2.png&quot;
+            icon=&quot;icons/runXYZ2.svg&quot;
             tooltip=&quot;Run XYZ2 Tool&quot; 
             helpContextId=&quot;com.xyz.run_action_context2&quot; 
             class=&quot;com.xyz.actions.RunXYZ2&quot;&gt; 

--- a/bundles/org.eclipse.ui/schema/views.exsd
+++ b/bundles/org.eclipse.ui/schema/views.exsd
@@ -395,7 +395,7 @@ If no value is supplied, a default ratio will be used.
          name=&quot;XYZ View&quot; 
          category=&quot;com.xyz.views.XYZviews&quot; 
          class=&quot;com.xyz.views.XYZView&quot; 
-         icon=&quot;icons/XYZ.png&quot;/&gt;
+         icon=&quot;icons/XYZ.svg&quot;/&gt;
    &lt;/extension&gt; 
 &lt;/pre&gt;
 &lt;/p&gt;

--- a/bundles/org.eclipse.ui/schema/workingSets.exsd
+++ b/bundles/org.eclipse.ui/schema/workingSets.exsd
@@ -147,7 +147,7 @@ Added in 3.4.
             id=&quot;org.eclipse.ui.resourceWorkingSetPage&quot;
             name=&quot;Resource&quot;
             description=&quot;Contains basic resources (files, folders, and projects)&quot;
-            icon=&quot;icons/resworkset.png&quot;
+            icon=&quot;icons/resworkset.svg&quot;
             pageClass=&quot;org.eclipse.ui.internal.dialogs.ResourceWorkingSetPage&quot;
             updaterClass=&quot;org.eclipse.ui.internal.workingsets.ResourceWorkingSetUpdater&quot;
             elementAdapterClass=&quot;org.eclipse.ui.internal.workingsets.ResourceWorkingSetElementAdapter&quot;&gt;

--- a/bundles/org.eclipse.ui/src/org/eclipse/ui/internal/UIPlugin.java
+++ b/bundles/org.eclipse.ui/src/org/eclipse/ui/internal/UIPlugin.java
@@ -42,7 +42,7 @@ public final class UIPlugin extends AbstractUIPlugin {
 	/**
 	 * Returns the image registry for this plugin.
 	 *
-	 * Where are the images? The images (typically png) are found in the same
+	 * Where are the images? The images (typically SVG) are found in the same
 	 * plugins directory.
 	 *
 	 * Note: The workbench uses the standard JFace ImageRegistry to track its


### PR DESCRIPTION
This PR adds SVGs for all icons in the bundles `org.eclipse.ui` except for the following as it is not available as SVG yet:

etool16/search.svg

See also this [PR](https://github.com/eclipse-platform/eclipse.platform/pull/1797) for more information.