### PR TITLE
Use on-the-fly disabled icons in several bundles

### DIFF
--- a/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringPluginImages.java
+++ b/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringPluginImages.java
@@ -140,10 +140,6 @@ public class RefactoringPluginImages {
 	//---- Helper methods to access icons on the file system --------------------------------------
 
 	private static void setImageDescriptors(IAction action, String type, String relPath) {
-		ImageDescriptor id= create("d" + type, relPath, false); //$NON-NLS-1$
-		if (id != null)
-			action.setDisabledImageDescriptor(id);
-
 		ImageDescriptor descriptor= create("e" + type, relPath, true); //$NON-NLS-1$
 		action.setImageDescriptor(descriptor);
 	}

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchPluginImages.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchPluginImages.java
@@ -109,8 +109,6 @@ public class SearchPluginImages {
 	public static void setImageDescriptors(IAction action, String type, String relPath) {
 		relPath= relPath.substring(NAME_PREFIX_LENGTH);
 
-		action.setDisabledImageDescriptor(create("d" + type, relPath, false)); //$NON-NLS-1$
-
 		ImageDescriptor desc= create("e" + type, relPath, true); //$NON-NLS-1$
 		action.setImageDescriptor(desc);
 	}

--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEWorkbenchAdvisor.java
@@ -702,30 +702,16 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 	protected void declareWorkbenchImages() {
 
 		final String ICONS_PATH = "$nl$/icons/full/";//$NON-NLS-1$
-		final String PATH_ELOCALTOOL = ICONS_PATH + "elcl16/"; // Enabled //$NON-NLS-1$
-
-		// toolbar
-		// icons.
-		final String PATH_DLOCALTOOL = ICONS_PATH + "dlcl16/"; // Disabled //$NON-NLS-1$
-		// //$NON-NLS-1$
-		// toolbar
-		// icons.
-		final String PATH_ETOOL = ICONS_PATH + "etool16/"; // Enabled toolbar //$NON-NLS-1$
-		// //$NON-NLS-1$
-		// icons.
-		final String PATH_DTOOL = ICONS_PATH + "dtool16/"; // Disabled toolbar //$NON-NLS-1$
-		// //$NON-NLS-1$
-		// icons.
-		final String PATH_OBJECT = ICONS_PATH + "obj16/"; // Model object //$NON-NLS-1$
-		// //$NON-NLS-1$
-		// icons
-		final String PATH_WIZBAN = ICONS_PATH + "wizban/"; // Wizard //$NON-NLS-1$
-		// //$NON-NLS-1$
-		// icons
-
+		// Local toolbar icons
+		final String PATH_ELOCALTOOL = ICONS_PATH + "elcl16/"; //$NON-NLS-1$
+		// Toolbar icons
+		final String PATH_ETOOL = ICONS_PATH + "etool16/"; //$NON-NLS-1$
+		// Model objects
+		final String PATH_OBJECT = ICONS_PATH + "obj16/"; //$NON-NLS-1$
+		// Wizard icons
+		final String PATH_WIZBAN = ICONS_PATH + "wizban/"; //$NON-NLS-1$
 		// View icons
 		final String PATH_EVIEW= ICONS_PATH + "eview16/"; //$NON-NLS-1$
-
 
 		Bundle ideBundle = Platform.getBundle(IDEWorkbenchPlugin.IDE_WORKBENCH);
 
@@ -734,20 +720,16 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 						+ "build_exec.svg", false); //$NON-NLS-1$
 		declareWorkbenchImage(ideBundle,
 				IDEInternalWorkbenchImages.IMG_ETOOL_BUILD_EXEC_HOVER,
-				PATH_ETOOL + "build_exec.svg", false); //$NON-NLS-1$
-		declareWorkbenchImage(ideBundle,
 				IDEInternalWorkbenchImages.IMG_ETOOL_BUILD_EXEC_DISABLED,
-				PATH_DTOOL + "build_exec.png", false); //$NON-NLS-1$
+				PATH_ETOOL + "build_exec.svg", false); //$NON-NLS-1$
 
 		declareWorkbenchImage(ideBundle,
 				IDEInternalWorkbenchImages.IMG_ETOOL_SEARCH_SRC, PATH_ETOOL
 						+ "search_src.svg", false); //$NON-NLS-1$
 		declareWorkbenchImage(ideBundle,
 				IDEInternalWorkbenchImages.IMG_ETOOL_SEARCH_SRC_HOVER,
-				PATH_ETOOL + "search_src.svg", false); //$NON-NLS-1$
-		declareWorkbenchImage(ideBundle,
 				IDEInternalWorkbenchImages.IMG_ETOOL_SEARCH_SRC_DISABLED,
-				PATH_DTOOL + "search_src.png", false); //$NON-NLS-1$
+				PATH_ETOOL + "search_src.svg", false); //$NON-NLS-1$
 
 		declareWorkbenchImage(ideBundle,
 				IDEInternalWorkbenchImages.IMG_ETOOL_NEXT_NAV, PATH_ETOOL
@@ -812,11 +794,8 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 		// Quick fix icons
 		declareWorkbenchImage(ideBundle,
 				IDEInternalWorkbenchImages.IMG_ELCL_QUICK_FIX_ENABLED,
-				PATH_ELOCALTOOL + "smartmode_co.svg", true); //$NON-NLS-1$
-
-		declareWorkbenchImage(ideBundle,
 				IDEInternalWorkbenchImages.IMG_DLCL_QUICK_FIX_DISABLED,
-				PATH_DLOCALTOOL + "smartmode_co.png", true); //$NON-NLS-1$
+				PATH_ELOCALTOOL + "smartmode_co.svg", true); //$NON-NLS-1$
 
 		declareWorkbenchImage(ideBundle,
 				IDEInternalWorkbenchImages.IMG_OBJS_FIXABLE_WARNING,
@@ -904,9 +883,18 @@ public class IDEWorkbenchAdvisor extends WorkbenchAdvisor {
 	 */
 	protected void declareWorkbenchImage(Bundle ideBundle, String symbolicName,
 			String path, boolean shared) {
+		declareWorkbenchImage(ideBundle, symbolicName, null, path, shared);
+	}
+
+	private void declareWorkbenchImage(Bundle ideBundle, String symbolicName, String disabledSymbolicName, String path,
+			boolean shared) {
 		URL url = FileLocator.find(ideBundle, IPath.fromOSString(path), null);
 		ImageDescriptor desc = ImageDescriptor.createFromURL(url);
 		getWorkbenchConfigurer().declareImage(symbolicName, desc, shared);
+		if (disabledSymbolicName != null) {
+			ImageDescriptor disabledDescriptor = ImageDescriptor.createWithFlags(desc, SWT.IMAGE_DISABLE);
+			getWorkbenchConfigurer().declareImage(disabledSymbolicName, disabledDescriptor, shared);
+		}
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ExtendedMarkersView.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ExtendedMarkersView.java
@@ -367,10 +367,6 @@ public class ExtendedMarkersView extends ViewPart {
 		if (id != null) {
 			filterAction.setImageDescriptor(id);
 		}
-		id = IDEWorkbenchPlugin.getIDEImageDescriptor("/dlcl16/filter_ps.png"); //$NON-NLS-1$
-		if (id != null) {
-			filterAction.setDisabledImageDescriptor(id);
-		}
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/ResourceMgmtActionProvider.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/ResourceMgmtActionProvider.java
@@ -251,7 +251,6 @@ public class ResourceMgmtActionProvider extends CommonActionProvider {
 				job.schedule();
 			}
 		};
-		refreshAction.setDisabledImageDescriptor(getImageDescriptor("dlcl16/refresh_nav.png"));//$NON-NLS-1$
 		refreshAction.setImageDescriptor(getImageDescriptor("elcl16/refresh_nav.svg"));//$NON-NLS-1$
 		refreshAction.setActionDefinitionId(IWorkbenchCommandConstants.FILE_REFRESH);
 

--- a/tests/org.eclipse.ui.tests.views.properties.tabbed/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.views.properties.tabbed/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.tests.views.properties.tabbed;singleton:=true
-Bundle-Version: 3.8.400.qualifier
+Bundle-Version: 3.8.500.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.eclipse.ui.tests.views.properties.tabbed/src/org/eclipse/ui/tests/views/properties/tabbed/dynamic/views/DynamicTestsView.java
+++ b/tests/org.eclipse.ui.tests.views.properties.tabbed/src/org/eclipse/ui/tests/views/properties/tabbed/dynamic/views/DynamicTestsView.java
@@ -161,7 +161,6 @@ public class DynamicTestsView extends ViewPart implements
 		};
 		staticAction.setToolTipText(staticText);
 		staticAction.setImageDescriptor(imageDescriptor);
-		staticAction.setDisabledImageDescriptor(imageDescriptor);
 
 		dynamicSectionsAction = new Action(dynamicSectionsText,
 				IAction.AS_CHECK_BOX) {
@@ -178,7 +177,6 @@ public class DynamicTestsView extends ViewPart implements
 		};
 		dynamicSectionsAction.setToolTipText(dynamicSectionsText);
 		dynamicSectionsAction.setImageDescriptor(imageDescriptor);
-		dynamicSectionsAction.setDisabledImageDescriptor(imageDescriptor);
 
 		dynamicTabsAction = new Action(dynamicTabsText, IAction.AS_CHECK_BOX) {
 			@Override


### PR DESCRIPTION
This replaces the usage of pre-generated disabled icons in different bundles. Most of the images / image descriptors were not reused anyway, so setting them at different actions is simply removes. Some shared image descriptors are adapted to generate the disabled version of the shared icon programmatically.