### PR TITLE
Add SVGs to org.eclipse.ui.navigator bundles

### DIFF
--- a/bundles/org.eclipse.ui.navigator.resources/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.navigator.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.navigator.resources; singleton:=true
-Bundle-Version: 3.9.600.qualifier
+Bundle-Version: 3.9.700.qualifier
 Bundle-Activator: org.eclipse.ui.internal.navigator.resources.plugin.WorkbenchNavigatorPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.ui.navigator.resources/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.navigator.resources/META-INF/MANIFEST.MF
@@ -27,3 +27,4 @@ Require-Bundle: org.eclipse.ui.ide;bundle-version="[3.21.0,4.0.0)",
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.ui.navigator.resources
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.ui.navigator.resources/icons/full/clcl16/collapseall.svg
+++ b/bundles/org.eclipse.ui.navigator.resources/icons/full/clcl16/collapseall.svg
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="collapseall.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient8303">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop8305" />
+      <stop
+         id="stop8313"
+         offset="0.25"
+         style="stop-color:#ffffff;stop-opacity:0.25" />
+      <stop
+         id="stop8311"
+         offset="0.77477288"
+         style="stop-color:#ffffff;stop-opacity:0.251" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop8307" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8198">
+      <stop
+         style="stop-color:#f8e088;stop-opacity:1"
+         offset="0"
+         id="stop8200" />
+      <stop
+         id="stop8206"
+         offset="0.5"
+         style="stop-color:#f8d880;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8f0b0;stop-opacity:1"
+         offset="1"
+         id="stop8202" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8303-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop8305-8" />
+      <stop
+         id="stop8313-2"
+         offset="0.25"
+         style="stop-color:#ffffff;stop-opacity:0.25" />
+      <stop
+         id="stop8311-4"
+         offset="0.77477288"
+         style="stop-color:#ffffff;stop-opacity:0.251" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop8307-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8198-1">
+      <stop
+         style="stop-color:#f8e088;stop-opacity:1"
+         offset="0"
+         id="stop8200-1" />
+      <stop
+         id="stop8206-5"
+         offset="0.5"
+         style="stop-color:#f8d880;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8f0b0;stop-opacity:1"
+         offset="1"
+         id="stop8202-2" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8"
+     inkscape:cx="36.279537"
+     inkscape:cy="4.7306908"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-0"
+     showgrid="true"
+     inkscape:window-width="1458"
+     inkscape:window-height="814"
+     inkscape:window-x="464"
+     inkscape:window-y="344"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="layer1-0"
+       inkscape:label="Layer 1"
+       transform="matrix(0.77393739,0,0,0.77393739,-0.808785,233.54106)">
+      <g
+         id="g3021"
+         transform="translate(0.04037792,-0.16151177)">
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           inkscape:connector-curvature="0"
+           id="path3017"
+           d="M 2.0000001,2.0937496 5.2656252,5.5156247"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           sodipodi:nodetypes="cc" />
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           inkscape:connector-curvature="0"
+           id="path3019"
+           d="m 5.4687502,2.9687496 0,2.6562501 -2.5625001,0"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         id="g3021-1"
+         transform="matrix(-1,0,0,1,24.015277,-0.12113381)">
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           inkscape:connector-curvature="0"
+           id="path3017-2"
+           d="M 2.0000001,2.0937496 5.3593752,5.6718747"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           sodipodi:nodetypes="cc" />
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           inkscape:connector-curvature="0"
+           id="path3019-2"
+           d="m 5.4687502,2.9687496 0,2.6562501 -2.5625001,0"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         id="g3021-1-3"
+         transform="matrix(-1,0,0,-1,23.995088,2096.7883)">
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           inkscape:connector-curvature="0"
+           id="path3017-2-3"
+           d="M 2.0000001,2.0937496 5.4531252,5.5781247"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           sodipodi:nodetypes="cc" />
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           inkscape:connector-curvature="0"
+           id="path3019-2-4"
+           d="m 5.4687502,2.9687496 0,2.6562501 -2.5625001,0"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <rect
+         style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.29209423;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3084"
+         width="5.1461229"
+         height="5.219964"
+         x="9.4648619"
+         y="1045.6892" />
+      <g
+         style="display:inline"
+         id="g3021-9"
+         transform="matrix(1,0,0,-1,0.04037791,2096.7883)">
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           inkscape:connector-curvature="0"
+           id="path3017-9"
+           d="M 2.0000001,2.0937496 5.5468752,5.6718747"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           sodipodi:nodetypes="cc" />
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           inkscape:connector-curvature="0"
+           id="path3019-0"
+           d="m 5.4687502,2.9687496 0,2.6562501 -2.5625001,0"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator.resources/icons/full/clcl16/synced.svg
+++ b/bundles/org.eclipse.ui.navigator.resources/icons/full/clcl16/synced.svg
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="synced.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4883-7">
+      <stop
+         style="stop-color:#7e622c;stop-opacity:1;"
+         offset="0"
+         id="stop4885-4" />
+      <stop
+         style="stop-color:#aa6f10;stop-opacity:1"
+         offset="1"
+         id="stop4887-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4883-7-9">
+      <stop
+         style="stop-color:#7f7f3f;stop-opacity:1"
+         offset="0"
+         id="stop4885-4-9" />
+      <stop
+         style="stop-color:#7f5f3f;stop-opacity:1"
+         offset="1"
+         id="stop4887-0-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1052.2216"
+       x2="11"
+       y1="1043.3622"
+       x1="11"
+       gradientTransform="matrix(-1,0,0,1,15.987978,-7)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4142-9"
+       xlink:href="#linearGradient4883-7-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-7-9"
+       id="linearGradient4253"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,15.987978,-7)"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1052.2216" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-7-9"
+       id="linearGradient4300"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,15.987978,-7)"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1052.2216" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-7-9"
+       id="linearGradient4208"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,15.987978,-7)"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1052.2216" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-7-9"
+       id="linearGradient4217"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,15.987978,-7)"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1052.2216" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-7-9"
+       id="linearGradient4219"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,15.987978,-7)"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1052.2216" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9999996"
+     inkscape:cx="9.0866478"
+     inkscape:cy="2.5128468"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="416"
+     inkscape:window-y="739"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g4105-1"
+       transform="matrix(-0.76488996,0,0,0.76488996,9.760959,251.34329)">
+      <g
+         id="g4220">
+        <path
+           style="display:inline;fill:#ffdf3f;fill-opacity:1;stroke:none"
+           d="m 11.987978,1040.3622 0,1.858 -7.0000023,0 0,3.4044 -4.25989613,-4.2713 4.28878533,-4.3667 -0.028889,3.3756 z"
+           id="path4108-1-2-3"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc" />
+        <path
+           style="display:inline;fill:url(#linearGradient4142-9);fill-opacity:1;stroke:none"
+           d="m 6.1902004,1035.9741 0,3.4494 4.7977776,0 0.942222,0.026 c 0.99185,0.9918 1.044102,2.8526 0.05778,3.8389 l -1,0 -4.7688884,0 0,3.4622 c 0,0.6519 -0.9720289,0.6375 -1.7311139,0 l -4.82194279,-5.3642 4.82194279,-5.4117 c 0.760225,-0.7602 1.7022247,-0.5203 1.7022247,0 z m -1.2769261,1.3713 -3.5930723,3.9791 3.5895674,3.9345 0.00598,-3.2456 6.5675036,0 c 0.276213,-0.2099 0.219666,-0.975 -0.05778,-1.2468 l -6.5122039,-0.072 z"
+           id="path4108-1-6-4-3"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccccccccc" />
+      </g>
+      <g
+         style="display:inline"
+         id="g4220-1">
+        <path
+           style="display:inline;fill:#ffdf3f;fill-opacity:1;stroke:none"
+           d="m 11.987978,1040.3622 0,1.858 -7.0000023,0 0,3.4044 -4.25989613,-4.2713 4.28878533,-4.3667 -0.028889,3.3756 z"
+           id="path4108-1-2-3-3"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc" />
+        <path
+           style="display:inline;fill:url(#linearGradient4253);fill-opacity:1;stroke:none"
+           d="m 6.1902004,1035.9741 0,3.4494 4.7977776,0 0.942222,0.026 c 0.99185,0.9918 1.044102,2.8526 0.05778,3.8389 l -1,0 -4.7688884,0 0,3.4622 c 0,0.6519 -0.9720289,0.6375 -1.7311139,0 l -4.82194279,-5.3642 4.82194279,-5.4117 c 0.760225,-0.7602 1.7022247,-0.5203 1.7022247,0 z m -1.2769261,1.3713 -3.5675376,4.0455 3.5640327,4.0315 0.00598,-3.409 6.5675036,0 c 0.276213,-0.2099 0.250308,-1.0414 -0.02714,-1.3132 l -6.5428459,0 z"
+           id="path4108-1-6-4-3-8"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccccccccc" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="g4105-1-1"
+       transform="matrix(0.76488996,0,0,0.76488996,6.2699229,244.37458)">
+      <g
+         style="display:inline"
+         id="g4220-1-9" />
+    </g>
+    <g
+       style="display:inline"
+       id="g4105-1-9"
+       transform="matrix(0.76488996,0,0,0.76488996,6.2673863,244.36065)">
+      <g
+         id="g4220-17">
+        <path
+           style="display:inline;fill:#ffdf3f;fill-opacity:1;stroke:none"
+           d="m 11.987978,1040.3622 0,1.858 -7.0000023,0 0,3.4044 -4.25989613,-4.2713 4.28878533,-4.3667 -0.028889,3.3756 z"
+           id="path4108-1-2-3-8"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc" />
+        <path
+           style="display:inline;fill:url(#linearGradient4217);fill-opacity:1;stroke:none"
+           d="m 6.1902004,1035.9741 0,3.4494 4.7977776,0 0.942222,0.026 c 0.99185,0.9918 1.044102,2.8526 0.05778,3.8389 l -1,0 -4.7688884,0 0,3.4622 c 0,0.6519 -0.9720289,0.6375 -1.7311139,0 l -4.82194279,-5.3642 4.82194279,-5.4117 c 0.760225,-0.7602 1.7022247,-0.5203 1.7022247,0 z m -1.2769261,1.3713 -3.5930723,3.9791 3.5895674,3.9345 0.00598,-3.2456 6.5675036,0 c 0.276213,-0.2099 0.219666,-0.975 -0.05778,-1.2468 l -6.5122039,-0.072 z"
+           id="path4108-1-6-4-3-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccccccccc" />
+      </g>
+      <g
+         style="display:inline"
+         id="g4220-1-1">
+        <path
+           style="display:inline;fill:#ffdf3f;fill-opacity:1;stroke:none"
+           d="m 11.987978,1040.3622 0,1.858 -7.0000023,0 0,3.4044 -4.25989613,-4.2713 4.28878533,-4.3667 -0.028889,3.3756 z"
+           id="path4108-1-2-3-3-2"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc" />
+        <path
+           style="display:inline;fill:url(#linearGradient4219);fill-opacity:1;stroke:none"
+           d="m 6.1902004,1035.9741 0,3.4494 4.7977776,0 0.942222,0.026 c 0.99185,0.9918 1.044102,2.8526 0.05778,3.8389 l -1,0 -4.7688884,0 0,3.4622 c 0,0.6519 -0.9720289,0.6375 -1.7311139,0 l -4.82194279,-5.3642 4.82194279,-5.4117 c 0.760225,-0.7602 1.7022247,-0.5203 1.7022247,0 z m -1.2769261,1.3713 -3.5675376,4.0455 3.5640327,4.0315 0.00598,-3.409 6.5675036,0 c 0.276213,-0.2099 0.250308,-1.0414 -0.02714,-1.3132 l -6.5428459,0 z"
+           id="path4108-1-6-4-3-8-7"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccccccccc" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator.resources/icons/full/cview16/filenav_nav.svg
+++ b/bundles/org.eclipse.ui.navigator.resources/icons/full/cview16/filenav_nav.svg
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="filenav_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5991"
+       inkscape:collect="always">
+      <stop
+         id="stop5993"
+         offset="0"
+         style="stop-color:#9c6a3e;stop-opacity:1;" />
+      <stop
+         id="stop5995"
+         offset="1"
+         style="stop-color:#c48d4f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5973">
+      <stop
+         id="stop5975"
+         offset="0"
+         style="stop-color:#ffffc7;stop-opacity:1" />
+      <stop
+         style="stop-color:#fff1a8;stop-opacity:1"
+         offset="0.55546904"
+         id="stop5977" />
+      <stop
+         id="stop5979"
+         offset="1"
+         style="stop-color:#ffd379;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5965">
+      <stop
+         id="stop5967"
+         offset="0"
+         style="stop-color:#ffffc7;stop-opacity:1" />
+      <stop
+         style="stop-color:#fff1a8;stop-opacity:1"
+         offset="0.55546904"
+         id="stop5969" />
+      <stop
+         id="stop5971"
+         offset="1"
+         style="stop-color:#ffd379;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5973"
+       id="linearGradient6301"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.50533162,0,0,-0.41430567,-6.6403642,1479.2214)"
+       x1="-17.950155"
+       y1="1064.538"
+       x2="-17.950155"
+       y2="1056.3333" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5991"
+       id="linearGradient6303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-21.84053,1.016466)"
+       x1="22.577229"
+       y1="1041.0941"
+       x2="22.577229"
+       y2="1037.0269" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5973"
+       id="linearGradient6301-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.50533162,0,0,-0.41430567,-6.6403642,1479.2214)"
+       x1="-17.950155"
+       y1="1064.538"
+       x2="-17.950155"
+       y2="1056.3333" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5991"
+       id="linearGradient6303-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-21.840531,1.0164445)"
+       x1="22.577229"
+       y1="1041.0941"
+       x2="22.577229"
+       y2="1037.0269" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5973"
+       id="linearGradient6301-3-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.50533162,0,0,-0.41430567,-0.6879621,1485.2227)"
+       x1="-17.950155"
+       y1="1064.538"
+       x2="-17.950155"
+       y2="1056.3333" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5991"
+       id="linearGradient6303-9-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-15.888128,7.0176448)"
+       x1="22.577229"
+       y1="1041.0941"
+       x2="22.577229"
+       y2="1037.0269" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="-100.98679"
+     inkscape:cy="-3.3255956"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1588"
+     inkscape:window-height="825"
+     inkscape:window-x="767"
+     inkscape:window-y="646"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5126" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:#858585;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6289"
+       width="15.005033"
+       height="14.997437"
+       x="0.50270867"
+       y="1036.8666" />
+    <g
+       id="g6291"
+       transform="translate(0,1.8561552)">
+      <g
+         transform="translate(0.92807761,0)"
+         id="g8391">
+        <path
+           sodipodi:nodetypes="cccccscccc"
+           inkscape:connector-curvature="0"
+           d="m 5.2410208,1039.0145 c 0,0 0.334171,-0.074 0.334171,0.6682 l 0,2.3582 -5.03374202,-0.011 0,-2.1262 0,-1.0528 c 0,-0.6447 0.29721,-0.8605 1.10178102,-0.8469 l 1.8584989,0 c 1.0358503,0 1.0931441,-0.077 1.0931441,1.0014 z"
+           style="display:inline;fill:url(#linearGradient6301);fill-opacity:1;stroke:url(#linearGradient6303);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path4887-8-4-7-4" />
+        <g
+           style="display:inline"
+           id="layer1-8-0"
+           inkscape:label="Layer 1"
+           transform="translate(0.00695065,-0.9965488)">
+          <path
+             sodipodi:nodetypes="ccccc"
+             inkscape:connector-curvature="0"
+             id="rect4035-1-1-5-2-4"
+             d="m 2.1438445,1043.3787 1.0000146,0 0,4.039 -1.0000146,0 z"
+             style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline" />
+          <path
+             inkscape:connector-curvature="0"
+             id="rect4035-1-1-5-2-2-1-5"
+             d="m 2.1438445,1046.5061 3.0000003,0 0,0.9999 -3.0000003,0 z"
+             style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline" />
+        </g>
+        <path
+           sodipodi:nodetypes="cccccscccc"
+           inkscape:connector-curvature="0"
+           d="m 5.2410208,1039.0145 c 0,0 0.334171,-0.074 0.334171,0.6682 l 0,2.3582 -5.03374202,-0.011 0,-2.1262 0,-1.0528 c 0,-0.6447 0.29721,-0.8605 1.10178102,-0.8469 l 1.8584989,0 c 1.0358503,0 1.0931441,-0.077 1.0931441,1.0014 z"
+           style="display:inline;fill:url(#linearGradient6301-3);fill-opacity:1;stroke:url(#linearGradient6303-9);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path4887-8-4-7-4-6" />
+      </g>
+      <path
+         inkscape:connector-curvature="0"
+         id="rect4035-1-1-5-2-2-1-5-0"
+         d="m 13.006736,1046.0674 3.000001,0 0,1.4197 -3.000001,0 z"
+         style="display:inline;fill:#5c7aaa;fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4035-1-1-5-2-2-1-5-0-6"
+         d="m 8.0017466,1039.0901 6.0141284,0 0,1.4197 -6.0141284,0 z"
+         style="display:inline;fill:#5c7aaa;fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="cccccscccc"
+         inkscape:connector-curvature="0"
+         d="m 11.193423,1045.0158 c 0,0 0.334171,-0.074 0.334171,0.6682 l 0,2.3582 -5.0337423,-0.011 0,-2.1262 0,-1.0528 c 0,-0.6447 0.29721,-0.8605 1.101781,-0.8469 l 1.858499,0 c 1.0358503,0 1.0931443,-0.077 1.0931443,1.0014 z"
+         style="display:inline;fill:url(#linearGradient6301-3-6);fill-opacity:1;stroke:url(#linearGradient6303-9-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path4887-8-4-7-4-6-5" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator.resources/icons/full/elcl16/collapseall.svg
+++ b/bundles/org.eclipse.ui.navigator.resources/icons/full/elcl16/collapseall.svg
@@ -1,0 +1,289 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="collapseall.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-4"
+       id="linearGradient4889-2"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9,0,0,0.9,-17.7,103.93622)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-4">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885-5" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887-5" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(18,-3)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9"
+       xlink:href="#linearGradient4910-4-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1"
+       xlink:href="#linearGradient4994-4-7-7"
+       inkscape:collect="always"
+       gradientTransform="translate(18,-3)" />
+    <linearGradient
+       id="linearGradient4994-4-7-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-4-7"
+       id="linearGradient4889-2-1"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9,0,0,0.9,-15.7,105.93622)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-4-7">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885-5-1" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887-5-1" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="translate(22,4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4970"
+       xlink:href="#linearGradient4989"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4989">
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="0"
+         id="stop4991" />
+      <stop
+         id="stop4995"
+         offset="0.5"
+         style="stop-color:#c3e9ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="1"
+         id="stop4993" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(20,-1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9-5"
+       xlink:href="#linearGradient4910-4-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8-7" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1-1"
+       xlink:href="#linearGradient4994-4-7-4"
+       inkscape:collect="always"
+       gradientTransform="translate(20,-1)" />
+    <linearGradient
+       id="linearGradient4994-4-7-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4-2"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="9.8506072"
+     inkscape:cy="9.9346296"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="809"
+     inkscape:window-x="175"
+     inkscape:window-y="175"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#a6afc4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 2,1038.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="rect3997-9-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 3,1039.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="rect3997-9-1-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient5062-9);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 0,7 -2,0 0,-9 z"
+       id="rect4853-82-7-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 7,0 0,-2 -9,0 z"
+       id="rect4853-82-0-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 4,1040.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="rect3997-9-1-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 5,1041.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="rect3997-9-1-1-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4970);fill-opacity:1;stroke:none;display:inline"
+       d="m 8,1047.3622 5,0 c 1,0 1,-1 0,-1 l -5,0 c -1,0 -1,1 0,1 z"
+       id="rect4853-82-0-6-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5062-9-5);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 0,7 -2,0 0,-9 z"
+       id="rect4853-82-7-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 7,0 0,-2 -9,0 z"
+       id="rect4853-82-0-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="fill:#01467a;fill-opacity:1;stroke:none;display:inline"
+       id="rect4167-8"
+       width="1"
+       height="7"
+       x="1045.3622"
+       y="-13"
+       transform="matrix(0,1,-1,0,0,0)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator.resources/icons/full/elcl16/filter_ps.svg
+++ b/bundles/org.eclipse.ui.navigator.resources/icons/full/elcl16/filter_ps.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="filter_ps.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1047">
+      <stop
+         style="stop-color:#96a0b9;stop-opacity:1"
+         offset="0"
+         id="stop1043" />
+      <stop
+         style="stop-color:#77849d;stop-opacity:1"
+         offset="1"
+         id="stop1045" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1039">
+      <stop
+         style="stop-color:#fbffff;stop-opacity:1"
+         offset="0"
+         id="stop1035" />
+      <stop
+         style="stop-color:#b9e7ff;stop-opacity:1"
+         offset="1"
+         id="stop1037" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4989">
+      <stop
+         id="stop4991"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1;"
+         offset="0.5"
+         id="stop4995" />
+      <stop
+         id="stop4993"
+         offset="1"
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1039"
+       id="linearGradient1041"
+       x1="2.1048543"
+       y1="1039.3379"
+       x2="12.850951"
+       y2="1039.2937"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1047"
+       id="linearGradient1049"
+       x1="1"
+       y1="1044.8622"
+       x2="14"
+       y2="1044.8622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#444248"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="2.7020062"
+     inkscape:cy="8.7735937"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       id="path859"
+       style="fill:url(#linearGradient1041);stroke:url(#linearGradient1049);stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1"
+       d="m 7.504725,1043.8623 h 1.99055 M 1.5,1037.8622 h 12 v 2 l -4,4 v 6 l -3.0000002,2 H 5.5 v -8 l -4,-4 z" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator.resources/icons/full/elcl16/synced.svg
+++ b/bundles/org.eclipse.ui.navigator.resources/icons/full/elcl16/synced.svg
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="synced.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1;"
+         offset="0"
+         id="stop4885" />
+      <stop
+         style="stop-color:#aa6f10;stop-opacity:1"
+         offset="1"
+         id="stop4887" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5103">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105" />
+      <stop
+         style="stop-color:#fce69e;stop-opacity:1"
+         offset="1"
+         id="stop5107" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5103"
+       id="linearGradient5109"
+       x1="11.906143"
+       y1="1042.3622"
+       x2="11.906143"
+       y2="1047.2684"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1,2.9999502)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883"
+       id="linearGradient4889"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1052.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-7"
+       id="linearGradient4889-1"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1052.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,15.987978,-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-7">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1;"
+         offset="0"
+         id="stop4885-4" />
+      <stop
+         style="stop-color:#aa6f10;stop-opacity:1"
+         offset="1"
+         id="stop4887-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5103-4">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105-8" />
+      <stop
+         style="stop-color:#fce69e;stop-opacity:1"
+         offset="1"
+         id="stop5107-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.2684"
+       x2="11.906143"
+       y1="1042.3622"
+       x1="11.906143"
+       gradientTransform="matrix(-1,0,0,1,16.987978,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4911"
+       xlink:href="#linearGradient5103-4"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.999999"
+     inkscape:cx="16.638127"
+     inkscape:cy="5.0891236"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="1124"
+     inkscape:window-y="592"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient5109);fill-opacity:1;stroke:none;display:inline"
+       d="m 4,1047.3622 0,1 7,0 0,3 3.999893,-3.5 -3.999893,-3.5 0,3 z"
+       id="path4108-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="fill:url(#linearGradient4889);fill-opacity:1;stroke:none;display:inline"
+       d="m 10,1043.3622 0,3 -5,0 -1,0 c -0.99185,0.9918 -0.986324,2.0137 0,3 l 1,0 5,0 0,3 c 0,0.6519 0.740915,0.6375 1.5,0 l 4.9375,-4.5 -4.9375,-4.5 c -0.760225,-0.7602 -1.5,-0.5203 -1.5,0 z m 1,1 4,3.5 -4,3.5 0,-3 -6.4375,0 c -0.276214,-0.2099 -0.277444,-0.7282 0,-1 l 6.4375,0 z"
+       id="path4108-1-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccc" />
+    <path
+       style="fill:url(#linearGradient4911);fill-opacity:1;stroke:none;display:inline"
+       d="m 11.987978,1040.3622 0,1 -7.0000023,0 0,3 -3.99989299,-3.5 3.99989299,-3.5 0,3 z"
+       id="path4108-1-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="fill:url(#linearGradient4889-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 5.9879757,1036.3622 0,3 5.0000023,0 1,0 c 0.99185,0.9918 0.986324,2.0137 0,3 l -1,0 -5.0000023,0 0,3 c 0,0.6519 -0.740915,0.6375 -1.5,0 l -4.93749974,-4.5 4.93749974,-4.5 c 0.760225,-0.7602 1.5,-0.5203 1.5,0 z m -1,1 -3.99999999,3.5 3.99999999,3.5 0,-3 6.4375023,0 c 0.276214,-0.2099 0.277444,-0.7282 0,-1 l -6.4375023,0 z"
+       id="path4108-1-6-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator.resources/icons/full/eview16/resource_persp.svg
+++ b/bundles/org.eclipse.ui.navigator.resources/icons/full/eview16/resource_persp.svg
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="resource_persp.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13826-7-7"
+       id="linearGradient13832-8-7"
+       x1="441.34924"
+       y1="387.30411"
+       x2="441.34924"
+       y2="350.53076"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(40,-4.3677625)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13826-7-7">
+      <stop
+         style="stop-color:#d8e1ed;stop-opacity:1"
+         offset="0"
+         id="stop13828-0-6" />
+      <stop
+         style="stop-color:#f8f9fa;stop-opacity:1"
+         offset="1"
+         id="stop13830-2-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13850-2-6"
+       id="linearGradient13840-9-0"
+       x1="428"
+       y1="388.23123"
+       x2="452.5"
+       y2="353.95593"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(40,-4.3677625)" />
+    <linearGradient
+       id="linearGradient13850-2-6">
+      <stop
+         id="stop13852-4-9"
+         offset="0"
+         style="stop-color:#807e66;stop-opacity:1;" />
+      <stop
+         id="stop13854-7-9"
+         offset="1"
+         style="stop-color:#ccab63;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13856-0-9"
+       id="linearGradient13848-8-3"
+       x1="428"
+       y1="388.23123"
+       x2="452.5"
+       y2="353.95593"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(40,-4.3677625)" />
+    <linearGradient
+       id="linearGradient13856-0-9">
+      <stop
+         style="stop-color:#807e66;stop-opacity:1;"
+         offset="0"
+         id="stop13858-8-7" />
+      <stop
+         style="stop-color:#ccab63;stop-opacity:1"
+         offset="1"
+         id="stop13860-4-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13717-3-9"
+       id="linearGradient13818-7-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.61871845,-4.4034358)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="372.91846" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13717-3-9">
+      <stop
+         style="stop-color:#c48a4e;stop-opacity:1;"
+         offset="0"
+         id="stop13719-9-6" />
+      <stop
+         style="stop-color:#b85f1b;stop-opacity:1"
+         offset="1"
+         id="stop13721-8-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13739-8-2"
+       id="linearGradient13820-2-2"
+       gradientUnits="userSpaceOnUse"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222"
+       gradientTransform="translate(0,-3.4718112)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13739-8-2">
+      <stop
+         style="stop-color:#ffca57;stop-opacity:1"
+         offset="0"
+         id="stop13741-3-4" />
+      <stop
+         style="stop-color:#fffec5;stop-opacity:1"
+         offset="1"
+         id="stop13743-3-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13733-1-0"
+       id="linearGradient13822-2-6"
+       gradientUnits="userSpaceOnUse"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.7739"
+       gradientTransform="translate(0,-3.4718112)" />
+    <linearGradient
+       id="linearGradient13733-1-0"
+       inkscape:collect="always">
+      <stop
+         id="stop13735-7-6"
+         offset="0"
+         style="stop-color:#73451c;stop-opacity:1" />
+      <stop
+         id="stop13737-8-8"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13799-7-9"
+       id="linearGradient13824-1-1"
+       gradientUnits="userSpaceOnUse"
+       x1="523.00781"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294"
+       gradientTransform="matrix(0.9148607,0,0,1,44.695973,-3.1358295)" />
+    <linearGradient
+       id="linearGradient13799-7-9">
+      <stop
+         style="stop-color:#b9772f;stop-opacity:1"
+         offset="0"
+         id="stop13801-4-8" />
+      <stop
+         id="stop13809-4-5"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop13807-7-9"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop13811-8-3" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop13803-6-3" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="2.8906458"
+     inkscape:cy="6.5866223"
+     inkscape:document-units="px"
+     inkscape:current-layer="g13813"
+     showgrid="true"
+     inkscape:window-width="1569"
+     inkscape:window-height="1111"
+     inkscape:window-x="989"
+     inkscape:window-y="452"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3928" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-129.79284,940.66514)"
+       style="display:inline"
+       id="g13862">
+      <path
+         sodipodi:nodetypes="cccccccc"
+         inkscape:connector-curvature="0"
+         id="rect13616"
+         d="m 466.94003,344.80692 19.63449,0 10.92548,9.82813 0,29.48437 -15,0 -15.55997,0 0,-19.65625 z"
+         style="fill:url(#linearGradient13832-8-7);fill-opacity:1;stroke:url(#linearGradient13840-9-0);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="rect13616-6"
+         d="m 486.57452,344.80692 10.92548,9.82813 -10.9375,-0.0156 z"
+         style="display:inline;fill:#dbbe7e;fill-opacity:1;stroke:url(#linearGradient13848-8-3);stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path13637"
+         d="m 472.66447,355.40889 8.50288,0"
+         style="fill:none;stroke:#547bba;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path13637-8"
+         d="m 472.66447,362.63258 9.75288,0"
+         style="display:inline;fill:none;stroke:#547bba;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path13637-8-4"
+         d="m 472.66447,369.85626 21.75288,0"
+         style="display:inline;fill:none;stroke:#547bba;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path13637-8-4-5"
+         d="m 472.66447,377.07995 21.75288,0"
+         style="display:inline;fill:none;stroke:#547bba;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <g
+         transform="translate(-40,0)"
+         id="g13813">
+        <rect
+           style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient13818-7-4);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect13693-3"
+           width="15"
+           height="16.625"
+           x="524.49121"
+           y="362.64615"
+           rx="2.625"
+           ry="2.625" />
+        <rect
+           style="fill:url(#linearGradient13820-2-2);fill-opacity:1;stroke:url(#linearGradient13822-2-6);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect13693"
+           width="35.964333"
+           height="25.112394"
+           x="521.38116"
+           y="370.09302"
+           rx="2.625"
+           ry="2.625" />
+        <path
+           style="fill:none;stroke:url(#linearGradient13824-1-1);stroke-width:3.42785048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 523.00373,370.09356 18.38298,0"
+           id="path13797"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator.resources/icons/full/obj16/nested_projects.svg
+++ b/bundles/org.eclipse.ui.navigator.resources/icons/full/obj16/nested_projects.svg
@@ -1,0 +1,835 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="nested_projects.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4830">
+      <stop
+         style="stop-color:#2e49b0;stop-opacity:1"
+         offset="0"
+         id="stop4832" />
+      <stop
+         id="stop4836"
+         offset="0.5"
+         style="stop-color:#565f9e;stop-opacity:1" />
+      <stop
+         style="stop-color:#8591c8;stop-opacity:0"
+         offset="1"
+         id="stop4834" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4756">
+      <stop
+         style="stop-color:#92b5eb;stop-opacity:1"
+         offset="0"
+         id="stop4758" />
+      <stop
+         style="stop-color:#b1e1fd;stop-opacity:1"
+         offset="1"
+         id="stop4760" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4807"
+       inkscape:collect="always">
+      <stop
+         id="stop4809"
+         offset="0"
+         style="stop-color:#2846b3;stop-opacity:1" />
+      <stop
+         id="stop4811"
+         offset="1"
+         style="stop-color:#60649d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3967"
+       inkscape:collect="always">
+      <stop
+         id="stop3969"
+         offset="0"
+         style="stop-color:#84909f;stop-opacity:1" />
+      <stop
+         id="stop3971"
+         offset="1"
+         style="stop-color:#757c8a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955">
+      <stop
+         id="stop3957"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:0" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961" />
+      <stop
+         id="stop3963"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-58.381352,-1.4843182)"
+       x1="529.21912"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955"
+       id="linearGradient3945"
+       gradientUnits="userSpaceOnUse"
+       x1="523.00781"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294"
+       gradientTransform="translate(-60.558602,0)" />
+    <linearGradient
+       y2="385.15216"
+       x2="537.90186"
+       y1="397.56107"
+       x1="537.94318"
+       gradientTransform="matrix(0.95640793,0,1.3306874e-8,1.3548175,367.50712,24.15968)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4776"
+       xlink:href="#linearGradient4756"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="382.12424"
+       x2="546.58252"
+       y1="397.26389"
+       x1="546.63287"
+       gradientTransform="matrix(0.95640793,0,1.3306874e-8,1.3548175,367.50712,24.15968)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4778"
+       xlink:href="#linearGradient4807"
+       inkscape:collect="always" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <linearGradient
+       y2="373.77069"
+       x2="548.45923"
+       y1="398.98798"
+       x1="548.45923"
+       gradientTransform="translate(-60.558592,7.1608197e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4795"
+       xlink:href="#linearGradient4830"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967-0"
+       id="linearGradient3939-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-58.381352,-1.4843182)"
+       x1="529.21912"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       id="linearGradient3967-0"
+       inkscape:collect="always">
+      <stop
+         id="stop3969-9"
+         offset="0"
+         style="stop-color:#84909f;stop-opacity:1" />
+      <stop
+         id="stop3971-5"
+         offset="1"
+         style="stop-color:#757c8a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4762-1"
+       id="linearGradient4933-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-60.558602,0)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4762-1">
+      <stop
+         style="stop-color:#ffd175;stop-opacity:1"
+         offset="0"
+         id="stop4764-8" />
+      <stop
+         style="stop-color:#fff1c2;stop-opacity:1"
+         offset="1"
+         id="stop4766-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955-2"
+       id="linearGradient3945-1"
+       gradientUnits="userSpaceOnUse"
+       x1="523.00781"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294"
+       gradientTransform="translate(-60.558602,0)" />
+    <linearGradient
+       id="linearGradient3955-2">
+      <stop
+         id="stop3957-7"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:0" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959-5" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961-4" />
+      <stop
+         id="stop3963-5"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965-8"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917-6">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <linearGradient
+       y2="373.77069"
+       x2="548.45923"
+       y1="398.98798"
+       x1="548.45923"
+       gradientTransform="translate(-60.558592,7.1608197e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4795-4"
+       xlink:href="#linearGradient4830-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4830-4">
+      <stop
+         style="stop-color:#2e49b0;stop-opacity:1"
+         offset="0"
+         id="stop4832-1" />
+      <stop
+         id="stop4836-7"
+         offset="0.5"
+         style="stop-color:#565f9e;stop-opacity:1" />
+      <stop
+         style="stop-color:#8591c8;stop-opacity:0"
+         offset="1"
+         id="stop4834-6" />
+    </linearGradient>
+    <linearGradient
+       y2="385.15216"
+       x2="537.90186"
+       y1="397.56107"
+       x1="537.94318"
+       gradientTransform="matrix(0.95640793,0,1.3306873e-8,1.3548175,367.50712,24.15968)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4776-1"
+       xlink:href="#linearGradient4756-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4756-9">
+      <stop
+         style="stop-color:#92b5eb;stop-opacity:1"
+         offset="0"
+         id="stop4758-9" />
+      <stop
+         style="stop-color:#b1e1fd;stop-opacity:1"
+         offset="1"
+         id="stop4760-7" />
+    </linearGradient>
+    <linearGradient
+       y2="382.12424"
+       x2="546.58252"
+       y1="397.26389"
+       x1="546.63287"
+       gradientTransform="matrix(0.95640793,0,1.3306873e-8,1.3548175,367.50712,24.15968)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4778-0"
+       xlink:href="#linearGradient4807-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4807-5"
+       inkscape:collect="always">
+      <stop
+         id="stop4809-9"
+         offset="0"
+         style="stop-color:#2846b3;stop-opacity:1" />
+      <stop
+         id="stop4811-6"
+         offset="1"
+         style="stop-color:#60649d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="385.15216"
+       x2="537.90186"
+       y1="397.56107"
+       x1="537.94318"
+       gradientTransform="matrix(0.95640793,0,1.3306873e-8,1.3548175,367.50712,24.15968)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3360"
+       xlink:href="#linearGradient4756-9"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="382.12424"
+       x2="546.58252"
+       y1="397.26389"
+       x1="546.63287"
+       gradientTransform="matrix(0.95640793,0,1.3306873e-8,1.3548175,367.50712,24.15968)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3362"
+       xlink:href="#linearGradient4807-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3955-0">
+      <stop
+         id="stop3957-75"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:0" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959-2" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961-7" />
+      <stop
+         id="stop3963-4"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965-1"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917-9">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <linearGradient
+       id="linearGradient4830-7">
+      <stop
+         style="stop-color:#2e49b0;stop-opacity:1"
+         offset="0"
+         id="stop4832-9" />
+      <stop
+         id="stop4836-0"
+         offset="0.5"
+         style="stop-color:#565f9e;stop-opacity:1" />
+      <stop
+         style="stop-color:#8591c8;stop-opacity:0"
+         offset="1"
+         id="stop4834-9" />
+    </linearGradient>
+    <linearGradient
+       y2="385.15216"
+       x2="537.90186"
+       y1="397.56107"
+       x1="537.94318"
+       gradientTransform="matrix(0.95640793,0,1.3306874e-8,1.3548175,367.50712,24.15968)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4776-3"
+       xlink:href="#linearGradient4756-7"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4756-7">
+      <stop
+         style="stop-color:#92b5eb;stop-opacity:1"
+         offset="0"
+         id="stop4758-6" />
+      <stop
+         style="stop-color:#b1e1fd;stop-opacity:1"
+         offset="1"
+         id="stop4760-3" />
+    </linearGradient>
+    <linearGradient
+       y2="382.12424"
+       x2="546.58252"
+       y1="397.26389"
+       x1="546.63287"
+       gradientTransform="matrix(0.95640793,0,1.3306874e-8,1.3548175,367.50712,24.15968)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4778-07"
+       xlink:href="#linearGradient4807-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4807-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4809-2"
+         offset="0"
+         style="stop-color:#2846b3;stop-opacity:1" />
+      <stop
+         id="stop4811-62"
+         offset="1"
+         style="stop-color:#60649d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967-2-0"
+       id="linearGradient3939-0-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-57.915825,-1.2391227)"
+       x1="529.21912"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       id="linearGradient3967-2-0"
+       inkscape:collect="always">
+      <stop
+         id="stop3969-95-8"
+         offset="0"
+         style="stop-color:#84909f;stop-opacity:1" />
+      <stop
+         id="stop3971-0-0"
+         offset="1"
+         style="stop-color:#757c8a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4762-13-3"
+       id="linearGradient4933-7-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-60.558602,0)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4762-13-3">
+      <stop
+         style="stop-color:#ffd175;stop-opacity:1"
+         offset="0"
+         id="stop4764-7-9" />
+      <stop
+         style="stop-color:#fff1c2;stop-opacity:1"
+         offset="1"
+         id="stop4766-8-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955-0-9"
+       id="linearGradient3945-7-3"
+       gradientUnits="userSpaceOnUse"
+       x1="523.00781"
+       y1="373.2294"
+       x2="535.76733"
+       y2="373.2294"
+       gradientTransform="translate(-54.855891,1.3485753)" />
+    <linearGradient
+       id="linearGradient3955-0-9">
+      <stop
+         id="stop3957-75-8"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:0" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959-2-4" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.4678632"
+         id="stop3961-7-4" />
+      <stop
+         id="stop3963-4-6"
+         offset="0.78191471"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965-1-2"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917-9-7">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919-1-8"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter4929-05-1"
+       x="-0.13757156"
+       width="1.2751431"
+       y="-0.37744918"
+       height="1.7548983">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="3.5620748"
+         id="feGaussianBlur4931-9-0" />
+    </filter>
+    <linearGradient
+       id="linearGradient4830-7-7">
+      <stop
+         style="stop-color:#2e49b0;stop-opacity:1"
+         offset="0"
+         id="stop4832-9-5" />
+      <stop
+         id="stop4836-0-8"
+         offset="0.5"
+         style="stop-color:#565f9e;stop-opacity:1" />
+      <stop
+         style="stop-color:#8591c8;stop-opacity:0"
+         offset="1"
+         id="stop4834-9-4" />
+    </linearGradient>
+    <linearGradient
+       y2="385.15216"
+       x2="537.90186"
+       y1="397.56107"
+       x1="537.94318"
+       gradientTransform="matrix(0.95640793,0,1.3306875e-8,1.3548175,367.50712,24.15968)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3503-7"
+       xlink:href="#linearGradient4756-7-3"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4756-7-3">
+      <stop
+         style="stop-color:#92b5eb;stop-opacity:1"
+         offset="0"
+         id="stop4758-6-0" />
+      <stop
+         style="stop-color:#b1e1fd;stop-opacity:1"
+         offset="1"
+         id="stop4760-3-9" />
+    </linearGradient>
+    <linearGradient
+       y2="382.12424"
+       x2="546.58252"
+       y1="397.26389"
+       x1="546.63287"
+       gradientTransform="matrix(0.95640793,0,1.3306875e-8,1.3548175,367.50712,24.15968)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3505-5"
+       xlink:href="#linearGradient4807-1-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4807-1-9"
+       inkscape:collect="always">
+      <stop
+         id="stop4809-2-8"
+         offset="0"
+         style="stop-color:#2846b3;stop-opacity:1" />
+      <stop
+         id="stop4811-62-4"
+         offset="1"
+         style="stop-color:#60649d;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="385.15216"
+       x2="537.90186"
+       y1="397.56107"
+       x1="537.94318"
+       gradientTransform="matrix(0.91520488,0,1.6900991e-8,1.336485,367.17968,15.484577)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3646"
+       xlink:href="#linearGradient4756-7-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="382.12424"
+       x2="546.58252"
+       y1="397.26389"
+       x1="546.63287"
+       gradientTransform="matrix(0.91520488,0,1.6900991e-8,1.336485,367.17968,15.484577)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3648"
+       xlink:href="#linearGradient4807-1-9"
+       inkscape:collect="always" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917-9-7-6">
+      <path
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919-1-8-8"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917-9-7-6-1">
+      <path
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919-1-8-8-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:collect="always"
+       id="filter4929-05-1-1"
+       x="-0.13757156"
+       width="1.2751431"
+       y="-0.37744918"
+       height="1.7548983">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="3.5620748"
+         id="feGaussianBlur4931-9-0-0" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967-2-0"
+       id="linearGradient4498"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-57.915825,-1.2391227)"
+       x1="529.21912"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955-0-9"
+       id="linearGradient4500"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-54.855891,1.3485753)"
+       x1="523.00781"
+       y1="373.2294"
+       x2="535.76733"
+       y2="373.2294" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4756-7-3"
+       id="linearGradient4502"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.91520488,0,1.6900991e-8,1.336485,367.17968,15.484577)"
+       x1="537.94318"
+       y1="397.56107"
+       x2="537.90186"
+       y2="385.15216" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4807-1-9"
+       id="linearGradient4504"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.91520488,0,1.6900991e-8,1.336485,367.17968,15.484577)"
+       x1="546.63287"
+       y1="397.26389"
+       x2="546.58252"
+       y2="382.12424" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627418"
+     inkscape:cx="3.4435053"
+     inkscape:cy="20.230269"
+     inkscape:document-units="px"
+     inkscape:current-layer="g13862"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1537"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3947"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-129.51159,939.94639)"
+       style="display:inline"
+       id="g13862">
+      <g
+         style="display:inline"
+         transform="matrix(0.68044672,0,0,0.64594697,154.56831,113.76244)"
+         id="g13813-5-0">
+        <g
+           id="g4300">
+          <rect
+             ry="2.625"
+             rx="2.625"
+             y="365.81027"
+             x="467.19391"
+             height="16.625"
+             width="15"
+             id="rect13693-3-5-6"
+             style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient3939-0-7);stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="sssssssss"
+             inkscape:connector-curvature="0"
+             id="rect13693-25-5"
+             d="m 465.52216,372.83781 26.18371,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,19.16 c 0,1.45425 -1.17337,2.53709 -2.625,2.625 l -26.18371,1.58563 c -1.45164,0.0879 -2.625,-1.17075 -2.625,-2.625 l 0,-20.74563 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+             style="fill:url(#linearGradient4933-7-3);fill-opacity:1;stroke:#757c8a;stroke-width:5.40566206;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path13797-5-3"
+             d="m 468.49968,372.83835 12.34282,0"
+             style="fill:none;stroke:url(#linearGradient3945-7-3);stroke-width:5.40566206;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <g
+             mask="url(#mask4917-9-7)"
+             id="g4914-0-2">
+            <rect
+               style="opacity:0.5;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2.38039374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;filter:url(#filter4929-05-1)"
+               id="rect13693-2-2-0-4"
+               width="30.899641"
+               height="22.649353"
+               x="860.68469"
+               y="542.8974"
+               rx="2.625"
+               ry="3.7184925"
+               transform="matrix(1,0,-0.70828043,0.70593118,0,0)" />
+          </g>
+          <rect
+             transform="matrix(1,0,-0.68706384,0.72659705,0,0)"
+             ry="3.5082729"
+             rx="2.4024127"
+             y="527.69006"
+             x="839.75519"
+             height="21.368906"
+             width="28.279503"
+             id="rect13693-2-9-7"
+             style="display:inline;fill:url(#linearGradient3646);fill-opacity:1;stroke:url(#linearGradient3648);stroke-width:6.25096321;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        </g>
+      </g>
+      <path
+         style="fill:#f2f2f2;stroke:#808080;stroke-width:3.32049179px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 485.97447,388.59513 -9.60793,0 0,-14.20105"
+         id="path3739"
+         inkscape:connector-curvature="0" />
+      <g
+         transform="matrix(0.68044672,0,0,0.64594697,175.79167,139.91329)"
+         style="display:inline"
+         id="g4300-5">
+        <rect
+           ry="2.625"
+           rx="2.625"
+           y="365.81027"
+           x="467.19391"
+           height="16.625"
+           width="15"
+           id="rect13693-3-5-6-9"
+           style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient4498);stroke-width:3.02792978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="sssssssss"
+           inkscape:connector-curvature="0"
+           id="rect13693-25-5-6"
+           d="m 465.52216,372.83781 26.18371,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,19.16 c 0,1.45425 -1.17337,2.53709 -2.625,2.625 l -26.18371,1.58563 c -1.45164,0.0879 -2.625,-1.17075 -2.625,-2.625 l 0,-20.74563 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+           style="fill:url(#linearGradient4933-1);fill-opacity:1;stroke:#757c8a;stroke-width:5.40566206;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path13797-5-3-8"
+           d="m 468.49968,372.83835 12.34282,0"
+           style="fill:none;stroke:url(#linearGradient4500);stroke-width:5.40566206;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <g
+           mask="url(#mask4917-9-7-6-1)"
+           id="g4914-0-2-6">
+          <rect
+             style="display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2.38039374;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4929-05-1-1)"
+             id="rect13693-2-2-0-4-6"
+             width="30.899641"
+             height="22.649353"
+             x="860.68469"
+             y="542.8974"
+             rx="2.625"
+             ry="3.7184925"
+             transform="matrix(1,0,-0.70828043,0.70593118,0,0)" />
+        </g>
+        <rect
+           transform="matrix(1,0,-0.68706384,0.72659705,0,0)"
+           ry="3.5082729"
+           rx="2.4024127"
+           y="527.69006"
+           x="839.75519"
+           height="21.368906"
+           width="28.279503"
+           id="rect13693-2-9-7-9"
+           style="display:inline;fill:url(#linearGradient4502);fill-opacity:1;stroke:url(#linearGradient4504);stroke-width:6.25096321;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator.resources/icons/full/obj16/otherprojects_workingsets.svg
+++ b/bundles/org.eclipse.ui.navigator.resources/icons/full/obj16/otherprojects_workingsets.svg
@@ -1,0 +1,351 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
+   sodipodi:docname="otherprojects_workingsets.svg">
+  <defs
+     id="defs4">
+    <filter
+       inkscape:collect="always"
+       id="filter19612"
+       x="-0.17105568"
+       width="1.3421114"
+       y="-0.18993131"
+       height="1.3798626">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.74211708"
+         id="feGaussianBlur19614" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3967-7">
+      <stop
+         style="stop-color:#c48a4e;stop-opacity:1;"
+         offset="0"
+         id="stop3969-4" />
+      <stop
+         style="stop-color:#ad6c24;stop-opacity:1"
+         offset="1"
+         id="stop3971-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3973-4">
+      <stop
+         style="stop-color:#f8d078;stop-opacity:1"
+         offset="0"
+         id="stop3975-8" />
+      <stop
+         style="stop-color:#f8f0c8;stop-opacity:1"
+         offset="1"
+         id="stop3977-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3949-45"
+       inkscape:collect="always">
+      <stop
+         id="stop3951-5"
+         offset="0"
+         style="stop-color:#9e6627;stop-opacity:1" />
+      <stop
+         id="stop3953-1"
+         offset="1"
+         style="stop-color:#c38536;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955-1">
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="0"
+         id="stop3957-5" />
+      <stop
+         id="stop3959-27"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop3961-61"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop3963-4" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop3965-2" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter19612-6"
+       x="-0.17105567"
+       width="1.3421113"
+       y="-0.1899313"
+       height="1.3798625">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.74211708"
+         id="feGaussianBlur19614-5" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3967-7-6">
+      <stop
+         style="stop-color:#c48a4e;stop-opacity:1;"
+         offset="0"
+         id="stop3969-4-9" />
+      <stop
+         style="stop-color:#ad6c24;stop-opacity:1"
+         offset="1"
+         id="stop3971-0-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3973-4-2">
+      <stop
+         style="stop-color:#f8d078;stop-opacity:1"
+         offset="0"
+         id="stop3975-8-0" />
+      <stop
+         style="stop-color:#f8f0c8;stop-opacity:1"
+         offset="1"
+         id="stop3977-8-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3949-45-0"
+       inkscape:collect="always">
+      <stop
+         id="stop3951-5-9"
+         offset="0"
+         style="stop-color:#9e6627;stop-opacity:1" />
+      <stop
+         id="stop3953-1-7"
+         offset="1"
+         style="stop-color:#c38536;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955-1-7">
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="0"
+         id="stop3957-5-4" />
+      <stop
+         id="stop3959-27-7"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop3961-61-6"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop3963-4-2" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop3965-2-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955-1-7"
+       id="linearGradient11220"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33025864,0,0,0.33025864,-167.65045,916.69385)"
+       x1="525.6676"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973-4-2"
+       id="linearGradient11223"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31447743,0,0,0.31447743,-159.41252,922.21727)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949-45-0"
+       id="linearGradient11225"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31447743,0,0,0.31447743,-159.41252,922.21727)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967-7-6"
+       id="linearGradient11228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33025864,0,0,0.33025864,-167.96051,916.37988)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955-1"
+       id="linearGradient11236"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33025864,0,0,0.33025864,-172.2775,919.93882)"
+       x1="525.6676"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973-4"
+       id="linearGradient11239"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31447743,0,0,0.31447743,-163.8658,925.51189)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949-45"
+       id="linearGradient11241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31447743,0,0,0.31447743,-163.8658,925.51189)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967-7"
+       id="linearGradient11244"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33025864,0,0,0.33025864,-172.48827,919.74897)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="5.7176645"
+     inkscape:cy="7.3399067"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1120"
+     inkscape:window-height="643"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3939" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g11349"
+       transform="matrix(0.89017036,0,0,0.89017036,0.83301922,114.20596)">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path13797-1-1"
+         d="m 5.9529699,1039.5187 5.6986341,0"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;filter:url(#filter19612-6)" />
+      <path
+         style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient11228);stroke-width:1.12338042;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 7.2660106,1037.6013 2.282522,0 c 0.4802784,0 0.8669294,0.3866 0.8669294,0.8669 l 0,3.7566 c 0,0.4802 -0.386651,0.8669 -0.8669294,0.8669 l -2.282522,0 c -0.480279,0 -0.866929,-0.3867 -0.866929,-0.8669 l 0,-3.7566 c 0,-0.4803 0.38665,-0.8669 0.866929,-0.8669 z"
+         id="rect13693-3-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         style="display:inline;fill:url(#linearGradient11223);fill-opacity:1;stroke:url(#linearGradient11225);stroke-width:1.12338042;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 7.9614162,1039.9018 6.3593048,0 c 0.457329,0 0.825504,0.3683 0.825504,0.8256 l 0,5.3284 c 0,0.4574 -0.368172,0.826 -0.825504,0.8255 l -8.263736,-0.01 c -0.457332,-6e-4 -0.8255033,-0.3681 -0.8255033,-0.8255 l 0,-5.3221 c 0,-0.4572 0.3541007,-0.8264 0.8255033,-0.8255 z"
+         id="rect13693-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssssc" />
+      <path
+         style="fill:none;stroke:url(#linearGradient11220);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         d="m 5.9529699,1039.9561 5.6986341,0"
+         id="path13797-0"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path13797-1"
+         d="m 1.3259271,1042.7637 5.698634,0"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;filter:url(#filter19612)" />
+      <path
+         style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient11244);stroke-width:1.12338042;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 2.7382615,1040.9704 2.282522,0 c 0.480278,0 0.866929,0.3866 0.866929,0.8669 l 0,3.7566 c 0,0.4802 -0.386651,0.8669 -0.866929,0.8669 l -2.282522,0 c -0.480279,0 -0.866929,-0.3867 -0.866929,-0.8669 l 0,-3.7566 c 0,-0.4803 0.38665,-0.8669 0.866929,-0.8669 z"
+         id="rect13693-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         style="display:inline;fill:url(#linearGradient11239);fill-opacity:1;stroke:url(#linearGradient11241);stroke-width:1.12338042;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 3.5081375,1043.1964 6.3593049,0 c 0.4573286,0 0.8255036,0.3683 0.8255036,0.8256 l 0,5.3284 c 0,0.4574 -0.368172,0.826 -0.8255036,0.8255 l -8.2637361,-0.01 c -0.457332,-6e-4 -0.82550334,-0.3681 -0.82550334,-0.8255 l 0,-5.3221 c 0,-0.4572 0.35410074,-0.8264 0.82550334,-0.8255 z"
+         id="rect13693"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssssc" />
+      <path
+         style="fill:none;stroke:url(#linearGradient11236);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         d="m 1.3259271,1043.2011 5.698634,0"
+         id="path13797"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <path
+       sodipodi:type="arc"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       id="path11406"
+       sodipodi:cx="-18.605747"
+       sodipodi:cy="-7.0472617"
+       sodipodi:rx="0.044194173"
+       sodipodi:ry="0.022097087"
+       d="m -18.561553,-7.0472617 a 0.04419417,0.02209709 0 0 1 -0.04419,0.022097 0.04419417,0.02209709 0 0 1 -0.04419,-0.022097 0.04419417,0.02209709 0 0 1 0.04419,-0.022097 0.04419417,0.02209709 0 0 1 0.04419,0.022097 z"
+       transform="translate(0,1036.3622)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator.resources/icons/full/obj16/workingsets.svg
+++ b/bundles/org.eclipse.ui.navigator.resources/icons/full/obj16/workingsets.svg
@@ -1,0 +1,391 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="workingsets.svg">
+  <defs
+     id="defs4">
+    <filter
+       inkscape:collect="always"
+       id="filter19612"
+       x="-0.17105568"
+       width="1.3421114"
+       y="-0.18993131"
+       height="1.3798626">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.74211708"
+         id="feGaussianBlur19614" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3967-7">
+      <stop
+         style="stop-color:#c48a4e;stop-opacity:1;"
+         offset="0"
+         id="stop3969-4" />
+      <stop
+         style="stop-color:#ad6c24;stop-opacity:1"
+         offset="1"
+         id="stop3971-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3973-4">
+      <stop
+         style="stop-color:#f8d078;stop-opacity:1"
+         offset="0"
+         id="stop3975-8" />
+      <stop
+         style="stop-color:#f8f0c8;stop-opacity:1"
+         offset="1"
+         id="stop3977-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3949-45"
+       inkscape:collect="always">
+      <stop
+         id="stop3951-5"
+         offset="0"
+         style="stop-color:#9e6627;stop-opacity:1" />
+      <stop
+         id="stop3953-1"
+         offset="1"
+         style="stop-color:#c38536;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955-1">
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="0"
+         id="stop3957-5" />
+      <stop
+         id="stop3959-27"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop3961-61"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop3963-4" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop3965-2" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter19612-6"
+       x="-0.17105567"
+       width="1.3421113"
+       y="-0.1899313"
+       height="1.3798625">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.74211708"
+         id="feGaussianBlur19614-5" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3967-7-6">
+      <stop
+         style="stop-color:#c48a4e;stop-opacity:1;"
+         offset="0"
+         id="stop3969-4-9" />
+      <stop
+         style="stop-color:#ad6c24;stop-opacity:1"
+         offset="1"
+         id="stop3971-0-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3973-4-2">
+      <stop
+         style="stop-color:#f8d078;stop-opacity:1"
+         offset="0"
+         id="stop3975-8-0" />
+      <stop
+         style="stop-color:#f8f0c8;stop-opacity:1"
+         offset="1"
+         id="stop3977-8-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3949-45-0"
+       inkscape:collect="always">
+      <stop
+         id="stop3951-5-9"
+         offset="0"
+         style="stop-color:#9e6627;stop-opacity:1" />
+      <stop
+         id="stop3953-1-7"
+         offset="1"
+         style="stop-color:#c38536;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955-1-7">
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="0"
+         id="stop3957-5-4" />
+      <stop
+         id="stop3959-27-7"
+         offset="0.15381166"
+         style="stop-color:#f2dc91;stop-opacity:1" />
+      <stop
+         id="stop3961-61-6"
+         offset="0.5"
+         style="stop-color:#fbdc8b;stop-opacity:1" />
+      <stop
+         style="stop-color:#e6bd7a;stop-opacity:1"
+         offset="0.75"
+         id="stop3963-4-2" />
+      <stop
+         style="stop-color:#ba772f;stop-opacity:1"
+         offset="1"
+         id="stop3965-2-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955-1-7"
+       id="linearGradient11220"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33025864,0,0,0.33025864,-167.65045,916.69385)"
+       x1="525.6676"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973-4-2"
+       id="linearGradient11223"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31447743,0,0,0.31447743,-159.41252,922.21727)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949-45-0"
+       id="linearGradient11225"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31447743,0,0,0.31447743,-159.41252,922.21727)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967-7-6"
+       id="linearGradient11228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33025864,0,0,0.33025864,-167.96051,916.37988)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955-1"
+       id="linearGradient11236"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33025864,0,0,0.33025864,-172.2775,919.93882)"
+       x1="525.6676"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973-4"
+       id="linearGradient11239"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31447743,0,0,0.31447743,-163.8658,925.51189)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949-45"
+       id="linearGradient11241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31447743,0,0,0.31447743,-163.8658,925.51189)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967-7"
+       id="linearGradient11244"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33025864,0,0,0.33025864,-172.48827,919.74897)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8"
+     inkscape:cx="-13.955053"
+     inkscape:cy="2.0366058"
+     inkscape:document-units="px"
+     inkscape:current-layer="g11349"
+     showgrid="true"
+     inkscape:window-width="1146"
+     inkscape:window-height="657"
+     inkscape:window-x="983"
+     inkscape:window-y="638"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3939" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g11349"
+       transform="matrix(0.89017036,0,0,0.89017036,0.83301922,114.20596)">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path13797-1-1"
+         d="m 5.9529699,1039.5187 5.6986341,0"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;filter:url(#filter19612-6)" />
+      <path
+         style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient11228);stroke-width:1.12338042;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 7.2660106,1037.6013 2.282522,0 c 0.4802784,0 0.8669294,0.3866 0.8669294,0.8669 l 0,3.7566 c 0,0.4802 -0.386651,0.8669 -0.8669294,0.8669 l -2.282522,0 c -0.480279,0 -0.866929,-0.3867 -0.866929,-0.8669 l 0,-3.7566 c 0,-0.4803 0.38665,-0.8669 0.866929,-0.8669 z"
+         id="rect13693-3-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         style="display:inline;fill:url(#linearGradient11223);fill-opacity:1;stroke:url(#linearGradient11225);stroke-width:1.12338042;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 7.9614162,1039.9018 6.3593048,0 c 0.457329,0 0.825504,0.3683 0.825504,0.8256 l 0,5.3284 c 0,0.4574 -0.368172,0.826 -0.825504,0.8255 l -8.263736,-0.01 c -0.457332,-6e-4 -0.8255033,-0.3681 -0.8255033,-0.8255 l 0,-5.3221 c 0,-0.4572 0.3541007,-0.8264 0.8255033,-0.8255 z"
+         id="rect13693-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssssc" />
+      <path
+         style="fill:none;stroke:url(#linearGradient11220);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         d="m 5.9529699,1039.9561 5.6986341,0"
+         id="path13797-0"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path13797-1"
+         d="m 1.3259271,1042.7637 5.698634,0"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;filter:url(#filter19612)" />
+      <path
+         style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient11244);stroke-width:1.12338042;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 2.7382615,1040.9704 2.282522,0 c 0.480278,0 0.866929,0.3866 0.866929,0.8669 l 0,3.7566 c 0,0.4802 -0.386651,0.8669 -0.866929,0.8669 l -2.282522,0 c -0.480279,0 -0.866929,-0.3867 -0.866929,-0.8669 l 0,-3.7566 c 0,-0.4803 0.38665,-0.8669 0.866929,-0.8669 z"
+         id="rect13693-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         style="display:inline;fill:url(#linearGradient11239);fill-opacity:1;stroke:url(#linearGradient11241);stroke-width:1.12338042;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 3.5081375,1043.1964 6.3593049,0 c 0.4573286,0 0.8255036,0.3683 0.8255036,0.8256 l 0,5.3284 c 0,0.4574 -0.368172,0.826 -0.8255036,0.8255 l -8.2637361,-0.01 c -0.457332,-6e-4 -0.82550334,-0.3681 -0.82550334,-0.8255 l 0,-5.3221 c 0,-0.4572 0.35410074,-0.8264 0.82550334,-0.8255 z"
+         id="rect13693"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssssc" />
+      <path
+         style="fill:none;stroke:url(#linearGradient11236);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         d="m 1.3259271,1043.2011 5.698634,0"
+         id="path13797"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <path
+       sodipodi:type="arc"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       id="path11406"
+       sodipodi:cx="-18.605747"
+       sodipodi:cy="-7.0472617"
+       sodipodi:rx="0.044194173"
+       sodipodi:ry="0.022097087"
+       d="m -18.561553,-7.0472617 a 0.04419417,0.02209709 0 0 1 -0.04419,0.022097 0.04419417,0.02209709 0 0 1 -0.04419,-0.022097 0.04419417,0.02209709 0 0 1 0.04419,-0.022097 0.04419417,0.02209709 0 0 1 0.04419,0.022097 z"
+       transform="translate(0,1036.3622)" />
+    <path
+       sodipodi:type="arc"
+       style="fill:#000000;fill-opacity:1;stroke:none"
+       id="path11408"
+       sodipodi:cx="-6.5186405"
+       sodipodi:cy="16.640816"
+       sodipodi:rx="0.99436891"
+       sodipodi:ry="0.99436891"
+       d="m -5.5242716,16.640816 a 0.99436891,0.99436891 0 0 1 -0.9943689,0.994369 0.99436891,0.99436891 0 0 1 -0.9943689,-0.994369 0.99436891,0.99436891 0 0 1 0.9943689,-0.994369 0.99436891,0.99436891 0 0 1 0.9943689,0.994369 z"
+       transform="matrix(0.95555553,0,0,0.95555553,7.1790979,1035.4666)" />
+    <path
+       sodipodi:type="arc"
+       style="fill:#000000;fill-opacity:1;stroke:none;display:inline"
+       id="path11408-0"
+       sodipodi:cx="-6.5186405"
+       sodipodi:cy="16.640816"
+       sodipodi:rx="0.99436891"
+       sodipodi:ry="0.99436891"
+       d="m -5.5242716,16.640816 a 0.99436891,0.99436891 0 0 1 -0.9943689,0.994369 0.99436891,0.99436891 0 0 1 -0.9943689,-0.994369 0.99436891,0.99436891 0 0 1 0.9943689,-0.994369 0.99436891,0.99436891 0 0 1 0.9943689,0.994369 z"
+       transform="matrix(1.0666666,0,0,1.0666666,21.890848,1033.5071)" />
+    <path
+       sodipodi:type="arc"
+       style="fill:#000000;fill-opacity:1;stroke:none;display:inline"
+       id="path11408-0-3"
+       sodipodi:cx="-6.5186405"
+       sodipodi:cy="16.640816"
+       sodipodi:rx="0.99436891"
+       sodipodi:ry="0.99436891"
+       d="m -5.5242716,16.640816 a 0.99436891,0.99436891 0 0 1 -0.9943689,0.994369 0.99436891,0.99436891 0 0 1 -0.9943689,-0.994369 0.99436891,0.99436891 0 0 1 0.9943689,-0.994369 0.99436891,0.99436891 0 0 1 0.9943689,0.994369 z"
+       transform="translate(21.522563,1020.7174)" />
+    <path
+       sodipodi:type="arc"
+       style="fill:#000000;fill-opacity:1;stroke:none;display:inline"
+       id="path11408-0-3-8"
+       sodipodi:cx="-6.5186405"
+       sodipodi:cy="16.640816"
+       sodipodi:rx="0.99436891"
+       sodipodi:ry="0.99436891"
+       d="m -5.5242716,16.640816 a 0.99436891,0.99436891 0 0 1 -0.9943689,0.994369 0.99436891,0.99436891 0 0 1 -0.9943689,-0.994369 0.99436891,0.99436891 0 0 1 0.9943689,-0.994369 0.99436891,0.99436891 0 0 1 0.9943689,0.994369 z"
+       transform="matrix(1.0222222,0,0,1.0222222,7.7241592,1020.3697)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator.resources/icons/full/ovr16/error_co.svg
+++ b/bundles/org.eclipse.ui.navigator.resources/icons/full/ovr16/error_co.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="7"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="error_co.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="-2.2785917"
+     inkscape:cy="0.92431971"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="831"
+     inkscape:window-height="877"
+     inkscape:window-x="929"
+     inkscape:window-y="501"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1044.3622)">
+    <rect
+       style="fill:#d8424f;fill-opacity:1;stroke:none;display:inline"
+       id="rect4244"
+       width="7"
+       height="8"
+       x="-1.1130133e-007"
+       y="1044.3622" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 0,1044.3622 7,8"
+       id="path4136"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 6.9999999,1044.3622 0,1052.3622"
+       id="path4136-9"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator.resources/icons/full/ovr16/warning_co.svg
+++ b/bundles/org.eclipse.ui.navigator.resources/icons/full/ovr16/warning_co.svg
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="7"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="warning_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5091">
+      <stop
+         style="stop-color:#c6852e;stop-opacity:1"
+         offset="0"
+         id="stop5093" />
+      <stop
+         style="stop-color:#e1a555;stop-opacity:1"
+         offset="1"
+         id="stop5095" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5081">
+      <stop
+         style="stop-color:#ffe296;stop-opacity:1"
+         offset="0"
+         id="stop5083" />
+      <stop
+         id="stop5089"
+         offset="0.5"
+         style="stop-color:#f8d880;stop-opacity:1" />
+      <stop
+         style="stop-color:#fffcd3;stop-opacity:1"
+         offset="1"
+         id="stop5085" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5081"
+       id="linearGradient5087"
+       x1="3.3833356"
+       y1="7.0159616"
+       x2="3.3833356"
+       y2="0.98171616"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5091"
+       id="linearGradient5097"
+       x1="6.3885393"
+       y1="7.2369323"
+       x2="6.3885393"
+       y2="0.39338252"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="-1.5208779"
+     inkscape:cy="2.0545684"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8472"
+     showgrid="false"
+     inkscape:window-width="1638"
+     inkscape:window-height="1174"
+     inkscape:window-x="398"
+     inkscape:window-y="172"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1044.3622)">
+    <g
+       style="display:inline"
+       id="g8472"
+       transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)">
+      <path
+         style="fill:url(#linearGradient5087);stroke:url(#linearGradient5097);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+         d="M 2.8125,0.90625 0.78125,5 C 0.17522066,6.0251238 0.58843406,7.4816983 1.71875,7.5 L 3,7.5 l 1,0 1.28125,0 C 6.4115665,7.4817738 6.8247794,6.0250615 6.21875,5 L 4.1875,0.90625 c -0.2942923,-0.55673837 -1.1188077,-0.46727236 -1.375,0 z"
+         id="path4292"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         transform="matrix(1.0698871,0,0,1.0698871,15.590192,1043.4798)" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#502800;fill-opacity:1;stroke:none"
+         id="path4253"
+         sodipodi:cx="3.484375"
+         sodipodi:cy="5.484375"
+         sodipodi:rx="0.625"
+         sodipodi:ry="0.625"
+         d="m 4.109375,5.484375 c 0,0.345178 -0.279822,0.625 -0.625,0.625 -0.345178,0 -0.625,-0.279822 -0.625,-0.625 0,-0.345178 0.279822,-0.625 0.625,-0.625 0.345178,0 0.625,0.279822 0.625,0.625 z"
+         transform="matrix(1.125929,0,0,1.125929,15.411638,1043.3738)" />
+      <path
+         style="fill:#502800;fill-opacity:1;stroke:none;display:inline"
+         d="m 19.350026,1045.5028 c -0.378471,0 -0.700512,0.3368 -0.700512,0.774 l 0.09137,1.4889 c 0,0.3887 0.272722,0.7037 0.609141,0.7037 0.336419,0 0.609139,-0.315 0.609139,-0.7037 l 0.06091,-1.4889 c 0,-0.4372 -0.291583,-0.774 -0.670056,-0.774 z"
+         id="path4253-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sccsccs" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator.resources/plugin.xml
+++ b/bundles/org.eclipse.ui.navigator.resources/plugin.xml
@@ -7,7 +7,7 @@
       <view
             category="org.eclipse.ui"
             class="org.eclipse.ui.navigator.resources.ProjectExplorer"
-            icon="$nl$/icons/full/eview16/resource_persp.png"
+            icon="$nl$/icons/full/eview16/resource_persp.svg"
             id="org.eclipse.ui.navigator.ProjectExplorer"
             name="%Common_Resource_Navigator"/>
    </extension>
@@ -82,7 +82,7 @@
       <navigatorContent
             name="%resource.extension.name"
             priority="low"
-            icon="$nl$/icons/full/eview16/resource_persp.png"
+            icon="$nl$/icons/full/eview16/resource_persp.svg"
             activeByDefault="true"
 			            contentProvider="org.eclipse.ui.internal.navigator.resources.workbench.ResourceExtensionContentProvider"
             			labelProvider="org.eclipse.ui.internal.navigator.resources.workbench.ResourceExtensionLabelProvider"
@@ -350,7 +350,7 @@
       <navigatorContent
             activeByDefault="true"
             contentProvider="org.eclipse.ui.internal.navigator.workingsets.WorkingSetsContentProvider"
-            icon="$nl$/icons/full/obj16/workingsets.png"
+            icon="$nl$/icons/full/obj16/workingsets.svg"
             id="org.eclipse.ui.navigator.resources.workingSets"
             labelProvider="org.eclipse.ui.internal.navigator.workingsets.WorkingSetsLabelProvider"
             name="%workingsets.extension.name"
@@ -443,7 +443,7 @@
             id="org.eclipse.ui.navigator.resources.nested.nestedProjectContentProvider"
             labelProvider="org.eclipse.ui.internal.navigator.resources.nested.NestedProjectsLabelProvider"
             name="%nestedProjects.provider.name"
-            icon="$nl$/icons/full/obj16/nested_projects.png"
+            icon="$nl$/icons/full/obj16/nested_projects.svg"
             priority="higher">
          <enablement>
             <adapt

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/ProjectExplorerFilterActionGroup.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/ProjectExplorerFilterActionGroup.java
@@ -36,7 +36,7 @@ public class ProjectExplorerFilterActionGroup extends FilterActionGroup {
 
 	public void makeActions() {
 		selectFiltersAction = new SelectFiltersAction(commonViewer, this);
-		String imageFilePath = "icons/full/elcl16/filter_ps.png"; //$NON-NLS-1$
+		String imageFilePath = "icons/full/elcl16/filter_ps.svg"; //$NON-NLS-1$
 		ResourceLocator.imageDescriptorFromBundle(getClass(), imageFilePath).ifPresent(d -> {
 			selectFiltersAction.setImageDescriptor(d);
 			selectFiltersAction.setHoverImageDescriptor(d);

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/ResourceMgmtActionProvider.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/ResourceMgmtActionProvider.java
@@ -252,7 +252,7 @@ public class ResourceMgmtActionProvider extends CommonActionProvider {
 			}
 		};
 		refreshAction.setDisabledImageDescriptor(getImageDescriptor("dlcl16/refresh_nav.png"));//$NON-NLS-1$
-		refreshAction.setImageDescriptor(getImageDescriptor("elcl16/refresh_nav.png"));//$NON-NLS-1$
+		refreshAction.setImageDescriptor(getImageDescriptor("elcl16/refresh_nav.svg"));//$NON-NLS-1$
 		refreshAction.setActionDefinitionId(IWorkbenchCommandConstants.FILE_REFRESH);
 
 		buildAction = new BuildAction(sp, IncrementalProjectBuilder.INCREMENTAL_BUILD);

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/WorkingSetRootModeActionGroup.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/WorkingSetRootModeActionGroup.java
@@ -197,7 +197,7 @@ public class WorkingSetRootModeActionGroup extends ActionGroup {
 				.setText(WorkbenchNavigatorMessages.WorkingSetRootModeActionGroup_Working_Set_);
 		workingSetsAction.setImageDescriptor(WorkbenchNavigatorPlugin
 				.getDefault().getImageRegistry().getDescriptor(
-						"full/obj16/workingsets.png")); //$NON-NLS-1$
+						"full/obj16/workingsets.svg")); //$NON-NLS-1$
 
 		return new IAction[] { projectsAction, workingSetsAction };
 	}

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/workingsets/WorkingSetsLabelProvider.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/workingsets/WorkingSetsLabelProvider.java
@@ -49,7 +49,7 @@ public class WorkingSetsLabelProvider implements ILabelProvider {
 	private Image getWorkingSetImage() {
 		if (workingSetImage == null) {
 			URL iconUrl = FileLocator.find(WorkbenchNavigatorPlugin.getDefault().getBundle(),
-					IPath.fromPortableString("icons/full/obj16/otherprojects_workingsets.png"), //$NON-NLS-1$
+					IPath.fromPortableString("icons/full/obj16/otherprojects_workingsets.svg"), //$NON-NLS-1$
 					Collections.emptyMap());
 			workingSetImage = ImageDescriptor.createFromURL(iconUrl).createImage();
 		}

--- a/bundles/org.eclipse.ui.navigator/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.navigator/META-INF/MANIFEST.MF
@@ -22,3 +22,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.ui.navigator
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.ui.navigator/icons/full/clcl16/collapseall.svg
+++ b/bundles/org.eclipse.ui.navigator/icons/full/clcl16/collapseall.svg
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="collapseall.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient8303">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop8305" />
+      <stop
+         id="stop8313"
+         offset="0.25"
+         style="stop-color:#ffffff;stop-opacity:0.25" />
+      <stop
+         id="stop8311"
+         offset="0.77477288"
+         style="stop-color:#ffffff;stop-opacity:0.251" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop8307" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8198">
+      <stop
+         style="stop-color:#f8e088;stop-opacity:1"
+         offset="0"
+         id="stop8200" />
+      <stop
+         id="stop8206"
+         offset="0.5"
+         style="stop-color:#f8d880;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8f0b0;stop-opacity:1"
+         offset="1"
+         id="stop8202" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8303-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop8305-8" />
+      <stop
+         id="stop8313-2"
+         offset="0.25"
+         style="stop-color:#ffffff;stop-opacity:0.25" />
+      <stop
+         id="stop8311-4"
+         offset="0.77477288"
+         style="stop-color:#ffffff;stop-opacity:0.251" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop8307-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8198-1">
+      <stop
+         style="stop-color:#f8e088;stop-opacity:1"
+         offset="0"
+         id="stop8200-1" />
+      <stop
+         id="stop8206-5"
+         offset="0.5"
+         style="stop-color:#f8d880;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8f0b0;stop-opacity:1"
+         offset="1"
+         id="stop8202-2" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="7.432938"
+     inkscape:cy="5.8085286"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-0"
+     showgrid="true"
+     inkscape:window-width="1458"
+     inkscape:window-height="814"
+     inkscape:window-x="464"
+     inkscape:window-y="344"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="layer1-0"
+       inkscape:label="Layer 1"
+       transform="matrix(0.77393739,0,0,0.77393739,-0.808785,233.54106)">
+      <g
+         id="g3021"
+         transform="translate(0.04037792,0)">
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           inkscape:connector-curvature="0"
+           id="path3017"
+           d="M 2.0000001,2.0937496 5.2656252,5.5156247"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           sodipodi:nodetypes="cc" />
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           inkscape:connector-curvature="0"
+           id="path3019"
+           d="m 5.4687502,2.9687496 0,2.6562501 -2.5625001,0"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         id="g3021-1"
+         transform="matrix(-1,0,0,1,23.995088,2.0846073e-8)">
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           inkscape:connector-curvature="0"
+           id="path3017-2"
+           d="M 2.0000001,2.0937496 5.3593752,5.6718747"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           sodipodi:nodetypes="cc" />
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           inkscape:connector-curvature="0"
+           id="path3019-2"
+           d="m 5.4687502,2.9687496 0,2.6562501 -2.5625001,0"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         id="g3021-1-3"
+         transform="matrix(-1,0,0,-1,23.995088,2096.7883)">
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           inkscape:connector-curvature="0"
+           id="path3017-2-3"
+           d="M 2.0000001,2.0937496 5.4531252,5.5781247"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           sodipodi:nodetypes="cc" />
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           inkscape:connector-curvature="0"
+           id="path3019-2-4"
+           d="m 5.4687502,2.9687496 0,2.6562501 -2.5625001,0"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <rect
+         style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.89999998;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="rect3084"
+         width="3.8437502"
+         height="3.9375002"
+         x="6.5625"
+         y="6.5624995"
+         transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)" />
+      <g
+         style="display:inline"
+         id="g3021-9"
+         transform="matrix(1,0,0,-1,0.04037791,2096.7883)">
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           inkscape:connector-curvature="0"
+           id="path3017-9"
+           d="M 2.0000001,2.0937496 5.5468752,5.6718747"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           sodipodi:nodetypes="cc" />
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           inkscape:connector-curvature="0"
+           id="path3019-0"
+           d="m 5.4687502,2.9687496 0,2.6562501 -2.5625001,0"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator/icons/full/clcl16/elipses.svg
+++ b/bundles/org.eclipse.ui.navigator/icons/full/clcl16/elipses.svg
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="elipses.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient8303">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop8305" />
+      <stop
+         id="stop8313"
+         offset="0.25"
+         style="stop-color:#ffffff;stop-opacity:0.25" />
+      <stop
+         id="stop8311"
+         offset="0.77477288"
+         style="stop-color:#ffffff;stop-opacity:0.251" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop8307" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8198">
+      <stop
+         style="stop-color:#f8e088;stop-opacity:1"
+         offset="0"
+         id="stop8200" />
+      <stop
+         id="stop8206"
+         offset="0.5"
+         style="stop-color:#f8d880;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8f0b0;stop-opacity:1"
+         offset="1"
+         id="stop8202" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8303-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop8305-8" />
+      <stop
+         id="stop8313-2"
+         offset="0.25"
+         style="stop-color:#ffffff;stop-opacity:0.25" />
+      <stop
+         id="stop8311-4"
+         offset="0.77477288"
+         style="stop-color:#ffffff;stop-opacity:0.251" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop8307-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8198-1">
+      <stop
+         style="stop-color:#f8e088;stop-opacity:1"
+         offset="0"
+         id="stop8200-1" />
+      <stop
+         id="stop8206-5"
+         offset="0.5"
+         style="stop-color:#f8d880;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8f0b0;stop-opacity:1"
+         offset="1"
+         id="stop8202-2" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.999999"
+     inkscape:cx="12.293365"
+     inkscape:cy="7.5294104"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-0"
+     showgrid="true"
+     inkscape:window-width="1458"
+     inkscape:window-height="814"
+     inkscape:window-x="464"
+     inkscape:window-y="344"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="layer1-0"
+       inkscape:label="Layer 1"
+       transform="matrix(0.77393739,0,0,0.77393739,-0.808785,233.54106)">
+      <g
+         style="display:inline"
+         id="g8248">
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,1.0450264,1037.3205)"
+           d="m 4.5961941,8.5753784 c 0,0.5613787 -0.4550873,1.016466 -1.016466,1.016466 -0.5613787,0 -1.016466,-0.4550873 -1.016466,-1.016466 0,-0.5613787 0.4550873,-1.016466 1.016466,-1.016466 0.5613787,0 1.016466,0.4550873 1.016466,1.016466 z"
+           sodipodi:ry="1.016466"
+           sodipodi:rx="1.016466"
+           sodipodi:cy="8.5753784"
+           sodipodi:cx="3.5797281"
+           id="path7442"
+           style="fill:#466f0a;fill-opacity:1;stroke:#466f0a;stroke-width:0.89999998;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           sodipodi:type="arc" />
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,7.4976695,1037.3205)"
+           d="m 4.5961941,8.5753784 c 0,0.5613787 -0.4550873,1.016466 -1.016466,1.016466 -0.5613787,0 -1.016466,-0.4550873 -1.016466,-1.016466 0,-0.5613787 0.4550873,-1.016466 1.016466,-1.016466 0.5613787,0 1.016466,0.4550873 1.016466,1.016466 z"
+           sodipodi:ry="1.016466"
+           sodipodi:rx="1.016466"
+           sodipodi:cy="8.5753784"
+           sodipodi:cx="3.5797281"
+           id="path7442-9"
+           style="fill:#668834;fill-opacity:1;stroke:#668833;stroke-width:0.89999998;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:type="arc" />
+        <path
+           transform="matrix(1.2920942,0,0,1.2920942,13.978864,1037.2348)"
+           d="m 4.5961941,8.5753784 c 0,0.5613787 -0.4550873,1.016466 -1.016466,1.016466 -0.5613787,0 -1.016466,-0.4550873 -1.016466,-1.016466 0,-0.5613787 0.4550873,-1.016466 1.016466,-1.016466 0.5613787,0 1.016466,0.4550873 1.016466,1.016466 z"
+           sodipodi:ry="1.016466"
+           sodipodi:rx="1.016466"
+           sodipodi:cy="8.5753784"
+           sodipodi:cx="3.5797281"
+           id="path7442-9-9"
+           style="fill:#749347;fill-opacity:1;stroke:#749347;stroke-width:0.89999998;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:type="arc" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator/icons/full/clcl16/pause.svg
+++ b/bundles/org.eclipse.ui.navigator/icons/full/clcl16/pause.svg
@@ -1,0 +1,347 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="pause.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient8303">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop8305" />
+      <stop
+         id="stop8313"
+         offset="0.25"
+         style="stop-color:#ffffff;stop-opacity:0.25" />
+      <stop
+         id="stop8311"
+         offset="0.77477288"
+         style="stop-color:#ffffff;stop-opacity:0.251" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop8307" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8198">
+      <stop
+         style="stop-color:#f8e088;stop-opacity:1"
+         offset="0"
+         id="stop8200" />
+      <stop
+         id="stop8206"
+         offset="0.5"
+         style="stop-color:#f8d880;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8f0b0;stop-opacity:1"
+         offset="1"
+         id="stop8202" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8190">
+      <stop
+         style="stop-color:#a07818;stop-opacity:1;"
+         offset="0"
+         id="stop8192" />
+      <stop
+         style="stop-color:#b89828;stop-opacity:1"
+         offset="1"
+         id="stop8194" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8190"
+       id="linearGradient8196"
+       x1="5.7773919"
+       y1="1066.6444"
+       x2="5.7773919"
+       y2="1054.3945"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(10.336754,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8198"
+       id="linearGradient8204"
+       x1="7.2620707"
+       y1="1065.3629"
+       x2="7.2620707"
+       y2="1057.5649"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(10.336754,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8190-8">
+      <stop
+         style="stop-color:#a07818;stop-opacity:1;"
+         offset="0"
+         id="stop8192-2" />
+      <stop
+         style="stop-color:#b89828;stop-opacity:1"
+         offset="1"
+         id="stop8194-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(10.336754,1.92e-5)"
+       y2="1054.3945"
+       x2="5.7773919"
+       y1="1066.6444"
+       x1="5.7773919"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8230"
+       xlink:href="#linearGradient8190-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8303"
+       id="linearGradient8309"
+       x1="5.9487009"
+       y1="1055.4524"
+       x2="5.9772525"
+       y2="1066.9878"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(10.336754,0)" />
+    <filter
+       inkscape:collect="always"
+       id="filter8319"
+       x="-0.23011701"
+       width="1.460234"
+       y="-0.081161905"
+       height="1.1623238">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.32163811"
+         id="feGaussianBlur8321" />
+    </filter>
+    <linearGradient
+       gradientTransform="translate(18.089319,3.22e-5)"
+       y2="1054.3945"
+       x2="5.7773919"
+       y1="1066.6444"
+       x1="5.7773919"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8230-17"
+       xlink:href="#linearGradient8190-8-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8190-8-4">
+      <stop
+         style="stop-color:#a07818;stop-opacity:1;"
+         offset="0"
+         id="stop8192-2-0" />
+      <stop
+         style="stop-color:#b89828;stop-opacity:1"
+         offset="1"
+         id="stop8194-7-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8303-8"
+       id="linearGradient8309-4"
+       x1="5.9487009"
+       y1="1055.4524"
+       x2="5.9772525"
+       y2="1066.9878"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(18.089319,5.71e-5)" />
+    <linearGradient
+       id="linearGradient8303-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop8305-8" />
+      <stop
+         id="stop8313-2"
+         offset="0.25"
+         style="stop-color:#ffffff;stop-opacity:0.25" />
+      <stop
+         id="stop8311-4"
+         offset="0.77477288"
+         style="stop-color:#ffffff;stop-opacity:0.251" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop8307-5" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter8319-5"
+       x="-0.23011701"
+       width="1.460234"
+       y="-0.081161901"
+       height="1.1623238">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.32163811"
+         id="feGaussianBlur8321-1" />
+    </filter>
+    <linearGradient
+       id="linearGradient8198-1">
+      <stop
+         style="stop-color:#f8e088;stop-opacity:1"
+         offset="0"
+         id="stop8200-1" />
+      <stop
+         id="stop8206-5"
+         offset="0.5"
+         style="stop-color:#f8d880;stop-opacity:1" />
+      <stop
+         style="stop-color:#f8f0b0;stop-opacity:1"
+         offset="1"
+         id="stop8202-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8190-6">
+      <stop
+         style="stop-color:#a07818;stop-opacity:1;"
+         offset="0"
+         id="stop8192-1" />
+      <stop
+         style="stop-color:#b89828;stop-opacity:1"
+         offset="1"
+         id="stop8194-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1057.5649"
+       x2="7.2620707"
+       y1="1065.3629"
+       x1="7.2620707"
+       gradientTransform="translate(18.089319,1.92e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7447"
+       xlink:href="#linearGradient8198-1"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1054.3945"
+       x2="5.7773919"
+       y1="1066.6444"
+       x1="5.7773919"
+       gradientTransform="translate(18.089319,1.92e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7449"
+       xlink:href="#linearGradient8190-6"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="127.99999"
+     inkscape:cx="4.6536998"
+     inkscape:cy="11.964602"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="1458"
+     inkscape:window-height="814"
+     inkscape:window-x="865"
+     inkscape:window-y="645"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="layer1-0"
+       inkscape:label="Layer 1"
+       transform="matrix(0.77393739,0,0,0.77393739,-0.808785,233.54106)">
+      <g
+         transform="translate(-8.2201167,-12.904699)"
+         id="g8159"
+         style="display:inline">
+        <g
+           id="g4184"
+           transform="translate(0.01009449,-1.2819998)">
+          <rect
+             y="1054.7385"
+             x="21.514849"
+             height="12.905286"
+             width="5.2249279"
+             id="rect8188-2"
+             style="display:inline;fill:url(#linearGradient7447);fill-opacity:1;stroke:url(#linearGradient7449);stroke-width:1.29209423;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <rect
+             y="1055.8076"
+             x="22.450056"
+             height="10.910031"
+             width="3.3545172"
+             id="rect8188-7-4-3"
+             style="display:inline;fill:none;stroke:url(#linearGradient8309-4);stroke-width:0.93548667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter8319-5)" />
+          <rect
+             y="1054.7385"
+             x="21.514849"
+             height="12.933839"
+             width="5.2249279"
+             id="rect8188-7-2"
+             style="display:inline;fill:none;stroke:url(#linearGradient8230-17);stroke-width:1.29209423;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <rect
+             y="1054.7385"
+             x="13.762284"
+             height="12.905286"
+             width="5.2249279"
+             id="rect8188"
+             style="fill:url(#linearGradient8204);fill-opacity:1;stroke:url(#linearGradient8196);stroke-width:1.29209423;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <rect
+             y="1055.8076"
+             x="14.69749"
+             height="10.910031"
+             width="3.3545172"
+             id="rect8188-7-4"
+             style="display:inline;fill:none;stroke:url(#linearGradient8309);stroke-width:0.93548667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter8319)" />
+          <rect
+             y="1054.7385"
+             x="13.762284"
+             height="12.933838"
+             width="5.2249279"
+             id="rect8188-7"
+             style="display:inline;fill:none;stroke:url(#linearGradient8230);stroke-width:1.29209423;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator/icons/full/clcl16/synced.svg
+++ b/bundles/org.eclipse.ui.navigator/icons/full/clcl16/synced.svg
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="synced.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4883-7">
+      <stop
+         style="stop-color:#7e622c;stop-opacity:1;"
+         offset="0"
+         id="stop4885-4" />
+      <stop
+         style="stop-color:#aa6f10;stop-opacity:1"
+         offset="1"
+         id="stop4887-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4883-7-9">
+      <stop
+         style="stop-color:#7f7f3f;stop-opacity:1"
+         offset="0"
+         id="stop4885-4-9" />
+      <stop
+         style="stop-color:#7f5f3f;stop-opacity:1"
+         offset="1"
+         id="stop4887-0-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1052.2216"
+       x2="11"
+       y1="1043.3622"
+       x1="11"
+       gradientTransform="matrix(-1,0,0,1,15.987978,-7)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4142-9"
+       xlink:href="#linearGradient4883-7-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-7-9"
+       id="linearGradient4253"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,15.987978,-7)"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1052.2216" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-7-9"
+       id="linearGradient4300"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,15.987978,-7)"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1052.2216" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-7-9"
+       id="linearGradient4208"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,15.987978,-7)"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1052.2216" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-7-9"
+       id="linearGradient4217"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,15.987978,-7)"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1052.2216" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-7-9"
+       id="linearGradient4219"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,15.987978,-7)"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1052.2216" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9999996"
+     inkscape:cx="9.0866478"
+     inkscape:cy="2.5128468"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="416"
+     inkscape:window-y="739"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g4105-1"
+       transform="matrix(-0.76488996,0,0,0.76488996,9.760959,251.34329)">
+      <g
+         id="g4220">
+        <path
+           style="display:inline;fill:#ffdf3f;fill-opacity:1;stroke:none"
+           d="m 11.987978,1040.3622 0,1.858 -7.0000023,0 0,3.4044 -4.25989613,-4.2713 4.28878533,-4.3667 -0.028889,3.3756 z"
+           id="path4108-1-2-3"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc" />
+        <path
+           style="display:inline;fill:url(#linearGradient4142-9);fill-opacity:1;stroke:none"
+           d="m 6.1902004,1035.9741 0,3.4494 4.7977776,0 0.942222,0.026 c 0.99185,0.9918 1.044102,2.8526 0.05778,3.8389 l -1,0 -4.7688884,0 0,3.4622 c 0,0.6519 -0.9720289,0.6375 -1.7311139,0 l -4.82194279,-5.3642 4.82194279,-5.4117 c 0.760225,-0.7602 1.7022247,-0.5203 1.7022247,0 z m -1.2769261,1.3713 -3.5930723,3.9791 3.5895674,3.9345 0.00598,-3.2456 6.5675036,0 c 0.276213,-0.2099 0.219666,-0.975 -0.05778,-1.2468 l -6.5122039,-0.072 z"
+           id="path4108-1-6-4-3"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccccccccc" />
+      </g>
+      <g
+         style="display:inline"
+         id="g4220-1">
+        <path
+           style="display:inline;fill:#ffdf3f;fill-opacity:1;stroke:none"
+           d="m 11.987978,1040.3622 0,1.858 -7.0000023,0 0,3.4044 -4.25989613,-4.2713 4.28878533,-4.3667 -0.028889,3.3756 z"
+           id="path4108-1-2-3-3"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc" />
+        <path
+           style="display:inline;fill:url(#linearGradient4253);fill-opacity:1;stroke:none"
+           d="m 6.1902004,1035.9741 0,3.4494 4.7977776,0 0.942222,0.026 c 0.99185,0.9918 1.044102,2.8526 0.05778,3.8389 l -1,0 -4.7688884,0 0,3.4622 c 0,0.6519 -0.9720289,0.6375 -1.7311139,0 l -4.82194279,-5.3642 4.82194279,-5.4117 c 0.760225,-0.7602 1.7022247,-0.5203 1.7022247,0 z m -1.2769261,1.3713 -3.5675376,4.0455 3.5640327,4.0315 0.00598,-3.409 6.5675036,0 c 0.276213,-0.2099 0.250308,-1.0414 -0.02714,-1.3132 l -6.5428459,0 z"
+           id="path4108-1-6-4-3-8"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccccccccc" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="g4105-1-1"
+       transform="matrix(0.76488996,0,0,0.76488996,6.2699229,244.37458)">
+      <g
+         style="display:inline"
+         id="g4220-1-9" />
+    </g>
+    <g
+       style="display:inline"
+       id="g4105-1-9"
+       transform="matrix(0.76488996,0,0,0.76488996,6.2673863,244.36065)">
+      <g
+         id="g4220-17">
+        <path
+           style="display:inline;fill:#ffdf3f;fill-opacity:1;stroke:none"
+           d="m 11.987978,1040.3622 0,1.858 -7.0000023,0 0,3.4044 -4.25989613,-4.2713 4.28878533,-4.3667 -0.028889,3.3756 z"
+           id="path4108-1-2-3-8"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc" />
+        <path
+           style="display:inline;fill:url(#linearGradient4217);fill-opacity:1;stroke:none"
+           d="m 6.1902004,1035.9741 0,3.4494 4.7977776,0 0.942222,0.026 c 0.99185,0.9918 1.044102,2.8526 0.05778,3.8389 l -1,0 -4.7688884,0 0,3.4622 c 0,0.6519 -0.9720289,0.6375 -1.7311139,0 l -4.82194279,-5.3642 4.82194279,-5.4117 c 0.760225,-0.7602 1.7022247,-0.5203 1.7022247,0 z m -1.2769261,1.3713 -3.5930723,3.9791 3.5895674,3.9345 0.00598,-3.2456 6.5675036,0 c 0.276213,-0.2099 0.219666,-0.975 -0.05778,-1.2468 l -6.5122039,-0.072 z"
+           id="path4108-1-6-4-3-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccccccccc" />
+      </g>
+      <g
+         style="display:inline"
+         id="g4220-1-1">
+        <path
+           style="display:inline;fill:#ffdf3f;fill-opacity:1;stroke:none"
+           d="m 11.987978,1040.3622 0,1.858 -7.0000023,0 0,3.4044 -4.25989613,-4.2713 4.28878533,-4.3667 -0.028889,3.3756 z"
+           id="path4108-1-2-3-3-2"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc" />
+        <path
+           style="display:inline;fill:url(#linearGradient4219);fill-opacity:1;stroke:none"
+           d="m 6.1902004,1035.9741 0,3.4494 4.7977776,0 0.942222,0.026 c 0.99185,0.9918 1.044102,2.8526 0.05778,3.8389 l -1,0 -4.7688884,0 0,3.4622 c 0,0.6519 -0.9720289,0.6375 -1.7311139,0 l -4.82194279,-5.3642 4.82194279,-5.4117 c 0.760225,-0.7602 1.7022247,-0.5203 1.7022247,0 z m -1.2769261,1.3713 -3.5675376,4.0455 3.5640327,4.0315 0.00598,-3.409 6.5675036,0 c 0.276213,-0.2099 0.250308,-1.0414 -0.02714,-1.3132 l -6.5428459,0 z"
+           id="path4108-1-6-4-3-8-7"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccccccccc" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator/icons/full/elcl16/collapseall.svg
+++ b/bundles/org.eclipse.ui.navigator/icons/full/elcl16/collapseall.svg
@@ -1,0 +1,289 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="collapseall.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-4"
+       id="linearGradient4889-2"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9,0,0,0.9,-17.7,103.93622)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-4">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885-5" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887-5" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(18,-3)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9"
+       xlink:href="#linearGradient4910-4-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1"
+       xlink:href="#linearGradient4994-4-7-7"
+       inkscape:collect="always"
+       gradientTransform="translate(18,-3)" />
+    <linearGradient
+       id="linearGradient4994-4-7-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-4-7"
+       id="linearGradient4889-2-1"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9,0,0,0.9,-15.7,105.93622)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-4-7">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885-5-1" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887-5-1" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="translate(22,4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4970"
+       xlink:href="#linearGradient4989"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4989">
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="0"
+         id="stop4991" />
+      <stop
+         id="stop4995"
+         offset="0.5"
+         style="stop-color:#c3e9ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="1"
+         id="stop4993" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(20,-1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9-5"
+       xlink:href="#linearGradient4910-4-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8-7" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1-1"
+       xlink:href="#linearGradient4994-4-7-4"
+       inkscape:collect="always"
+       gradientTransform="translate(20,-1)" />
+    <linearGradient
+       id="linearGradient4994-4-7-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4-2"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="9.8506072"
+     inkscape:cy="9.9346296"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="809"
+     inkscape:window-x="200"
+     inkscape:window-y="200"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#a6afc4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 2,1038.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="rect3997-9-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 3,1039.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="rect3997-9-1-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient5062-9);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 0,7 -2,0 0,-9 z"
+       id="rect4853-82-7-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 7,0 0,-2 -9,0 z"
+       id="rect4853-82-0-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 4,1040.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="rect3997-9-1-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 5,1041.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="rect3997-9-1-1-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4970);fill-opacity:1;stroke:none;display:inline"
+       d="m 8,1047.3622 5,0 c 1,0 1,-1 0,-1 l -5,0 c -1,0 -1,1 0,1 z"
+       id="rect4853-82-0-6-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5062-9-5);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 0,7 -2,0 0,-9 z"
+       id="rect4853-82-7-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 7,0 0,-2 -9,0 z"
+       id="rect4853-82-0-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="fill:#01467a;fill-opacity:1;stroke:none;display:inline"
+       id="rect4167-8"
+       width="1"
+       height="7"
+       x="1045.3622"
+       y="-13"
+       transform="matrix(0,1,-1,0,0,0)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator/icons/full/elcl16/content.svg
+++ b/bundles/org.eclipse.ui.navigator/icons/full/elcl16/content.svg
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="content.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13468-0-8"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13296-9-6-5"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-6-2-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-7-1-5-8">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-5-3-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-0-2-1-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-4-2-3-4" />
+    </linearGradient>
+    <linearGradient
+       y2="457.95499"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5029"
+       xlink:href="#linearGradient10798-1-9-3-7-6-6-7-1-5-8"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8"
+     inkscape:cx="9.1720802"
+     inkscape:cy="-0.62916904"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1138"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-104.28208,915.45401)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1">
+        <path
+           sodipodi:nodetypes="ccccc"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#737986;fill-opacity:1;stroke:#595e68;stroke-width:1.49197865;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 382.27681,447.1119 0,42.23796 2.23796,0 0,-42.23796 z"
+           id="path9518-1-56"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#737986;fill-opacity:1;stroke:#595e68;stroke-width:1.49197865;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 404.51477,459.65793 -22.23796,0 0,2.23796 22.23796,0 z"
+           id="path9518-1-1-0"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#737986;fill-opacity:1;stroke:#595e68;stroke-width:1.49197865;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 404.51477,480.18827 -22.23796,0 0,2.23796 22.23796,0 z"
+           id="path9518-1-1-7-3"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="translate(-2e-6,1.9398499e-6)"
+         style="fill:#737986;fill-opacity:1;stroke:none;display:inline"
+         id="g13408-7-8">
+        <path
+           sodipodi:nodetypes="ccccc"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#737986;fill-opacity:1;stroke:none;stroke-width:1.49197865;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 382.27681,447.1119 0,42.23796 2.23796,0 0,-42.23796 z"
+           id="path9518-1-5-2"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#737986;fill-opacity:1;stroke:none;stroke-width:1.49197865;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 404.51477,459.65793 -22.23796,0 0,2.23796 22.23796,0 z"
+           id="path9518-1-1-9-2"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#737986;fill-opacity:1;stroke:none;stroke-width:1.49197865;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 404.51477,480.18827 -22.23796,0 0,2.23796 22.23796,0 z"
+           id="path9518-1-1-7-6-2"
+           inkscape:connector-curvature="0" />
+      </g>
+      <path
+         transform="matrix(0.78619955,0,0,0.78619955,78.156559,74.5285)"
+         d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10796-2-6-2"
+         style="fill:url(#linearGradient13468-0-8);fill-opacity:1;stroke:#14733c;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+         sodipodi:type="arc" />
+      <path
+         transform="matrix(0.78619955,0,0,0.78619955,96.015939,92.64905)"
+         d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10796-2-6-3-8"
+         style="fill:url(#linearGradient13296-9-6-5);fill-opacity:1;stroke:#14733c;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+         sodipodi:type="arc" />
+      <path
+         transform="matrix(0.78619955,0,0,0.78619955,96.015939,113.17939)"
+         d="m 398.75,468.23718 c 0,5.86803 -4.75697,10.625 -10.625,10.625 -5.86803,0 -10.625,-4.75697 -10.625,-10.625 0,-5.86802 4.75697,-10.625 10.625,-10.625 5.86803,0 10.625,4.75698 10.625,10.625 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10796-2-6-3-6-4"
+         style="fill:url(#linearGradient5029);fill-opacity:1;stroke:#14733c;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+         sodipodi:type="arc" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator/icons/full/elcl16/filter_ps.svg
+++ b/bundles/org.eclipse.ui.navigator/icons/full/elcl16/filter_ps.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="filter_ps.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1047">
+      <stop
+         style="stop-color:#96a0b9;stop-opacity:1"
+         offset="0"
+         id="stop1043" />
+      <stop
+         style="stop-color:#77849d;stop-opacity:1"
+         offset="1"
+         id="stop1045" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1039">
+      <stop
+         style="stop-color:#fbffff;stop-opacity:1"
+         offset="0"
+         id="stop1035" />
+      <stop
+         style="stop-color:#b9e7ff;stop-opacity:1"
+         offset="1"
+         id="stop1037" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4989">
+      <stop
+         id="stop4991"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1;"
+         offset="0.5"
+         id="stop4995" />
+      <stop
+         id="stop4993"
+         offset="1"
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1039"
+       id="linearGradient1041"
+       x1="2.1048543"
+       y1="1039.3379"
+       x2="12.850951"
+       y2="1039.2937"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1047"
+       id="linearGradient1049"
+       x1="1"
+       y1="1044.8622"
+       x2="14"
+       y2="1044.8622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#444248"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="2.7020062"
+     inkscape:cy="8.7735937"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       id="path859"
+       style="fill:url(#linearGradient1041);stroke:url(#linearGradient1049);stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1"
+       d="m 7.504725,1043.8623 h 1.99055 M 1.5,1037.8622 h 12 v 2 l -4,4 v 6 l -3.0000002,2 H 5.5 v -8 l -4,-4 z" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator/icons/full/elcl16/synced.svg
+++ b/bundles/org.eclipse.ui.navigator/icons/full/elcl16/synced.svg
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="synced.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1;"
+         offset="0"
+         id="stop4885" />
+      <stop
+         style="stop-color:#aa6f10;stop-opacity:1"
+         offset="1"
+         id="stop4887" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5103">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105" />
+      <stop
+         style="stop-color:#fce69e;stop-opacity:1"
+         offset="1"
+         id="stop5107" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5103"
+       id="linearGradient5109"
+       x1="11.906143"
+       y1="1042.3622"
+       x2="11.906143"
+       y2="1047.2684"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1,2.9999502)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883"
+       id="linearGradient4889"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1052.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-7"
+       id="linearGradient4889-1"
+       x1="11"
+       y1="1043.3622"
+       x2="11"
+       y2="1052.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,15.987978,-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-7">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1;"
+         offset="0"
+         id="stop4885-4" />
+      <stop
+         style="stop-color:#aa6f10;stop-opacity:1"
+         offset="1"
+         id="stop4887-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5103-4">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop5105-8" />
+      <stop
+         style="stop-color:#fce69e;stop-opacity:1"
+         offset="1"
+         id="stop5107-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.2684"
+       x2="11.906143"
+       y1="1042.3622"
+       x1="11.906143"
+       gradientTransform="matrix(-1,0,0,1,16.987978,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4911"
+       xlink:href="#linearGradient5103-4"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.999999"
+     inkscape:cx="16.638127"
+     inkscape:cy="5.0891236"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="1124"
+     inkscape:window-y="592"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient5109);fill-opacity:1;stroke:none;display:inline"
+       d="m 4,1047.3622 0,1 7,0 0,3 3.999893,-3.5 -3.999893,-3.5 0,3 z"
+       id="path4108-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="fill:url(#linearGradient4889);fill-opacity:1;stroke:none;display:inline"
+       d="m 10,1043.3622 0,3 -5,0 -1,0 c -0.99185,0.9918 -0.986324,2.0137 0,3 l 1,0 5,0 0,3 c 0,0.6519 0.740915,0.6375 1.5,0 l 4.9375,-4.5 -4.9375,-4.5 c -0.760225,-0.7602 -1.5,-0.5203 -1.5,0 z m 1,1 4,3.5 -4,3.5 0,-3 -6.4375,0 c -0.276214,-0.2099 -0.277444,-0.7282 0,-1 l 6.4375,0 z"
+       id="path4108-1-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccc" />
+    <path
+       style="fill:url(#linearGradient4911);fill-opacity:1;stroke:none;display:inline"
+       d="m 11.987978,1040.3622 0,1 -7.0000023,0 0,3 -3.99989299,-3.5 3.99989299,-3.5 0,3 z"
+       id="path4108-1-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="fill:url(#linearGradient4889-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 5.9879757,1036.3622 0,3 5.0000023,0 1,0 c 0.99185,0.9918 0.986324,2.0137 0,3 l -1,0 -5.0000023,0 0,3 c 0,0.6519 -0.740915,0.6375 -1.5,0 l -4.93749974,-4.5 4.93749974,-4.5 c 0.760225,-0.7602 1.5,-0.5203 1.5,0 z m -1,1 -3.99999999,3.5 3.99999999,3.5 0,-3 6.4375023,0 c 0.276214,-0.2099 0.277444,-0.7282 0,-1 l -6.4375023,0 z"
+       id="path4108-1-6-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/CommonNavigatorActionGroup.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/CommonNavigatorActionGroup.java
@@ -112,7 +112,7 @@ public class CommonNavigatorActionGroup extends ActionGroup implements IMementoA
 				.getBooleanConfigProperty(INavigatorViewerDescriptor.PROP_HIDE_LINK_WITH_EDITOR_ACTION);
 		if (!hideLinkWithEditorAction) {
 			toggleLinkingAction = new LinkEditorAction(commonNavigator, commonViewer, linkHelperService);
-			String imageFilePath = "icons/full/elcl16/synced.png"; //$NON-NLS-1$
+			String imageFilePath = "icons/full/elcl16/synced.svg"; //$NON-NLS-1$
 			ResourceLocator.imageDescriptorFromBundle(getClass(), imageFilePath).ifPresent(d -> {
 				toggleLinkingAction.setImageDescriptor(d);
 				toggleLinkingAction.setHoverImageDescriptor(d);
@@ -125,7 +125,7 @@ public class CommonNavigatorActionGroup extends ActionGroup implements IMementoA
 				.getBooleanConfigProperty(INavigatorViewerDescriptor.PROP_HIDE_COLLAPSE_ALL_ACTION);
 		if (!hideCollapseAllAction) {
 			collapseAllAction = new CollapseAllAction(commonViewer);
-			String imageFilePath = "icons/full/elcl16/collapseall.png"; //$NON-NLS-1$
+			String imageFilePath = "icons/full/elcl16/collapseall.svg"; //$NON-NLS-1$
 			ResourceLocator.imageDescriptorFromBundle(getClass(), imageFilePath).ifPresent(d -> {
 				collapseAllAction.setImageDescriptor(d);
 				collapseAllAction.setHoverImageDescriptor(d);

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/filters/CommonFilterSelectionDialog.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/filters/CommonFilterSelectionDialog.java
@@ -48,8 +48,8 @@ import org.eclipse.ui.navigator.INavigatorViewerDescriptor;
  */
 public class CommonFilterSelectionDialog extends TrayDialog {
 
-	private static final String FILTER_ICON = "icons/full/elcl16/filter_ps.png"; //$NON-NLS-1$
-	private static final String CONTENT_ICON = "icons/full/elcl16/content.png"; //$NON-NLS-1$
+	private static final String FILTER_ICON = "icons/full/elcl16/filter_ps.svg"; //$NON-NLS-1$
+	private static final String CONTENT_ICON = "icons/full/elcl16/content.svg"; //$NON-NLS-1$
 
 	private static final int TAB_WIDTH_IN_DLUS = 300;
 

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/filters/FilterActionGroup.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/filters/FilterActionGroup.java
@@ -141,7 +141,7 @@ public class FilterActionGroup extends ActionGroup implements IMementoAware {
 				.getBooleanConfigProperty(INavigatorViewerDescriptor.PROP_HIDE_AVAILABLE_CUSTOMIZATIONS_DIALOG);
 		if (!hideAvailableCustomizationsDialog) {
 			selectFiltersAction = new SelectFiltersAction(commonViewer, this);
-			String imageFilePath = "icons/full/elcl16/filter_ps.png"; //$NON-NLS-1$
+			String imageFilePath = "icons/full/elcl16/filter_ps.svg"; //$NON-NLS-1$
 			ResourceLocator.imageDescriptorFromBundle(getClass(), imageFilePath).ifPresent(d -> {
 				selectFiltersAction.setImageDescriptor(d);
 				selectFiltersAction.setHoverImageDescriptor(d);


### PR DESCRIPTION
This PR adds SVGs for all icons in the bundles `org.eclipse.ui.navigator` and `org.eclipse.ui.navigator.resources`.

See also this [PR](https://github.com/eclipse-platform/eclipse.platform/pull/1797) for more information.