### PR TITLE
Add FreeBSD platforms' build.

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/html/BrowserInformationControl.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/html/BrowserInformationControl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.jface.internal.text.html;
 
@@ -294,7 +295,7 @@ public class BrowserInformationControl extends AbstractInformationControl implem
 
 		String scrollbarStyle= "overflow:scroll;"; //$NON-NLS-1$
 		// workaround for bug 546870, don't use a horizontal scrollbar on Linux as its broken for GTK3 and WebKit
-		if (Util.isLinux()) {
+		if (Util.isLinux() || Util.isFreeBSD()) {
 			scrollbarStyle= "word-wrap:break-word;"; //$NON-NLS-1$
 		}
 		// The default "overflow:auto" would not result in a predictable width for the client area

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/util/Util.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/util/Util.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 
 package org.eclipse.jface.util;
@@ -560,6 +561,16 @@ public final class Util {
 	public static boolean isMac() {
 		final String ws = SWT.getPlatform();
 		return WS_CARBON.equals(ws) || WS_COCOA.equals(ws);
+	}
+
+	/**
+	 * Common WS query helper method.
+	 * @return <code>true</code> for FreeBSD platform
+	 * @since 3.5
+	 */
+	public static boolean isFreeBSD() {
+		final String ws = SWT.getPlatform();
+		return WS_GTK.equals(ws);
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.browser/plugin.xml
+++ b/bundles/org.eclipse.ui.browser/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <!--
-    Copyright (c) 2005, 2015 IBM Corporation and others.
+    Copyright (c) 2005, 2025 IBM Corporation and others.
 
     This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,7 @@
          IBM Corporation - initial API and implementation
           Martin Oberhuber (Wind River) - [292882] Default Browser on Solaris
           Martin Oberhuber (Wind River) - [293175] Default external web browser not found when running 32-bit Eclipse on 64-bit Ubuntu 9.04
+         Tue Ton - support for FreeBSD
  -->
 
 <plugin>
@@ -94,7 +95,7 @@
       <browser
          id="org.eclipse.ui.browser.firefox"
          name="%browserFirefox"
-         os="linux,aix,hpux,solaris"
+         os="freebsd,linux,aix,hpux,solaris"
          executable="firefox"
          factoryclass="org.eclipse.ui.internal.browser.browsers.MozillaFactory">
          <location>
@@ -104,28 +105,28 @@
       <browser
          id="org.eclipse.ui.browser.chrome"
          name="%browserChrome"
-         os="linux,aix,hpux,solaris"
+         os="freebsd,linux,aix,hpux,solaris"
          executable="google-chrome">
          <location>usr/bin/google-chrome</location>
       </browser>
       <browser
          id="org.eclipse.ui.browser.chromium"
          name="%browserChromium"
-         os="linux"
+         os="freebsd,linux"
          executable="chromium-browser">
          <location>usr/bin/chromium-browser</location>
       </browser>
       <browser
          id="org.eclipse.ui.browser.konqueror"
          name="%browserKonqueror"
-         os="linux,aix,hpux,solaris"
+         os="freebsd,linux,aix,hpux,solaris"
          executable="konqueror">
          <location>usr/bin/konqueror</location>
       </browser>
       <browser
          id="org.eclipse.ui.browser.epiphany"
          name="%browserEpiphany"
-         os="linux"
+         os="freebsd,linux"
          executable="epiphany">
          <location>
          	usr/bin/epiphany

--- a/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/WebBrowserUtil.java
+++ b/bundles/org.eclipse.ui.browser/src/org/eclipse/ui/internal/browser/WebBrowserUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2019 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
  *     Martin Oberhuber (Wind River) - [292882] Default Browser on Solaris
  *     Tomasz Zarna (Tasktop Technologies) - [429546] External Browser with parameters
  *     Christoph Läubrich - Bug 552773 - Simplify logging in platform code base
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.ui.internal.browser;
 
@@ -71,6 +72,18 @@ public class WebBrowserUtil {
 	public static boolean isLinux() {
 		String os = System.getProperty("os.name"); //$NON-NLS-1$
 		if (os != null && os.toLowerCase().contains("lin")) //$NON-NLS-1$
+			return true;
+		return false;
+	}
+
+	/**
+	 * Returns true if we're running on FreeBSD.
+	 *
+	 * @return boolean
+	 */
+	public static boolean isFreeBSD() {
+		String os = System.getProperty("os.name"); //$NON-NLS-1$
+		if (os != null && os.toLowerCase().contains("freebsd")) //$NON-NLS-1$
 			return true;
 		return false;
 	}

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/TitleRegion.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/TitleRegion.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.ui.internal.forms.widgets;
 
@@ -210,6 +211,9 @@ public class TitleRegion extends Canvas {
 					int tw = width - HMARGIN * 2 - SPACING * 2;
 					String os = System.getProperty("os.name"); //$NON-NLS-1$
 					if (Constants.OS_LINUX.equalsIgnoreCase(os)) {
+						tw += 1; // See Bug 342610
+					}
+					else if (Constants.OS_FREEBSD.equalsIgnoreCase(os)) {
 						tw += 1; // See Bug 342610
 					}
 					if (bsize != null)

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/part/ResourceTransfer.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/part/ResourceTransfer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Andrey Loskutov <loskutov@gmx.de> - Bug 205678
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.ui.part;
 
@@ -167,7 +168,7 @@ public class ResourceTransfer extends ByteArrayTransfer {
 			int count = in.readInt();
 			if (count > MAX_RESOURCES_TO_TRANSFER) {
 				String message = "Transfer aborted, too many resources: " + count + "."; //$NON-NLS-1$ //$NON-NLS-2$
-				if (Util.isLinux()) {
+				if (Util.isLinux() || Util.isFreeBSD()) {
 					message += "\nIf you are running in x11vnc environment please consider to switch to vncserver " + //$NON-NLS-1$
 							"+ vncviewer or to run x11vnc without clipboard support " + //$NON-NLS-1$
 							"(use '-noclipboard' and '-nosetclipboard' arguments)."; //$NON-NLS-1$

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/handlers/ShowInSystemExplorerHandler.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/handlers/ShowInSystemExplorerHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2016 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 474273
  *     Simon Scholz <simon.scholz@vogella.com> - Bug 487772, 486777
+ *     Tue Ton - support for FreeBSD
  ******************************************************************************/
 
 package org.eclipse.ui.internal.ide.handlers;
@@ -97,7 +98,7 @@ public class ShowInSystemExplorerHandler extends AbstractHandler {
 
 				File dir = item.getWorkspace().getRoot().getLocation().toFile();
 				Process p;
-				if (Util.isLinux() || Util.isMac()) {
+				if (Util.isLinux() || Util.isMac() || Util.isFreeBSD()) {
 					p = Runtime.getRuntime().exec(new String[] { "/bin/sh", "-c", launchCmd }, null, dir); //$NON-NLS-1$ //$NON-NLS-2$
 				} else {
 					p = Runtime.getRuntime().exec(launchCmd, null, dir);
@@ -180,7 +181,7 @@ public class ShowInSystemExplorerHandler extends AbstractHandler {
 	}
 
 	private String quotePath(String path) {
-		if (Util.isLinux() || Util.isMac()) {
+		if (Util.isLinux() || Util.isMac() || Util.isFreeBSD()) {
 			// Quote for usage inside "", man sh, topic QUOTING:
 			path = path.replaceAll("[\"$`]", "\\\\$0"); //$NON-NLS-1$ //$NON-NLS-2$
 		}

--- a/bundles/org.eclipse.ui.themes/plugin.xml
+++ b/bundles/org.eclipse.ui.themes/plugin.xml
@@ -8,6 +8,12 @@
             id="org.eclipse.e4.ui.css.theme.e4_classic"
             label="%theme.classic">
       </theme>
+      <theme
+        basestylesheeturi="css/e4-dark_linux.css"
+        id="org.eclipse.e4.ui.css.theme.e4_dark"
+        label="%theme.dark"
+        os="freebsd">
+      </theme>
     <theme
         basestylesheeturi="css/e4-dark_linux.css"
         id="org.eclipse.e4.ui.css.theme.e4_dark"
@@ -33,6 +39,12 @@
         label="%theme.dark"
         os="macosx">
     </theme>
+      <theme
+            basestylesheeturi="css/e4_default_gtk.css"
+            id="org.eclipse.e4.ui.css.theme.e4_default"
+            label="%theme.light"
+            os="freebsd">
+      </theme>
       <theme
             basestylesheeturi="css/e4_default_gtk.css"
             id="org.eclipse.e4.ui.css.theme.e4_default"

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/FindReplaceDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     SAP SE, christian.georgi@sap.com - Bug 487357: Make find dialog content scrollable
  *     Pierre-Yves B., pyvesdev@gmail.com - Bug 121634: [find/replace] status bar must show the string being searched when "String Not Found"
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.ui.texteditor;
 
@@ -1157,7 +1158,7 @@ class FindReplaceDialog extends Dialog {
 			fFindField.removeModifyListener(fFindModifyListener);
 
 			// XXX: Workaround for Combo bug on Linux (see bug 404202 and bug 410603)
-			if (Util.isLinux()) {
+			if (Util.isLinux() || Util.isFreeBSD()) {
 				fFindModifyListener.ignoreNextEvent();
 			}
 
@@ -1174,7 +1175,7 @@ class FindReplaceDialog extends Dialog {
 			fReplaceField.removeModifyListener(fReplaceModifyListener);
 
 			// XXX: Workaround for Combo bug on Linux (see bug 404202 and bug 410603)
-			if (Util.isLinux()) {
+			if (Util.isLinux() || Util.isFreeBSD()) {
 				fReplaceModifyListener.ignoreNextEvent();
 			}
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/themes/WorkbenchThemeManager.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/themes/WorkbenchThemeManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2017 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.ui.internal.themes;
 
@@ -179,7 +180,7 @@ public class WorkbenchThemeManager extends EventManager implements IThemeManager
 	private void updateThemes() {
 		// This code was added to fix a windows specific issue, see Bug 19229
 		// However, it's causing issues on Linux, see Bug 563001
-		if (Util.isLinux()) {
+		if (Util.isLinux() || Util.isFreeBSD()) {
 			return;
 		}
 

--- a/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/IOperatingSystemRegistration.java
+++ b/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/IOperatingSystemRegistration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 SAP SE and others.
+ * Copyright (c) 2018, 2025 SAP SE and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     SAP SE - initial version
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.urischeme;
 
@@ -14,13 +15,13 @@ import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.urischeme.internal.registration.RegistrationLinux;
 import org.eclipse.urischeme.internal.registration.RegistrationMacOsX;
+import org.eclipse.urischeme.internal.registration.RegistrationUnix;
 import org.eclipse.urischeme.internal.registration.RegistrationWindows;
 
 /**
  * Interface for registration or uri schemes in the different operating systems
- * (macOS, Linux and Windows)<br>
+ * (macOS, Linux, FreeBSD and Windows)<br>
  * Call <code>getInstance()</code> to get an OS specific instance.
  */
 public interface IOperatingSystemRegistration {
@@ -35,7 +36,9 @@ public interface IOperatingSystemRegistration {
 		if (Platform.OS_MACOSX.equals(Platform.getOS())) {
 			return new RegistrationMacOsX();
 		} else if (Platform.OS_LINUX.equals(Platform.getOS())) {
-			return new RegistrationLinux();
+			return new RegistrationUnix();
+		} else if (Platform.OS_FREEBSD.equals(Platform.getOS())) {
+			return new RegistrationUnix();
 		} else if (Platform.OS_WIN32.equals(Platform.getOS())) {
 			return new RegistrationWindows();
 		}

--- a/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/internal/registration/RegistrationUnix.java
+++ b/bundles/org.eclipse.urischeme/src/org/eclipse/urischeme/internal/registration/RegistrationUnix.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2018 SAP SE and others.
+ * Copyright (c) 2018, 2025 SAP SE and others.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,6 +8,7 @@
  *
  * Contributors:
  *     SAP SE - initial version
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.urischeme.internal.registration;
 
@@ -22,7 +24,7 @@ import org.eclipse.urischeme.IOperatingSystemRegistration;
 import org.eclipse.urischeme.IScheme;
 import org.eclipse.urischeme.ISchemeInformation;
 
-public class RegistrationLinux implements IOperatingSystemRegistration {
+public class RegistrationUnix implements IOperatingSystemRegistration {
 
 	private static final String DEFAULT_PRODUCT_NAME = "Eclipse SDK"; //$NON-NLS-1$
 	private static final String USER_HOME = System.getProperty("user.home"); //$NON-NLS-1$
@@ -39,7 +41,7 @@ public class RegistrationLinux implements IOperatingSystemRegistration {
 	private IProcessExecutor processExecutor;
 	private String productName;
 
-	public RegistrationLinux() {
+	public RegistrationUnix() {
 		this(new FileProvider(), new ProcessExecutor(), getProductName());
 	}
 
@@ -49,7 +51,7 @@ public class RegistrationLinux implements IOperatingSystemRegistration {
 		return name == null ? DEFAULT_PRODUCT_NAME : name;
 	}
 
-	public RegistrationLinux(IFileProvider fileProvider, IProcessExecutor processExecutor, String productName) {
+	public RegistrationUnix(IFileProvider fileProvider, IProcessExecutor processExecutor, String productName) {
 		this.fileProvider = fileProvider;
 		this.processExecutor = processExecutor;
 		this.productName = productName;
@@ -171,8 +173,8 @@ public class RegistrationLinux implements IOperatingSystemRegistration {
 	}
 
 	/**
-	 * Only one application can handle a specific uri scheme on Linux. This
-	 * information is stored de-centrally in the .desktop file and registered in a
+	 * Only one application can handle a specific uri scheme on Unix-based FreeBSD/Linux.
+	 * This information is stored de-centrally in the .desktop file and registered in a
 	 * central database. Registering an uri scheme that is already handled by
 	 * another application would also include changing the other application's
 	 * .desktop file - which can have unknown side effects.

--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -221,6 +221,20 @@
          version="0.0.0"/>
 
    <plugin
+         id="org.eclipse.equinox.launcher.gtk.freebsd.aarch64"
+         os="freebsd"
+         ws="gtk"
+         arch="aarch64"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.equinox.launcher.gtk.freebsd.x86_64"
+         os="freebsd"
+         ws="gtk"
+         arch="x86_64"
+         version="0.0.0"/>
+
+   <plugin
          id="org.eclipse.equinox.launcher.win32.win32.aarch64"
          os="win32"
          ws="win32"
@@ -276,6 +290,20 @@
    <plugin
          id="org.eclipse.swt.gtk.linux.x86_64"
          os="linux"
+         ws="gtk"
+         arch="x86_64"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.swt.gtk.freebsd.aarch64"
+         os="freebsd"
+         ws="gtk"
+         arch="aarch64"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.swt.gtk.freebsd.x86_64"
+         os="freebsd"
          ws="gtk"
          arch="x86_64"
          version="0.0.0"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2012, 2016 Eclipse Foundation and others.
+  Copyright (c) 2012, 2025 Eclipse Foundation and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
   Contributors:
      Igor Fedorenko - initial implementation
      Lars Vogel <Lars.Vogel@vogella.com> - Bug 421291, 427127, 430981, 471835, 487723
+     Tue Ton - support for FreeBSD
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -90,6 +91,8 @@
                     <plugin id="org.eclipse.equinox.launcher.gtk.linux.aarch64" />
                     <plugin id="org.eclipse.equinox.launcher.gtk.linux.riscv64" />
                     <plugin id="org.eclipse.equinox.launcher.gtk.linux.x86_64" />
+                    <plugin id="org.eclipse.equinox.launcher.gtk.freebsd.aarch" />
+                    <plugin id="org.eclipse.equinox.launcher.gtk.freebsd.x86_64" />
                     <plugin id="org.eclipse.equinox.launcher.win32.win32.aarch64" />
                     <plugin id="org.eclipse.equinox.launcher.win32.win32.x86_64" />
                   </excludes>

--- a/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitRegistrationUnix.java
+++ b/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitRegistrationUnix.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 SAP SE and others.
+ * Copyright (c) 2018, 2025 SAP SE and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     SAP SE - initial version
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.urischeme.internal.registration;
 
@@ -32,7 +33,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestUnitRegistrationLinux {
+public class TestUnitRegistrationUnix {
 
 	private static final String PRODUCT_NAME = "myProduct";
 	private static final String USER_HOME = System.getProperty("user.home");
@@ -68,7 +69,7 @@ public class TestUnitRegistrationLinux {
 		System.setProperty(ECLIPSE_HOME_LOCATION, "file:/home/myuser/Eclipse/");
 		System.setProperty(ECLIPSE_LAUNCHER, "/home/myuser/Eclipse/Eclipse");
 
-		registration = new RegistrationLinux(fileProvider, processStub, PRODUCT_NAME);
+		registration = new RegistrationUnix(fileProvider, processStub, PRODUCT_NAME);
 	}
 
 	@BeforeClass

--- a/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/suite/AllUnitTests.java
+++ b/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/suite/AllUnitTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 SAP SE and others.
+ * Copyright (c) 2018, 2025 SAP SE and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     SAP SE - initial version
+ *     Tue Ton - support for FreeBSD
  *******************************************************************************/
 package org.eclipse.urischeme.suite;
 
@@ -17,8 +18,8 @@ import org.eclipse.urischeme.TestUnitAutoRegisterSchemeHandlersJob;
 import org.eclipse.urischeme.internal.UriSchemeProcessorUnitTest;
 import org.eclipse.urischeme.internal.registration.TestUnitDesktopFileWriter;
 import org.eclipse.urischeme.internal.registration.TestUnitPlistFileWriter;
-import org.eclipse.urischeme.internal.registration.TestUnitRegistrationLinux;
 import org.eclipse.urischeme.internal.registration.TestUnitRegistrationMacOsX;
+import org.eclipse.urischeme.internal.registration.TestUnitRegistrationUnix;
 import org.eclipse.urischeme.internal.registration.TestUnitRegistrationWindows;
 import org.eclipse.urischeme.internal.registration.TestUnitRegistryWriter;
 import org.eclipse.urischeme.internal.registration.TestUnitWinRegistry;
@@ -31,7 +32,7 @@ import org.junit.runners.Suite.SuiteClasses;
 		TestUnitPlistFileWriter.class, //
 		TestUnitDesktopFileWriter.class, //
 		TestUnitRegistrationMacOsX.class, //
-		TestUnitRegistrationLinux.class, //
+		TestUnitRegistrationUnix.class, //
 		TestUnitRegistrationWindows.class, //
 		TestUnitRegistryWriter.class, //
 		TestUnitWinRegistry.class, //


### PR DESCRIPTION
Part of eclipse-platform/eclipse.platform.releng.aggregator#2959

Note that this PR requires the PR eclipse-equinox/equinox#929 be merged first, as this PR requires the new launcher bundles for FreeBSD:
```
org.eclipse.equinox.launcher.gtk.freebsd.aarch64
org.eclipse.equinox.launcher.gtk.freebsd.x86_64
```
to be present.
