### PR TITLE
Workaround for unexpected scrollbars in MultipleHyperlinkPresenter

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/hyperlink/MultipleHyperlinkPresenter.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/hyperlink/MultipleHyperlinkPresenter.java
@@ -152,6 +152,14 @@ public class MultipleHyperlinkPresenter extends DefaultHyperlinkPresenter implem
 			fForegroundColor= foregroundColor;
 			fBackgroundColor= backgroundColor;
 			create();
+			getShell().addListener(SWT.ZoomChanged, event -> {
+				final Shell shell= getShell();
+				shell.getDisplay().asyncExec(() -> {
+					if (!shell.isDisposed()) {
+						shell.setSize(computeSizeHint());
+					}
+				});
+			});
 		}
 
 		@Override
@@ -217,6 +225,13 @@ public class MultipleHyperlinkPresenter extends DefaultHyperlinkPresenter implem
 			int width;
 			if (preferedSize.y - scrollBarHeight <= constraints.y) {
 				width= preferedSize.x - scrollBarWidth;
+				if (Util.isWin32()) {
+					/*
+					 * compensate rounding issue in windows
+					 * +1 for preferedSize and +1 for scrollBarWidth
+					 */
+					width+= 2;
+				}
 				fTable.getVerticalBar().setVisible(false);
 			} else {
 				width= Math.min(preferedSize.x, constraints.x);
@@ -225,6 +240,13 @@ public class MultipleHyperlinkPresenter extends DefaultHyperlinkPresenter implem
 			int height;
 			if (preferedSize.x - scrollBarWidth <= constraints.x) {
 				height= preferedSize.y - scrollBarHeight;
+				if (Util.isWin32()) {
+					/*
+					 * compensate rounding issue in windows
+					 * +1 for preferedSize and +1 for scrollBarHeight
+					 */
+					height+= 2;
+				}
 				fTable.getHorizontalBar().setVisible(false);
 			} else {
 				height= Math.min(preferedSize.y, constraints.y);


### PR DESCRIPTION
This PR adds two additional points to the width and height when calculating the size of the composite containing the Hyperlinks in the MultipleHyperlinkPresenter. This serves as a workaround for a current limitation in the SWT implementation on Windows. With certain zoom settings (e.g., 125%, 175% or 225%), the calculated size may be too small, causing the Composite to show Scrollbars, although it calculated to not need scrollbars. This additional width/height is only added for windows and when no scrollbars should be thrown. This is intended as a temporary workaround.

**This is intended as a temporary workaround.** If we merge this, we should either revert it after the release to reintroduce the issue or have hopefully a proper fix inside of SWT. Still, as it affects a quite central element, I would propose to merge this PR.

#### How to test

Use this Snippet and open it on a 225% monitor.
```java
package test;

public class TestClass {
	public static void main(String[] args) {
		// TODO Auto-generated method stub
	}
}
```
Without the PR you will see:
![image](https://github.com/user-attachments/assets/39643029-06a7-46ae-a34d-898b1832427e)

