### PR TITLE
Always set disabled icons in AbstractContributionItem

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/AbstractContributionItem.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/AbstractContributionItem.java
@@ -149,10 +149,17 @@ public abstract class AbstractContributionItem extends ContributionItem {
 	}
 
 	protected Image getImage(String iconURI, LocalResourceManager resourceManager) {
+		return createImage(iconURI, resourceManager, false);
+	}
+
+	private Image createImage(String iconURI, LocalResourceManager resourceManager, boolean disabled) {
 		Image image = null;
 
 		if (iconURI != null && iconURI.length() > 0) {
 			ImageDescriptor iconDescriptor = resUtils.imageDescriptorFromURI(URI.createURI(iconURI));
+			if (disabled) {
+				iconDescriptor = ImageDescriptor.createWithFlags(iconDescriptor, SWT.IMAGE_DISABLE);
+			}
 			if (iconDescriptor != null) {
 				try {
 					image = resourceManager.create(iconDescriptor);
@@ -167,6 +174,10 @@ public abstract class AbstractContributionItem extends ContributionItem {
 			}
 		}
 		return image;
+	}
+
+	private Image getDisabledImage(String iconURI, LocalResourceManager resourceManager) {
+		return createImage(iconURI, resourceManager, true);
 	}
 
 	protected void updateIcons() {
@@ -184,13 +195,22 @@ public abstract class AbstractContributionItem extends ContributionItem {
 			Image iconImage = getImage(iconURI, resourceManager);
 			item.setImage(iconImage);
 			item.setData(ICON_URI, iconURI);
-			if (item instanceof ToolItem) {
+			if (item instanceof ToolItem toolItem) {
 				iconImage = getImage(disabledURI, resourceManager);
-				((ToolItem) item).setDisabledImage(iconImage);
-				item.setData(DISABLED_URI, disabledURI);
+				toolItem.setDisabledImage(iconImage);
+				toolItem.setData(DISABLED_URI, disabledURI);
 			}
 			disposeOldImages();
 			localResourceManager = resourceManager;
+		}
+		// if there is no explicit disabled icon and the element becomes disabled,
+		// create it
+		boolean hasExplicitDisabledImage = "".equals(disabledURI); //$NON-NLS-1$
+		if (!modelItem.isEnabled() && !hasExplicitDisabledImage && item instanceof ToolItem toolItem) {
+			if (toolItem.getDisabledImage() == null) {
+				Image iconImage = getDisabledImage(iconURI, localResourceManager);
+				toolItem.setDisabledImage(iconImage);
+			}
 		}
 	}
 


### PR DESCRIPTION
AbstractionContributionItems only set a disabled icon on the ToolItem in case such a disabled icon is specified via an explicit URI to that icon. If no such URI is specified, the ToolItem creates a disabled icon on the fly. Since the ToolItem creates a new image every time the enablement state of the ToolItem changes, this leads to unnecessary repeated creation of images.
In contrast, ActionContributionItems always set the disabled icon for their ToolItem, even if no disabled image descriptor is specified for them, to avoid that the ToolItem repeatedly created that icon.

This change align the AbstractContributionItem handling for disabled icons with the one of ActionContributionItems: in case no URI to a disabled icon is specified, the SWT disablement mechanism is used to create a disabled version and to explicitly set it at the ToolItem. This avoids unnecessary repeated creation of the disabled version of an icon for those items.

@vogella maybe you know this code best and have an opinion on it? It would be nice to bring this in for M3/RC1 as otherwise the replacement of the pre-generated disabled icons (PNGs) with on-the-fly generated disabled version (based on SVGs) will lead to unnecessary, repeated image creations in the upcoming release.