### PR TITLE
Provide file contents when determining content type for search #3014

### DIFF
--- a/bundles/org.eclipse.search.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.search.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search.core;singleton:=true
-Bundle-Version: 3.16.400.qualifier
+Bundle-Version: 3.16.500.qualifier
 Bundle-Activator: org.eclipse.search.internal.core.SearchCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.search.core/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
+++ b/bundles/org.eclipse.search.core/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
@@ -442,7 +442,12 @@ public class TextSearchVisitor {
 	private final IContentType TEXT_TYPE = Platform.getContentTypeManager().getContentType(IContentTypeManager.CT_TEXT);
 
 	private boolean hasBinaryContentType(IFile file) {
-		IContentType[] contentTypes = Platform.getContentTypeManager().findContentTypesFor(file.getName());
+		IContentType[] contentTypes;
+		try (java.io.InputStream contents = file.getContents()) {
+			contentTypes = Platform.getContentTypeManager().findContentTypesFor(contents, file.getName());
+		} catch (IOException | CoreException e) {
+			return false; // unknown due to failure
+		}
 		for (IContentType contentType : contentTypes) {
 			if (contentType.isKindOf(TEXT_TYPE)) {
 				return false; // is text

--- a/bundles/org.eclipse.search.core/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
+++ b/bundles/org.eclipse.search.core/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
@@ -446,7 +446,8 @@ public class TextSearchVisitor {
 		try (java.io.InputStream contents = file.getContents()) {
 			contentTypes = Platform.getContentTypeManager().findContentTypesFor(contents, file.getName());
 		} catch (IOException | CoreException e) {
-			return false; // unknown due to failure
+			SearchCorePlugin.log(e);
+			contentTypes = Platform.getContentTypeManager().findContentTypesFor(file.getName());
 		}
 		for (IContentType contentType : contentTypes) {
 			if (contentType.isKindOf(TEXT_TYPE)) {

--- a/tests/org.eclipse.search.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.search.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search.tests;singleton:=true
-Bundle-Version: 3.11.700.qualifier
+Bundle-Version: 3.11.800.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.search.core.tests;x-internal:=true,


### PR DESCRIPTION
Ensures that describers are taken into account when deciding if a content type is binary. Adds a regression test that registers a binary content type with a describer and verifies that it only causes files with content matching the describer to be considered binary.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3014