### PR TITLE
Replace deprecated key classes to use jface bindings API

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/EmacsKeyFormatter.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/EmacsKeyFormatter.java
@@ -16,10 +16,10 @@ package org.eclipse.ui.internal.keys;
 
 import java.util.Comparator;
 import java.util.ResourceBundle;
+import org.eclipse.jface.bindings.keys.KeySequence;
+import org.eclipse.jface.bindings.keys.KeyStroke;
 import org.eclipse.ui.internal.util.Util;
 import org.eclipse.ui.keys.Key;
-import org.eclipse.ui.keys.KeySequence;
-import org.eclipse.ui.keys.KeyStroke;
 import org.eclipse.ui.keys.ModifierKey;
 
 /**
@@ -62,13 +62,11 @@ public class EmacsKeyFormatter extends AbstractKeyFormatter {
 		return super.format(key).toLowerCase();
 	}
 
-	@SuppressWarnings("removal")
 	@Override
 	protected String getKeyDelimiter() {
 		return Util.translateString(RESOURCE_BUNDLE, KEY_DELIMITER_KEY, KeyStroke.KEY_DELIMITER, false, false);
 	}
 
-	@SuppressWarnings("removal")
 	@Override
 	protected String getKeyStrokeDelimiter() {
 		return Util.translateString(RESOURCE_BUNDLE, KEY_STROKE_DELIMITER_KEY, KeySequence.KEY_STROKE_DELIMITER, false,

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/FormalKeyFormatter.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/FormalKeyFormatter.java
@@ -15,9 +15,9 @@
 package org.eclipse.ui.internal.keys;
 
 import java.util.Comparator;
+import org.eclipse.jface.bindings.keys.KeySequence;
+import org.eclipse.jface.bindings.keys.KeyStroke;
 import org.eclipse.ui.keys.Key;
-import org.eclipse.ui.keys.KeySequence;
-import org.eclipse.ui.keys.KeyStroke;
 
 /**
  * Formats the keys in the internal key sequence grammar. This is used for
@@ -39,13 +39,13 @@ public class FormalKeyFormatter extends AbstractKeyFormatter {
 		return key.toString();
 	}
 
-	@SuppressWarnings("removal")
+
 	@Override
 	protected String getKeyDelimiter() {
 		return KeyStroke.KEY_DELIMITER;
 	}
 
-	@SuppressWarnings("removal")
+
 	@Override
 	protected String getKeyStrokeDelimiter() {
 		return KeySequence.KEY_STROKE_DELIMITER;

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/MacKeyFormatter.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/MacKeyFormatter.java
@@ -17,10 +17,10 @@ package org.eclipse.ui.internal.keys;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.ResourceBundle;
+import org.eclipse.jface.bindings.keys.KeySequence;
 import org.eclipse.ui.internal.util.Util;
 import org.eclipse.ui.keys.CharacterKey;
 import org.eclipse.ui.keys.Key;
-import org.eclipse.ui.keys.KeySequence;
 import org.eclipse.ui.keys.ModifierKey;
 import org.eclipse.ui.keys.SpecialKey;
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/NativeKeyFormatter.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/NativeKeyFormatter.java
@@ -17,11 +17,11 @@ package org.eclipse.ui.internal.keys;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.ResourceBundle;
+import org.eclipse.jface.bindings.keys.KeySequence;
+import org.eclipse.jface.bindings.keys.KeyStroke;
 import org.eclipse.ui.internal.util.Util;
 import org.eclipse.ui.keys.CharacterKey;
 import org.eclipse.ui.keys.Key;
-import org.eclipse.ui.keys.KeySequence;
-import org.eclipse.ui.keys.KeyStroke;
 import org.eclipse.ui.keys.ModifierKey;
 import org.eclipse.ui.keys.SpecialKey;
 


### PR DESCRIPTION
The classes `KeySequence` and `KeyStroke` from `org.eclipse.ui.keys` are deprecated. They have been replaced to use the corresponding classes from `org.eclipse.jface.bindings.keys` .