### PR TITLE
Filter e4 view contributions in "Show View -> Other" via activities

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchContributionFactory.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchContributionFactory.java
@@ -28,6 +28,7 @@ import org.osgi.framework.Bundle;
 class WorkbenchContributionFactory implements IContributionFactory {
 
 	private static final String BUNDLE_CLASS_PREFIX = "bundleclass://"; //$NON-NLS-1$
+	private static final String PLATFORM_PLUGIN_PREFIX = "platform:/plugin/"; //$NON-NLS-1$
 
 	private final IContributionFactory delegate;
 
@@ -61,6 +62,8 @@ class WorkbenchContributionFactory implements IContributionFactory {
 			String identifierId = uriString;
 			if (uriString.startsWith(BUNDLE_CLASS_PREFIX)) {
 				identifierId = uriString.substring(BUNDLE_CLASS_PREFIX.length());
+			} else if (uriString.startsWith(PLATFORM_PLUGIN_PREFIX)) {
+				identifierId = uriString.substring(PLATFORM_PLUGIN_PREFIX.length());
 			}
 			if (activitySupport == null) {
 				activitySupport = context.get(IWorkbenchActivitySupport.class);


### PR DESCRIPTION
Activities filtering for e4 is possible since
04f719b2f08eb8c8ab3ec81c3be15c9a428e172e, see
org.eclipse.e4.core.services.contributions.IContributionFactory

Allow "Show View -> Other" to filter e4 contributed views.

This is the one part of the fix for PDE activities not covering SWT tooling. Second part is to extend PDE activity patterns.

See https://github.com/eclipse-platform/eclipse.platform/issues/1869