### PR TITLE
Fix SVG icons for import/export preferences #2956

### DIFF
--- a/bundles/org.eclipse.ui/icons/full/pref/export_wiz.svg
+++ b/bundles/org.eclipse.ui/icons/full/pref/export_wiz.svg
@@ -2,853 +2,114 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="75"
-   height="66"
+   width="24"
+   height="24"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
    sodipodi:docname="export_wiz.svg"
-   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
-   inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4432">
+       id="provider-bg-6">
       <stop
-         style="stop-color:#ced8e7;stop-opacity:1;"
+         style="stop-color:#85a2cd;stop-opacity:1;"
          offset="0"
-         id="stop4434" />
+         id="stop4923" />
       <stop
-         style="stop-color:#b7c5e0;stop-opacity:1"
+         style="stop-color:#d3dce9;stop-opacity:1;"
          offset="1"
-         id="stop4436" />
+         id="stop4925" />
+    </linearGradient>
+    <linearGradient
+       id="provider-stroke-7">
+      <stop
+         style="stop-color:#4e6b9b;stop-opacity:1"
+         offset="0"
+         id="stop4915" />
+      <stop
+         style="stop-color:#6783b1;stop-opacity:1"
+         offset="1"
+         id="stop4917" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient4420">
-      <stop
-         style="stop-color:#5b7aaa;stop-opacity:1"
-         offset="0"
-         id="stop4422" />
-      <stop
-         style="stop-color:#96aaca;stop-opacity:1"
-         offset="1"
-         id="stop4424" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4541">
-      <stop
-         style="stop-color:#a1adb2;stop-opacity:1"
-         offset="0"
-         id="stop4543" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4545" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4972">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0"
-         id="stop4974" />
-      <stop
-         style="stop-color:#f5f8fd;stop-opacity:1"
-         offset="1"
-         id="stop4976" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4964">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0"
-         id="stop4966" />
-      <stop
-         style="stop-color:#e8eefa;stop-opacity:1"
-         offset="1"
-         id="stop4968" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4956">
-      <stop
-         style="stop-color:#fcfdfe;stop-opacity:1"
-         offset="0"
-         id="stop4958" />
-      <stop
-         style="stop-color:#dee6f8;stop-opacity:1"
-         offset="1"
-         id="stop4960" />
-    </linearGradient>
-    <filter
-       style="color-interpolation-filters:sRGB"
-       inkscape:label="Drop Shadow"
-       id="filter8854">
-      <feFlood
-         flood-opacity="0.933333"
-         flood-color="rgb(244,248,254)"
-         result="flood"
-         id="feFlood8856" />
-      <feComposite
-         in="flood"
-         in2="SourceGraphic"
-         operator="in"
-         result="composite1"
-         id="feComposite8858" />
-      <feGaussianBlur
-         in="composite1"
-         stdDeviation="1.2"
-         result="blur"
-         id="feGaussianBlur8860" />
-      <feOffset
-         dx="-1"
-         dy="3"
-         result="offset"
-         id="feOffset8862" />
-      <feComposite
-         in="SourceGraphic"
-         in2="offset"
-         operator="over"
-         result="composite2"
-         id="feComposite8864" />
-    </filter>
-    <linearGradient
-       id="linearGradient6122">
-      <stop
-         style="stop-color:#c0c0c0;stop-opacity:1"
-         offset="0"
-         id="stop6124" />
-      <stop
-         id="stop6132"
-         offset="0.5"
-         style="stop-color:#adadad;stop-opacity:1" />
-      <stop
-         style="stop-color:#808080;stop-opacity:1"
-         offset="1"
-         id="stop6126" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7087">
-      <stop
-         style="stop-color:#17325d;stop-opacity:1;"
-         offset="0"
-         id="stop7089" />
-      <stop
-         id="stop7091"
-         offset="0.25"
-         style="stop-color:#b4d0e2;stop-opacity:1" />
-      <stop
-         id="stop7093"
-         offset="0.5"
-         style="stop-color:#b7d2e4;stop-opacity:1" />
-      <stop
-         style="stop-color:#acc9de;stop-opacity:1"
-         offset="0.75"
-         id="stop7095" />
-      <stop
-         style="stop-color:#3e72a7;stop-opacity:1"
-         offset="1"
-         id="stop7097" />
-    </linearGradient>
-    <mask
-       id="mask7366"
-       maskUnits="userSpaceOnUse">
-      <path
-         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
-         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
-         id="path7368"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccc" />
-    </mask>
-    <linearGradient
-       id="linearGradient7584-5">
-      <stop
-         id="stop7586-4"
-         offset="0"
-         style="stop-color:#f9cd5f;stop-opacity:1" />
-      <stop
-         id="stop7588-5"
-         offset="1"
-         style="stop-color:#fbf0b4;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7592-1">
-      <stop
-         id="stop7594-6"
-         offset="0"
-         style="stop-color:#bd8416;stop-opacity:1" />
-      <stop
-         id="stop7596-9"
-         offset="1"
-         style="stop-color:#a66b10;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
-      <stop
-         style="stop-color:#5aad60;stop-opacity:1;"
-         offset="0"
-         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
-      <stop
-         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
-         offset="0.5"
-         style="stop-color:#5bb26a;stop-opacity:1;" />
-      <stop
-         style="stop-color:#a4c589;stop-opacity:1"
-         offset="1"
-         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
-    </linearGradient>
-    <mask
-       maskUnits="userSpaceOnUse"
-       id="mask7366-4">
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path7368-2"
-         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
-         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
-    </mask>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7087"
-       id="linearGradient9331"
+       xlink:href="#provider-stroke-7"
+       id="linearGradient4919"
+       x1="1.860189"
+       y1="1051.5892"
+       x2="1.860189"
+       y2="1046.8492"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-20,0)"
-       x1="4.7776356"
-       y1="1039.8118"
-       x2="4.7776356"
-       y2="1041.911" />
+       gradientTransform="matrix(1.0234842,0,0,1.0234842,-17.402505,-25.185931)" />
     <linearGradient
-       y2="1041.911"
-       x2="4.7776356"
-       y1="1039.8118"
-       x1="4.7776356"
-       gradientTransform="translate(-18,4.7e-5)"
+       inkscape:collect="always"
+       xlink:href="#provider-bg-6"
+       id="linearGradient4927"
+       x1="1.860189"
+       y1="1051.5892"
+       x2="1.860189"
+       y2="1046.8492"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient9333"
-       xlink:href="#linearGradient7087"
+       gradientTransform="matrix(1.0234842,0,0,1.0234842,-17.402505,-25.185931)" />
+    <linearGradient
+       id="arrow-bg-3">
+      <stop
+         style="stop-color:#4e8fbd;stop-opacity:1;"
+         offset="0"
+         id="stop4791" />
+      <stop
+         style="stop-color:#8dacc3;stop-opacity:1"
+         offset="1"
+         id="stop4793" />
+    </linearGradient>
+    <linearGradient
+       y2="1049.5981"
+       x2="-2.2873085"
+       y1="1044.6919"
+       x1="-2.2873085"
+       gradientTransform="matrix(1.0493833,1.0493833,1.0493833,-1.0493833,-1079.5505,2143.7383)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3924"
+       xlink:href="#arrow-bg-3"
        inkscape:collect="always" />
-    <linearGradient
-       y2="1041.911"
-       x2="4.7776356"
-       y1="1039.8118"
-       x1="4.7776356"
-       gradientTransform="translate(-16,4.7e-5)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient9335"
-       xlink:href="#linearGradient7087"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1041.911"
-       x2="4.7776356"
-       y1="1039.8118"
-       x1="4.7776356"
-       gradientTransform="translate(-14,4.7e-5)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient9337"
-       xlink:href="#linearGradient7087"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1041.911"
-       x2="4.7776356"
-       y1="1039.8118"
-       x1="4.7776356"
-       gradientTransform="translate(-12,4.7e-5)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient9339"
-       xlink:href="#linearGradient7087"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-80,0)"
-       gradientUnits="userSpaceOnUse"
-       y2="1042.7973"
-       x2="163.22012"
-       y1="1042.7973"
-       x1="88.220117"
-       id="linearGradient68073"
-       xlink:href="#linearGradient4956"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-80,0)"
-       gradientUnits="userSpaceOnUse"
-       y2="1032.2669"
-       x2="163.22012"
-       y1="1032.2668"
-       x1="94.469681"
-       id="linearGradient68075"
-       xlink:href="#linearGradient4964"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-80,0)"
-       gradientUnits="userSpaceOnUse"
-       y2="1032.2668"
-       x2="152.72206"
-       y1="1032.2668"
-       x1="88.220116"
-       id="linearGradient68077"
-       xlink:href="#linearGradient4972"
-       inkscape:collect="always" />
-    <filter
-       id="filter8854-9"
-       inkscape:label="Drop Shadow"
-       style="color-interpolation-filters:sRGB">
-      <feFlood
-         id="feFlood8856-0"
-         result="flood"
-         flood-color="rgb(244,248,254)"
-         flood-opacity="0.933333" />
-      <feComposite
-         id="feComposite8858-2"
-         result="composite1"
-         operator="in"
-         in2="SourceGraphic"
-         in="flood" />
-      <feGaussianBlur
-         id="feGaussianBlur8860-3"
-         result="blur"
-         stdDeviation="1.2"
-         in="composite1" />
-      <feOffset
-         id="feOffset8862-2"
-         result="offset"
-         dy="3"
-         dx="-1" />
-      <feComposite
-         id="feComposite8864-3"
-         result="composite2"
-         operator="over"
-         in2="offset"
-         in="SourceGraphic" />
-    </filter>
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
-      <stop
-         id="stop10800-5-2-1-8-20-6-4-9-8-2"
-         offset="0"
-         style="stop-color:#7564b1;stop-opacity:1" />
-      <stop
-         style="stop-color:#5d4aa1;stop-opacity:1"
-         offset="0.5"
-         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
-      <stop
-         id="stop10802-1-5-3-0-4-8-4-2-9-2"
-         offset="1"
-         style="stop-color:#9283c3;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7540-2-3-8-7">
-      <stop
-         id="stop7542-8-7-5-3"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:0.502" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0.47623286"
-         id="stop7544-8-2-0-5" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="0.5"
-         id="stop7546-1-7-9-5" />
-      <stop
-         id="stop7548-98-9-2-4"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient7272-66-4-5-5-5-8">
-      <stop
-         style="stop-color:#8f6c10;stop-opacity:1"
-         offset="0"
-         id="stop7274-6-0-1-7-4-7" />
-      <stop
-         style="stop-color:#c9a645;stop-opacity:1"
-         offset="1"
-         id="stop7276-66-6-3-9-1-4" />
-    </linearGradient>
-    <linearGradient
-       y2="1030.3411"
-       x2="-10.159802"
-       y1="1030.3411"
-       x1="-22.453552"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient10540"
-       xlink:href="#linearGradient7540-2-3-8-7"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1030.3411"
-       x2="-10.159802"
-       y1="1030.3411"
-       x1="-22.453552"
-       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient10542"
-       xlink:href="#linearGradient7540-2-3-8-7"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1023.2569"
-       x2="-15.945988"
-       y1="1037.4661"
-       x1="-15.945988"
-       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient10544"
-       xlink:href="#linearGradient7272-66-4-5-5-5-8"
-       inkscape:collect="always" />
-    <mask
-       id="mask10620"
-       maskUnits="userSpaceOnUse">
-      <path
-         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
-         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
-         sodipodi:ry="10.625"
-         sodipodi:rx="10.625"
-         sodipodi:cy="468.23718"
-         sodipodi:cx="388.125"
-         id="path10622"
-         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
-         sodipodi:type="arc" />
-    </mask>
-    <linearGradient
-       id="linearGradient4528-9-5-7-9-7-3">
-      <stop
-         id="stop4530-0-5-0-5-8-4"
-         offset="0"
-         style="stop-color:#e0c576;stop-opacity:1;" />
-      <stop
-         id="stop4532-7-9-3-3-6-1"
-         offset="1"
-         style="stop-color:#9e7916;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
-      <stop
-         style="stop-color:#f7f9fb;stop-opacity:1"
-         offset="0"
-         id="stop6283-0-2-2-1-2-0-1-6-0" />
-      <stop
-         style="stop-color:#ffd680;stop-opacity:1"
-         offset="1"
-         id="stop6285-5-0-9-7-6-9-9-1-9" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4972-7"
-       id="linearGradient4978"
-       x1="88.220116"
-       y1="1032.2668"
-       x2="163.22012"
-       y2="1032.2668"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-88.220116,-999.2669)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4972-7">
-      <stop
-         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
-         offset="0"
-         id="stop4974-8" />
-      <stop
-         style="stop-color:#6e97e2;stop-opacity:0.10196079"
-         offset="1"
-         id="stop4976-1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4964-3"
-       id="linearGradient4970"
-       x1="118.38584"
-       y1="1032.1835"
-       x2="163.22012"
-       y2="1032.2668"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-88.220117,-999.2669)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4964-3">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.349"
-         offset="0"
-         id="stop4966-1" />
-      <stop
-         style="stop-color:#91ade6;stop-opacity:1"
-         offset="1"
-         id="stop4968-1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4956-2"
-       id="linearGradient4962"
-       x1="88.220116"
-       y1="1042.7972"
-       x2="163.22012"
-       y2="1042.7972"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-88.220116,-999.2669)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4956-2">
-      <stop
-         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
-         offset="0"
-         id="stop4958-5" />
-      <stop
-         style="stop-color:#98aae7;stop-opacity:0.40392157"
-         offset="1"
-         id="stop4960-6" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3827">
-      <stop
-         id="stop3829"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0.60149658"
-         id="stop3835" />
-      <stop
-         id="stop3831"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
-      <stop
-         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
-         offset="0"
-         style="stop-color:#f3faed;stop-opacity:1" />
-      <stop
-         style="stop-color:#e7f4da;stop-opacity:1"
-         offset="0.65917557"
-         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
-      <stop
-         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
-         offset="1"
-         style="stop-color:#67bf1f;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4541"
-       id="linearGradient5885"
-       x1="41"
-       y1="1007.8622"
-       x2="60"
-       y2="1008.3622"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
-    <linearGradient
-       id="linearGradient11146-4-4-4-6-2">
-      <stop
-         id="stop11150-4-72-3-9-7"
-         offset="0"
-         style="stop-color:#faefba;stop-opacity:1" />
-      <stop
-         style="stop-color:#9e6542;stop-opacity:1"
-         offset="1"
-         id="stop11152-9-0-7-3-8" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10507">
-      <stop
-         style="stop-color:#5f392d;stop-opacity:1"
-         offset="0"
-         id="stop10509" />
-      <stop
-         id="stop10511"
-         offset="0.18181793"
-         style="stop-color:#9e7058;stop-opacity:1" />
-      <stop
-         id="stop10513"
-         offset="0.36363617"
-         style="stop-color:#794f40;stop-opacity:1" />
-      <stop
-         id="stop10515"
-         offset="0.49999985"
-         style="stop-color:#794f40;stop-opacity:1" />
-      <stop
-         id="stop10517"
-         offset="0.63636351"
-         style="stop-color:#794f40;stop-opacity:1" />
-      <stop
-         style="stop-color:#9e7058;stop-opacity:1"
-         offset="0.81818175"
-         id="stop10519" />
-      <stop
-         style="stop-color:#5f392d;stop-opacity:1"
-         offset="1"
-         id="stop10522" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4456"
-       id="linearGradient4462"
-       x1="63.734764"
-       y1="1039.3618"
-       x2="61.727211"
-       y2="1006.3618"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,-0.72750163,1,733.40264,2.0004)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4456">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.659"
-         offset="0"
-         id="stop4458" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.369"
-         offset="1"
-         id="stop4460" />
-    </linearGradient>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4606"
-       x="-0.062976152"
-       width="1.1259522"
-       y="-0.10879012"
-       height="1.2175802">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.5412116"
-         id="feGaussianBlur4608" />
-    </filter>
-    <linearGradient
-       id="linearGradient11146-4-4-4-6-2-8">
-      <stop
-         id="stop11150-4-72-3-9-7-2"
-         offset="0"
-         style="stop-color:#faefba;stop-opacity:1" />
-      <stop
-         style="stop-color:#ad6e48;stop-opacity:1"
-         offset="1"
-         id="stop11152-9-0-7-3-8-0" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4368">
-      <stop
-         id="stop4370"
-         offset="0"
-         style="stop-color:#9c7561;stop-opacity:1" />
-      <stop
-         style="stop-color:#966d59;stop-opacity:1"
-         offset="0.18181793"
-         id="stop4372" />
-      <stop
-         style="stop-color:#8c6250;stop-opacity:1"
-         offset="0.36363617"
-         id="stop4374" />
-      <stop
-         style="stop-color:#794f40;stop-opacity:1"
-         offset="0.49999985"
-         id="stop4376" />
-      <stop
-         style="stop-color:#8c6250;stop-opacity:1"
-         offset="0.63636351"
-         id="stop4378" />
-      <stop
-         id="stop4380"
-         offset="0.81818175"
-         style="stop-color:#966d59;stop-opacity:1" />
-      <stop
-         id="stop4382"
-         offset="1"
-         style="stop-color:#99705c;stop-opacity:1" />
-    </linearGradient>
-    <filter
-       height="1.2013515"
-       y="-0.10067577"
-       width="1.2017672"
-       x="-0.1"
-       id="filter4285-9-8"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur4287-9-5"
-         stdDeviation="0.10000000000000001"
-         inkscape:collect="always" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4496"
-       id="linearGradient4494"
-       x1="8"
-       y1="1013.3622"
-       x2="19"
-       y2="1024.3622"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.88619287,0,0,0.87964908,22.674808,110.55825)" />
-    <linearGradient
-       id="linearGradient4496"
-       inkscape:collect="always">
-      <stop
-         id="stop4498"
-         offset="0"
-         style="stop-color:#6885b2;stop-opacity:1" />
-      <stop
-         style="stop-color:#5777a7;stop-opacity:1"
-         offset="0.54585904"
-         id="stop4512" />
-      <stop
-         style="stop-color:#355286;stop-opacity:1"
-         offset="0.63636416"
-         id="stop4500" />
-      <stop
-         id="stop4502"
-         offset="1"
-         style="stop-color:#2c4a81;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4504"
-       id="linearGradient4510"
-       x1="3.2928932"
-       y1="1020.7158"
-       x2="20"
-       y2="1020.7158"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.88619287,0,0,0.87964908,22.674808,110.55825)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4504">
-      <stop
-         style="stop-color:#b0c1db;stop-opacity:1"
-         offset="0"
-         id="stop4506" />
-      <stop
-         style="stop-color:#8299c2;stop-opacity:1"
-         offset="1"
-         id="stop4508" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4420"
-       id="linearGradient4426"
-       x1="68.572693"
-       y1="1016.118"
-       x2="67.579018"
-       y2="1015.3881"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99967036,0.02567416,-0.02567416,0.99967036,-14.525917,-1.4292246)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4432"
-       id="linearGradient4438"
-       x1="8"
-       y1="1019.3622"
-       x2="52"
-       y2="1039.3622"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9893617,0,0,0.97823962,0.31914907,22.399103)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4506"
-       x="-0.092571429"
-       width="1.1851429"
-       y="-0.0324"
-       height="1.0648">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.27"
-         id="feGaussianBlur4508" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4524"
-       x="-0.029837838"
-       width="1.0596757"
-       y="-0.12266667"
-       height="1.2453333">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.46"
-         id="feGaussianBlur4526" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4566"
-       x="-0.08775"
-       width="1.1755"
-       y="-0.1404"
-       height="1.2808">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.2925"
-         id="feGaussianBlur4568" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4588"
-       x="-0.042439024"
-       width="1.084878"
-       y="-0.10235294"
-       height="1.2047059">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.725"
-         id="feGaussianBlur4590" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4661"
-       x="-0.14766911"
-       width="1.2953382"
-       y="-0.11646623"
-       height="1.2329325">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.36234727"
-         id="feGaussianBlur4663" />
-    </filter>
   </defs>
   <sodipodi:namedview
      id="base"
-     pagecolor="#a5a5a5"
+     pagecolor="#ffffff"
      bordercolor="#666666"
      borderopacity="1.0"
-     inkscape:pageopacity="0"
+     inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="26.213333"
-     inkscape:cx="40.276938"
-     inkscape:cy="29.125507"
+     inkscape:zoom="16"
+     inkscape:cx="12.8125"
+     inkscape:cy="11.09375"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
-     inkscape:window-width="2560"
-     inkscape:window-height="1391"
-     inkscape:window-x="0"
-     inkscape:window-y="1"
-     inkscape:window-maximized="1"
+     inkscape:window-width="1418"
+     inkscape:window-height="1138"
+     inkscape:window-x="201"
+     inkscape:window-y="100"
+     inkscape:window-maximized="0"
      showguides="true"
      inkscape:guide-bbox="true"
-     inkscape:snap-global="false"
-     inkscape:snap-bbox="true"
-     inkscape:bbox-nodes="true">
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid4112"
-       empspacing="5"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
+       id="grid4039"
+       originx="0"
+       originy="0" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -858,262 +119,34 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:groupmode="layer"
-     id="layer2"
-     inkscape:label="Background"
-     style="display:inline"
-     sodipodi:insensitive="true">
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       id="rect4113-1"
-       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
-       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       id="rect4113-1-0"
-       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
-       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
-    <g
-       id="g11331-3-1-1-7"
-       style="display:inline"
-       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
-      <g
-         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
-         id="g13408-8-2" />
-    </g>
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       id="rect4113-1-7"
-       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
-       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
-  </g>
-  <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="old"
-     style="display:inline">
-    <image
-       y="0"
-       x="75"
-       id="image4415"
-       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAACXBIWXMAAAsTAAALEwEAmpwYAAAK
-TWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQ
-WaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec
-5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28A
-AgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0
-ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaO
-WJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHi
-wmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryM
-AgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0l
-YqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHi
-NLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYA
-QH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6c
-wR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBie
-whi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1c
-QPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqO
-Y4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hM
-WEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgoh
-JZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSU
-Eko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/p
-dLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Y
-b1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7O
-UndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsb
-di97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W
-7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83
-MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxr
-PGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW
-2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1
-U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd
-8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H0
-8PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+H
-vqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsG
-Lww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjg
-R2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4
-qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWY
-EpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1Ir
-eZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/Pb
-FWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYj
-i1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVk
-Ve9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0Ibw
-Da0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vz
-DoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+y
-CW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawt
-o22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtd
-UV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3r
-O9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0
-/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv95
-63Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+
-UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMA
-APn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAAPMElEQVR42uxce4wd1Xn/fefMfe7du3d3bS+Y
-NaxZP8DGYIhpISEFIqQmFVKBKC1Vowi1f1QKVVUJNVLTqtCqUitCSqNWSZqUghCVYhGVhwglIhHh
-VUhCWqCBpBgHO2t7vV7v+3HvPM736x8z996513ftxY81rDPS7MzcmTNz5nd+3+/7znfOrOBXS8fl
-3m8dtCTyJHtIdAMoeL+CpQWgDIACibIqu0gU0ufPebDu//YhS6JLibwqC1R2KZHtdO05C9Y/PTZa
-UEWRZJaABdkNMne8MucUWF9/8rBRIkeym4QVAUgUQZYAyInKnzNgfeOpsW4liwIYEkDMprIAWVnm
-PVY9WA88PVZQImYSAMYUKhDoFkD4Pu4lqxWkh757JEuiTDKjCigBkiDRTbKoCqgSynjrki0ZX3tO
-gPXIs+NWyTKJfB2gBCwBWCGRVU1+O5fB+vfvjXeRKJE0yiablPAA9FDp1cE5GbBWhWbtfu5oJmFT
-FgDY+rKeEfSR70+fViVYj/7gaJcSJYEYgu1m44lIH8lTBupDDdZ/vDhhVNFLMCsE2sEQiRmlhJCn
-55kfSrAef2kir0SPSCNmagNKPBH0USHHwvghBOvx5/cMkRiKnKs45U4XKZzyeucUkdOdzmnFOX38
-zt/ddWu63BMvT5YJdAnZEQYBPDGnR6NWHKzHn98zBOAOAFcAqAAYAjBEAk4VqsTUzCKqfojZuSpm
-5qs4OjGD7ryHrZsvqtTv851XJ40SvSSyXNq1e8ZIn54mjVpxsG65fvO+x5/fsw/A3QAwMR/hlyOH
-kfEspueqCMIIwBhGx/PwgxA1P8Ch/SO4fNvFCCMdAoCnfziVIdEnoFkKBBFYY6SPhIBn5l3MSpjc
-LddvfgjAlQCmy0UPV10puGDDGqwfqGDjYAH9lX54noExgumjE4jCCIdGxxE5HXrmR1MFEaw5bl0F
-Yg0qcobjRrNSGnXL9ZtfV+VGOPe61i7AZUMZ3HDtFlx71WYUSuuRy3iYnZ5FdWERxhpADKLIYd/I
-wR0nNA8rfSJyxq1kxcACgNtu3DL9mZsuudIT+ebEpEU5SxSLPdg4fBF2XbsL1UUfxlgYYzE2Po3I
-KeYXqhuOC5SRsqyQo1pRsOrLzR8f/uLgOtw7dnRm/uiRCfR3zSGfz+Lq666BzWRgrAdjDKJI4QdR
-ean7WCNFY1pTv6sOLACz2y9+6VnS+519B2ex5/8mYXQCQ8ODGL50G5ikUiamZlGt+ts7Vtwgaw26
-z3A9hURGlQVVFs9SnJUD8Fsv/ejtS+/Le8To0QUUpnxICdiy4xIcHDmAqbHDqNV8RB16tSKwVqTC
-0+n1CNEYGI9EhnHnW846s0SC4G8e+MInizlz5//8/AAm5vw3jNj7qpMTkIUZ7Lj6Koi1mJtfRK0W
-XNtePmOlInJqno+AKJGNHLsix0rk2K/KMokiiUynjMxZAesvvv7iUH9P7sH3RsYR0ZveODhw18eu
-3v4PhXzuD6KFudkSAmy+bAfm5xcROW0HqixycoJOwjpFPnIsRxH7nWOZRCFh0QdTs3q7c48tLixW
-DozPY8P5a+6+9vLhtwHgox/Z9kxvpfxpDfy31lcK6K70wQ+ij6YEPfd+BZ2EOEU+itgTOfaqssQl
-hro+cGD97YOv3F/MYOebe0Zx/sCa3Z/82GWPps//2s6tb23ffNGnrTHP9JSKiCIXV1RgPSs9y32O
-U2Qjx+7Iab8qSwQyp1p3u5JA/dU3XrplXW/+H9985yBy+eJPr9kx/PlKuejXhbruBXvLJX/r8IYn
-9rx3aLbqhzeOT84+s2Xj+giArV9DJiuaWyUkciyGym5V5OMMKY+5rlG2/fcPClh//tUXhwZ6C/85
-OjaZn5wLZ7Zt2vCHl28ZPMBUZrNR4aTyW4c3/PfB0YlXSsW8Hdqwbi79UumXVcKGjqXIsVtjTybN
-+54+sFYsdOgpZR6LQr+yb3QGm4YuuOe6ncNv6TJc/8037XrNWulVPfacEpkwYtEpMuSZf4eOYN31
-lefuF5GdThXqFE4VzunrTnWmfqza3KryoW/93Wf2LfWQe7758oM9RbvzlTdGMLC2f/fNv3H5bi4D
-KRGIZ6VMAE98/9Vdo0cmdyUnjDUmI2IsSfhBOOAH4UC67LbNm7526ebNe884WAR2grgBrdS84Tj3
-+QGAjmB98Wsv3rGuN3/H2+8eRKHQ9dav79h493Irl/WkBMCSwOiRqV0T03N/tNyyVb9WWhFmqSoA
-wZ997hqICERitykiMAKIAM45fO+He/HUC+8sefMv/PPzO9f25O8fn5jGzKKbvXLbhX+6acPa2eWY
-n2cla4wUk+Ep63k2BwCP3ve5OFqUZn7GJPtB4PDsf72LB558deXM0CWBoAAIgghhGMWA1YETwcEj
-M1ishkuK4pce+XFfEEYPGkSVd/ZPYHho8O4bPrJpWTolIpLxpKwKiSKWIkXOiDScUS2I4Acu1Xhx
-OD96ZB7VarSymqUpNQ3CCPMLtWbFjMCIYH7RjxuXBNvUlWT24aff+ldqtPOFn+zF2jW9u2/7xBW7
-uUwVznpScg7dkWMhHkluSR3DDxxm530YkeZqBFNTNfAMKr1ZilnOKUSkLrTJ2uyQicR5yU5Ve2PP
-+N+vX9N169xCFYPn9Y/83m9e8RXPyrICYAGKkXLQKYvslPmURnI0Va/mhe4MgtXZDFPMEqlXDQid
-g3OEiec1IZ7f1Mqs2QX/jw+Nz99ZzBn0lArhpz5+6XfP6+teV/U1HJsKDvsh3RJOxaqy2xozQPC4
-wPpBhKofwjMGhbyXNJxAyYaErJwZ1jUraTFJ/szN+5iaq8ImtE9MrgUsa+TWvnIuO7dQxY1XXzx6
-Xn8pUGKrUqIw4sHO/TcWVVGyRrpE4B2PHJMzVfx871FQgQsv6EE+5yEKFSQROYXTs8QsQdP0GvsC
-/HTvOCDE/GJQn8YDANhzoJo9OOE+O9CTuWvLhWv+pLsrt0BgI5QYmwx3d+pBJGmRrAisNVI40bv+
-22M/hnPEVZesx8bBCmZm/ZhV8XjjyoPVEHhJRYcNbRC8+e5YMuNEoUlfYe+haobxuB4OT+uXVfnl
-TQV+3hr5fT/kvyzUNGiNvmM21Z/iWekCTjyM9er/xuHcxRt6YYw0nIwqETm2SMgKMivFqBSrjAhU
-FST++tF7b78HAN4brRkSfe1a886B2lcH12af2z/m/ywlTlaVZaTSJMZIxohk9Tj299nfvulhVX1Y
-Cdz/4LefbbSlAE5jYY+cwrkVZ1bcrUyDlPZAWu+FNj1UL4BMJ1aMHGkCRbKg8QR8aQtAu0/WicXz
-qerM0pVnVjPOkhavWF+pTVHfP1Yrk8jyhPlt9pDIdYjUixCYkxpFFgEZm55Tnk3NkmPiq5hlsYsm
-iZEjfkHJrhO0vKdkBTw2HZQMuRdO5v0kiTdcwio9e2ClzDAVOkAQx1iqECMGQPn4QLFIssNwFQVU
-8ayUQNjWJFWSC27oZXPfQE0rYePpjk4Za1aSBQEAz4j1RD1CoYJ4TXJbCkKRbAmoNKdHpnNdjuI0
-NVmnM1h1AUlq2Sr08fmssZu/9ND3ryMJ1hNsCeNIoLsrX7LWZkA2dCUhqc0YyXrW5PI5rxupBFx7
-og4p/JK+fGuisD4/NGGXc2wIfCknlXLGX0dqByBikKj1+7A5mxmAU4lCJ0HgTLAYmZpT0RNqljQ8
-jjTNMdGJmh/evndk/HYmb1sHKQYu+Q1sAaEexJ6uJS3uDc1K7l/KSl/BhgPNujTBSLMHTbBIQiOV
-IFTxjYhVip44n5Wy+2a/KwaskMvitk9sTz20ztMlAGFKZMgmVdv6OjG0bbnd1LPbl+3DA0lKOQaq
-3RvmM9KTFbeWkgKrkbKuN3CDoapEFKlUlSAoNT8ytdnAztdZdUIzbPQLE6HPZTxcPNiPy7euT7US
-W1q6sSOp10yFHkh3oVKtjFSrI3U+XaZ+TDSnZNdXl/QLNTHDnIc+z7iwpV5t5h7zQiIlqqHKPAEG
-zixMVDNH5kNbbZ9cuARYmg7eGwFqVzGL6dlqTH0STM0jr/+mGgNoklSOJP3IRi4s2YdIXC6Juuum
-RGUjDdSegjEiEAgipwidIowUQeQaHjHSpjfMetLrJaSgtDI8MYhQKTWCC6oSBs5MTVa9A+OLmaOh
-E7f8tHLiAo5J0aDpUcBWM2xqAJupnHT6pBGCJErYcAZsEV4k18QBcGpNSjJpFKdN82tqVrO7kzXo
-M8Jsm7UrgEiJKiFOiarv7Oicb0fGFrIj86GpqS4d8XlLuPxUR7qpG83hI7aBxIYOgICYJjDNl0UL
-gDED0YjZ6n3M9hyVpBoLIo0AtMX86vtOk7AH8Kz0GrCU0r+AQFUpM0qZDZwZWQjt/sladv/EojcZ
-quiJnI+3lJepa9eh8TlUaz6MmBgkrbdqMoHW1Y/jlyDjWMxYk6RyDKw1sSlZgTUmyeEnghzF2YIo
-itMsIgbWxNdZI7BiYG28FQiCyKEWONTCCH4QwQ/jYz+MWoJSa9Br4hnwESFVJRYczViosr8a2fdm
-/My+icXs2GJkfF2mhz4us5564Weo+WGzdw80WlNdrG0uZQZ1861rjCQvHR8DJtmPO+sxEyJXF2Zt
-lG2WiUGqb0kiiBz8UBGEEYLIIQg12TqEkcNCtdbiSAlZdJRfhmr2Bc78Yi7M7J2oZUfmfW/R6fuL
-Y44B67WX38j95SOvZZwSDz/5E+CYkdpmVNj++0oMdC53UcJ3lFFH84tA7buLkffulJ/dNxNkpiN3
-clX12oAyAHKb1vfck896g33lwhprJOdZyWczXpdnTdEIPMTzl4wIbCIpNpEbk3bPzRSM8dITZNmC
-+RLgtx23lmnVDHaQkHK5PLvosodrzh6YC7OHZoPMVOAkmRt3cq3acULY3GJkSKwlYZQUp+gj4TU+
-OauLcpJHqncn6ueZ+jwNpOQytk8JUWryqdqxn69R0Qg9mtv0dXHPQtue1fnaZhlSO5/XDtenPPOy
-R3dE0APAMJ5T2XcqcyIynilAVsd3jceAtVBzXYDkkw7/KQElgFgrBaySxbTOD3AWQAngKTOqziqR
-1fO1bDuzKognYpwyUMkMmFXDqhawaoErAMjFpnfqn3asNlY1wApCNQKpnA5GrVZWNZkl6CXQDzk9
-MwE9KzlZhf8GwURO8wDOP11AAUDGShGrcDEANp7Or6oyRrIiYlYjWP8/ABVzRoT3Sqt3AAAAAElF
-TkSuQmCC
-"
-       style="image-rendering:optimizeSpeed"
-       preserveAspectRatio="none"
-       height="66"
-       width="75" />
-  </g>
-  <g
-     inkscape:label="Foreground"
+     inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
      style="display:inline"
-     transform="translate(0,-986.3622)">
+     transform="translate(0,-1036.3622)">
+    <g
+       id="provider"
+       transform="matrix(1.45,0,0,1.45,26.607637,-466.10093)">
+      <title
+         id="title3210">provider</title>
+      <path
+         style="fill:url(#linearGradient4927);fill-opacity:1;stroke:url(#linearGradient4919);stroke-width:0.716439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m -17.306554,1043.8942 v 7.1004 h 7.132406 7.1324058 v -7.1004 H -6.048227 v 2.015 h 0.9275325 v 3.0704 h -5.0534535 -5.053453 v -3.0704 h 0.927532 v -2.015 z"
+         id="path4143"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccc" />
+    </g>
     <path
-       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4426);stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 21.369661,1023.8 13.432176,-16.6606"
-       id="path4418"
-       inkscape:connector-curvature="0" />
-    <path
-       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient4462);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4606)"
-       d="m 47.000294,1007.3622 -12.319149,16.9335 -12.416197,17.0669 16.933329,0 17.066666,0 12.416197,-17.0669 0.09676,-0.133 12.2221,-16.8001 -17.066666,0 -16.933329,0 z"
-       id="rect10961-8-3-6-1"
-       inkscape:connector-curvature="0"
-       transform="matrix(1.2008267,0,0.09173299,0.36603268,-108.57532,660.98864)"
-       inkscape:transform-center-x="4.4580006"
-       inkscape:transform-center-y="0.53407962" />
-    <path
-       style="display:inline;fill:url(#linearGradient4494);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4510);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 26.662676,1001.5215 13.292893,0 0,13.1948 z"
-       id="path4478"
-       inkscape:connector-curvature="0" />
-    <path
-       sodipodi:type="star"
-       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4285-9-8)"
-       id="path4252-6-0"
-       sodipodi:sides="4"
-       sodipodi:cx="4.7729707"
-       sodipodi:cy="1041.2474"
-       sodipodi:r1="3.3255017"
-       sodipodi:r2="0.49178758"
-       sodipodi:arg1="2.432965"
-       sodipodi:arg2="-3.0800218"
-       inkscape:flatsided="false"
-       inkscape:rounded="0"
-       inkscape:randomized="-0.017554997"
-       d="m 2.2999628,1043.3702 1.9823895,-2.1047 -1.6734053,-2.5419 2.1987064,2.0209 2.4513363,-1.6427 -2.0383649,2.1623 1.7419712,2.4882 -2.2030799,-2.0431 z"
-       transform="matrix(-0.68431401,1.2284231,-1.0636666,-0.87657521,1143.5516,1913.5172)"
-       inkscape:transform-center-x="0.16252253"
-       inkscape:transform-center-y="0.33382692" />
-    <path
-       style="fill:url(#linearGradient4438);fill-opacity:1;fill-rule:evenodd;stroke:#3d5b8a;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 6.7500001,1018.1127 0,22.4995 46.4999999,0 0,-22.4995 -11,-4e-4 0,7.9997 3.085106,4e-4 -3.19e-4,6.9996 -31.584946,4e-4 3.19e-4,-6.9997 2.99984,-9e-4 0,-7.9997 z"
-       id="path4430"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccccccccc" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#edf2f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4506)"
-       d="m 15.342812,1019.5906 -7.0000002,0 0,20"
-       id="path4480"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#eef1f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4524)"
-       d="m 11.162866,1034.8767 36,0 0,-9"
-       id="path4510"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccc" />
-    <path
-       style="opacity:0.98000004;fill:none;fill-rule:evenodd;stroke:#eef1f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4566)"
-       d="m 43.900881,1024.6827 0,-5 8,0"
-       id="path4528"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#5d7aad;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4588)"
-       d="m 10.260003,1038.6222 41,0 0,-17"
-       id="path4570"
-       inkscape:connector-curvature="0" />
-    <path
-       sodipodi:type="star"
-       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4661)"
-       id="path4252-6-0-1"
-       sodipodi:sides="4"
-       sodipodi:cx="4.7729707"
-       sodipodi:cy="1041.2474"
-       sodipodi:r1="3.3255017"
-       sodipodi:r2="1.0287941"
-       sodipodi:arg1="2.432965"
-       sodipodi:arg2="3.1299058"
-       inkscape:flatsided="false"
-       inkscape:rounded="0"
-       inkscape:randomized="-0.017554997"
-       d="m 2.2999628,1043.3702 1.5012045,-2.162 -1.1922203,-2.4846 2.095707,1.5226 2.5543357,-1.1444 -1.4929874,2.1437 1.1965937,2.5068 -2.164271,-1.4559 z"
-       transform="matrix(-0.3564605,0.66452158,-0.554066,-0.47418772,601.0265,1514.0687)"
-       inkscape:transform-center-x="0.084658908"
-       inkscape:transform-center-y="0.18052959" />
+       style="display:inline;fill:url(#linearGradient3924);fill-opacity:1;stroke:none;stroke-width:1.45"
+       d="m 7.4007052,1050.8732 0.950721,0.9506 9.1130538,-9.113 1.901441,1.9014 0.486902,-5.078 -5.078184,0.4403 1.785501,1.7857 z"
+       id="arrow"
+       inkscape:connector-curvature="0">
+      <title
+         id="title3208">arrow</title>
+    </path>
   </g>
 </svg>

--- a/bundles/org.eclipse.ui/icons/full/pref/import_wiz.svg
+++ b/bundles/org.eclipse.ui/icons/full/pref/import_wiz.svg
@@ -2,853 +2,135 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="75"
-   height="66"
+   width="24"
+   height="24"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
    sodipodi:docname="import_wiz.svg"
-   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
-   inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   viewBox="0 0 16.551724 16.551724"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4432">
+       id="receiver-bg-6">
       <stop
-         style="stop-color:#ced8e7;stop-opacity:1;"
+         style="stop-color:#85a2cd;stop-opacity:1;"
          offset="0"
-         id="stop4434" />
+         id="stop4923" />
       <stop
-         style="stop-color:#b7c5e0;stop-opacity:1"
+         style="stop-color:#d3dce9;stop-opacity:1;"
          offset="1"
-         id="stop4436" />
+         id="stop4925" />
+    </linearGradient>
+    <linearGradient
+       id="receiver-stroke-7">
+      <stop
+         style="stop-color:#4e6b9b;stop-opacity:1"
+         offset="0"
+         id="stop4915" />
+      <stop
+         style="stop-color:#6783b1;stop-opacity:1"
+         offset="1"
+         id="stop4917" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient4420">
-      <stop
-         style="stop-color:#5b7aaa;stop-opacity:1"
-         offset="0"
-         id="stop4422" />
-      <stop
-         style="stop-color:#96aaca;stop-opacity:1"
-         offset="1"
-         id="stop4424" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4541">
-      <stop
-         style="stop-color:#a1adb2;stop-opacity:1"
-         offset="0"
-         id="stop4543" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4545" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4972">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0"
-         id="stop4974" />
-      <stop
-         style="stop-color:#f5f8fd;stop-opacity:1"
-         offset="1"
-         id="stop4976" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4964">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0"
-         id="stop4966" />
-      <stop
-         style="stop-color:#e8eefa;stop-opacity:1"
-         offset="1"
-         id="stop4968" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4956">
-      <stop
-         style="stop-color:#fcfdfe;stop-opacity:1"
-         offset="0"
-         id="stop4958" />
-      <stop
-         style="stop-color:#dee6f8;stop-opacity:1"
-         offset="1"
-         id="stop4960" />
-    </linearGradient>
-    <filter
-       style="color-interpolation-filters:sRGB"
-       inkscape:label="Drop Shadow"
-       id="filter8854">
-      <feFlood
-         flood-opacity="0.933333"
-         flood-color="rgb(244,248,254)"
-         result="flood"
-         id="feFlood8856" />
-      <feComposite
-         in="flood"
-         in2="SourceGraphic"
-         operator="in"
-         result="composite1"
-         id="feComposite8858" />
-      <feGaussianBlur
-         in="composite1"
-         stdDeviation="1.2"
-         result="blur"
-         id="feGaussianBlur8860" />
-      <feOffset
-         dx="-1"
-         dy="3"
-         result="offset"
-         id="feOffset8862" />
-      <feComposite
-         in="SourceGraphic"
-         in2="offset"
-         operator="over"
-         result="composite2"
-         id="feComposite8864" />
-    </filter>
-    <linearGradient
-       id="linearGradient6122">
-      <stop
-         style="stop-color:#c0c0c0;stop-opacity:1"
-         offset="0"
-         id="stop6124" />
-      <stop
-         id="stop6132"
-         offset="0.5"
-         style="stop-color:#adadad;stop-opacity:1" />
-      <stop
-         style="stop-color:#808080;stop-opacity:1"
-         offset="1"
-         id="stop6126" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7087">
-      <stop
-         style="stop-color:#17325d;stop-opacity:1;"
-         offset="0"
-         id="stop7089" />
-      <stop
-         id="stop7091"
-         offset="0.25"
-         style="stop-color:#b4d0e2;stop-opacity:1" />
-      <stop
-         id="stop7093"
-         offset="0.5"
-         style="stop-color:#b7d2e4;stop-opacity:1" />
-      <stop
-         style="stop-color:#acc9de;stop-opacity:1"
-         offset="0.75"
-         id="stop7095" />
-      <stop
-         style="stop-color:#3e72a7;stop-opacity:1"
-         offset="1"
-         id="stop7097" />
-    </linearGradient>
-    <mask
-       id="mask7366"
-       maskUnits="userSpaceOnUse">
-      <path
-         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
-         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
-         id="path7368"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccc" />
-    </mask>
-    <linearGradient
-       id="linearGradient7584-5">
-      <stop
-         id="stop7586-4"
-         offset="0"
-         style="stop-color:#f9cd5f;stop-opacity:1" />
-      <stop
-         id="stop7588-5"
-         offset="1"
-         style="stop-color:#fbf0b4;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7592-1">
-      <stop
-         id="stop7594-6"
-         offset="0"
-         style="stop-color:#bd8416;stop-opacity:1" />
-      <stop
-         id="stop7596-9"
-         offset="1"
-         style="stop-color:#a66b10;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
-      <stop
-         style="stop-color:#5aad60;stop-opacity:1;"
-         offset="0"
-         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
-      <stop
-         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
-         offset="0.5"
-         style="stop-color:#5bb26a;stop-opacity:1;" />
-      <stop
-         style="stop-color:#a4c589;stop-opacity:1"
-         offset="1"
-         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
-    </linearGradient>
-    <mask
-       maskUnits="userSpaceOnUse"
-       id="mask7366-4">
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path7368-2"
-         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
-         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
-    </mask>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient7087"
-       id="linearGradient9331"
+       xlink:href="#receiver-stroke-7"
+       id="linearGradient4919"
+       x1="1.860189"
+       y1="1051.5892"
+       x2="1.860189"
+       y2="1046.8492"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-20,0)"
-       x1="4.7776356"
-       y1="1039.8118"
-       x2="4.7776356"
-       y2="1041.911" />
+       gradientTransform="matrix(1.0224167,0,0,1.0224167,-16.732246,-23.887876)" />
     <linearGradient
-       y2="1041.911"
-       x2="4.7776356"
-       y1="1039.8118"
-       x1="4.7776356"
-       gradientTransform="translate(-18,4.7e-5)"
+       inkscape:collect="always"
+       xlink:href="#receiver-bg-6"
+       id="linearGradient4927"
+       x1="1.860189"
+       y1="1051.5892"
+       x2="1.860189"
+       y2="1046.8492"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient9333"
-       xlink:href="#linearGradient7087"
+       gradientTransform="matrix(1.0224167,0,0,1.0224167,-16.732246,-23.887876)" />
+    <linearGradient
+       id="arrow-bg-3">
+      <stop
+         style="stop-color:#4e8fbd;stop-opacity:1;"
+         offset="0"
+         id="stop4791" />
+      <stop
+         style="stop-color:#6991ae;stop-opacity:1"
+         offset="1"
+         id="stop4793" />
+    </linearGradient>
+    <linearGradient
+       y2="1049.5981"
+       x2="-2.2873085"
+       y1="1044.6919"
+       x1="-2.2873085"
+       gradientTransform="matrix(0.72295781,-0.72295781,0.72295781,0.72295781,-746.4484,286.79833)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3924"
+       xlink:href="#arrow-bg-3"
        inkscape:collect="always" />
-    <linearGradient
-       y2="1041.911"
-       x2="4.7776356"
-       y1="1039.8118"
-       x1="4.7776356"
-       gradientTransform="translate(-16,4.7e-5)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient9335"
-       xlink:href="#linearGradient7087"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1041.911"
-       x2="4.7776356"
-       y1="1039.8118"
-       x1="4.7776356"
-       gradientTransform="translate(-14,4.7e-5)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient9337"
-       xlink:href="#linearGradient7087"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1041.911"
-       x2="4.7776356"
-       y1="1039.8118"
-       x1="4.7776356"
-       gradientTransform="translate(-12,4.7e-5)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient9339"
-       xlink:href="#linearGradient7087"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-80,0)"
-       gradientUnits="userSpaceOnUse"
-       y2="1042.7973"
-       x2="163.22012"
-       y1="1042.7973"
-       x1="88.220117"
-       id="linearGradient68073"
-       xlink:href="#linearGradient4956"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-80,0)"
-       gradientUnits="userSpaceOnUse"
-       y2="1032.2669"
-       x2="163.22012"
-       y1="1032.2668"
-       x1="94.469681"
-       id="linearGradient68075"
-       xlink:href="#linearGradient4964"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-80,0)"
-       gradientUnits="userSpaceOnUse"
-       y2="1032.2668"
-       x2="152.72206"
-       y1="1032.2668"
-       x1="88.220116"
-       id="linearGradient68077"
-       xlink:href="#linearGradient4972"
-       inkscape:collect="always" />
-    <filter
-       id="filter8854-9"
-       inkscape:label="Drop Shadow"
-       style="color-interpolation-filters:sRGB">
-      <feFlood
-         id="feFlood8856-0"
-         result="flood"
-         flood-color="rgb(244,248,254)"
-         flood-opacity="0.933333" />
-      <feComposite
-         id="feComposite8858-2"
-         result="composite1"
-         operator="in"
-         in2="SourceGraphic"
-         in="flood" />
-      <feGaussianBlur
-         id="feGaussianBlur8860-3"
-         result="blur"
-         stdDeviation="1.2"
-         in="composite1" />
-      <feOffset
-         id="feOffset8862-2"
-         result="offset"
-         dy="3"
-         dx="-1" />
-      <feComposite
-         id="feComposite8864-3"
-         result="composite2"
-         operator="over"
-         in2="offset"
-         in="SourceGraphic" />
-    </filter>
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
-      <stop
-         id="stop10800-5-2-1-8-20-6-4-9-8-2"
-         offset="0"
-         style="stop-color:#7564b1;stop-opacity:1" />
-      <stop
-         style="stop-color:#5d4aa1;stop-opacity:1"
-         offset="0.5"
-         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
-      <stop
-         id="stop10802-1-5-3-0-4-8-4-2-9-2"
-         offset="1"
-         style="stop-color:#9283c3;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7540-2-3-8-7">
-      <stop
-         id="stop7542-8-7-5-3"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:0.502" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0.47623286"
-         id="stop7544-8-2-0-5" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="0.5"
-         id="stop7546-1-7-9-5" />
-      <stop
-         id="stop7548-98-9-2-4"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient7272-66-4-5-5-5-8">
-      <stop
-         style="stop-color:#8f6c10;stop-opacity:1"
-         offset="0"
-         id="stop7274-6-0-1-7-4-7" />
-      <stop
-         style="stop-color:#c9a645;stop-opacity:1"
-         offset="1"
-         id="stop7276-66-6-3-9-1-4" />
-    </linearGradient>
-    <linearGradient
-       y2="1030.3411"
-       x2="-10.159802"
-       y1="1030.3411"
-       x1="-22.453552"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient10540"
-       xlink:href="#linearGradient7540-2-3-8-7"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1030.3411"
-       x2="-10.159802"
-       y1="1030.3411"
-       x1="-22.453552"
-       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient10542"
-       xlink:href="#linearGradient7540-2-3-8-7"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1023.2569"
-       x2="-15.945988"
-       y1="1037.4661"
-       x1="-15.945988"
-       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient10544"
-       xlink:href="#linearGradient7272-66-4-5-5-5-8"
-       inkscape:collect="always" />
-    <mask
-       id="mask10620"
-       maskUnits="userSpaceOnUse">
-      <path
-         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
-         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
-         sodipodi:ry="10.625"
-         sodipodi:rx="10.625"
-         sodipodi:cy="468.23718"
-         sodipodi:cx="388.125"
-         id="path10622"
-         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
-         sodipodi:type="arc" />
-    </mask>
-    <linearGradient
-       id="linearGradient4528-9-5-7-9-7-3">
-      <stop
-         id="stop4530-0-5-0-5-8-4"
-         offset="0"
-         style="stop-color:#e0c576;stop-opacity:1;" />
-      <stop
-         id="stop4532-7-9-3-3-6-1"
-         offset="1"
-         style="stop-color:#9e7916;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
-      <stop
-         style="stop-color:#f7f9fb;stop-opacity:1"
-         offset="0"
-         id="stop6283-0-2-2-1-2-0-1-6-0" />
-      <stop
-         style="stop-color:#ffd680;stop-opacity:1"
-         offset="1"
-         id="stop6285-5-0-9-7-6-9-9-1-9" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4972-7"
-       id="linearGradient4978"
-       x1="88.220116"
-       y1="1032.2668"
-       x2="163.22012"
-       y2="1032.2668"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-88.220116,-999.2669)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4972-7">
-      <stop
-         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
-         offset="0"
-         id="stop4974-8" />
-      <stop
-         style="stop-color:#6e97e2;stop-opacity:0.10196079"
-         offset="1"
-         id="stop4976-1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4964-3"
-       id="linearGradient4970"
-       x1="118.38584"
-       y1="1032.1835"
-       x2="163.22012"
-       y2="1032.2668"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-88.220117,-999.2669)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4964-3">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.349"
-         offset="0"
-         id="stop4966-1" />
-      <stop
-         style="stop-color:#91ade6;stop-opacity:1"
-         offset="1"
-         id="stop4968-1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4956-2"
-       id="linearGradient4962"
-       x1="88.220116"
-       y1="1042.7972"
-       x2="163.22012"
-       y2="1042.7972"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-88.220116,-999.2669)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4956-2">
-      <stop
-         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
-         offset="0"
-         id="stop4958-5" />
-      <stop
-         style="stop-color:#98aae7;stop-opacity:0.40392157"
-         offset="1"
-         id="stop4960-6" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3827">
-      <stop
-         id="stop3829"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0.60149658"
-         id="stop3835" />
-      <stop
-         id="stop3831"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
-      <stop
-         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
-         offset="0"
-         style="stop-color:#f3faed;stop-opacity:1" />
-      <stop
-         style="stop-color:#e7f4da;stop-opacity:1"
-         offset="0.65917557"
-         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
-      <stop
-         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
-         offset="1"
-         style="stop-color:#67bf1f;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4541"
-       id="linearGradient5885"
-       x1="41"
-       y1="1007.8622"
-       x2="60"
-       y2="1008.3622"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
-    <linearGradient
-       id="linearGradient11146-4-4-4-6-2">
-      <stop
-         id="stop11150-4-72-3-9-7"
-         offset="0"
-         style="stop-color:#faefba;stop-opacity:1" />
-      <stop
-         style="stop-color:#9e6542;stop-opacity:1"
-         offset="1"
-         id="stop11152-9-0-7-3-8" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient10507">
-      <stop
-         style="stop-color:#5f392d;stop-opacity:1"
-         offset="0"
-         id="stop10509" />
-      <stop
-         id="stop10511"
-         offset="0.18181793"
-         style="stop-color:#9e7058;stop-opacity:1" />
-      <stop
-         id="stop10513"
-         offset="0.36363617"
-         style="stop-color:#794f40;stop-opacity:1" />
-      <stop
-         id="stop10515"
-         offset="0.49999985"
-         style="stop-color:#794f40;stop-opacity:1" />
-      <stop
-         id="stop10517"
-         offset="0.63636351"
-         style="stop-color:#794f40;stop-opacity:1" />
-      <stop
-         style="stop-color:#9e7058;stop-opacity:1"
-         offset="0.81818175"
-         id="stop10519" />
-      <stop
-         style="stop-color:#5f392d;stop-opacity:1"
-         offset="1"
-         id="stop10522" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4456"
-       id="linearGradient4462"
-       x1="63.734764"
-       y1="1039.3618"
-       x2="61.727211"
-       y2="1006.3618"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,-0.72750163,1,733.40264,2.0004)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4456">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.659"
-         offset="0"
-         id="stop4458" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.369"
-         offset="1"
-         id="stop4460" />
-    </linearGradient>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4606"
-       x="-0.062976152"
-       width="1.1259522"
-       y="-0.10879012"
-       height="1.2175802">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.5412116"
-         id="feGaussianBlur4608" />
-    </filter>
-    <linearGradient
-       id="linearGradient11146-4-4-4-6-2-8">
-      <stop
-         id="stop11150-4-72-3-9-7-2"
-         offset="0"
-         style="stop-color:#faefba;stop-opacity:1" />
-      <stop
-         style="stop-color:#ad6e48;stop-opacity:1"
-         offset="1"
-         id="stop11152-9-0-7-3-8-0" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4368">
-      <stop
-         id="stop4370"
-         offset="0"
-         style="stop-color:#9c7561;stop-opacity:1" />
-      <stop
-         style="stop-color:#966d59;stop-opacity:1"
-         offset="0.18181793"
-         id="stop4372" />
-      <stop
-         style="stop-color:#8c6250;stop-opacity:1"
-         offset="0.36363617"
-         id="stop4374" />
-      <stop
-         style="stop-color:#794f40;stop-opacity:1"
-         offset="0.49999985"
-         id="stop4376" />
-      <stop
-         style="stop-color:#8c6250;stop-opacity:1"
-         offset="0.63636351"
-         id="stop4378" />
-      <stop
-         id="stop4380"
-         offset="0.81818175"
-         style="stop-color:#966d59;stop-opacity:1" />
-      <stop
-         id="stop4382"
-         offset="1"
-         style="stop-color:#99705c;stop-opacity:1" />
-    </linearGradient>
-    <filter
-       height="1.2013515"
-       y="-0.10067577"
-       width="1.2017672"
-       x="-0.1"
-       id="filter4285-9-8"
-       style="color-interpolation-filters:sRGB"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur4287-9-5"
-         stdDeviation="0.10000000000000001"
-         inkscape:collect="always" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4496"
-       id="linearGradient4494"
-       x1="8"
-       y1="1013.3622"
-       x2="19"
-       y2="1024.3622"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.88619287,0,0,-0.87964908,19.219239,1914.8255)" />
-    <linearGradient
-       id="linearGradient4496"
-       inkscape:collect="always">
-      <stop
-         id="stop4498"
-         offset="0"
-         style="stop-color:#6885b2;stop-opacity:1" />
-      <stop
-         style="stop-color:#5777a7;stop-opacity:1"
-         offset="0.54585904"
-         id="stop4512" />
-      <stop
-         style="stop-color:#355286;stop-opacity:1"
-         offset="0.63636416"
-         id="stop4500" />
-      <stop
-         id="stop4502"
-         offset="1"
-         style="stop-color:#2c4a81;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4504"
-       id="linearGradient4510"
-       x1="3.2928932"
-       y1="1020.7158"
-       x2="20"
-       y2="1020.7158"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.88619287,0,0,-0.87964908,19.219239,1914.8255)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4504">
-      <stop
-         style="stop-color:#b0c1db;stop-opacity:1"
-         offset="0"
-         id="stop4506" />
-      <stop
-         style="stop-color:#8299c2;stop-opacity:1"
-         offset="1"
-         id="stop4508" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4420"
-       id="linearGradient4426"
-       x1="68.572693"
-       y1="1016.118"
-       x2="67.579018"
-       y2="1015.3881"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99587969,-0.09068428,-0.09068428,-0.99587969,47.64461,2028.4309)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4432"
-       id="linearGradient4438"
-       x1="8"
-       y1="1019.3622"
-       x2="52"
-       y2="1039.3622"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9893617,0,0,0.97823962,0.31914907,22.399103)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4506"
-       x="-0.092571429"
-       width="1.1851429"
-       y="-0.0324"
-       height="1.0648">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.27"
-         id="feGaussianBlur4508" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4524"
-       x="-0.029837838"
-       width="1.0596757"
-       y="-0.12266667"
-       height="1.2453333">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.46"
-         id="feGaussianBlur4526" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4566"
-       x="-0.08775"
-       width="1.1755"
-       y="-0.1404"
-       height="1.2808">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.2925"
-         id="feGaussianBlur4568" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4588"
-       x="-0.042439024"
-       width="1.084878"
-       y="-0.10235294"
-       height="1.2047059">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.725"
-         id="feGaussianBlur4590" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter4661"
-       x="-0.14766911"
-       width="1.2953382"
-       y="-0.11646623"
-       height="1.2329325">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.36234727"
-         id="feGaussianBlur4663" />
-    </filter>
   </defs>
   <sodipodi:namedview
      id="base"
-     pagecolor="#a5a5a5"
+     pagecolor="#ffffff"
      bordercolor="#666666"
      borderopacity="1.0"
-     inkscape:pageopacity="0"
+     inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="13.106667"
-     inkscape:cx="75"
-     inkscape:cy="20.792472"
+     inkscape:zoom="32"
+     inkscape:cx="11.546875"
+     inkscape:cy="11.625"
      inkscape:document-units="px"
-     inkscape:current-layer="layer1"
+     inkscape:current-layer="receiver"
      showgrid="true"
-     inkscape:window-width="2560"
-     inkscape:window-height="1391"
-     inkscape:window-x="0"
-     inkscape:window-y="1"
+     inkscape:window-width="1720"
+     inkscape:window-height="1369"
+     inkscape:window-x="-8"
+     inkscape:window-y="-6"
      inkscape:window-maximized="1"
      showguides="true"
      inkscape:guide-bbox="true"
-     inkscape:snap-global="false"
-     inkscape:snap-bbox="true"
-     inkscape:bbox-nodes="true">
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <sodipodi:guide
+       position="0,1.6666667e-08"
+       orientation="0,16"
+       id="guide4039"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="11.034483,1.6666667e-08"
+       orientation="-16,0"
+       id="guide4041"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="11.034483,11.034483"
+       orientation="0,-16"
+       id="guide4043"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="0,11.034483"
+       orientation="16,0"
+       id="guide4045"
+       inkscape:locked="false" />
     <inkscape:grid
        type="xygrid"
-       id="grid4112"
-       empspacing="5"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
+       id="grid4047"
+       originx="0"
+       originy="0" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -858,262 +140,35 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:groupmode="layer"
-     id="layer2"
-     inkscape:label="Background"
-     style="display:inline"
-     sodipodi:insensitive="true">
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       id="rect4113-1"
-       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
-       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       id="rect4113-1-0"
-       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
-       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
-    <g
-       id="g11331-3-1-1-7"
-       style="display:inline"
-       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
-      <g
-         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
-         id="g13408-8-2" />
-    </g>
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       id="rect4113-1-7"
-       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
-       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
-  </g>
-  <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="old"
-     style="display:inline"
-     sodipodi:insensitive="true">
-    <image
-       y="0"
-       x="75"
-       id="image4762"
-       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAACXBIWXMAAAsTAAALEwEAmpwYAAAK
-TWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQ
-WaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec
-5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28A
-AgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0
-ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaO
-WJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHi
-wmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryM
-AgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0l
-YqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHi
-NLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYA
-QH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6c
-wR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBie
-whi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1c
-QPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqO
-Y4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hM
-WEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgoh
-JZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSU
-Eko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/p
-dLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Y
-b1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7O
-UndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsb
-di97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W
-7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83
-MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxr
-PGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW
-2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1
-U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd
-8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H0
-8PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+H
-vqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsG
-Lww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjg
-R2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4
-qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWY
-EpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1Ir
-eZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/Pb
-FWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYj
-i1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVk
-Ve9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0Ibw
-Da0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vz
-DoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+y
-CW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawt
-o22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtd
-UV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3r
-O9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0
-/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv95
-63Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+
-UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMA
-APn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAAPF0lEQVR42uxbbYwd1Xl+3jNz537s7t0PYxaM
-AYNJQ0pluQntD9K0JKoqFalBoq3USLSlUtVW/ZOiSP2VCKP+qJRWilAqtaJNQ1MqUZGWgCgqhcQk
-AWSIYxuDjYm/7669Xtv7vfdjZs55n/6YmXtn7+56be+uDUtGGs3MvTPnnnnO8z7vxzlX8PNtye3r
-z5zxSJRI9pPoA1D2fw7LAoAKAMokqqrsIVHOf/+xB+sb3z3rkehRoqTKMpU9SgRL3fuxBeubz42V
-VVEhGRDwQPaBLF7qmY8VWP/0wjmjRJFkHwlPBCBRAdkLQFZ6/mMD1pMvjvcpWRHAkAASNlUFCOQy
-29jwYH3rpfGyEgmTADChUJlAnwDCK2hrw4L11MvnAxJVkgVhAhISoPogqOQ/+9iC9fQrFzwlqyRK
-XWCICAYABOTVtb2hwPqPVy/0kOgVwCzAQ+AbQT8VPlfR/oYA6z93XyykbAoAoIs5vhEMkVemTxsS
-rGdfu9ijRK9ADLtUSABfRIZIrhqojzRY//3jCaOKQYLBUmItiekNKSHk2vzmRxKs770+UVKiX6Qd
-M3UruS+CISrkyn3eBgLr+TcmqwR6hFwSBgF8MWujUR9ZsP5nz6RRYpBc3vUL4BsjQ7pGGtW9mbVo
-JLbuYZK/u15AvfTWVAGQzYKlqwGpRnmeJ0MQyHr1Y9XMaoXxH9ab8b/VW/FZkqMi8tZadvB/354q
-Exi4pEgLxBMMrIfprRos0hoRXwFgrh49MT45J0q55dTZ2W+SfEhERteic/+3d7pKsmclb+Z7MkTC
-J7muUnBVZijiKxl6ADA5F37h/HRr+tDxc5icrf/Kk987+ARJb7Ude/Wn0wMAelYcbSNVuUbae9Wa
-JVJ0APALt5UO+Z7/4NS8rb918DSo9qFd//zmv1xtu7v3z5jv75u+AVhY0l1q84xUjFn5vg+NwItU
-4s/t7N8z0Ff51ZmGvrPvcA3Dg8Ejjz35xrevtK3XDswYAEMCFFbsuEHgGfStMz5CoqDKsiora+IN
-RfqiL/3WzSdKpdL9XqF04MCR0UsCRp4eIGt/RY7sJkd3k6O7nda+IoLNkJWBEoHnGRlYU1gIUSJw
-yooq+53jJue4SZX9JHpIVNbUzZITlb/+h/eC+Xpzt4ubO3fevRXjU9FTj//ZZ/+kc09tF2C+DHgD
-gJcjt0IZv/ni682Rvt4bHlUCSoAklIBq59z3ZBNJXxVQEskRUGXXMfuei753CnGOBetYUGXBKXwl
-QS5KxPNx3DrkbbsP3vLKW2dftFFz5y9/aivGp6Ondv3p1kcBsxvwdiZW5iMBKwNMsf+DCdTGQ1T7
-Nm9ZDizPSBWCsipxpWA5R88qCs5p4ByCRfevAJZZD7Ae+vyOM7/92S1f9IPygf3vj2B4IHjk2e9P
-ngQKO5O4spjuZQAlAEXs/2AOtfFwJUEvXqmgkxCnKFnLfus4qMpecvngdt0j+KW2L35ux8jv/PqW
-B/2gcmD/+yO4OGUHnv/RxRSkDDAfgMH+Dy6gNj6H2ZBwTpfuqMDzPem/3N93isA69lmnm1TZy8tw
-GtcNLAB44L4dtb/78t3Ydusm7Ds8gnMXZvHi66dTsJKffufoKGrjs6ijiNGxSYSRW7Ktgm8GVpIN
-AmIdK5HjkFNWlSh+6HLD5U2gtqunFOx89Eufwh23bca+98ehbgw/2DsCADhx5jTGJycQ+xVMTNfR
-arbQiuxioDzpFVk+8CTgxY59seUmJSrg+rzXkiP1lSd2PyIi25wqjADWKqLYwqlCnSZH7RxV+dQz
-f/v7p7rCg22AdzIzu2bo4R//6xCmZ6bxwK/djt6eKubqLZyrFzEbAkcOHYWow203DeKT2+9sC7wR
-BJ4ng8+9sufesfOT96bgZCmhMcYURMRj7gsCuPuu7S/ffsvWcVKXdgC6hENYQeD9ZUbqj4eqF+93
-bguMAKqKas8oaucEs/NLZiCvATjVNQ6PJc37AAooFwP85e99Bv/+0nsAiugrl3BmxoMVwchIDbNz
-8ygWfIQ5ZolAfE+qBDB2fureiem5P79cFkxMTb1z+y1bx9c9kSaJgd4iHn7gdlA3w/PqILcjigez
-lwBJvLrnGF744QfLWfj9SVjgt8OEUgB8/t6bMN+IMD7vEBQtZqcUp0+dgbMOVKIVWuzYHt1z4Fhw
-KPClF4CXH+ln//6PEnOQNrsg6bm1ipdfP4pvvbDn2lUdhESjeSPAAVSKEZQF1JslWOegSogAtbFp
-zDeiSxRtZVsiiVksBRw8ehLnpyYxGQ3DGQfDSRw5fAzz9bDN/TCyKBUqt/qeO2qMVFQJEp7ve22x
-tqqp1xSISCJQApwZm0Ozaa9ticapIrYOgAenDtYp6s065puEdQojgpm5ZjK4JJYvjZj2/pPD53B8
-tIVzrSpCRhg5eRwH3t6PZn0eN229GUExgDEGrcii4Pu/VPB1ryrEWvZaRdGIeBmh6o0Ys/MhjEhn
-N4ILFxtYzzLNkmCFkcV8I4Qx5zAzvwnN0KLgT8EzhHP92aQALj0dwFMAtwHA24fGcGxkCidniKOn
-RnHi8BHMTk0CVKg6jJwawfCWm+AbD2FoYYzscA591rGs7HJCXebX3rOBvtZgOVX4Xg3N8DNoxYpm
-aFFv9sO5SYSxhUmW6rS1a6nRjC2+WvDjp/e8N46jtTn89OhF7N13GBNjZ+D5PozxQSroEo965vQI
-CtvvQBhZCMw2p6ws99phZNEMY/jGoFzy04ETKJcPatcNLHWKMxeGoCzA2hai2EFEMDVbxNTcDLyU
-9pkz6Abrg1qjevwsfnC8Vnvz4nR038H3a3j33Z+h4BTDNyZlckLSsCNhlzpFWG+gFVp4nnfXch2e
-nGniyPGLoAJbhvtQKvqwsYJMJMLpdWBWxniRZAagfS7Ae8cvAMJE4NPYJNt+NtIsE+jZd+jE42Fk
-74utwx233YRbt2xGFDvENtHDOHbpMb1OP0tCB8HwYGF4bDJe5Pr/9bmfwDni03dvwSe2DWFmNkxY
-5fT6gKUpWG0hkJw+QHDw2DgSL6VQdqaDj442AwIDIPDpX7zjMSUeW6rEogSYBIKedVpVRUDA+8Qt
-+hueKffNNez25Tq8590knLvz1kEYI20no0pYx/ZAX2Nm5RiVE3QjifmQePzZr//BruyZ42ebBSbz
-epe1KVlRRXt5ou9Jz8lz3kHVCEq+0f3ODz/4m99R1e8ogW98+7uvtMdSAKeJsFuncO6aM4tJ6TBn
-ekkgkJxrV05wcqxlSPQTXDknIzxVVpErkxgjBSMS6FV4MrJTs7JpKnZ9zDDntfNumtol6oJBAIWV
-lhWQLGuyAF+6prL6rsrji4BMTM8pr6dm5eMYybFM0oQz6dTp8VaVRMAV69vs5xIlE9+TCgTmStdv
-SJrEuqwSev3Ayplhyiq0NQugKghg5HxYVrJnBTPxlRwAkZtLpIAqAnhGTI+SAqY2lR47ern4vDMG
-neqBI2HTUCSdT/R8UZ9QqCDZkXhuBaFIjwRU0s9TdUnP6SiaX3/iLyO+neETdAl98r0RMQCqK5hd
-hWRfLoDzoM4XZ0viXCBGBuCSpdWiGQWTBIkKaDuOa9fjJdPFDNsMKFXCObYFvrcoA9VCeCOpi4DI
-vDI1a4ftej8BWCexVYlDZ6KmNS2nSe8uqVnS9jgLTZIkrPJrf/E3z3yNSNiQvRSRmmj7POUAOxWN
-tSsudsS9rVlp+72BDJW9eLjTlw4YzAGHDlgkoVYlio2EsZMwVhOvXKLJ2X0n70r0qlwM8NAX7sn9
-aMbTZQDJralObpDFJccM0Pz9yN+6uEZ5z/ZhMLUCp4u9Yakg/YG4zZQcWGn7nQFuM1SVEltFSwkC
-ErasadZj08xYtaIZimCB0BcLPu7cugk7PrklN0pcMNLtE8m9Zi75bZu1dG5l2mPm2pAlnsmuiXzF
-k21TdE6hqRkWfQz5xsUL+tU+bw8slRIr0YoV84Q0I2fqk83C+bnIa3Svl1sGLG0vc2oDBqCnEmB6
-tplQn8yi8LQsy/YcHkkYk5ROJM0jTWrK2TlEkufSqDszJSoXPJMvwRgRCATWKWKniK0isq6tWVY7
-3jDwZdBPSUFZyPDUeq1SWgTrqhJHzkxPNv2RC43CxdiJu/xKqRIEFwCWmWPmUcCFZtjRALZDDeTL
-J+0QJFXCNPxgru7NlJHZfZKafuc605cEWJdjVne6UzAYMEK/beadcpJVoklIXYlW5MzYbOiPjNeD
-0fnYNFNHf2Vl5W6QAOm8VCriC3WrIwxiOsB0XjZnkpJ6ovYkAds55oIaVc5ks/AlC0AXmF8KnHOa
-hj1AwZNNBqxmXQcQE2gqZUYps5EzI/XYOz3ZCmoTDX8iVtGVnI+/nJfJtOvshTk0WyGMmASkrGOK
-dLYnu05egsmMDIxn0lKOgeeZxJQ8gWcMRADnUkG2SbXA2qTMImLgmeQ+zwi83LVAEFmHVuTQii3C
-yCKMk+swtguCUs9g0CSLui0hTSUajmY8Vqk1rXdiJiycmmgE4w1rwstNsy7JrJd+fASNVtTJ7pGL
-a1yibdkoZ3rDNNI3Jtk9kwJlAJOeJ8l6wgTrMmFO+G8k/0wCVnYkicg6hHEyNRdZhyjW9JiUeerN
-1gJHSkjDUWqxmlORMyfm4sLxiVYwMh/6DXeFyegisPa+8U7xq0/vLTglnnp+L7q9eX5yrvvzdV6l
-eEWbEqGjjDmaE5F6xxrWPz4VBidnosK0dVfXVb8LKAOgeNeW/l0CDN8wULmhFPi9viclI+IHvtfr
-+6YMopCRIJUUL5Ubk3fPCxZ1eF6pK6xCLrpaDH7Xdfckal4zuISEVKvV2YYLzrWcNzoXB2dno8JU
-5MTqEn1b1Yw0AMzUbQnEoHaKd1VVljUvymkdKUsnspld5mZ7ScL3TMWIVJQKly0Fyq+Vyp7hpZYR
-JZmFdv3WSkuO1n1Geq5h0/pUexpxCFe5yFUA8Y2U9UNkomu6MEQE/Uj+s7cqoNLVL+X1XMh/XcGq
-t1wPIKU0OlkVUAKI50kZG2RbAFYzdB6AXoCrZlTGKtkgrFqKWQNIFmKsGqh0BcyGYdUCsFqRKwMo
-JqYnq/7HwkZjVRusKFYjkIG1YNRGZVWHWYJBApsga/MfGN+TomBjsQoAjHVaAnDzWgGVZvwVbMDN
-ALhjLf9VVTASSDKZseG2/x8AeW7Aj7mVvz8AAAAASUVORK5CYII=
-"
-       style="image-rendering:optimizeSpeed"
-       preserveAspectRatio="none"
-       height="66"
-       width="75" />
-  </g>
-  <g
-     inkscape:label="Foreground"
+     inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
      style="display:inline"
-     transform="translate(0,-986.3622)">
+     transform="translate(0,-1036.3622)">
+    <g
+       id="receiver"
+       transform="translate(17.6875)">
+      <title
+         id="title3214">receiver</title>
+      <path
+         style="fill:url(#linearGradient4927);fill-opacity:1;stroke:url(#linearGradient4919);stroke-width:0.715692;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m -16.636395,1044.0772 v 7.0931 h 7.1249663 7.1249674 v -7.0931 h -3.0033491 v 2.013 h 0.9265651 v 3.0672 h -5.0481834 -5.0481823 v -3.0672 h 0.926565 v -2.013 z"
+         id="path4143"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccc" />
+    </g>
     <path
-       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4426);stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 16.736,1003.0392 14.488067,15.7511"
-       id="path4418"
-       inkscape:connector-curvature="0" />
-    <path
-       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient4462);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4606)"
-       d="m 47.000294,1007.3622 -12.319149,16.9335 -12.416197,17.0669 16.933329,0 17.066666,0 12.416197,-17.0669 0.09676,-0.133 12.2221,-16.8001 -17.066666,0 -16.933329,0 z"
-       id="rect10961-8-3-6-1"
-       inkscape:connector-curvature="0"
-       transform="matrix(1.2008267,0,0.09173299,0.36603268,-108.57532,660.98864)"
-       inkscape:transform-center-x="4.4580006"
-       inkscape:transform-center-y="0.53407962" />
-    <path
-       style="display:inline;fill:url(#linearGradient4494);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4510);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 23.207107,1023.8622 13.292893,0 0,-13.1948 z"
-       id="path4478"
-       inkscape:connector-curvature="0" />
-    <path
-       sodipodi:type="star"
-       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4285-9-8)"
-       id="path4252-6-0"
-       sodipodi:sides="4"
-       sodipodi:cx="4.7729707"
-       sodipodi:cy="1041.2474"
-       sodipodi:r1="3.3255017"
-       sodipodi:r2="0.49178758"
-       sodipodi:arg1="2.432965"
-       sodipodi:arg2="-3.0800218"
-       inkscape:flatsided="false"
-       inkscape:rounded="0"
-       inkscape:randomized="-0.017554997"
-       d="m 2.2999628,1043.3702 1.9823895,-2.1047 -1.6734053,-2.5419 2.1987064,2.0209 2.4513363,-1.6427 -2.0383649,2.1623 1.7419712,2.4882 -2.2030799,-2.0431 z"
-       transform="matrix(-0.68431401,-1.2284231,-1.0636666,0.87657521,1139.9713,112.35675)"
-       inkscape:transform-center-x="0.16252253"
-       inkscape:transform-center-y="-0.33383187" />
-    <path
-       style="fill:url(#linearGradient4438);fill-opacity:1;fill-rule:evenodd;stroke:#3d5b8a;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 6.7500001,1018.1127 0,22.4995 46.4999999,0 0,-22.4995 -11,-4e-4 0,7.9997 3.085106,4e-4 -3.19e-4,6.9996 -31.584946,4e-4 3.19e-4,-6.9997 2.99984,-9e-4 0,-7.9997 z"
-       id="path4430"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccccccccc" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#edf2f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4506)"
-       d="m 15.342812,1019.5906 -7.0000002,0 0,20"
-       id="path4480"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#eef1f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4524)"
-       d="m 11.162866,1034.8767 36,0 0,-9"
-       id="path4510"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccc" />
-    <path
-       style="opacity:0.98000004;fill:none;fill-rule:evenodd;stroke:#eef1f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4566)"
-       d="m 43.900881,1024.6827 0,-5 8,0"
-       id="path4528"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#5d7aad;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4588)"
-       d="m 10.260003,1038.6222 41,0 0,-17"
-       id="path4570"
-       inkscape:connector-curvature="0" />
-    <path
-       sodipodi:type="star"
-       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4661)"
-       id="path4252-6-0-1"
-       sodipodi:sides="4"
-       sodipodi:cx="4.7729707"
-       sodipodi:cy="1041.2474"
-       sodipodi:r1="3.3255017"
-       sodipodi:r2="1.0287941"
-       sodipodi:arg1="2.432965"
-       sodipodi:arg2="3.1299058"
-       inkscape:flatsided="false"
-       inkscape:rounded="0"
-       inkscape:randomized="-0.017554997"
-       d="m 2.2999628,1043.3702 1.5012045,-2.162 -1.1922203,-2.4846 2.095707,1.5226 2.5543357,-1.1444 -1.4929874,2.1437 1.1965937,2.5068 -2.164271,-1.4559 z"
-       transform="matrix(-0.3564605,-0.66452158,-0.554066,0.47418772,596.13721,512.95467)"
-       inkscape:transform-center-x="0.084658908"
-       inkscape:transform-center-y="-0.18053454" />
+       style="display:inline;fill:url(#linearGradient3924);fill-opacity:1;stroke:none"
+       d="m 2.3913486,1039.7123 0.6549857,-0.6549 6.2783105,6.2782 1.3099712,-1.3099 0.335443,3.4985 -3.4985424,-0.3034 1.2300951,-1.2302 z"
+       id="arrow"
+       inkscape:connector-curvature="0">
+      <title
+         id="title3212">arrow</title>
+    </path>
   </g>
 </svg>


### PR DESCRIPTION
The SVGs for opening the import/export preferences wizard inside the preferences dialog have erroneously been taken from wizard banner icons, which have more details and are larger than the actual icons to be used. This leads to either blurry icons or icons that are too large within the preferences dialog.

This change replaces the SVGs with ones that are resized (from 16x16 to 24x24) from the existing import/export wizard tool icons to conform with the existing PNG icons.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2956

### How it looks on Windows

#### Before
![image](https://github.com/user-attachments/assets/7e7aa30e-2a1a-474a-b094-3d061a33b40f)

#### After
![image](https://github.com/user-attachments/assets/762bf4e5-baa5-495c-bbd8-9028e2798372)

### How it looks on MacOS

#### Before
<img width="302" alt="image" src="https://github.com/user-attachments/assets/6a9de770-bd5b-449b-b5dd-934737290ad3" />

#### After
<img width="157" alt="image" src="https://github.com/user-attachments/assets/c9eea1f9-c5f3-431d-9750-3f3c993221e2" />