### PR TITLE
Fix paint problems of QuickAccessEntry #3006

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/OpenResourceQuickAccessComputer.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/OpenResourceQuickAccessComputer.java
@@ -107,7 +107,7 @@ public class OpenResourceQuickAccessComputer implements IQuickAccessComputer, IQ
 
 		@Override
 		public ImageDescriptor getImageDescriptor() {
-			return ImageDescriptor.createFromImageDataProvider(zoom -> fLabelProvider.getImage(fFile).getImageData());
+			return ImageDescriptor.createFromImageDataProvider(fLabelProvider.getImage(fFile)::getImageData);
 		}
 
 		@Override


### PR DESCRIPTION
QuickAccessEntry uses an image data provider returning the same image data at every zoom. That's breaks the assumption of an image to have a linear scaling of the image's / image data's bounds according to the zoom, potentially leading to errors when drawing scaled version.

This change corrects the image data provider in
OpenResourceQuickAccessComputer used by QuickAccessEntry to return image data at the proper zoom.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3006