### PR TITLE
Handle paths illegal on Windows in ImageDescriptor.createFromFile()

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageDescriptor.java
@@ -16,9 +16,9 @@ package org.eclipse.jface.resource;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.nio.file.Path;
 import java.util.function.Supplier;
 
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.util.Policy;
 import org.eclipse.swt.SWTException;
 import org.eclipse.swt.graphics.Device;
@@ -92,7 +92,8 @@ public abstract class ImageDescriptor extends DeviceResourceDescriptor<Image> {
 		URL url;
 		if (location == null) {
 			try {
-				url = Path.of(filename).toUri().toURL();
+				// Use IPath, which can handle illegal path's on Windows like: /C:/data/other
+				url = IPath.fromOSString(filename).toPath().toUri().toURL();
 			} catch (MalformedURLException e) {
 				Policy.logException(e);
 				url = null;

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/FileImageDescriptorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/FileImageDescriptorTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.URL;
@@ -55,7 +54,7 @@ public class FileImageDescriptorTest {
 	 * Test loading the image descriptors.
 	 */
 	@Test
-	public void testFileImageDescriptorWorkbench() {
+	public void testFileImageDescriptorWorkbench() throws IOException {
 
 		Class<?> missing = null;
 		ArrayList<Image> images = new ArrayList<>();
@@ -64,7 +63,6 @@ public class FileImageDescriptorTest {
 		Enumeration<String> bundleEntries = bundle.getEntryPaths(IMAGES_DIRECTORY);
 
 		while (bundleEntries.hasMoreElements()) {
-			ImageDescriptor descriptor;
 			String localImagePath = bundleEntries.nextElement();
 			URL[] files = FileLocator.findEntries(bundle, IPath.fromOSString(localImagePath));
 
@@ -75,12 +73,8 @@ public class FileImageDescriptorTest {
 					continue;
 				}
 
-				try {
-					descriptor = ImageDescriptor.createFromFile(missing, FileLocator.toFileURL(file).getFile());
-				} catch (IOException e) {
-					fail(e.getLocalizedMessage());
-					continue;
-				}
+				ImageDescriptor descriptor = ImageDescriptor.createFromFile(missing,
+						FileLocator.toFileURL(file).getFile());
 
 				Image image = descriptor.createImage();
 				images.add(image);


### PR DESCRIPTION
Handle filenames, that are used as file-system paths because the context class is null and are illegal on Windows, for example like: `/C:/data/other`

This happens if retrieved from a URL/URI by just using `URL/URI.getPath()` instead of using `Path.of(uri)` or `new File(uri)`.

Using `IPath.fromOSString()` instead of `Path.of()`, allows to use these kind of illegal paths.

This fixes the test-failure introduced in
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/2899#issuecomment-2833461917