### PR TITLE
Colors are null in Section onPaint and cause null pointer exception #2972

### DIFF
--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/Section.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/Section.java
@@ -316,7 +316,8 @@ public class Section extends ExpandableComposite {
 	@Override
 	protected void onPaint(PaintEvent e) {
 		Color bg = (titleColors != null) ? titleColors.getOrDefault(COLOR_BG, getBackground()) : getBackground();
-		Color fg = (titleColors != null) ? getTitleBarForeground() : getForeground();
+		Color fg = (titleColors != null) ? (getTitleBarForeground() != null
+				? getTitleBarForeground() : getForeground()) : getForeground();
 		Color border = (titleColors != null) ? titleColors.getOrDefault(COLOR_BORDER, fg) : fg;
 
 		GC gc = e.gc;

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/Section.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/Section.java
@@ -316,8 +316,7 @@ public class Section extends ExpandableComposite {
 	@Override
 	protected void onPaint(PaintEvent e) {
 		Color bg = (titleColors != null) ? titleColors.getOrDefault(COLOR_BG, getBackground()) : getBackground();
-		Color fg = (titleColors != null) ? (getTitleBarForeground() != null
-				? getTitleBarForeground() : getForeground()) : getForeground();
+		Color fg = (getTitleBarForeground() != null) ? getTitleBarForeground() : getForeground();
 		Color border = (titleColors != null) ? titleColors.getOrDefault(COLOR_BORDER, fg) : fg;
 
 		GC gc = e.gc;


### PR DESCRIPTION
Changed code found in Section.class (onPaint) which lets null values slip through and cause null pointer exception.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2972