### PR TITLE
Updated bundles with comparator errors

### DIFF
--- a/bundles/org.eclipse.text.quicksearch/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.text.quicksearch/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.text.quicksearch;singleton:=true
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Bundle-Activator: org.eclipse.text.quicksearch.internal.ui.QuickSearchActivator
 Require-Bundle: org.eclipse.ui;bundle-version="[3.113.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.13.0,4.0.0)",

--- a/bundles/org.eclipse.text.quicksearch/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.text.quicksearch/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2995
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3137


### PR DESCRIPTION
Changes to ecj are to remove redundant bytecode, see: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3465

See: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3137