### PR TITLE
Remove EXPERIMENTAL from all viewer limit based feature java docs.

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.37.0.qualifier
+Bundle-Version: 3.37.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/ColumnViewer.java
@@ -973,12 +973,6 @@ public abstract class ColumnViewer extends StructuredViewer {
 	}
 
 	/**
-	 * <p>
-	 * <strong>EXPERIMENTAL</strong>. This class or interface has been added as part
-	 * of a work in progress. There is no guarantee that this API will work or that
-	 * it will remain the same. Please do not use this API without consulting with
-	 * the API development team.
-	 * </p>
 	 * Sets the viewers items limit on direct children at one level.
 	 * <p>
 	 * If the number of direct children will exceed this limit, the viewer will only
@@ -1031,12 +1025,7 @@ public abstract class ColumnViewer extends StructuredViewer {
 	}
 
 	/**
-	 * <p>
-	 * <strong>EXPERIMENTAL</strong>. This class or interface has been added as part
-	 * of a work in progress. There is no guarantee that this API will work or that
-	 * it will remain the same. Please do not use this API without consulting with
-	 * the API development team.
-	 * </p>
+	 * Return if it is an instance of ExpandableNode
 	 *
 	 * @param element model object representing a special "expandable" node
 	 * @return return if it is an instance of ExpandableNode

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/IWorkbenchPreferenceConstants.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/IWorkbenchPreferenceConstants.java
@@ -701,13 +701,6 @@ public interface IWorkbenchPreferenceConstants {
 	String DISPOSE_CLOSED_BROWSER_HOVER_TIMEOUT = "disposeClosedBrowserHoverTimeout"; //$NON-NLS-1$
 
 	/**
-	 * <p>
-	 * <strong>EXPERIMENTAL</strong>. This class or interface has been added as part
-	 * of a work in progress. There is no guarantee that this API will work or that
-	 * it will remain the same. Please do not use this API without consulting with
-	 * the API development team.
-	 * </p>
-	 *
 	 * This preference specifies the limit for number of children that can be shown
 	 * per parent element without expanding.
 	 * <p>

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/views/WorkbenchViewerSetup.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/views/WorkbenchViewerSetup.java
@@ -26,10 +26,10 @@ import org.eclipse.ui.internal.WorkbenchPlugin;
 
 /**
  * <p>
- * <strong>EXPERIMENTAL</strong>. This class or interface has been added as part
- * of a work in progress. There is no guarantee that this API will work or that
- * it will remain the same. Please do not use this API without consulting with
- * the API development team.
+ * Configure a {@link ColumnViewer} to show limited items per parent before
+ * showing an ExpandableNode. Limit used is read from preference
+ * {@link IWorkbenchPreferenceConstants#LARGE_VIEW_LIMIT}. Client must call this
+ * before {@link Viewer#setInput(Object)}
  * </p>
  *
  * @since 3.130
@@ -60,13 +60,6 @@ public class WorkbenchViewerSetup {
 	}
 
 	/**
-	 * <p>
-	 * <strong>EXPERIMENTAL</strong>. This class or interface has been added as part
-	 * of a work in progress. There is no guarantee that this API will work or that
-	 * it will remain the same. Please do not use this API without consulting with
-	 * the API development team.
-	 * </p>
-	 *
 	 * Returns the current viewer limit set in the {@code General} preference page.
 	 *
 	 * @return {@link IWorkbenchPreferenceConstants#LARGE_VIEW_LIMIT}
@@ -80,13 +73,6 @@ public class WorkbenchViewerSetup {
 	}
 
 	/**
-	 * <p>
-	 * <strong>EXPERIMENTAL</strong>. This class or interface has been added as part
-	 * of a work in progress. There is no guarantee that this API will work or that
-	 * it will remain the same. Please do not use this API without consulting with
-	 * the API development team.
-	 * </p>
-	 *
 	 * Configure a {@link ColumnViewer} to show limited items per parent before
 	 * showing an ExpandableNode. Limit used is read from preference
 	 * {@link IWorkbenchPreferenceConstants#LARGE_VIEW_LIMIT}. Client must call this


### PR DESCRIPTION
Limit based items population feature for JFace Tree&Table viewers is exists in eclipse since 4.30 release. So far there are no side effects/new issues have been observed.
This feature can be NON-EXPERIMENTAL now.

see https://github.com/eclipse-platform/eclipse.platform.ui/issues/3023