### PR TITLE
Newer Workspace Version popup dialog ui alignment changes.

### DIFF
--- a/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
+++ b/bundles/org.eclipse.ui.ide.application/src/org/eclipse/ui/internal/ide/application/IDEApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2020 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -56,6 +56,8 @@ import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
@@ -726,6 +728,17 @@ public class IDEApplication implements IApplication, IExecutableExtension {
 			buttonLabelToId.put(IDEWorkbenchMessages.IDEApplication_version_exit, IDialogConstants.CLOSE_ID);
 			MessageDialogWithToggle dialog = new MessageDialogWithToggle(shell, title, null, message, severity,
 					buttonLabelToId, 0, IDEWorkbenchMessages.IDEApplication_version_doNotWarnAgain, false) {
+				@Override
+				protected Control createDialogArea(Composite parent) {
+					Composite composite = (Composite) super.createDialogArea(parent);
+					Button toggle = getToggleButton();
+					if (toggle != null && !toggle.isDisposed()) {
+						GridData toggleData = new GridData(SWT.BEGINNING, SWT.TOP, false, false);
+						toggleData.horizontalIndent = 50;
+						toggle.setLayoutData(toggleData);
+					}
+					return composite;
+				}
 				@Override
 				protected Shell getParentShell() {
 					// Bug 429308: Make workspace selection dialog visible


### PR DESCRIPTION
Before the fix the dialog used to show up as 
![image](https://github.com/user-attachments/assets/2445896e-b0c3-4fac-8ce5-8dc22ba393c4)


After the fix the dialog now is showed up as 
![image](https://github.com/user-attachments/assets/c0dab43a-2fcc-4950-a0c6-d20f52934baf)


This popup dialog basically comes when a workspace for example already used/edited/saved in 4.36 and now attempted to open with an older eclipse say 4.35 or lower, this pop up shows up. 

Change 1 : check box is aligned.
Change 2 : Button bar is center aligned.

Here we are changing the behavior of the current popup dialog leaving the original dialog alignments as-is.