### PR TITLE
Adjust Icon References for using SVGs

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/activities/ActivityCategoryPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/activities/ActivityCategoryPreferencePage.java
@@ -131,7 +131,7 @@ public final class ActivityCategoryPreferencePage extends PreferencePage
 		public CategoryLabelProvider(boolean decorate) {
 			this.decorate = decorate;
 			lockDescriptor = ResourceLocator.imageDescriptorFromBundle(PlatformUI.PLUGIN_ID,
-					"icons/full/ovr16/lock_ovr.png"); //$NON-NLS-1$
+					"icons/full/ovr16/lock_ovr.svg"); //$NON-NLS-1$
 		}
 
 		@Override

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/HeapStatus.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/HeapStatus.java
@@ -121,7 +121,7 @@ public class HeapStatus extends Composite {
 		canvas = new Canvas(this, SWT.NONE);
 		canvas.setToolTipText(WorkbenchMessages.HeapStatus_buttonToolTip);
 
-		ImageDescriptor imageDesc = WorkbenchImages.getWorkbenchImageDescriptor("elcl16/trash.png"); //$NON-NLS-1$
+		ImageDescriptor imageDesc = WorkbenchImages.getWorkbenchImageDescriptor("elcl16/trash.svg"); //$NON-NLS-1$
 		Display display = getDisplay();
 		gcImage = imageDesc.createImage();
 		if (gcImage != null) {

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchImages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchImages.java
@@ -127,7 +127,7 @@ public/* final */class WorkbenchImages {
 
 		// other toolbar buttons
 		declareImage(ISharedImages.IMG_ETOOL_SAVE_EDIT, ISharedImages.IMG_ETOOL_SAVE_EDIT_DISABLED, //
-				PATH_ETOOL + "save_edit.png", true); //$NON-NLS-1$
+				PATH_ETOOL + "save_edit.svg", true); //$NON-NLS-1$
 
 		declareImage(ISharedImages.IMG_ETOOL_SAVEAS_EDIT, ISharedImages.IMG_ETOOL_SAVEAS_EDIT_DISABLED, //
 				PATH_ETOOL + "saveas_edit.svg", true); //$NON-NLS-1$

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/cpd/CustomizePerspectiveDialog.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/cpd/CustomizePerspectiveDialog.java
@@ -158,10 +158,10 @@ public class CustomizePerspectiveDialog extends TrayDialog {
 	 * Flag showing that we have initialized all legacy action sets for given window
 	 */
 	private static final String ALL_SETS_INITIALIZED = "ALL_SETS_INITIALIZED"; //$NON-NLS-1$
-	private static final String TOOLBAR_ICON = "$nl$/icons/full/obj16/toolbar.png"; //$NON-NLS-1$
-	private static final String SUBMENU_ICON = "$nl$/icons/full/obj16/submenu.png"; //$NON-NLS-1$
-	private static final String MENU_ICON = "$nl$/icons/full/obj16/menu.png"; //$NON-NLS-1$
-	private static final String WARNING_ICON = "$nl$/icons/full/obj16/warn_tsk.png"; //$NON-NLS-1$
+	private static final String TOOLBAR_ICON = "$nl$/icons/full/obj16/toolbar.svg"; //$NON-NLS-1$
+	private static final String SUBMENU_ICON = "$nl$/icons/full/obj16/submenu.svg"; //$NON-NLS-1$
+	private static final String MENU_ICON = "$nl$/icons/full/obj16/menu.svg"; //$NON-NLS-1$
+	private static final String WARNING_ICON = "$nl$/icons/full/obj16/warn_tsk.svg"; //$NON-NLS-1$
 
 	private static final String SHORTCUT_CONTRIBUTION_ITEM_ID_OPEN_PERSPECTIVE = "openPerspective"; //$NON-NLS-1$
 	private static final String SHORTCUT_CONTRIBUTION_ITEM_ID_SHOW_VIEW = "showView"; //$NON-NLS-1$

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/ImageFactory.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/ImageFactory.java
@@ -29,14 +29,14 @@ final class ImageFactory {
 	private static Map map = new HashMap();
 
 	static {
-		put("blank", "$nl$/icons/full/obj16/blank.png"); //$NON-NLS-1$//$NON-NLS-2$
-		put("change", "$nl$/icons/full/obj16/change_obj.png"); //$NON-NLS-1$//$NON-NLS-2$
+		put("blank", "$nl$/icons/full/obj16/blank.svg"); //$NON-NLS-1$//$NON-NLS-2$
+		put("change", "$nl$/icons/full/obj16/change_obj.svg"); //$NON-NLS-1$//$NON-NLS-2$
 
 		/*
 		 * TODO Remove these images from the registry if they are no longer needed.
 		 */
-		put("minus", "$nl$/icons/full/obj16/delete_obj.png"); //$NON-NLS-1$//$NON-NLS-2$
-		put("plus", "$nl$/icons/full/obj16/add_obj.png"); //$NON-NLS-1$//$NON-NLS-2$
+		put("minus", "$nl$/icons/full/obj16/delete_obj.svg"); //$NON-NLS-1$//$NON-NLS-2$
+		put("plus", "$nl$/icons/full/obj16/add_obj.svg"); //$NON-NLS-1$//$NON-NLS-2$
 	}
 
 	static Image getImage(String key) {

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressAnimationItem.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressAnimationItem.java
@@ -285,9 +285,9 @@ public class ProgressAnimationItem extends AnimationItem implements FinishedJobs
 
 		if (okImage == null) {
 			Display display = parent.getDisplay();
-			noneImage = WorkbenchImages.getWorkbenchImageDescriptor("progress/progress_none.png").createImage(display); //$NON-NLS-1$
-			okImage = WorkbenchImages.getWorkbenchImageDescriptor("progress/progress_ok.png").createImage(display); //$NON-NLS-1$
-			errorImage = WorkbenchImages.getWorkbenchImageDescriptor("progress/progress_error.png") //$NON-NLS-1$
+			noneImage = WorkbenchImages.getWorkbenchImageDescriptor("progress/progress_none.svg").createImage(display); //$NON-NLS-1$
+			okImage = WorkbenchImages.getWorkbenchImageDescriptor("progress/progress_ok.svg").createImage(display); //$NON-NLS-1$
+			errorImage = WorkbenchImages.getWorkbenchImageDescriptor("progress/progress_error.svg") //$NON-NLS-1$
 					.createImage(display);
 		}
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressInfoItem.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressInfoItem.java
@@ -153,17 +153,17 @@ public class ProgressInfoItem extends Composite {
 	private boolean isThemed;
 
 	static {
-		ImageDescriptor processStopDescriptor = WorkbenchImages.getWorkbenchImageDescriptor("elcl16/progress_stop.png"); //$NON-NLS-1$
+		ImageDescriptor processStopDescriptor = WorkbenchImages.getWorkbenchImageDescriptor("elcl16/progress_stop.svg"); //$NON-NLS-1$
 		JFaceResources.getImageRegistry().put(STOP_IMAGE_KEY, processStopDescriptor);
 		ImageDescriptor disabledProcessStopDescriptor = ImageDescriptor.createWithFlags(processStopDescriptor,
 				SWT.IMAGE_DISABLE);
 		JFaceResources.getImageRegistry().put(DISABLED_STOP_IMAGE_KEY, disabledProcessStopDescriptor);
 
 		JFaceResources.getImageRegistry().put(DEFAULT_JOB_KEY,
-				WorkbenchImages.getWorkbenchImageDescriptor("progress/progress_task.png")); //$NON-NLS-1$
+				WorkbenchImages.getWorkbenchImageDescriptor("progress/progress_task.svg")); //$NON-NLS-1$
 
 		ImageDescriptor processRemoveDescriptor = WorkbenchImages
-				.getWorkbenchImageDescriptor("elcl16/progress_rem.png"); //$NON-NLS-1$
+				.getWorkbenchImageDescriptor("elcl16/progress_rem.svg"); //$NON-NLS-1$
 		JFaceResources.getImageRegistry().put(CLEAR_FINISHED_JOB_KEY, processRemoveDescriptor);
 		ImageDescriptor disabledProcessRemoveDescriptor = ImageDescriptor.createWithFlags(processRemoveDescriptor,
 				SWT.IMAGE_DISABLE);

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressManager.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressManager.java
@@ -94,7 +94,7 @@ public class ProgressManager extends ProgressProvider implements IProgressServic
 	@Deprecated
 	public static final QualifiedName PROPERTY_IN_DIALOG = IProgressConstants.PROPERTY_IN_DIALOG;
 
-	private static final String ERROR_JOB = "errorstate.png"; //$NON-NLS-1$
+	private static final String ERROR_JOB = "errorstate.svg"; //$NON-NLS-1$
 
 	static final String ERROR_JOB_KEY = "ERROR_JOB"; //$NON-NLS-1$
 
@@ -114,11 +114,11 @@ public class ProgressManager extends ProgressProvider implements IProgressServic
 
 	static final String PROGRESS_FOLDER = "$nl$/icons/full/progress/"; //$NON-NLS-1$
 
-	private static final String SLEEPING_JOB = "sleeping.png"; //$NON-NLS-1$
+	private static final String SLEEPING_JOB = "sleeping.svg"; //$NON-NLS-1$
 
-	private static final String WAITING_JOB = "waiting.png"; //$NON-NLS-1$
+	private static final String WAITING_JOB = "waiting.svg"; //$NON-NLS-1$
 
-	private static final String BLOCKED_JOB = "lockedstate.png"; //$NON-NLS-1$
+	private static final String BLOCKED_JOB = "lockedstate.svg"; //$NON-NLS-1$
 
 	/**
 	 * The key for the sleeping job icon.

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressView.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressView.java
@@ -244,7 +244,7 @@ public class ProgressView extends ViewPart {
 			}
 		};
 		clearAllAction.setToolTipText(ProgressMessages.NewProgressView_RemoveAllJobsToolTip);
-		ImageDescriptor id = WorkbenchImages.getWorkbenchImageDescriptor("/elcl16/progress_remall.png"); //$NON-NLS-1$
+		ImageDescriptor id = WorkbenchImages.getWorkbenchImageDescriptor("/elcl16/progress_remall.svg"); //$NON-NLS-1$
 		if (id != null) {
 			clearAllAction.setImageDescriptor(id);
 		}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/plugin/AbstractUIPlugin.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/plugin/AbstractUIPlugin.java
@@ -576,8 +576,8 @@ public abstract class AbstractUIPlugin extends Plugin {
 	 * relative to the root of the plug-in, and takes into account files coming from
 	 * plug-in fragments. The path may include $arg$ elements. However, the path
 	 * must not have a leading "." or path separator. Clients should use a path like
-	 * "icons/mysample.png" rather than "./icons/mysample.png" or
-	 * "/icons/mysample.png".
+	 * "icons/mysample.svg" rather than "./icons/mysample.svg" or
+	 * "/icons/mysample.svg".
 	 * </p>
 	 *
 	 * @param pluginId      the id of the plug-in containing the image file;


### PR DESCRIPTION
The bundle `org.eclipse.ui.workbench` contains references to icons in the bundle `org.eclipse.ui`. As these icons are now provided as SVG in `org.eclipse.ui` the references can be adjusted so SVGs are used for loading icons in `org.eclipse.ui.workbench`.