### PR TITLE
Make DnD consumer utilize internal state of Rectangle with APIs of and clone

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.addons.swt;singleton:=true
-Bundle-Version: 1.5.700.qualifier
+Bundle-Version: 1.5.800.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -12,7 +12,7 @@ Require-Bundle: org.eclipse.e4.ui.model.workbench;bundle-version="1.0.0",
  org.eclipse.e4.core.services;bundle-version="0.9.1",
  org.eclipse.e4.ui.workbench.renderers.swt;bundle-version="0.9.1",
  org.eclipse.e4.ui.widgets;bundle-version="0.11.0",
- org.eclipse.swt;bundle-version="[3.7.0,4.0.0)",
+ org.eclipse.swt;bundle-version="[3.131.0,4.0.0)",
  org.eclipse.jface;bundle-version="[3.7.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.e4.ui.di;bundle-version="0.10.0",

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/DetachedDropAgent.java
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/DetachedDropAgent.java
@@ -94,8 +94,9 @@ public class DetachedDropAgent extends DropAgent {
 		}
 
 		Point cp = Display.getCurrent().getCursorLocation();
-		curRect.x = cp.x - 15;
-		curRect.y = cp.y - 15;
+		cp.x -= 15;
+		cp.y -= 15;
+		curRect = Rectangle.of(cp, curRect.width, curRect.height);
 
 		return curRect;
 	}

--- a/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/DnDManager.java
+++ b/bundles/org.eclipse.e4.ui.workbench.addons.swt/src/org/eclipse/e4/ui/workbench/addons/dndaddon/DnDManager.java
@@ -464,8 +464,11 @@ class DnDManager {
 		Rectangle bounds = null;
 		for (Rectangle fr : frames) {
 			if (fr.width > 6) {
-				Rectangle outerBounds = new Rectangle(fr.x - 3, fr.y - 3, fr.width + 6,
-						fr.height + 6);
+				Rectangle outerBounds = fr.clone();
+				outerBounds.x -= 3;
+				outerBounds.y -= 3;
+				outerBounds.width += 6;
+				outerBounds.height += 6;
 				if (bounds == null) {
 					bounds = outerBounds;
 				}


### PR DESCRIPTION
**Depends on:** https://github.com/eclipse-platform/eclipse.platform.swt/pull/2186

This PR enforces the usage of Rectangle.copyWith and Rectangle.of
while copying a rectangle from an existing rectangle and creating a
rectangle from a Point making sure the internal state of the source
resources are copied to the new resource.

**Configuration for reproducing:**

Right (Primary) - 150%
Left - 100%
Steps to reproduce:

- Keep your IDE on the primary monitor.
- Drag an editor across the monitors.
- The drag and drop rectangle moves away from the cursor.
- Expected behaviour: The Drag and Drop region should always have its top left corner around the cursor.

This happens because when a rectangle is copied into a new object using the default constructor, it loses its monitor information. However, the cursor location always has the right monitor zoom in the DnDManager and the rectangle created there should use that monitor reference while creating a rectangle from the cursor location and this rectangle should further only be copied using clone method to copy the right internal state of the rectangle so that we still have the monitor information - leading to right scaling.

contributes to https://github.com/eclipse-platform/eclipse.platform.swt/issues/62 and https://github.com/eclipse-platform/eclipse.platform.swt/issues/128