### PR TITLE
Add SVGs to org.eclipse.ui.genericeditor bundles

### DIFF
--- a/bundles/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
@@ -25,3 +25,4 @@ Bundle-Activator: org.eclipse.ui.internal.genericeditor.GenericEditorPlugin
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.ui.genericeditor
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.ui.genericeditor/icons/full/etool16/mark_occurrences.svg
+++ b/bundles/org.eclipse.ui.genericeditor/icons/full/etool16/mark_occurrences.svg
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="mark_occurrences.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4994">
+      <stop
+         id="stop4996"
+         offset="0"
+         style="stop-color:#a19a7c;stop-opacity:1" />
+      <stop
+         style="stop-color:#a29d80;stop-opacity:1"
+         offset="0.13130741"
+         id="stop5002" />
+      <stop
+         style="stop-color:#c5c3b5;stop-opacity:1"
+         offset="0.26261482"
+         id="stop4998" />
+      <stop
+         id="stop5004"
+         offset="0.63130742"
+         style="stop-color:#a29d80;stop-opacity:1" />
+      <stop
+         id="stop5000"
+         offset="1"
+         style="stop-color:#9e9070;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4976">
+      <stop
+         style="stop-color:#a8a38c;stop-opacity:1"
+         offset="0"
+         id="stop4978" />
+      <stop
+         id="stop4984"
+         offset="0.26261482"
+         style="stop-color:#c5c3b5;stop-opacity:1" />
+      <stop
+         style="stop-color:#a19a7c;stop-opacity:1"
+         offset="1"
+         id="stop4980" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4960">
+      <stop
+         style="stop-color:#eac826;stop-opacity:1"
+         offset="0"
+         id="stop4962" />
+      <stop
+         style="stop-color:#c5a334;stop-opacity:1"
+         offset="1"
+         id="stop4964" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4952">
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="0"
+         id="stop4954" />
+      <stop
+         id="stop4970"
+         offset="0.25"
+         style="stop-color:#fdf39f;stop-opacity:1" />
+      <stop
+         id="stop4968"
+         offset="0.62763387"
+         style="stop-color:#fee745;stop-opacity:1" />
+      <stop
+         style="stop-color:#eac826;stop-opacity:1"
+         offset="1"
+         id="stop4956" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4942">
+      <stop
+         style="stop-color:#f5d71e;stop-opacity:1"
+         offset="0"
+         id="stop4944" />
+      <stop
+         style="stop-color:#fdf39f;stop-opacity:1"
+         offset="1"
+         id="stop4946" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4942"
+       id="linearGradient4948"
+       x1="17.662846"
+       y1="1052.5724"
+       x2="19.885061"
+       y2="1052.5724"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-2.1397741)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4952"
+       id="linearGradient4958"
+       x1="26.461384"
+       y1="1045.0045"
+       x2="29.825548"
+       y2="1048.598"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.1397741,4.8953347e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4960"
+       id="linearGradient4966"
+       x1="28.021715"
+       y1="1042.9713"
+       x2="32.686157"
+       y2="1046.8485"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.1397741,4.8953347e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4976"
+       id="linearGradient4982"
+       x1="26.544964"
+       y1="1057.6731"
+       x2="30.345661"
+       y2="1061.172"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-14.978419)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient4992"
+       x1="29.5947"
+       y1="1053.5125"
+       x2="35.038246"
+       y2="1058.7136"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-14.978419)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313709"
+     inkscape:cx="27.607793"
+     inkscape:cy="3.0183401"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8472"
+     showgrid="false"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="50"
+     inkscape:window-y="50"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8472"
+       transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)">
+      <rect
+         style="fill:url(#linearGradient4948);fill-opacity:1;stroke:none"
+         id="rect4172"
+         width="5.3480377"
+         height="1.0668679"
+         x="15.590192"
+         y="1049.8992" />
+      <g
+         transform="translate(15.600543,0)"
+         id="g8421" />
+      <path
+         style="fill:url(#linearGradient4958);fill-opacity:1;stroke:url(#linearGradient4966);stroke-width:1.06988704px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 25.874196,1042.866 -5.532085,5.3903 c 0,0 -0.425545,1.3948 0.33098,1.9858 0.756524,0.5911 5.933987,0.2601 5.933987,0.2601 l 3.90083,-3.8299 z"
+         id="path4950"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4982);fill-opacity:1;stroke:#999072;stroke-width:1.06988704px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 30.106004,1047.3342 -4.633711,-4.3499 3.889236,-3.8893 4.468222,4.3027 z"
+         id="path4972"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:url(#linearGradient4992);fill-opacity:1;stroke:#9c9170;stroke-width:1.06988704px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 30.36606,1044.5919 c -0.532814,-0.6954 -1.460212,-1.6094 -2.245932,-2.1042 -0.785721,-0.4947 -1.820388,-0.6616 -1.820388,-0.6616 0,0 0.09457,-0.993 1.205712,-1.9859 l 8.700031,-8.854 0,12.542 -2.742401,2.3641 c -0.898374,0.5438 -2.316857,0.662 -2.316857,0.662 0.127896,-0.6188 -0.247352,-1.267 -0.780165,-1.9624 z"
+         id="path4974"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zzccccccz" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.genericeditor/icons/full/obj16/generic_editor.svg
+++ b/bundles/org.eclipse.ui.genericeditor/icons/full/obj16/generic_editor.svg
@@ -1,0 +1,993 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="generic_editor.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5135-7"
+       id="linearGradient4873-1"
+       x1="7.0070496"
+       y1="1051.8571"
+       x2="12.016466"
+       y2="1051.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-37.736949,1.2700771)" />
+    <linearGradient
+       id="linearGradient5135-7"
+       inkscape:collect="always">
+      <stop
+         id="stop5137-4"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5139-0"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5141-4"
+       id="linearGradient4875-9"
+       x1="7.0070496"
+       y1="1049.8571"
+       x2="14"
+       y2="1049.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0010081,0,0,1,-37.744013,1.2804705)" />
+    <linearGradient
+       id="linearGradient5141-4"
+       inkscape:collect="always">
+      <stop
+         id="stop5143-8"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5145-8"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5147-4"
+       id="linearGradient4871-2"
+       x1="7.0070496"
+       y1="1047.8571"
+       x2="14"
+       y2="1047.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0010081,0,0,1,-37.744013,1.2804705)" />
+    <linearGradient
+       id="linearGradient5147-4"
+       inkscape:collect="always">
+      <stop
+         id="stop5149-5"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5151-5"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861-1"
+       id="linearGradient4869-17"
+       x1="7.0070496"
+       y1="1045.8571"
+       x2="14"
+       y2="1045.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0010081,0,0,1,-37.744013,1.2804705)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861-1">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4863-1" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop4865-52" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877-6"
+       id="linearGradient4867-7"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-37.736949,1.2700771)" />
+    <linearGradient
+       id="linearGradient4877-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4879-1"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4881-4"
+         offset="1"
+         style="stop-color:#5e76a3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient4908-2"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99095428,0,0,1.0031864,-37.658076,-0.08475452)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902-3">
+      <stop
+         style="stop-color:#bfb688;stop-opacity:1"
+         offset="0"
+         id="stop4904-2" />
+      <stop
+         style="stop-color:#8392b0;stop-opacity:1"
+         offset="1"
+         id="stop4906-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894-6"
+       id="linearGradient4900-1"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.706521,3.2796435)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4894-6">
+      <stop
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0"
+         id="stop4896-8" />
+      <stop
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1"
+         id="stop4898-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-6">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996-1" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998-89" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101"
+       xlink:href="#linearGradient4994-6"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.89359064,0,0,0.9258402,-36.62284,80.770548)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient4908-2-6"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99095428,0,0,1.0031864,-39.658076,-2.0847625)" />
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101-1"
+       xlink:href="#linearGradient4994-6"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.89359064,0,0,0.9258402,-38.62284,78.770547)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient4908-2-7"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99095428,0,0,1.0031864,16.052444,-4.3521)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894-6"
+       id="linearGradient4900-1-1"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20.003999,-0.9877)" />
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101-13"
+       xlink:href="#linearGradient4994-6"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.89359064,0,0,0.9258402,17.08768,76.50321)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient4908-2-7-1"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99095428,0,0,1.0031864,36.052444,-4.3521)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894-6"
+       id="linearGradient4900-1-1-4"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(40.003999,-0.9877)" />
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101-13-3"
+       xlink:href="#linearGradient4994-6"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.89359064,0,0,0.9258402,37.08768,76.50321)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient4908-2-7-10"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99095428,0,0,1.0031864,36.052444,15.6479)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894-6"
+       id="linearGradient4900-1-1-7"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(40.003999,19.0123)" />
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101-13-8"
+       xlink:href="#linearGradient4994-6"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.89359064,0,0,0.9258402,37.08768,96.50321)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient4908-2-7-2"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99095428,0,0,1.0031864,16.052444,15.6479)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894-6"
+       id="linearGradient4900-1-1-3"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(20.003999,19.0123)" />
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101-13-1"
+       xlink:href="#linearGradient4994-6"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.89359064,0,0,0.9258402,17.08768,96.50321)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient4908-2-7-3"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99287852,0,0,1.0031864,-3.9581341,-4.3521)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894-6"
+       id="linearGradient4900-1-1-9"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.0233789,-0.9902001)" />
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101-13-31"
+       xlink:href="#linearGradient4994-6"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.89359064,0,0,0.9258402,-2.9123201,76.50321)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4371"
+       x="-0.10560744"
+       width="1.2112149"
+       y="-0.13893449"
+       height="1.277869">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.8251755"
+         id="feGaussianBlur4373" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4291"
+       id="linearGradient6172"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4419231,0,0,1.4954213,-304.05134,-149.24538)"
+       x1="557.2915"
+       y1="357.21786"
+       x2="548.21069"
+       y2="336.6817" />
+    <linearGradient
+       id="linearGradient4291"
+       inkscape:collect="always">
+      <stop
+         id="stop4293"
+         offset="0"
+         style="stop-color:#db9303;stop-opacity:1" />
+      <stop
+         id="stop4295"
+         offset="1"
+         style="stop-color:#fdbc3a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.62104081,0,0,0.60705081,41.725748,412.06323)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4426"
+       id="linearGradient4432"
+       x1="6.5387306"
+       y1="1040.6232"
+       x2="9.3119564"
+       y2="1047.3741"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4426">
+      <stop
+         style="stop-color:#bb94c8;stop-opacity:1"
+         offset="0"
+         id="stop4428" />
+      <stop
+         style="stop-color:#9955a7;stop-opacity:1"
+         offset="1"
+         id="stop4430" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter6169"
+       x="-0.36302817"
+       width="1.7260563"
+       y="-0.43994996"
+       height="1.8798999">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.45503657"
+         id="feGaussianBlur6171" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter6165"
+       x="-0.43994999"
+       width="1.8799"
+       y="-0.36302489"
+       height="1.7260498">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.45503657"
+         id="feGaussianBlur6167" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter6437"
+       x="-0.38563621"
+       width="1.7712724"
+       y="-0.31820786"
+       height="1.6364157">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.39886031"
+         id="feGaussianBlur6439" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter6153"
+       x="-0.30973551"
+       width="1.619471"
+       y="-0.30972427"
+       height="1.6194485">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.45503657"
+         id="feGaussianBlur6155" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter6149"
+       x="-0.30973554"
+       width="1.6194711"
+       y="-0.30972427"
+       height="1.6194485">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.45503657"
+         id="feGaussianBlur6151" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter6145"
+       x="-0.30972427"
+       width="1.6194485"
+       y="-0.30974185"
+       height="1.6194837">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.45503657"
+         id="feGaussianBlur6147" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4318"
+       x="-0.18241493"
+       width="1.3648299"
+       y="-0.18241493"
+       height="1.3648299">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.56468031"
+         id="feGaussianBlur4320" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902-3"
+       id="linearGradient4908-2-7-3-3"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99095428,0,0,1.0031864,-3.1937084,13.123868)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894-6"
+       id="linearGradient4900-1-1-9-4"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.7578465,16.488268)" />
+    <linearGradient
+       y2="1051.8378"
+       x2="9.8946028"
+       y1="1039.153"
+       x1="9.8946028"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4101-13-31-8"
+       xlink:href="#linearGradient4994-6"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.89359064,0,0,0.9258402,-2.1584724,93.979178)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="26.825864"
+     inkscape:cx="13.461732"
+     inkscape:cy="6.458602"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="display:inline;fill:url(#linearGradient4101-13-1);fill-opacity:1;stroke:none"
+       d="m 22,1058.3622 6.263775,0 2.736225,2.7836 0,9.2164 -9,0 z"
+       id="rect4001-3-47-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#758bb4;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 24.315073,1064.116 -0.0642,1.7751 c -0.391584,-0.1352 -0.628889,-0.1139 -1.106591,0.045 -0.160756,0.3523 -0.24244,0.6632 0.05544,1.0405 0.398222,0.2028 0.665203,0.084 1.017619,0.026 l 0.08278,1.7645 1.60007,0.045 c -0.20379,-0.9569 0.17985,-1.2355 0.837419,-1.286 0.834441,0.3256 0.726896,0.8323 0.628065,1.2746 l 1.600069,-0.033 0.02991,-1.6001 c -1.206457,0.074 -1.122686,-0.021 -1.256129,-0.8226 0.147121,-0.9444 0.779603,-0.5914 1.219275,-0.6581 l -0.008,-1.5851 -1.745228,-0.047 c 0.01497,-0.566 0.301313,-1.0404 -0.43804,-1.2394 -1.169176,0.212 -0.726009,0.6627 -0.702835,1.2411 z"
+       id="path4739"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4101-1);fill-opacity:1;stroke:none"
+       d="m -33.71052,1040.6295 6.263775,0 2.736225,2.7836 0,9.2164 -9,0 z"
+       id="rect4001-3-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient4908-2-6);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       d="m -34.21052,1040.1295 6.946261,0 3.034359,3.0161 0,9.9864 -9.98062,0 z"
+       id="rect4001-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4101);fill-opacity:1;stroke:none"
+       d="m -31.71052,1042.6295 6.263775,0 2.736225,2.7836 0,9.2164 -9,0 z"
+       id="rect4001-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4900-1);fill-opacity:1;stroke:none"
+       d="m -25.7299,1041.7208 0,3.9112 3.977478,0 z"
+       id="path4884"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient4908-2);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       d="m -32.21052,1042.1295 6.946261,0 3.034359,3.0161 0,9.9864 -9.98062,0 z"
+       id="rect4001"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867-7);fill-opacity:1;stroke:none"
+       id="rect4001-1"
+       width="3.9929504"
+       height="1.0103934"
+       x="-30.7299"
+       y="1044.6216" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4869-17);fill-opacity:1;stroke:none"
+       id="rect4001-1-7"
+       width="7"
+       height="1.0103934"
+       x="-30.7299"
+       y="1046.632" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4871-2);fill-opacity:1;stroke:none"
+       id="rect4001-1-7-4"
+       width="7"
+       height="1.0103934"
+       x="-30.7299"
+       y="1048.632" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4875-9);fill-opacity:1;stroke:none"
+       id="rect4001-1-7-4-0"
+       width="7"
+       height="1.0103934"
+       x="-30.7299"
+       y="1050.632" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4873-1);fill-opacity:1;stroke:none"
+       id="rect4001-1-7-4-0-9"
+       width="5.0094166"
+       height="1.0103934"
+       x="-30.7299"
+       y="1052.6216" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4246"
+       width="15.9"
+       height="15.9"
+       x="20.049999"
+       y="1036.4122" />
+    <rect
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4246-6"
+       width="15.9"
+       height="15.9"
+       x="40.049999"
+       y="1036.4122" />
+    <rect
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4246-3"
+       width="15.9"
+       height="15.9"
+       x="20.050001"
+       y="1056.4122" />
+    <rect
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4246-6-2"
+       width="15.9"
+       height="15.9"
+       x="40.049999"
+       y="1056.4122" />
+    <path
+       style="display:inline;fill:url(#linearGradient4101-13);fill-opacity:1;stroke:none"
+       d="m 22,1038.3622 6.263775,0 2.736225,2.7836 0,9.2164 -9,0 z"
+       id="rect4001-3-47"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4900-1-1);fill-opacity:1;stroke:none"
+       d="m 27.98062,1037.4535 0,3.9112 3.977478,0 z"
+       id="path4884-8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient4908-2-7);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 21.5,1037.8622 6.946261,0 3.034359,3.0161 0,9.9864 -9.98062,0 z"
+       id="rect4001-39"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4101-13-3);fill-opacity:1;stroke:none"
+       d="m 42,1038.3622 6.263775,0 2.736225,2.7836 0,9.2164 -9,0 z"
+       id="rect4001-3-47-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4900-1-1-4);fill-opacity:1;stroke:none"
+       d="m 47.98062,1037.4535 0,3.9112 3.977478,0 z"
+       id="path4884-8-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient4908-2-7-1);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 41.5,1037.8622 6.946261,0 3.034359,3.0161 0,9.9864 -9.98062,0 z"
+       id="rect4001-39-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4101-13-8);fill-opacity:1;stroke:none"
+       d="m 42,1058.3622 6.263775,0 2.736225,2.7836 0,9.2164 -9,0 z"
+       id="rect4001-3-47-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4900-1-1-7);fill-opacity:1;stroke:none"
+       d="m 47.98062,1057.4535 0,3.9112 3.977478,0 z"
+       id="path4884-8-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient4908-2-7-10);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 41.5,1057.8622 6.946261,0 3.034359,3.0161 0,9.9864 -9.98062,0 z"
+       id="rect4001-39-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4900-1-1-3);fill-opacity:1;stroke:none"
+       d="m 27.98062,1057.4535 0,3.9112 3.977478,0 z"
+       id="path4884-8-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient4908-2-7-2);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 21.5,1057.8622 6.946261,0 3.034359,3.0161 0,9.9864 -9.98062,0 z"
+       id="rect4001-39-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4101-13-31);fill-opacity:1;stroke:none"
+       d="m 2,1038.3622 6.263775,0 2.736225,2.7836 0,9.2164 -9,0 z"
+       id="rect4001-3-47-41"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4900-1-1-9);fill-opacity:1;stroke:none"
+       d="m 8,1037.451 0,3.9112 3.977478,0 z"
+       id="path4884-8-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient4908-2-7-3);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 1.5,1037.8622 6.9597489,0 3.0402511,3.0161 0,9.9864 -10,0 z"
+       id="rect4001-39-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <g
+       transform="matrix(0.14245923,0,0,0.13648921,-43.952172,994.46045)"
+       style="display:inline"
+       id="g4335">
+      <path
+         transform="matrix(1.2605511,0,0,1.2605511,-46.715155,-144.39926)"
+         style="display:inline;opacity:0.70099996;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter4371)"
+         d="m 408.58203,408.00377 21.08292,20.94242 20.39542,-20.94242 -10.31231,-10.58626 -20.62458,0 z"
+         id="path6164-6"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccccc"
+         style="fill:#fcb018;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6172);stroke-width:7.19368029;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 470.65921,367.06266 23.93569,24.83279 24.07001,-24.91198 -13.10779,-12.43032 -22.09879,0 z"
+         id="path6164"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         style="fill:#fdcc69;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.58380508px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 473.31237,367.01408 10.76057,-10.65834 20.85825,0.0792 10.85421,10.49995 z"
+         id="path6166"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4246"
+         d="m 484.01143,356.38958 10.64078,10.64972 10.13721,-10.64972 z"
+         style="fill:#ffe7ba;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4258"
+         d="m 473.52453,367.03594 21.21068,-0.0357 -0.15738,22.44498 z"
+         style="fill:#fee0a6;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         inkscape:transform-center-y="0.051513549"
+         inkscape:transform-center-x="0.12878552"
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0"
+         id="path6168"
+         d="m 484.03462,361.78745 8.6854,-5.57084 -5.01697,9.25533 11.83603,16.06637 -15.31182,-12.20529 -15.89781,12.01265 12.01262,-15.96604 -5.56279,-9.14697 z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.58380508px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <g
+       id="g4670"
+       transform="translate(-13.308426,3.358201)">
+      <g
+         transform="matrix(0.6060734,0,0,0.59246575,43.803142,423.99807)"
+         id="g4322"
+         style="display:inline">
+        <path
+           style="display:inline;opacity:0.34200003;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.66752225;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter6169)"
+           d="m 11.611159,1074.3574 2,0 0.504136,-2.4822 -3.008273,-10e-5 z"
+           id="rect4279-6-1-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc"
+           transform="matrix(0.97647727,0,0,1.001784,14.497533,-24.487726)" />
+        <path
+           style="display:inline;opacity:0.34200003;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.66752225;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter6165)"
+           d="m 5.6053138,1068.3426 0,-2 2.4821998,-0.5042 10e-5,3.0083 z"
+           id="rect4279-8-5-4"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc"
+           transform="matrix(0.97647727,0,0,1.001784,14.497533,-24.487726)" />
+        <path
+           style="display:inline;opacity:0.34200003;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.66752225;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter6437)"
+           d="m 16.403991,1066.7151 0,2 -2.4822,0.5042 -1e-4,-3.0083 z"
+           id="rect4279-4-2-0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc"
+           transform="matrix(0.91692368,0,0,1.0211377,18.632448,-45.503266)" />
+        <path
+           style="display:inline;opacity:0.34200003;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.66752225;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter6153)"
+           d="m 18.275675,1063.0702 -1.414213,-1.4142 -2.111659,1.3987 2.1271,2.1273 z"
+           id="rect4279-2-2-4-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc"
+           transform="matrix(0.97647727,0,0,1.001784,14.497533,-24.487726)" />
+        <path
+           style="display:inline;opacity:0.34200003;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.66752225;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter6149)"
+           d="m 6.9466418,1071.5709 1.4142128,1.4142 2.1116584,-1.3987 -2.1270994,-2.1273 z"
+           id="rect4279-2-6-7-0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc"
+           transform="matrix(0.97647727,0,0,1.001784,14.497533,-24.487726)" />
+        <path
+           style="display:inline;opacity:0.34200003;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.66752225;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter6145)"
+           d="m 16.817701,1072.9631 1.4142,-1.4142 -1.3987,-2.1116 -2.1273,2.1271 z"
+           id="rect4279-2-1-8-4"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc"
+           transform="matrix(0.97647727,0,0,1.001784,14.497533,-24.487726)" />
+        <circle
+           style="display:inline;opacity:0.372;fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.0080471;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter4318)"
+           id="path4266-2-4"
+           cx="12.601501"
+           cy="1067.3292"
+           r="3.7146981"
+           transform="matrix(0.97647727,0,0,1.001784,14.497533,-24.487726)" />
+      </g>
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4279"
+         d="m 59.337594,1038.4964 1.212146,0 0.305545,1.4706 -1.823236,10e-5 z"
+         style="display:inline;opacity:1;fill:#c39cd0;fill-opacity:1;stroke:none;stroke-width:0.40000001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4279-6"
+         d="m 59.350477,1046.7929 1.212146,0 0.305545,-1.4706 -1.823235,0 z"
+         style="display:inline;opacity:1;fill:#9b59a9;fill-opacity:1;stroke:none;stroke-width:0.40000001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4279-8"
+         d="m 55.710493,1043.2294 0,-1.1849 1.504396,-0.2988 6e-5,1.7824 z"
+         style="display:inline;opacity:1;fill:#b58ac3;fill-opacity:1;stroke:none;stroke-width:0.40000001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4279-4"
+         d="m 64.194825,1042.0574 0,1.1849 -1.504395,0.2987 -6.1e-5,-1.7822 z"
+         style="display:inline;opacity:1;fill:#a871b6;fill-opacity:1;stroke:none;stroke-width:0.40000001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4279-2"
+         d="m 56.53845,1040.1074 0.857117,-0.8378 1.279821,0.8286 -1.289179,1.2604 z"
+         style="display:inline;opacity:1;fill:#c099cd;fill-opacity:1;stroke:none;stroke-width:0.40000001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4279-2-2"
+         d="m 63.389664,1040.1057 -0.857117,-0.8379 -1.279821,0.8287 1.289179,1.2604 z"
+         style="display:inline;opacity:1;fill:#b78dc4;fill-opacity:1;stroke:none;stroke-width:0.40000001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4279-2-6"
+         d="m 56.523438,1045.142 0.857116,0.838 1.27982,-0.8288 -1.289178,-1.2603 z"
+         style="display:inline;opacity:1;fill:#a871b6;fill-opacity:1;stroke:none;stroke-width:0.40000001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4279-2-1"
+         d="m 62.506024,1045.9669 0.857109,-0.8379 -0.847715,-1.251 -1.289299,1.2602 z"
+         style="display:inline;opacity:1;fill:#9b58a9;fill-opacity:1;stroke:none;stroke-width:0.40000001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <ellipse
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient4432);stroke-width:1.49999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4266"
+       cx="46.70216"
+       cy="1046.0364"
+       rx="2.3069789"
+       ry="2.2550106" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m -12.115394,1059.0799 c 0.124831,-0.1252 0.327255,-0.1252 0.452081,0 l 6.2288377,6.2285 c 0.124831,0.1253 0.124831,0.3274 0,0.4522 -0.12483,0.125 -0.327139,0.125 -0.45208,0 l -0.7877036,-0.7877 -0.8677106,-0.8678 -4.5731945,-4.5732 c -0.12506,-0.1251 -0.12506,-0.3273 -2.3e-4,-0.452 z m 0.361528,0.075 c -0.07921,-0.079 -0.207816,-0.079 -0.287136,0 -0.07921,0.079 -0.07932,0.208 0,0.2872 l 0.551118,0.5512 c 0.07921,0.079 0.207815,0.079 0.287135,0 0.07932,-0.079 0.07932,-0.2078 1.14e-4,-0.2871 l -0.551231,-0.5513 z m 5.9274897,6.502 c 0.07921,0.079 0.207815,0.079 0.28702,-2e-4 0.0792,-0.079 0.07932,-0.2077 1.14e-4,-0.2871 l -0.5512317,-0.5512 c -0.012672,-0.015 -0.027162,-0.023 -0.041956,-0.031 -0.00855,0.068 -0.037604,0.1344 -0.089989,0.1868 -0.052384,0.052 -0.1184028,0.081 -0.1866093,0.09 0.0087,0.015 0.018688,0.029 0.031406,0.041 l 0.551232,0.5515 z"
+       id="path4"
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <path
+       style="fill:#647ba7;fill-opacity:1;stroke:#687eaa;stroke-width:0.06791718;stroke-opacity:1"
+       id="path6"
+       d="m 26.62318,1062.901 c 0.108667,0 0.217335,0.027 0.319211,0.082 0.07471,0.041 0.142626,0.1019 0.183376,0.1766 0.115459,0.2173 0.115459,0.4551 0,0.6452 -0.04754,0.075 -0.04754,0.163 -0.0068,0.2377 0.04075,0.075 0.115459,0.1223 0.203752,0.1223 l 1.589262,0 0,1.5213 c -0.122251,-0.061 -0.258086,-0.095 -0.400712,-0.095 l 0,0 c -0.156209,0 -0.312419,0.041 -0.461836,0.1223 -0.122251,0.068 -0.224127,0.1698 -0.292044,0.292 -0.15621,0.2989 -0.15621,0.6249 0.0068,0.8965 0.15621,0.2581 0.43467,0.4143 0.740298,0.4143 0.135834,0 0.27846,-0.034 0.400711,-0.095 l 0,1.5213 -1.514553,0 c 0.06112,-0.1223 0.09508,-0.2581 0.09508,-0.4007 0,-0.4754 -0.387128,-0.8626 -0.862548,-0.8626 -0.149418,0 -0.305628,0.041 -0.448254,0.1155 -0.129042,0.068 -0.230918,0.1698 -0.292043,0.292 -0.15621,0.2853 -0.163002,0.5909 -0.02717,0.8558 l -1.521345,0 0,-1.5893 c 0,-0.129 -0.101876,-0.2309 -0.230919,-0.2309 -0.04754,0 -0.08829,0.014 -0.122251,0.034 -0.09508,0.061 -0.203751,0.088 -0.312419,0.088 -0.210543,0 -0.400711,-0.1087 -0.509378,-0.2853 -0.11546,-0.1834 -0.11546,-0.4143 0,-0.6248 0.04075,-0.075 0.101875,-0.1426 0.176584,-0.1834 0.108668,-0.061 0.217335,-0.088 0.332794,-0.088 0.108668,0 0.217335,0.034 0.312419,0.088 0.04075,0.02 0.0815,0.034 0.122251,0.034 0.129043,0 0.230919,-0.1019 0.230919,-0.231 l 0,-1.5892 1.589262,0 c 0.08829,0 0.163001,-0.048 0.203751,-0.1155 0.04075,-0.075 0.04075,-0.1698 -0.0068,-0.2377 -0.06113,-0.095 -0.08829,-0.2037 -0.08829,-0.3124 0,-0.1562 0.06113,-0.3056 0.176585,-0.4211 0.115459,-0.1155 0.258085,-0.1766 0.414295,-0.1766 l 0,0 m 0,-0.1358 c -0.400712,0 -0.726714,0.326 -0.726714,0.7267 0,0.1426 0.04075,0.2717 0.108667,0.3803 0.04075,0.068 0,0.1495 -0.0815,0.1495 l -1.630013,0 c -0.05433,0 -0.09508,0.041 -0.09508,0.095 l 0,1.6301 c 0,0.054 -0.04754,0.095 -0.09508,0.095 -0.02038,0 -0.03396,-0.01 -0.05433,-0.014 -0.108668,-0.068 -0.244502,-0.1087 -0.387128,-0.1087 -0.129043,0 -0.258086,0.034 -0.39392,0.1019 -0.101876,0.054 -0.183376,0.1358 -0.230918,0.2377 -0.292044,0.5637 0.101875,1.1206 0.624838,1.1206 0.142626,0 0.271668,-0.041 0.380336,-0.1087 0.02038,-0.014 0.03396,-0.014 0.05433,-0.014 0.04754,0 0.09508,0.041 0.09508,0.095 l 0,1.63 c 0,0.054 0.04075,0.095 0.09508,0.095 l 1.630012,0 c 0.07471,0 0.122251,-0.082 0.0815,-0.1494 -0.129043,-0.2105 -0.15621,-0.4958 -0.0068,-0.781 0.05433,-0.1019 0.135834,-0.1834 0.23771,-0.231 0.129043,-0.068 0.258085,-0.1018 0.387128,-0.1018 0.400711,0 0.726714,0.326 0.726714,0.7267 0,0.1426 -0.04075,0.2717 -0.108668,0.3803 -0.04075,0.068 0,0.1494 0.0815,0.1494 l 1.630012,0 c 0.05433,0 0.09508,-0.041 0.09508,-0.095 l 0,-1.6301 c 0,-0.054 -0.04754,-0.095 -0.09508,-0.095 -0.02038,0 -0.03396,0.01 -0.05433,0.014 -0.108668,0.068 -0.244502,0.1087 -0.380337,0.1087 -0.522962,0 -0.923673,-0.5569 -0.631629,-1.1138 0.05433,-0.1019 0.135834,-0.1834 0.230918,-0.2377 0.135834,-0.075 0.264877,-0.1019 0.39392,-0.1019 0.142626,0 0.271668,0.041 0.387128,0.1087 0.01358,0.014 0.03396,0.014 0.05433,0.014 0.04754,0 0.09508,-0.041 0.09508,-0.095 l 0,-1.6233 c 0,-0.054 -0.04075,-0.095 -0.09508,-0.095 l -1.630012,0 c -0.07471,0 -0.122251,-0.082 -0.0815,-0.1494 0.129043,-0.2105 0.15621,-0.4958 0.0068,-0.781 -0.05433,-0.1019 -0.135834,-0.1834 -0.23771,-0.2309 -0.129043,-0.068 -0.258085,-0.1019 -0.380336,-0.1019 l 0,0 z"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:url(#linearGradient4101-13-31-8);fill-opacity:1;stroke:none"
+       d="m 2.7538476,1055.8382 6.263775,0 2.7362254,2.7836 0,9.2164 -9.0000004,0 z"
+       id="rect4001-3-47-41-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <polyline
+       transform="matrix(0.25622371,-0.18497795,0.18497795,0.25622371,-8.8593294,1071.8347)"
+       points="58.484,23.954 54.628,12.083 64.726,19.418 52.244,19.418 62.342,12.083 58.484,23.954 "
+       id="polyline8-4-7"
+       style="display:inline;fill:#dbbf7f;fill-opacity:1" />
+    <path
+       style="display:inline;fill:url(#linearGradient4900-1-1-9-4);fill-opacity:1;stroke:none"
+       d="m 8.7344676,1054.9295 0,3.9112 3.9774784,0 z"
+       id="path4884-8-2-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:url(#linearGradient4908-2-7-3-3);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 2.2538476,1055.3382 6.946261,0 3.0343594,3.0161 0,9.9864 -9.9806204,0 z"
+       id="rect4001-39-7-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <polyline
+       transform="matrix(0.34861724,-0.25168046,0.25168046,0.34861724,-18.985803,1067.3725)"
+       points="58.484,23.954 54.628,12.083 64.726,19.418 52.244,19.418 62.342,12.083 58.484,23.954 "
+       id="polyline8-0"
+       style="display:inline;fill:#dbbf7f;fill-opacity:1" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#394e75;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 8.1289141,1061.0546 6.3691649,6.3058"
+       id="path4268-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.50000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 8.1879759,1061.0742 0.4715288,0.4656"
+       id="path4268-6-3"
+       inkscape:connector-curvature="0" />
+    <polyline
+       transform="matrix(0.14867703,-0.27885941,0.27885941,0.14867703,-8.2424504,1077.1013)"
+       points="58.484,23.954 54.628,12.083 64.726,19.418 52.244,19.418 62.342,12.083 58.484,23.954 "
+       id="polyline8-4-9-0"
+       style="display:inline;fill:#dbbf7f;fill-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4344"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.5863061px;line-height:125%;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#7f0055;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 9,1051.2906 0,1.0716 -0.9175476,0 q -0.9217759,0 -1.3446089,-0.4192 -0.4228329,-0.4189 -0.4228329,-1.3379 l 0,-0.9142 q 0,-0.7144 -0.2283298,-0.9907 -0.2283298,-0.2808 -0.8287527,-0.2808 l -0.2579281,0 0,-1.062 0.2579281,0 q 0.6004229,0 0.8287527,-0.2761 0.2283298,-0.2763 0.2283298,-0.9906 l 0,-0.9762 q 0,-0.919 0.4228329,-1.3332 0.422833,-0.4191 1.3446089,-0.4191 l 0.9175476,0 0,1.0715 -0.2917547,0 q -0.5961945,0 -0.7780127,0.2093 -0.1775898,0.2049 -0.1775898,0.881 l 0,0.7905 q 0,0.7476 -0.190275,1.0858 -0.1902748,0.338 -0.6553909,0.4572 0.4693445,0.1287 0.6553909,0.4666 0.190275,0.3382 0.190275,1.081 l 0,0.7905 q 0,0.6809 0.1775898,0.8857 0.1818182,0.2093 0.7780127,0.2093 l 0.2917547,0 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4346"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.5863061px;line-height:125%;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#7f0055;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 12,1051.2907 0.295983,0 q 0.591966,0 0.769556,-0.2094 0.181818,-0.2047 0.181818,-0.8856 l 0,-0.7906 q 0,-0.7429 0.190275,-1.0809 0.190275,-0.3383 0.65962,-0.4667 -0.469345,-0.1196 -0.65962,-0.4572 -0.190275,-0.3381 -0.190275,-1.0858 l 0,-0.7905 q 0,-0.6761 -0.181818,-0.881 -0.177589,-0.2094 -0.769556,-0.2094 l -0.295983,0 0,-1.0714 0.917548,0 q 0.921776,0 1.344608,0.419 0.422833,0.4143 0.422833,1.3333 l 0,0.9762 q 0,0.7142 0.228331,0.9905 0.228329,0.2761 0.828752,0.2761 l 0.257928,0 0,1.062 -0.257928,0 q -0.600423,0 -0.828752,0.2809 -0.228331,0.2763 -0.228331,0.9905 l 0,0.9143 q 0,0.919 -0.422833,1.338 -0.422832,0.4192 -1.344608,0.4192 l -0.917548,0 0,-1.0715 z" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.genericeditor/plugin.xml
+++ b/bundles/org.eclipse.ui.genericeditor/plugin.xml
@@ -167,7 +167,6 @@
          point="org.eclipse.ui.commandImages">
       <image
             commandId="org.eclipse.ui.genericeditor.togglehighlight"
-            disabledIcon="icons/full/dtool16/mark_occurrences.png"
             icon="icons/full/etool16/mark_occurrences.svg">
       </image>
    </extension>

--- a/bundles/org.eclipse.ui.genericeditor/plugin.xml
+++ b/bundles/org.eclipse.ui.genericeditor/plugin.xml
@@ -33,7 +33,7 @@
             class="org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor"
             contributorClass="org.eclipse.ui.editors.text.TextEditorActionContributor"
             default="true"
-            icon="icons/full/obj16/generic_editor.png"
+            icon="icons/full/obj16/generic_editor.svg"
             id="org.eclipse.ui.genericeditor.GenericEditor"
             name="%genericEditor_name">
          <contentTypeBinding
@@ -168,7 +168,7 @@
       <image
             commandId="org.eclipse.ui.genericeditor.togglehighlight"
             disabledIcon="icons/full/dtool16/mark_occurrences.png"
-            icon="icons/full/etool16/mark_occurrences.png">
+            icon="icons/full/etool16/mark_occurrences.svg">
       </image>
    </extension>
    <extension point="org.eclipse.ui.editors.annotationTypes">

--- a/bundles/org.eclipse.ui.genericeditor/schema/icons.exsd
+++ b/bundles/org.eclipse.ui.genericeditor/schema/icons.exsd
@@ -99,7 +99,7 @@
  point=&quot;org.eclipse.ui.genericeditor.icons&quot;&gt;
   &lt;icon
   contentType=&quot;org.eclipse.core.runtime.xml&quot;
-  icon=&quot;icons/xml_content.png&quot; /&gt;
+  icon=&quot;icons/xml_content.svg&quot; /&gt;
  &lt;/extension&gt;
 &lt;/pre&gt;
 &lt;pre&gt;
@@ -107,7 +107,7 @@
  point=&quot;org.eclipse.ui.genericeditor.icons&quot;&gt;
   &lt;icon
   contentType=&quot;org.eclipse.core.runtime.text&quot;
-  icon=&quot;platform:/plugin/org.eclipse.ui.test/icons/text_content.png&quot; /&gt;
+  icon=&quot;platform:/plugin/org.eclipse.ui.test/icons/text_content.svg&quot; /&gt;
  &lt;/extension&gt;
 &lt;/pre&gt;
       </documentation>

--- a/tests/org.eclipse.ui.genericeditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.genericeditor.tests/META-INF/MANIFEST.MF
@@ -27,3 +27,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.ui.genericeditor.tests
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/tests/org.eclipse.ui.genericeditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.genericeditor.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.genericeditor.tests;singleton:=true
-Bundle-Version: 1.3.700.qualifier
+Bundle-Version: 1.3.800.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.genericeditor.tests,

--- a/tests/org.eclipse.ui.genericeditor.tests/icons/newfile_wiz.svg
+++ b/tests/org.eclipse.ui.genericeditor.tests/icons/newfile_wiz.svg
@@ -1,0 +1,418 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="newfile_wiz.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5068">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5070" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5072" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4863">
+      <stop
+         style="stop-color:#ba9726;stop-opacity:1;"
+         offset="0"
+         id="stop4865" />
+      <stop
+         style="stop-color:#997413;stop-opacity:1"
+         offset="1"
+         id="stop4867" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4823">
+      <stop
+         id="stop4825"
+         offset="0"
+         style="stop-color:#fefdef;stop-opacity:1" />
+      <stop
+         id="stop4827"
+         offset="1"
+         style="stop-color:#fbdd83;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4815">
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1;"
+         offset="0"
+         id="stop4817" />
+      <stop
+         style="stop-color:#989891;stop-opacity:1"
+         offset="1"
+         id="stop4819" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4753">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1"
+         offset="0"
+         id="stop4755" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4757" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.8479968,0,0,1.8479968,10.267503,1029.4109)"
+       y2="7.549418"
+       x2="0.9375"
+       y1="4.8437853"
+       x1="0.9375"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5618"
+       xlink:href="#linearGradient4823"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4753"
+       id="linearGradient4759"
+       x1="7.4641018"
+       y1="3"
+       x2="7.4641018"
+       y2="15"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,1036.3622)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4815"
+       id="linearGradient4821"
+       x1="8"
+       y1="1038.3622"
+       x2="8"
+       y2="1052.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4863"
+       id="linearGradient4869"
+       x1="12.578125"
+       y1="1037.7841"
+       x2="12.578125"
+       y2="1043.7627"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient5074"
+       x1="12"
+       y1="1038.3622"
+       x2="10.007812"
+       y2="1038.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0078125,0.015625)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient5076"
+       x1="10"
+       y1="1040.3622"
+       x2="10.007812"
+       y2="1038.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0078125,0.015625)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient5078"
+       x1="10"
+       y1="1041.3622"
+       x2="8.0078125"
+       y2="1041.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0078125,0.015625)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient5080"
+       x1="10"
+       y1="5"
+       x2="10.007812"
+       y2="6.9843998"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0078125,1036.3778)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient5082"
+       x1="12"
+       y1="1042.3622"
+       x2="10.007812"
+       y2="1042.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0078125,0.015625)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient5084"
+       x1="12"
+       y1="1043.3622"
+       x2="12"
+       y2="1045.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0078125,0.015625)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient5086"
+       x1="13"
+       y1="1043.3622"
+       x2="15.007812"
+       y2="1043.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0078125,0.015625)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5068"
+       id="linearGradient5088"
+       x1="14"
+       y1="1041.3622"
+       x2="14"
+       y2="1043.3466"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.0078125,0.015625)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4863"
+       id="linearGradient3052"
+       gradientUnits="userSpaceOnUse"
+       x1="12.578125"
+       y1="1037.7841"
+       x2="12.578125"
+       y2="1043.7627" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4823"
+       id="linearGradient3054"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8479968,0,0,1.8479968,10.267503,1029.4109)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9"
+       id="radialGradient4534-5"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4528-9">
+      <stop
+         style="stop-color:#e0c576;stop-opacity:1;"
+         offset="0"
+         id="stop4530-0" />
+      <stop
+         style="stop-color:#9e7916;stop-opacity:1"
+         offset="1"
+         id="stop4532-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6"
+       id="linearGradient4526-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <linearGradient
+       id="linearGradient6281-8-0-1-6">
+      <stop
+         id="stop6283-0-2-2-1"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9"
+       id="radialGradient3091"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6"
+       id="linearGradient3093"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9-5"
+       id="radialGradient3091-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574" />
+    <linearGradient
+       id="linearGradient4528-9-5">
+      <stop
+         style="stop-color:#e0c576;stop-opacity:1;"
+         offset="0"
+         id="stop4530-0-5" />
+      <stop
+         style="stop-color:#9e7916;stop-opacity:1"
+         offset="1"
+         id="stop4532-7-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6-6"
+       id="linearGradient3093-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6">
+      <stop
+         id="stop6283-0-2-2-1-2"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7-6"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32.245621"
+     inkscape:cx="1.0389008"
+     inkscape:cy="5.1945038"
+     inkscape:document-units="px"
+     inkscape:current-layer="g3038"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3971"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4821);fill-opacity:1;stroke:none;display:inline"
+       d="m 3,1038.3622 0,14 11,0 0,-14 -11,0 z m 1,1 9,0 0,12 -9,0 0,-12 z"
+       id="rect3983-9"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4759);fill-opacity:1;stroke:none"
+       id="rect3983"
+       width="9"
+       height="12"
+       x="4"
+       y="1039.3622" />
+    <g
+       id="g3038"
+       transform="matrix(1.1954268,0,0,1.1954268,-2.4071696,-204.29183)">
+      <g
+         style="display:inline"
+         id="g4514"
+         transform="matrix(0.83652132,0,0,0.83652132,9.9187208,156.77841)">
+        <g
+           id="g4522"
+           transform="translate(-9.9375,0)">
+          <rect
+             style="fill:url(#radialGradient3091-1);fill-opacity:1;stroke:#a27d18;stroke-width:1.03243756;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+             id="rect3910"
+             width="4.5825453"
+             height="4.454073"
+             x="-758.82336"
+             y="-740.41083"
+             transform="matrix(-0.70710678,-0.70710678,0.70710678,-0.70710678,0,0)" />
+          <path
+             sodipodi:nodetypes="ccccccccccccc"
+             inkscape:connector-curvature="0"
+             id="path5581-5-5"
+             d="m 12.471186,1054.309 1.001133,0 0,1.946 1.986639,0 0,1.0167 -1.986639,0 0,2.043 -1.001133,0 0,-2.043 -1.98664,0 0,-1.0167 1.98664,0 z"
+             style="fill:url(#linearGradient3093-5);fill-opacity:1;stroke:none;display:inline" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/tests/org.eclipse.ui.genericeditor.tests/icons/newfolder_wiz.svg
+++ b/tests/org.eclipse.ui.genericeditor.tests/icons/newfolder_wiz.svg
@@ -1,0 +1,350 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg25490"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="newfolder_wiz.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs25492">
+    <linearGradient
+       id="linearGradient3967-5"
+       inkscape:collect="always">
+      <stop
+         id="stop3969-3"
+         offset="0"
+         style="stop-color:#c48a4e;stop-opacity:1;" />
+      <stop
+         id="stop3971-6"
+         offset="1"
+         style="stop-color:#ad6c24;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3973-6"
+       inkscape:collect="always">
+      <stop
+         id="stop3975-0"
+         offset="0"
+         style="stop-color:#f8d078;stop-opacity:1" />
+      <stop
+         id="stop3977-3"
+         offset="1"
+         style="stop-color:#f8f0c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3949-4">
+      <stop
+         style="stop-color:#9e6627;stop-opacity:1"
+         offset="0"
+         id="stop3951-7" />
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="1"
+         id="stop3953-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955-1">
+      <stop
+         id="stop3957-4"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959-2" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961-1" />
+      <stop
+         id="stop3963-4"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965-5"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955-1"
+       id="linearGradient5310"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33025863,0,0,0.33025863,-170.67123,917.62896)"
+       x1="523.00781"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973-6"
+       id="linearGradient5313"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33025863,0,0,0.33025863,-170.67123,917.16039)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949-4"
+       id="linearGradient5315"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33025863,0,0,0.33025863,-170.67123,917.16039)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967-5"
+       id="linearGradient5318"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33025863,0,0,0.33025863,-170.93807,917.63774)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4823-5"
+       id="linearGradient5618-4"
+       gradientUnits="userSpaceOnUse"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418"
+       gradientTransform="matrix(1.8479968,0,0,1.8479968,-4.74031,1039.6687)" />
+    <linearGradient
+       id="linearGradient4823-5">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop4825-5" />
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="1"
+         id="stop4827-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-15.007813,10.2578)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.7627"
+       x2="12.578125"
+       y1="1037.7841"
+       x1="12.578125"
+       id="linearGradient4869-53"
+       xlink:href="#linearGradient4863-20"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4863-20"
+       inkscape:collect="always">
+      <stop
+         id="stop4865-6"
+         offset="0"
+         style="stop-color:#ba9726;stop-opacity:1;" />
+      <stop
+         id="stop4867-5"
+         offset="1"
+         style="stop-color:#997413;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9-5"
+       id="radialGradient3091-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574" />
+    <linearGradient
+       id="linearGradient4528-9-5">
+      <stop
+         style="stop-color:#e0c576;stop-opacity:1;"
+         offset="0"
+         id="stop4530-0-5" />
+      <stop
+         style="stop-color:#9e7916;stop-opacity:1"
+         offset="1"
+         id="stop4532-7-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6-6"
+       id="linearGradient3093-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6">
+      <stop
+         id="stop6283-0-2-2-1-2"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7-6"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9-5-7"
+       id="radialGradient3091-1-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574" />
+    <linearGradient
+       id="linearGradient4528-9-5-7">
+      <stop
+         style="stop-color:#e0c576;stop-opacity:1;"
+         offset="0"
+         id="stop4530-0-5-0" />
+      <stop
+         style="stop-color:#9e7916;stop-opacity:1"
+         offset="1"
+         id="stop4532-7-9-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6-6-4"
+       id="linearGradient3093-5-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4">
+      <stop
+         id="stop6283-0-2-2-1-2-0"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7-6-9"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="3.53125"
+     inkscape:cy="3.90625"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:snap-global="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid26727"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata25495">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="font-size:11.05178356px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient5318);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:AustralianFlyingCorpsStencil;-inkscape-font-specification:AustralianFlyingCorpsStencil"
+       id="rect13693-3"
+       width="4.9538794"
+       height="5.4905496"
+       x="2.4840126"
+       y="1038.859"
+       rx="0.86692888"
+       ry="0.86692888" />
+    <path
+       style="font-size:11.05178356px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient5313);fill-opacity:1;stroke:url(#linearGradient5315);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;font-family:AustralianFlyingCorpsStencil;-inkscape-font-specification:AustralianFlyingCorpsStencil"
+       d="m 2.3206642,1040.8912 10.2822228,0 c 0.480278,0 0.866929,0.3866 0.866929,0.8669 l 0,6.2808 c 0,0.4803 -0.386654,0.8693 -0.866929,0.8669 l -10.2822228,-0.051 c -0.480272,0 -0.8669289,-0.3866 -0.8669289,-0.8669 l 0,-6.2299 c 0,-0.4803 0.3866503,-0.8669 0.8669289,-0.8669 z"
+       id="rect13693"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       style="font-size:11.05178356px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:none;stroke:url(#linearGradient5310);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;font-family:AustralianFlyingCorpsStencil;-inkscape-font-specification:AustralianFlyingCorpsStencil"
+       d="m 1.994689,1040.8912 6.6361344,0"
+       id="path13797"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g6432"
+       transform="translate(14,-11.1875)">
+      <g
+         style="display:inline"
+         id="g4514"
+         transform="translate(-5.536708,-5.6240351)">
+        <g
+           id="g4522"
+           transform="translate(-9.9375,0)">
+          <rect
+             style="fill:url(#radialGradient3091-1-9);fill-opacity:1;stroke:#a27d18;stroke-width:1.03243756;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+             id="rect3910"
+             width="4.5825453"
+             height="4.454073"
+             x="-758.82336"
+             y="-740.41083"
+             transform="matrix(-0.70710678,-0.70710678,0.70710678,-0.70710678,0,0)" />
+          <path
+             sodipodi:nodetypes="ccccccccccccc"
+             inkscape:connector-curvature="0"
+             id="path5581-5-5"
+             d="m 12.471186,1054.309 1.001133,0 0,1.946 1.986639,0 0,1.0167 -1.986639,0 0,2.043 -1.001133,0 0,-2.043 -1.98664,0 0,-1.0167 1.98664,0 z"
+             style="fill:url(#linearGradient3093-5-2);fill-opacity:1;stroke:none;display:inline" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/tests/org.eclipse.ui.genericeditor.tests/plugin.xml
+++ b/tests/org.eclipse.ui.genericeditor.tests/plugin.xml
@@ -271,13 +271,13 @@
           point="org.eclipse.ui.genericeditor.icons">
         <icon
              contentType="org.eclipse.ui.genericeditor.tests.content-type"
-             icon="icons/newfile_wiz.png"/>
+             icon="icons/newfile_wiz.svg"/>
         <icon
              contentType="org.eclipse.ui.genericeditor.tests.specialized-content-type"
-             icon="icons/newfolder_wiz.png"/>
+             icon="icons/newfolder_wiz.svg"/>
         <icon
              contentType="org.eclipse.ui.genericeditor.tests.sub-specialized-content-type"
-             icon="platform:/plugin/org.eclipse.ui.ide/icons/full/etool16/newprj_wiz.png"/>
+             icon="platform:/plugin/org.eclipse.ui.ide/icons/full/etool16/newprj_wiz.svg"/>
     </extension>
     <extension
           point="org.eclipse.ui.genericeditor.quickAssistProcessors">


### PR DESCRIPTION
This PR adds SVGs for all icons in the bundles `org.eclipse.ui.genericeditor` and `org.eclipse.ui.genericeditor.tests` .

See also this [PR](https://github.com/eclipse-platform/eclipse.platform/pull/1797) for more information.

❗ This depends on and thus has to be merged after https://github.com/eclipse-platform/eclipse.platform.ui/pull/2913