### PR TITLE
Add MouseEnter & MouseMove Event in PopupCloser

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/PopupCloser.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/PopupCloser.java
@@ -109,6 +109,9 @@ class PopupCloser extends ShellAdapter implements FocusListener, SelectionListen
 
 			fDisplay.addFilter(SWT.Deactivate, this);
 			fDisplay.addFilter(SWT.MouseUp, this);
+
+			fDisplay.addFilter(SWT.MouseMove, this);
+			fDisplay.addFilter(SWT.MouseEnter, this);
 		}
 	}
 
@@ -130,6 +133,9 @@ class PopupCloser extends ShellAdapter implements FocusListener, SelectionListen
 
 			fDisplay.removeFilter(SWT.Deactivate, this);
 			fDisplay.removeFilter(SWT.MouseUp, this);
+
+			fDisplay.removeFilter(SWT.MouseMove, this);
+			fDisplay.removeFilter(SWT.MouseEnter, this);
 		}
 	}
 
@@ -206,6 +212,8 @@ class PopupCloser extends ShellAdapter implements FocusListener, SelectionListen
 				}
 				break;
 
+			case SWT.MouseEnter:
+			case SWT.MouseMove:
 			case SWT.MouseUp:
 				if (fAdditionalInfoController == null || fAdditionalInfoController.getInternalAccessor().isReplaceInProgress())
 					break;
@@ -224,7 +232,7 @@ class PopupCloser extends ShellAdapter implements FocusListener, SelectionListen
 							}
 
 							// XXX: workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=212392 :
-							control.getShell().getDisplay().asyncExec(() -> fAdditionalInfoController.getInternalAccessor().replaceInformationControl(true));
+							fAdditionalInfoController.getInternalAccessor().replaceInformationControl(event.type == SWT.MouseUp);
 						}
 					}
 				}

--- a/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.editors; singleton:=true
-Bundle-Version: 3.20.0.qualifier
+Bundle-Version: 3.20.100.qualifier
 Bundle-Activator: org.eclipse.ui.internal.editors.text.EditorsPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/TextEditorMessages.properties
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/TextEditorMessages.properties
@@ -12,7 +12,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 
-EditorsPlugin_additionalInfo_affordance=Press 'Tab' from proposal table or click for focus
+EditorsPlugin_additionalInfo_affordance=Press 'Tab' from proposal table or click/hover for focus
 EditorsPlugin_internal_error=Internal Error
 
 TextEditorPreferencePage_displayedTabWidth=Displayed &tab width:


### PR DESCRIPTION
This commit adds MouseEnter and MouseMove event in the PopupCloser, as Edge browser can only react to mouse movements and not mouse clicks. This also makes the beahviour of PopupCloser consistent with AbstractHoverInformationControl:Closer.

See https://github.com/eclipse-platform/eclipse.platform.swt/pull/1551

fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/2072

**Explanation:** The reason why edge browser doesn't react to a mouse hover over the jvadoc tooltip is because the controller responsible for managing the javadoc tooltip in this case is AdditionalInfoController and the closer needed to replace the tooltip on the mouse event is a PopUpCloser. The PopUpCloser doesn't have any mouse movement events (MouseMove & MouseEnter) registered like AbstractHoverInformationControl:Closer (Which is responsible for javadoc tooltip on code hover), hence the javadoc tooltip is not replaced.

**Fix:** Simply register PopUpCloser with the MouseMove and MouseEnter events and handle these events to trigger the replacement of the control similar to AbstractHoverInformationControl:Closer.