### PR TITLE
[#2909] fix wrong hover size in composite hovers

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/DefaultInformationControl.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/DefaultInformationControl.java
@@ -368,6 +368,11 @@ public class DefaultInformationControl extends AbstractInformationControl implem
 
 	@Override
 	public Point computeSizeHint() {
+		if (getShell().getChildren().length == 0) {
+			// no content yet, return default size
+			// computeSize would return 2,2 here
+			return getShell().getSize();
+		}
 		// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=117602
 		int widthHint= SWT.DEFAULT;
 		Point constraints= getSizeConstraints();

--- a/bundles/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.genericeditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.ui.genericeditor;singleton:=true
-Bundle-Version: 1.3.600.qualifier
+Bundle-Version: 1.3.700.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ui.workbench.texteditor;bundle-version="3.10.0",

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/hover/CompositeInformationControl.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/hover/CompositeInformationControl.java
@@ -175,7 +175,12 @@ public class CompositeInformationControl extends AbstractInformationControl impl
 			Supplier<Point> getDefault) {
 		return controls.values().stream().map(computeSize).reduce(
 				(size1, size2) -> new Point(Math.max(size1.x, size2.x), size1.y + size2.y + layout.verticalSpacing))
-				.orElseGet(getDefault);
+				.map(size -> {
+					var shellSize = getShell().computeSize(SWT.DEFAULT, SWT.DEFAULT, true);
+					int width = Math.max(size.x, shellSize.x);
+					int height = Math.max(size.y, shellSize.y);
+					return new Point(width, height);
+				}).orElseGet(getDefault);
 	}
 
 }

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/hover/CompositeInformationControl.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/hover/CompositeInformationControl.java
@@ -141,8 +141,7 @@ public class CompositeInformationControl extends AbstractInformationControl impl
 			LinkedHashMap<ITextHover, IInformationControlCreator> presenterCreators = new LinkedHashMap<>();
 			boolean allNull = true;
 			for (Entry<ITextHover, AbstractInformationControl> hover : this.controls.entrySet()) {
-				IInformationControlCreator creator = hover.getValue()
-							.getInformationPresenterControlCreator();
+				IInformationControlCreator creator = hover.getValue().getInformationPresenterControlCreator();
 				if (creator == null) {
 					creator = this.creators.get(hover.getKey());
 				} else {
@@ -174,8 +173,8 @@ public class CompositeInformationControl extends AbstractInformationControl impl
 
 	private Point computeCompositeSize(Function<AbstractInformationControl, Point> computeSize,
 			Supplier<Point> getDefault) {
-		return controls.values().stream().map(computeSize)
-				.reduce((size1, size2) -> new Point(size1.x + size2.x, size1.y + size2.y + layout.verticalSpacing))
+		return controls.values().stream().map(computeSize).reduce(
+				(size1, size2) -> new Point(Math.max(size1.x, size2.x), size1.y + size2.y + layout.verticalSpacing))
 				.orElseGet(getDefault);
 	}
 

--- a/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/markers/MarkerInformationControl.java
+++ b/bundles/org.eclipse.ui.genericeditor/src/org/eclipse/ui/internal/genericeditor/markers/MarkerInformationControl.java
@@ -161,7 +161,10 @@ public class MarkerInformationControl extends AbstractInformationControl impleme
 
 	@Override
 	public Point computeSizeHint() {
-		getShell().pack();
+		if (getShell().getChildren().length > 0) {
+			// Do not pack the shell/control if it has no children, as it will size to 2,2
+			getShell().pack();
+		}
 		return getShell().getSize();
 	}
 


### PR DESCRIPTION
These two changes require each other:

* Do not add sizes in computeCompositeSize as only the max. should be used in x-direction

* Prevent shrinking of the hover shell when the size calculation fails

fixes #2909