### PR TITLE
Replace deprecated File.toURL()

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.css.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-SymbolicName: org.eclipse.e4.ui.css.core;singleton:=true
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 0.14.500.qualifier
+Bundle-Version: 0.14.600.qualifier
 Export-Package: org.eclipse.e4.ui.css.core;x-internal:=true,
  org.eclipse.e4.ui.css.core.css2;x-friends:="org.eclipse.e4.ui.css.swt.theme,org.eclipse.e4.ui.css.swt,org.eclipse.e4.ui.css.jface",
  org.eclipse.e4.ui.css.core.dom;x-friends:="org.eclipse.e4.ui.css.swt,org.eclipse.ui.views.properties.tabbed,org.eclipse.ui.forms",

--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/util/impl/resources/HttpResourcesLocatorImpl.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/util/impl/resources/HttpResourcesLocatorImpl.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.css.core.util.impl.resources;
 
-import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
 import org.eclipse.e4.ui.css.core.util.resources.IResourceLocator;
@@ -33,7 +32,7 @@ public class HttpResourcesLocatorImpl implements IResourceLocator {
 
 	@Override
 	public InputStream getInputStream(String uri) throws Exception {
-		URL url = new java.net.URL((new File("./")).toURL(), uri);
+		URL url = new URL(uri);
 		return url.openStream();
 	}
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceData.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceData.java
@@ -21,8 +21,11 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.StringTokenizer;
 
+import org.eclipse.core.filesystem.URIUtil;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.ConfigurationScope;
@@ -540,13 +543,12 @@ public class ChooseWorkspaceData {
 			}
 
 			// make sure the file exists
-			url = new URL(dir.toURL(), PERS_FILENAME);
-			File persFile = new File(url.getFile());
-			if (!persFile.exists() && (!create || !persFile.createNewFile())) {
+			Path p = Path.of(URIUtil.toURI(baseUrl.getPath() + File.pathSeparator + PERS_FILENAME));
+			if (!Files.exists(p) && (!create || !p.toFile().createNewFile())) {
 				return null;
 			}
 
-			return persFile.toURL();
+			return p.toUri().toURL();
 		} catch (IOException e) {
 			// cannot log because instance area has not been set
 			return null;


### PR DESCRIPTION
`java.io.File.toURL()` is deprecated and marked for removal. Replace it with `file.toURI().toURL()`, where `toURL()` is called on a `java.net.URI` instance, which is not deprecated and handles encoding correctly.







