### PR TITLE
Remove definition of unused 'plugin-path' ANT property in browser.tests

### DIFF
--- a/tests/org.eclipse.ui.tests.browser/test.xml
+++ b/tests/org.eclipse.ui.tests.browser/test.xml
@@ -28,7 +28,6 @@
       <property name="data-dir" value="${wst-folder}"/>
       <property name="plugin-name" value="${plugin-name}"/>
       <property name="classname" value="org.eclipse.wst.internet.webbrowser.tests.AllTests" />
-   	<property name="plugin-path" value="${eclipse-home}/plugins/${plugin-name}"/>
     </ant>
   </target>
 


### PR DESCRIPTION
The `PLUGIN_PATH` system-property is not used in these tests.