### PR TITLE
Converting Support tray to use Image with constructor that utilizes imageGCDrawer instead of imageData 

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/statushandlers/SupportTray.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/statushandlers/SupportTray.java
@@ -31,7 +31,7 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
-import org.eclipse.swt.graphics.PaletteData;
+import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.GridData;
@@ -66,6 +66,8 @@ public class SupportTray extends DialogTray implements ISelectionChangedListener
 	private boolean hideSupportButtons;
 	private Image normal;
 	private Image hover;
+	private static final int[] closeButtonPolygon = new int[] { 3, 3, 5, 3, 7, 5, 8, 5, 10, 3, 12, 3, 12, 5, 10, 7, 10,
+			8, 12, 10, 12, 12, 10, 12, 8, 10, 7, 10, 5, 12, 3, 12, 3, 10, 5, 8, 5, 7, 3, 5 };
 
 	/**
 	 * This composite occupies the whole space that is available to the support
@@ -142,40 +144,38 @@ public class SupportTray extends DialogTray implements ISelectionChangedListener
 	 */
 	private void createImages() {
 		Display display = Display.getCurrent();
-		int[] shape = new int[] { 3, 3, 5, 3, 7, 5, 8, 5, 10, 3, 12, 3, 12, 5, 10, 7, 10, 8, 12, 10, 12, 12, 10, 12, 8,
-				10, 7, 10, 5, 12, 3, 12, 3, 10, 5, 8, 5, 7, 3, 5 };
 
-		/*
-		 * Use magenta as transparency color since it is used infrequently.
-		 */
+
 		Color border = display.getSystemColor(SWT.COLOR_WIDGET_DARK_SHADOW);
 		Color background = display.getSystemColor(SWT.COLOR_LIST_BACKGROUND);
 		Color backgroundHot = new Color(display, new RGB(252, 160, 160));
-		Color transparent = display.getSystemColor(SWT.COLOR_MAGENTA);
+		normal = new Image(display, createCloseButtonDrawer(background, border), 16, 16);
+		hover = new Image(display, createCloseButtonDrawer(backgroundHot, border), 16, 16);
+	}
 
-		PaletteData palette = new PaletteData(
-				new RGB[] { transparent.getRGB(), border.getRGB(), background.getRGB(), backgroundHot.getRGB() });
-		ImageData data = new ImageData(16, 16, 8, palette);
-		data.transparentPixel = 0;
+	private ImageGcDrawer createCloseButtonDrawer(Color fillColor, Color borderColor) {
 
-		normal = new Image(display, data);
-		normal.setBackground(transparent);
-		GC gc = new GC(normal);
-		gc.setBackground(background);
-		gc.fillPolygon(shape);
-		gc.setForeground(border);
-		gc.drawPolygon(shape);
-		gc.dispose();
+		return new ImageGcDrawer() {
+			@Override
+			public void drawOn(GC gc, int width, int height) {
+				gc.setBackground(fillColor);
+				gc.fillPolygon(closeButtonPolygon);
+				gc.setForeground(borderColor);
+				gc.drawPolygon(closeButtonPolygon);
+				gc.dispose();
+			}
 
-		hover = new Image(display, data);
-		hover.setBackground(transparent);
-		gc = new GC(hover);
-		gc.setBackground(backgroundHot);
-		gc.fillPolygon(shape);
-		gc.setForeground(border);
-		gc.drawPolygon(shape);
-		gc.dispose();
+			@Override
+			public void postProcess(ImageData imageData) {
+				// Used to remove opaque background in the image.
+				imageData.transparentPixel = 0;
+			}
 
+			@Override
+			public int getGcStyle() {
+				return SWT.TRANSPARENT;
+			}
+		};
 	}
 
 	/**


### PR DESCRIPTION
The `SupportTray` class previously used the `Image(Device, ImageData)` constructor to draw the close button on the ToolBar positioned alongside the support tray.

![image](https://github.com/user-attachments/assets/0b25952d-de79-4b93-86d6-771642e4f2b2)


This PR modifies SupportTray to use the `Image `constructor that utilizes `ImageGCDrawer ` instead of `ImageData`, since scaling ImageData is a destructive operation.

Triggering a supporttray is not so straight forward in runtime workspace. To test this implementation, the following example can be used. It simply opens a support tray with a toolbar and waits for it to be closed.

```
package org.eclipse.swt.snippets;


import java.util.*;

import org.eclipse.core.runtime.*;
import org.eclipse.jface.dialogs.*;
import org.eclipse.swt.widgets.*;
import org.eclipse.ui.internal.statushandlers.*;
import org.eclipse.ui.statushandlers.*;

public class SupportTrayExample {

	public static void main(String[] args) {
		Display display = new Display();
		Shell shell = new Shell(display);

		final TrayDialog[] td = new TrayDialog[1];
		try {
			td[0] = new TrayDialog(shell) {
				
			};

			Map<Object, Object> dialogState = new HashMap<>();
			dialogState.put(IStatusDialogConstants.CURRENT_STATUS_ADAPTER, new StatusAdapter(Status.OK_STATUS));

			SupportTray supportTray = new SupportTray(dialogState, event -> td[0].closeTray());

			td[0].setBlockOnOpen(false);
			td[0].open();
			td[0].openTray(supportTray);

			
			while (!shell.isDisposed()) {
				if (!display.readAndDispatch()) {
					display.sleep();
				}
			}
		} finally {
			display.dispose();
		}
	}
}

```
Note To run this example, you may need to temporarily add the following to the MANIFEST.MF file in the org.eclipse.swt.snippets project:

```
Require-Bundle: org.eclipse.swt,
 org.eclipse.core.runtime,
 org.eclipse.jface,
 org.eclipse.ui.workbench
```
Alternatively, you can fix the project setup by following the error prompts in the IDE for this example.