### PR TITLE
Redesign Message Dialog

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/IconAndMessageDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/IconAndMessageDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -100,13 +100,15 @@ public abstract class IconAndMessageDialog extends Dialog {
 		if (message != null) {
 			messageLabel = new Label(composite, getMessageLabelStyle());
 			messageLabel.setText(message);
+			int xHint = message.length() > 40
+					? convertHorizontalDLUsToPixels(IDialogConstants.MINIMUM_MESSAGE_AREA_WIDTH)
+					: convertHorizontalDLUsToPixels(IDialogConstants.MINIMUM_MESSAGE_AREA_WIDTH - 50);
 			GridDataFactory
 					.fillDefaults()
 					.align(SWT.FILL, SWT.BEGINNING)
 					.grab(true, false)
-					.hint(
-							convertHorizontalDLUsToPixels(IDialogConstants.MINIMUM_MESSAGE_AREA_WIDTH),
-							SWT.DEFAULT).applyTo(messageLabel);
+					.hint(xHint, SWT.DEFAULT)
+					.applyTo(messageLabel);
 		}
 		return composite;
 	}


### PR DESCRIPTION
Removes unwanted space and aligns message content & buttons to center

Before 
<img width="711" alt="image" src="https://github.com/user-attachments/assets/fcc5c1a9-f615-4159-8003-ea1408584bae" /> <br>
After
<img width="453" alt="Screenshot 2025-04-22 at 1 02 49 PM" src="https://github.com/user-attachments/assets/fd6e3b57-1f6e-48dd-b949-906fc77fb666" />



Fixes : https://github.com/eclipse-platform/eclipse.platform.ui/issues/2929