### PR TITLE
Correct SVG icon for showing menu in part stacks and shared images

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/icons/full/elcl16/view_menu.svg
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/icons/full/elcl16/view_menu.svg
@@ -2,61 +2,82 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    viewBox="0 0 16 16"
-   id="svg4136"
+   id="svg2"
    version="1.1"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="view_menu_new.svg">
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   sodipodi:docname="view_menu.svg"
+   inkscape:export-filename="..\..\..\..\..\..\..\..\..\..\Users\hklare\Desktop\view_menu.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs4138" />
+     id="defs4" />
   <sodipodi:namedview
      id="base"
-     pagecolor="#c8c8c8"
+     pagecolor="#b8b8b8"
      bordercolor="#666666"
      borderopacity="1.0"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="26.53125"
-     inkscape:cx="19.238293"
-     inkscape:cy="6.7547354"
+     inkscape:zoom="17.5625"
+     inkscape:cx="-3.1032028"
+     inkscape:cy="6.2064057"
      inkscape:document-units="px"
-     inkscape:current-layer="g4745"
+     inkscape:current-layer="layer1"
      showgrid="true"
      units="px"
      inkscape:snap-bbox="true"
      inkscape:bbox-nodes="true"
-     inkscape:window-width="1680"
-     inkscape:window-height="942"
+     inkscape:window-width="1720"
+     inkscape:window-height="1369"
      inkscape:window-x="-8"
-     inkscape:window-y="-8"
+     inkscape:window-y="-6"
      inkscape:window-maximized="1"
-     inkscape:snap-bbox-midpoints="false"
-     inkscape:snap-bbox-edge-midpoints="false"
-     inkscape:snap-nodes="false"
-     inkscape:snap-others="false"
-     inkscape:snap-global="true">
+     showguides="false"
+     objecttolerance="10000"
+     inkscape:snap-nodes="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#b8b8b8">
     <inkscape:grid
        type="xygrid"
-       id="grid4684" />
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,13"
+       orientation="0,4"
+       id="guide817"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
-     id="metadata4141">
+     id="metadata7">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
+        <dc:title />
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Remain BV, W.S. Jongman</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>Eclipse Foundation</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <cc:license
+           rdf:resource="https://www.eclipse.org/legal/epl-2.0/" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -64,50 +85,24 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(0,-1036.3621)">
-    <g
-       id="g4745"
-       transform="translate(-2,0)">
-      <rect
-         style="fill:#515658;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4522"
-         width="16"
-         height="16.00004"
-         x="32"
-         y="1036.3621" />
-      <rect
-         style="fill:#e0e0e0;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4522-5-8"
-         width="16"
-         height="16.00004"
-         x="-16"
-         y="1036.3621" />
-      <rect
-         style="fill:#f3f3f3;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4522-5"
-         width="3"
-         height="16.00004"
-         x="20"
-         y="1036.3621" />
-      <rect
-         style="fill:#48494c;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4522-4-7"
-         width="16"
-         height="16.00004"
-         x="20"
-         y="1053.3621" />
-      <rect
-         style="fill:#434346;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="rect4522-4"
-         width="16"
-         height="16.00004"
-         x="2"
-         y="1054.3621" />
-      <path
-         style="fill:#fafafa;fill-opacity:1;stroke:#696969;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="M 5.1953123,1039.8614 H 14.804628 L 9.9999697,1044.65 Z"
-         id="path4520"
-         inkscape:connector-curvature="0" />
-    </g>
+     transform="translate(0,-1036.3622)">
+    <circle
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.5175;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4790"
+       cx="7.993598"
+       cy="1039.3524"
+       r="1.725" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.5175;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4790-4"
+       cx="8.0007048"
+       cy="1044.3724"
+       r="1.725" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.5175;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4790-4-7"
+       cx="8.0007048"
+       cy="1049.366"
+       r="1.725" />
   </g>
 </svg>

--- a/bundles/org.eclipse.ui/icons/full/elcl16/view_menu.svg
+++ b/bundles/org.eclipse.ui/icons/full/elcl16/view_menu.svg
@@ -2,23 +2,23 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    viewBox="0 0 16 16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
    sodipodi:docname="view_menu.svg"
-   inkscape:export-filename="C:\Users\jongw\Desktop\view_menu@2x.png"
-   inkscape:export-xdpi="192"
-   inkscape:export-ydpi="192">
+   inkscape:export-filename="..\..\..\..\..\..\..\..\..\..\Users\hklare\Desktop\view_menu.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4" />
   <sodipodi:namedview
@@ -28,23 +28,26 @@
      borderopacity="1.0"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="35.968673"
-     inkscape:cx="7.7830763"
-     inkscape:cy="5.9552658"
+     inkscape:zoom="17.5625"
+     inkscape:cx="-3.1032028"
+     inkscape:cy="6.2064057"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
      units="px"
      inkscape:snap-bbox="true"
      inkscape:bbox-nodes="true"
-     inkscape:window-width="1707"
-     inkscape:window-height="907"
+     inkscape:window-width="1720"
+     inkscape:window-height="1369"
      inkscape:window-x="-8"
-     inkscape:window-y="-8"
+     inkscape:window-y="-6"
      inkscape:window-maximized="1"
      showguides="false"
      objecttolerance="10000"
-     inkscape:snap-nodes="true">
+     inkscape:snap-nodes="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#b8b8b8">
     <inkscape:grid
        type="xygrid"
        id="grid4136" />
@@ -60,7 +63,7 @@
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:title></dc:title>
+        <dc:title />
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
@@ -84,22 +87,22 @@
      id="layer1"
      transform="translate(0,-1036.3622)">
     <circle
-       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#747474;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.5175;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="path4790"
-       cx="10.499991"
-       cy="1040.8622"
-       r="1.5" />
+       cx="7.993598"
+       cy="1039.3524"
+       r="1.725" />
     <circle
-       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#747474;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.5175;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="path4790-4"
-       cx="10.499983"
-       cy="1044.8622"
-       r="1.5" />
+       cx="8.0007048"
+       cy="1044.3724"
+       r="1.725" />
     <circle
-       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#747474;stroke-width:0.44999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.5175;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="path4790-4-7"
-       cx="10.499983"
-       cy="1048.8622"
-       r="1.5" />
+       cx="8.0007048"
+       cy="1049.366"
+       r="1.725" />
   </g>
 </svg>


### PR DESCRIPTION
The SVG version of the icon for showing the menu in part stacks erroneously contained the "thin" version of that icon, showing an error instead of three dots. In addition, the shared image version of that icon contained the three dots shifted to the bottom right and smaller than intended.

This change replaces both SVG version with the same icon containing the correct three-dot-version of the view_menu icon.

### Before
![image](https://github.com/user-attachments/assets/b8e0dea8-d8cb-4c7b-80c6-0a6d56792e81)

### After
![image](https://github.com/user-attachments/assets/a2037c46-7d7a-4a37-a891-c60086ff77cb)

