### PR TITLE
Replacing Image(Device, ImageData) constructor in DefaultRangeIndicator with Image(Device, ImageDataProvider)

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/DefaultRangeIndicator.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/DefaultRangeIndicator.java
@@ -20,6 +20,7 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
@@ -139,16 +140,31 @@ public class DefaultRangeIndicator extends Annotation implements IAnnotationPres
 		int height= size.y;
 
 
-		ImageData imageData= new ImageData(width, height, 1, createPalette(display, rangeIndicatorColor));
+		ImageDataProvider imageDataProvider = zoom -> {
 
-		for (int y= 0, offset= 1; y < height; y++, offset= (offset + 1) % 2)
-			for (int x= offset; x < width; x += 2)
-				imageData.setPixel(x, y, 1);
+			float scaleFactor = (float) ((zoom) / 100.0);
+			int scaled_width = Math.round(width * scaleFactor);
+			int scaled_height = Math.round(height * scaleFactor);
+			ImageData imageData = new ImageData(scaled_width, scaled_height,
+					1,
+					createPalette(display, rangeIndicatorColor));
+			int blockSize = Math.round(scaleFactor);
+			for (int y = 0; y < scaled_height; y++)
+				for (int x = 0; x < scaled_width; x++) {
+					if (((x / blockSize) + (y / blockSize)) % 2 == 0) {
+						imageData.setPixel(x, y, 1);
+					}
 
-		imageData.transparentPixel= 1;
+				}
+			imageData.transparentPixel = 1;
+			return imageData;
+
+		};
 
 
-		return new Image(display, imageData);
+
+
+		return new Image(display, imageDataProvider);
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/DefaultRangeIndicator.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/DefaultRangeIndicator.java
@@ -143,8 +143,8 @@ public class DefaultRangeIndicator extends Annotation implements IAnnotationPres
 		ImageDataProvider imageDataProvider = zoom -> {
 
 			float scaleFactor = (float) ((zoom) / 100.0);
-			int scaled_width = Math.round(width * scaleFactor);
-			int scaled_height = Math.round(height * scaleFactor);
+			int scaledWidth = Math.round(width * scaleFactor);
+			int scaledHeight = Math.round(height * scaleFactor);
 			ImageData imageData = new ImageData(scaled_width, scaled_height,
 					1,
 					createPalette(display, rangeIndicatorColor));


### PR DESCRIPTION
DefaultRangeIndicator previously used ` Image(Device, ImageData)` constructor to draw a grid to display the selected range.



Previously, the grid was rendered using a 1×1 pixel checkerboard pattern (blue and white), which was mainly inteded to work at 100% zoom. However, at higher zoom levels (e.g., 150%, 200%), the visual intensity of the pattern becomes different, causing the grid to appear  visually inconsistent across zooms.


**Figures below uses Image(Device, ImageData)**
<table>
  <tr>
    <td align="center" valign="top">
      <img src="https://github.com/user-attachments/assets/1bbe1cfc-c6c4-4be0-8efe-c7002c147206" />
      <br/>
      <sub>200%</sub>
    </td>
    <td align="center" valign="top">
      <img src="https://github.com/user-attachments/assets/92fda84b-642f-4b9d-b12b-3de293e7f28f" />
      <br/>
      <sub>100%</sub>
    </td>
  </tr>
</table>



The new implementation uses `Image(Device, ImageDataProvider)` adapts the grid's block size based on the zoom scale. Instead of always using 1×1 blocks, it calculates the block size by rounding the zoom factor:

For zoom levels like 100%, 125%, etc., block size = 1 (no change).

For higher zoom levels like 150%, 200%, etc., block size = 2.

This means the grid will now use 2×2 rectangles for higher zooms, resulting in a visual appearance that better matches how the original 1×1 pattern looks on standard (100%) displays. This preserves visual consistency across different zoom levels and monitor scaling settings.

**Figures below Uses Image(Device, ImageDataProvider)**

<table>
  <tr>
    <td align="center" valign="top">
      <img src="https://github.com/user-attachments/assets/012343c2-d967-4156-aea0-37c683c719a0" />
      <br/>
      <sub> 100%</sub>
    </td>
    <td align="center" valign="top">
      <img src="https://github.com/user-attachments/assets/7fc4addb-e50f-4ef5-8a31-52f38a86c0db" />
      <br/>
      <sub> 125%</sub>
    </td>
   <td align="center" valign="top">
      <img src="https://github.com/user-attachments/assets/a1539176-07f7-4942-ae6d-9db909dfa3ac" />
      <br/>
      <sub>150%</sub>
    </td>
    <td align="center" valign="top">
      <img src="https://github.com/user-attachments/assets/5685774e-6d08-47fd-b89b-5574a584e3c6" />
      <br/>
      <sub>175%</sub>
    </td>
<td align="center" valign="top">
      <img src="https://github.com/user-attachments/assets/3d54d20c-96c0-4362-990c-9ff58212e19b" />
      <br/>
      <sub>200%</sub>
    </td>
  

  </tr>
</table>




  

Contributes to https://github.com/vi-eclipse/Eclipse-Platform/issues/199