### PR TITLE
Fix NPE when viewer control doesn't adapt to CompareConfiguration

### DIFF
--- a/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/PreviewWizardPage.java
+++ b/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/PreviewWizardPage.java
@@ -673,7 +673,9 @@ public class PreviewWizardPage extends RefactoringWizardPage implements IPreview
 						if (container != null) {
 							if (newViewer.getControl() instanceof IAdaptable adaptable) {
 								CompareConfiguration config = adaptable.getAdapter(CompareConfiguration.class);
-								config.setContainer(new WizardCompareContainer(container));
+								if (config != null) {
+									config.setContainer(new WizardCompareContainer(container));
+								}
 							}
 						}
 					} else {


### PR DESCRIPTION
Follow up to https://github.com/eclipse-platform/eclipse.platform.ui/pull/2629

which introduced an NPE when doing refactor->rename in CDT: https://github.com/eclipse-cdt/cdt/issues/1172