### PR TITLE
Add explicit type check to UpdateStrategy.convert()

### DIFF
--- a/bundles/org.eclipse.core.databinding/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.databinding
-Bundle-Version: 1.13.500.qualifier
+Bundle-Version: 1.13.600.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.databinding;version="1.0.0",

--- a/bundles/org.eclipse.core.databinding/src/org/eclipse/core/databinding/UpdateStrategy.java
+++ b/bundles/org.eclipse.core.databinding/src/org/eclipse/core/databinding/UpdateStrategy.java
@@ -677,6 +677,10 @@ import org.eclipse.core.runtime.Status;
 
 		@Override
 		public Object convert(Object fromObject) {
+			// Explicit cast necessary due to potential type erasure
+			if (toType instanceof Class<?> clazz) {
+				return clazz.cast(fromObject);
+			}
 			return fromObject;
 		}
 

--- a/tests/org.eclipse.jface.tests.databinding/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.tests.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.tests.databinding
-Bundle-Version: 1.12.600.qualifier
+Bundle-Version: 1.12.700.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.databinding;bundle-version="[1.3.0,2.0.0)",

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/UpdateStrategyTest.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/core/tests/databinding/UpdateStrategyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007 IBM Corporation and others.
+ * Copyright (c) 2007, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,11 +16,15 @@ package org.eclipse.core.tests.databinding;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.eclipse.core.databinding.UpdateValueStrategy;
 import org.eclipse.core.databinding.conversion.IConverter;
@@ -353,5 +357,17 @@ public class UpdateStrategyTest extends AbstractDefaultRealmTestCase {
 			this.conv = converter;
 			return super.setConverter(converter);
 		}
+	}
+
+	@Test
+	public void testDefaultConverterWithTypeErasure() {
+		WritableValue<Set<?>> source = WritableValue.withValueType(Set.class);
+		WritableValue<List<?>> destination = WritableValue.withValueType(List.class);
+
+		UpdateStrategyStub<Set<?>, List<?>> strategy = new UpdateStrategyStub<>();
+		strategy.fillDefaults(source, destination);
+
+		RuntimeException ex = assertThrows(RuntimeException.class, () -> strategy.convert(new HashSet<>()));
+		assertTrue("Type erasure was missed", ex.getCause() instanceof ClassCastException);
 	}
 }


### PR DESCRIPTION
When using the DefaultConverter, type erasure may occur, where the "convert" method returns an object of type S, but treats it as type D. 

The conversion must fail early in such a case, in order to prevent obscure error messages when passing the value to successive methods.

Closes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3008
