### PR TITLE
Replace PNGs with SVGs in org.eclipse.ui.workbench and use on-the-fly disabled icons (incl. shared images)

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchImages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchImages.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
@@ -71,11 +72,7 @@ public/* final */class WorkbenchImages {
 
 	private static final String PATH_ETOOL = ICONS_PATH + "etool16/"; // Enabled toolbar icons.//$NON-NLS-1$
 
-	private static final String PATH_DTOOL = ICONS_PATH + "dtool16/"; // Disabled toolbar icons.//$NON-NLS-1$
-
 	private static final String PATH_ELOCALTOOL = ICONS_PATH + "elcl16/"; // Enabled local toolbar icons.//$NON-NLS-1$
-
-	private static final String PATH_DLOCALTOOL = ICONS_PATH + "dlcl16/"; // Disabled local toolbar icons.//$NON-NLS-1$
 
 	private static final String PATH_EVIEW = ICONS_PATH + "eview16/"; // View icons//$NON-NLS-1$
 
@@ -101,9 +98,17 @@ public/* final */class WorkbenchImages {
 	 *               <code>false</code> if this is not a shared image
 	 */
 	private static final void declareImage(String key, String path, boolean shared) {
-		ImageDescriptor desc = ImageDescriptor
-				.createFromURLSupplier(true, () -> BundleUtility.find(PlatformUI.PLUGIN_ID, path));
+		declareImage(key, null, path, shared);
+	}
+
+	private static final void declareImage(String key, String disabledKey, String path, boolean shared) {
+		ImageDescriptor desc = ImageDescriptor.createFromURLSupplier(true,
+				() -> BundleUtility.find(PlatformUI.PLUGIN_ID, path));
 		declareImage(key, desc, shared);
+		if (disabledKey != null) {
+			ImageDescriptor disabledImageDescriptor = ImageDescriptor.createWithFlags(desc, SWT.IMAGE_DISABLE);
+			declareImage(disabledKey, disabledImageDescriptor, shared);
+		}
 	}
 
 	/**
@@ -117,91 +122,90 @@ public/* final */class WorkbenchImages {
 		declareImage(ISharedImages.IMG_DEC_FIELD_WARNING, PATH_OVERLAY + "warning_ovr.svg", true); //$NON-NLS-1$
 
 		// Pinning
-		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_PIN_EDITOR, PATH_ETOOL + "pin_editor.svg", false); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_PIN_EDITOR_DISABLED, PATH_DTOOL + "pin_editor.png", false); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_PIN_EDITOR,
+				IWorkbenchGraphicConstants.IMG_ETOOL_PIN_EDITOR_DISABLED, PATH_ETOOL + "pin_editor.svg", false); //$NON-NLS-1$
 
 		// other toolbar buttons
+		declareImage(ISharedImages.IMG_ETOOL_SAVE_EDIT, ISharedImages.IMG_ETOOL_SAVE_EDIT_DISABLED, //
+				PATH_ETOOL + "save_edit.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ETOOL_SAVE_EDIT, PATH_ETOOL + "save_edit.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_ETOOL_SAVE_EDIT_DISABLED, PATH_DTOOL + "save_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ETOOL_SAVEAS_EDIT, ISharedImages.IMG_ETOOL_SAVEAS_EDIT_DISABLED, //
+				PATH_ETOOL + "saveas_edit.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ETOOL_SAVEAS_EDIT, PATH_ETOOL + "saveas_edit.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_ETOOL_SAVEAS_EDIT_DISABLED, PATH_DTOOL + "saveas_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ETOOL_SAVEALL_EDIT, ISharedImages.IMG_ETOOL_SAVEALL_EDIT_DISABLED, //
+				PATH_ETOOL + "saveall_edit.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ETOOL_SAVEALL_EDIT, PATH_ETOOL + "saveall_edit.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_ETOOL_SAVEALL_EDIT_DISABLED, PATH_DTOOL + "saveall_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_UNDO, ISharedImages.IMG_TOOL_UNDO_DISABLED, //
+				PATH_ETOOL + "undo_edit.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_UNDO, PATH_ETOOL + "undo_edit.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_UNDO_DISABLED, PATH_DTOOL + "undo_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_REDO, ISharedImages.IMG_TOOL_REDO_DISABLED, //
+				PATH_ETOOL + "redo_edit.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_REDO, PATH_ETOOL + "redo_edit.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_REDO_DISABLED, PATH_DTOOL + "redo_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_CUT, ISharedImages.IMG_TOOL_CUT_DISABLED, //
+				PATH_ETOOL + "cut_edit.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_CUT, PATH_ETOOL + "cut_edit.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_CUT_DISABLED, PATH_DTOOL + "cut_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_COPY, ISharedImages.IMG_TOOL_COPY_DISABLED, //
+				PATH_ETOOL + "copy_edit.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_COPY, PATH_ETOOL + "copy_edit.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_COPY_DISABLED, PATH_DTOOL + "copy_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_PASTE, ISharedImages.IMG_TOOL_PASTE_DISABLED, //
+				PATH_ETOOL + "paste_edit.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_PASTE, PATH_ETOOL + "paste_edit.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_PASTE_DISABLED, PATH_DTOOL + "paste_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_DELETE, ISharedImages.IMG_TOOL_DELETE_DISABLED, //
+				PATH_ETOOL + "delete_edit.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_DELETE, PATH_ETOOL + "delete_edit.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_DELETE_DISABLED, PATH_DTOOL + "delete_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ETOOL_DELETE, ISharedImages.IMG_ETOOL_DELETE_DISABLED, //
+				PATH_ETOOL + "delete.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ETOOL_DELETE, PATH_ETOOL + "delete.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_ETOOL_DELETE_DISABLED, PATH_DTOOL + "delete.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ETOOL_CLEAR, ISharedImages.IMG_ETOOL_CLEAR_DISABLED, //
+				PATH_ETOOL + "clear.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ETOOL_CLEAR, PATH_ETOOL + "clear.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_ETOOL_CLEAR_DISABLED, PATH_DTOOL + "clear.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_NEW_WIZARD, ISharedImages.IMG_TOOL_NEW_WIZARD_DISABLED, //
+				PATH_ETOOL + "new_wiz.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_NEW_WIZARD, PATH_ETOOL + "new_wiz.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_NEW_WIZARD_DISABLED, PATH_DTOOL + "new_wiz.png", true); //$NON-NLS-1$
-
-		declareImage(ISharedImages.IMG_ETOOL_PRINT_EDIT, PATH_ETOOL + "print_edit.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_ETOOL_PRINT_EDIT_DISABLED, PATH_DTOOL + "print_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ETOOL_PRINT_EDIT, ISharedImages.IMG_ETOOL_PRINT_EDIT_DISABLED, //
+				PATH_ETOOL + "print_edit.svg", true); //$NON-NLS-1$
 
 		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_HELP_CONTENTS, PATH_ETOOL + "help_contents.svg", true); //$NON-NLS-1$
 		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_HELP_SEARCH, PATH_ETOOL + "help_search.svg", true); //$NON-NLS-1$
 		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_TIPS_AND_TRICKS, PATH_ETOOL + "tricks.svg", true); //$NON-NLS-1$
 
-		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_NEW_FASTVIEW, PATH_ETOOL + "new_fastview.svg", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_DTOOL_NEW_FASTVIEW, PATH_DTOOL + "new_fastview.png", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_NEW_FASTVIEW,
+				IWorkbenchGraphicConstants.IMG_DTOOL_NEW_FASTVIEW, PATH_ETOOL + "new_fastview.svg", true); //$NON-NLS-1$
 
 		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_RESTORE_TRIMPART, PATH_ETOOL + "fastview_restore.svg", true); //$NON-NLS-1$
 		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_EDITOR_TRIMPART, PATH_ETOOL + "editor_area.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_FORWARD, PATH_ELOCALTOOL + "forward_nav.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_FORWARD_DISABLED, PATH_DLOCALTOOL + "forward_nav.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_FORWARD, ISharedImages.IMG_TOOL_FORWARD_DISABLED, //
+				PATH_ELOCALTOOL + "forward_nav.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_BACK, PATH_ELOCALTOOL + "backward_nav.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_BACK_DISABLED, PATH_DLOCALTOOL + "backward_nav.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_BACK, ISharedImages.IMG_TOOL_BACK_DISABLED, //
+				PATH_ELOCALTOOL + "backward_nav.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_UP, PATH_ELOCALTOOL + "up_nav.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_UP_DISABLED, PATH_DLOCALTOOL + "up_nav.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_UP, ISharedImages.IMG_TOOL_UP_DISABLED, //
+				PATH_ELOCALTOOL + "up_nav.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ELCL_SYNCED, PATH_ELOCALTOOL + "synced.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_ELCL_SYNCED_DISABLED, PATH_DLOCALTOOL + "synced.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ELCL_SYNCED, ISharedImages.IMG_ELCL_SYNCED_DISABLED, //
+				PATH_ELOCALTOOL + "synced.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ELCL_COLLAPSEALL, PATH_ELOCALTOOL + "collapseall.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_ELCL_COLLAPSEALL_DISABLED, PATH_DLOCALTOOL + "collapseall.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ELCL_COLLAPSEALL, ISharedImages.IMG_ELCL_COLLAPSEALL_DISABLED, //
+				PATH_ELOCALTOOL + "collapseall.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ELCL_REMOVE, PATH_ELOCALTOOL + "remove.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_ELCL_REMOVE_DISABLED, PATH_DLOCALTOOL + "remove.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ELCL_REMOVE, ISharedImages.IMG_ELCL_REMOVE_DISABLED, //
+				PATH_ELOCALTOOL + "remove.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ELCL_REMOVEALL, PATH_ELOCALTOOL + "removeall.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_ELCL_REMOVEALL_DISABLED, PATH_DLOCALTOOL + "removeall.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ELCL_REMOVEALL, ISharedImages.IMG_ELCL_REMOVEALL_DISABLED, //
+				PATH_ELOCALTOOL + "removeall.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ELCL_COLLAPSEALL, PATH_ELOCALTOOL + "collapseall.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_ELCL_COLLAPSEALL_DISABLED, PATH_DLOCALTOOL + "collapseall.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ELCL_COLLAPSEALL, ISharedImages.IMG_ELCL_COLLAPSEALL_DISABLED, //
+				PATH_ELOCALTOOL + "collapseall.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ELCL_STOP, PATH_ELOCALTOOL + "stop.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_ELCL_STOP_DISABLED, PATH_DLOCALTOOL + "stop.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ELCL_STOP, ISharedImages.IMG_ELCL_STOP_DISABLED, //
+				PATH_ELOCALTOOL + "stop.svg", true); //$NON-NLS-1$
 
 		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_NEW_PAGE, PATH_EVIEW + "new_persp.svg", false); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ETOOL_HOME_NAV, PATH_ELOCALTOOL + "home_nav.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_ETOOL_HOME_NAV_DISABLED, PATH_DLOCALTOOL + "home_nav.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ETOOL_HOME_NAV, ISharedImages.IMG_ETOOL_HOME_NAV_DISABLED, //
+				PATH_ELOCALTOOL + "home_nav.svg", true); //$NON-NLS-1$
 
 		declareImage(ISharedImages.IMG_ETOOL_DEF_PERSPECTIVE, PATH_EVIEW + "default_persp.svg", true); //$NON-NLS-1$
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchImages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchImages.java
@@ -52,10 +52,10 @@ import org.eclipse.ui.internal.util.BundleUtility;
  * Some Images are also made available to other plugins by being placed in the
  * descriptor table of the SharedImages class.
  *
- * Where are the images? The images (typically png file) are found the plugins
+ * Where are the images? The images (typically SVG file) are found the plugins
  * install directory
  *
- * How to add a new image Place the png file into the appropriate directories.
+ * How to add a new image Place the SVG file into the appropriate directories.
  * Add a constant to IWorkbenchGraphicConstants following the conventions Add
  * the declaration to this file
  */
@@ -113,182 +113,182 @@ public/* final */class WorkbenchImages {
 	@SuppressWarnings("removal")
 	private static final void declareImages() {
 		// Overlays
-		declareImage(ISharedImages.IMG_DEC_FIELD_ERROR, PATH_OVERLAY + "error_ovr.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_DEC_FIELD_WARNING, PATH_OVERLAY + "warning_ovr.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_DEC_FIELD_ERROR, PATH_OVERLAY + "error_ovr.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_DEC_FIELD_WARNING, PATH_OVERLAY + "warning_ovr.svg", true); //$NON-NLS-1$
 
 		// Pinning
-		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_PIN_EDITOR, PATH_ETOOL + "pin_editor.png", false); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_PIN_EDITOR, PATH_ETOOL + "pin_editor.svg", false); //$NON-NLS-1$
 		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_PIN_EDITOR_DISABLED, PATH_DTOOL + "pin_editor.png", false); //$NON-NLS-1$
 
 		// other toolbar buttons
 
-		declareImage(ISharedImages.IMG_ETOOL_SAVE_EDIT, PATH_ETOOL + "save_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ETOOL_SAVE_EDIT, PATH_ETOOL + "save_edit.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_ETOOL_SAVE_EDIT_DISABLED, PATH_DTOOL + "save_edit.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ETOOL_SAVEAS_EDIT, PATH_ETOOL + "saveas_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ETOOL_SAVEAS_EDIT, PATH_ETOOL + "saveas_edit.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_ETOOL_SAVEAS_EDIT_DISABLED, PATH_DTOOL + "saveas_edit.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ETOOL_SAVEALL_EDIT, PATH_ETOOL + "saveall_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ETOOL_SAVEALL_EDIT, PATH_ETOOL + "saveall_edit.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_ETOOL_SAVEALL_EDIT_DISABLED, PATH_DTOOL + "saveall_edit.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_UNDO, PATH_ETOOL + "undo_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_UNDO, PATH_ETOOL + "undo_edit.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_TOOL_UNDO_DISABLED, PATH_DTOOL + "undo_edit.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_REDO, PATH_ETOOL + "redo_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_REDO, PATH_ETOOL + "redo_edit.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_TOOL_REDO_DISABLED, PATH_DTOOL + "redo_edit.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_CUT, PATH_ETOOL + "cut_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_CUT, PATH_ETOOL + "cut_edit.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_TOOL_CUT_DISABLED, PATH_DTOOL + "cut_edit.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_COPY, PATH_ETOOL + "copy_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_COPY, PATH_ETOOL + "copy_edit.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_TOOL_COPY_DISABLED, PATH_DTOOL + "copy_edit.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_PASTE, PATH_ETOOL + "paste_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_PASTE, PATH_ETOOL + "paste_edit.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_TOOL_PASTE_DISABLED, PATH_DTOOL + "paste_edit.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_DELETE, PATH_ETOOL + "delete_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_DELETE, PATH_ETOOL + "delete_edit.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_TOOL_DELETE_DISABLED, PATH_DTOOL + "delete_edit.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ETOOL_DELETE, PATH_ETOOL + "delete.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ETOOL_DELETE, PATH_ETOOL + "delete.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_ETOOL_DELETE_DISABLED, PATH_DTOOL + "delete.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ETOOL_CLEAR, PATH_ETOOL + "clear.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ETOOL_CLEAR, PATH_ETOOL + "clear.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_ETOOL_CLEAR_DISABLED, PATH_DTOOL + "clear.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_NEW_WIZARD, PATH_ETOOL + "new_wiz.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_NEW_WIZARD, PATH_ETOOL + "new_wiz.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_TOOL_NEW_WIZARD_DISABLED, PATH_DTOOL + "new_wiz.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ETOOL_PRINT_EDIT, PATH_ETOOL + "print_edit.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ETOOL_PRINT_EDIT, PATH_ETOOL + "print_edit.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_ETOOL_PRINT_EDIT_DISABLED, PATH_DTOOL + "print_edit.png", true); //$NON-NLS-1$
 
-		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_HELP_CONTENTS, PATH_ETOOL + "help_contents.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_HELP_SEARCH, PATH_ETOOL + "help_search.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_TIPS_AND_TRICKS, PATH_ETOOL + "tricks.png", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_HELP_CONTENTS, PATH_ETOOL + "help_contents.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_HELP_SEARCH, PATH_ETOOL + "help_search.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_TIPS_AND_TRICKS, PATH_ETOOL + "tricks.svg", true); //$NON-NLS-1$
 
-		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_NEW_FASTVIEW, PATH_ETOOL + "new_fastview.png", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_NEW_FASTVIEW, PATH_ETOOL + "new_fastview.svg", true); //$NON-NLS-1$
 		declareImage(IWorkbenchGraphicConstants.IMG_DTOOL_NEW_FASTVIEW, PATH_DTOOL + "new_fastview.png", true); //$NON-NLS-1$
 
-		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_RESTORE_TRIMPART, PATH_ETOOL + "fastview_restore.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_EDITOR_TRIMPART, PATH_ETOOL + "editor_area.png", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_RESTORE_TRIMPART, PATH_ETOOL + "fastview_restore.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_EDITOR_TRIMPART, PATH_ETOOL + "editor_area.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_FORWARD, PATH_ELOCALTOOL + "forward_nav.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_FORWARD, PATH_ELOCALTOOL + "forward_nav.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_TOOL_FORWARD_DISABLED, PATH_DLOCALTOOL + "forward_nav.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_BACK, PATH_ELOCALTOOL + "backward_nav.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_BACK, PATH_ELOCALTOOL + "backward_nav.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_TOOL_BACK_DISABLED, PATH_DLOCALTOOL + "backward_nav.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_TOOL_UP, PATH_ELOCALTOOL + "up_nav.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_UP, PATH_ELOCALTOOL + "up_nav.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_TOOL_UP_DISABLED, PATH_DLOCALTOOL + "up_nav.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ELCL_SYNCED, PATH_ELOCALTOOL + "synced.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ELCL_SYNCED, PATH_ELOCALTOOL + "synced.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_ELCL_SYNCED_DISABLED, PATH_DLOCALTOOL + "synced.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ELCL_COLLAPSEALL, PATH_ELOCALTOOL + "collapseall.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ELCL_COLLAPSEALL, PATH_ELOCALTOOL + "collapseall.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_ELCL_COLLAPSEALL_DISABLED, PATH_DLOCALTOOL + "collapseall.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ELCL_REMOVE, PATH_ELOCALTOOL + "remove.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ELCL_REMOVE, PATH_ELOCALTOOL + "remove.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_ELCL_REMOVE_DISABLED, PATH_DLOCALTOOL + "remove.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ELCL_REMOVEALL, PATH_ELOCALTOOL + "removeall.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ELCL_REMOVEALL, PATH_ELOCALTOOL + "removeall.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_ELCL_REMOVEALL_DISABLED, PATH_DLOCALTOOL + "removeall.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ELCL_COLLAPSEALL, PATH_ELOCALTOOL + "collapseall.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ELCL_COLLAPSEALL, PATH_ELOCALTOOL + "collapseall.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_ELCL_COLLAPSEALL_DISABLED, PATH_DLOCALTOOL + "collapseall.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ELCL_STOP, PATH_ELOCALTOOL + "stop.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ELCL_STOP, PATH_ELOCALTOOL + "stop.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_ELCL_STOP_DISABLED, PATH_DLOCALTOOL + "stop.png", true); //$NON-NLS-1$
 
-		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_NEW_PAGE, PATH_EVIEW + "new_persp.png", false); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_NEW_PAGE, PATH_EVIEW + "new_persp.svg", false); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ETOOL_HOME_NAV, PATH_ELOCALTOOL + "home_nav.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ETOOL_HOME_NAV, PATH_ELOCALTOOL + "home_nav.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_ETOOL_HOME_NAV_DISABLED, PATH_DLOCALTOOL + "home_nav.png", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_ETOOL_DEF_PERSPECTIVE, PATH_EVIEW + "default_persp.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_ETOOL_DEF_PERSPECTIVE, PATH_EVIEW + "default_persp.svg", true); //$NON-NLS-1$
 
-		declareImage(IWorkbenchGraphicConstants.IMG_WIZBAN_NEW_WIZ, PATH_WIZBAN + "new_wiz.png", false); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_WIZBAN_NEW_WIZ, PATH_WIZBAN + "new_wiz.svg", false); //$NON-NLS-1$
 
-		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_IMPORT_WIZ, PATH_ETOOL + "import_wiz.png", false); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_EXPORT_WIZ, PATH_ETOOL + "export_wiz.png", false); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_WIZBAN_IMPORT_WIZ, PATH_WIZBAN + "import_wiz.png", false); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_WIZBAN_EXPORT_WIZ, PATH_WIZBAN + "export_wiz.png", false); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_WIZBAN_IMPORT_PREF_WIZ, PATH_WIZBAN + "importpref_wiz.png", false); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_WIZBAN_EXPORT_PREF_WIZ, PATH_WIZBAN + "exportpref_wiz.png", false); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_IMPORT_WIZ, PATH_ETOOL + "import_wiz.svg", false); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_ETOOL_EXPORT_WIZ, PATH_ETOOL + "export_wiz.svg", false); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_WIZBAN_IMPORT_WIZ, PATH_WIZBAN + "import_wiz.svg", false); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_WIZBAN_EXPORT_WIZ, PATH_WIZBAN + "export_wiz.svg", false); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_WIZBAN_IMPORT_PREF_WIZ, PATH_WIZBAN + "importpref_wiz.svg", false); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_WIZBAN_EXPORT_PREF_WIZ, PATH_WIZBAN + "exportpref_wiz.svg", false); //$NON-NLS-1$
 
-		declareImage(IWorkbenchGraphicConstants.IMG_WIZBAN_WORKINGSET_WIZ, PATH_WIZBAN + "workset_wiz.png", false); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_WIZBAN_WORKINGSET_WIZ, PATH_WIZBAN + "workset_wiz.svg", false); //$NON-NLS-1$
 
-		declareImage(IWorkbenchGraphicConstants.IMG_VIEW_DEFAULTVIEW_MISC, PATH_EVIEW + "defaultview_misc.png", false); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_VIEW_DEFAULTVIEW_MISC, PATH_EVIEW + "defaultview_misc.svg", false); //$NON-NLS-1$
 
-		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_FONT, PATH_OBJECT + "font.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_THEME_CATEGORY, PATH_OBJECT + "theme_category.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_ACTIVITY, PATH_OBJECT + "activity.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_ACTIVITY_CATEGORY, PATH_OBJECT + "activity_category.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_WORKING_SETS, PATH_OBJECT + "workingsets.png", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_FONT, PATH_OBJECT + "font.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_THEME_CATEGORY, PATH_OBJECT + "theme_category.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_ACTIVITY, PATH_OBJECT + "activity.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_ACTIVITY_CATEGORY, PATH_OBJECT + "activity_category.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_WORKING_SETS, PATH_OBJECT + "workingsets.svg", true); //$NON-NLS-1$
 
-		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_SEPARATOR, PATH_OBJECT + "separator.png", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_SEPARATOR, PATH_OBJECT + "separator.svg", true); //$NON-NLS-1$
 
-		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_NODE, PATH_OBJECT + "generic_elements.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_ELEMENT, PATH_OBJECT + "generic_element.png", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_NODE, PATH_OBJECT + "generic_elements.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_ELEMENT, PATH_OBJECT + "generic_element.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_OBJ_ADD, PATH_OBJECT + "add_obj.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJ_FILE, PATH_OBJECT + "file_obj.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJ_FOLDER, PATH_OBJECT + "fldr_obj.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJ_ELEMENT, PATH_OBJECT + "elements_obj.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_DEF_VIEW, PATH_EVIEW + "defaultview_misc.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJ_ADD, PATH_OBJECT + "add_obj.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJ_FILE, PATH_OBJECT + "file_obj.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJ_FOLDER, PATH_OBJECT + "fldr_obj.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJ_ELEMENT, PATH_OBJECT + "elements_obj.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_DEF_VIEW, PATH_EVIEW + "defaultview_misc.svg", true); //$NON-NLS-1$
 
-		declareImage(IWorkbenchGraphicConstants.IMG_LCL_CLOSE_VIEW, PATH_ELOCALTOOL + "close_view.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_LCL_MIN_VIEW, PATH_ELOCALTOOL + "min_view.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_LCL_VIEW_MENU, PATH_ELOCALTOOL + "view_menu.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_LCL_BUTTON_MENU, PATH_ELOCALTOOL + "button_menu.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_LCL_LINKTO_HELP, PATH_ELOCALTOOL + "linkto_help.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_LCL_RENDERED_VIEW_MENU, PATH_ELOCALTOOL + "view_menu.png", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_LCL_CLOSE_VIEW, PATH_ELOCALTOOL + "close_view.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_LCL_MIN_VIEW, PATH_ELOCALTOOL + "min_view.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_LCL_VIEW_MENU, PATH_ELOCALTOOL + "view_menu.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_LCL_BUTTON_MENU, PATH_ELOCALTOOL + "button_menu.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_LCL_LINKTO_HELP, PATH_ELOCALTOOL + "linkto_help.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_LCL_RENDERED_VIEW_MENU, PATH_ELOCALTOOL + "view_menu.svg", true); //$NON-NLS-1$
 
-		declareImage(IWorkbenchGraphicConstants.IMG_LCL_CLOSE_VIEW_THIN, PATH_ELOCALTOOL + "thin_close_view.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_LCL_HIDE_TOOLBAR_THIN, PATH_ELOCALTOOL + "thin_hide_toolbar.png", //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_LCL_CLOSE_VIEW_THIN, PATH_ELOCALTOOL + "thin_close_view.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_LCL_HIDE_TOOLBAR_THIN, PATH_ELOCALTOOL + "thin_hide_toolbar.svg", //$NON-NLS-1$
 				true);
-		declareImage(IWorkbenchGraphicConstants.IMG_LCL_MAX_VIEW_THIN, PATH_ELOCALTOOL + "thin_max_view.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_LCL_MIN_VIEW_THIN, PATH_ELOCALTOOL + "thin_min_view.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_LCL_RESTORE_VIEW_THIN, PATH_ELOCALTOOL + "thin_restore_view.png", //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_LCL_MAX_VIEW_THIN, PATH_ELOCALTOOL + "thin_max_view.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_LCL_MIN_VIEW_THIN, PATH_ELOCALTOOL + "thin_min_view.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_LCL_RESTORE_VIEW_THIN, PATH_ELOCALTOOL + "thin_restore_view.svg", //$NON-NLS-1$
 				true);
-		declareImage(IWorkbenchGraphicConstants.IMG_LCL_SHOW_TOOLBAR_THIN, PATH_ELOCALTOOL + "thin_show_toolbar.png", //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_LCL_SHOW_TOOLBAR_THIN, PATH_ELOCALTOOL + "thin_show_toolbar.svg", //$NON-NLS-1$
 				true);
-		declareImage(IWorkbenchGraphicConstants.IMG_LCL_VIEW_MENU_THIN, PATH_ELOCALTOOL + "thin_view_menu.png", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_LCL_VIEW_MENU_THIN, PATH_ELOCALTOOL + "thin_view_menu.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_OBJS_ERROR_TSK, PATH_OBJECT + "error_tsk.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_WARN_TSK, PATH_OBJECT + "warn_tsk.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_INFO_TSK, PATH_OBJECT + "info_tsk.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_ERROR_TSK, PATH_OBJECT + "error_tsk.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_WARN_TSK, PATH_OBJECT + "warn_tsk.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_INFO_TSK, PATH_OBJECT + "info_tsk.svg", true); //$NON-NLS-1$
 
-		declareImage(ISharedImages.IMG_OBJS_DND_LEFT_SOURCE, PATH_POINTER + "left_source.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_LEFT_MASK, PATH_POINTER + "left_mask.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_RIGHT_SOURCE, PATH_POINTER + "right_source.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_RIGHT_MASK, PATH_POINTER + "right_mask.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_TOP_SOURCE, PATH_POINTER + "top_source.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_TOP_MASK, PATH_POINTER + "top_mask.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_BOTTOM_SOURCE, PATH_POINTER + "bottom_source.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_BOTTOM_MASK, PATH_POINTER + "bottom_mask.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_INVALID_SOURCE, PATH_POINTER + "invalid_source.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_INVALID_MASK, PATH_POINTER + "invalid_mask.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_STACK_SOURCE, PATH_POINTER + "stack_source.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_STACK_MASK, PATH_POINTER + "stack_mask.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_OFFSCREEN_SOURCE, PATH_POINTER + "offscreen_source.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_OFFSCREEN_MASK, PATH_POINTER + "offscreen_mask.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_TOFASTVIEW_SOURCE, PATH_POINTER + "tofastview_source.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_TOFASTVIEW_MASK, PATH_POINTER + "tofastview_mask.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_LEFT, PATH_POINTER + "left.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_RIGHT, PATH_POINTER + "right.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_TOP, PATH_POINTER + "top.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_BOTTOM, PATH_POINTER + "bottom.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_INVALID, PATH_POINTER + "invalid.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_STACK, PATH_POINTER + "stack.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_OFFSCREEN, PATH_POINTER + "offscreen.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_OBJS_DND_TOFASTVIEW, PATH_POINTER + "tofastview.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_LEFT_SOURCE, PATH_POINTER + "left_source.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_LEFT_MASK, PATH_POINTER + "left_mask.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_RIGHT_SOURCE, PATH_POINTER + "right_source.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_RIGHT_MASK, PATH_POINTER + "right_mask.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_TOP_SOURCE, PATH_POINTER + "top_source.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_TOP_MASK, PATH_POINTER + "top_mask.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_BOTTOM_SOURCE, PATH_POINTER + "bottom_source.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_BOTTOM_MASK, PATH_POINTER + "bottom_mask.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_INVALID_SOURCE, PATH_POINTER + "invalid_source.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_INVALID_MASK, PATH_POINTER + "invalid_mask.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_STACK_SOURCE, PATH_POINTER + "stack_source.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_STACK_MASK, PATH_POINTER + "stack_mask.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_OFFSCREEN_SOURCE, PATH_POINTER + "offscreen_source.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_OFFSCREEN_MASK, PATH_POINTER + "offscreen_mask.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_TOFASTVIEW_SOURCE, PATH_POINTER + "tofastview_source.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_TOFASTVIEW_MASK, PATH_POINTER + "tofastview_mask.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_LEFT, PATH_POINTER + "left.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_RIGHT, PATH_POINTER + "right.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_TOP, PATH_POINTER + "top.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_BOTTOM, PATH_POINTER + "bottom.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_INVALID, PATH_POINTER + "invalid.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_STACK, PATH_POINTER + "stack.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_OFFSCREEN, PATH_POINTER + "offscreen.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_OBJS_DND_TOFASTVIEW, PATH_POINTER + "tofastview.svg", true); //$NON-NLS-1$
 
 		// signed jar images
-		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_SIGNED_YES, PATH_OBJECT + "signed_yes_tbl.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_SIGNED_NO, PATH_OBJECT + "signed_no_tbl.png", true); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_SIGNED_UNKNOWN, PATH_OBJECT + "signed_unkn_tbl.png", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_SIGNED_YES, PATH_OBJECT + "signed_yes_tbl.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_SIGNED_NO, PATH_OBJECT + "signed_no_tbl.svg", true); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_OBJ_SIGNED_UNKNOWN, PATH_OBJECT + "signed_unkn_tbl.svg", true); //$NON-NLS-1$
 
-		declareImage(IWorkbenchGraphicConstants.IMG_PREF_IMPORT, PATH_PREF + "import_wiz.png", false); //$NON-NLS-1$
-		declareImage(IWorkbenchGraphicConstants.IMG_PREF_EXPORT, PATH_PREF + "export_wiz.png", false); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_PREF_IMPORT, PATH_PREF + "import_wiz.svg", false); //$NON-NLS-1$
+		declareImage(IWorkbenchGraphicConstants.IMG_PREF_EXPORT, PATH_PREF + "export_wiz.svg", false); //$NON-NLS-1$
 
 		declareHoverImages();
 
@@ -304,16 +304,16 @@ public/* final */class WorkbenchImages {
 	 */
 	@Deprecated
 	private static final void declareHoverImages() {
-		declareImage(ISharedImages.IMG_TOOL_UNDO_HOVER, PATH_ETOOL + "undo_edit.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_REDO_HOVER, PATH_ETOOL + "redo_edit.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_CUT_HOVER, PATH_ETOOL + "cut_edit.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_COPY_HOVER, PATH_ETOOL + "copy_edit.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_PASTE_HOVER, PATH_ETOOL + "paste_edit.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_FORWARD_HOVER, PATH_ELOCALTOOL + "forward_nav.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_DELETE_HOVER, PATH_ETOOL + "delete_edit.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_NEW_WIZARD_HOVER, PATH_ETOOL + "new_wiz.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_BACK_HOVER, PATH_ELOCALTOOL + "backward_nav.png", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_UP_HOVER, PATH_ELOCALTOOL + "up_nav.png", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_UNDO_HOVER, PATH_ETOOL + "undo_edit.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_REDO_HOVER, PATH_ETOOL + "redo_edit.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_CUT_HOVER, PATH_ETOOL + "cut_edit.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_COPY_HOVER, PATH_ETOOL + "copy_edit.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_PASTE_HOVER, PATH_ETOOL + "paste_edit.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_FORWARD_HOVER, PATH_ELOCALTOOL + "forward_nav.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_DELETE_HOVER, PATH_ETOOL + "delete_edit.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_NEW_WIZARD_HOVER, PATH_ETOOL + "new_wiz.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_BACK_HOVER, PATH_ELOCALTOOL + "backward_nav.svg", true); //$NON-NLS-1$
+		declareImage(ISharedImages.IMG_TOOL_UP_HOVER, PATH_ELOCALTOOL + "up_nav.svg", true); //$NON-NLS-1$
 	}
 
 	/**
@@ -454,7 +454,7 @@ public/* final */class WorkbenchImages {
 	 * Local enabled toolbar ELCL_ Local Disable toolbar DLCL_ Object large OBJL_
 	 * Object small OBJS_ View VIEW_ Product images PROD_ Misc images MISC_
 	 *
-	 * Where are the images? The images (typically png files) are found in the same
+	 * Where are the images? The images (typically SVG files) are found in the same
 	 * location as this plugin class. This may mean the same package directory as
 	 * the package holding this class. The images are declared using this.getClass()
 	 * to ensure they are looked up via this plugin class.

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressInfoItem.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressInfoItem.java
@@ -153,20 +153,21 @@ public class ProgressInfoItem extends Composite {
 	private boolean isThemed;
 
 	static {
-		JFaceResources.getImageRegistry().put(STOP_IMAGE_KEY,
-				WorkbenchImages.getWorkbenchImageDescriptor("elcl16/progress_stop.png"));//$NON-NLS-1$
-
-		JFaceResources.getImageRegistry().put(DISABLED_STOP_IMAGE_KEY,
-				WorkbenchImages.getWorkbenchImageDescriptor("dlcl16/progress_stop.png"));//$NON-NLS-1$
+		ImageDescriptor processStopDescriptor = WorkbenchImages.getWorkbenchImageDescriptor("elcl16/progress_stop.png"); //$NON-NLS-1$
+		JFaceResources.getImageRegistry().put(STOP_IMAGE_KEY, processStopDescriptor);
+		ImageDescriptor disabledProcessStopDescriptor = ImageDescriptor.createWithFlags(processStopDescriptor,
+				SWT.IMAGE_DISABLE);
+		JFaceResources.getImageRegistry().put(DISABLED_STOP_IMAGE_KEY, disabledProcessStopDescriptor);
 
 		JFaceResources.getImageRegistry().put(DEFAULT_JOB_KEY,
 				WorkbenchImages.getWorkbenchImageDescriptor("progress/progress_task.png")); //$NON-NLS-1$
 
-		JFaceResources.getImageRegistry().put(CLEAR_FINISHED_JOB_KEY,
-				WorkbenchImages.getWorkbenchImageDescriptor("elcl16/progress_rem.png")); //$NON-NLS-1$
-
-		JFaceResources.getImageRegistry().put(DISABLED_CLEAR_FINISHED_JOB_KEY,
-				WorkbenchImages.getWorkbenchImageDescriptor("dlcl16/progress_rem.png")); //$NON-NLS-1$
+		ImageDescriptor processRemoveDescriptor = WorkbenchImages
+				.getWorkbenchImageDescriptor("elcl16/progress_rem.png"); //$NON-NLS-1$
+		JFaceResources.getImageRegistry().put(CLEAR_FINISHED_JOB_KEY, processRemoveDescriptor);
+		ImageDescriptor disabledProcessRemoveDescriptor = ImageDescriptor.createWithFlags(processRemoveDescriptor,
+				SWT.IMAGE_DISABLE);
+		JFaceResources.getImageRegistry().put(DISABLED_CLEAR_FINISHED_JOB_KEY, disabledProcessRemoveDescriptor);
 
 		// Mac has different Gamma value
 		int shift = Util.isMac() ? -25 : -10;

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressView.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressView.java
@@ -248,10 +248,6 @@ public class ProgressView extends ViewPart {
 		if (id != null) {
 			clearAllAction.setImageDescriptor(id);
 		}
-		id = WorkbenchImages.getWorkbenchImageDescriptor("/dlcl16/progress_remall.png"); //$NON-NLS-1$
-		if (id != null) {
-			clearAllAction.setDisabledImageDescriptor(id);
-		}
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/EditorIconTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/EditorIconTest.java
@@ -44,7 +44,7 @@ public class EditorIconTest {
 		try {
 			i1 = PlatformUI.getWorkbench().getEditorRegistry().getDefaultEditor(
 					"foo.icontest1").getImageDescriptor().createImage();
-			i2 = ResourceLocator.imageDescriptorFromBundle("org.eclipse.ui", "icons/full/obj16/font.png")
+			i2 = ResourceLocator.imageDescriptorFromBundle("org.eclipse.ui", "icons/full/obj16/font.svg")
 					.orElseThrow(AssertionError::new).createImage();
 			ImageTests.assertEquals(i1, i2);
 		}
@@ -67,7 +67,7 @@ public class EditorIconTest {
 					.getDefaultEditor(
 					"foo.icontest2").getImageDescriptor().createImage();
 			i2 = ResourceLocator.imageDescriptorFromBundle(
-					"org.eclipse.debug.ui", "icons/full/obj16/file_obj.png") // layer breaker!
+					"org.eclipse.debug.ui", "icons/full/obj16/file_obj.svg") // layer breaker!
 					.orElseThrow(AssertionError::new).createImage();
 			ImageTests.assertEquals(i1, i2);
 		}
@@ -89,7 +89,7 @@ public class EditorIconTest {
 		try {
 			i1 = PlatformUI.getWorkbench().getEditorRegistry().getDefaultEditor(
 					"foo.icontest3").getImageDescriptor().createImage();
-			i2 = ResourceLocator.imageDescriptorFromBundle("org.eclipse.ui", "icons/full/obj16/file_obj.png")
+			i2 = ResourceLocator.imageDescriptorFromBundle("org.eclipse.ui", "icons/full/obj16/file_obj.svg")
 					.orElseThrow(AssertionError::new).createImage();
 			ImageTests.assertEquals(i1, i2);
 		}
@@ -109,7 +109,7 @@ public class EditorIconTest {
 	@Test
 	public void testBug395126() {
 		ImageDescriptor imageDescriptor = ResourceLocator.imageDescriptorFromBundle("org.eclipse.jface",
-				"platform:/plugin/org.eclipse.jface/$nl$/icons/full/message_error.png")
+				"platform:/plugin/org.eclipse.jface/$nl$/icons/full/message_error.svg")
 				.orElseThrow(AssertionError::new);
 		Image image = null;
 		try {
@@ -145,7 +145,7 @@ public class EditorIconTest {
 	 */
 	@Test
 	public void testBug474072() throws Exception {
-		URL url = FileLocator.find(new URL("platform:/plugin/org.eclipse.jface/$nl$/icons/full/message_error.png"));
+		URL url = FileLocator.find(new URL("platform:/plugin/org.eclipse.jface/$nl$/icons/full/message_error.svg"));
 		ImageDescriptor imageDescriptor = ResourceLocator.imageDescriptorFromBundle("org.eclipse.jface", url.toString())
 				.orElseThrow(AssertionError::new);
 		Image image = null;
@@ -164,7 +164,7 @@ public class EditorIconTest {
 	 */
 	@Test
 	public void testBug474072_missing() throws Exception {
-		String url = FileLocator.find(new URL("platform:/plugin/org.eclipse.jface/$nl$/icons/full/message_error.png"))
+		String url = FileLocator.find(new URL("platform:/plugin/org.eclipse.jface/$nl$/icons/full/message_error.svg"))
 				.toString();
 		url += "does-not-exist";
 		ImageDescriptor imageDescriptor = ResourceLocator.imageDescriptorFromBundle("org.eclipse.jface", url)

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/MenuHelperTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/MenuHelperTest.java
@@ -57,7 +57,7 @@ public class MenuHelperTest {
 		assertNotNull(uri);
 		// contribution specifies "IMG_OBJ_FOLDER"
 		assertEquals(
-				"platform:/plugin/org.eclipse.ui/icons/full/obj16/fldr_obj.png",
+				"platform:/plugin/org.eclipse.ui/icons/full/obj16/fldr_obj.svg",
 				uri);
 	}
 }

--- a/tests/org.eclipse.ui.tests/plugin.xml
+++ b/tests/org.eclipse.ui.tests/plugin.xml
@@ -716,14 +716,14 @@
  
 	   <editor
             class="org.eclipse.ui.tests.api.MockEditorPart"
-            icon="platform:/plugin/org.eclipse.ui/icons/full/obj16/font.png"
+            icon="platform:/plugin/org.eclipse.ui/icons/full/obj16/font.svg"
             default="true"
             name="Plugin Icon Test 1"
             id="org.eclipse.ui.tests.IconTestEditor1"
             extensions="icontest1"/>            
        <editor
             class="org.eclipse.ui.tests.api.MockEditorPart"
-            icon="platform:/plugin/org.eclipse.debug.ui/icons/full/obj16/file_obj.png"
+            icon="platform:/plugin/org.eclipse.debug.ui/icons/full/obj16/file_obj.svg"
             default="true"
             name="Plugin Icon Test 2"
             id="org.eclipse.ui.tests.IconTestEditor2"


### PR DESCRIPTION
This replaces the PNGs registered in org.eclipse.ui.workbench with SVGs and replaces the usage of pre-generated disabled icons with on-the-fly generated disabled images. It also adapts the initialization of shared images to programmatically create the disabled versions of the icons.