### PR TITLE
Fix Icon Size in Text Editor Search Overlay

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/icons/full/elcl16/search_all.svg
+++ b/bundles/org.eclipse.ui.workbench.texteditor/icons/full/elcl16/search_all.svg
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
    version="1"
-   viewBox="0 0 48 48"
+   viewBox="0 0 16 16"
    enable-background="new 0 0 48 48"
    id="svg440"
-   sodipodi:docname="search.svg"
+   sodipodi:docname="search_all.svg"
    inkscape:export-filename="search.png"
    inkscape:export-xdpi="32"
    inkscape:export-ydpi="32"
-   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   width="16"
+   height="16"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -25,81 +27,64 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="20.875"
-     inkscape:cx="13.844311"
-     inkscape:cy="24.670659"
-     inkscape:window-width="3440"
-     inkscape:window-height="1369"
-     inkscape:window-x="1912"
-     inkscape:window-y="-8"
+     inkscape:zoom="29.521708"
+     inkscape:cx="8.9086986"
+     inkscape:cy="9.1288756"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg440" />
-  <g
-     fill="#616161"
-     id="g432"
-     transform="translate(-3.3053892,3.3532934)"
-     style="fill:#979797;fill-opacity:1">
-    <rect
-       x="34.599998"
-       y="28.1"
-       transform="matrix(0.707,-0.707,0.707,0.707,-15.154,36.586)"
-       width="4"
-       height="17"
-       id="rect428"
-       style="fill:#979797;fill-opacity:1" />
-    <circle
-       cx="20"
-       cy="20"
-       r="16"
-       id="circle430"
-       style="fill:#979797;fill-opacity:1" />
-  </g>
-  <circle
-     fill="#64b5f6"
-     cx="16.694611"
-     cy="23.353292"
-     r="13"
-     id="circle436"
-     style="fill:#9dcff7;fill-opacity:1" />
-  <path
-     fill="#bbdefb"
-     d="m 23.594611,17.553293 c -1.7,-2 -4.2,-3.2 -6.9,-3.2 -2.7,0 -5.2,1.2 -6.9000002,3.2 -0.4,0.4 -0.3,1.1 0.1,1.4 0.4000002,0.4 1.1000002,0.3 1.4000002,-0.1 1.4,-1.6 3.3,-2.5 5.4,-2.5 2.1,0 4,0.9 5.4,2.5 0.2,0.2 0.5,0.4 0.8,0.4 0.2,0 0.5,-0.1 0.6,-0.2 0.4,-0.4 0.4,-1.1 0.1,-1.5 z"
-     id="path438" />
-  <g
-     fill="#616161"
-     id="g432-0"
-     transform="translate(3.7734817,-2.8790029)">
-    <rect
-       x="34.599998"
-       y="28.1"
-       transform="matrix(0.707,-0.707,0.707,0.707,-15.154,36.586)"
-       width="4"
-       height="17"
-       id="rect428-2"
-       style="fill:#979797;fill-opacity:1" />
-    <circle
-       cx="20"
-       cy="20"
-       r="16"
-       id="circle430-3"
-       style="fill:#979797;fill-opacity:1" />
-  </g>
-  <circle
-     fill="#64b5f6"
-     cx="23.773481"
-     cy="17.120995"
-     r="13"
-     id="circle436-5"
-     style="fill:#9dcff7;fill-opacity:1" />
-  <path
-     fill="#bbdefb"
-     d="m 30.673482,11.320997 c -1.7,-1.9999999 -4.2,-3.1999999 -6.9,-3.1999999 -2.7,0 -5.2,1.2 -6.9,3.1999999 -0.4,0.4 -0.3,1.1 0.1,1.4 0.4,0.4 1.1,0.3 1.4,-0.1 1.4,-1.6 3.3,-2.5 5.4,-2.5 2.1,0 4,0.9 5.4,2.5 0.2,0.2 0.5,0.4 0.8,0.4 0.2,0 0.5,-0.1 0.6,-0.2 0.4,-0.4 0.4,-1.1 0.1,-1.5 z"
-     id="path438-4" />
+  <rect
+     x="-1.7135983"
+     y="14.228544"
+     transform="matrix(0.67927442,-0.73388437,0.67927442,0.73388437,0,0)"
+     width="1.2841617"
+     height="5.4576874"
+     id="rect428"
+     style="fill:#979797;fill-opacity:1;stroke-width:1.00134" />
   <ellipse
-     style="fill:#00ffff;fill-rule:evenodd"
-     id="path700"
-     cx="-16.167665"
-     cy="34.059879"
-     rx="0.11976048"
-     ry="0.095808387" />
+     cx="5.6710796"
+     cy="7.7038746"
+     id="circle430"
+     style="fill:#979797;fill-opacity:1;stroke-width:0.999998"
+     rx="4.9352088"
+     ry="5.3319726" />
+  <ellipse
+     fill="#64b5f6"
+     cx="5.6710796"
+     cy="7.7038732"
+     id="circle436"
+     style="fill:#9dcff7;fill-opacity:1;stroke-width:0.999999"
+     rx="4.0098577"
+     ry="4.3322282" />
+  <rect
+     x="1.3086243"
+     y="14.420753"
+     transform="matrix(0.67927442,-0.73388437,0.67927442,0.73388437,0,0)"
+     width="1.2841617"
+     height="5.4576874"
+     id="rect428-2"
+     style="fill:#979797;fill-opacity:1;stroke-width:1.00134" />
+  <ellipse
+     cx="7.8545613"
+     cy="5.6269727"
+     id="circle430-3"
+     style="fill:#979797;fill-opacity:1;stroke-width:0.999998"
+     rx="4.9352088"
+     ry="5.3319726" />
+  <ellipse
+     fill="#64b5f6"
+     cx="7.8545613"
+     cy="5.6269693"
+     id="circle436-5"
+     style="fill:#9dcff7;fill-opacity:1;stroke-width:0.999999"
+     rx="4.0098577"
+     ry="4.3322282" />
+  <path
+     fill="#bbdefb"
+     d="M 9.9828703,3.6941317 C 9.4585045,3.027636 8.6873775,2.627738 7.8545613,2.627738 c -0.8328164,0 -1.603943,0.399898 -2.1283088,1.0663937 -0.1233802,0.1332993 -0.092534,0.3665736 0.030844,0.4665484 0.1233803,0.1332995 0.3392956,0.099968 0.4318308,-0.033327 0.4318308,-0.5331976 1.017887,-0.8331209 1.6656327,-0.8331209 0.6477474,0 1.2338028,0.2999233 1.6656331,0.8331209 0.061697,0.066654 0.1542271,0.1332981 0.2467617,0.1332981 0.061697,0 0.1542242,-0.033327 0.1850696,-0.066654 0.1233816,-0.1332993 0.1233816,-0.3665736 0.030848,-0.499873 z"
+     id="path438-4"
+     style="stroke-width:0.999999" />
 </svg>


### PR DESCRIPTION
This PR fixes the icon size of the icon `search_all.svg` in the bundle `org.eclipse.ui.workbench.texteditor` as described in the regression [issue](https://github.com/eclipse-platform/eclipse.platform.ui/issues/2951) for the following merged [PR](https://github.com/eclipse-platform/eclipse.platform.ui/pull/2924).

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2951.

Before:
![image](https://github.com/user-attachments/assets/f5774a80-2303-46b7-bbc3-798c1e9dc878)

After:
![image](https://github.com/user-attachments/assets/61d65a35-1b76-4c60-b38c-e150c2f6dc80)
