### PR TITLE
Prevent shutdown hang when changing theme and disabling theming

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
@@ -381,6 +381,10 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 			WorkbenchPlugin.log("Failed to set SWT renderer preferences", e); //$NON-NLS-1$
 		}
 
+		boolean showRestartDialog = false;
+		String restartDialogTitle = null;
+		String restartDialogMessage = null;
+
 		if (engine != null) {
 			ITheme theme = getSelectedTheme();
 			boolean themeChanged = theme != null && !theme.equals(currentTheme);
@@ -400,15 +404,24 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 			colorFontsDecorator.hide();
 
 			if (themeChanged || colorsAndFontsThemeChanged) {
-				showRestartDialog(WorkbenchMessages.ThemeChangeWarningTitle, WorkbenchMessages.ThemeChangeWarningText);
+				showRestartDialog = true;
+				restartDialogTitle = WorkbenchMessages.ThemeChangeWarningTitle;
+				restartDialogMessage = WorkbenchMessages.ThemeChangeWarningText;
 			}
 		}
 		if (themingEnabledChanged) {
-			showRestartDialog(WorkbenchMessages.ThemeChangeWarningTitle, WorkbenchMessages.ThemeChangeWarningText);
+			showRestartDialog = true;
+			restartDialogTitle = WorkbenchMessages.ThemeChangeWarningTitle;
+			restartDialogMessage = WorkbenchMessages.ThemeChangeWarningText;
 		}
 		if (isRescaleAtRuntimeChanged) {
-			showRestartDialog(WorkbenchMessages.RescaleAtRuntimeSettingChangeWarningTitle,
-					WorkbenchMessages.RescaleAtRuntimeSettingChangeWarningText);
+			showRestartDialog = true;
+			restartDialogTitle = WorkbenchMessages.RescaleAtRuntimeSettingChangeWarningTitle;
+			restartDialogMessage = WorkbenchMessages.RescaleAtRuntimeSettingChangeWarningText;
+		}
+
+		if (showRestartDialog) {
+			showRestartDialog(restartDialogTitle, restartDialogMessage);
 		}
 
 		return super.performOk();


### PR DESCRIPTION
When changing the current theme via the Appearance preference page, and disabling theming, two calls to IWorkbench.restart() are triggered during ViewsPreferencePage.performOk(). This results in a hang at shutdown, during the second restart call.

This change ensures only one restart is triggered, preventing the hang.

Fixes: #2950