### PR TITLE
Try to stabilize flacky PartRenderingEngineTest

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.ui.tests;singleton:=true
-Bundle-Version: 0.15.800.qualifier
+Bundle-Version: 0.15.900.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.emf.ecore.xmi;bundle-version="2.4.0",

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2023 IBM Corporation and others.
+ * Copyright (c) 2009, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2445,7 +2445,7 @@ public class PartRenderingEngineTests {
 		partStackForPartBPartC.setSelectedElement(partB);
 
 		MPart partC = ems.createModelElement(MPart.class);
-		partB.getTags().add(EPartService.REMOVE_ON_HIDE_TAG);
+		partC.getTags().add(EPartService.REMOVE_ON_HIDE_TAG);
 		partStackForPartBPartC.getChildren().add(partC);
 		partStackForPartBPartC.setSelectedElement(partC);
 


### PR DESCRIPTION
Due to an oversight, the REMOVE_ON_HIDE tag is set on "partB" twice, as opposed to "partB" and "partC". This may occasionally keep the part stack rendered, because "partC" is not removed from the model when hidden.

Closes https://github.com/eclipse-platform/eclipse.platform.ui/issues/751