### PR TITLE
Workaround for unexpected text wrapping in ExpandableComposite

### DIFF
--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/ExpandableComposite.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/ExpandableComposite.java
@@ -22,6 +22,7 @@ package org.eclipse.ui.forms.widgets;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.ListenerList;
+import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
@@ -287,7 +288,13 @@ public class ExpandableComposite extends Canvas {
 			Point labelDefault = this.textLabelCache.computeSize(SWT.DEFAULT, SWT.DEFAULT);
 
 			int tcWidthBeforeSplit = Math.min(width, tcDefault.x);
-			int labelWidthBeforeSplit = Math.min(width, labelDefault.x);
+
+			int additionalLabelWidthPadding = 0;
+			if (OS.isWindows()) {
+				/* compensate rounding issue in windows */
+				additionalLabelWidthPadding = 1;
+			}
+			int labelWidthBeforeSplit = Math.min(width, labelDefault.x + additionalLabelWidthPadding);
 
 			int tcWidthAfterSplit = tcWidthBeforeSplit;
 			int labelWidthAfterSplit = labelWidthBeforeSplit;


### PR DESCRIPTION
This PR adds one additional point to the width when calculating the minimum size of the textLabel in ExpandableComposite. This serves as a workaround for a current limitation in the SWT implementation on Windows. With certain zoom settings (e.g., 125% or 175%), depending on the length of the label text, the calculated width may be too small, causing the text to wrap unnecessarily. 

**This is intended as a temporary workaround.** If we merge this, we should either revert it after the release to reintroduce the issue or have hopefully a proper fix inside of SWT.

I want to emphasize this PR is only a workaround not my preferred one, but the only one, I see feasible as of now. We could still come to the conclusion to not merge/close this PR if the effect is acceptable for now until this issue can be solved inside of SWT.

## How to test

You can see this effect e.g. in the Manifest Editor as well. You should see the issue in 175% in the _Build_ tab and the _Runtime Information_ section.

### Screenshot before
![before](https://github.com/user-attachments/assets/1f989920-0e2c-451e-b291-8773a63d8f6e)

### Screenshot after
![after](https://github.com/user-attachments/assets/3083fa3f-f62a-4ae7-b54d-a1c1c98ebeaa)
