### PR TITLE
Add cycle detection for e4.ui.dialogs.filteredtree.PatternFilter

### DIFF
--- a/bundles/org.eclipse.e4.ui.dialogs/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.dialogs/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.ui.dialogs
-Bundle-Version: 1.6.100.qualifier
+Bundle-Version: 1.7.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
Enabling it, prevents stack-overflows when handling trees/tables with recurring elements (which are not trees from a graph-theory point of view as these graphs have cycles).

This is useful for example in
- https://github.com/eclipse-pde/eclipse.pde/pull/1737

As far as I can tell, there are no testes for this class yet, I only found `PatternFilterTest` which tests the equivalent `PatternFilter` from the package `org.eclipse.ui.dialogs`. I'll check if the latter can be used as a foundation for this case.