### PR TITLE
Use TestUtil.cleanUp across the tests

### DIFF
--- a/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.editors.tests;singleton:=true
-Bundle-Version: 3.13.800.qualifier
+Bundle-Version: 3.13.900.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface.text.tests.codemining,

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningTest.java
@@ -55,6 +55,8 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
 
+import org.eclipse.ui.editors.tests.TestUtil;
+
 public class CodeMiningTest {
 	private static String PROJECT_NAME = "test_" + new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
 
@@ -78,6 +80,7 @@ public class CodeMiningTest {
 		drainEventQueue();
 		CodeMiningTestProvider.provideContentMiningAtOffset = -1;
 		CodeMiningTestProvider.provideHeaderMiningAtLine = -1;
+		TestUtil.cleanUp();
 	}
 
 	private static void closeAllEditors() {

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/StatusEditorTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/StatusEditorTest.java
@@ -68,6 +68,7 @@ public class StatusEditorTest {
 		window.close();
 		page = null;
 		processEvents();
+		TestUtil.cleanUp();
 	}
 
 	/*

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/TextMultiCaretNavigationTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/TextMultiCaretNavigationTest.java
@@ -61,8 +61,9 @@ public class TextMultiCaretNavigationTest {
 
 	@After
 	public void tearDown() {
-		editor.dispose();
+		editor.close(false);
 		file.delete();
+		TestUtil.cleanUp();
 	}
 
 

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/TextMultiCaretSelectionCommandsTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/TextMultiCaretSelectionCommandsTest.java
@@ -85,8 +85,9 @@ public class TextMultiCaretSelectionCommandsTest {
 
 	@After
 	public void tearDown() {
-		editor.dispose();
+		editor.close(false);
 		file.delete();
+		TestUtil.cleanUp();
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/TextNavigationTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/TextNavigationTest.java
@@ -68,8 +68,9 @@ public class TextNavigationTest {
 
 	@After
 	public void tearDown() {
-		editor.dispose();
+		editor.close(false);
 		file.delete();
+		TestUtil.cleanUp();
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/DefaultStickyLinesProviderTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/DefaultStickyLinesProviderTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,6 +42,8 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.texteditor.stickyscroll.IStickyLine;
 import org.eclipse.ui.texteditor.stickyscroll.IStickyLinesProvider.StickyLinesProperties;
 
+import org.eclipse.ui.editors.tests.TestUtil;
+
 public class DefaultStickyLinesProviderTest {
 
 	private Shell shell;
@@ -59,6 +62,11 @@ public class DefaultStickyLinesProviderTest {
 		textWidget = sourceViewer.getTextWidget();
 		editorPart = mock(IEditorPart.class);
 		stickyLinesProperties = new StickyLinesProperties(4, editorPart);
+	}
+
+	@After
+	public void teardown() {
+		TestUtil.cleanUp();
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyLinesProviderRegistryTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyLinesProviderRegistryTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -18,6 +19,8 @@ import org.eclipse.jface.text.source.ISourceViewer;
 
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.eclipse.ui.texteditor.stickyscroll.IStickyLinesProvider;
+
+import org.eclipse.ui.editors.tests.TestUtil;
 
 public class StickyLinesProviderRegistryTest {
 
@@ -38,6 +41,11 @@ public class StickyLinesProviderRegistryTest {
 				.thenReturn(configurationElement);
 
 		cut = new StickyLinesProviderRegistry(extensionRegistry, e -> stickyLinesProviderDescriptor);
+	}
+
+	@After
+	public void teardown() {
+		TestUtil.cleanUp();
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
@@ -48,6 +48,8 @@ import org.eclipse.jface.text.source.SourceViewer;
 
 import org.eclipse.ui.texteditor.stickyscroll.IStickyLine;
 
+import org.eclipse.ui.editors.tests.TestUtil;
+
 public class StickyScrollingControlTest {
 
 	private Shell shell;
@@ -86,6 +88,7 @@ public class StickyScrollingControlTest {
 		lineNumberColor.dispose();
 		hoverColor.dispose();
 		backgroundColor.dispose();
+		TestUtil.cleanUp();
 	}
 
 	@Test
@@ -183,13 +186,17 @@ public class StickyScrollingControlTest {
 
 	@Test
 	public void testWithoutVerticalRuler() {
-		sourceViewer = new SourceViewer(shell, null, SWT.None);
-		settings = new StickyScrollingControlSettings(5, lineNumberColor, hoverColor, backgroundColor, separatorColor,
-				true);
-		stickyScrollingControl = new StickyScrollingControl(sourceViewer, settings);
-
-		StyledText stickyLineNumber = getStickyLineNumber();
-		assertFalse(stickyLineNumber.isVisible());
+		SourceViewer sourceViewerWithoutRuler = new SourceViewer(shell, null, SWT.None);
+		StickyScrollingControl stickyScrollingControlWithoutRuler = new StickyScrollingControl(sourceViewerWithoutRuler,
+				new StickyScrollingControlSettings(5, lineNumberColor, hoverColor, backgroundColor, separatorColor,
+						true));
+		try {
+			StyledText stickyLineNumber = getStickyLineNumber();
+			assertFalse(stickyLineNumber.isVisible());
+		} finally {
+			sourceViewerWithoutRuler.getControl().dispose();
+			stickyScrollingControlWithoutRuler.dispose();
+		}
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandlerTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandlerTest.java
@@ -59,6 +59,8 @@ import org.eclipse.ui.texteditor.stickyscroll.IStickyLine;
 import org.eclipse.ui.texteditor.stickyscroll.IStickyLinesProvider;
 import org.eclipse.ui.texteditor.stickyscroll.IStickyLinesProvider.StickyLinesProperties;
 
+import org.eclipse.ui.editors.tests.TestUtil;
+
 public class StickyScrollingHandlerTest {
 
 	private Shell shell;
@@ -99,6 +101,7 @@ public class StickyScrollingHandlerTest {
 	@After
 	public void teardown() {
 		shell.dispose();
+		TestUtil.cleanUp();
 	}
 
 	@Test


### PR DESCRIPTION
- This ensures that the tests don't leak jobs that are only detected by a subsequent test.
- Use editor.close(false) rather than editor.dispose() to clean up the thread/job properly.

https://github.com/eclipse-platform/eclipse.platform.ui/pull/3025