### PR TITLE
Sync maximized tag with application model also in case of a maximized shell

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/WBWRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/WBWRenderer.java
@@ -534,8 +534,11 @@ public class WBWRenderer extends SWTPartRenderer {
 				@Override
 				public void controlResized(ControlEvent e) {
 					// Don't store the maximized size in the model
+					// But set the maximized tag so that the user can access the current state
 					if (shell.getMaximized()) {
-						return;
+						me.getTags().add(ShellMaximizedTag);
+					} else {
+						me.getTags().remove(ShellMaximizedTag);
 					}
 
 					try {


### PR DESCRIPTION
Before this change the WBWRenderer did not update the size of the application in the application model if the shell was maximized, only if the shell got re-sized.

This lead to outdated information in the application model and forces clients which are interested in the actual size of the Window to check in the Shell instead in the model.

This was introduced by
https://bugs.eclipse.org/bugs/attachment.cgi?id=183776&action=diff. The actual logic of restoring of size is done via a tag, so putting the size in the application should not affect the application behavior.

Fixes #3054