### PR TITLE
Add SVGs to org.eclipse.ui.editors

### DIFF
--- a/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
@@ -31,3 +31,4 @@ Require-Bundle:
  org.eclipse.jdt.annotation;bundle-version="2.3";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.ui.editors
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.ui.editors/icons/full/elcl16/collapseall.svg
+++ b/bundles/org.eclipse.ui.editors/icons/full/elcl16/collapseall.svg
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="collapseall.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(18,-3)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9"
+       xlink:href="#blue_gradient_left"
+       inkscape:collect="always" />
+           <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(20,-1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9-5"
+       xlink:href="#blue_gradient_left"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="blue_gradient_left">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="blue_gradient_left_stop_0" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="blue_gradient_left_stop_1" />
+    </linearGradient>
+       
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1"
+       xlink:href="#blue_gradient_top"
+       inkscape:collect="always"
+       gradientTransform="translate(18,-3)" />
+       
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1-1"
+       xlink:href="#blue_gradient_top"
+       inkscape:collect="always"
+       gradientTransform="translate(20,-1)" />
+    <linearGradient
+       id="blue_gradient_top"
+       inkscape:collect="always">
+      <stop
+         id="blue_gradient_top_stop_0"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="blue_gradient_top_stop_1"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+       
+    <linearGradient
+       y2="1043.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="translate(22,4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4970"
+       xlink:href="#minus_shadow_gradient"
+       inkscape:collect="always" />
+    <linearGradient
+       id="minus_shadow_gradient">
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="0"
+         id="minus_shadow_gradient_stop_0" />
+      <stop
+         id="minus_shadow_gradient_stop_1"
+         offset="0.5"
+         style="stop-color:#c3e9ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="1"
+         id="minus_shadow_gradient_stop_2" />
+    </linearGradient>
+
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="8.1029364"
+     inkscape:cy="7.6300717"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1138"
+     inkscape:window-height="951"
+     inkscape:window-x="1043"
+     inkscape:window-y="364"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#ffffff;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       d="m 3,1039.2997 8.971875,0 0.02812,9.1563 -8.971875,0 z"
+       id="front_background-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#a6afc4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 2,1038.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="back_rect"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="fill:url(#linearGradient5062-9);fill-opacity:1.0;stroke:none;display:inline"
+       d="m 5,1041.3622 0,7 -2,0 0,-9 z"
+       id="back_left_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1);fill-opacity:1.0;stroke:none;display:inline"
+       d="m 5,1041.3622 7,0 0,-2 -9,0 z"
+       id="back_top_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 4,1040.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="front_rect"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 5,1041.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="front_background"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4970);fill-opacity:1.0;stroke:none;display:inline"
+       d="m 8,1047.3622 5,0 c 1,0 1,-1 0,-1 l -5,0 c -1,0 -1,1 0,1 z"
+       id="minus_sign_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5062-9-5);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 0,7 -2,0 0,-9 z"
+       id="left_top_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 7,0 0,-2 -9,0 z"
+       id="front_top_shadow"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="fill:#01467a;fill-opacity:1;stroke:none;display:inline"
+       id="minus_sign"
+       width="1"
+       height="7"
+       x="1045.3622"
+       y="-13"
+       transform="matrix(0,1,-1,0,0,0)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.editors/icons/full/elcl16/expandall.svg
+++ b/bundles/org.eclipse.ui.editors/icons/full/elcl16/expandall.svg
@@ -1,0 +1,334 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="expandall.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4989">
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="0"
+         id="stop4991" />
+      <stop
+         id="stop4995"
+         offset="0.5"
+         style="stop-color:#c3e9ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="1"
+         id="stop4993" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1"
+       xlink:href="#linearGradient4994-4-7"
+       inkscape:collect="always"
+       gradientTransform="translate(18,-3)" />
+    <linearGradient
+       id="linearGradient4994-4-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(18,-3)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9"
+       xlink:href="#linearGradient4910-4-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-4"
+       id="linearGradient4889-2"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9,0,0,0.9,-17.7,103.93622)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-4">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885-5" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-4-7"
+       id="linearGradient4889-2-1"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9,0,0,0.9,-15.7,105.93622)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-4-7">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885-5-1" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887-5-1" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(20,-1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9-5"
+       xlink:href="#linearGradient4910-4-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8-7" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1-1"
+       xlink:href="#linearGradient4994-4-7-4"
+       inkscape:collect="always"
+       gradientTransform="translate(20,-1)" />
+    <linearGradient
+       id="linearGradient4994-4-7-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4-2"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="translate(22,4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4970"
+       xlink:href="#linearGradient4989"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4989-1">
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="0"
+         id="stop4991-2" />
+      <stop
+         id="stop4995-3"
+         offset="0.5"
+         style="stop-color:#c3e9ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="1"
+         id="stop4993-3" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="matrix(0,1,-1,0,1053.3622,1058.3622)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5050"
+       xlink:href="#linearGradient4989-1"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.9999998"
+     inkscape:cx="1.5251501"
+     inkscape:cy="27.213599"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="75"
+     inkscape:window-y="75"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 2,1038.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="rect3997-9-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 3,1039.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="rect3997-9-1-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient5062-9);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 0,7 -2,0 0,-9 z"
+       id="rect4853-82-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 7,0 0,-2 -9,0 z"
+       id="rect4853-82-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 4,1040.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="rect3997-9-1-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 5,1041.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="rect3997-9-1-1-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4970);fill-opacity:1;stroke:none;display:inline"
+       d="m 8,1047.3622 5,0 c 1,0 1,-1 0,-1 l -5,0 c -1,0 -1,1 0,1 z"
+       id="rect4853-82-0-6-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5062-9-5);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 0,7 -2,0 0,-9 z"
+       id="rect4853-82-7-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 7,0 0,-2 -9,0 z"
+       id="rect4853-82-0-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5050);fill-opacity:1;stroke:none;display:inline"
+       d="m 10,1044.3622 0,5 c 0,1 1,1 1,0 l 0,-5 c 0,-1 -1,-1 -1,0 z"
+       id="rect4853-82-0-6-8-41"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="fill:#01467a;fill-opacity:1;stroke:none"
+       id="rect4167"
+       width="1"
+       height="7"
+       x="9"
+       y="1042.3622" />
+    <rect
+       style="fill:#01467a;fill-opacity:1;stroke:none;display:inline"
+       id="rect4167-8"
+       width="1"
+       height="7"
+       x="1045.3622"
+       y="-13"
+       transform="matrix(0,1,-1,0,0,0)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.editors/icons/full/etool16/last_edit_pos.svg
+++ b/bundles/org.eclipse.ui.editors/icons/full/etool16/last_edit_pos.svg
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="last_edit_pos.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#ffffee;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#ffecad;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#ba7f0d;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#a2660b;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="11.0625"
+       y1="1038.5497"
+       x2="11.0625"
+       y2="1049.912"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,17,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="4.5"
+       y1="1042.047"
+       x2="4.5"
+       y2="1046.4902"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,17,0)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4499"
+       x="-0.072151147"
+       width="1.1443022"
+       y="-0.071849167"
+       height="1.1436983">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.21929058"
+         id="feGaussianBlur4501" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#c0c0c0"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.84375"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2318"
+     inkscape:window-height="1264"
+     inkscape:window-x="116"
+     inkscape:window-y="179"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.5,1038.8622 0,3 5.78125,0 c 0.667867,0 1.21875,0.5509 1.21875,1.2188 l 0,2.5625 c 0,0.6678 -0.550883,1.2187 -1.21875,1.2187 l -5.78125,0 0,3 -1,0 -5.5,-5.5 5.5,-5.5 1,0 z"
+       id="rect3968"
+       inkscape:connector-curvature="0" />
+    <image
+       y="1036.3622"
+       x="-18"
+       id="image4221"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAUlJREFU OI2lk79PwlAQxz+P8AdAYtLRf8BNbByRGUcTGEzcHJg12mhYmhoSSFwYdHKCgcWBgambmhAGVx1w cpCQEAcTpNpzKKUFimi4y3u5997d9+7dDyUIq1BsJeswgJ4z50KxTU1sU/s1xJieM6XXbQlAr9sS H8g2Ndk5fVoaQbxppcgaHbY3dbJGm6aVwt74mzFAfPbi9blF+uQRkSF+fhd9I3P2puJZo4MXRZur gz6HN2s8ZD4AUED6+A4AEe/sbWNgNFF+GfWcKffXW9MakxKrkBwCKO8HXzhfv4T3oqesxNOfsvOB ZSIOP92gjLulvrqtFEEccL+CJb7sjFfwNhq5qNlOrBeSsndkTJw1ylZU/gDIVwcKieBaISFO90Kc F0tqhYRE6fgc2cr56kA1KiVwvxd692muD8IgdZJLJ20uB/+llafxBx7GpAnvdjELAAAAAElFTkSu QmCC "
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <ellipse
+       style="display:inline;opacity:0.90399996;fill:#e9deb7;fill-opacity:1;stroke:none;stroke-width:1.37168431;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4499)"
+       id="path4469"
+       cx="13.727267"
+       cy="1039.1163"
+       rx="3.6471865"
+       ry="3.6625156"
+       transform="matrix(0.82766114,0,0,0.8242015,-8.861585,184.92095)" />
+    <g
+       style="display:inline"
+       id="g4521"
+       transform="matrix(0.70781815,0,0,0.72750345,-23.767608,285.37698)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4430"
+         d="m 37.150891,1035.0263 0,8.2474"
+         style="fill:none;fill-rule:evenodd;stroke:#355883;stroke-width:1.39354694px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4430-8-3"
+         d="m 34.161058,1036.9375 6.06822,4.5836"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#355883;stroke-width:1.39354694px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4430-8-3-1"
+         d="m 39.98197,1036.8345 -5.979458,4.6998"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#355883;stroke-width:1.39354694px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.editors/icons/full/etool16/new_untitled_text_file.svg
+++ b/bundles/org.eclipse.ui.editors/icons/full/etool16/new_untitled_text_file.svg
@@ -1,0 +1,520 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="new_untitled_text_file.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5068">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5070" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5072" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4863">
+      <stop
+         style="stop-color:#ba9726;stop-opacity:1;"
+         offset="0"
+         id="stop4865" />
+      <stop
+         style="stop-color:#997413;stop-opacity:1"
+         offset="1"
+         id="stop4867" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4823">
+      <stop
+         id="stop4825"
+         offset="0"
+         style="stop-color:#fefdef;stop-opacity:1" />
+      <stop
+         id="stop4827"
+         offset="1"
+         style="stop-color:#fbdd83;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4815">
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1;"
+         offset="0"
+         id="stop4817" />
+      <stop
+         style="stop-color:#989891;stop-opacity:1"
+         offset="1"
+         id="stop4819" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4753">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1"
+         offset="0"
+         id="stop4755" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4757" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.8479968,0,0,1.8479968,10.267503,1029.4109)"
+       y2="7.549418"
+       x2="0.9375"
+       y1="4.8437853"
+       x1="0.9375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5618"
+       xlink:href="#linearGradient4823"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4753"
+       id="linearGradient4759"
+       x1="7.4641018"
+       y1="3"
+       x2="7.4641018"
+       y2="15"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,1036.3622)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4815"
+       id="linearGradient4821"
+       x1="8"
+       y1="1038.3622"
+       x2="8"
+       y2="1052.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4863"
+       id="linearGradient4869"
+       x1="12.578125"
+       y1="1037.7841"
+       x2="12.578125"
+       y2="1043.7627"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient5074"
+       x1="12"
+       y1="1038.3622"
+       x2="10.007812"
+       y2="1038.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0078125,0.015625)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient5076"
+       x1="10"
+       y1="1040.3622"
+       x2="10.007812"
+       y2="1038.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0078125,0.015625)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient5078"
+       x1="10"
+       y1="1041.3622"
+       x2="8.0078125"
+       y2="1041.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0078125,0.015625)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient5080"
+       x1="10"
+       y1="5"
+       x2="10.007812"
+       y2="6.9843998"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0078125,1036.3778)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient5082"
+       x1="12"
+       y1="1042.3622"
+       x2="10.007812"
+       y2="1042.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0078125,0.015625)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient5084"
+       x1="12"
+       y1="1043.3622"
+       x2="12"
+       y2="1045.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0078125,0.015625)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient5086"
+       x1="13"
+       y1="1043.3622"
+       x2="15.007812"
+       y2="1043.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0078125,0.015625)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient5088"
+       x1="14"
+       y1="1041.3622"
+       x2="14"
+       y2="1043.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0078125,0.015625)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4863"
+       id="linearGradient3052"
+       gradientUnits="userSpaceOnUse"
+       x1="12.578125"
+       y1="1037.7841"
+       x2="12.578125"
+       y2="1043.7627" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4823"
+       id="linearGradient3054"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8479968,0,0,1.8479968,10.267503,1029.4109)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9"
+       id="radialGradient4534-5"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4528-9">
+      <stop
+         style="stop-color:#e0c576;stop-opacity:1;"
+         offset="0"
+         id="stop4530-0" />
+      <stop
+         style="stop-color:#9e7916;stop-opacity:1"
+         offset="1"
+         id="stop4532-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6"
+       id="linearGradient4526-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <linearGradient
+       id="linearGradient6281-8-0-1-6">
+      <stop
+         id="stop6283-0-2-2-1"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9"
+       id="radialGradient3091"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6"
+       id="linearGradient3093"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9-5"
+       id="radialGradient3091-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5482486,-7.3730329e-6,7.0712347e-6,1.4848746,426.93416,369.29871)"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574" />
+    <linearGradient
+       id="linearGradient4528-9-5">
+      <stop
+         style="stop-color:#e0c576;stop-opacity:1;"
+         offset="0"
+         id="stop4530-0-5" />
+      <stop
+         style="stop-color:#9e7916;stop-opacity:1"
+         offset="1"
+         id="stop4532-7-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6-6"
+       id="linearGradient3093-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9407202,0,0,1.9407202,10.140577,1029.3648)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6">
+      <stop
+         id="stop6283-0-2-2-1-2"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7-6"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877-6"
+       id="linearGradient4867-7"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83652132,0,0,0.83652132,0.33470939,169.23039)" />
+    <linearGradient
+       id="linearGradient4877-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4879-1"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4881-4"
+         offset="1"
+         style="stop-color:#5e76a3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861-1"
+       id="linearGradient4869-17"
+       x1="7.0070496"
+       y1="1045.8571"
+       x2="14"
+       y2="1045.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83652132,0,0,0.83652132,0.33470939,169.22164)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861-1">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4863-1" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop4865-52" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861-1"
+       id="linearGradient4871-2"
+       x1="7.0070496"
+       y1="1047.8571"
+       x2="14"
+       y2="1047.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83652132,0,0,0.83652132,0.33470939,169.22158)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861-1"
+       id="linearGradient4875-9"
+       x1="7.0070496"
+       y1="1049.8571"
+       x2="14"
+       y2="1049.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83652132,0,0,0.83652132,0.33470933,169.23035)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861-1"
+       id="linearGradient4873-1"
+       x1="7.0070496"
+       y1="1051.8571"
+       x2="12.016466"
+       y2="1051.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83652132,0,0,0.83652132,0.33470939,169.2216)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#cbcbcb"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="26.8125"
+     inkscape:cx="0.76456877"
+     inkscape:cy="6.3589744"
+     inkscape:document-units="px"
+     inkscape:current-layer="g3038"
+     showgrid="true"
+     inkscape:window-width="1902"
+     inkscape:window-height="1033"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3971"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4821);fill-opacity:1;stroke:none;display:inline"
+       d="m 3,1038.3622 0,14 11,0 0,-14 -11,0 z m 1,1 9,0 0,12 -9,0 0,-12 z"
+       id="rect3983-9"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4759);fill-opacity:1;stroke:none"
+       id="rect3983"
+       width="9"
+       height="12"
+       x="4"
+       y="1039.3622" />
+    <g
+       id="g3038"
+       transform="matrix(1.1954268,0,0,1.1954268,-2.4071696,-204.29183)">
+      <rect
+         style="display:inline;fill:url(#radialGradient3091-1);fill-opacity:1;stroke:#a27d18;stroke-width:0.86365604;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3910"
+         width="3.8333969"
+         height="3.7259271"
+         x="-746.76648"
+         y="-729.09308"
+         transform="matrix(-0.70710678,-0.70710678,0.70710678,-0.70710678,0,0)" />
+      <path
+         sodipodi:nodetypes="ccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path5581-5-5"
+         d="m 12.051904,1038.6701 0.836522,0 0,1.673 1.651638,0 0,0.8365 -1.651638,0 0,1.6731 -0.836522,0 0,-1.6731 -1.673042,0 0,-0.8365 1.673042,0 z"
+         style="display:inline;fill:url(#linearGradient3093-5);fill-opacity:1;stroke:none" />
+      <rect
+         style="display:inline;fill:url(#linearGradient4867-7);fill-opacity:1;stroke:none"
+         id="rect4001-1"
+         width="3.3401883"
+         height="0.84521562"
+         x="6.1962552"
+         y="1042.0161" />
+      <rect
+         style="display:inline;fill:url(#linearGradient4869-17);fill-opacity:1;stroke:none"
+         id="rect4001-1-7"
+         width="5.8497519"
+         height="0.84521562"
+         x="6.1962552"
+         y="1043.6805" />
+      <rect
+         style="display:inline;fill:url(#linearGradient4871-2);fill-opacity:1;stroke:none"
+         id="rect4001-1-7-4"
+         width="5.8497519"
+         height="0.84521562"
+         x="6.1962552"
+         y="1045.3535" />
+      <rect
+         style="display:inline;fill:url(#linearGradient4875-9);fill-opacity:1;stroke:none"
+         id="rect4001-1-7-4-0"
+         width="5.8497519"
+         height="0.84521562"
+         x="6.1962552"
+         y="1047.0353" />
+      <rect
+         style="display:inline;fill:url(#linearGradient4873-1);fill-opacity:1;stroke:none"
+         id="rect4001-1-7-4-0-9"
+         width="4.1904836"
+         height="0.84521562"
+         x="6.1962552"
+         y="1048.6996" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.editors/icons/full/etool16/next_nav.svg
+++ b/bundles/org.eclipse.ui.editors/icons/full/etool16/next_nav.svg
@@ -1,0 +1,374 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   sodipodi:docname="next_nav.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient7038">
+      <stop
+         id="stop7040"
+         offset="0"
+         style="stop-color:#bcb489;stop-opacity:1" />
+      <stop
+         id="stop7042"
+         offset="1"
+         style="stop-color:#798da2;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4403">
+      <stop
+         style="stop-color:#8593ae;stop-opacity:1"
+         offset="0"
+         id="stop4405" />
+      <stop
+         style="stop-color:#979ea3;stop-opacity:1"
+         offset="1"
+         id="stop4407" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4081">
+      <stop
+         style="stop-color:#286296;stop-opacity:1"
+         offset="0"
+         id="stop4083" />
+      <stop
+         style="stop-color:#778cb4;stop-opacity:1"
+         offset="1"
+         id="stop4085" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-6">
+      <stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974-71" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-4-1-2">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6799-4-3-3">
+      <stop
+         style="stop-color:#bcb489;stop-opacity:1"
+         offset="0"
+         id="stop6801-4-0-8" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-5-7">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-5-2-6">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-3-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-9-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4741"
+       inkscape:collect="always">
+      <stop
+         id="stop4743"
+         offset="0"
+         style="stop-color:#ba7f0d;stop-opacity:1" />
+      <stop
+         id="stop4745"
+         offset="1"
+         style="stop-color:#a2660b;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4749"
+       inkscape:collect="always">
+      <stop
+         id="stop4751"
+         offset="0"
+         style="stop-color:#ffffee;stop-opacity:1" />
+      <stop
+         id="stop4753"
+         offset="1"
+         style="stop-color:#fbdd83;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient5232"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1299052"
+       y1="1043.8982"
+       x2="13.428"
+       y2="1043.8982"
+       gradientTransform="matrix(0,0.65104166,0.65104166,0,-672.04862,1036.0982)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient5234"
+       gradientUnits="userSpaceOnUse"
+       x1="5.2061925"
+       y1="1044.488"
+       x2="16.2465"
+       y2="1044.488"
+       gradientTransform="matrix(0,0.65104166,0.65104166,0,-672.04862,1036.0982)" />
+    <linearGradient
+       id="linearGradient4972-5-7-2">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-4-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-3-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-6-5">
+      <stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974-71-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-5-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-4-1-2-8">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-4-3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-6-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4081"
+       id="linearGradient4087"
+       x1="-2.5863335"
+       y1="1045.1082"
+       x2="-1.7672856"
+       y2="1045.1082"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2209298,0,0,1.1309974,1052.7324,-1175.0041)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4403"
+       id="linearGradient4409"
+       x1="-1052.5747"
+       y1="4.5035412"
+       x2="-1048.5747"
+       y2="4.5035412"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3-3"
+       id="linearGradient7050"
+       x1="3.0035219"
+       y1="1039.5747"
+       x2="3.0035219"
+       y2="1052.5747"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(14,-7.73625e-5)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#efefef"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="42.956752"
+     inkscape:cx="8.0080542"
+     inkscape:cy="8.0080542"
+     inkscape:document-units="px"
+     inkscape:current-layer="g5253-5"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4250"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g5542"
+       transform="translate(-0.94286168,0.40625002)">
+      <g
+         transform="translate(-1.0606602,-0.61871837)"
+         id="g5253-5"
+         style="display:inline">
+        <path
+           style="opacity:1;fill:none;fill-opacity:0.52156863;stroke:url(#linearGradient7050);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:3.70000005;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 16.503522,1039.5747 0,13"
+           id="rect7028"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2"
+           width="4"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1040.5747"
+           transform="scale(-1,-1)" />
+        <g
+           id="g1">
+          <path
+             sodipodi:nodetypes="ccsssscccccc"
+             inkscape:connector-curvature="0"
+             id="rect3968"
+             d="m 3.5035215,1043.0851 h 2 v -4.2167 c 0,-0.4348 0.070964,-0.7937 0.5057943,-0.7937 H 8.70886 c 0.4347656,0 0.7946615,0.4374 0.7946615,0.8722 v 4.1378 h 1.9999995 v 0.652 l -3.9413407,4.338 -4.0586588,-4.3385 z"
+             style="fill:url(#linearGradient5232);fill-opacity:1;stroke:url(#linearGradient5234);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        </g>
+        <rect
+           transform="matrix(0,1,1,0,0,0)"
+           style="fill:url(#linearGradient4087);fill-opacity:1;stroke:none"
+           id="rect6999"
+           width="1.9999614"
+           height="3.006958"
+           x="1049.5747"
+           y="6.0035219" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5"
+           width="2"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1042.5747"
+           transform="scale(-1,-1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9"
+           width="2"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1044.5747"
+           transform="scale(-1,-1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9-5"
+           width="2"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1048.5747"
+           transform="scale(-1,-1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9-0"
+           width="2"
+           height="1.0000386"
+           x="-12.003522"
+           y="-1048.5747"
+           transform="scale(-1,-1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-51"
+           width="5"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1050.5747"
+           transform="scale(-1,-1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-3"
+           width="3"
+           height="1.0000386"
+           x="-15.003522"
+           y="-1046.5747"
+           transform="scale(-1,-1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4409);fill-opacity:1;stroke:none;stroke-width:0.69427586;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-51-3"
+           width="4.0000386"
+           height="1.0000386"
+           x="-1052.5747"
+           y="4.0035219"
+           transform="matrix(0,-1,1,0,0,0)" />
+        <rect
+           style="opacity:0.15700001;fill:none;fill-opacity:0.52156863;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:3.70000005;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect7026"
+           width="12"
+           height="13"
+           x="5.0035219"
+           y="1039.5747" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.editors/icons/full/etool16/prev_nav.svg
+++ b/bundles/org.eclipse.ui.editors/icons/full/etool16/prev_nav.svg
@@ -1,0 +1,362 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   sodipodi:docname="prev_nav.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4403">
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1"
+         offset="0"
+         id="stop4405" />
+      <stop
+         style="stop-color:#b5b08f;stop-opacity:1"
+         offset="1"
+         id="stop4407" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4081">
+      <stop
+         style="stop-color:#286296;stop-opacity:1"
+         offset="0"
+         id="stop4083" />
+      <stop
+         style="stop-color:#778cb4;stop-opacity:1"
+         offset="1"
+         id="stop4085" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-6">
+      <stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974-71" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-4-1-2">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6799-4-3-3">
+      <stop
+         style="stop-color:#bcb489;stop-opacity:1"
+         offset="0"
+         id="stop6801-4-0-8" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-5-7">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-5-2-6">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-3-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-9-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4741"
+       inkscape:collect="always">
+      <stop
+         id="stop4743"
+         offset="0"
+         style="stop-color:#ba7f0d;stop-opacity:1" />
+      <stop
+         id="stop4745"
+         offset="1"
+         style="stop-color:#a2660b;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4749"
+       inkscape:collect="always">
+      <stop
+         id="stop4751"
+         offset="0"
+         style="stop-color:#ffffee;stop-opacity:1" />
+      <stop
+         id="stop4753"
+         offset="1"
+         style="stop-color:#fbdd83;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient5232"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1299052"
+       y1="1043.8982"
+       x2="13.428"
+       y2="1043.8982"
+       gradientTransform="matrix(0,-0.65104166,0.65104166,0,-674.05214,1052.8412)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient5234"
+       gradientUnits="userSpaceOnUse"
+       x1="5.2061925"
+       y1="1044.488"
+       x2="16.2465"
+       y2="1044.488"
+       gradientTransform="matrix(0,-0.65104166,0.65104166,0,-674.05214,1052.8412)" />
+    <linearGradient
+       id="linearGradient4972-5-7-2">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-4-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-3-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-6-5">
+      <stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974-71-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-5-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-4-1-2-8">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-4-3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-6-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4081"
+       id="linearGradient4087"
+       x1="-2.5863335"
+       y1="1045.1082"
+       x2="-1.7672856"
+       y2="1045.1082"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2209298,0,0,1.1309974,-1036.2046,-1177.0077)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4403"
+       id="linearGradient4409"
+       x1="-1052.5747"
+       y1="4.5035412"
+       x2="-1048.5747"
+       y2="4.5035412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2493679,0,0,1,2352.4176,-2.003522)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3-3"
+       id="linearGradient7050"
+       x1="3.0035219"
+       y1="1039.5747"
+       x2="3.0035219"
+       y2="1052.5747"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(11.99648,-2.2126746)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#f3f3f3"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.96875"
+     inkscape:cx="8.0069505"
+     inkscape:cy="8.0069505"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1392"
+     inkscape:window-height="1027"
+     inkscape:window-x="231"
+     inkscape:window-y="34"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4250"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g3"
+       inkscape:label="document">
+      <g
+         id="g2"
+         inkscape:label="border">
+        <path
+           style="display:inline;fill:none;fill-opacity:0.521569;stroke:url(#linearGradient7050);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:3.7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 14.5,1037.3622 v 13"
+           id="rect7028"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc"
+           inkscape:label="rect7028" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4409);fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-51-3"
+           width="4.99752"
+           height="1.0000386"
+           x="1037.3645"
+           y="2"
+           transform="matrix(0,1,1,0,0,0)"
+           inkscape:label="rect6891-5-7-31-2-51-3" />
+      </g>
+      <g
+         id="g1"
+         inkscape:label="lines">
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2"
+           width="4"
+           height="1.0000386"
+           x="-13"
+           y="1048.3622"
+           transform="scale(-1,1)"
+           inkscape:label="rect6891-5-7-31-2" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5"
+           width="2"
+           height="1.0000386"
+           x="-13"
+           y="1046.3622"
+           transform="scale(-1,1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9"
+           width="2"
+           height="1.0000386"
+           x="-13"
+           y="1044.3622"
+           transform="scale(-1,1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9-5"
+           width="2"
+           height="1.0000386"
+           x="-13"
+           y="1040.3622"
+           transform="scale(-1,1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-5-9-0"
+           width="2"
+           height="1.0000386"
+           x="-10"
+           y="1040.3622"
+           transform="scale(-1,1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:3.7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-51"
+           width="5"
+           height="1.0000386"
+           x="-13"
+           y="1038.3622"
+           transform="scale(-1,1)" />
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c1c6d9;fill-opacity:1;stroke:none;stroke-width:0.694276;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect6891-5-7-31-2-3"
+           width="3"
+           height="1.0000386"
+           x="-13"
+           y="1042.3622"
+           transform="scale(-1,1)" />
+        <rect
+           transform="rotate(-90)"
+           style="display:inline;fill:url(#linearGradient4087);fill-opacity:1;stroke:none"
+           id="rect6999"
+           width="1.9999614"
+           height="3.006958"
+           x="-1039.3622"
+           y="3.9999993"
+           inkscape:label="rect6999" />
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccsssscccccc"
+       inkscape:connector-curvature="0"
+       id="rect3968"
+       d="m 1.4999996,1045.8583 2,0.01 v 5.205 c 0,0.4348 0.070964,0.7934 0.5057943,0.7934 h 2.6995442 c 0.4347656,0 0.7947917,-0.4366 0.7946615,-0.8714 v -5.131 h 1.9999997 v -0.659 l -3.9999997,-4.341 -4,4.3409 z"
+       style="fill:url(#linearGradient5232);fill-opacity:1;stroke:url(#linearGradient5234);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:label="arrow" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.editors/icons/full/obj16/file_obj.svg
+++ b/bundles/org.eclipse.ui.editors/icons/full/obj16/file_obj.svg
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="file_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5135-7"
+       id="linearGradient4873-1"
+       x1="7.0070496"
+       y1="1051.8571"
+       x2="12.016466"
+       y2="1051.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       id="linearGradient5135-7"
+       inkscape:collect="always">
+      <stop
+         id="stop5137-4"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5139-0"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5141-4"
+       id="linearGradient4875-9"
+       x1="7.0070496"
+       y1="1049.8571"
+       x2="14"
+       y2="1049.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       id="linearGradient5141-4"
+       inkscape:collect="always">
+      <stop
+         id="stop5143-8"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5145-8"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5147-4"
+       id="linearGradient4871-2"
+       x1="7.0070496"
+       y1="1047.8571"
+       x2="14"
+       y2="1047.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       id="linearGradient5147-4"
+       inkscape:collect="always">
+      <stop
+         id="stop5149-5"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5151-5"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861-1"
+       id="linearGradient4869-17"
+       x1="7.0070496"
+       y1="1045.8571"
+       x2="14"
+       y2="1045.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861-1">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4863-1" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop4865-52" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877-6"
+       id="linearGradient4867-7"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-3.044194)" />
+    <linearGradient
+       id="linearGradient4877-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4879-1"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4881-4"
+         offset="1"
+         style="stop-color:#5e76a3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient4908-2"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.977903,-1.044194)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902-3">
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1"
+         offset="0"
+         id="stop4904-2" />
+      <stop
+         style="stop-color:#8392b0;stop-opacity:1"
+         offset="1"
+         id="stop4906-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894-6"
+       id="linearGradient4900-1"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.022097,-1.044194)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4894-6">
+      <stop
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0"
+         id="stop4896-8" />
+      <stop
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1"
+         id="stop4898-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-6">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996-1" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998-89" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101"
+       xlink:href="#linearGradient4994-6"
+       inkscape:collect="always"
+       gradientTransform="translate(-1.977903,-1.044194)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313709"
+     inkscape:cx="39.563403"
+     inkscape:cy="1.2514114"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1440"
+     inkscape:window-height="900"
+     inkscape:window-x="81"
+     inkscape:window-y="29"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4101);fill-opacity:1;stroke:none;display:inline"
+       d="m 3.5193795,1037.8597 7.0096695,0 3.062057,3.0066 0,9.9546 -10.0717265,0 z"
+       id="rect4001-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:url(#linearGradient4900-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 9.998718,1037.397 0,3.9112 3.977478,0 z"
+       id="path4884"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:url(#linearGradient4908-2);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+       d="m 3.5193795,1037.8597 7.0096695,0 3.062057,3.0066 0,9.9546 -10.0717265,0 z"
+       id="rect4001"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <rect
+       style="fill:url(#linearGradient4867-7);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1"
+       width="3.9929504"
+       height="1.0103934"
+       x="5.0291462"
+       y="1040.3074" />
+    <rect
+       style="fill:url(#linearGradient4869-17);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7"
+       width="6.9929504"
+       height="1.0103934"
+       x="5.0291462"
+       y="1042.3074" />
+    <rect
+       style="fill:url(#linearGradient4871-2);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4"
+       width="6.9929504"
+       height="1.0103934"
+       x="5.0291462"
+       y="1044.3074" />
+    <rect
+       style="fill:url(#linearGradient4875-9);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4-0"
+       width="6.9929504"
+       height="1.0103934"
+       x="5.0291462"
+       y="1046.3074" />
+    <rect
+       style="fill:url(#linearGradient4873-1);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4-0-9"
+       width="5.0094166"
+       height="1.0103934"
+       x="5.0291462"
+       y="1048.3074" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.editors/icons/full/obj16/quick_assist_obj.svg
+++ b/bundles/org.eclipse.ui.editors/icons/full/obj16/quick_assist_obj.svg
@@ -1,0 +1,311 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="quickassist_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5894">
+      <stop
+         style="stop-color:#309858;stop-opacity:1"
+         offset="0"
+         id="stop5896" />
+      <stop
+         style="stop-color:#b8d0a0;stop-opacity:1"
+         offset="1"
+         id="stop5898" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5992">
+      <stop
+         style="stop-color:#fcf5ce;stop-opacity:1"
+         offset="0"
+         id="stop5994" />
+      <stop
+         id="stop6002"
+         offset="0.38312635"
+         style="stop-color:#f1f2c5;stop-opacity:1" />
+      <stop
+         id="stop6000"
+         offset="0.59470785"
+         style="stop-color:#dceab4;stop-opacity:1" />
+      <stop
+         style="stop-color:#d8e8b0;stop-opacity:1"
+         offset="1"
+         id="stop5996" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5933">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5935" />
+      <stop
+         style="stop-color:#abb6c2;stop-opacity:1"
+         offset="1"
+         id="stop5937" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5925">
+      <stop
+         style="stop-color:#9eacbc;stop-opacity:1;"
+         offset="0"
+         id="stop5927" />
+      <stop
+         style="stop-color:#667480;stop-opacity:1"
+         offset="1"
+         id="stop5929" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5925"
+       id="linearGradient5931"
+       x1="27.072289"
+       y1="1048.3826"
+       x2="28.339197"
+       y2="1050.1135"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89997441,0,0,0.89997441,-17.690817,103.73383)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5933"
+       id="linearGradient5939"
+       x1="27.072289"
+       y1="1048.3826"
+       x2="28.339197"
+       y2="1050.1135"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89997441,0,0,0.89997441,-17.690817,103.73383)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5992"
+       id="radialGradient5998"
+       cx="28.6875"
+       cy="1046.2943"
+       fx="28.6875"
+       fy="1046.2943"
+       r="4.5"
+       gradientTransform="matrix(1.2880604,0,0,1.7157634,-28.824033,-749.12751)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5894"
+       id="linearGradient5900"
+       x1="3.2902069"
+       y1="1038.3929"
+       x2="3.2902069"
+       y2="1046.9003"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89997441,0,0,0.89997441,0.308671,103.73383)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5992-4"
+       id="radialGradient5998-1"
+       cx="28.6875"
+       cy="1046.2943"
+       fx="28.6875"
+       fy="1046.2943"
+       r="4.5"
+       gradientTransform="matrix(1.2880604,0,0,1.7157634,-28.824033,-749.12751)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5992-4">
+      <stop
+         style="stop-color:#fcf5ce;stop-opacity:1"
+         offset="0"
+         id="stop5994-6" />
+      <stop
+         id="stop6002-8"
+         offset="0.38312635"
+         style="stop-color:#f1f2c5;stop-opacity:1" />
+      <stop
+         id="stop6000-4"
+         offset="0.59470785"
+         style="stop-color:#dceab4;stop-opacity:1" />
+      <stop
+         style="stop-color:#d8e8b0;stop-opacity:1"
+         offset="1"
+         id="stop5996-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5894-4"
+       id="linearGradient5900-9"
+       x1="3.2902069"
+       y1="1038.3929"
+       x2="3.2902069"
+       y2="1046.9003"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89997441,0,0,0.89997441,0.308671,103.73383)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5894-4">
+      <stop
+         style="stop-color:#309858;stop-opacity:1"
+         offset="0"
+         id="stop5896-5" />
+      <stop
+         style="stop-color:#b8d0a0;stop-opacity:1"
+         offset="1"
+         id="stop5898-7" />
+    </linearGradient>
+    <radialGradient
+       r="4.5"
+       fy="1046.2943"
+       fx="28.6875"
+       cy="1046.2943"
+       cx="28.6875"
+       gradientTransform="matrix(1.2880604,0,0,1.7157634,-28.824033,-749.1275)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3053"
+       xlink:href="#linearGradient5992-4"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1046.9003"
+       x2="3.2902069"
+       y1="1038.3929"
+       x1="3.2902069"
+       gradientTransform="matrix(0.89997441,0,0,0.89997441,0.308671,103.73382)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3055"
+       xlink:href="#linearGradient5894-4"
+       inkscape:collect="always" />
+    <radialGradient
+       r="4.5"
+       fy="1046.2943"
+       fx="28.6875"
+       cy="1046.2943"
+       cx="28.6875"
+       gradientTransform="matrix(1.2880604,0,0,1.7157634,-28.824033,-749.1275)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3053-2"
+       xlink:href="#linearGradient5992-4-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5992-4-0">
+      <stop
+         style="stop-color:#fcf5ce;stop-opacity:1"
+         offset="0"
+         id="stop5994-6-9" />
+      <stop
+         id="stop6002-8-1"
+         offset="0.38312635"
+         style="stop-color:#f1f2c5;stop-opacity:1" />
+      <stop
+         id="stop6000-4-6"
+         offset="0.59470785"
+         style="stop-color:#dceab4;stop-opacity:1" />
+      <stop
+         style="stop-color:#d8e8b0;stop-opacity:1"
+         offset="1"
+         id="stop5996-5-3" />
+    </linearGradient>
+    <linearGradient
+       y2="1046.9003"
+       x2="3.2902069"
+       y1="1038.3929"
+       x1="3.2902069"
+       gradientTransform="matrix(0.89997441,0,0,0.89997441,0.308671,103.73382)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3055-2"
+       xlink:href="#linearGradient5894-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5894-4-2">
+      <stop
+         style="stop-color:#309858;stop-opacity:1"
+         offset="0"
+         id="stop5896-5-3" />
+      <stop
+         style="stop-color:#b8d0a0;stop-opacity:1"
+         offset="1"
+         id="stop5898-7-4" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="10.093623"
+     inkscape:cy="8.1106702"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="88"
+     inkscape:window-y="128"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.0485959,1036.8692 c -2.4374703,0 -4.4171757,1.9797 -4.4171757,4.4173 0,2.8152 2.217317,6.2976 2.2430968,9.2234 l 4.348158,0 c 0,-2.7914 2.243096,-6.3448 2.243096,-9.2234 0,-2.4376 -1.979705,-4.4173 -4.4171751,-4.4173 z"
+       id="path5108-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccs" />
+    <rect
+       style="fill:#4a607a;fill-opacity:1;stroke:#4a607a;stroke-width:0.89997447;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       id="rect5896-7"
+       width="1.828073"
+       height="2.624912"
+       x="7.0303555"
+       y="1047.2892" />
+    <path
+       style="fill:url(#radialGradient3053);fill-opacity:1;stroke:url(#linearGradient3055);stroke-width:0.89997447;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       d="m 7.958454,1037.7835 c -1.986483,0 -3.599898,1.6134 -3.599898,3.6 0,2.2943 1.807063,3.0434 1.828073,5.4279 l 3.54365,0 c 0,-2.275 1.828073,-3.0819 1.828073,-5.4279 0,-1.9866 -1.613415,-3.6 -3.599898,-3.6 z"
+       id="path5108"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccs" />
+    <rect
+       style="fill:url(#linearGradient5939);fill-opacity:1;stroke:url(#linearGradient5931);stroke-width:0.89997446999999986;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect5896"
+       width="3.5436492"
+       height="2.1374233"
+       x="6.1866293"
+       y="1046.7831" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.editors/icons/full/obj16/quick_fix_error_obj.svg
+++ b/bundles/org.eclipse.ui.editors/icons/full/obj16/quick_fix_error_obj.svg
@@ -1,0 +1,250 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="quick_fix_error_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5894">
+      <stop
+         style="stop-color:#e9a328;stop-opacity:1"
+         offset="0"
+         id="stop5896" />
+      <stop
+         style="stop-color:#f9c537;stop-opacity:1"
+         offset="1"
+         id="stop5898" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5992">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop5994" />
+      <stop
+         id="stop6002"
+         offset="0.38312635"
+         style="stop-color:#fdfbeb;stop-opacity:1" />
+      <stop
+         id="stop6000"
+         offset="0.59470785"
+         style="stop-color:#f8eb99;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe4b1;stop-opacity:1"
+         offset="1"
+         id="stop5996" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5933">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5935" />
+      <stop
+         style="stop-color:#abb6c2;stop-opacity:1"
+         offset="1"
+         id="stop5937" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5925">
+      <stop
+         style="stop-color:#9eacbc;stop-opacity:1;"
+         offset="0"
+         id="stop5927" />
+      <stop
+         style="stop-color:#667480;stop-opacity:1"
+         offset="1"
+         id="stop5929" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5992"
+       id="radialGradient6262"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4312189,0,0,1.9064579,-34.245592,-947.65067)"
+       cx="28.6875"
+       cy="1046.2943"
+       fx="28.6875"
+       fy="1046.2943"
+       r="4.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5894"
+       id="linearGradient6264"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.875,0)"
+       x1="3.2902069"
+       y1="1038.3929"
+       x2="3.2902069"
+       y2="1046.9003" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5933"
+       id="linearGradient6266"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-21.875,0)"
+       x1="27.739658"
+       y1="1048.96"
+       x2="28.339197"
+       y2="1050.1135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5925"
+       id="linearGradient6268"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-21.875,0)"
+       x1="26.384804"
+       y1="1047.3513"
+       x2="28.898684"
+       y2="1051.0419" />
+    <filter
+       inkscape:collect="always"
+       id="filter7038"
+       x="-0.2404681"
+       width="1.4809362"
+       y="-0.23953372"
+       height="1.4790674">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.66240056"
+         id="feGaussianBlur7040" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4229"
+       x="-0.078808117"
+       width="1.1576162"
+       y="-0.072642858"
+       height="1.1452857">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.45347304"
+         id="feGaussianBlur4231" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#cfcfcf"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.84375"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:#ffffff;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1;filter:url(#filter4229);opacity:0.934"
+       d="m 1.3112467,1041.37 0.1115955,-3.571 1.6460331,-1.4507 5.3286835,0.056 1.3949434,1.6461 0.2789888,3.2084 5.049695,0.1115 -0.0837,9.932 -8.9555361,0.028 -0.055798,-1.0322 -3.4315606,0.028 0.027899,-3.878 -1.0880558,-1.088 z"
+       id="path4223"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#edaa2b;stroke-width:0.82638889999999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;filter:url(#filter7038)"
+       d="m 5.5022998,1038.5281 c -1.8240601,0 -3.3055556,1.4814 -3.3055556,3.3055 0,2.1067 1.6593104,1.1418 1.6786025,3.3314 l 3.2539062,0 c 0,-2.089 1.6786025,-1.1771 1.6786025,-3.3314 0,-1.8241 -1.4814955,-3.3055 -3.3055556,-3.3055 z"
+       id="path5108-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccs" />
+    <g
+       id="g6257"
+       transform="matrix(0.77997385,0,0,0.73483496,0.334973,276.05573)">
+      <path
+         sodipodi:nodetypes="sccccs"
+         inkscape:connector-curvature="0"
+         id="path5108"
+         d="m 6.625,1037.8622 c -2.207266,0 -4,1.7927 -4,4 0,2.5493 2.007905,3.3816 2.03125,6.0313 l 3.9375,0 c 0,-2.5279 2.03125,-3.4244 2.03125,-6.0313 0,-2.2073 -1.792734,-4 -4,-4 z"
+         style="fill:url(#radialGradient6262);fill-opacity:1;stroke:url(#linearGradient6264);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <rect
+         y="1048.4247"
+         x="5.59375"
+         height="3.4375"
+         width="2.03125"
+         id="rect5896-7"
+         style="fill:#4a607a;fill-opacity:1;stroke:#4a607a;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+      <rect
+         y="1047.8622"
+         x="4.65625"
+         height="3"
+         width="3.9375"
+         id="rect5896"
+         style="fill:url(#linearGradient6266);fill-opacity:1;stroke:url(#linearGradient6268);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+    </g>
+    <rect
+       style="fill:#d8424f;fill-opacity:1;stroke:none;display:inline"
+       id="rect4244"
+       width="7"
+       height="8"
+       x="7.0009851"
+       y="1042.3551" />
+    <path
+       inkscape:connector-curvature="0"
+       style="font-size:7.68999243px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:125%;letter-spacing:0px;word-spacing:0px;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.27519909;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 8.2509853,1044.1366 0,0.125 0,0.5 0,0.125 0.125,0 0.375,0 1.1875,1.4063 -1.21875,1.5312 -0.34375,0 -0.125,0 0,0.125 0,0.5 0,0.125 0.125,0 1.5,0 0.1249997,0 0,-0.125 0,-0.5 0,-0.125 -0.1249997,0 0.6249997,-0.8437 0.625,0.8437 -0.125,0 0,0.125 0,0.5 0,0.125 0.125,0 1.5,0 0.125,0 0,-0.125 0,-0.5 0,-0.125 -0.125,0 -0.3125,0 -1.25,-1.5625 1.15625,-1.375 0.40625,0 0.125,0 0,-0.125 0,-0.5 0,-0.125 -0.125,0 -1.5,0 -0.125,0 0,0.125 0,0.5 0,0.125 0.0625,0 -0.5625,0.7188 -0.5624997,-0.7188 0.0625,0 0,-0.125 0,-0.5 0,-0.125 -0.1249988,0 -1.5,0 -0.125,0 z"
+       id="path4187" />
+    <image
+       y="1036.2994"
+       x="-15.993026"
+       id="image4220"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAZZJREFU
+OI2lkz0sQ1EYhp9zb9GfqEqblIgIEqWLGCRdJH5CIjEIEZ1ILGxiNVnFZKukkZRFDNKtg5TB2MHi
+r0Gs/koJKXXvPQZppXrdSLzTOec75/m+9zvnCCkl/5Htx9yMJv4KkNm9GfTMFSgqGDqqtxlP/7q0
+goiChef9WSmETnX7WDH4craDgYq7d+3XSpTCQHtO4wyOYIh3dCWPId5xBEf4yKatHHxbUOwgK1VQ
+fYCBREFq9wj7t8Wf1ZcApJJHV3UqnG0g30DYuRhaBjzcrYyWZQ4k46UWnC0T5I4jaPkTFFsDWv4E
+AFd3F76pMBX1fnxTYVzdXeY9qGpdwF0fQpxvfAUuNwFwdATwTn8d9E6HcXQEzHsACKVpSSZ3Fqm2
+PfJw5KaVW55299GyWfzzc9ysRnhNHZpXUFBKThIK1hI9qCvzbaYygMzdE08c4KrUAKgZ7Ctm98/P
+UTPYZw3obPQQ3U4wPtwDQO40TSa2xWvqkExsi4/rm5L9wuQzFRfSA+XXV1AgGRe/AUxhJip9SFab
+rPQJYsCG+TBzCWwAAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.editors/icons/full/obj16/quick_fix_info_obj.svg
+++ b/bundles/org.eclipse.ui.editors/icons/full/obj16/quick_fix_info_obj.svg
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="quick_fix_info_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5894">
+      <stop
+         style="stop-color:#e9a328;stop-opacity:1"
+         offset="0"
+         id="stop5896" />
+      <stop
+         style="stop-color:#f9c537;stop-opacity:1"
+         offset="1"
+         id="stop5898" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5992">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop5994" />
+      <stop
+         id="stop6002"
+         offset="0.38312635"
+         style="stop-color:#fdfbeb;stop-opacity:1" />
+      <stop
+         id="stop6000"
+         offset="0.59470785"
+         style="stop-color:#f8eb99;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe4b1;stop-opacity:1"
+         offset="1"
+         id="stop5996" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5933">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5935" />
+      <stop
+         style="stop-color:#abb6c2;stop-opacity:1"
+         offset="1"
+         id="stop5937" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5925">
+      <stop
+         style="stop-color:#9eacbc;stop-opacity:1;"
+         offset="0"
+         id="stop5927" />
+      <stop
+         style="stop-color:#667480;stop-opacity:1"
+         offset="1"
+         id="stop5929" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5992"
+       id="radialGradient6262"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4312189,0,0,1.9064579,-34.245592,-947.65067)"
+       cx="28.6875"
+       cy="1046.2943"
+       fx="28.6875"
+       fy="1046.2943"
+       r="4.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5894"
+       id="linearGradient6264"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.875,0)"
+       x1="3.2902069"
+       y1="1038.3929"
+       x2="3.2902069"
+       y2="1046.9003" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5933"
+       id="linearGradient6266"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-21.875,0)"
+       x1="27.739658"
+       y1="1048.96"
+       x2="28.339197"
+       y2="1050.1135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5925"
+       id="linearGradient6268"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-21.875,0)"
+       x1="26.384804"
+       y1="1047.3513"
+       x2="28.898684"
+       y2="1051.0419" />
+    <filter
+       inkscape:collect="always"
+       id="filter7038"
+       x="-0.2404681"
+       width="1.4809362"
+       y="-0.23953372"
+       height="1.4790674">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.66240056"
+         id="feGaussianBlur7040" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4196"
+       x="-0.1068"
+       width="1.2136"
+       y="-0.1068"
+       height="1.2136">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.445"
+         id="feGaussianBlur4198" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#656565"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="64.542987"
+     inkscape:cx="16.193494"
+     inkscape:cy="7.9660085"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1396"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="opacity:0.91100003;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4196)"
+       d="m 3,1046.3622 0,3.0097 1.0128295,0.9903 3.9871705,0 0,1 5,0 0,-7 -3,-3 -7,0 z"
+       id="path4162"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <image
+       y="1036.3622"
+       x="23"
+       id="image4220"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACx jwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAu NvyMY98AAAJUSURBVDhPjZJLaBNBHMZXLUGKFRFvevDkwYOe1IMeqiJIURFEEDyUngVFFMHqoQdr oUJBSypRGyRxW43EmBBramK2Vduq2Ef6SGnTVJvH5mXiJml3s69+zsJig2mrP/iY2f9833+WmaHK AUVtgI0yaGqiqI16+d9oZjFk3iuxb9rE5PugxHqKCjeJZT7hRDS6XbetjrarELMfFSM9Qv7DJaRf HESGKN29H5y/Huqv4CgymRrdXglroqrFqH0w/+kKcs4TkGcfYTnmgPL9GTjPOXDei1CFdLNur2Rx uHFfaZ5Wc+5jkGaMUOM2KIluyIkuyFELco5DkDNfZnR7JfzozcPCjAmc6wAU9jmkpAVi2kzUCSn1 FHlfHcTYWxDmiLbqsRV4256dQpguFZlTEELNKGWsEDk3pHwvmdMoeGvB5pbw0DuNFMeTI/sLNFEG ke218mONWOo/DrnAQBEXoEpJ8OPXIARuwDcRR02Dlf8aTmt/Mq9HVyh8M+2QUn1ZfqAOcvIlVCUP dXEO/NAZiMU40mTnvkkW2aKwegMN7c5Dn++Ddrhhe/0KZprGgOceQqEQWuwjqL7whO2fYtdpoCi+ 4cAYLA4fImwKrncf0WV3kieQwXQ0h83nTWAmYms3IAvM0EgQLUYr7D0MbrV2oL2T1gIIRrIwnDWC GV+/QXvqZw63Wx+j/uodNFy/i/CPqBbA1EIWVacfwB+IaJ9rNthGxGiOcrQzuNzhx6aTbaxrMKyV snqkErJYRXSEqFYfE7Isk+EPqm79P0hgC9FuXbv0chkU9Rt6avtnpfSaAQAAAABJRU5ErkJggg== "
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16.000017"
+       width="16" />
+    <path
+       style="fill:none;stroke:#edaa2b;stroke-width:0.82638889999999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;filter:url(#filter7038)"
+       d="m 5.5022998,1038.5281 c -1.8240601,0 -3.3055556,1.4814 -3.3055556,3.3055 0,2.1067 1.6593104,1.1418 1.6786025,3.3314 l 3.2539062,0 c 0,-2.089 1.6786025,-1.1771 1.6786025,-3.3314 0,-1.8241 -1.4814955,-3.3055 -3.3055556,-3.3055 z"
+       id="path5108-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccs" />
+    <g
+       id="g6257"
+       transform="matrix(0.77997385,0,0,0.73483496,0.334973,276.05573)">
+      <path
+         sodipodi:nodetypes="sccccs"
+         inkscape:connector-curvature="0"
+         id="path5108"
+         d="m 6.625,1037.8622 c -2.207266,0 -4,1.7927 -4,4 0,2.5493 2.007905,3.3816 2.03125,6.0313 l 3.9375,0 c 0,-2.5279 2.03125,-3.4244 2.03125,-6.0313 0,-2.2073 -1.792734,-4 -4,-4 z"
+         style="fill:url(#radialGradient6262);fill-opacity:1;stroke:url(#linearGradient6264);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <rect
+         y="1048.4247"
+         x="5.59375"
+         height="3.4375"
+         width="2.03125"
+         id="rect5896-7"
+         style="fill:#4a607a;fill-opacity:1;stroke:#4a607a;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+      <rect
+         y="1047.8622"
+         x="4.65625"
+         height="3"
+         width="3.9375"
+         id="rect5896"
+         style="fill:url(#linearGradient6266);fill-opacity:1;stroke:url(#linearGradient6268);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+    </g>
+    <path
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:AppleMyungjo;-inkscape-font-specification:AppleMyungjo;letter-spacing:0px;word-spacing:0px;fill:#044d92;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 10.511433,1043.3622 q 0.213872,0 0.371951,0.1505 0.158079,0.1504 0.158079,0.3629 0,0.2035 -0.14878,0.3451 -0.148781,0.1415 -0.371952,0.1415 -0.22317,0 -0.371951,-0.1415 Q 10,1044.0791 10,1043.8756 q 0,-0.2036 0.14878,-0.354 0.15808,-0.1594 0.362653,-0.1594 z"
+       id="path4233"
+       inkscape:connector-curvature="0" />
+    <path
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:AppleMyungjo;-inkscape-font-specification:AppleMyungjo;letter-spacing:0px;word-spacing:0px;fill:#044d92;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 9,1045.3622 2,0 0,3.728 c 0,0.2376 0.193749,0.272 0.464481,0.272 l 0.535519,0 0,1 -3,0 1.8e-6,-1 0.5628327,0 C 9.884784,1049.3622 10,1049.2998 10,1049.0062 l 0,-2.144 c 0,-0.3913 -0.1036578,-0.5 -0.5719506,-0.5 l -0.4280488,0 c -10e-7,-0.3333 -6e-7,-0.6667 -6e-7,-1 z"
+       id="path4228"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccssccccsssccc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.editors/icons/full/obj16/quick_fix_warning_obj.svg
+++ b/bundles/org.eclipse.ui.editors/icons/full/obj16/quick_fix_warning_obj.svg
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="quick_fix_warning_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       y2="0.39338252"
+       x2="6.3885393"
+       y1="7.2369323"
+       x1="6.3885393"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4200"
+       xlink:href="#linearGradient5091"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="0.98171616"
+       x2="3.3833356"
+       y1="7.0159616"
+       x1="3.3833356"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4198"
+       xlink:href="#linearGradient5081"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5081">
+      <stop
+         id="stop5083"
+         offset="0"
+         style="stop-color:#ffe296;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8d880;stop-opacity:1"
+         offset="0.5"
+         id="stop5089" />
+      <stop
+         id="stop5085"
+         offset="1"
+         style="stop-color:#fffcd3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5091"
+       inkscape:collect="always">
+      <stop
+         id="stop5093"
+         offset="0"
+         style="stop-color:#c6852e;stop-opacity:1" />
+      <stop
+         id="stop5095"
+         offset="1"
+         style="stop-color:#e1a555;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       height="1.4790674"
+       y="-0.23953372"
+       width="1.4809362"
+       x="-0.2404681"
+       id="filter7038"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur7040"
+         stdDeviation="0.66240056"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       y2="1051.0419"
+       x2="28.898684"
+       y1="1047.3513"
+       x1="26.384804"
+       gradientTransform="translate(-21.875,0)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6268"
+       xlink:href="#linearGradient5925-1"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1050.1135"
+       x2="28.339197"
+       y1="1048.96"
+       x1="27.739658"
+       gradientTransform="translate(-21.875,0)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6266"
+       xlink:href="#linearGradient5933-5"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1046.9003"
+       x2="3.2902069"
+       y1="1038.3929"
+       x1="3.2902069"
+       gradientTransform="translate(-1.875,0)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6264"
+       xlink:href="#linearGradient5894-4"
+       inkscape:collect="always" />
+    <radialGradient
+       r="4.5"
+       fy="1046.2943"
+       fx="28.6875"
+       cy="1046.2943"
+       cx="28.6875"
+       gradientTransform="matrix(1.4312189,0,0,1.9064579,-34.245592,-947.65067)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient6262"
+       xlink:href="#linearGradient5992-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5925-1"
+       inkscape:collect="always">
+      <stop
+         id="stop5927-1"
+         offset="0"
+         style="stop-color:#9eacbc;stop-opacity:1;" />
+      <stop
+         id="stop5929-5"
+         offset="1"
+         style="stop-color:#667480;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5933-5"
+       inkscape:collect="always">
+      <stop
+         id="stop5935-1"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop5937-7"
+         offset="1"
+         style="stop-color:#abb6c2;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5992-4">
+      <stop
+         id="stop5994-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         style="stop-color:#fdfbeb;stop-opacity:1"
+         offset="0.38312635"
+         id="stop6002-8" />
+      <stop
+         style="stop-color:#f8eb99;stop-opacity:1"
+         offset="0.59470785"
+         id="stop6000-2" />
+      <stop
+         id="stop5996-45"
+         offset="1"
+         style="stop-color:#ffe4b1;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5894-4"
+       inkscape:collect="always">
+      <stop
+         id="stop5896-0"
+         offset="0"
+         style="stop-color:#e9a328;stop-opacity:1" />
+      <stop
+         id="stop5898-9"
+         offset="1"
+         style="stop-color:#f9c537;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4330"
+       x="-0.060812648"
+       width="1.1216253"
+       y="-0.052584405"
+       height="1.1051688">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.30819939"
+         id="feGaussianBlur4332" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#dfdfdf"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.995035"
+     inkscape:cx="-0.70708725"
+     inkscape:cy="1.3278902"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1858"
+     inkscape:window-height="1193"
+     inkscape:window-x="75"
+     inkscape:window-y="75"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="opacity:0.93699999;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4330)"
+       d="m 1.6454249,1041.3927 0.032263,-3.1941 2.0003203,-1.6454 4.1942201,10e-5 2.1293737,2.9359 0.03226,1.8712 1.935794,-0.032 2.710111,4.1296 0.03226,5.7752 -7.8077016,0.096 0.032266,-1.0647 -4.2910096,-0.032 -0.032263,-4.5491 -0.7097911,-1.3228 z"
+       id="path4320"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccc" />
+    <g
+       style="display:inline"
+       id="layer1-0"
+       inkscape:label="Layer 1"
+       transform="translate(-0.02631863,0.0390477)">
+      <path
+         sodipodi:nodetypes="sccccs"
+         inkscape:connector-curvature="0"
+         id="path5108-6-7"
+         d="m 5.5022998,1038.5281 c -1.8240601,0 -3.3055556,1.4814 -3.3055556,3.3055 0,2.1067 1.6593104,1.1418 1.6786025,3.3314 l 3.2539062,0 c 0,-2.089 1.6786025,-1.1771 1.6786025,-3.3314 0,-1.8241 -1.4814955,-3.3055 -3.3055556,-3.3055 z"
+         style="fill:none;stroke:#edaa2b;stroke-width:0.8263889;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;filter:url(#filter7038)" />
+      <g
+         transform="matrix(0.77997385,0,0,0.73483496,0.334973,276.05573)"
+         id="g6257">
+        <path
+           style="fill:url(#radialGradient6262);fill-opacity:1;stroke:url(#linearGradient6264);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+           d="m 6.625,1037.8622 c -2.207266,0 -4,1.7927 -4,4 0,2.5493 2.007905,3.3816 2.03125,6.0313 l 3.9375,0 c 0,-2.5279 2.03125,-3.4244 2.03125,-6.0313 0,-2.2073 -1.792734,-4 -4,-4 z"
+           id="path5108-3"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sccccs" />
+        <rect
+           style="fill:#4a607a;fill-opacity:1;stroke:#4a607a;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+           id="rect5896-7-0"
+           width="2.03125"
+           height="3.4375"
+           x="5.59375"
+           y="1048.4247" />
+        <rect
+           style="fill:url(#linearGradient6266);fill-opacity:1;stroke:url(#linearGradient6268);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+           id="rect5896-73"
+           width="3.9375"
+           height="3"
+           x="4.65625"
+           y="1047.8622" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="layer1-5"
+       inkscape:label="Layer 1"
+       transform="matrix(0.70552057,0,0,0.70552057,4.8741663,309.9897)">
+      <g
+         transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)"
+         id="g8472"
+         style="display:inline">
+        <g
+           transform="matrix(1.4166388,0,0,1.4166388,-3.2411359,-441.5072)"
+           id="g4193">
+          <path
+             style="fill:url(#linearGradient4198);fill-opacity:1;stroke:url(#linearGradient4200);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="M 2.8125,0.90625 0.78125,5 C 0.17522066,6.0251238 0.58843406,7.4816983 1.71875,7.5 L 3,7.5 l 1,0 1.28125,0 C 6.4115665,7.4817738 6.8247794,6.0250615 6.21875,5 L 4.1875,0.90625 c -0.2942923,-0.55673837 -1.1188077,-0.46727236 -1.375,0 z"
+             id="path4292"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccccccc"
+             transform="matrix(1.0698871,0,0,1.0698871,15.590192,1043.4798)" />
+          <path
+             sodipodi:type="arc"
+             style="fill:#502800;fill-opacity:1;stroke:none"
+             id="path4253"
+             sodipodi:cx="3.484375"
+             sodipodi:cy="5.484375"
+             sodipodi:rx="0.625"
+             sodipodi:ry="0.625"
+             d="m 4.109375,5.484375 a 0.625,0.625 0 0 1 -0.625,0.625 0.625,0.625 0 0 1 -0.625,-0.625 0.625,0.625 0 0 1 0.625,-0.625 0.625,0.625 0 0 1 0.625,0.625 z"
+             transform="matrix(1.125929,0,0,1.125929,15.411638,1043.3738)" />
+          <path
+             style="fill:#502800;fill-opacity:1;stroke:none;display:inline"
+             d="m 19.350026,1045.5028 c -0.378471,0 -0.700512,0.3368 -0.700512,0.774 l 0.09137,1.4889 c 0,0.3887 0.272722,0.7037 0.609141,0.7037 0.336419,0 0.609139,-0.315 0.609139,-0.7037 l 0.06091,-1.4889 c 0,-0.4372 -0.291583,-0.774 -0.670056,-0.774 z"
+             id="path4253-7"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="sccsccs" />
+        </g>
+      </g>
+    </g>
+    <image
+       y="1036.3932"
+       x="-16.001282"
+       id="image4317"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAcRJREFU
+OI2lk09IVFEUh79734yNMzZMOGqOOtIkIWPRQoihRYTLkCBBXEkSRBBtClq4GcJtMOsRRKhli2gh
+uZsyNw9aOzQ0kiUv8B/KY+zp+N67LWJmdHpvCPqt7jnn8t3zO9wjlFL8jwJNsRdN/CtAHRQe4Ox9
+A6mB66B1XiI2tqhaQUTNgvnhkRLC4fzwRL1Y+fIWF43o7XnfTmTtYJslwulxXHGMI6u44pj29Dgn
+B6VWDhoWZAhUmwZaHHBRSJS9iwg1LNa69gQoWcXRHILhK6COQISwf20hAifsrOSwDJ32oTt03Zg5
+M5O6hXBqEmstj10tIgN92NUiVjH/J2/oJKeyWOX3/jM4d/kp0d4M4utrANy1PNHETcxNl57REe5d
+vUbP6Ag7K7nTdhoAQMjBF3wsd6EX9ymUe5EDWSxDP/Nicyxp0mc1RSZ9gYXVi/xYmqWjLwLA3PNb
+AHQkImwuzfoDlLXLu+VVIm02mOvEkikOtytkX37icLtCLJlCmev+gOsDMRbeLPN4+i7GRgkRjKN1
+9/PwyQRadz8yGMfYaPwN4bFM9cRP/RXfC7nmOoNjz0hk7gs/gCfMQwL+3kbPS630G8HvnqRjJrKv
+AAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.editors/plugin.xml
+++ b/bundles/org.eclipse.ui.editors/plugin.xml
@@ -153,11 +153,11 @@
       <image
             commandId="org.eclipse.ui.edit.text.folding.collapse_all"
             disabledIcon="$nl$/icons/full/dlcl16/collapseall.png"
-            icon="$nl$/icons/full/elcl16/collapseall.png">
+            icon="$nl$/icons/full/elcl16/collapseall.svg">
       </image>
       <image
             commandId="org.eclipse.ui.edit.text.folding.expand_all"
-            icon="$nl$/icons/full/elcl16/expandall.png">
+            icon="$nl$/icons/full/elcl16/expandall.svg">
       </image>
   </extension>
    
@@ -266,7 +266,7 @@
          point="org.eclipse.ui.editors">
       <editor
             name="%Editors.DefaultTextEditor"
-            icon="$nl$/icons/full/obj16/file_obj.png"
+            icon="$nl$/icons/full/obj16/file_obj.svg"
             class="org.eclipse.ui.editors.text.TextEditor"
             contributorClass="org.eclipse.ui.editors.text.TextEditorActionContributor"
             id="org.eclipse.ui.DefaultTextEditor">
@@ -477,7 +477,7 @@
          point="org.eclipse.ui.newWizards">
       <wizard
             name="%NewUntitledTextFile.label"
-            icon="$nl$/icons/full/etool16/new_untitled_text_file.png"
+            icon="$nl$/icons/full/etool16/new_untitled_text_file.svg"
             category="org.eclipse.ui.Basic"
             class="org.eclipse.ui.internal.editors.text.UntitledTextFileWizard"
             canFinishEarly="true"
@@ -512,7 +512,7 @@
                class="org.eclipse.ui.internal.editors.text.PreviousPulldownActionDelegate"
                definitionId="org.eclipse.ui.navigate.previous"
                disabledIcon="$nl$/icons/full/dtool16/prev_nav.png"
-               icon="$nl$/icons/full/etool16/prev_nav.png"
+               icon="$nl$/icons/full/etool16/prev_nav.svg"
                label="%goToPreviousAnnotation.label"
                retarget="true"
                tooltip="%goToPreviousAnnotation.tooltip">
@@ -525,7 +525,7 @@
                class="org.eclipse.ui.internal.editors.text.NextPulldownActionDelegate"
                definitionId="org.eclipse.ui.navigate.next"
                disabledIcon="$nl$/icons/full/dtool16/next_nav.png"
-               icon="$nl$/icons/full/etool16/next_nav.png"
+               icon="$nl$/icons/full/etool16/next_nav.svg"
                label="%goToNextAnnotation.label"
                retarget="true"
                tooltip="%goToNextAnnotation.tooltip">
@@ -554,7 +554,7 @@
                class="org.eclipse.ui.texteditor.GotoLastEditPositionAction"
                definitionId="org.eclipse.ui.edit.text.gotoLastEditPosition"
                disabledIcon="$nl$/icons/full/dtool16/last_edit_pos.png"
-               icon="$nl$/icons/full/etool16/last_edit_pos.png"
+               icon="$nl$/icons/full/etool16/last_edit_pos.svg"
                helpContextId="org.eclipse.ui.goto_last_edit_position_action_context"
                label="%goToLastEditPosition.label"
                menubarPath="navigate/"
@@ -608,7 +608,7 @@
       		annotationType="org.eclipse.ui.workbench.texteditor.spelling"
             label="%spelling.label"
             symbolicIcon="warning"
-            quickFixIcon="$nl$/icons/full/obj16/quick_fix_warning_obj.png"
+            quickFixIcon="$nl$/icons/full/obj16/quick_fix_warning_obj.svg"
             presentationLayer="5"
             contributesToHeader="true"
             colorPreferenceKey="spellingIndicationColor"
@@ -640,7 +640,7 @@
             colorPreferenceKey="errorIndicationColor"
             showInNextPrevDropdownToolbarActionKey="showErrorInNextPrevDropdownToolbarAction"
             symbolicIcon="error"
-            quickFixIcon="$nl$/icons/full/obj16/quick_fix_error_obj.png"
+            quickFixIcon="$nl$/icons/full/obj16/quick_fix_error_obj.svg"
             isGoToNextNavigationTargetKey="isErrorGoToNextNavigationTarget"
             isGoToNextNavigationTarget="true"
             isGoToPreviousNavigationTargetKey="isErrorGoToPreviousNavigationTarget"
@@ -666,7 +666,7 @@
             colorPreferenceKey="warningIndicationColor"
             showInNextPrevDropdownToolbarActionKey="showWarningInNextPrevDropdownToolbarAction"
             symbolicIcon="warning"
-            quickFixIcon="$nl$/icons/full/obj16/quick_fix_warning_obj.png"
+            quickFixIcon="$nl$/icons/full/obj16/quick_fix_warning_obj.svg"
             isGoToNextNavigationTargetKey="isWarningGoToNextNavigationTarget"
             isGoToNextNavigationTarget="true"
             isGoToPreviousNavigationTargetKey="isWarningGoToPreviousNavigationTarget"
@@ -704,7 +704,7 @@
             contributesToHeader="false"
             colorPreferenceValue="130,160,190"
             overviewRulerPreferenceValue="true"
-            quickFixIcon="$nl$/icons/full/obj16/quick_fix_info_obj.png"
+            quickFixIcon="$nl$/icons/full/obj16/quick_fix_info_obj.svg"
             textStylePreferenceKey="infoTextStyle"
             textStylePreferenceValue="SQUIGGLES">
       </specification>

--- a/bundles/org.eclipse.ui.editors/plugin.xml
+++ b/bundles/org.eclipse.ui.editors/plugin.xml
@@ -152,7 +152,6 @@
    <extension point="org.eclipse.ui.commandImages">
       <image
             commandId="org.eclipse.ui.edit.text.folding.collapse_all"
-            disabledIcon="$nl$/icons/full/dlcl16/collapseall.png"
             icon="$nl$/icons/full/elcl16/collapseall.svg">
       </image>
       <image
@@ -511,7 +510,6 @@
                toolbarPath="org.eclipse.ui.workbench.navigate/history.group"
                class="org.eclipse.ui.internal.editors.text.PreviousPulldownActionDelegate"
                definitionId="org.eclipse.ui.navigate.previous"
-               disabledIcon="$nl$/icons/full/dtool16/prev_nav.png"
                icon="$nl$/icons/full/etool16/prev_nav.svg"
                label="%goToPreviousAnnotation.label"
                retarget="true"
@@ -524,7 +522,6 @@
                toolbarPath="org.eclipse.ui.workbench.navigate/history.group"
                class="org.eclipse.ui.internal.editors.text.NextPulldownActionDelegate"
                definitionId="org.eclipse.ui.navigate.next"
-               disabledIcon="$nl$/icons/full/dtool16/next_nav.png"
                icon="$nl$/icons/full/etool16/next_nav.svg"
                label="%goToNextAnnotation.label"
                retarget="true"
@@ -540,7 +537,6 @@
                id="org.eclipse.ui.edit.text.gotoNextEditPosition"
                class="org.eclipse.ui.texteditor.GotoNextEditPositionAction"
                definitionId="org.eclipse.ui.edit.text.gotoNextEditPosition"
-               disabledIcon="$nl$/icons/full/dtool16/next_edit_pos.png"
                icon="$nl$/icons/full/etool16/next_edit_pos.png"
                helpContextId="org.eclipse.ui.goto_next_edit_position_action_context"
                label="%goToNextEditPosition.label"
@@ -553,7 +549,6 @@
                id="org.eclipse.ui.edit.text.gotoLastEditPosition"
                class="org.eclipse.ui.texteditor.GotoLastEditPositionAction"
                definitionId="org.eclipse.ui.edit.text.gotoLastEditPosition"
-               disabledIcon="$nl$/icons/full/dtool16/last_edit_pos.png"
                icon="$nl$/icons/full/etool16/last_edit_pos.svg"
                helpContextId="org.eclipse.ui.goto_last_edit_position_action_context"
                label="%goToLastEditPosition.label"


### PR DESCRIPTION
This PR adds SVGs for all icons in the bundle `org.eclipse.ui.editors` except for the following as it is not available as SVG yet:

etool16/next_edit_pos

See also this [PR](https://github.com/eclipse-platform/eclipse.platform/pull/1797) for more information.