### PR TITLE
Use a Job as the Reconciler Thread for AbstractReconciler

### DIFF
--- a/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.text
-Bundle-Version: 3.28.0.qualifier
+Bundle-Version: 3.28.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 


### PR DESCRIPTION
Currently AbstractReconciler uses a raw thread for reconciling requests. This has the problem that if the job framework is suspended (e.g, during startup of the IDE) some code is still executed because the reconciler is called from the creation of the text viewer and starts immediately.

This replaces the bare thread with a job but retains current behaviour. Note that the job cannot be manually terminated, just as the thread continued to run indefinitely until explicitly terminated.

https://github.com/eclipse-platform/eclipse.platform.ui/pull/3018