### PR TITLE
Use constructor Image(Device, ImageDataProvider) for  Radial gradients

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/properties/GradientBackgroundListener.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/properties/GradientBackgroundListener.java
@@ -37,6 +37,7 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.Point;
@@ -133,13 +134,17 @@ public class GradientBackgroundListener implements Listener {
 				}
 			}
 
-			BufferedImage image = getBufferedImage(size.x, size.y, colors,
-					CSSSWTColorHelper.getPercents(grad));
-			// long startTime = System.currentTimeMillis();
-			ImageData imagedata = convertToSWT(image);
-			// System.out.println("Conversion took "
-			// + (System.currentTimeMillis() - startTime) + " ms");
-			gradientImage = new Image(control.getDisplay(), imagedata);
+			ImageDataProvider imageDataProvider = zoom -> {
+				float scaleFactor = zoom / 100f;
+				int scaledWidth = Math.round(size.x * scaleFactor);
+				int scaledHeight = Math.round(size.y * scaleFactor);
+				BufferedImage image = getBufferedImage(scaledWidth, scaledHeight, colors,
+						CSSSWTColorHelper.getPercents(grad));
+				ImageData imagedata = convertToSWT(image);
+				return imagedata;
+			};
+
+			gradientImage = new Image(control.getDisplay(), imageDataProvider);
 			radialGradient = true;
 		} else if (oldImage == null || oldImage.isDisposed()
 				|| oldImage.getBounds().height != size.y || radialGradient


### PR DESCRIPTION
This PR does not cause a visual impact but is meant for completeness to replace `Image(Device, ImageData)` with `Image(Device, ImageDataProvider)`, making sure the earlier behaviour is preserved.

### Steps to reproduce

The radial gradients are in the CSS selector.

1) Open CSS Spy  
2) For the background color field, enter a list that is a radial gradient. I entered the below list:

```
gradient radial white black gainsboro lightgray silver gray dimgray darkslategray black midnightblue navy darkblue mediumblue blue dodgerblue deepskyblue lightseagreen mediumseagreen seagreen forestgreen green darkgreen
```

### Screenshot

![Provider_225](https://github.com/user-attachments/assets/2d60b43e-ab77-4410-a1a6-50f1eb48a6a2)
