### PR TITLE
Add SVGs to org.eclipse.ui.views bundles

### DIFF
--- a/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.ui.views.log;singleton:=true
-Bundle-Version: 1.4.700.qualifier
+Bundle-Version: 1.4.800.qualifier
 Bundle-Activator: org.eclipse.ui.internal.views.log.Activator
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.internal.views.log;x-friends:="org.eclipse.pde.ui"
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.ui.views.log
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.ui.views.log/icons/elcl16/clear.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/elcl16/clear.svg
@@ -1,0 +1,480 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="clear_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5147"
+       inkscape:collect="always">
+      <stop
+         id="stop5149"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5151"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5141"
+       inkscape:collect="always">
+      <stop
+         id="stop5143"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5145"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5135"
+       inkscape:collect="always">
+      <stop
+         id="stop5137"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5139"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902">
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1;"
+         offset="0"
+         id="stop4904" />
+      <stop
+         style="stop-color:#9a9a8f;stop-opacity:1"
+         offset="1"
+         id="stop4906" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4894">
+      <stop
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0"
+         id="stop4896" />
+      <stop
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1"
+         id="stop4898" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4877"
+       inkscape:collect="always">
+      <stop
+         id="stop4879"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4881"
+         offset="1"
+         style="stop-color:#5e76a3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4863" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop4865" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867"
+       x1="7.0070496"
+       y1="1043.857"
+       x2="11"
+       y2="1043.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861"
+       id="linearGradient4869"
+       x1="7.0070496"
+       y1="1045.857"
+       x2="14"
+       y2="1045.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5147"
+       id="linearGradient4871"
+       x1="7.0070496"
+       y1="1047.857"
+       x2="14"
+       y2="1047.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5135"
+       id="linearGradient4873"
+       x1="7.0070496"
+       y1="1051.857"
+       x2="12.016466"
+       y2="1051.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5141"
+       id="linearGradient4875"
+       x1="7.0070496"
+       y1="1049.857"
+       x2="14"
+       y2="1049.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894"
+       id="linearGradient4900"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-2)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4908"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-2)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient5000"
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-2)" />
+    <linearGradient
+       id="linearGradient4852-7-8"
+       inkscape:collect="always">
+      <stop
+         id="stop4854-4-1"
+         offset="0"
+         style="stop-color:#707070;stop-opacity:1" />
+      <stop
+         id="stop4856-0-2"
+         offset="1"
+         style="stop-color:#a0a0a0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4844-4-1">
+      <stop
+         id="stop4846-8-4"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4848-8-9"
+         offset="1"
+         style="stop-color:#303030;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6120"
+       xlink:href="#linearGradient4852-7-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6122"
+       xlink:href="#linearGradient4844-4-1"
+       inkscape:collect="always" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask6204">
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 1,1036.3935 0,0.5 0,12.9687 0,0.5 0.5,0 10.0625,0 0.5,0 0,-0.5 0,-9.9687 0,-0.2188 -0.15625,-0.125 -3.0625,-3 -0.125,-0.1562 -0.21875,0 -7,0 -0.5,0 z"
+         id="path6206"
+         inkscape:connector-curvature="0" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter6988"
+       x="-0.24001802"
+       width="1.480036"
+       y="-0.23998199"
+       height="1.479964">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.2049008"
+         id="feGaussianBlur6990" />
+    </filter>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6120-1"
+       xlink:href="#linearGradient4852-7-8-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4852-7-8-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4854-4-1-9"
+         offset="0"
+         style="stop-color:#707070;stop-opacity:1" />
+      <stop
+         id="stop4856-0-2-1"
+         offset="1"
+         style="stop-color:#a0a0a0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6122-0"
+       xlink:href="#linearGradient4844-4-1-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4844-4-1-4">
+      <stop
+         id="stop4846-8-4-2"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4848-8-9-2"
+         offset="1"
+         style="stop-color:#303030;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6120-4"
+       xlink:href="#linearGradient4852-7-8-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4852-7-8-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4854-4-1-5"
+         offset="0"
+         style="stop-color:#707070;stop-opacity:1" />
+      <stop
+         id="stop4856-0-2-9"
+         offset="1"
+         style="stop-color:#a0a0a0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6122-8"
+       xlink:href="#linearGradient4844-4-1-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4844-4-1-7">
+      <stop
+         id="stop4846-8-4-5"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4848-8-9-3"
+         offset="1"
+         style="stop-color:#303030;stop-opacity:1;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4.0000002"
+     inkscape:cx="18.223534"
+     inkscape:cy="-36.6021"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-8-8"
+     showgrid="true"
+     inkscape:window-width="1542"
+     inkscape:window-height="975"
+     inkscape:window-x="1006"
+     inkscape:window-y="492"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient5000);fill-opacity:1;stroke:none;display:inline"
+       d="m 1.4972825,1036.9037 7.0096685,0 3.062057,3.0066 0,9.9546 -10.0717255,0 z"
+       id="rect4001-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:url(#linearGradient4900);fill-opacity:1;stroke:none"
+       d="m 7.976621,1036.441 0,3.9112 3.977476,0 z"
+       id="path4884"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:url(#linearGradient4908);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0"
+       d="m 1.4972825,1036.9037 7.0096685,0 3.062057,3.0066 0,9.9546 -10.0717255,0 z"
+       id="rect4001"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <rect
+       style="fill:url(#linearGradient4867);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1"
+       width="3.9929504"
+       height="1.0103934"
+       x="3.0070496"
+       y="1039.3518" />
+    <rect
+       style="fill:url(#linearGradient4869);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7"
+       width="6.9929504"
+       height="1.0103934"
+       x="3.0070496"
+       y="1041.3518" />
+    <rect
+       style="fill:url(#linearGradient4871);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4"
+       width="6.9929504"
+       height="1.0103934"
+       x="3.0070496"
+       y="1043.3518" />
+    <rect
+       style="fill:url(#linearGradient4875);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4-0"
+       width="6.9929504"
+       height="1.0103934"
+       x="3.0070496"
+       y="1045.3518" />
+    <rect
+       style="fill:url(#linearGradient4873);fill-opacity:1;stroke:none;display:inline"
+       id="rect4001-1-7-4-0-9"
+       width="5.0094166"
+       height="1.0103934"
+       x="3.0070496"
+       y="1047.3518" />
+    <g
+       id="g6200"
+       mask="url(#mask6204)"
+       transform="matrix(1.4660179,0,0,1.2212682,-5.6373987,-232.07964)">
+      <g
+         transform="matrix(0.53947849,0,0,0.53947849,7.846281,484.46953)"
+         inkscape:label="Layer 1"
+         id="layer1-8"
+         style="opacity:0.75;fill:#ffffff;stroke:#ffffff;stroke-width:3.70728397;stroke-miterlimit:4;stroke-dasharray:none;display:inline;filter:url(#filter6988)">
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.70728397;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+           d="m 13.419292,1038.6553 c -0.468185,-0.4682 -1.221974,-0.4682 -1.690135,-10e-5 l -3.1127968,3.1129 -3.1127723,-3.1128 c -0.4681138,-0.4682 -1.221974,-0.4682 -1.690134,0 l -0.8600555,0.8601 c -0.4681391,0.468 -0.4681272,1.2218 3.66e-5,1.6901 l 3.1127223,3.1128 -3.1127269,3.1127 c -0.4682099,0.4682 -0.468198,1.222 -1.34e-5,1.6902 l 0.8601016,0.8601 c 0.4681344,0.4681 1.2219244,0.4681 1.6901337,0 l 3.1127774,-3.1128 3.1344053,3.1344 c 0.468135,0.4682 1.221925,0.4682 1.690135,0 l 0.860055,-0.86 c 0.46816,-0.4682 0.463458,-1.2173 -3.7e-5,-1.6902 l -3.134406,-3.1344 3.112777,-3.1127 c 0.468181,-0.4683 0.468169,-1.2221 3.4e-5,-1.6902 z"
+           id="rect4043"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sccccccccssccsccsccss" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="layer1-8-8"
+       inkscape:label="Layer 1"
+       transform="matrix(0.50767387,0,0,0.5061245,8.120638,519.33645)">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.50689858;stroke-opacity:1"
+         d="m 10.09375,7.0489054 c -0.3172668,0.031974 -0.6221509,0.15383 -0.78125,0.3125 l -0.59375,0.5625 C 8.400566,8.241043 8.3380492,9.7451599 8.65625,10.0625 L 10.25,11.59375 8.59375,13.1875 C 8.4346339,13.346119 8.405526,13.69178 8.4375,14.03125 l 3.59375,0 0,-5.7010946 -1.125,-1.09375 c -0.159083,-0.15867 -0.495233,-0.2194744 -0.8125,-0.1875 z"
+         transform="matrix(1.9697685,0,0,1.9757984,-15.995777,1021.5387)"
+         id="rect3911"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccccccccs" />
+      <path
+         sodipodi:nodetypes="sccccccccssccsccsccss"
+         inkscape:connector-curvature="0"
+         id="rect4043-2"
+         d="m 13.419292,1038.6553 c -0.468185,-0.4682 -1.221974,-0.4682 -1.690135,-10e-5 l -3.1127968,3.1129 -3.1127723,-3.1128 c -0.4681138,-0.4682 -1.221974,-0.4682 -1.690134,0 l -0.8600555,0.8601 c -0.4681391,0.468 -0.4681272,1.2218 3.66e-5,1.6901 l 3.1127223,3.1128 -3.1127269,3.1127 c -0.4682099,0.4682 -0.468198,1.222 -1.34e-5,1.6902 l 0.8601016,0.8601 c 0.4681344,0.4681 1.2219244,0.4681 1.6901337,0 l 3.1127774,-3.1128 3.1344053,3.1344 c 0.468135,0.4682 1.221925,0.4682 1.690135,0 l 0.860055,-0.86 c 0.46816,-0.4682 0.463458,-1.2173 -3.7e-5,-1.6902 l -3.134406,-3.1344 3.112777,-3.1127 c 0.468181,-0.4683 0.468169,-1.2221 3.4e-5,-1.6902 z"
+         style="fill:url(#linearGradient6120);fill-opacity:1;stroke:url(#linearGradient6122);stroke-width:1.97278117;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/elcl16/collapseall.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/elcl16/collapseall.svg
@@ -1,0 +1,289 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="collapseall.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-4"
+       id="linearGradient4889-2"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9,0,0,0.9,-17.7,103.93622)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-4">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885-5" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887-5" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(18,-3)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9"
+       xlink:href="#linearGradient4910-4-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1"
+       xlink:href="#linearGradient4994-4-7-7"
+       inkscape:collect="always"
+       gradientTransform="translate(18,-3)" />
+    <linearGradient
+       id="linearGradient4994-4-7-7"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883-4-7"
+       id="linearGradient4889-2-1"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9,0,0,0.9,-15.7,105.93622)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883-4-7">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885-5-1" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887-5-1" />
+    </linearGradient>
+    <linearGradient
+       y2="1043.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientTransform="translate(22,4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4970"
+       xlink:href="#linearGradient4989"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4989">
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="0"
+         id="stop4991" />
+      <stop
+         id="stop4995"
+         offset="0.5"
+         style="stop-color:#c3e9ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;"
+         offset="1"
+         id="stop4993" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(20,-1)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062-9-5"
+       xlink:href="#linearGradient4910-4-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4-4-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8-8-7" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8-8-6" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2-1-1"
+       xlink:href="#linearGradient4994-4-7-4"
+       inkscape:collect="always"
+       gradientTransform="translate(20,-1)" />
+    <linearGradient
+       id="linearGradient4994-4-7-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5-4-2"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5-0-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="9.8506072"
+     inkscape:cy="9.9346296"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="809"
+     inkscape:window-x="175"
+     inkscape:window-y="175"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#a6afc4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 2,1038.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="rect3997-9-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 3,1039.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="rect3997-9-1-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient5062-9);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 0,7 -2,0 0,-9 z"
+       id="rect4853-82-7-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 7,0 0,-2 -9,0 z"
+       id="rect4853-82-0-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 4,1040.3622 0,11 11,0 0,-11 z m 1,1 9,0 0,9 -9,0 z"
+       id="rect3997-9-1-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889-2-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 5,1041.3622 8.971875,0 0.02812,9 -8.971875,0 z"
+       id="rect3997-9-1-1-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4970);fill-opacity:1;stroke:none;display:inline"
+       d="m 8,1047.3622 5,0 c 1,0 1,-1 0,-1 l -5,0 c -1,0 -1,1 0,1 z"
+       id="rect4853-82-0-6-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient5062-9-5);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 0,7 -2,0 0,-9 z"
+       id="rect4853-82-7-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2-1-1);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1043.3622 7,0 0,-2 -9,0 z"
+       id="rect4853-82-0-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="fill:#01467a;fill-opacity:1;stroke:none;display:inline"
+       id="rect4167-8"
+       width="1"
+       height="7"
+       x="1045.3622"
+       y="-13"
+       transform="matrix(0,1,-1,0,0,0)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/elcl16/export_log.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/elcl16/export_log.svg
@@ -1,0 +1,565 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="export_log.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4483">
+      <stop
+         style="stop-color:#4077a7;stop-opacity:1"
+         offset="0"
+         id="stop4485" />
+      <stop
+         style="stop-color:#0d5c9a;stop-opacity:1"
+         offset="1"
+         id="stop4487" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4460">
+      <stop
+         style="stop-color:#a8a286;stop-opacity:1"
+         offset="0"
+         id="stop4462" />
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1"
+         offset="1"
+         id="stop4464" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         id="stop7089"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093" />
+      <stop
+         id="stop7095"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter7378"
+       x="-0.11264625"
+       width="1.2252925"
+       y="-0.44767511"
+       height="1.8953502">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.3754875"
+         id="feGaussianBlur7380" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient7541"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       id="linearGradient7087-7">
+      <stop
+         id="stop7089-4"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9" />
+      <stop
+         id="stop7095-4"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7117"
+       xlink:href="#linearGradient7087-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4">
+      <stop
+         id="stop7089-4-5"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1" />
+      <stop
+         id="stop7095-4-7"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7160"
+       xlink:href="#linearGradient7087-7-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4-2">
+      <stop
+         id="stop7089-4-5-7"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5-6" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1-1" />
+      <stop
+         id="stop7095-4-7-4"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1-2"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7203"
+       xlink:href="#linearGradient7087-7-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4-2-2">
+      <stop
+         id="stop7089-4-5-7-1"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5-6-6" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1-1-8" />
+      <stop
+         id="stop7095-4-7-4-5"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1-2-7"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7246"
+       xlink:href="#linearGradient7087-7-4-2-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#fbf0b4;stop-opacity:1"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.72293526,0,0,1,-0.03086799,-2091.7193)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.8571"
+       x2="14"
+       y1="1047.8571"
+       x1="7.0070496"
+       id="linearGradient4871"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5147">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop5149" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop5151" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.57546531,0,0,1,1.00246,-2091.7193)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.8571"
+       x2="14"
+       y1="1045.8571"
+       x1="7.0070496"
+       id="linearGradient4869"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.82571734,0,0,1,-0.75106699,-2091.7193)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.8571"
+       x2="11"
+       y1="1043.8571"
+       x1="7.0070496"
+       id="linearGradient4867"
+       xlink:href="#linearGradient4877"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4879" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop4881" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.72293526,0,0,1,-0.030868,-2089.7194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.8571"
+       x2="14"
+       y1="1047.8571"
+       x1="7.0070496"
+       id="linearGradient4871-8"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4460"
+       id="linearGradient4466"
+       x1="-1046.3622"
+       y1="12.5"
+       x2="-1037.3622"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.1667483e-7,3)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4483"
+       id="linearGradient4489"
+       x1="13"
+       y1="1050.3622"
+       x2="15"
+       y2="1052.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1047.2885,1063.3622)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="43.583483"
+     inkscape:cx="17.092315"
+     inkscape:cy="4.0148715"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2348"
+     inkscape:window-height="1311"
+     inkscape:window-x="57"
+     inkscape:window-y="54"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid6272" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:nodetypes="ccccccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9"
+       d="m 6,1037.3622 9.226335,0 0.0058,9.4978 -2.568358,3.0564 -5.7180776,0.018 c -0.4153006,-0.022 -0.9041922,-0.5519 -0.9041922,-1.0385 z"
+       style="display:inline;fill:#e6f8ff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <rect
+       style="display:inline;opacity:0.99715307;fill:#989891;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4367-3"
+       width="6"
+       height="1"
+       x="6"
+       y="1049.3622" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9-4-5"
+       d="M 12.720747,1050.3622 16,1047.0482 l 0,-0.686 -3.99982,4 z"
+       style="display:inline;fill:#d4b268;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <g
+       id="g7358"
+       mask="url(#mask7366)"
+       transform="matrix(0,-1,1,0,-1034.7801,1032.6792)">
+      <g
+         id="g7205-6"
+         style="display:inline;opacity:0.75;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter7378)">
+        <path
+           style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -15.584151,1041.8789 0,-2.013"
+           id="path7045-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -13.584151,1041.8789 0,-2.013"
+           id="path7045-0-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -11.584151,1041.8789 0,-2.013"
+           id="path7045-3-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -9.584151,1041.8789 0,-2.013"
+           id="path7045-3-4-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -7.584151,1041.8789 0,-2.013"
+           id="path7045-3-4-7-2"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+      </g>
+    </g>
+    <g
+       id="g7205"
+       transform="matrix(0,-1,-1,0,1047.386,1032.2781)">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7045"
+         d="m -15.584151,1041.8789 0,-2.013"
+         style="fill:none;stroke:url(#linearGradient7541);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7045-8"
+         d="m -13.584151,1041.8789 0,-2.013"
+         style="display:inline;fill:none;stroke:url(#linearGradient7117);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7045-8-1"
+         d="m -11.584151,1041.8789 0,-2.013"
+         style="display:inline;fill:none;stroke:url(#linearGradient7160);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7045-8-1-3"
+         d="m -9.584151,1041.8789 0,-2.013"
+         style="display:inline;fill:none;stroke:url(#linearGradient7203);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7045-8-1-3-6"
+         d="m -7.584151,1041.8789 0,-2.013"
+         style="display:inline;fill:none;stroke:url(#linearGradient7246);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <g
+       transform="translate(-11.117495,16.574943)"
+       style="display:inline"
+       id="g7590-7" />
+    <g
+       transform="matrix(0.40514455,0,0,0.40514455,49.493535,621.6127)"
+       style="display:inline"
+       id="g7827-7" />
+    <rect
+       style="opacity:0.99715307;fill:#c7b571;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4367"
+       width="9"
+       height="1"
+       x="6"
+       y="1037.3622" />
+    <rect
+       style="display:inline;opacity:0.99715307;fill:url(#linearGradient4466);fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4367-3-6"
+       width="8.9999828"
+       height="1"
+       x="-1046.3622"
+       y="15"
+       transform="matrix(0,-1,1,0,0,0)" />
+    <g
+       id="g4361"
+       transform="translate(3.9652262,-0.99483804)">
+      <rect
+         transform="scale(1,-1)"
+         style="display:inline;fill:url(#linearGradient4867);fill-opacity:1;stroke:none"
+         id="rect4001-1"
+         width="3.2970483"
+         height="1.0103934"
+         x="5.0347738"
+         y="-1048.3674" />
+      <rect
+         transform="scale(1,-1)"
+         style="display:inline;fill:url(#linearGradient4869);fill-opacity:1;stroke:none"
+         id="rect4001-1-7"
+         width="4.0242004"
+         height="1.0103934"
+         x="5.0347738"
+         y="-1046.3674" />
+      <rect
+         transform="scale(1,-1)"
+         style="display:inline;fill:url(#linearGradient4871);fill-opacity:1;stroke:none"
+         id="rect4001-1-7-4"
+         width="5.0554504"
+         height="1.0103934"
+         x="5.0347738"
+         y="-1044.3674" />
+      <rect
+         transform="scale(1,-1)"
+         style="display:inline;fill:url(#linearGradient4871-8);fill-opacity:1;stroke:none"
+         id="rect4001-1-7-4-6"
+         width="5.0554504"
+         height="1.0103934"
+         x="5.0347738"
+         y="-1042.3674" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9-4"
+       d="m 12.002413,1046.3622 3.997407,0 -3.99982,4 z"
+       style="display:inline;fill:#e6c8ad;fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9-4-1"
+       d="m 5.0737,1048.3647 0,3.9974 L 1,1048.3622 Z"
+       style="display:inline;fill:url(#linearGradient4489);fill-opacity:1;stroke:none" />
+    <image
+       y="1036.3622"
+       x="17"
+       id="image4633"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAWdJREFU
+OI2lk8ErRFEUxr87KStrZWdtZzErkT9ANhYW2Cm2o0QzshHKYspGUxZCzWOkTCELYSFTbEiUlUQj
+BuW9O+67b2Y+i6eZN817Rjn1dU6dztevzjmCJP4TDUGNzF7kT84iiOCriLoGlwcRhPwaXWMGT26e
+0Boe+tWgVAoFE+SLIAhAAMsbGShbQ0oFUyrYSmMh1ofz3XGAZI06I0nuXz2yuX2QpkOaBdZkyyEP
+tycZSPDpgBBuvbKZgVIallSQ8gvKdjAX7cPZTqw+wYdmrRxXaWM6mODdqWxhPfVDkHcJopFegMBx
+aqY+wavNsl489atNJldngwledIXA2HK3YFkKo2ELGg/Q8g1a5uoTPCsy69F9Js67wxiv0yMk6d5B
+94RB0y7iLpd3N7A2LLK2/yVap1PQMoe2niUBeE7Za/K5NiwSiUVfg46W2/JwlUHFpICL+IDwG/aL
+ql84mu8XTY2BD+ob3xcTczsCvhyeAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/elcl16/filter_ps.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/elcl16/filter_ps.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="filter_ps.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1047">
+      <stop
+         style="stop-color:#96a0b9;stop-opacity:1"
+         offset="0"
+         id="stop1043" />
+      <stop
+         style="stop-color:#77849d;stop-opacity:1"
+         offset="1"
+         id="stop1045" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1039">
+      <stop
+         style="stop-color:#fbffff;stop-opacity:1"
+         offset="0"
+         id="stop1035" />
+      <stop
+         style="stop-color:#b9e7ff;stop-opacity:1"
+         offset="1"
+         id="stop1037" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4989">
+      <stop
+         id="stop4991"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1;"
+         offset="0.5"
+         id="stop4995" />
+      <stop
+         id="stop4993"
+         offset="1"
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1039"
+       id="linearGradient1041"
+       x1="2.1048543"
+       y1="1039.3379"
+       x2="12.850951"
+       y2="1039.2937"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1047"
+       id="linearGradient1049"
+       x1="1"
+       y1="1044.8622"
+       x2="14"
+       y2="1044.8622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#444248"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="2.7020062"
+     inkscape:cy="8.7735937"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       id="path859"
+       style="fill:url(#linearGradient1041);stroke:url(#linearGradient1049);stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1"
+       d="m 7.504725,1043.8623 h 1.99055 M 1.5,1037.8622 h 12 v 2 l -4,4 v 6 l -3.0000002,2 H 5.5 v -8 l -4,-4 z" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/elcl16/find_obj.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/elcl16/find_obj.svg
@@ -1,0 +1,360 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="find_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4245">
+      <stop
+         style="stop-color:#b99866;stop-opacity:1"
+         offset="0"
+         id="stop4247" />
+      <stop
+         style="stop-color:#906f4e;stop-opacity:1"
+         offset="1"
+         id="stop4249" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4235">
+      <stop
+         style="stop-color:#f4d684;stop-opacity:0"
+         offset="0"
+         id="stop4237" />
+      <stop
+         id="stop4239"
+         offset="0.25"
+         style="stop-color:#fcf4c6;stop-opacity:1" />
+      <stop
+         id="stop4241"
+         offset="0.5"
+         style="stop-color:#fbeebc;stop-opacity:1" />
+      <stop
+         style="stop-color:#eeb960;stop-opacity:1"
+         offset="1"
+         id="stop4243" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5448">
+      <stop
+         style="stop-color:#ad8e5f;stop-opacity:1"
+         offset="0"
+         id="stop5450" />
+      <stop
+         style="stop-color:#8f6e4d;stop-opacity:1"
+         offset="1"
+         id="stop5452" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5440">
+      <stop
+         style="stop-color:#ad8e5f;stop-opacity:1"
+         offset="0"
+         id="stop5442" />
+      <stop
+         style="stop-color:#8f6e4d;stop-opacity:1"
+         offset="1"
+         id="stop5444" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5428">
+      <stop
+         style="stop-color:#f0a53b;stop-opacity:1;"
+         offset="0"
+         id="stop5430" />
+      <stop
+         id="stop5438"
+         offset="0.26895422"
+         style="stop-color:#f2d58f;stop-opacity:1" />
+      <stop
+         id="stop5436"
+         offset="0.60424823"
+         style="stop-color:#efb965;stop-opacity:1" />
+      <stop
+         style="stop-color:#df9833;stop-opacity:1"
+         offset="1"
+         id="stop5432" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5378">
+      <stop
+         id="stop5380"
+         offset="0"
+         style="stop-color:#f4d684;stop-opacity:1" />
+      <stop
+         style="stop-color:#fcf4c6;stop-opacity:1"
+         offset="0.25"
+         id="stop5382" />
+      <stop
+         style="stop-color:#fbeebc;stop-opacity:1"
+         offset="0.5"
+         id="stop5384" />
+      <stop
+         id="stop5386"
+         offset="1"
+         style="stop-color:#eeb960;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5351">
+      <stop
+         style="stop-color:#e4a239;stop-opacity:1;"
+         offset="0"
+         id="stop5353" />
+      <stop
+         style="stop-color:#fada7d;stop-opacity:1"
+         offset="1"
+         id="stop5355" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5331">
+      <stop
+         style="stop-color:#fef48d;stop-opacity:1"
+         offset="0"
+         id="stop5333" />
+      <stop
+         id="stop5341"
+         offset="0.3251386"
+         style="stop-color:#fffffe;stop-opacity:1" />
+      <stop
+         id="stop5339"
+         offset="0.66393197"
+         style="stop-color:#fffffe;stop-opacity:1" />
+      <stop
+         style="stop-color:#fef48d;stop-opacity:1"
+         offset="1"
+         id="stop5335" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5206">
+      <stop
+         style="stop-color:#bbb8bb;stop-opacity:1"
+         offset="0"
+         id="stop5208" />
+      <stop
+         id="stop5216"
+         offset="0.25"
+         style="stop-color:#ccc8cb;stop-opacity:1" />
+      <stop
+         id="stop5214"
+         offset="0.5"
+         style="stop-color:#bdb6bc;stop-opacity:1" />
+      <stop
+         style="stop-color:#9b8c98;stop-opacity:1"
+         offset="1"
+         id="stop5210" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5109">
+      <stop
+         style="stop-color:#906f4e;stop-opacity:1"
+         offset="0"
+         id="stop5111" />
+      <stop
+         style="stop-color:#dfbd7f;stop-opacity:1"
+         offset="1"
+         id="stop5113" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5109"
+       id="linearGradient5368"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.3742784e-7,-0.01182114)"
+       x1="29.714636"
+       y1="1041.3262"
+       x2="29.714636"
+       y2="1039.1387" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5378"
+       id="linearGradient5370"
+       gradientUnits="userSpaceOnUse"
+       x1="27.009878"
+       y1="1046.1316"
+       x2="32.176903"
+       y2="1046.1316" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5331"
+       id="linearGradient5372"
+       gradientUnits="userSpaceOnUse"
+       x1="26.880592"
+       y1="1056.9694"
+       x2="32.471878"
+       y2="1056.9694" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5351"
+       id="linearGradient5374"
+       gradientUnits="userSpaceOnUse"
+       x1="25.982219"
+       y1="1056.9694"
+       x2="33.275511"
+       y2="1056.9694" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5206"
+       id="linearGradient5376"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.3742784e-7,-4.4137428e-5)"
+       x1="26.45211"
+       y1="1052.0043"
+       x2="32.842041"
+       y2="1052.0043" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5428"
+       id="linearGradient5434"
+       x1="26.107269"
+       y1="1045.9496"
+       x2="33.162997"
+       y2="1045.9496"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5440"
+       id="linearGradient5446"
+       x1="25.367371"
+       y1="1051.4068"
+       x2="33.890359"
+       y2="1051.4068"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5448"
+       id="linearGradient5454"
+       x1="25.367543"
+       y1="1054.8198"
+       x2="33.890187"
+       y2="1054.8198"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4245"
+       id="linearGradient4251"
+       x1="30.011103"
+       y1="1041.2635"
+       x2="30.011591"
+       y2="1044.8075"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.04728278,-0.09456555)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="13.423122"
+     inkscape:cy="8.4136027"
+     inkscape:document-units="px"
+     inkscape:current-layer="g5359"
+     showgrid="true"
+     inkscape:window-width="1009"
+     inkscape:window-height="947"
+     inkscape:window-x="1032"
+     inkscape:window-y="557"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4161" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8472"
+       transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)">
+      <g
+         transform="translate(15.600543,0)"
+         id="g8421">
+        <g
+           id="g5359"
+           transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,730.34515,280.80707)">
+          <path
+             sodipodi:nodetypes="ccccc"
+             inkscape:connector-curvature="0"
+             id="rect4221-4"
+             d="m 28.565245,1040.0695 -1.069887,2.1398 4.279549,0 -1.069887,-2.1398 c -0.472828,-0.9477 -1.844257,-0.7625 -2.139775,0 z"
+             style="fill:none;stroke:url(#linearGradient5368);stroke-width:1.06988706;stroke-miterlimit:3.79999995;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+          <path
+             sodipodi:nodetypes="ccccc"
+             inkscape:connector-curvature="0"
+             id="rect4221"
+             d="m 26.607269,1042.2428 c 1.259438,-1.6377 4.858466,-1.5046 6.055728,0 l 0,8.5925 -6.055728,0 z"
+             style="fill:url(#linearGradient5370);fill-opacity:1;stroke:url(#linearGradient5434);stroke-opacity:1;stroke-width:1.06988706;stroke-miterlimit:3.79999995;stroke-dasharray:none" />
+          <path
+             sodipodi:nodetypes="ccccc"
+             inkscape:connector-curvature="0"
+             id="path5028"
+             d="m 29.526238,1042.1318 c -0.440696,0.012 -0.86969,0.051 -1.279613,0.12 l 0,2.8791 c 0.409923,-0.068 0.838917,-0.1076 1.279613,-0.1199 z"
+             style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#496da1;fill-opacity:1;stroke:none;stroke-width:1.06988704;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+          <path
+             sodipodi:nodetypes="sccccs"
+             inkscape:connector-curvature="0"
+             id="rect4221-7-1"
+             d="m 29.645582,1053.51 c -1.546954,0 -3.096933,0.3554 -3.778039,1.0365 l 0,0.5683 c 1.362214,1.3622 6.178977,1.3438 7.522644,0 l 0,-0.5683 c -0.671834,-0.6719 -2.197651,-1.0342 -3.744605,-1.0365 z"
+             style="fill:#ffffc9;fill-opacity:1;stroke:url(#linearGradient5454);stroke-width:1.06988706;stroke-opacity:1;display:inline;stroke-miterlimit:3.79999995;stroke-dasharray:none" />
+          <path
+             sodipodi:nodetypes="ccccc"
+             inkscape:connector-curvature="0"
+             id="rect4221-7-1-2"
+             d="m 26.422196,1052.4196 0,12.1257 6.413338,0 0,-12.1257 z"
+             style="fill:url(#linearGradient5372);fill-opacity:1;stroke:url(#linearGradient5374);stroke-width:1.06988706;stroke-opacity:1;display:inline;stroke-miterlimit:3.79999995;stroke-dasharray:none" />
+          <path
+             inkscape:connector-curvature="0"
+             id="rect4221-7"
+             d="m 25.867543,1050.1666 0,4.3799 c 1.778049,-1.9187 5.89609,-1.8666 7.522644,0 l 0,-4.3799 c -1.258456,-2.537 -6.051006,-2.5281 -7.522644,0 z"
+             style="fill:url(#linearGradient5376);fill-opacity:1;stroke:url(#linearGradient5446);stroke-width:1.06988706;stroke-linejoin:round;stroke-miterlimit:3.79999995;stroke-opacity:1;stroke-dasharray:none;display:inline"
+             sodipodi:nodetypes="ccccc" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="rect4221-9"
+             d="m 26.678193,1042.8208 -0.02364,-0.6726 c 1.259438,-1.6377 4.858466,-1.5046 6.055728,0 l 0.02364,0.6726"
+             style="display:inline;fill:none;fill-opacity:1;stroke:url(#linearGradient4251);stroke-width:0.96289837;stroke-miterlimit:3.79999995;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/elcl16/import_log.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/elcl16/import_log.svg
@@ -1,0 +1,563 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="import_log.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4483">
+      <stop
+         style="stop-color:#4077a7;stop-opacity:1"
+         offset="0"
+         id="stop4485" />
+      <stop
+         style="stop-color:#0d5c9a;stop-opacity:1"
+         offset="1"
+         id="stop4487" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4460">
+      <stop
+         style="stop-color:#a8a286;stop-opacity:1"
+         offset="0"
+         id="stop4462" />
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1"
+         offset="1"
+         id="stop4464" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         id="stop7089"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093" />
+      <stop
+         id="stop7095"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter7378"
+       x="-0.11264625"
+       width="1.2252925"
+       y="-0.44767511"
+       height="1.8953502">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.3754875"
+         id="feGaussianBlur7380" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient7541"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       id="linearGradient7087-7">
+      <stop
+         id="stop7089-4"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9" />
+      <stop
+         id="stop7095-4"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7117"
+       xlink:href="#linearGradient7087-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4">
+      <stop
+         id="stop7089-4-5"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1" />
+      <stop
+         id="stop7095-4-7"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7160"
+       xlink:href="#linearGradient7087-7-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4-2">
+      <stop
+         id="stop7089-4-5-7"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5-6" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1-1" />
+      <stop
+         id="stop7095-4-7-4"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1-2"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7203"
+       xlink:href="#linearGradient7087-7-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4-2-2">
+      <stop
+         id="stop7089-4-5-7-1"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5-6-6" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1-1-8" />
+      <stop
+         id="stop7095-4-7-4-5"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1-2-7"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7246"
+       xlink:href="#linearGradient7087-7-4-2-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#fbf0b4;stop-opacity:1"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.72293526,0,0,1,-0.03086799,-2091.7193)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.8571"
+       x2="14"
+       y1="1047.8571"
+       x1="7.0070496"
+       id="linearGradient4871"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5147">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop5149" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop5151" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.57546531,0,0,1,1.00246,-2091.7193)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.8571"
+       x2="14"
+       y1="1045.8571"
+       x1="7.0070496"
+       id="linearGradient4869"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.82571734,0,0,1,-0.75106699,-2091.7193)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.8571"
+       x2="11"
+       y1="1043.8571"
+       x1="7.0070496"
+       id="linearGradient4867"
+       xlink:href="#linearGradient4877"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4879" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop4881" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.72293526,0,0,1,-0.030868,-2089.7194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.8571"
+       x2="14"
+       y1="1047.8571"
+       x1="7.0070496"
+       id="linearGradient4871-8"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4460"
+       id="linearGradient4466"
+       x1="-1046.3622"
+       y1="12.5"
+       x2="-1037.3622"
+       y2="12.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4483"
+       id="linearGradient4489"
+       x1="13"
+       y1="1050.3622"
+       x2="15"
+       y2="1052.3622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="56.010664"
+     inkscape:cx="17.074461"
+     inkscape:cy="8.7141671"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2348"
+     inkscape:window-height="1311"
+     inkscape:window-x="57"
+     inkscape:window-y="54"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid6272" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:nodetypes="ccccccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9"
+       d="m 3,1037.3622 9.226335,0 0.0058,9.4978 -2.5683582,3.0564 -5.7180774,0.018 c -0.4153006,-0.022 -0.9041922,-0.5519 -0.9041922,-1.0385 z"
+       style="display:inline;fill:#e6f8ff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <rect
+       style="display:inline;opacity:0.99715307;fill:#989891;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4367-3"
+       width="6"
+       height="1"
+       x="3"
+       y="1049.3622" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9-4-5"
+       d="M 9.720747,1050.3622 13,1047.0482 l 0,-0.686 -3.99982,4 z"
+       style="display:inline;fill:#d4b268;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <g
+       id="g7358"
+       mask="url(#mask7366)"
+       transform="matrix(0,-1,1,0,-1037.7801,1032.6792)">
+      <g
+         id="g7205-6"
+         style="display:inline;opacity:0.75;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter7378)">
+        <path
+           style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -15.584151,1041.8789 0,-2.013"
+           id="path7045-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -13.584151,1041.8789 0,-2.013"
+           id="path7045-0-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -11.584151,1041.8789 0,-2.013"
+           id="path7045-3-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -9.584151,1041.8789 0,-2.013"
+           id="path7045-3-4-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -7.584151,1041.8789 0,-2.013"
+           id="path7045-3-4-7-2"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+      </g>
+    </g>
+    <g
+       id="g7205"
+       transform="matrix(0,-1,-1,0,1044.386,1032.2781)">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7045"
+         d="m -15.584151,1041.8789 0,-2.013"
+         style="fill:none;stroke:url(#linearGradient7541);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7045-8"
+         d="m -13.584151,1041.8789 0,-2.013"
+         style="display:inline;fill:none;stroke:url(#linearGradient7117);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7045-8-1"
+         d="m -11.584151,1041.8789 0,-2.013"
+         style="display:inline;fill:none;stroke:url(#linearGradient7160);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7045-8-1-3"
+         d="m -9.584151,1041.8789 0,-2.013"
+         style="display:inline;fill:none;stroke:url(#linearGradient7203);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7045-8-1-3-6"
+         d="m -7.584151,1041.8789 0,-2.013"
+         style="display:inline;fill:none;stroke:url(#linearGradient7246);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <g
+       transform="translate(-11.117495,16.574943)"
+       style="display:inline"
+       id="g7590-7" />
+    <g
+       transform="matrix(0.40514455,0,0,0.40514455,49.493535,621.6127)"
+       style="display:inline"
+       id="g7827-7" />
+    <rect
+       style="opacity:0.99715307;fill:#c7b571;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4367"
+       width="9"
+       height="1"
+       x="3"
+       y="1037.3622" />
+    <rect
+       style="display:inline;opacity:0.99715307;fill:url(#linearGradient4466);fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4367-3-6"
+       width="8.9999828"
+       height="1"
+       x="-1046.3622"
+       y="12"
+       transform="matrix(0,-1,1,0,0,0)" />
+    <g
+       id="g4361"
+       transform="translate(0.96522617,-0.99483826)">
+      <rect
+         transform="scale(1,-1)"
+         style="display:inline;fill:url(#linearGradient4867);fill-opacity:1;stroke:none"
+         id="rect4001-1"
+         width="3.2970483"
+         height="1.0103934"
+         x="5.0347738"
+         y="-1048.3674" />
+      <rect
+         transform="scale(1,-1)"
+         style="display:inline;fill:url(#linearGradient4869);fill-opacity:1;stroke:none"
+         id="rect4001-1-7"
+         width="4.0242004"
+         height="1.0103934"
+         x="5.0347738"
+         y="-1046.3674" />
+      <rect
+         transform="scale(1,-1)"
+         style="display:inline;fill:url(#linearGradient4871);fill-opacity:1;stroke:none"
+         id="rect4001-1-7-4"
+         width="5.0554504"
+         height="1.0103934"
+         x="5.0347738"
+         y="-1044.3674" />
+      <rect
+         transform="scale(1,-1)"
+         style="display:inline;fill:url(#linearGradient4871-8);fill-opacity:1;stroke:none"
+         id="rect4001-1-7-4-6"
+         width="5.0554504"
+         height="1.0103934"
+         x="5.0347738"
+         y="-1042.3674" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9-4"
+       d="m 9.002413,1046.3622 3.997407,0 -3.99982,4 z"
+       style="display:inline;fill:#e6c8ad;fill-opacity:1;stroke:none" />
+    <image
+       y="1036.3622"
+       x="17"
+       id="image4399"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAXJJREFU
+OI2lkr1LA0EQxd/F/A+CnbWdRbAQP1pBbFLYaCdoaSwMJGCnhahgY2MRopALCkJArVKk8tKKpLhC
+RPwiiQrJXbJ3e7lnEe8SuWgCDjx2WXZmfrvzFJL4T4S9jXYVG6jSxNy+8uOAJEii4ZD9dHO5Tu++
+pxAATG+oLJSeMRpZ/rO764Z6P6Gwt6g0WuB9MQ0COM5qEJYN0xSomwKWsLGbjMJxh4JVSWIqluH1
+7ROHx5dYl2TdYWA1JJm/iAee4BPUJKgX03ABpLIahLBhmAKm2YSwJHYSUchWuD/Bp82gZFu57Nbv
+BB8SLGltgtOzb4JGmyARWwAISDkAQcWir3LXvmKRano7QKB4Tizb8I2knrenYBgCaxEDNh5hm++w
+zSrG5o+CRuomeBPka5cetAPq+STvcquB7iQ7TnwRZC/9ljyzmaH/iQCQSx32dN/kSBB7Nq6ybrUA
+oPMHg4aXrFcbqJ2sKD3m0i/ZgV5t+mdfMuDJ6DUH0PsAAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect3997-9-4-1"
+       d="m 14.9975,1052.3622 -3.9974,0 3.9999,-4.0737 z"
+       style="display:inline;fill:url(#linearGradient4489);fill-opacity:1;stroke:none" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/elcl16/open_log.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/elcl16/open_log.svg
@@ -1,0 +1,487 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="page_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5147"
+       inkscape:collect="always">
+      <stop
+         id="stop5149"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5151"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5141"
+       inkscape:collect="always">
+      <stop
+         id="stop5143"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5145"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5135"
+       inkscape:collect="always">
+      <stop
+         id="stop5137"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop5139"
+         offset="1"
+         style="stop-color:#637aa7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994">
+      <stop
+         style="stop-color:#f9fafc;stop-opacity:1;"
+         offset="0"
+         id="stop4996" />
+      <stop
+         style="stop-color:#dce7f7;stop-opacity:1"
+         offset="1"
+         id="stop4998" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4902">
+      <stop
+         style="stop-color:#c7b571;stop-opacity:1;"
+         offset="0"
+         id="stop4904" />
+      <stop
+         style="stop-color:#9a9a8f;stop-opacity:1"
+         offset="1"
+         id="stop4906" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4894">
+      <stop
+         style="stop-color:#e0c88f;stop-opacity:1"
+         offset="0"
+         id="stop4896" />
+      <stop
+         style="stop-color:#d5b269;stop-opacity:1"
+         offset="1"
+         id="stop4898" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4877"
+       inkscape:collect="always">
+      <stop
+         id="stop4879"
+         offset="0"
+         style="stop-color:#91a5c7;stop-opacity:1;" />
+      <stop
+         id="stop4881"
+         offset="1"
+         style="stop-color:#5e76a3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4861">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4863" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop4865" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867"
+       x1="7.0070496"
+       y1="1043.857"
+       x2="11"
+       y2="1043.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.9449709,-2.9907914)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4861"
+       id="linearGradient4869"
+       x1="7.0070496"
+       y1="1045.857"
+       x2="14"
+       y2="1045.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0013691,0,0,0.98980409,-2.0191666,7.6358418)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5147"
+       id="linearGradient4871"
+       x1="7.0070496"
+       y1="1047.857"
+       x2="14"
+       y2="1047.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0035898,0,0,0.96856508,-2.0502566,29.955202)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5135"
+       id="linearGradient4873"
+       x1="7.0070496"
+       y1="1051.857"
+       x2="12.016466"
+       y2="1051.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812022,0,0,0.98971353,0.00612244,7.8250365)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5141"
+       id="linearGradient4875"
+       x1="7.0070496"
+       y1="1049.857"
+       x2="14"
+       y2="1049.857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0013691,0,0,1.0006833,-2.03023,-3.7729963)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4894"
+       id="linearGradient4900"
+       x1="7.9987183"
+       y1="1042.2307"
+       x2="9.9874563"
+       y2="1040.3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(2.023379,-0.9900341)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4908"
+       x1="10.544736"
+       y1="1038.5779"
+       x2="10.544736"
+       y2="1052.3228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99287847,0,0,1.0029935,-1.9581335,-4.1515444)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient5000"
+       x1="9.8946028"
+       y1="1039.153"
+       x2="9.8946028"
+       y2="1051.8378"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.0112622,-1.0460341)" />
+    <linearGradient
+       id="linearGradient4844-4-1">
+      <stop
+         id="stop4846-8-4"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4848-8-9"
+         offset="1"
+         style="stop-color:#303030;stop-opacity:1;" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask6204">
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 1,1036.3935 0,0.5 0,12.9687 0,0.5 0.5,0 10.0625,0 0.5,0 0,-0.5 0,-9.9687 0,-0.2188 -0.15625,-0.125 -3.0625,-3 -0.125,-0.1562 -0.21875,0 -7,0 -0.5,0 z"
+         id="path6206"
+         inkscape:connector-curvature="0" />
+    </mask>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6120-1"
+       xlink:href="#linearGradient4852-7-8-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4852-7-8-1"
+       inkscape:collect="always">
+      <stop
+         id="stop4854-4-1-9"
+         offset="0"
+         style="stop-color:#707070;stop-opacity:1" />
+      <stop
+         id="stop4856-0-2-1"
+         offset="1"
+         style="stop-color:#a0a0a0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6122-0"
+       xlink:href="#linearGradient4844-4-1-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4844-4-1-4">
+      <stop
+         id="stop4846-8-4-2"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4848-8-9-2"
+         offset="1"
+         style="stop-color:#303030;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6120-4"
+       xlink:href="#linearGradient4852-7-8-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4852-7-8-6"
+       inkscape:collect="always">
+      <stop
+         id="stop4854-4-1-5"
+         offset="0"
+         style="stop-color:#707070;stop-opacity:1" />
+      <stop
+         id="stop4856-0-2-9"
+         offset="1"
+         style="stop-color:#a0a0a0;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6122-8"
+       xlink:href="#linearGradient4844-4-1-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4844-4-1-7">
+      <stop
+         id="stop4846-8-4-5"
+         offset="0"
+         style="stop-color:#3f3f3f;stop-opacity:1;" />
+      <stop
+         id="stop4848-8-9-3"
+         offset="1"
+         style="stop-color:#303030;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867-5"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99419538,0,0,1.000733,-4.9031953,-3.754382)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867-5-1"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99419538,0,0,1.000733,-4.9031953,-1.7543822)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867-5-2"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99419538,0,0,1.000733,-4.9031953,0.24561776)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867-5-6"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99419538,0,0,1.000733,-4.9031953,2.2456178)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4877"
+       id="linearGradient4867-5-0"
+       x1="7.0070496"
+       y1="1043.8571"
+       x2="11"
+       y2="1043.8571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99419538,0,0,1.000733,-4.9031953,4.2456178)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="49.321052"
+     inkscape:cx="17.49301"
+     inkscape:cy="8.0000174"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1997"
+     inkscape:window-height="1119"
+     inkscape:window-x="348"
+     inkscape:window-y="87"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="display:inline;fill:url(#linearGradient5000);fill-opacity:1;stroke:none"
+       d="m 3.4860203,1037.8577 7.0096687,0 3.062057,3.0066 0,9.9546 -10.0717257,0 z"
+       id="rect4001-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:url(#linearGradient4900);fill-opacity:1;stroke:none"
+       d="m 10,1037.451 0,3.9112 3.977476,0 z"
+       id="path4884"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:url(#linearGradient4908);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 3.5,1037.8622 6.959749,0 3.040251,3.0156 0,9.9844 -10,0 z"
+       id="rect4001"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867);fill-opacity:1;stroke:none"
+       id="rect4001-1"
+       width="2.0223048"
+       height="0.99932742"
+       x="6.9995785"
+       y="1040.3611" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4869);fill-opacity:1;stroke:none"
+       id="rect4001-1-7"
+       width="5"
+       height="1.0000174"
+       x="7"
+       y="1042.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4871);fill-opacity:1;stroke:none"
+       id="rect4001-1-7-4"
+       width="5"
+       height="1.0000174"
+       x="7"
+       y="1044.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4875);fill-opacity:1;stroke:none"
+       id="rect4001-1-7-4-0"
+       width="5"
+       height="1.0000174"
+       x="7"
+       y="1046.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4873);fill-opacity:1;stroke:none"
+       id="rect4001-1-7-4-0-9"
+       width="5"
+       height="1"
+       x="7"
+       y="1048.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867-5);fill-opacity:1;stroke:none"
+       id="rect4001-1-1"
+       width="1"
+       height="1"
+       x="5"
+       y="1040.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867-5-1);fill-opacity:1;stroke:none"
+       id="rect4001-1-1-2"
+       width="1"
+       height="1"
+       x="5"
+       y="1042.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867-5-2);fill-opacity:1;stroke:none"
+       id="rect4001-1-1-7"
+       width="1"
+       height="1"
+       x="5"
+       y="1044.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867-5-6);fill-opacity:1;stroke:none"
+       id="rect4001-1-1-1"
+       width="1"
+       height="1"
+       x="5"
+       y="1046.3622" />
+    <rect
+       style="display:inline;fill:url(#linearGradient4867-5-0);fill-opacity:1;stroke:none"
+       id="rect4001-1-1-8"
+       width="1"
+       height="1"
+       x="5"
+       y="1048.3622" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/elcl16/properties.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/elcl16/properties.svg
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="properties.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient7491">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7493" />
+      <stop
+         style="stop-color:#a0b0cc;stop-opacity:1;"
+         offset="1"
+         id="stop7495" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7254">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7254"
+       id="linearGradient7260"
+       x1="15.000595"
+       y1="2"
+       x2="-8"
+       y2="1.375"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.03125,1035.7997)" />
+    <linearGradient
+       id="linearGradient7254-6">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-5" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.93721973,0,0,1,1036.3976,-3.562483)"
+       y2="2"
+       x2="-3.2642515"
+       y1="2"
+       x1="15.000595"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7277"
+       xlink:href="#linearGradient7254-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7254-62">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-0" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-16.03125,1037.7997)"
+       y2="2"
+       x2="-17.187742"
+       y1="2"
+       x1="15.000595"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7328"
+       xlink:href="#linearGradient7254-62"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7254-6-4">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-5-4" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-7-4" />
+    </linearGradient>
+    <linearGradient
+       y2="2"
+       x2="-28.335314"
+       y1="2"
+       x1="15.000595"
+       gradientTransform="matrix(0.93721973,0,0,1,1036.3977,-16.624983)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7362"
+       xlink:href="#linearGradient7254-6-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7491"
+       id="linearGradient7497"
+       x1="1.9445436"
+       y1="3.0732041"
+       x2="14.142135"
+       y2="3.0732041"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99637681,0,0,1,0.01998962,1035.7997)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="10.07852"
+     inkscape:cy="11.787627"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="1384"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4046" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7499"
+       width="14.142136"
+       height="13.169864"
+       x="0.9410218"
+       y="1037.3481" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415-2"
+       width="1.125"
+       height="12.09375"
+       x="-1042.5184"
+       y="1.96875"
+       transform="matrix(0,-1,1,0,0,0)" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415"
+       width="1.125"
+       height="12.9375"
+       x="5.09375"
+       y="1037.4247" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient7362);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244-4-4"
+       width="13.0625"
+       height="1"
+       x="1037.3934"
+       y="-15.0625"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient7277);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244-4"
+       width="13.0625"
+       height="1"
+       x="1037.3934"
+       y="-2"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <rect
+       style="opacity:0.67558528;color:#000000;fill:url(#linearGradient7497);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7489"
+       width="12.153398"
+       height="1.1932427"
+       x="1.9574878"
+       y="1038.2762" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient7260);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244"
+       width="13.9375"
+       height="1"
+       x="1.03125"
+       y="1037.3622" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient7328);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244-7"
+       width="13.9375"
+       height="1"
+       x="-14.96875"
+       y="1039.3622"
+       transform="scale(-1,1)" />
+    <rect
+       style="color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244-4-4-8"
+       width="14.0625"
+       height="1"
+       x="1.03125"
+       y="1049.4247" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415-2-4"
+       width="1.125"
+       height="12.125"
+       x="-1044.7281"
+       y="1.9375"
+       transform="matrix(0,-1,1,0,0,0)" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415-2-4-3"
+       width="1.125"
+       height="12.09375"
+       x="-1047.0262"
+       y="1.96875"
+       transform="matrix(0,-1,1,0,0,0)" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415-2-4-3-9"
+       width="1.125"
+       height="12.0625"
+       x="-1049.3685"
+       y="2"
+       transform="matrix(0,-1,1,0,0,0)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/elcl16/refresh.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/elcl16/refresh.svg
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="refresh.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-5-1"
+       id="linearGradient7608-3-3"
+       gradientUnits="userSpaceOnUse"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345" />
+    <linearGradient
+       id="linearGradient7584-5-1">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-4-6" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-5-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-1-2"
+       id="linearGradient7610-5-8"
+       gradientUnits="userSpaceOnUse"
+       x1="23.551146"
+       y1="1037.3622"
+       x2="23.551146"
+       y2="1045.3622" />
+    <linearGradient
+       id="linearGradient7592-1-2">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6-7" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7596-9-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-9-3-2"
+       id="linearGradient7608-9-7-1"
+       gradientUnits="userSpaceOnUse"
+       x1="22.930616"
+       y1="1039.6982"
+       x2="22.930616"
+       y2="1041.7356" />
+    <linearGradient
+       id="linearGradient7584-9-3-2">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-6-3-6" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-9-9-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7134"
+       id="linearGradient7140"
+       x1="25.363291"
+       y1="1044.7311"
+       x2="25.363291"
+       y2="1037.7311"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7134">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7136" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7138" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="14.77039"
+     inkscape:cy="-0.49944469"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="665"
+     inkscape:window-y="497"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4090" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g7604"
+       transform="translate(-13.086169,0.51822429)">
+      <path
+         sodipodi:nodetypes="ccssscscsssszcc"
+         inkscape:connector-curvature="0"
+         id="path7582"
+         d="m 23.585155,1039.3249 0,-1.591 c 0,0 -0.353553,-0.8397 -1.370019,-0.044 -1.016466,0.7955 -2.209709,2.0772 -2.386486,2.4307 -0.176776,0.3536 -0.928077,0.9723 0.08839,1.9446 1.016466,0.9722 2.121321,1.9887 2.121321,1.9887 0,0 1.546796,1.4584 1.546796,0.088 0,-1.37 0,-1.812 0,-1.812 1.366404,-0.063 1.694788,0.3552 2.039845,0.6884 0.345482,0.3336 0.8125,1.9687 1.21875,2.0937 0.40625,0.125 0.625,-2.1875 0.625,-2.625 0,-0.4375 -0.174793,-1.2439 -0.71875,-1.9687 -0.293544,-0.3911 -1.006571,-0.9555 -1.53125,-1.0998 -0.524679,-0.1444 -1.633595,-0.094 -1.633595,-0.094 z"
+         style="fill:url(#linearGradient7608-3-3);fill-opacity:1;stroke:url(#linearGradient7610-5-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         sodipodi:nodetypes="ccssscc"
+         transform="translate(0,1036.3622)"
+         inkscape:connector-curvature="0"
+         id="path7602"
+         d="m 23.069359,2.3660973 0,-0.5966213 c 0,0 0.110485,-0.3756505 -0.220971,-0.243068 -0.331456,0.1325826 -0.972272,0.6629126 -1.038563,0.773398 -0.06629,0.1104855 -0.751301,0.5966214 -0.596622,0.8175923 0.15468,0.2209709 1.458408,0.066291 1.458408,0.066291 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       style="display:inline"
+       id="g7604-6"
+       transform="matrix(-1,0,0,-1,29.049623,2089.2948)">
+      <path
+         sodipodi:nodetypes="ccssscsscsssszcc"
+         inkscape:connector-curvature="0"
+         id="path7582-7"
+         d="m 23.585155,1039.3249 0,-1.591 c 0,0 -0.353553,-0.8397 -1.370019,-0.044 -1.016466,0.7955 -2.209709,2.0772 -2.386486,2.4307 -0.176776,0.3536 -0.928077,0.9723 0.08839,1.9446 1.016466,0.9722 2.121321,1.9887 2.121321,1.9887 0,0 0.404271,0.3812 0.799458,0.5707 0.37782,0.1811 0.747338,0.1871 0.747338,-0.4827 0,-1.37 0,-1.812 0,-1.812 1.366404,-0.063 1.727345,0.3446 2.039845,0.6884 0.3125,0.3437 0.8125,1.9687 1.21875,2.0937 0.40625,0.125 0.625,-2.1875 0.625,-2.625 0,-0.4375 -0.09375,-1.3125 -0.71875,-1.9687 -0.625,-0.6563 -1.006571,-0.9555 -1.53125,-1.0998 -0.524679,-0.1444 -1.633595,-0.094 -1.633595,-0.094 z"
+         style="fill:url(#linearGradient7608-9-7-1);fill-opacity:1;stroke:url(#linearGradient7140);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         sodipodi:nodetypes="ccssscc"
+         inkscape:connector-curvature="0"
+         id="path7602-2"
+         d="m 23.069359,1042.9731 0,0.5966 c 0,0 0.110485,0.3757 -0.220971,0.2431 -0.331456,-0.1326 -0.972272,-0.6629 -1.038563,-0.7734 -0.06629,-0.1105 -0.751301,-0.5966 -0.596622,-0.8176 0.15468,-0.221 1.458408,-0.066 1.458408,-0.066 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <image
+       y="1052.3622"
+       x="0"
+       id="image3013"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAXZJREFU
+OI2lUj1Iw1AQ/l5wKF1MKTaDiy7F3bEu6iS0Dh0EaREnQVoc1EVEkNDgYpbSqdBBhbpVLYhDbRYR
+3Cw42UkcSgzWgqKm9uccNCHBpBX94IN3j7vvvnfvGBHhP+B+k6RIAimS4Nipr4AiCTS5cfs3B+di
+wCzudAglUaCSaHfC3GZwtjVE08ltcJ4R2/2bdo3LgzRmRI31dNBqE/BaA5qajd7BYYTmFnCRHSUA
+GHATmN15ZIU1P4VjEXC+IIoZGQAQjkXg9QWhVZ/7zyAq19nxXhHdRhXtNiEq19mREbe6X0lEBCJC
+ORUg69ka5xM85RO8LTbOZkG30zCLyqkA6bpqE3Gj+YSPVhOhZBbWhRmPp+G2QAYYEUGRBArFVwF+
+7EeCrlZwo+QwsXzPnAQ4AJjafGBKbhdQrwBdtdEDHS+1994ODBTW/QQCCEB4aQXQ73C6f4Ko/OTY
+3fYLVuYTPOmVRdvk3ei4yodJHwHAfKbh3vkbn+0qFz9A+1qMAAAAAElFTkSuQmCC
+"
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/elcl16/remove.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/elcl16/remove.svg
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="rem_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4852"
+       id="linearGradient4858"
+       x1="4.7528968"
+       y1="1051.0466"
+       x2="4.7528968"
+       y2="1038.5814"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.962068e-6,-2.1458883e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4852">
+      <stop
+         style="stop-color:#df2c33;stop-opacity:1"
+         offset="0"
+         id="stop4854" />
+      <stop
+         style="stop-color:#f5817d;stop-opacity:1"
+         offset="1"
+         id="stop4856" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4844"
+       id="linearGradient4850"
+       x1="8.6566515"
+       y1="1050.7386"
+       x2="8.6566515"
+       y2="1037.7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.962068e-6,-2.1458883e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4844">
+      <stop
+         style="stop-color:#c51325;stop-opacity:1;"
+         offset="0"
+         id="stop4846" />
+      <stop
+         style="stop-color:#ca5d49;stop-opacity:1"
+         offset="1"
+         id="stop4848" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4013"
+       xlink:href="#linearGradient4852"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="translate(1.9961442e-6,-9.9830355e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4015"
+       xlink:href="#linearGradient4844"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="20.48"
+     inkscape:cx="2.9255652"
+     inkscape:cy="12.766785"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="953"
+     inkscape:window-height="789"
+     inkscape:window-x="275"
+     inkscape:window-y="275"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4013);fill-opacity:1;stroke:url(#linearGradient4015);stroke-width:0.98060334;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       d="m 13.419292,1038.6553 c -0.468185,-0.4682 -1.221974,-0.4682 -1.690135,-10e-5 l -3.1127968,3.1129 -3.1127723,-3.1128 c -0.4681138,-0.4682 -1.221974,-0.4682 -1.690134,0 l -0.8600555,0.8601 c -0.4681391,0.468 -0.4681272,1.2218 3.66e-5,1.6901 l 3.1127223,3.1128 -3.1127269,3.1127 c -0.4682099,0.4682 -0.468198,1.222 -1.34e-5,1.6902 l 0.8601016,0.8601 c 0.4681344,0.4681 1.2219244,0.4681 1.6901337,0 l 3.1127774,-3.1128 3.1344053,3.1344 c 0.468135,0.4682 1.221925,0.4682 1.690135,0 l 0.860055,-0.86 c 0.46816,-0.4682 0.463458,-1.2173 -3.7e-5,-1.6902 l -3.134406,-3.1344 3.112777,-3.1127 c 0.468181,-0.4683 0.468169,-1.2221 3.4e-5,-1.6902 z"
+       id="rect4043"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccccssccsccsccss" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/elcl16/restore_log.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/elcl16/restore_log.svg
@@ -1,0 +1,536 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="restore_log.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         id="stop7089"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093" />
+      <stop
+         id="stop7095"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter7378"
+       x="-0.11264625"
+       width="1.2252925"
+       y="-0.44767511"
+       height="1.8953502">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.3754875"
+         id="feGaussianBlur7380" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient7541"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       id="linearGradient7087-7">
+      <stop
+         id="stop7089-4"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9" />
+      <stop
+         id="stop7095-4"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7117"
+       xlink:href="#linearGradient7087-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4">
+      <stop
+         id="stop7089-4-5"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1" />
+      <stop
+         id="stop7095-4-7"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7160"
+       xlink:href="#linearGradient7087-7-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4-2">
+      <stop
+         id="stop7089-4-5-7"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5-6" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1-1" />
+      <stop
+         id="stop7095-4-7-4"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1-2"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7203"
+       xlink:href="#linearGradient7087-7-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4-2-2">
+      <stop
+         id="stop7089-4-5-7-1"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5-6-6" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1-1-8" />
+      <stop
+         id="stop7095-4-7-4-5"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1-2-7"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7246"
+       xlink:href="#linearGradient7087-7-4-2-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-5"
+       id="linearGradient7063"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.81692317,0,0,0.74072578,1.8105725,259.32714)"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345" />
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#fbf0b4;stop-opacity:1"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.72293526,0,0,1,-0.03086799,-2091.7193)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.8571"
+       x2="14"
+       y1="1047.8571"
+       x1="7.0070496"
+       id="linearGradient4871"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5147">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop5149" />
+      <stop
+         style="stop-color:#637aa7;stop-opacity:1"
+         offset="1"
+         id="stop5151" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.57546531,0,0,1,1.00246,-2091.7193)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.8571"
+       x2="14"
+       y1="1045.8571"
+       x1="7.0070496"
+       id="linearGradient4869"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(0.82571734,0,0,1,-0.75106699,-2091.7193)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.8571"
+       x2="11"
+       y1="1043.8571"
+       x1="7.0070496"
+       id="linearGradient4867"
+       xlink:href="#linearGradient4877"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4877">
+      <stop
+         style="stop-color:#91a5c7;stop-opacity:1;"
+         offset="0"
+         id="stop4879" />
+      <stop
+         style="stop-color:#5e76a3;stop-opacity:1"
+         offset="1"
+         id="stop4881" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.72293526,0,0,1,-0.030868,-2089.7194)"
+       gradientUnits="userSpaceOnUse"
+       y2="1047.8571"
+       x2="14"
+       y1="1047.8571"
+       x1="7.0070496"
+       id="linearGradient4871-8"
+       xlink:href="#linearGradient5147"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627418"
+     inkscape:cx="0.43979443"
+     inkscape:cy="12.389841"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1208"
+     inkscape:window-height="847"
+     inkscape:window-x="1144"
+     inkscape:window-y="599"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid6272" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4908"
+       transform="translate(17.6875,0)">
+      <g
+         transform="translate(-18.599558,-2.010247)"
+         style="display:inline"
+         id="layer1-8"
+         inkscape:label="Layer 1">
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="rect3997-9"
+           d="m 2.9043501,1040.3481 11.0066719,0 0.486136,9.5157 -2.983353,3.0385 -6.982679,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+           style="display:inline;fill:#e6f8ff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           style="display:inline;opacity:0.99715307;fill:#8996ac;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4367-3"
+           width="8.3526983"
+           height="1.0606689"
+           x="2.9007957"
+           y="1052.3395" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="rect3997-9-4"
+           d="m 10.885887,1049.3225 3.997407,0 -3.99982,4.0737 z"
+           style="fill:#e6c8ad;fill-opacity:1;stroke:none;display:inline" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect3997-9-4-5"
+           d="m 11.604042,1053.3998 3.274053,-3.3145 0.0052,-0.7628 -3.99982,4.0737 z"
+           style="fill:#d4b268;fill-opacity:1;stroke:none;display:inline;stroke-opacity:1;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none" />
+        <g
+           id="g4226"
+           transform="matrix(0,-1,1,0,-1036.441,1056.3351)">
+          <g
+             transform="translate(21,-1)"
+             mask="url(#mask7366)"
+             id="g7358">
+            <g
+               style="display:inline;opacity:0.75;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter7378)"
+               id="g7205-6">
+              <path
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 id="path7045-6"
+                 d="m -15.584151,1041.8789 0,-2.013"
+                 style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 id="path7045-0-6"
+                 d="m -13.584151,1041.8789 0,-2.013"
+                 style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 id="path7045-3-5"
+                 d="m -11.584151,1041.8789 0,-2.013"
+                 style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 id="path7045-3-4-1"
+                 d="m -9.584151,1041.8789 0,-2.013"
+                 style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 id="path7045-3-4-7-2"
+                 d="m -7.584151,1041.8789 0,-2.013"
+                 style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            </g>
+          </g>
+          <g
+             transform="translate(21,-1)"
+             id="g7205">
+            <path
+               style="fill:none;stroke:url(#linearGradient7541);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+               d="m -15.584151,1041.8789 0,-2.013"
+               id="path7045"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+            <path
+               style="display:inline;fill:none;stroke:url(#linearGradient7117);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+               d="m -13.584151,1041.8789 0,-2.013"
+               id="path7045-8"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+            <path
+               style="display:inline;fill:none;stroke:url(#linearGradient7160);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+               d="m -11.584151,1041.8789 0,-2.013"
+               id="path7045-8-1"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+            <path
+               style="display:inline;fill:none;stroke:url(#linearGradient7203);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+               d="m -9.584151,1041.8789 0,-2.013"
+               id="path7045-8-1-3"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+            <path
+               style="display:inline;fill:none;stroke:url(#linearGradient7246);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+               d="m -7.584151,1041.8789 0,-2.013"
+               id="path7045-8-1-3-6"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+          </g>
+        </g>
+        <g
+           transform="translate(-11.593765,19.531347)"
+           style="display:inline"
+           id="g7590-7" />
+        <g
+           transform="matrix(0.40514455,0,0,0.40514455,49.017265,624.5691)"
+           style="display:inline"
+           id="g7827-7" />
+        <rect
+           style="opacity:0.99715307;fill:#bfb688;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4367"
+           width="10.960155"
+           height="1.0606601"
+           x="2.9007957"
+           y="1040.3186" />
+        <rect
+           style="display:inline;opacity:0.99715307;fill:#9fa49d;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4367-3-6"
+           width="8.3526983"
+           height="1.0606689"
+           x="-1049.4006"
+           y="13.794655"
+           transform="matrix(0,-1,1,0,0,0)" />
+      </g>
+    </g>
+    <g
+       id="g4361">
+      <rect
+         transform="scale(1,-1)"
+         style="display:inline;fill:url(#linearGradient4867);fill-opacity:1;stroke:none"
+         id="rect4001-1"
+         width="3.2970483"
+         height="1.0103934"
+         x="5.0347738"
+         y="-1048.3674" />
+      <rect
+         transform="scale(1,-1)"
+         style="display:inline;fill:url(#linearGradient4869);fill-opacity:1;stroke:none"
+         id="rect4001-1-7"
+         width="4.0242004"
+         height="1.0103934"
+         x="5.0347738"
+         y="-1046.3674" />
+      <rect
+         transform="scale(1,-1)"
+         style="display:inline;fill:url(#linearGradient4871);fill-opacity:1;stroke:none"
+         id="rect4001-1-7-4"
+         width="5.0554504"
+         height="1.0103934"
+         x="5.0347738"
+         y="-1044.3674" />
+      <rect
+         transform="scale(1,-1)"
+         style="display:inline;fill:url(#linearGradient4871-8);fill-opacity:1;stroke:none"
+         id="rect4001-1-7-4-6"
+         width="5.0554504"
+         height="1.0103934"
+         x="5.0347738"
+         y="-1042.3674" />
+    </g>
+    <g
+       id="g4302"
+       transform="matrix(-1.2106738,0,0,1.2106738,36.952825,-207.35493)"
+       style="stroke-width:0.82598633;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         sodipodi:nodetypes="csscccscsszccc"
+         inkscape:connector-curvature="0"
+         id="path7582"
+         d="m 20.977446,1028.0307 c 0,0 -0.188442,-0.6494 -1.018816,-0.06 -0.830374,0.5892 -1.805162,1.5384 -1.949575,1.8004 -0.144414,0.2619 -0.758169,0.7201 0.07221,1.4403 0.974651,0.7053 2.893963,3.005 2.951398,2.0283 l 0.01291,-1.4185 c 1.116246,-0.047 1.287718,-0.021 1.763192,0.3422 0.298173,0.2276 0.599218,1.213 0.931095,1.3056 0.331875,0.092 0.510577,-1.6204 0.510577,-1.9443 0,-0.3242 -0.142792,-0.9215 -0.587165,-1.4585 -0.239801,-0.2895 -0.770666,-0.5785 -1.199288,-0.6854 -0.428623,-0.1072 -1.477406,-0.089 -1.477406,-0.089 0,-0.7967 -0.0091,-1.2607 -0.0091,-1.2607 z"
+         style="display:inline;fill:url(#linearGradient7063);fill-opacity:1;stroke:#9a7e20;stroke-width:0.82598632;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccssscc"
+         inkscape:connector-curvature="0"
+         id="path7602-2-3"
+         d="m 20.544192,1029.0701 0,-0.4343 c 0,0 0.08043,-0.2735 -0.160866,-0.177 -0.241299,0.097 -0.70781,0.4826 -0.75607,0.5631 -0.04826,0.08 -0.546944,0.4343 -0.434338,0.5952 0.112606,0.1609 1.061715,0.048 1.061715,0.048 z"
+         style="display:inline;opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.82598633;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/eview16/error_log.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/eview16/error_log.svg
@@ -1,0 +1,636 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="error_log.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         id="stop7089"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093" />
+      <stop
+         id="stop7095"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter7378"
+       x="-0.11264625"
+       width="1.2252925"
+       y="-0.44767511"
+       height="1.8953502">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.3754875"
+         id="feGaussianBlur7380" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient7541"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       id="linearGradient7087-7">
+      <stop
+         id="stop7089-4"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9" />
+      <stop
+         id="stop7095-4"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7117"
+       xlink:href="#linearGradient7087-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4">
+      <stop
+         id="stop7089-4-5"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1" />
+      <stop
+         id="stop7095-4-7"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7160"
+       xlink:href="#linearGradient7087-7-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4-2">
+      <stop
+         id="stop7089-4-5-7"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5-6" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1-1" />
+      <stop
+         id="stop7095-4-7-4"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1-2"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7203"
+       xlink:href="#linearGradient7087-7-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4-2-2">
+      <stop
+         id="stop7089-4-5-7-1"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5-6-6" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1-1-8" />
+      <stop
+         id="stop7095-4-7-4-5"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1-2-7"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7246"
+       xlink:href="#linearGradient7087-7-4-2-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#fbf0b4;stop-opacity:1"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4284">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:0"
+         offset="0"
+         id="stop4286" />
+      <stop
+         id="stop4288"
+         offset="0.49999967"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:0"
+         offset="1"
+         id="stop4290" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-9-7-0-5">
+      <stop
+         id="stop10450-3-5-6-7"
+         offset="0"
+         style="stop-color:#cf9307;stop-opacity:1" />
+      <stop
+         style="stop-color:#f7d87b;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-4-1-5-3" />
+      <stop
+         id="stop10452-22-7-8-4"
+         offset="1"
+         style="stop-color:#ebb313;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-0-0-3">
+      <stop
+         id="stop10442-43-2-0-9"
+         offset="0"
+         style="stop-color:#ae7603;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e8d8a3;stop-opacity:1"
+         offset="0.5"
+         id="stop10521-1-2-5-3" />
+      <stop
+         id="stop10444-3-4-0-4"
+         offset="1"
+         style="stop-color:#bb9221;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10748-8">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10750-5" />
+      <stop
+         id="stop10752-8"
+         offset="0.25"
+         style="stop-color:#f1ce66;stop-opacity:1" />
+      <stop
+         id="stop10754-8"
+         offset="0.5"
+         style="stop-color:#f6e5a6;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1cf6c;stop-opacity:1"
+         offset="0.75"
+         id="stop10756-4" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10758-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-90">
+      <stop
+         id="stop10450-0"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe38d;stop-opacity:1"
+         offset="0.25"
+         id="stop10458-2" />
+      <stop
+         style="stop-color:#fdf5d2;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-96" />
+      <stop
+         id="stop10460-3"
+         offset="0.75"
+         style="stop-color:#ffeba7;stop-opacity:1" />
+      <stop
+         id="stop10452-1"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10414-9">
+      <stop
+         id="stop10416-3"
+         offset="0"
+         style="stop-color:#5078b9;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6d8cbd;stop-opacity:1"
+         offset="0.5"
+         id="stop10422-8" />
+      <stop
+         id="stop10418-4"
+         offset="1"
+         style="stop-color:#5f88c9;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10432-3">
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="0"
+         id="stop10434-4" />
+      <stop
+         id="stop10436-2"
+         offset="0.5"
+         style="stop-color:#4e6da1;stop-opacity:1" />
+      <stop
+         style="stop-color:#567ebc;stop-opacity:1"
+         offset="1"
+         id="stop10438-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10157-6">
+      <stop
+         id="stop10159-5"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:1" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.5"
+         id="stop10165-9" />
+      <stop
+         id="stop10161-55"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10396-5">
+      <stop
+         id="stop10398-7"
+         offset="0"
+         style="stop-color:#1b3e79;stop-opacity:1;" />
+      <stop
+         style="stop-color:#728fbf;stop-opacity:1"
+         offset="0.5"
+         id="stop10404-9" />
+      <stop
+         id="stop10400-9"
+         offset="1"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10149-6-5-4">
+      <stop
+         id="stop10151-5-7-2"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#b9c7df;stop-opacity:1"
+         offset="0.5"
+         id="stop10394-3" />
+      <stop
+         id="stop10153-8-1-2"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="465.52719"
+       x2="388.63736"
+       y1="470.63007"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8163-2"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.50645089,0,0,0.50645089,-180.93852,819.3237)" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1">
+      <stop
+         id="stop10800-5-2-1-8-2-8-1-7-3-7"
+         offset="0"
+         style="stop-color:#e17673;stop-opacity:1;" />
+      <stop
+         style="stop-color:#d04046;stop-opacity:1;"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-95-0-5-4-8" />
+      <stop
+         id="stop10802-1-5-3-0-2-0-9-8-4-3"
+         offset="1"
+         style="stop-color:#e17673;stop-opacity:1;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32.000001"
+     inkscape:cx="6.4212743"
+     inkscape:cy="-1.1356661"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-8"
+     showgrid="true"
+     inkscape:window-width="1208"
+     inkscape:window-height="847"
+     inkscape:window-x="1148"
+     inkscape:window-y="599"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid6272" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4908"
+       transform="translate(19.6875,1.0294101)">
+      <g
+         transform="translate(-18.599558,-2.010247)"
+         style="display:inline"
+         id="layer1-8"
+         inkscape:label="Layer 1">
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="rect3997-9"
+           d="m 3.4981,1039.2874 10.412922,0 0.486136,10.5764 -2.983353,3.0385 -6.3889291,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+           style="display:inline;fill:#e6f8ff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           style="display:inline;opacity:0.99715307;fill:#8996ac;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4367-3"
+           width="7.3526988"
+           height="0.99816895"
+           x="3.9007957"
+           y="1052.402" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="rect3997-9-4"
+           d="m 10.885887,1049.3225 3.997407,0 -3.99982,4.0737 z"
+           style="display:inline;fill:#e6c8ad;fill-opacity:1;stroke:none" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect3997-9-4-5"
+           d="m 11.604042,1053.3998 3.274053,-3.3145 0.0052,-0.7628 -3.99982,4.0737 z"
+           style="display:inline;fill:#d4b268;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <g
+           id="g4226"
+           transform="matrix(0,-1,1,0,-1035.4853,1056.2688)">
+          <g
+             transform="translate(21,-1)"
+             mask="url(#mask7366)"
+             id="g7358">
+            <g
+               style="display:inline;opacity:0.75;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter7378)"
+               id="g7205-6">
+              <path
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 id="path7045-6"
+                 d="m -15.584151,1041.8789 0,-2.013"
+                 style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 id="path7045-0-6"
+                 d="m -13.584151,1041.8789 0,-2.013"
+                 style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 id="path7045-3-5"
+                 d="m -11.584151,1041.8789 0,-2.013"
+                 style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 id="path7045-3-4-1"
+                 d="m -9.584151,1041.8789 0,-2.013"
+                 style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 id="path7045-3-4-7-2"
+                 d="m -7.584151,1041.8789 0,-2.013"
+                 style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            </g>
+          </g>
+          <g
+             transform="translate(21,-1)"
+             id="g7205">
+            <path
+               style="fill:none;stroke:url(#linearGradient7541);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+               d="m -15.584151,1041.8789 0,-2.013"
+               id="path7045"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+            <path
+               style="display:inline;fill:none;stroke:url(#linearGradient7117);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+               d="m -13.584151,1041.8789 0,-2.013"
+               id="path7045-8"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+            <path
+               style="display:inline;fill:none;stroke:url(#linearGradient7160);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+               d="m -11.584151,1041.8789 0,-2.013"
+               id="path7045-8-1"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+            <path
+               style="display:inline;fill:none;stroke:url(#linearGradient7203);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+               d="m -9.584151,1041.8789 0,-2.013"
+               id="path7045-8-1-3"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+            <path
+               style="display:inline;fill:none;stroke:url(#linearGradient7246);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+               d="m -7.584151,1041.8789 0,-2.013"
+               id="path7045-8-1-3-6"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+          </g>
+        </g>
+        <g
+           transform="translate(-11.593765,19.531347)"
+           style="display:inline"
+           id="g7590-7" />
+        <g
+           transform="matrix(0.40514455,0,0,0.40514455,49.017265,624.5691)"
+           style="display:inline"
+           id="g7827-7" />
+        <rect
+           style="opacity:0.99715307;fill:#bfb688;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4367"
+           width="12.065009"
+           height="1.0606689"
+           x="2.8566015"
+           y="1039.3022" />
+        <rect
+           style="display:inline;opacity:0.99715307;fill:#bfb688;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4367-3-6"
+           width="9.0377283"
+           height="0.9722805"
+           x="-1049.4006"
+           y="13.90514"
+           transform="matrix(0,-1,1,0,0,0)" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="layer1-5"
+       inkscape:label="Layer 1"
+       transform="translate(-21.31326,-1.1882634)">
+      <g
+         transform="translate(11.779883,-12.842199)"
+         id="g8159"
+         style="display:inline">
+        <g
+           id="g4329">
+          <circle
+             r="4.5685406"
+             cy="1056.4629"
+             cx="15.627731"
+             style="display:inline;fill:url(#linearGradient8163-2);fill-opacity:1;stroke:#c93e35;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path10796-2-6-0" />
+          <g
+             id="g5025"
+             transform="matrix(1.1880342,0,0,1.1860465,13.541945,-197.60925)">
+            <g
+               id="g4095"
+               transform="matrix(1.0905016,0,0,1.0905016,-0.09572826,-95.681285)">
+              <path
+                 style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+                 d="m 6.6906013,4.3803222 c -0.3088198,0.010926 -1.1015625,0.65625 -1.1015625,0.65625 0,0 0.2885111,0.2731764 0.78125,0.6796875 C 6.8630277,6.1227708 6.8614643,5.9867052 6.96875,6.46875 7.068619,6.9173537 7.1051563,7.3329889 7.15625,7.75 L 4.7756189,10.43934 5.6651334,11.338333 7.4375,9.375 c 0.2792655,0.4616799 0.2209937,0.1631611 0.4368495,0.5299491 0.2533102,0.3539999 0.6860498,0.7341889 1.40625,1.0937499 1.2858975,0.641907 1.1050685,0.565316 1.1050685,0.565316 l 0.965609,-0.791649 c 0,0 -0.202967,-0.247189 -1.5081775,-0.8986669 -0.5753531,-0.287132 -0.7234498,-0.506893 -0.875,-0.71875 C 8.4482832,8.5641085 8.6327445,8.816423 8.5,8.1875 L 11.143575,5.2390072 10.195027,4.4836456 8.28125,6.5 C 8.263796,6.4030643 8.2724218,6.3194727 8.25,6.21875 8.0333974,5.2456067 7.7831729,5.211497 7.1827888,4.7162597 6.9105297,4.502143 6.9447337,4.5647088 6.6906013,4.3803222 Z"
+                 transform="matrix(0.77187105,0,0,0.77316463,-4.647127,1051.0563)"
+                 id="path5021"
+                 inkscape:connector-curvature="0"
+                 sodipodi:nodetypes="ccscccccccccccccccccc" />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/eview16/event_next.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/eview16/event_next.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="next_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#ffffee;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,1,0,-1036.3626,1036.3626)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,1,0,-1036.3626,1036.3626)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="-7.4627612"
+     inkscape:cy="10.319471"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="104"
+     inkscape:window-y="89"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 2.5,1044.8626 3,0 0,-5.7812 c 0,-0.6679 0.5509,-1.2188 1.2188,-1.2188 l 2.5625,0 c 0.6678,0 1.2187,0.5508 1.2187,1.2188 l 0,5.7812 3,0 0,1 -5.5,5.5 -5.5,-5.5 0,-1 z"
+       id="rect3968"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/eview16/event_prev.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/eview16/event_prev.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="prev_nav.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#fbdd83;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1036.3626,1052.3618)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="1.6861235"
+       y1="1040.7402"
+       x2="14.375154"
+       y2="1040.7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1036.3626,1052.3618)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="-4.5683281"
+     inkscape:cy="9.6786205"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1164"
+     inkscape:window-height="982"
+     inkscape:window-x="104"
+     inkscape:window-y="89"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="m 2.5,1043.8618 3,0 0,5.7812 c 0,0.6679 0.5509,1.2188 1.2188,1.2188 l 2.5625,0 c 0.6678,0 1.2187,-0.5508 1.2187,-1.2188 l 0,-5.7812 3,0 0,-1 -5.5,-5.5 -5.5,5.5 0,1 z"
+       id="rect3968"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/obj16/error_st_obj.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/obj16/error_st_obj.svg
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="error_st_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1"
+       id="linearGradient8163-2"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="470.63007"
+       x2="388.63736"
+       y2="465.52719"
+       gradientTransform="matrix(0.5092115,0,0,0.51241298,-180.88498,817.90706)" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1">
+      <stop
+         style="stop-color:#e17673;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8"
+         offset="0.5"
+         style="stop-color:#d04046;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e17673;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="11.412462"
+     inkscape:cy="-3.3569328"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4155"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="851"
+     inkscape:window-y="531"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4099" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <g
+         id="g4155"
+         transform="translate(-0.03125,-1.0625)">
+        <ellipse
+           id="path10796-2-6-0"
+           style="display:inline;fill:url(#linearGradient8163-2);fill-opacity:1;stroke:#c93e35;stroke-width:1.00860667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           cx="16.752731"
+           cy="1057.8379"
+           rx="4.9704876"
+           ry="5.0017376" />
+        <g
+           transform="matrix(1.1880342,0,0,1.1860465,14.354445,-196.67175)"
+           id="g5025">
+          <g
+             transform="matrix(1.0905016,0,0,1.0905016,-0.09572826,-95.681285)"
+             id="g4095">
+            <path
+               sodipodi:nodetypes="ccscccccccccccccccccc"
+               inkscape:connector-curvature="0"
+               id="path5021"
+               transform="matrix(0.77187105,0,0,0.77316463,-4.647127,1051.0563)"
+               d="M 6.2265625,3.6953125 C 5.9177427,3.7062384 5.125,4.3515625 5.125,4.3515625 c 0,0 0.2885111,0.2731764 0.78125,0.6796875 0.4927389,0.4065111 0.9552143,0.9554552 1.0625,1.4375 C 7.068619,6.9173537 7.1051563,7.3329889 7.15625,7.75 L 4.2010947,10.96967 5.0906092,11.868663 7.4375,9.375 c 0.2792655,0.4616799 0.5966442,0.914462 0.8125,1.28125 0.2533102,0.354 0.6860498,0.734189 1.40625,1.09375 1.285897,0.641907 1.105068,0.565316 1.105068,0.565316 l 0.965609,-0.791649 c 0,0 -0.202967,-0.247189 -1.508177,-0.898667 C 9.6433969,10.337868 9.4953002,10.118107 9.34375,9.90625 8.8239337,9.3154094 8.6327445,8.816423 8.5,8.1875 L 11.629711,4.6423859 10.681163,3.8870243 8.28125,6.5 C 8.263796,6.4030643 8.2724218,6.3194727 8.25,6.21875 8.0333974,5.2456067 7.3191341,4.5264873 6.71875,4.03125 6.4464909,3.8171333 6.4806949,3.8796991 6.2265625,3.6953125 Z"
+               style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate" />
+          </g>
+        </g>
+        <ellipse
+           id="path10796-2-6-0-9"
+           style="display:inline;fill:none;fill-opacity:1;stroke:#c93e35;stroke-width:1.00860667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           cx="16.752731"
+           cy="1057.8379"
+           rx="4.9704876"
+           ry="5.0017376" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/obj16/error_stack.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/obj16/error_stack.svg
@@ -1,0 +1,636 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="error_log.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         id="stop7089"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093" />
+      <stop
+         id="stop7095"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <filter
+       inkscape:collect="always"
+       id="filter7378"
+       x="-0.11264625"
+       width="1.2252925"
+       y="-0.44767511"
+       height="1.8953502">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.3754875"
+         id="feGaussianBlur7380" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient7541"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       id="linearGradient7087-7">
+      <stop
+         id="stop7089-4"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9" />
+      <stop
+         id="stop7095-4"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7117"
+       xlink:href="#linearGradient7087-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4">
+      <stop
+         id="stop7089-4-5"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1" />
+      <stop
+         id="stop7095-4-7"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7160"
+       xlink:href="#linearGradient7087-7-4"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4-2">
+      <stop
+         id="stop7089-4-5-7"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5-6" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1-1" />
+      <stop
+         id="stop7095-4-7-4"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1-2"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7203"
+       xlink:href="#linearGradient7087-7-4-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7087-7-4-2-2">
+      <stop
+         id="stop7089-4-5-7-1"
+         offset="0"
+         style="stop-color:#17325d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b4d0e2;stop-opacity:1"
+         offset="0.25"
+         id="stop7091-0-5-6-6" />
+      <stop
+         style="stop-color:#b7d2e4;stop-opacity:1"
+         offset="0.5"
+         id="stop7093-9-1-1-8" />
+      <stop
+         id="stop7095-4-7-4-5"
+         offset="0.75"
+         style="stop-color:#acc9de;stop-opacity:1" />
+      <stop
+         id="stop7097-8-1-2-7"
+         offset="1"
+         style="stop-color:#3e72a7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7246"
+       xlink:href="#linearGradient7087-7-4-2-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#fbf0b4;stop-opacity:1"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4284">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:0"
+         offset="0"
+         id="stop4286" />
+      <stop
+         id="stop4288"
+         offset="0.49999967"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:0"
+         offset="1"
+         id="stop4290" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-9-7-0-5">
+      <stop
+         id="stop10450-3-5-6-7"
+         offset="0"
+         style="stop-color:#cf9307;stop-opacity:1" />
+      <stop
+         style="stop-color:#f7d87b;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-4-1-5-3" />
+      <stop
+         id="stop10452-22-7-8-4"
+         offset="1"
+         style="stop-color:#ebb313;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10440-1-0-0-3">
+      <stop
+         id="stop10442-43-2-0-9"
+         offset="0"
+         style="stop-color:#ae7603;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e8d8a3;stop-opacity:1"
+         offset="0.5"
+         id="stop10521-1-2-5-3" />
+      <stop
+         id="stop10444-3-4-0-4"
+         offset="1"
+         style="stop-color:#bb9221;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10748-8">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10750-5" />
+      <stop
+         id="stop10752-8"
+         offset="0.25"
+         style="stop-color:#f1ce66;stop-opacity:1" />
+      <stop
+         id="stop10754-8"
+         offset="0.5"
+         style="stop-color:#f6e5a6;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1cf6c;stop-opacity:1"
+         offset="0.75"
+         id="stop10756-4" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10758-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10448-90">
+      <stop
+         id="stop10450-0"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe38d;stop-opacity:1"
+         offset="0.25"
+         id="stop10458-2" />
+      <stop
+         style="stop-color:#fdf5d2;stop-opacity:1"
+         offset="0.5"
+         id="stop10456-96" />
+      <stop
+         id="stop10460-3"
+         offset="0.75"
+         style="stop-color:#ffeba7;stop-opacity:1" />
+      <stop
+         id="stop10452-1"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10414-9">
+      <stop
+         id="stop10416-3"
+         offset="0"
+         style="stop-color:#5078b9;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6d8cbd;stop-opacity:1"
+         offset="0.5"
+         id="stop10422-8" />
+      <stop
+         id="stop10418-4"
+         offset="1"
+         style="stop-color:#5f88c9;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10432-3">
+      <stop
+         style="stop-color:#1f4d9a;stop-opacity:1"
+         offset="0"
+         id="stop10434-4" />
+      <stop
+         id="stop10436-2"
+         offset="0.5"
+         style="stop-color:#4e6da1;stop-opacity:1" />
+      <stop
+         style="stop-color:#567ebc;stop-opacity:1"
+         offset="1"
+         id="stop10438-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10157-6">
+      <stop
+         id="stop10159-5"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:1" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.5"
+         id="stop10165-9" />
+      <stop
+         id="stop10161-55"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10396-5">
+      <stop
+         id="stop10398-7"
+         offset="0"
+         style="stop-color:#1b3e79;stop-opacity:1;" />
+      <stop
+         style="stop-color:#728fbf;stop-opacity:1"
+         offset="0.5"
+         id="stop10404-9" />
+      <stop
+         id="stop10400-9"
+         offset="1"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10149-6-5-4">
+      <stop
+         id="stop10151-5-7-2"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#b9c7df;stop-opacity:1"
+         offset="0.5"
+         id="stop10394-3" />
+      <stop
+         id="stop10153-8-1-2"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="465.52719"
+       x2="388.63736"
+       y1="470.63007"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8163-2"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.50645089,0,0,0.50645089,-180.93852,819.3237)" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1">
+      <stop
+         id="stop10800-5-2-1-8-2-8-1-7-3-7"
+         offset="0"
+         style="stop-color:#e17673;stop-opacity:1;" />
+      <stop
+         style="stop-color:#d04046;stop-opacity:1;"
+         offset="0.5"
+         id="stop10806-6-8-5-3-2-95-0-5-4-8" />
+      <stop
+         id="stop10802-1-5-3-0-2-0-9-8-4-3"
+         offset="1"
+         style="stop-color:#e17673;stop-opacity:1;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32.000001"
+     inkscape:cx="6.4212743"
+     inkscape:cy="-1.1356661"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-8"
+     showgrid="true"
+     inkscape:window-width="1208"
+     inkscape:window-height="847"
+     inkscape:window-x="1148"
+     inkscape:window-y="599"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid6272" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4908"
+       transform="translate(19.6875,1.0294101)">
+      <g
+         transform="translate(-18.599558,-2.010247)"
+         style="display:inline"
+         id="layer1-8"
+         inkscape:label="Layer 1">
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="rect3997-9"
+           d="m 3.4981,1039.2874 10.412922,0 0.486136,10.5764 -2.983353,3.0385 -6.3889291,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+           style="display:inline;fill:#e6f8ff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           style="display:inline;opacity:0.99715307;fill:#8996ac;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4367-3"
+           width="7.3526988"
+           height="0.99816895"
+           x="3.9007957"
+           y="1052.402" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="rect3997-9-4"
+           d="m 10.885887,1049.3225 3.997407,0 -3.99982,4.0737 z"
+           style="display:inline;fill:#e6c8ad;fill-opacity:1;stroke:none" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect3997-9-4-5"
+           d="m 11.604042,1053.3998 3.274053,-3.3145 0.0052,-0.7628 -3.99982,4.0737 z"
+           style="display:inline;fill:#d4b268;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <g
+           id="g4226"
+           transform="matrix(0,-1,1,0,-1035.4853,1056.2688)">
+          <g
+             transform="translate(21,-1)"
+             mask="url(#mask7366)"
+             id="g7358">
+            <g
+               style="display:inline;opacity:0.75;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter7378)"
+               id="g7205-6">
+              <path
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 id="path7045-6"
+                 d="m -15.584151,1041.8789 0,-2.013"
+                 style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 id="path7045-0-6"
+                 d="m -13.584151,1041.8789 0,-2.013"
+                 style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 id="path7045-3-5"
+                 d="m -11.584151,1041.8789 0,-2.013"
+                 style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 id="path7045-3-4-1"
+                 d="m -9.584151,1041.8789 0,-2.013"
+                 style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 id="path7045-3-4-7-2"
+                 d="m -7.584151,1041.8789 0,-2.013"
+                 style="display:inline;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            </g>
+          </g>
+          <g
+             transform="translate(21,-1)"
+             id="g7205">
+            <path
+               style="fill:none;stroke:url(#linearGradient7541);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+               d="m -15.584151,1041.8789 0,-2.013"
+               id="path7045"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+            <path
+               style="display:inline;fill:none;stroke:url(#linearGradient7117);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+               d="m -13.584151,1041.8789 0,-2.013"
+               id="path7045-8"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+            <path
+               style="display:inline;fill:none;stroke:url(#linearGradient7160);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+               d="m -11.584151,1041.8789 0,-2.013"
+               id="path7045-8-1"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+            <path
+               style="display:inline;fill:none;stroke:url(#linearGradient7203);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+               d="m -9.584151,1041.8789 0,-2.013"
+               id="path7045-8-1-3"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+            <path
+               style="display:inline;fill:none;stroke:url(#linearGradient7246);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+               d="m -7.584151,1041.8789 0,-2.013"
+               id="path7045-8-1-3-6"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cc" />
+          </g>
+        </g>
+        <g
+           transform="translate(-11.593765,19.531347)"
+           style="display:inline"
+           id="g7590-7" />
+        <g
+           transform="matrix(0.40514455,0,0,0.40514455,49.017265,624.5691)"
+           style="display:inline"
+           id="g7827-7" />
+        <rect
+           style="opacity:0.99715307;fill:#bfb688;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4367"
+           width="12.065009"
+           height="1.0606689"
+           x="2.8566015"
+           y="1039.3022" />
+        <rect
+           style="display:inline;opacity:0.99715307;fill:#bfb688;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect4367-3-6"
+           width="9.0377283"
+           height="0.9722805"
+           x="-1049.4006"
+           y="13.90514"
+           transform="matrix(0,-1,1,0,0,0)" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="layer1-5"
+       inkscape:label="Layer 1"
+       transform="translate(-21.31326,-1.1882634)">
+      <g
+         transform="translate(11.779883,-12.842199)"
+         id="g8159"
+         style="display:inline">
+        <g
+           id="g4329">
+          <circle
+             r="4.5685406"
+             cy="1056.4629"
+             cx="15.627731"
+             style="display:inline;fill:url(#linearGradient8163-2);fill-opacity:1;stroke:#c93e35;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path10796-2-6-0" />
+          <g
+             id="g5025"
+             transform="matrix(1.1880342,0,0,1.1860465,13.541945,-197.60925)">
+            <g
+               id="g4095"
+               transform="matrix(1.0905016,0,0,1.0905016,-0.09572826,-95.681285)">
+              <path
+                 style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+                 d="m 6.6906013,4.3803222 c -0.3088198,0.010926 -1.1015625,0.65625 -1.1015625,0.65625 0,0 0.2885111,0.2731764 0.78125,0.6796875 C 6.8630277,6.1227708 6.8614643,5.9867052 6.96875,6.46875 7.068619,6.9173537 7.1051563,7.3329889 7.15625,7.75 L 4.7756189,10.43934 5.6651334,11.338333 7.4375,9.375 c 0.2792655,0.4616799 0.2209937,0.1631611 0.4368495,0.5299491 0.2533102,0.3539999 0.6860498,0.7341889 1.40625,1.0937499 1.2858975,0.641907 1.1050685,0.565316 1.1050685,0.565316 l 0.965609,-0.791649 c 0,0 -0.202967,-0.247189 -1.5081775,-0.8986669 -0.5753531,-0.287132 -0.7234498,-0.506893 -0.875,-0.71875 C 8.4482832,8.5641085 8.6327445,8.816423 8.5,8.1875 L 11.143575,5.2390072 10.195027,4.4836456 8.28125,6.5 C 8.263796,6.4030643 8.2724218,6.3194727 8.25,6.21875 8.0333974,5.2456067 7.7831729,5.211497 7.1827888,4.7162597 6.9105297,4.502143 6.9447337,4.5647088 6.6906013,4.3803222 Z"
+                 transform="matrix(0.77187105,0,0,0.77316463,-4.647127,1051.0563)"
+                 id="path5021"
+                 inkscape:connector-curvature="0"
+                 sodipodi:nodetypes="ccscccccccccccccccccc" />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/obj16/hierarchical.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/obj16/hierarchical.svg
@@ -1,0 +1,356 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="hierarchicalLayout.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4980"
+       inkscape:collect="always">
+      <stop
+         id="stop4982"
+         offset="0"
+         style="stop-color:#6c8ab7;stop-opacity:1" />
+      <stop
+         id="stop4984"
+         offset="1"
+         style="stop-color:#607ead;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4974"
+       inkscape:collect="always">
+      <stop
+         id="stop4976"
+         offset="0"
+         style="stop-color:#7694be;stop-opacity:1" />
+      <stop
+         id="stop4978"
+         offset="1"
+         style="stop-color:#607ead;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4962">
+      <stop
+         style="stop-color:#6c8ab7;stop-opacity:1"
+         offset="0"
+         id="stop4964" />
+      <stop
+         style="stop-color:#607ead;stop-opacity:1"
+         offset="1"
+         id="stop4966" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4871">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4873" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4875" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871"
+       id="linearGradient4877"
+       x1="3"
+       y1="1045.8622"
+       x2="4"
+       y2="1045.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871"
+       id="linearGradient4879"
+       x1="4.4999781"
+       y1="1044.3466"
+       x2="4.4999781"
+       y2="1045.3433"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871-7"
+       id="linearGradient4877-1"
+       x1="3"
+       y1="1045.8622"
+       x2="4"
+       y2="1045.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4871-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4873-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4875-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871-7"
+       id="linearGradient4879-9"
+       x1="4.4999781"
+       y1="1044.3466"
+       x2="4.4999781"
+       y2="1045.3433"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871-7-1"
+       id="linearGradient4877-1-7"
+       x1="3"
+       y1="1045.8622"
+       x2="4"
+       y2="1045.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4871-7-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4873-4-1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4875-0-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871-7-1"
+       id="linearGradient4879-9-2"
+       x1="4.4999781"
+       y1="1044.3466"
+       x2="4.4999781"
+       y2="1045.3433"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4962"
+       id="linearGradient4968"
+       x1="11"
+       y1="1048.8622"
+       x2="14"
+       y2="1048.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4980"
+       id="linearGradient4970"
+       x1="11"
+       y1="1044.8622"
+       x2="14"
+       y2="1044.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4974"
+       id="linearGradient4972"
+       x1="7"
+       y1="1040.8622"
+       x2="14"
+       y2="1040.8622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.999999"
+     inkscape:cx="12.066523"
+     inkscape:cy="7.9808044"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1458"
+     inkscape:window-height="814"
+     inkscape:window-x="150"
+     inkscape:window-y="150"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4970);fill-opacity:1;stroke:none;display:inline"
+       d="m 11,1044.3622 3,0 0,1 -3,0 z"
+       id="rect4035-1-1-5-2-2-6-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4968);fill-opacity:1;stroke:none;display:inline"
+       d="m 11,1048.3622 3,0 0,1 -3,0 z"
+       id="rect4035-1-1-5-2-2-6-5-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <g
+       id="g5029"
+       transform="matrix(0.59562329,0,0,0.59562329,1.42626,418.31576)">
+      <path
+         id="rect4035-17"
+         d="m 2.6421734,1042.6833 0,5.0367 5.0367406,0 0,-5.0367 z m 1.6789131,1.6789 1.6789135,0 0,1.6789 -1.6789135,0 z"
+         style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc" />
+      <g
+         id="g4094"
+         transform="matrix(0.55964608,0,0,0.55963589,2.6421482,459.89962)">
+        <rect
+           style="fill:#91a5c7;fill-opacity:1;stroke:none;display:inline"
+           id="rect4035-1-1"
+           width="3"
+           height="3.0000174"
+           x="3"
+           y="1044.3622" />
+        <path
+           style="opacity:0.5;fill:url(#linearGradient4877);fill-opacity:1;stroke:none;display:inline"
+           d="m 3,1044.3622 1,1 0,2 -1,0 z"
+           id="rect4035-1-7-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="opacity:0.5;fill:url(#linearGradient4879);fill-opacity:1;stroke:none;display:inline"
+           d="m 3,1044.3622 1,1 2,0 0,-1 z"
+           id="rect4035-1-7-4-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="g5029-8"
+       transform="matrix(0.59562329,0,0,0.59562329,5.42626,422.31576)">
+      <path
+         id="rect4035-17-2"
+         d="m 2.6421734,1042.6833 0,5.0367 5.0367406,0 0,-5.0367 z m 1.6789131,1.6789 1.6789135,0 0,1.6789 -1.6789135,0 z"
+         style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc" />
+      <g
+         id="g4094-4"
+         transform="matrix(0.55964608,0,0,0.55963589,2.6421482,459.89962)">
+        <rect
+           style="fill:#91a5c7;fill-opacity:1;stroke:none;display:inline"
+           id="rect4035-1-1-5"
+           width="3"
+           height="3.0000174"
+           x="3"
+           y="1044.3622" />
+        <path
+           style="opacity:0.5;fill:url(#linearGradient4877-1);fill-opacity:1;stroke:none;display:inline"
+           d="m 3,1044.3622 1,1 0,2 -1,0 z"
+           id="rect4035-1-7-1-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="opacity:0.5;fill:url(#linearGradient4879-9);fill-opacity:1;stroke:none;display:inline"
+           d="m 3,1044.3622 1,1 2,0 0,-1 z"
+           id="rect4035-1-7-4-5-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="g5029-8-7"
+       transform="matrix(0.59562329,0,0,0.59562329,5.42626,426.31576)">
+      <path
+         id="rect4035-17-2-6"
+         d="m 2.6421734,1042.6833 0,5.0367 5.0367406,0 0,-5.0367 z m 1.6789135,1.6912 1.6789135,0 0,1.6913 -1.6789135,0 z"
+         style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc" />
+      <g
+         id="g4094-4-1"
+         transform="matrix(0.55964608,0,0,0.55963589,2.6421482,459.89962)">
+        <rect
+           style="fill:#91a5c7;fill-opacity:1;stroke:none;display:inline"
+           id="rect4035-1-1-5-4"
+           width="3"
+           height="3.0000174"
+           x="3"
+           y="1044.3622" />
+        <path
+           style="opacity:0.5;fill:url(#linearGradient4877-1-7);fill-opacity:1;stroke:none;display:inline"
+           d="m 3,1044.3622 1,1 0,2 -1,0 z"
+           id="rect4035-1-7-1-5-2"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="opacity:0.5;fill:url(#linearGradient4879-9-2);fill-opacity:1;stroke:none;display:inline"
+           d="m 3,1044.3622 1,1 2,0 0,-1 z"
+           id="rect4035-1-7-4-5-1-3"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+      </g>
+    </g>
+    <path
+       style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline"
+       d="m 3.9999997,1042.3622 1.0000146,0 0,7 -1.0000146,0 z"
+       id="rect4035-1-1-5-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline"
+       d="m 3.9999997,1044.3622 3.0000003,0 0,1 -3.0000003,0 z"
+       id="rect4035-1-1-5-2-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline"
+       d="m 3.9999997,1048.3622 3.0000003,0 0,0.9999 -3.0000003,0 z"
+       id="rect4035-1-1-5-2-2-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4972);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1040.3622 7,0 0,1 -7,0 z"
+       id="rect4035-1-1-5-2-2-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/obj16/info_st_obj.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/obj16/info_st_obj.svg
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="info_tsk.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4890">
+      <stop
+         style="stop-color:#2857bd;stop-opacity:1;"
+         offset="0"
+         id="stop4892" />
+      <stop
+         style="stop-color:#3d5384;stop-opacity:1;"
+         offset="1"
+         id="stop4894" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4996-4">
+      <stop
+         style="stop-color:#02468c;stop-opacity:1"
+         offset="0"
+         id="stop4998-5" />
+      <stop
+         style="stop-color:#0e62a4;stop-opacity:1"
+         offset="1"
+         id="stop5000-5" />
+    </linearGradient>
+    <linearGradient
+       y2="1051.7347"
+       x2="13.903196"
+       y1="1062.1353"
+       x1="13.903196"
+       gradientTransform="translate(38.469436,55.035191)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5028"
+       xlink:href="#linearGradient4996-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4890"
+       id="linearGradient4896"
+       x1="14.256123"
+       y1="1056.5471"
+       x2="18.340696"
+       y2="1056.5471"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4890"
+       id="linearGradient4898"
+       gradientUnits="userSpaceOnUse"
+       x1="16.307018"
+       y1="1055.0179"
+       x2="16.307018"
+       y2="1060.6793" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254832"
+     inkscape:cx="4.4561136"
+     inkscape:cy="6.7876447"
+     inkscape:document-units="px"
+     inkscape:current-layer="text4140-1-8"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="1387"
+     inkscape:window-y="399"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4099" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <g
+         style="font-size:15.07241725999999993px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient4896);fill-opacity:1;stroke:none;display:inline;font-family:Kozuka Mincho Pr6N H;-inkscape-font-specification:Kozuka Mincho Pr6N H Heavy"
+         id="text4140-1-8"
+         transform="matrix(1.0865583,0,0,1,-1.7201207,-0.04419418)">
+        <path
+           d="m 16.245657,1050.9177 c -0.355456,0.01 -0.65062,0.1291 -0.885494,0.3674 -0.234876,0.2383 -0.35671,0.5529 -0.365501,0.9439 0.0088,0.3981 0.130625,0.7172 0.365502,0.9571 0.234873,0.2399 0.530037,0.363 0.885493,0.3692 0.362672,-0.01 0.662232,-0.1293 0.898681,-0.3692 0.236442,-0.2399 0.358903,-0.559 0.367386,-0.9571 -0.0057,-0.3778 -0.122466,-0.6886 -0.35043,-0.9326 -0.227971,-0.244 -0.533183,-0.3702 -0.915637,-0.3787 z m 0.94955,3.3912 c -1.039986,0.4346 -2.019679,0.6808 -2.939084,0.7386 l 0,0.6029 c 0.435838,-0.02 0.70965,0.039 0.821436,0.1771 0.111784,0.1381 0.159513,0.476 0.143187,1.0136 l 0,3.4515 c 0.01539,0.5401 -0.03423,0.888 -0.148838,1.0438 -0.114613,0.1557 -0.386541,0.2248 -0.815785,0.2072 l 0,0.633 4.084573,0 0,-0.633 c -0.386544,0.017 -0.634608,-0.051 -0.744192,-0.2054 -0.109591,-0.1541 -0.157947,-0.4977 -0.145069,-1.0305 l 0,-5.8631 z"
+           style="fill:url(#linearGradient4898);fill-opacity:1"
+           id="path5058"
+           inkscape:connector-curvature="0" />
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-size:15.07241726px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient5028);fill-opacity:1;stroke:none;display:inline;font-family:Kozuka Mincho Pr6N H;-inkscape-font-specification:Kozuka Mincho Pr6N H Heavy"
+         x="50.288464"
+         y="1117.2119"
+         id="text4140-1-8-1"
+         sodipodi:linespacing="125%"><tspan
+           sodipodi:role="line"
+           id="tspan4142-7-8-7"
+           x="50.288464"
+           y="1117.2119"
+           style="fill:url(#linearGradient5028);fill-opacity:1">Kozuka Mincho Pr6N H</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/obj16/ok_st_obj.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/obj16/ok_st_obj.svg
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="ok_st_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4883">
+      <stop
+         style="stop-color:#ebf9ff;stop-opacity:1"
+         offset="0"
+         id="stop4885" />
+      <stop
+         style="stop-color:#fcffff;stop-opacity:1"
+         offset="1"
+         id="stop4887" />
+    </linearGradient>
+    <linearGradient
+       y2="1047.3622"
+       x2="-15"
+       y1="1047.3622"
+       x1="-12"
+       gradientTransform="translate(18,-3.000037)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5062"
+       xlink:href="#linearGradient4910-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4910-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop4912-8" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1"
+         offset="1"
+         id="stop4914-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1045.3622"
+       x2="-11"
+       y1="1042.3622"
+       x1="-11"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4975-2"
+       xlink:href="#linearGradient4994-4"
+       inkscape:collect="always"
+       gradientTransform="translate(18,-3.000037)" />
+    <linearGradient
+       id="linearGradient4994-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4996-5"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:1" />
+      <stop
+         id="stop4998-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4883"
+       id="linearGradient4889"
+       x1="28"
+       y1="1039.3622"
+       x2="28"
+       y2="1049.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="-5.6436176"
+     inkscape:cy="1.709725"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="379"
+     inkscape:window-y="250"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#8b96ab;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 2,1038.3622 0.03125,12 11.96875,0 -0.03125,-12 z m 1,1 9.96875,0 0.03125,10 -9.96875,0 z"
+       id="rect3997-9-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90" />
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:url(#linearGradient4889);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="m 3,1039.3622 9.96875,0 0.03125,10 -9.96875,0 z"
+       id="rect3997-9-1-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient5062);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 0,8 -2,0 0,-10 z"
+       id="rect4853-82-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4975-2);fill-opacity:1;stroke:none;display:inline"
+       d="m 5,1041.3622 8,0 0,-2 -10,0 z"
+       id="rect4853-82-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:none;stroke:#334e6f;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 3.9687503,1044.3309 2.5000001,2.5313 5.5000006,-5.4375"
+       id="path4065"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/icons/obj16/warning_st_obj.svg
+++ b/bundles/org.eclipse.ui.views.log/icons/obj16/warning_st_obj.svg
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="warning.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5091">
+      <stop
+         style="stop-color:#c6852e;stop-opacity:1"
+         offset="0"
+         id="stop5093" />
+      <stop
+         style="stop-color:#e1a555;stop-opacity:1"
+         offset="1"
+         id="stop5095" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5081">
+      <stop
+         style="stop-color:#ffe69e;stop-opacity:1"
+         offset="0"
+         id="stop5083" />
+      <stop
+         id="stop5089"
+         offset="0.37960318"
+         style="stop-color:#ffc85a;stop-opacity:1" />
+      <stop
+         style="stop-color:#fffcd3;stop-opacity:1"
+         offset="1"
+         id="stop5085" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5091"
+       id="linearGradient4200"
+       gradientUnits="userSpaceOnUse"
+       x1="6.3885393"
+       y1="7.2369323"
+       x2="6.3885393"
+       y2="0.39338252"
+       gradientTransform="matrix(1.0698871,0,0,1.0698871,15.590192,1043.527)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5081"
+       id="radialGradient4963"
+       cx="19.36529"
+       cy="1051.1095"
+       fx="19.36529"
+       fy="1051.1095"
+       r="3.7734281"
+       gradientTransform="matrix(2.8249601,0,0,1.7930635,-35.371372,-833.43041)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="-11.10583"
+     inkscape:cy="-21.989605"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8472"
+     showgrid="true"
+     inkscape:window-width="1280"
+     inkscape:window-height="1024"
+     inkscape:window-x="150"
+     inkscape:window-y="138"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4202"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8472"
+       transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)">
+      <g
+         id="g4193"
+         transform="matrix(1.4166388,0,0,1.4166388,-3.2411359,-441.5072)"
+         style="opacity:1">
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0"
+           id="path4292"
+           d="m 18.599249,1044.4966 -2.362015,4.3798 c -0.648383,1.0968 -0.206291,2.7732 1.003019,2.7928 l 1.5596,0 1.069887,0 1.5596,0 c 1.209311,-0.019 1.651402,-1.6961 1.003019,-2.7928 l -2.362015,-4.3798 c -0.314859,-0.5957 -1.196998,-0.4999 -1.471095,0 z"
+           style="fill:url(#radialGradient4963);fill-opacity:1;stroke:url(#linearGradient4200);stroke-width:0.75522922999999986;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           transform="matrix(1.125929,0,0,1.125929,15.411638,1043.5862)"
+           d="m 4.109375,5.484375 c 0,0.345178 -0.279822,0.625 -0.625,0.625 -0.345178,0 -0.625,-0.279822 -0.625,-0.625 0,-0.345178 0.279822,-0.625 0.625,-0.625 0.345178,0 0.625,0.279822 0.625,0.625 z"
+           sodipodi:ry="0.625"
+           sodipodi:rx="0.625"
+           sodipodi:cy="5.484375"
+           sodipodi:cx="3.484375"
+           id="path4253"
+           style="fill:#7b5113;fill-opacity:1;stroke:none"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="sccsccs"
+           inkscape:connector-curvature="0"
+           id="path4253-7"
+           d="m 19.350026,1045.7152 c -0.378471,0 -0.700512,0.3368 -0.700512,0.774 l 0.09137,1.4889 c 0,0.3887 0.272722,0.7037 0.609141,0.7037 0.336419,0 0.609139,-0.315 0.609139,-0.7037 l 0.06091,-1.4889 c 0,-0.4372 -0.291583,-0.774 -0.670056,-0.774 z"
+           style="fill:#7b5113;fill-opacity:1;stroke:none;display:inline" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views.log/plugin.xml
+++ b/bundles/org.eclipse.ui.views.log/plugin.xml
@@ -18,7 +18,7 @@
          point="org.eclipse.ui.views">
       <view
             name="%views.errorLog.name"
-            icon="$nl$/icons/eview16/error_log.png"
+            icon="$nl$/icons/eview16/error_log.svg"
             category="org.eclipse.ui"
             class="org.eclipse.ui.internal.views.log.LogView"
             id="org.eclipse.pde.runtime.LogView">

--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/Activator.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/Activator.java
@@ -65,22 +65,14 @@ public class Activator extends AbstractUIPlugin {
 		registerImageDescriptor(registry, SharedImages.DESC_HIERARCHICAL_LAYOUT_OBJ);
 
 		registerImageDescriptor(registry, SharedImages.DESC_CLEAR);
-		registerImageDescriptor(registry, SharedImages.DESC_CLEAR_DISABLED);
 		registerImageDescriptor(registry, SharedImages.DESC_OPEN_CONSOLE);
 		registerImageDescriptor(registry, SharedImages.DESC_REMOVE_LOG);
-		registerImageDescriptor(registry, SharedImages.DESC_REMOVE_LOG_DISABLED);
 		registerImageDescriptor(registry, SharedImages.DESC_EXPORT);
-		registerImageDescriptor(registry, SharedImages.DESC_EXPORT_DISABLED);
 		registerImageDescriptor(registry, SharedImages.DESC_FILTER);
-		registerImageDescriptor(registry, SharedImages.DESC_FILTER_DISABLED);
 		registerImageDescriptor(registry, SharedImages.DESC_IMPORT);
-		registerImageDescriptor(registry, SharedImages.DESC_IMPORT_DISABLED);
 		registerImageDescriptor(registry, SharedImages.DESC_OPEN_LOG);
-		registerImageDescriptor(registry, SharedImages.DESC_OPEN_LOG_DISABLED);
 		registerImageDescriptor(registry, SharedImages.DESC_PROPERTIES);
-		registerImageDescriptor(registry, SharedImages.DESC_PROPERTIES_DISABLED);
 		registerImageDescriptor(registry, SharedImages.DESC_READ_LOG);
-		registerImageDescriptor(registry, SharedImages.DESC_READ_LOG_DISABLED);
 	}
 
 	private void registerImageDescriptor(ImageRegistry registry, String id) {

--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogView.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogView.java
@@ -393,7 +393,6 @@ public class LogView extends ViewPart implements LogListener {
 			}
 		};
 		action.setImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_CLEAR));
-		action.setDisabledImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_CLEAR_DISABLED));
 		action.setToolTipText(Messages.LogView_clear_tooltip);
 		action.setText(Messages.LogView_clear);
 		return action;
@@ -419,7 +418,6 @@ public class LogView extends ViewPart implements LogListener {
 		};
 		action.setToolTipText(Messages.LogView_delete_tooltip);
 		action.setImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_REMOVE_LOG));
-		action.setDisabledImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_REMOVE_LOG_DISABLED));
 		action.setEnabled(fInputFile.exists() && fInputFile.equals(Platform.getLogFileLocation().toFile()));
 		return action;
 	}
@@ -433,7 +431,6 @@ public class LogView extends ViewPart implements LogListener {
 		};
 		action.setToolTipText(Messages.LogView_export_tooltip);
 		action.setImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_EXPORT));
-		action.setDisabledImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_EXPORT_DISABLED));
 		action.setEnabled(fInputFile.exists());
 		return action;
 	}
@@ -447,7 +444,6 @@ public class LogView extends ViewPart implements LogListener {
 		};
 		action.setToolTipText(Messages.LogView_exportEntry_tooltip);
 		action.setImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_EXPORT));
-		action.setDisabledImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_EXPORT_DISABLED));
 		action.setEnabled(!fFilteredTree.getViewer().getSelection().isEmpty());
 		return action;
 	}
@@ -461,7 +457,6 @@ public class LogView extends ViewPart implements LogListener {
 		};
 		action.setToolTipText(Messages.LogView_filter);
 		action.setImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_FILTER));
-		action.setDisabledImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_FILTER_DISABLED));
 		return action;
 	}
 
@@ -469,7 +464,6 @@ public class LogView extends ViewPart implements LogListener {
 		Action action = new ImportLogAction(this, Messages.LogView_import, fMemento);
 		action.setToolTipText(Messages.LogView_import_tooltip);
 		action.setImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_IMPORT));
-		action.setDisabledImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_IMPORT_DISABLED));
 		return action;
 	}
 
@@ -497,7 +491,6 @@ public class LogView extends ViewPart implements LogListener {
 		}
 		action.setText(Messages.LogView_view_currentLog);
 		action.setImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_OPEN_LOG));
-		action.setDisabledImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_OPEN_LOG_DISABLED));
 		action.setEnabled(fInputFile.exists());
 		action.setToolTipText(Messages.LogView_view_currentLog_tooltip);
 		return action;
@@ -506,7 +499,6 @@ public class LogView extends ViewPart implements LogListener {
 	private Action createPropertiesAction() {
 		Action action = new EventDetailsDialogAction(this, fTree, fFilteredTree.getViewer(), fMemento);
 		action.setImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_PROPERTIES));
-		action.setDisabledImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_PROPERTIES_DISABLED));
 		action.setToolTipText(Messages.LogView_properties_tooltip);
 		action.setEnabled(false);
 		return action;
@@ -522,7 +514,6 @@ public class LogView extends ViewPart implements LogListener {
 		};
 		action.setToolTipText(Messages.LogView_readLog_restore_tooltip);
 		action.setImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_READ_LOG));
-		action.setDisabledImageDescriptor(SharedImages.getImageDescriptor(SharedImages.DESC_READ_LOG_DISABLED));
 		return action;
 	}
 

--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/SharedImages.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/SharedImages.java
@@ -26,7 +26,6 @@ public final class SharedImages {
 
 	private static final String PATH_OBJ = ICONS_PATH + "obj16/"; //$NON-NLS-1$
 	private static final String PATH_LCL = ICONS_PATH + "elcl16/"; //$NON-NLS-1$
-	private static final String PATH_LCL_DISABLED = ICONS_PATH + "dlcl16/"; //$NON-NLS-1$
 	private static final String PATH_EVENTS = ICONS_PATH + "eview16/"; //$NON-NLS-1$
 
 	/* Event Details */
@@ -34,22 +33,14 @@ public final class SharedImages {
 	public static final String DESC_NEXT_EVENT = PATH_EVENTS + "event_next.svg"; //$NON-NLS-1$
 
 	public static final String DESC_CLEAR = PATH_LCL + "clear.svg"; //$NON-NLS-1$
-	public static final String DESC_CLEAR_DISABLED = PATH_LCL_DISABLED + "clear.png"; //$NON-NLS-1$
 	public static final String DESC_OPEN_CONSOLE = PATH_LCL + "open_console_obj.svg"; //$NON-NLS-1$
 	public static final String DESC_REMOVE_LOG = PATH_LCL + "remove.svg"; //$NON-NLS-1$
-	public static final String DESC_REMOVE_LOG_DISABLED = PATH_LCL_DISABLED + "remove.png"; //$NON-NLS-1$
 	public static final String DESC_EXPORT = PATH_LCL + "export_log.svg"; //$NON-NLS-1$
-	public static final String DESC_EXPORT_DISABLED = PATH_LCL_DISABLED + "export_log.png"; //$NON-NLS-1$
 	public static final String DESC_FILTER = PATH_LCL + "filter_ps.svg"; //$NON-NLS-1$
-	public static final String DESC_FILTER_DISABLED = PATH_LCL_DISABLED + "filter_ps.png"; //$NON-NLS-1$
 	public static final String DESC_IMPORT = PATH_LCL + "import_log.svg"; //$NON-NLS-1$
-	public static final String DESC_IMPORT_DISABLED = PATH_LCL_DISABLED + "import_log.png"; //$NON-NLS-1$
 	public static final String DESC_OPEN_LOG = PATH_LCL + "open_log.svg"; //$NON-NLS-1$
-	public static final String DESC_OPEN_LOG_DISABLED = PATH_LCL_DISABLED + "open_log.png"; //$NON-NLS-1$
 	public static final String DESC_PROPERTIES = PATH_LCL + "properties.svg"; //$NON-NLS-1$
-	public static final String DESC_PROPERTIES_DISABLED = PATH_LCL_DISABLED + "properties.png"; //$NON-NLS-1$
 	public static final String DESC_READ_LOG = PATH_LCL + "restore_log.svg"; //$NON-NLS-1$
-	public static final String DESC_READ_LOG_DISABLED = PATH_LCL_DISABLED + "restore_log.png"; //$NON-NLS-1$
 
 	public static final String DESC_ERROR_ST_OBJ = PATH_OBJ + "error_st_obj.svg"; //$NON-NLS-1$
 	public static final String DESC_ERROR_STACK_OBJ = PATH_OBJ + "error_stack.svg"; //$NON-NLS-1$

--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/SharedImages.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/SharedImages.java
@@ -30,33 +30,33 @@ public final class SharedImages {
 	private static final String PATH_EVENTS = ICONS_PATH + "eview16/"; //$NON-NLS-1$
 
 	/* Event Details */
-	public static final String DESC_PREV_EVENT = PATH_EVENTS + "event_prev.png"; //$NON-NLS-1$
-	public static final String DESC_NEXT_EVENT = PATH_EVENTS + "event_next.png"; //$NON-NLS-1$
+	public static final String DESC_PREV_EVENT = PATH_EVENTS + "event_prev.svg"; //$NON-NLS-1$
+	public static final String DESC_NEXT_EVENT = PATH_EVENTS + "event_next.svg"; //$NON-NLS-1$
 
-	public static final String DESC_CLEAR = PATH_LCL + "clear.png"; //$NON-NLS-1$
+	public static final String DESC_CLEAR = PATH_LCL + "clear.svg"; //$NON-NLS-1$
 	public static final String DESC_CLEAR_DISABLED = PATH_LCL_DISABLED + "clear.png"; //$NON-NLS-1$
-	public static final String DESC_OPEN_CONSOLE = PATH_LCL + "open_console_obj.png"; //$NON-NLS-1$
-	public static final String DESC_REMOVE_LOG = PATH_LCL + "remove.png"; //$NON-NLS-1$
+	public static final String DESC_OPEN_CONSOLE = PATH_LCL + "open_console_obj.svg"; //$NON-NLS-1$
+	public static final String DESC_REMOVE_LOG = PATH_LCL + "remove.svg"; //$NON-NLS-1$
 	public static final String DESC_REMOVE_LOG_DISABLED = PATH_LCL_DISABLED + "remove.png"; //$NON-NLS-1$
-	public static final String DESC_EXPORT = PATH_LCL + "export_log.png"; //$NON-NLS-1$
+	public static final String DESC_EXPORT = PATH_LCL + "export_log.svg"; //$NON-NLS-1$
 	public static final String DESC_EXPORT_DISABLED = PATH_LCL_DISABLED + "export_log.png"; //$NON-NLS-1$
-	public static final String DESC_FILTER = PATH_LCL + "filter_ps.png"; //$NON-NLS-1$
+	public static final String DESC_FILTER = PATH_LCL + "filter_ps.svg"; //$NON-NLS-1$
 	public static final String DESC_FILTER_DISABLED = PATH_LCL_DISABLED + "filter_ps.png"; //$NON-NLS-1$
-	public static final String DESC_IMPORT = PATH_LCL + "import_log.png"; //$NON-NLS-1$
+	public static final String DESC_IMPORT = PATH_LCL + "import_log.svg"; //$NON-NLS-1$
 	public static final String DESC_IMPORT_DISABLED = PATH_LCL_DISABLED + "import_log.png"; //$NON-NLS-1$
-	public static final String DESC_OPEN_LOG = PATH_LCL + "open_log.png"; //$NON-NLS-1$
+	public static final String DESC_OPEN_LOG = PATH_LCL + "open_log.svg"; //$NON-NLS-1$
 	public static final String DESC_OPEN_LOG_DISABLED = PATH_LCL_DISABLED + "open_log.png"; //$NON-NLS-1$
-	public static final String DESC_PROPERTIES = PATH_LCL + "properties.png"; //$NON-NLS-1$
+	public static final String DESC_PROPERTIES = PATH_LCL + "properties.svg"; //$NON-NLS-1$
 	public static final String DESC_PROPERTIES_DISABLED = PATH_LCL_DISABLED + "properties.png"; //$NON-NLS-1$
-	public static final String DESC_READ_LOG = PATH_LCL + "restore_log.png"; //$NON-NLS-1$
+	public static final String DESC_READ_LOG = PATH_LCL + "restore_log.svg"; //$NON-NLS-1$
 	public static final String DESC_READ_LOG_DISABLED = PATH_LCL_DISABLED + "restore_log.png"; //$NON-NLS-1$
 
-	public static final String DESC_ERROR_ST_OBJ = PATH_OBJ + "error_st_obj.png"; //$NON-NLS-1$
-	public static final String DESC_ERROR_STACK_OBJ = PATH_OBJ + "error_stack.png"; //$NON-NLS-1$
-	public static final String DESC_INFO_ST_OBJ = PATH_OBJ + "info_st_obj.png"; //$NON-NLS-1$
-	public static final String DESC_OK_ST_OBJ = PATH_OBJ + "ok_st_obj.png"; //$NON-NLS-1$
-	public static final String DESC_WARNING_ST_OBJ = PATH_OBJ + "warning_st_obj.png"; //$NON-NLS-1$
-	public static final String DESC_HIERARCHICAL_LAYOUT_OBJ = PATH_OBJ + "hierarchical.png"; //$NON-NLS-1$
+	public static final String DESC_ERROR_ST_OBJ = PATH_OBJ + "error_st_obj.svg"; //$NON-NLS-1$
+	public static final String DESC_ERROR_STACK_OBJ = PATH_OBJ + "error_stack.svg"; //$NON-NLS-1$
+	public static final String DESC_INFO_ST_OBJ = PATH_OBJ + "info_st_obj.svg"; //$NON-NLS-1$
+	public static final String DESC_OK_ST_OBJ = PATH_OBJ + "ok_st_obj.svg"; //$NON-NLS-1$
+	public static final String DESC_WARNING_ST_OBJ = PATH_OBJ + "warning_st_obj.svg"; //$NON-NLS-1$
+	public static final String DESC_HIERARCHICAL_LAYOUT_OBJ = PATH_OBJ + "hierarchical.svg"; //$NON-NLS-1$
 
 	public static ImageDescriptor getImageDescriptor(String key) {
 		return Activator.getDefault().getImageRegistry().getDescriptor(key);

--- a/bundles/org.eclipse.ui.views/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.views; singleton:=true
-Bundle-Version: 3.12.500.qualifier
+Bundle-Version: 3.12.600.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.internal.views.contentoutline;x-internal:=true,

--- a/bundles/org.eclipse.ui.views/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.jface;bundle-version="[3.31.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.ui.views
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.ui.views/icons/full/elcl16/defaults_ps.svg
+++ b/bundles/org.eclipse.ui.views/icons/full/elcl16/defaults_ps.svg
@@ -1,0 +1,349 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="defaults_ps.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient7491">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7493" />
+      <stop
+         style="stop-color:#a0b0cc;stop-opacity:1;"
+         offset="1"
+         id="stop7495" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7254">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7254"
+       id="linearGradient7260"
+       x1="15.000595"
+       y1="2"
+       x2="-8"
+       y2="1.375"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.03125,1035.7997)" />
+    <linearGradient
+       id="linearGradient7254-6">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-5" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.93721973,0,0,1,1036.3976,-3.562483)"
+       y2="2"
+       x2="-3.2642515"
+       y1="2"
+       x1="15.000595"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7277"
+       xlink:href="#linearGradient7254-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7254-62">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-0" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-16.03125,1037.7997)"
+       y2="2"
+       x2="-17.187742"
+       y1="2"
+       x1="15.000595"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7328"
+       xlink:href="#linearGradient7254-62"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7254-6-4">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-5-4" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-7-4" />
+    </linearGradient>
+    <linearGradient
+       y2="2"
+       x2="-28.335314"
+       y1="2"
+       x1="15.000595"
+       gradientTransform="matrix(0.93721973,0,0,1,1036.3977,-16.624983)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7362"
+       xlink:href="#linearGradient7254-6-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7491"
+       id="linearGradient7497"
+       x1="1.9445436"
+       y1="3.0732041"
+       x2="14.142135"
+       y2="3.0732041"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99637681,0,0,1,0.01998962,1035.7997)" />
+    <linearGradient
+       y2="1044.5624"
+       x2="24.928591"
+       y1="1038.3658"
+       x1="24.928591"
+       gradientTransform="matrix(0.72799609,0,0,0.72799609,20.936643,283.97383)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7065"
+       xlink:href="#linearGradient7592-1"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1040.7345"
+       x2="22.519354"
+       y1="1042.0283"
+       x1="22.519354"
+       gradientTransform="matrix(0.72799609,0,0,0.72799609,20.936643,283.97383)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7063"
+       xlink:href="#linearGradient7584-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       id="filter9306"
+       x="-0.19433198"
+       width="1.388664"
+       y="-0.19433198"
+       height="1.388664">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.48582996"
+         id="feGaussianBlur9308" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="14.57852"
+     inkscape:cy="3.4756659"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-7"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="1384"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4046" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7499"
+       width="14.142136"
+       height="13.169864"
+       x="0.9410218"
+       y="1037.3481" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415-2"
+       width="1.125"
+       height="12.09375"
+       x="-1042.5184"
+       y="2"
+       transform="matrix(0,-1,1,0,0,0)" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415"
+       width="1.125"
+       height="12.9375"
+       x="5.09375"
+       y="1037.4247" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient7362);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244-4-4"
+       width="13.0625"
+       height="1"
+       x="1037.3934"
+       y="-15.0625"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient7277);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244-4"
+       width="13.0625"
+       height="1"
+       x="1037.3934"
+       y="-2"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <rect
+       style="opacity:0.67558528;color:#000000;fill:url(#linearGradient7497);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7489"
+       width="12.153398"
+       height="1.1932427"
+       x="1.9574878"
+       y="1038.2762" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient7260);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244"
+       width="13.9375"
+       height="1"
+       x="1.03125"
+       y="1037.3622" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient7328);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244-7"
+       width="13.9375"
+       height="1"
+       x="-14.96875"
+       y="1039.3622"
+       transform="scale(-1,1)" />
+    <rect
+       style="color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244-4-4-8"
+       width="14.0625"
+       height="1"
+       x="1.03125"
+       y="1049.4247" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415-2-4"
+       width="1.125"
+       height="12.125"
+       x="-1044.7281"
+       y="1.9375"
+       transform="matrix(0,-1,1,0,0,0)" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415-2-4-3"
+       width="1.125"
+       height="12.09375"
+       x="-1047.0262"
+       y="1.96875"
+       transform="matrix(0,-1,1,0,0,0)" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415-2-4-3-9"
+       width="1.125"
+       height="12.0625"
+       x="-1049.3685"
+       y="2"
+       transform="matrix(0,-1,1,0,0,0)" />
+    <g
+       style="display:inline"
+       id="layer1-7"
+       inkscape:label="Layer 1"
+       transform="matrix(1.3170263,0,0,1.4044518,0.30812959,-429.67462)">
+      <path
+         sodipodi:type="arc"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;filter:url(#filter9306)"
+         id="path9304"
+         sodipodi:cx="5"
+         sodipodi:cy="11"
+         sodipodi:rx="3"
+         sodipodi:ry="3"
+         d="M 8,11 C 8,12.656854 6.6568542,14 5,14 3.3431458,14 2,12.656854 2,11 2,9.3431458 3.3431458,8 5,8 6.6568542,8 8,9.3431458 8,11 z"
+         transform="matrix(1.3129325,0,0,1.231204,1.933171,1038.8954)" />
+      <g
+         transform="translate(-17,10.0625)"
+         id="g7056">
+        <path
+           sodipodi:nodetypes="ccssscscsssszcc"
+           inkscape:connector-curvature="0"
+           id="path7582"
+           d="m 38.106543,1040.5982 0,-1.1582 c 0,0 -0.257386,-0.6113 -0.997369,-0.032 -0.739983,0.5791 -1.608659,1.5121 -1.737352,1.7695 -0.128693,0.2574 -0.675637,0.7078 0.06435,1.4156 0.739983,0.7079 1.544313,1.4478 1.544313,1.4478 0,0 1.126061,1.0617 1.126061,0.064 0,-0.9975 0,-1.3192 0,-1.3192 0.994736,-0.046 1.2338,0.2586 1.484999,0.5012 0.25151,0.2428 0.591496,1.4331 0.887246,1.5242 0.295748,0.091 0.454997,-1.5926 0.454997,-1.911 0,-0.3185 -0.127248,-0.9056 -0.523248,-1.4333 -0.213698,-0.2846 -0.732779,-0.6955 -1.114743,-0.8006 -0.381965,-0.1053 -1.189251,-0.068 -1.189251,-0.068 z"
+           style="fill:url(#linearGradient7063);fill-opacity:1;stroke:url(#linearGradient7065);stroke-width:0.58239686;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           transform="translate(-12.551145,0)" />
+        <path
+           transform="translate(-12.551145,0)"
+           sodipodi:nodetypes="ccssscc"
+           inkscape:connector-curvature="0"
+           id="path7602-2-3"
+           d="m 37.645884,1040.3848 0,-0.4343 c 0,0 0.08043,-0.2735 -0.160866,-0.177 -0.241299,0.097 -0.70781,0.4826 -0.75607,0.5631 -0.04826,0.08 -0.546944,0.4343 -0.434338,0.5952 0.112606,0.1609 1.061715,0.048 1.061715,0.048 z"
+           style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none;display:inline" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views/icons/full/elcl16/filter_ps.svg
+++ b/bundles/org.eclipse.ui.views/icons/full/elcl16/filter_ps.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="filter_ps.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1047">
+      <stop
+         style="stop-color:#96a0b9;stop-opacity:1"
+         offset="0"
+         id="stop1043" />
+      <stop
+         style="stop-color:#77849d;stop-opacity:1"
+         offset="1"
+         id="stop1045" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1039">
+      <stop
+         style="stop-color:#fbffff;stop-opacity:1"
+         offset="0"
+         id="stop1035" />
+      <stop
+         style="stop-color:#b9e7ff;stop-opacity:1"
+         offset="1"
+         id="stop1037" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4989">
+      <stop
+         id="stop4991"
+         offset="0"
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;" />
+      <stop
+         style="stop-color:#c3e9ff;stop-opacity:1;"
+         offset="0.5"
+         id="stop4995" />
+      <stop
+         id="stop4993"
+         offset="1"
+         style="stop-color:#c3e9ff;stop-opacity:0.49019608;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1039"
+       id="linearGradient1041"
+       x1="2.1048543"
+       y1="1039.3379"
+       x2="12.850951"
+       y2="1039.2937"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1047"
+       id="linearGradient1049"
+       x1="1"
+       y1="1044.8622"
+       x2="14"
+       y2="1044.8622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#444248"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627416"
+     inkscape:cx="2.7020062"
+     inkscape:cy="8.7735937"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       id="path859"
+       style="fill:url(#linearGradient1041);stroke:url(#linearGradient1049);stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1"
+       d="m 7.504725,1043.8623 h 1.99055 M 1.5,1037.8622 h 12 v 2 l -4,4 v 6 l -3.0000002,2 H 5.5 v -8 l -4,-4 z" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views/icons/full/elcl16/new.svg
+++ b/bundles/org.eclipse.ui.views/icons/full/elcl16/new.svg
@@ -1,0 +1,546 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="new.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       y2="1050.0707"
+       x2="8.0137892"
+       y1="1042.3622"
+       x1="8.0137892"
+       gradientTransform="translate(0,2.000063)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4046-24"
+       xlink:href="#linearGradient4810-5"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4810-5">
+      <stop
+         style="stop-color:#be9a4b;stop-opacity:1"
+         offset="0"
+         id="stop4812-0" />
+      <stop
+         style="stop-color:#877e60;stop-opacity:1"
+         offset="1"
+         id="stop4814-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4910-4-0"
+       id="linearGradient5062-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(18,-4.000037)"
+       x1="-13"
+       y1="1047.3622"
+       x2="-15"
+       y2="1047.3622" />
+    <linearGradient
+       id="linearGradient4910-4-0"
+       inkscape:collect="always">
+      <stop
+         id="stop4912-8-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0" />
+      <stop
+         id="stop4914-8-1"
+         offset="1"
+         style="stop-color:#c5dff4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(18,1.999963)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994-4-5"
+       id="linearGradient4975-2-1"
+       gradientUnits="userSpaceOnUse"
+       x1="-11"
+       y1="1042.3622"
+       x2="-11"
+       y2="1044.3622" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4994-4-5">
+      <stop
+         style="stop-color:#c5dff4;stop-opacity:1"
+         offset="0"
+         id="stop4996-5-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4998-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4082-3"
+       id="linearGradient4063-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.0001)"
+       x1="8.0137892"
+       y1="1039.876"
+       x2="8.0137892"
+       y2="1041.8765" />
+    <linearGradient
+       id="linearGradient4082-3">
+      <stop
+         id="stop4084-8"
+         offset="0"
+         style="stop-color:#4476aa;stop-opacity:1" />
+      <stop
+         style="stop-color:#5a9ccc;stop-opacity:1"
+         offset="0.5"
+         id="stop4864-7" />
+      <stop
+         id="stop4086-2"
+         offset="1"
+         style="stop-color:#4476aa;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       inkscape:collect="always"
+       id="filter7823-3-4-6"
+       x="-0.18344673"
+       width="1.4377165"
+       y="-0.16038014"
+       height="1.382678">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.6188839"
+         id="feGaussianBlur7825-1-3-8" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7272-66-4-5-5-5"
+       id="linearGradient7736-9-7-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       x1="-15.945988"
+       y1="1037.4661"
+       x2="-15.945988"
+       y2="1023.2569" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7540-2-3-8"
+       id="linearGradient7738-6-2-3"
+       gradientUnits="userSpaceOnUse"
+       x1="-22.453552"
+       y1="1030.3411"
+       x2="-10.159802"
+       y2="1030.3411" />
+    <linearGradient
+       id="linearGradient7540-2-3-8">
+      <stop
+         id="stop7542-8-7-5"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9" />
+      <stop
+         id="stop7548-98-9-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7540-6-33-6-3"
+       id="linearGradient7740-1-3-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       x1="-22.453552"
+       y1="1030.3411"
+       x2="-10.159802"
+       y2="1030.3411" />
+    <linearGradient
+       id="linearGradient7540-6-33-6-3">
+      <stop
+         id="stop7542-4-4-3-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-5-3-8-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-2-9-1-2" />
+      <stop
+         id="stop7548-9-2-0-9"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask8465">
+      <path
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 2.005808,1041.3724 0,0.5 0,11.0313 0,0.5 0.5,0 12.9375,0 0.5,0 0,-0.5 0,-11.0313 0,-0.5 -0.5,0 -12.9375,0 -0.5,0 z"
+         id="path8467"
+         inkscape:connector-curvature="0" />
+    </mask>
+    <linearGradient
+       y2="6.9843998"
+       x2="10.007812"
+       y1="5"
+       x1="10"
+       gradientTransform="translate(-15.015625,1046.6356)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6323"
+       xlink:href="#linearGradient5068-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5068-6"
+       inkscape:collect="always">
+      <stop
+         id="stop5070-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop5072-3"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1045.3466"
+       x2="12"
+       y1="1043.3622"
+       x1="12"
+       id="linearGradient5084-3"
+       xlink:href="#linearGradient5068-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.3466"
+       x2="15.007812"
+       y1="1043.3622"
+       x1="13"
+       id="linearGradient5086-8"
+       xlink:href="#linearGradient5068-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.3622"
+       x2="10.007812"
+       y1="1042.3622"
+       x1="12"
+       id="linearGradient5082-1"
+       xlink:href="#linearGradient5068-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1041.3466"
+       x2="8.0078125"
+       y1="1041.3622"
+       x1="10"
+       id="linearGradient5078-8"
+       xlink:href="#linearGradient5068-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1038.3466"
+       x2="10.007812"
+       y1="1040.3622"
+       x1="10"
+       id="linearGradient5076-5"
+       xlink:href="#linearGradient5068-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1038.3466"
+       x2="10.007812"
+       y1="1038.3622"
+       x1="12"
+       id="linearGradient5074-2"
+       xlink:href="#linearGradient5068-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-15.015625,10.2734)"
+       gradientUnits="userSpaceOnUse"
+       y2="1043.3466"
+       x2="14"
+       y1="1041.3622"
+       x1="14"
+       id="linearGradient5088-1"
+       xlink:href="#linearGradient5068-6"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9-5-7"
+       id="radialGradient3091-1-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574" />
+    <linearGradient
+       id="linearGradient4528-9-5-7">
+      <stop
+         style="stop-color:#e0c576;stop-opacity:1;"
+         offset="0"
+         id="stop4530-0-5-0" />
+      <stop
+         style="stop-color:#9e7916;stop-opacity:1"
+         offset="1"
+         id="stop4532-7-9-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6-6-4"
+       id="linearGradient3093-5-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4">
+      <stop
+         id="stop6283-0-2-2-1-2-0"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7-6-9"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4528-9-5-7-6"
+       id="radialGradient3091-1-9-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8508179,-8.813921e-6,8.4531434e-6,1.7750589,644.24981,572.63612)"
+       cx="-757.20496"
+       cy="-738.83777"
+       fx="-757.20496"
+       fy="-738.83777"
+       r="3.4803574" />
+    <linearGradient
+       id="linearGradient4528-9-5-7-6">
+      <stop
+         style="stop-color:#e0c576;stop-opacity:1;"
+         offset="0"
+         id="stop4530-0-5-0-1" />
+      <stop
+         style="stop-color:#9e7916;stop-opacity:1"
+         offset="1"
+         id="stop4532-7-9-3-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6281-8-0-1-6-6-4-1"
+       id="linearGradient3093-5-2-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.3199889,0,0,2.3199889,10.199693,1043.1852)"
+       x1="0.9375"
+       y1="4.8437853"
+       x2="0.9375"
+       y2="7.549418" />
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-1">
+      <stop
+         id="stop6283-0-2-2-1-2-0-1"
+         offset="0"
+         style="stop-color:#f7f9fb;stop-opacity:1" />
+      <stop
+         id="stop6285-5-0-9-7-6-9-1"
+         offset="1"
+         style="stop-color:#ffd680;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="7.546875"
+     inkscape:cy="7.109375"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1-8"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid6272"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4908"
+       transform="translate(17.6875,0)">
+      <g
+         transform="translate(-18.599558,-2.010247)"
+         style="display:inline"
+         id="layer1-8"
+         inkscape:label="Layer 1">
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect3997-9"
+           d="m 2.500702,1041.8621 12.927706,0 0,11.033 -12.927706,0 z"
+           style="fill:#f4fcff;fill-opacity:1;stroke:url(#linearGradient4046-24);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect4853-82-7"
+           d="m 4,1045.3622 0,7.0312 -1,0 0,-8.0312 z"
+           style="fill:url(#linearGradient5062-4);fill-opacity:1;stroke:none;display:inline" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect4853-82-0"
+           d="m 4,1045.3622 10.928078,0 0,-1 -11.928078,0 z"
+           style="fill:url(#linearGradient4975-2-1);fill-opacity:1;stroke:none;display:inline" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect3997-9-9"
+           d="m 2.500702,1041.8621 12.883511,0 0,2.0053 -12.883511,0 z"
+           style="fill:#58b6e8;fill-opacity:1;stroke:url(#linearGradient4063-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+        <path
+           transform="matrix(0.40514455,0,0,0.40514455,48.017265,625.5691)"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path7813-2"
+           d="m -106.1326,1054.8481 c 15.377466,0 21.179561,-6.8234 21.179561,-24.2257"
+           style="fill:none;stroke:#ffe99f;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;filter:url(#filter7823-3-4-6)" />
+        <path
+           style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+           d="m 12.422762,1049.0556 c 0,0 0.0781,0.3441 0.303204,0.59 0.225108,0.2459 0.56093,0.3542 0.56093,0.3542 0,0 -0.342043,0.076 -0.590001,0.3031 -0.247957,0.227 -0.354126,0.5609 -0.354126,0.5609 0,0 -0.06889,-0.3339 -0.303205,-0.5899 -0.234327,-0.2561 -0.56093,-0.3542 -0.56093,-0.3542 0,0 0.350102,-0.084 0.590001,-0.3032 0.239908,-0.2196 0.354127,-0.5609 0.354127,-0.5609 z"
+           id="rect6501-4-4-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="czczczczc" />
+        <path
+           style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+           d="m 11.386908,1050.8215 c 0,0 -0.131805,0.319 -0.0908,0.6427 0.04104,0.3235 0.248295,0.5996 0.248295,0.5996 0,0 -0.316348,-0.1322 -0.642582,-0.09 -0.326253,0.041 -0.599601,0.2483 -0.599601,0.2483 0,0 0.133515,-0.3057 0.09081,-0.6425 -0.0427,-0.3369 -0.248297,-0.5996 -0.248297,-0.5996 0,0 0.326935,0.1309 0.642582,0.09 0.315656,-0.04 0.599602,-0.2483 0.599602,-0.2483 z"
+           id="rect6501-4-4-1-7"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="czczczczc" />
+        <path
+           style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+           d="m 9.1131569,1051.6911 c 0,0 -0.036027,0.2767 0.063869,0.5208 0.099907,0.2441 0.3196179,0.4161 0.3196179,0.4161 0,0 -0.2747289,-0.037 -0.5207938,0.064 -0.2460648,0.1008 -0.4161058,0.3196 -0.4161058,0.3196 0,0 0.040122,-0.2667 -0.063869,-0.5208 -0.1039866,-0.254 -0.319618,-0.4161 -0.319618,-0.4161 0,0 0.2827212,0.034 0.5207942,-0.064 0.2380696,-0.097 0.4161055,-0.3196 0.4161055,-0.3196 z"
+           id="rect6501-4-4-7-0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="czczczczc" />
+        <path
+           inkscape:transform-center-y="0.625"
+           inkscape:transform-center-x="1.4375"
+           style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+           d="m 7.0086025,1052.4527 c 0,0 -0.029292,0.1772 0.029576,0.3364 0.058888,0.1592 0.1964181,0.2748 0.1964181,0.2748 0,0 -0.175934,-0.03 -0.3364077,0.029 -0.1605102,0.059 -0.2747164,0.1964 -0.2747164,0.1964 0,0 0.031682,-0.1707 -0.029616,-0.3364 -0.06129,-0.1657 -0.1964182,-0.2747 -0.1964182,-0.2747 0,0 0.1811118,0.028 0.3364118,-0.03 0.1552919,-0.057 0.2747123,-0.1963 0.2747123,-0.1963 z"
+           id="rect6501-4-4-93-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="czczczczc" />
+        <path
+           style="opacity:0.85;fill:#fee9ac;fill-opacity:0.96862745;stroke:none;display:inline"
+           d="m 13.773399,1046.3172 c 0,0 -0.05151,0.4757 0.12879,0.8904 0.180313,0.4147 0.563366,0.7016 0.563366,0.7016 0,0 -0.472359,-0.053 -0.890472,0.1287 -0.418126,0.1818 -0.701541,0.5634 -0.701541,0.5634 0,0 0.05889,-0.4588 -0.12879,-0.8905 -0.187682,-0.4317 -0.563367,-0.7015 -0.563367,-0.7015 0,0 0.485949,0.047 0.890474,-0.1288 0.404539,-0.1759 0.70154,-0.5633 0.70154,-0.5633 z"
+           id="rect6501-4-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="czczczczc" />
+        <g
+           style="display:inline"
+           id="g6432"
+           transform="translate(15.897498,-9.2747423)">
+          <g
+             style="display:inline"
+             id="g4514"
+             transform="translate(-5.536708,-5.6240351)">
+            <g
+               id="g4522"
+               transform="translate(-9.9375,0)">
+              <rect
+                 style="fill:url(#radialGradient3091-1-9-3);fill-opacity:1;stroke:#a27d18;stroke-width:1.03243756;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+                 id="rect3910"
+                 width="4.5825453"
+                 height="4.454073"
+                 x="-758.82336"
+                 y="-740.41083"
+                 transform="matrix(-0.70710678,-0.70710678,0.70710678,-0.70710678,0,0)" />
+              <path
+                 sodipodi:nodetypes="ccccccccccccc"
+                 inkscape:connector-curvature="0"
+                 id="path5581-5-5"
+                 d="m 12.471186,1054.309 1.001133,0 0,1.946 1.986639,0 0,1.0167 -1.986639,0 0,2.043 -1.001133,0 0,-2.043 -1.98664,0 0,-1.0167 1.98664,0 z"
+                 style="fill:url(#linearGradient3093-5-2-3);fill-opacity:1;stroke:none;display:inline" />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views/icons/full/elcl16/tree_mode.svg
+++ b/bundles/org.eclipse.ui.views/icons/full/elcl16/tree_mode.svg
@@ -1,0 +1,356 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="tree_mode.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4980"
+       inkscape:collect="always">
+      <stop
+         id="stop4982"
+         offset="0"
+         style="stop-color:#6c8ab7;stop-opacity:1" />
+      <stop
+         id="stop4984"
+         offset="1"
+         style="stop-color:#607ead;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4974"
+       inkscape:collect="always">
+      <stop
+         id="stop4976"
+         offset="0"
+         style="stop-color:#7694be;stop-opacity:1" />
+      <stop
+         id="stop4978"
+         offset="1"
+         style="stop-color:#607ead;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4962">
+      <stop
+         style="stop-color:#6c8ab7;stop-opacity:1"
+         offset="0"
+         id="stop4964" />
+      <stop
+         style="stop-color:#607ead;stop-opacity:1"
+         offset="1"
+         id="stop4966" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4871">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4873" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4875" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871"
+       id="linearGradient4877"
+       x1="3"
+       y1="1045.8622"
+       x2="4"
+       y2="1045.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871"
+       id="linearGradient4879"
+       x1="4.4999781"
+       y1="1044.3466"
+       x2="4.4999781"
+       y2="1045.3433"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871-7"
+       id="linearGradient4877-1"
+       x1="3"
+       y1="1045.8622"
+       x2="4"
+       y2="1045.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4871-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4873-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4875-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871-7"
+       id="linearGradient4879-9"
+       x1="4.4999781"
+       y1="1044.3466"
+       x2="4.4999781"
+       y2="1045.3433"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871-7-1"
+       id="linearGradient4877-1-7"
+       x1="3"
+       y1="1045.8622"
+       x2="4"
+       y2="1045.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4871-7-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4873-4-1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4875-0-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4871-7-1"
+       id="linearGradient4879-9-2"
+       x1="4.4999781"
+       y1="1044.3466"
+       x2="4.4999781"
+       y2="1045.3433"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4962"
+       id="linearGradient4968"
+       x1="11"
+       y1="1048.8622"
+       x2="14"
+       y2="1048.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4980"
+       id="linearGradient4970"
+       x1="11"
+       y1="1044.8622"
+       x2="14"
+       y2="1044.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4974"
+       id="linearGradient4972"
+       x1="7"
+       y1="1040.8622"
+       x2="14"
+       y2="1040.8622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.999999"
+     inkscape:cx="12.066523"
+     inkscape:cy="7.9808044"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1458"
+     inkscape:window-height="814"
+     inkscape:window-x="865"
+     inkscape:window-y="645"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4970);fill-opacity:1;stroke:none;display:inline"
+       d="m 11,1044.3622 3,0 0,1 -3,0 z"
+       id="rect4035-1-1-5-2-2-6-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4968);fill-opacity:1;stroke:none;display:inline"
+       d="m 11,1048.3622 3,0 0,1 -3,0 z"
+       id="rect4035-1-1-5-2-2-6-5-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <g
+       id="g5029"
+       transform="matrix(0.59562329,0,0,0.59562329,1.42626,418.31576)">
+      <path
+         id="rect4035-17"
+         d="m 2.6421734,1042.6833 0,5.0367 5.0367406,0 0,-5.0367 z m 1.6789131,1.6789 1.6789135,0 0,1.6789 -1.6789135,0 z"
+         style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc" />
+      <g
+         id="g4094"
+         transform="matrix(0.55964608,0,0,0.55963589,2.6421482,459.89962)">
+        <rect
+           style="fill:#91a5c7;fill-opacity:1;stroke:none;display:inline"
+           id="rect4035-1-1"
+           width="3"
+           height="3.0000174"
+           x="3"
+           y="1044.3622" />
+        <path
+           style="opacity:0.5;fill:url(#linearGradient4877);fill-opacity:1;stroke:none;display:inline"
+           d="m 3,1044.3622 1,1 0,2 -1,0 z"
+           id="rect4035-1-7-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="opacity:0.5;fill:url(#linearGradient4879);fill-opacity:1;stroke:none;display:inline"
+           d="m 3,1044.3622 1,1 2,0 0,-1 z"
+           id="rect4035-1-7-4-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="g5029-8"
+       transform="matrix(0.59562329,0,0,0.59562329,5.42626,422.31576)">
+      <path
+         id="rect4035-17-2"
+         d="m 2.6421734,1042.6833 0,5.0367 5.0367406,0 0,-5.0367 z m 1.6789131,1.6789 1.6789135,0 0,1.6789 -1.6789135,0 z"
+         style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc" />
+      <g
+         id="g4094-4"
+         transform="matrix(0.55964608,0,0,0.55963589,2.6421482,459.89962)">
+        <rect
+           style="fill:#91a5c7;fill-opacity:1;stroke:none;display:inline"
+           id="rect4035-1-1-5"
+           width="3"
+           height="3.0000174"
+           x="3"
+           y="1044.3622" />
+        <path
+           style="opacity:0.5;fill:url(#linearGradient4877-1);fill-opacity:1;stroke:none;display:inline"
+           d="m 3,1044.3622 1,1 0,2 -1,0 z"
+           id="rect4035-1-7-1-5"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="opacity:0.5;fill:url(#linearGradient4879-9);fill-opacity:1;stroke:none;display:inline"
+           d="m 3,1044.3622 1,1 2,0 0,-1 z"
+           id="rect4035-1-7-4-5-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="g5029-8-7"
+       transform="matrix(0.59562329,0,0,0.59562329,5.42626,426.31576)">
+      <path
+         id="rect4035-17-2-6"
+         d="m 2.6421734,1042.6833 0,5.0367 5.0367406,0 0,-5.0367 z m 1.6789135,1.6912 1.6789135,0 0,1.6913 -1.6789135,0 z"
+         style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc" />
+      <g
+         id="g4094-4-1"
+         transform="matrix(0.55964608,0,0,0.55963589,2.6421482,459.89962)">
+        <rect
+           style="fill:#91a5c7;fill-opacity:1;stroke:none;display:inline"
+           id="rect4035-1-1-5-4"
+           width="3"
+           height="3.0000174"
+           x="3"
+           y="1044.3622" />
+        <path
+           style="opacity:0.5;fill:url(#linearGradient4877-1-7);fill-opacity:1;stroke:none;display:inline"
+           d="m 3,1044.3622 1,1 0,2 -1,0 z"
+           id="rect4035-1-7-1-5-2"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           style="opacity:0.5;fill:url(#linearGradient4879-9-2);fill-opacity:1;stroke:none;display:inline"
+           d="m 3,1044.3622 1,1 2,0 0,-1 z"
+           id="rect4035-1-7-4-5-1-3"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+      </g>
+    </g>
+    <path
+       style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline"
+       d="m 3.9999997,1042.3622 1.0000146,0 0,7 -1.0000146,0 z"
+       id="rect4035-1-1-5-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline"
+       d="m 3.9999997,1044.3622 3.0000003,0 0,1 -3.0000003,0 z"
+       id="rect4035-1-1-5-2-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#5c7aaa;fill-opacity:1;stroke:none;display:inline"
+       d="m 3.9999997,1048.3622 3.0000003,0 0,0.9999 -3.0000003,0 z"
+       id="rect4035-1-1-5-2-2-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4972);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1040.3622 7,0 0,1 -7,0 z"
+       id="rect4035-1-1-5-2-2-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views/icons/full/eview16/outline_co.svg
+++ b/bundles/org.eclipse.ui.views/icons/full/eview16/outline_co.svg
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="outline_co.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient8292">
+      <stop
+         style="stop-color:#71baff;stop-opacity:1;"
+         offset="0"
+         id="stop8294" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop8296" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082-3">
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1"
+         offset="0"
+         id="stop4084-8" />
+      <stop
+         id="stop4864-7"
+         offset="0.5"
+         style="stop-color:#5a9ccc;stop-opacity:1" />
+      <stop
+         style="stop-color:#4476aa;stop-opacity:1"
+         offset="1"
+         id="stop4086-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8292"
+       id="linearGradient8298"
+       x1="4.0797281"
+       y1="1043.2366"
+       x2="4.0797281"
+       y2="1039.6121"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.04419417,-1.11019)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8292-9"
+       id="linearGradient8298-2"
+       x1="4.0797281"
+       y1="1043.2366"
+       x2="4.0797281"
+       y2="1039.6121"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.04419417,-19.04769)" />
+    <linearGradient
+       id="linearGradient8292-9">
+      <stop
+         style="stop-color:#71baff;stop-opacity:1;"
+         offset="0"
+         id="stop8294-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop8296-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1039.6121"
+       x2="4.0797281"
+       y1="1043.2366"
+       x1="4.0797281"
+       gradientTransform="translate(0.04419417,7.817057)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8315"
+       xlink:href="#linearGradient8292-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8292-2"
+       id="linearGradient8298-1"
+       x1="4.0797281"
+       y1="1043.2366"
+       x2="4.0797281"
+       y2="1039.6121"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.04419417,-1.11019)" />
+    <linearGradient
+       id="linearGradient8292-2">
+      <stop
+         style="stop-color:#71baff;stop-opacity:1;"
+         offset="0"
+         id="stop8294-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop8296-3" />
+    </linearGradient>
+    <linearGradient
+       y2="1039.6121"
+       x2="4.0797281"
+       y1="1043.2366"
+       x1="4.0797281"
+       gradientTransform="translate(7.1066942,4.9523344)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient8415"
+       xlink:href="#linearGradient8292-2"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="9.4001157"
+     inkscape:cy="14.292562"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1208"
+     inkscape:window-height="913"
+     inkscape:window-x="980"
+     inkscape:window-y="435"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid8762" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="fill:url(#linearGradient8298);fill-opacity:1;stroke:#1469ab;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect7504"
+       width="5.1707182"
+       height="4.9939418"
+       x="1.4584078"
+       y="1037.817" />
+    <rect
+       style="fill:url(#linearGradient8315);fill-opacity:1;stroke:#1469ab;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="rect7504-6"
+       width="5.1707182"
+       height="4.9939418"
+       x="1.4584078"
+       y="1046.7443" />
+    <g
+       id="g8372"
+       transform="translate(0,18)">
+      <path
+         sodipodi:nodetypes="cc"
+         transform="translate(0,1036.3622)"
+         inkscape:connector-curvature="0"
+         id="path8334"
+         d="m 8.0801553,-13.4375 5.9388007,0"
+         style="fill:none;stroke:#10558a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path8334-0"
+         d="m 8.0801553,1021.9082 5.9388007,0"
+         style="fill:none;stroke:#c1e8ff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+    </g>
+    <g
+       style="display:inline"
+       id="g8372-7"
+       transform="translate(0,26.993514)">
+      <path
+         sodipodi:nodetypes="cc"
+         transform="translate(0,1036.3622)"
+         inkscape:connector-curvature="0"
+         id="path8334-4"
+         d="m 8.0801553,-13.4375 5.9388007,0"
+         style="fill:none;stroke:#10558a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path8334-0-2"
+         d="m 8.0801553,1021.9082 5.9388007,0"
+         style="fill:none;stroke:#c1e8ff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+    </g>
+    <rect
+       style="fill:url(#linearGradient8415);fill-opacity:1;stroke:#1469ab;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="rect7504-2"
+       width="2.0457182"
+       height="1.9313965"
+       x="8.5209074"
+       y="1043.8795" />
+    <g
+       style="display:inline"
+       id="g8372-7-1"
+       transform="translate(4.0625,21.868514)">
+      <path
+         sodipodi:nodetypes="cc"
+         transform="translate(0,1036.3622)"
+         inkscape:connector-curvature="0"
+         id="path8334-4-7"
+         d="m 8.0801553,-13.4375 1.9482227,0"
+         style="fill:none;stroke:#10558a;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views/icons/full/eview16/prop_ps.svg
+++ b/bundles/org.eclipse.ui.views/icons/full/eview16/prop_ps.svg
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="prop_ps.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient7491">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7493" />
+      <stop
+         style="stop-color:#a0b0cc;stop-opacity:1;"
+         offset="1"
+         id="stop7495" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7254">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7254"
+       id="linearGradient7260"
+       x1="15.000595"
+       y1="2"
+       x2="-8"
+       y2="1.375"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.03125,1035.7997)" />
+    <linearGradient
+       id="linearGradient7254-6">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-5" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.93721973,0,0,1,1036.3976,-3.562483)"
+       y2="2"
+       x2="-3.2642515"
+       y1="2"
+       x1="15.000595"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7277"
+       xlink:href="#linearGradient7254-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7254-62">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-0" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-16.03125,1037.7997)"
+       y2="2"
+       x2="-17.187742"
+       y1="2"
+       x1="15.000595"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7328"
+       xlink:href="#linearGradient7254-62"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7254-6-4">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-5-4" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-7-4" />
+    </linearGradient>
+    <linearGradient
+       y2="2"
+       x2="-28.335314"
+       y1="2"
+       x1="15.000595"
+       gradientTransform="matrix(0.93721973,0,0,1,1036.3977,-16.624983)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7362"
+       xlink:href="#linearGradient7254-6-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7491"
+       id="linearGradient7497"
+       x1="1.9445436"
+       y1="3.0732041"
+       x2="14.142135"
+       y2="3.0732041"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99637681,0,0,1,0.01998962,1035.7997)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="10.07852"
+     inkscape:cy="11.787627"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="1384"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4046" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <rect
+       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7499"
+       width="14.142136"
+       height="13.169864"
+       x="0.9410218"
+       y="1037.3481" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415-2"
+       width="1.125"
+       height="12.09375"
+       x="-1042.5184"
+       y="1.96875"
+       transform="matrix(0,-1,1,0,0,0)" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415"
+       width="1.125"
+       height="12.9375"
+       x="5.09375"
+       y="1037.4247" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient7362);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244-4-4"
+       width="13.0625"
+       height="1"
+       x="1037.3934"
+       y="-15.0625"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient7277);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244-4"
+       width="13.0625"
+       height="1"
+       x="1037.3934"
+       y="-2"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <rect
+       style="opacity:0.67558528;color:#000000;fill:url(#linearGradient7497);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7489"
+       width="12.153398"
+       height="1.1932427"
+       x="1.9574878"
+       y="1038.2762" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient7260);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244"
+       width="13.9375"
+       height="1"
+       x="1.03125"
+       y="1037.3622" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient7328);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244-7"
+       width="13.9375"
+       height="1"
+       x="-14.96875"
+       y="1039.3622"
+       transform="scale(-1,1)" />
+    <rect
+       style="color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7244-4-4-8"
+       width="14.0625"
+       height="1"
+       x="1.03125"
+       y="1049.4247" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415-2-4"
+       width="1.125"
+       height="12.125"
+       x="-1044.7281"
+       y="1.9375"
+       transform="matrix(0,-1,1,0,0,0)" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415-2-4-3"
+       width="1.125"
+       height="12.09375"
+       x="-1047.0262"
+       y="1.96875"
+       transform="matrix(0,-1,1,0,0,0)" />
+    <rect
+       style="opacity:0.3487395;color:#000000;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect7415-2-4-3-9"
+       width="1.125"
+       height="12.0625"
+       x="-1049.3685"
+       y="2"
+       transform="matrix(0,-1,1,0,0,0)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.ui.views/plugin.xml
+++ b/bundles/org.eclipse.ui.views/plugin.xml
@@ -8,13 +8,13 @@
             allowMultiple="true"
             category="org.eclipse.ui"
             class="org.eclipse.ui.views.properties.PropertySheet"
-            icon="$nl$/icons/full/eview16/prop_ps.png"
+            icon="$nl$/icons/full/eview16/prop_ps.svg"
             id="org.eclipse.ui.views.PropertySheet"
             name="%Views.PropertySheet">
       </view>
       <view
             name="%Views.ContentOutline"
-            icon="$nl$/icons/full/eview16/outline_co.png"
+            icon="$nl$/icons/full/eview16/outline_co.svg"
             category="org.eclipse.ui"
             class="org.eclipse.ui.views.contentoutline.ContentOutline"
             id="org.eclipse.ui.views.ContentOutline">
@@ -26,7 +26,7 @@
 				locationURI="popup:org.eclipse.ui.menus.showInMenu">
 			<command
 				commandId="org.eclipse.ui.views.properties.NewPropertySheetCommand"
-				icon="platform:/plugin/org.eclipse.ui.views/icons/full/eview16/prop_ps.png"
+				icon="platform:/plugin/org.eclipse.ui.views/icons/full/eview16/prop_ps.svg"
 				label="%Views.PropertySheet"
 				style="push">
 	        </command>
@@ -35,7 +35,7 @@
         locationURI="menu:org.eclipse.ui.views.PropertySheet">
      <command
            commandId="org.eclipse.ui.views.properties.NewPropertySheetCommand"
-           icon="icons/full/elcl16/new.png"
+           icon="icons/full/elcl16/new.svg"
            label="%Views.NewPropertySheet"
            style="push">
      </command>

--- a/bundles/org.eclipse.ui.views/src/org/eclipse/ui/views/properties/PropertySheetPage.java
+++ b/bundles/org.eclipse.ui.views/src/org/eclipse/ui/views/properties/PropertySheetPage.java
@@ -413,7 +413,7 @@ public class PropertySheetPage extends Page implements IPropertySheetPage, IAdap
 		defaultsAction = new DefaultsAction(viewer, "defaults"); //$NON-NLS-1$
 		defaultsAction.setText(PropertiesMessages.Defaults_text);
 		defaultsAction.setToolTipText(PropertiesMessages.Defaults_toolTip);
-		defaultsAction.setImageDescriptor(createImageDescriptor("elcl16/defaults_ps.png")); //$NON-NLS-1$
+		defaultsAction.setImageDescriptor(createImageDescriptor("elcl16/defaults_ps.svg")); //$NON-NLS-1$
 		defaultsAction.setDisabledImageDescriptor(createImageDescriptor("dlcl16/defaults_ps.png")); //$NON-NLS-1$
 		defaultsAction.setEnabled(false);
 
@@ -421,14 +421,14 @@ public class PropertySheetPage extends Page implements IPropertySheetPage, IAdap
 		filterAction = new FilterAction(viewer, "filter"); //$NON-NLS-1$
 		filterAction.setText(PropertiesMessages.Filter_text);
 		filterAction.setToolTipText(PropertiesMessages.Filter_toolTip);
-		filterAction.setImageDescriptor(createImageDescriptor("elcl16/filter_ps.png")); //$NON-NLS-1$
+		filterAction.setImageDescriptor(createImageDescriptor("elcl16/filter_ps.svg")); //$NON-NLS-1$
 		filterAction.setChecked(false);
 
 		// Show Categories
 		categoriesAction = new CategoriesAction(viewer, "categories"); //$NON-NLS-1$
 		categoriesAction.setText(PropertiesMessages.Categories_text);
 		categoriesAction.setToolTipText(PropertiesMessages.Categories_toolTip);
-		categoriesAction.setImageDescriptor(createImageDescriptor("elcl16/tree_mode.png")); //$NON-NLS-1$
+		categoriesAction.setImageDescriptor(createImageDescriptor("elcl16/tree_mode.svg")); //$NON-NLS-1$
 		categoriesAction.setChecked(true);
 
 		// Columns...

--- a/bundles/org.eclipse.ui.views/src/org/eclipse/ui/views/properties/PropertySheetPage.java
+++ b/bundles/org.eclipse.ui.views/src/org/eclipse/ui/views/properties/PropertySheetPage.java
@@ -414,7 +414,6 @@ public class PropertySheetPage extends Page implements IPropertySheetPage, IAdap
 		defaultsAction.setText(PropertiesMessages.Defaults_text);
 		defaultsAction.setToolTipText(PropertiesMessages.Defaults_toolTip);
 		defaultsAction.setImageDescriptor(createImageDescriptor("elcl16/defaults_ps.svg")); //$NON-NLS-1$
-		defaultsAction.setDisabledImageDescriptor(createImageDescriptor("dlcl16/defaults_ps.png")); //$NON-NLS-1$
 		defaultsAction.setEnabled(false);
 
 		// Show Advanced Properties


### PR DESCRIPTION
This PR adds SVGs for all icons in the bundles `org.eclipse.ui.views` and `org.eclipse.ui.views.log`.

See also this [PR](https://github.com/eclipse-platform/eclipse.platform/pull/1797) for more information.