### PR TITLE
Remove unnecessary hover image descriptors

### DIFF
--- a/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/PreviewWizardPage.java
+++ b/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/PreviewWizardPage.java
@@ -130,7 +130,6 @@ public class PreviewWizardPage extends RefactoringWizardPage implements IPreview
 			setId(NEXT_CHANGE_ID);
 			setImageDescriptor(CompareUI.DESC_ETOOL_NEXT);
 			setDisabledImageDescriptor(CompareUI.DESC_DTOOL_NEXT);
-			setHoverImageDescriptor(CompareUI.DESC_CTOOL_NEXT);
 			setToolTipText(RefactoringUIMessages.PreviewWizardPage_next_Change);
 			PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IRefactoringHelpContextIds.NEXT_CHANGE_ACTION);
 		}
@@ -145,7 +144,6 @@ public class PreviewWizardPage extends RefactoringWizardPage implements IPreview
 			setId(PREVIOUS_CHANGE_ID);
 			setImageDescriptor(CompareUI.DESC_ETOOL_PREV);
 			setDisabledImageDescriptor(CompareUI.DESC_DTOOL_PREV);
-			setHoverImageDescriptor(CompareUI.DESC_CTOOL_PREV);
 			setToolTipText(RefactoringUIMessages.PreviewWizardPage_previous_Change);
 			PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IRefactoringHelpContextIds.PREVIOUS_CHANGE_ACTION);
 		}

--- a/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringPluginImages.java
+++ b/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringPluginImages.java
@@ -145,7 +145,6 @@ public class RefactoringPluginImages {
 			action.setDisabledImageDescriptor(id);
 
 		ImageDescriptor descriptor= create("e" + type, relPath, true); //$NON-NLS-1$
-		action.setHoverImageDescriptor(descriptor);
 		action.setImageDescriptor(descriptor);
 	}
 

--- a/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringStatusViewer.java
+++ b/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringStatusViewer.java
@@ -74,7 +74,6 @@ public class RefactoringStatusViewer extends SashForm {
 		public NextProblem() {
 			setImageDescriptor(CompareUI.DESC_ETOOL_NEXT);
 			setDisabledImageDescriptor(CompareUI.DESC_DTOOL_NEXT);
-			setHoverImageDescriptor(CompareUI.DESC_CTOOL_NEXT);
 			setToolTipText(RefactoringUIMessages.ErrorWizardPage_next_Change);
 			PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IRefactoringHelpContextIds.NEXT_PROBLEM_ACTION);
 		}
@@ -97,7 +96,6 @@ public class RefactoringStatusViewer extends SashForm {
 		public PreviousProblem() {
 			setImageDescriptor(CompareUI.DESC_ETOOL_PREV);
 			setDisabledImageDescriptor(CompareUI.DESC_DTOOL_PREV);
-			setHoverImageDescriptor(CompareUI.DESC_CTOOL_PREV);
 			setToolTipText(RefactoringUIMessages.ErrorWizardPage_previous_Change);
 			PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IRefactoringHelpContextIds.PREVIOUS_PROBLEM_ACTION);
 		}

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/CopyToClipboardAction.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/CopyToClipboardAction.java
@@ -61,7 +61,6 @@ public class CopyToClipboardAction extends Action {
 		ISharedImages workbenchImages= PlatformUI.getWorkbench().getSharedImages();
 		setDisabledImageDescriptor(workbenchImages.getImageDescriptor(ISharedImages.IMG_TOOL_COPY_DISABLED));
 		setImageDescriptor(workbenchImages.getImageDescriptor(ISharedImages.IMG_TOOL_COPY));
-		setHoverImageDescriptor(workbenchImages.getImageDescriptor(ISharedImages.IMG_TOOL_COPY));
 
 	}
 

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchPluginImages.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchPluginImages.java
@@ -112,7 +112,6 @@ public class SearchPluginImages {
 		action.setDisabledImageDescriptor(create("d" + type, relPath, false)); //$NON-NLS-1$
 
 		ImageDescriptor desc= create("e" + type, relPath, true); //$NON-NLS-1$
-		action.setHoverImageDescriptor(desc);
 		action.setImageDescriptor(desc);
 	}
 

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/ProjectExplorerFilterActionGroup.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/ProjectExplorerFilterActionGroup.java
@@ -39,7 +39,6 @@ public class ProjectExplorerFilterActionGroup extends FilterActionGroup {
 		String imageFilePath = "icons/full/elcl16/filter_ps.svg"; //$NON-NLS-1$
 		ResourceLocator.imageDescriptorFromBundle(getClass(), imageFilePath).ifPresent(d -> {
 			selectFiltersAction.setImageDescriptor(d);
-			selectFiltersAction.setHoverImageDescriptor(d);
 		});
 	}
 

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/plugin/NavigatorUIPluginImages.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/plugin/NavigatorUIPluginImages.java
@@ -119,11 +119,6 @@ public class NavigatorUIPluginImages {
 	 *            - The relative path of the icon.
 	 */
 	public static void setImageDescriptors(IAction action, String type, String relPath) {
-		// /*relPath= relPath.substring(NAVIGATORUI_NAME_PREFIX_LENGTH);*/
-		// action.setDisabledImageDescriptor(create("d" + type, relPath));
-		// //$NON-NLS-1$
-		// action.setHoverImageDescriptor(create("c" + type, relPath));
-		// //$NON-NLS-1$
 		action.setImageDescriptor(create("e" + type, relPath)); //$NON-NLS-1$
 	}
 

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/CommonNavigatorActionGroup.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/CommonNavigatorActionGroup.java
@@ -115,7 +115,6 @@ public class CommonNavigatorActionGroup extends ActionGroup implements IMementoA
 			String imageFilePath = "icons/full/elcl16/synced.svg"; //$NON-NLS-1$
 			ResourceLocator.imageDescriptorFromBundle(getClass(), imageFilePath).ifPresent(d -> {
 				toggleLinkingAction.setImageDescriptor(d);
-				toggleLinkingAction.setHoverImageDescriptor(d);
 			});
 			service.activateHandler(toggleLinkingAction.getActionDefinitionId(),
 					new ActionHandler(toggleLinkingAction));
@@ -128,7 +127,6 @@ public class CommonNavigatorActionGroup extends ActionGroup implements IMementoA
 			String imageFilePath = "icons/full/elcl16/collapseall.svg"; //$NON-NLS-1$
 			ResourceLocator.imageDescriptorFromBundle(getClass(), imageFilePath).ifPresent(d -> {
 				collapseAllAction.setImageDescriptor(d);
-				collapseAllAction.setHoverImageDescriptor(d);
 			});
 			collapseAllHandler = new CollapseAllHandler(commonViewer);
 			service.activateHandler(CollapseAllHandler.COMMAND_ID, collapseAllHandler);

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/filters/FilterActionGroup.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/filters/FilterActionGroup.java
@@ -144,7 +144,6 @@ public class FilterActionGroup extends ActionGroup implements IMementoAware {
 			String imageFilePath = "icons/full/elcl16/filter_ps.svg"; //$NON-NLS-1$
 			ResourceLocator.imageDescriptorFromBundle(getClass(), imageFilePath).ifPresent(d -> {
 				selectFiltersAction.setImageDescriptor(d);
-				selectFiltersAction.setHoverImageDescriptor(d);
 			});
 			filtersMenu = new MenuManager(CommonNavigatorMessages.FilterActionGroup_RecentFilters);
 			menuListener = manager -> {


### PR DESCRIPTION
All explicit hover images use the same or equal image descriptors than used for the original image of an action rendering them obsolete. This change removes the unnecessary hover image specifications.