### PR TITLE
Fix LineNumberRuler glitch from incorrect listener order on zoom

### DIFF
--- a/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.text
-Bundle-Version: 3.28.0.qualifier
+Bundle-Version: 3.28.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/LineNumberRulerColumn.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/LineNumberRulerColumn.java
@@ -618,11 +618,13 @@ public class LineNumberRulerColumn implements IVerticalRulerColumn {
 		});
 
 		fCanvas.addListener(SWT.ZoomChanged, e -> {
-			computeIndentations();
-			if (fBuffer != null) {
-				fBuffer.dispose();
-				fBuffer= null;
-			}
+			Display.getDefault().asyncExec(() -> {
+				computeIndentations();
+				if (fBuffer != null) {
+					fBuffer.dispose();
+					fBuffer= null;
+				}
+			});
 		});
 
 		fMouseHandler= new MouseHandler();


### PR DESCRIPTION
This change ensures that zoom change events occur *after* all the listeners have been executed in LineNumberRuler.

Previously, zoom changes triggered buffer image invalidation prematurely, leading to multiple redundant resize events. This caused incorrect top pixel calculations when the scrollbar was adjusted after zoom, resulting in rendering glitches during redraws of line numbers.

By deferring the SWT.ZoomChanged event until all the listeners have completed, we avoid early image invalidation. Now, the redraw uses a correctly invalidated buffer image, and top pixel calculations are accurate, eliminating rendering artifacts.

Tested by simulating zoom changes and full scroll-down scenarios—line number ruler now renders consistently without glitches.

### How to Test

**Description**
When moving between Monitors when a Java Editor is opened the LineNumberRulerColumn does not seems to properly redraw everything

**Reproduction**

- Open a Java File
- Scroll down till the end
- Move the IDE to another monitor, see

https://github.com/user-attachments/assets/6d9e1c6b-202e-4afd-8426-f8afe941843b

Expected Behavior
The line number should always be correct

Necessary configuration:
Left monitor was 175%, right monitor was 150%. Could be important that I moved from the bigger to the smaller monitor.

### Proposed Solution

Below I have tried to explain the issue with the order of listeners being called. 

**Before Fix**

Resize Called From Styled Text
Zoom Changed <--- clears the buffer image
Resize Called From Styled Text <--- (Resize happens due to zoom change (This create a new image for the line ruler)
Resize Called From Styled Text <--- (Resize happens due to adjustment of scroll bar) <--- Top pixel is calculated wrongly if you scroll down completely
Redraw Line Number and my buffer is = Image {{150=org.eclipse.swt.graphics.Image$ImageHandle@1fb61db4}} <--- Uses the top pixel to redraw the line numbers that are now visible and copy the ones that were already visible previously

**After Fix**

If we make sure that SWT.ZoomChange happens after DPIZoomChangeRegistery handle all the DPI changes for the composites and all of its listener then we get this order 

Resize Called From Styled Text <--- Resize on the primary monitor 
Resize Called From Styled Text <--- Resize happens due to zoom change (Top Pixel is still calculated wrongly)
Resize Called From Styled Text <--- Resize happens due to adjustment of scroll bar
Zoom Changed <--- Clears the image (now we don't care about how top pixel was calculated during the zoom change)
Redraw Line Number and my buffer is = null <--- Here the new image is drawn and glitch is gone
