### PR TITLE
Replacing usages of Image(Display, Rectangle)

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench3/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench3/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench3;singleton:=true
-Bundle-Version: 0.17.400.qualifier
+Bundle-Version: 0.17.500.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench3/src/org/eclipse/ui/testing/dumps/TimeoutDumpTimer.java
+++ b/bundles/org.eclipse.e4.ui.workbench3/src/org/eclipse/ui/testing/dumps/TimeoutDumpTimer.java
@@ -42,6 +42,7 @@ import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageLoader;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
@@ -285,7 +286,8 @@ public class TimeoutDumpTimer extends TimerTask {
 
 					// Take a screenshot:
 					GC gc = new GC(display);
-					final Image image = new Image(display, display.getBounds());
+					Rectangle bounds = display.getBounds();
+					final Image image = new Image(display, bounds.width, bounds.height);
 					gc.copyArea(image, 0, 0);
 					gc.dispose();
 

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/jface/tests/internal/databinding/swt/Screenshots.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/jface/tests/internal/databinding/swt/Screenshots.java
@@ -89,7 +89,7 @@ public class Screenshots {
 		GC gc = new GC(display);
 		Rectangle displayBounds= display.getBounds();
 		out.println("Display @ " + displayBounds);
-		final Image image = new Image(display, displayBounds);
+		final Image image = new Image(display, displayBounds.width, displayBounds.height);
 		gc.copyArea(image, 0, 0);
 		gc.dispose();
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/AbstractFactoryTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/AbstractFactoryTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.jface.tests.widgets;
 
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -27,7 +26,7 @@ public class AbstractFactoryTest {
 
 	@BeforeClass
 	public static void classSetup() {
-		image = new Image(null, new Rectangle(1, 1, 1, 1));
+		image = new Image(null, 1, 1);
 	}
 
 	@Before

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/ScreenshotTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/ScreenshotTest.java
@@ -117,7 +117,7 @@ public class ScreenshotTest {
 		GC gc = new GC(display);
 		Rectangle displayBounds= display.getBounds();
 		out.println("Display @ " + displayBounds);
-		final Image image = new Image(display, displayBounds);
+		final Image image= new Image(display, displayBounds.width, displayBounds.height);
 		gc.copyArea(image, 0, 0);
 		gc.dispose();
 


### PR DESCRIPTION
Replacing usages of Image(Display, Rectangle) in favor of Image(Display, int ,int) since the prior one is getting deprecated.

Note to myself (@fedejeanne): merge this PR **before** (or at least together with) https://github.com/eclipse-platform/eclipse.platform.swt/pull/2088 so we don't see unnecessary warnings about deprecation/removal.