### PR TITLE
Improve empty workspace helper layout

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/helpers/EmptyWorkspaceHelper.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/helpers/EmptyWorkspaceHelper.java
@@ -191,7 +191,7 @@ public final class EmptyWorkspaceHelper {
 
 		Composite optionsArea = new Composite(infoArea, SWT.NONE);
 		GridLayoutFactory.swtDefaults().numColumns(2).applyTo(optionsArea);
-		GridDataFactory.swtDefaults().indent(5, 0).grab(true, true).applyTo(optionsArea);
+		GridDataFactory.swtDefaults().indent(5, 0).align(SWT.FILL, SWT.CENTER).grab(true, true).applyTo(optionsArea);
 
 		final FormToolkit toolkit = new FormToolkit(emptyArea.getDisplay());
 		emptyArea.addDisposeListener(e -> toolkit.dispose());
@@ -283,7 +283,7 @@ public final class EmptyWorkspaceHelper {
 				action.run();
 			}
 		});
-		GridDataFactory.swtDefaults().align(SWT.FILL, SWT.FILL).grab(true, false).applyTo(addLink);
+		GridDataFactory.swtDefaults().align(SWT.BEGINNING, SWT.FILL).grab(true, false).applyTo(addLink);
 	}
 
 	private IAction getAction(IWizardRegistry registry, String id) {


### PR DESCRIPTION
This PR adjusts the grid layout in EmptyWorkspaceHelper to address an issue in Windows with monitor specific scaling active. This commit will not fully solve the issue, but significantly lower the scenarios when it is triggered.

It reduces the effect the mentioned issue by letting the parent Composite fill its that. That way the issue will only occur when the View has a specific width. The proper fix will need additional effort in SWT which could cause other regressions, therefor I'd recommend this PR this late in the release cycle.

Contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/2003

The Border are of course only added temporarily for the screenshots

#### Layout Before
![ewh_before](https://github.com/user-attachments/assets/6d1fb40f-c360-425c-bb5e-cb76d79d5937)

#### Layout After
![ewh_after](https://github.com/user-attachments/assets/5751d22d-2d3b-42be-832c-4b27ccba2e05)
