### PR TITLE
Migrate UI test suite to JUnit 5 and add dependencies for JUnit 5 and

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/UiTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/UiTestSuite.java
@@ -59,14 +59,14 @@ import org.eclipse.ui.tests.stress.OpenCloseTest;
 import org.eclipse.ui.tests.systeminplaceeditor.OpenSystemInPlaceEditorTest;
 import org.eclipse.ui.tests.themes.ThemesTestSuite;
 import org.eclipse.ui.tests.zoom.ZoomTestSuite;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Test all areas of the UI.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	StartupTest.class,
 	UIAutomatedSuite.class,
 	ApiTestSuite.class,

--- a/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse UI Tests
 Bundle-SymbolicName: org.eclipse.ui.tests; singleton:=true
-Bundle-Version: 3.15.2000.qualifier
+Bundle-Version: 3.15.2100.qualifier
 Eclipse-BundleShape: dir
 Bundle-Activator: org.eclipse.ui.tests.TestPlugin
 Bundle-Vendor: Eclipse.org

--- a/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -47,6 +47,10 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="3.14.0",
  org.eclipse.emf.ecore
 Import-Package: jakarta.annotation,
  jakarta.inject,
+ org.junit.jupiter.api;version="[5.12.0,6.0.0)",
+ org.junit.platform.runner;version="[1.12.0,2.0.0)",
+ org.junit.platform.suite.api;version="[1.12.0,2.0.0)",
+ org.junit.vintage.engine;version="[5.12.0,6.0.0)",
  org.osgi.service.event
 Eclipse-AutoStart: true
 Export-Package: org.eclipse.ui.tests.api,


### PR DESCRIPTION
JUnit 4 interoperability

- Update UiTestSuite to use JUnit 5 @Suite and @SelectClasses
- Add org.junit.jupiter.api, org.junit.platform.runner, and org.junit.vintage.engine as dependencies (with and without version range) in MANIFEST.MF
- Ensure both JUnit 5 and JUnit 4 tests can be run together
- Modernize test infrastructure for future compatibility