### PR TITLE
Set size of InformationControl before setLocation

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/AbstractInformationControlManager.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/AbstractInformationControlManager.java
@@ -1185,8 +1185,8 @@ abstract public class AbstractInformationControlManager {
 			cropToClosestMonitor(controlBounds);
 			location= Geometry.getLocation(controlBounds);
 			size= Geometry.getSize(controlBounds);
-			informationControl.setLocation(location);
 			informationControl.setSize(size.x, size.y);
+			informationControl.setLocation(location);
 
 			showInformationControl(subjectArea);
 		}


### PR DESCRIPTION
This PR changes the order of how size and location of a newly created InformationControl is set. The order must be setSize followed by setLocation as setting location of the control first could cause DPI_CHANGE events in win32 since the OS is responsible for providing the size to the control o creation and tthis size can be very big spanning across multiple monitors.

contributes to
https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/127