### PR TITLE
LogView: Date column should be more fine grained

### DIFF
--- a/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.views.log/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.ui.views.log;singleton:=true
-Bundle-Version: 1.4.800.qualifier
+Bundle-Version: 1.4.900.qualifier
 Bundle-Activator: org.eclipse.ui.internal.views.log.Activator
 Bundle-Vendor: %provider-name
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogEntry.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogEntry.java
@@ -31,9 +31,9 @@ public class LogEntry extends AbstractEntry {
 
 	public static final String SPACE = " "; //$NON-NLS-1$
 	public static final String F_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS"; //$NON-NLS-1$
-	private static final DateTimeFormatter GREGORIAN_SDF = DateTimeFormatter.ofPattern(F_DATE_FORMAT, Locale.ENGLISH)
+	static final DateTimeFormatter GREGORIAN_SDF = DateTimeFormatter.ofPattern(F_DATE_FORMAT, Locale.ENGLISH)
 			.withZone(ZoneId.systemDefault());
-	private static final DateTimeFormatter LOCAL_SDF = DateTimeFormatter.ofPattern(F_DATE_FORMAT)
+	static final DateTimeFormatter LOCAL_SDF = DateTimeFormatter.ofPattern(F_DATE_FORMAT)
 			.withZone(ZoneId.systemDefault());
 
 	private String pluginId;

--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogSession.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogSession.java
@@ -15,9 +15,11 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.views.log;
 
+import static org.eclipse.ui.internal.views.log.LogEntry.GREGORIAN_SDF;
+import static org.eclipse.ui.internal.views.log.LogEntry.LOCAL_SDF;
+
 import java.io.PrintWriter;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Date;
 
 /**
@@ -31,8 +33,10 @@ public class LogSession extends Group {
 	 * @since 3.5
 	 */
 	public static final String SESSION = "!SESSION"; //$NON-NLS-1$
+
 	private String sessionData;
 	private Date date;
+	private String fDateString;
 
 	public LogSession() {
 		super(Messages.LogViewLabelProvider_Session);
@@ -42,11 +46,30 @@ public class LogSession extends Group {
 		return date;
 	}
 
+	/**
+	 * Returns a pretty-print formatting for the date for this entry
+	 * 
+	 * @return the formatted date for this entry
+	 */
+	public String getFormattedDate() {
+		if (fDateString == null) {
+			Date tmpdate = getDate();
+			if (tmpdate != null) {
+				fDateString = LOCAL_SDF.format(tmpdate.toInstant());
+			}
+		}
+		return fDateString;
+	}
+
 	public void setDate(String dateString) {
-		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS"); //$NON-NLS-1$
 		try {
-			date = formatter.parse(dateString);
-		} catch (ParseException e) { // do nothing
+			Date parsed = Date.from(Instant.from(GREGORIAN_SDF.parse(dateString)));
+			if (parsed != null) {
+				this.date = parsed;
+				fDateString = LOCAL_SDF.format(parsed.toInstant());
+			}
+		} catch (Exception e) {
+			// do nothing
 		}
 	}
 

--- a/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogViewLabelProvider.java
+++ b/bundles/org.eclipse.ui.views.log/src/org/eclipse/ui/internal/views/log/LogViewLabelProvider.java
@@ -15,7 +15,6 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.views.log;
 
-import java.text.DateFormat;
 import java.util.ArrayList;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.resource.JFaceResources;
@@ -34,8 +33,6 @@ public class LogViewLabelProvider extends LabelProvider implements ITableLabelPr
 	private Image errorWithStackImage;
 	private Image hierarchicalImage;
 	ArrayList<Object> consumers = new ArrayList<>();
-	private DateFormat dateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT);
-
 	private LogView logView;
 
 	public LogViewLabelProvider(LogView logView) {
@@ -81,7 +78,7 @@ public class LogViewLabelProvider extends LabelProvider implements ITableLabelPr
 			if (session.getDate() == null)
 				return ""; //$NON-NLS-1$
 
-			return dateFormat.format(session.getDate());
+			return session.getFormattedDate();
 		}
 
 		if ((element instanceof Group) && (columnIndex == 0)) {
@@ -106,7 +103,7 @@ public class LogViewLabelProvider extends LabelProvider implements ITableLabelPr
 					if (entry.getPluginId() != null)
 						return entry.getPluginId();
 				case 2 :
-					return dateFormat.format(entry.getDate());
+					return entry.getFormattedDate();
 			}
 		}
 


### PR DESCRIPTION
- and show `yyyy-MM-dd HH:mm:ss.SSS` instead of just minute precision
- this is useful where you want to see the exact time of log events in cases where seconds or even milliseconds matter

Shows this:

<img width="993" alt="image" src="https://github.com/user-attachments/assets/6b9ef5ff-5c8a-45bf-85d5-919d4bf47273" />

instead of 

<img width="975" alt="image" src="https://github.com/user-attachments/assets/61a949ea-5f7b-436f-9d41-94391f85df2b" />
