### PR TITLE
Allow using visible regions with projections

### DIFF
--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/ProjectionViewerTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/ProjectionViewerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Red Hat, Inc. and others.
+ * Copyright (c) 2022, 2025 Red Hat, Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.Clipboard;
 import org.eclipse.swt.dnd.TextTransfer;
 import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.jface.text.BadLocationException;
@@ -29,11 +30,27 @@ import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.source.AnnotationModel;
+import org.eclipse.jface.text.source.IOverviewRuler;
+import org.eclipse.jface.text.source.IVerticalRuler;
 import org.eclipse.jface.text.source.projection.IProjectionPosition;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
 import org.eclipse.jface.text.source.projection.ProjectionViewer;
 
 public class ProjectionViewerTest {
+
+	/**
+	 * A {@link ProjectionViewer} that provides access to {@link #getVisibleDocument()}.
+	 */
+	private final class TestProjectionViewer extends ProjectionViewer {
+		private TestProjectionViewer(Composite parent, IVerticalRuler ruler, IOverviewRuler overviewRuler, boolean showsAnnotationOverview, int styles) {
+			super(parent, ruler, overviewRuler, showsAnnotationOverview, styles);
+		}
+
+		@Override
+		public IDocument getVisibleDocument() {
+			return super.getVisibleDocument();
+		}
+	}
 
 	private static final class ProjectionPosition extends Position implements IProjectionPosition {
 
@@ -71,6 +88,282 @@ public class ProjectionViewerTest {
 			assertEquals(document.get(), ((ITextSelection) viewer.getSelection()).getText());
 			viewer.getTextOperationTarget().doOperation(ITextOperationTarget.COPY);
 			assertEquals(document.get(), new Clipboard(viewer.getTextWidget().getDisplay()).getContents(TextTransfer.getInstance()));
+		} finally {
+			shell.dispose();
+		}
+	}
+
+	@Test
+	public void testVisibleRegionDoesNotChangeWithProjections() {
+		Shell shell= new Shell();
+		shell.setLayout(new FillLayout());
+		ProjectionViewer viewer= new ProjectionViewer(shell, null, null, false, SWT.NONE);
+		String documentContent= """
+				Hello
+				World
+				123
+				456
+				""";
+		Document document= new Document(documentContent);
+		viewer.setDocument(document, new AnnotationModel());
+		int regionLength= documentContent.indexOf('\n');
+		viewer.setVisibleRegion(0, regionLength);
+		viewer.enableProjection();
+		viewer.getProjectionAnnotationModel().addAnnotation(new ProjectionAnnotation(false), new ProjectionPosition(document));
+		shell.setVisible(true);
+		try {
+			assertEquals(0, viewer.getVisibleRegion().getOffset());
+			assertEquals(regionLength, viewer.getVisibleRegion().getLength());
+
+			viewer.getTextOperationTarget().doOperation(ProjectionViewer.COLLAPSE_ALL);
+			assertEquals(0, viewer.getVisibleRegion().getOffset());
+			assertEquals(regionLength, viewer.getVisibleRegion().getLength());
+		} finally {
+			shell.dispose();
+		}
+	}
+
+	@Test
+	public void testVisibleRegionProjectionCannotBeExpanded() {
+		Shell shell= new Shell();
+		shell.setLayout(new FillLayout());
+		TestProjectionViewer viewer= new TestProjectionViewer(shell, null, null, false, SWT.NONE);
+		String documentContent= """
+				Hello
+				World
+				123
+				456
+				""";
+		Document document= new Document(documentContent);
+		viewer.setDocument(document, new AnnotationModel());
+		int secondLineStart= documentContent.indexOf("World");
+		int secondLineEnd= documentContent.indexOf('\n', secondLineStart);
+		viewer.setVisibleRegion(secondLineStart, secondLineEnd - secondLineStart);
+		viewer.enableProjection();
+		shell.setVisible(true);
+		try {
+			assertEquals("World", viewer.getVisibleDocument().get());
+			viewer.getTextOperationTarget().doOperation(ProjectionViewer.EXPAND_ALL);
+			assertEquals("World", viewer.getVisibleDocument().get());
+		} finally {
+			shell.dispose();
+		}
+	}
+
+	@Test
+	public void testVisibleRegionAddsProjectionAnnotationsIfProjectionsEnabled() {
+		testProjectionAnnotationsFromVisibleRegion(true);
+	}
+
+	@Test
+	public void testEnableProjectionAddsProjectionAnnotationsIfVisibleRegionEnabled() {
+		testProjectionAnnotationsFromVisibleRegion(false);
+	}
+
+	private void testProjectionAnnotationsFromVisibleRegion(boolean enableProjectionFirst) {
+		Shell shell= new Shell();
+		shell.setLayout(new FillLayout());
+		TestProjectionViewer viewer= new TestProjectionViewer(shell, null, null, false, SWT.NONE);
+		String documentContent= """
+				Hello
+				World
+				123
+				456
+				""";
+		Document document= new Document(documentContent);
+		viewer.setDocument(document, new AnnotationModel());
+		int secondLineStart= documentContent.indexOf("World");
+		int secondLineEnd= documentContent.indexOf('\n', secondLineStart);
+
+		shell.setVisible(true);
+		if (enableProjectionFirst) {
+			viewer.enableProjection();
+			viewer.setVisibleRegion(secondLineStart, secondLineEnd - secondLineStart);
+		} else {
+			viewer.setVisibleRegion(secondLineStart, secondLineEnd - secondLineStart);
+			viewer.enableProjection();
+		}
+
+		try {
+			assertEquals("World", viewer.getVisibleDocument().get().trim());
+		} finally {
+			shell.dispose();
+		}
+	}
+
+	@Test
+	public void testInsertIntoVisibleRegion() throws BadLocationException {
+		Shell shell= new Shell();
+		shell.setLayout(new FillLayout());
+		TestProjectionViewer viewer= new TestProjectionViewer(shell, null, null, false, SWT.NONE);
+		String documentContent= """
+				Hello
+				World
+				123
+				456
+				""";
+		Document document= new Document(documentContent);
+		viewer.setDocument(document, new AnnotationModel());
+		int secondLineStart= documentContent.indexOf("World");
+		int secondLineEnd= documentContent.indexOf('\n', secondLineStart);
+
+		shell.setVisible(true);
+
+		try {
+			viewer.setVisibleRegion(secondLineStart, secondLineEnd - secondLineStart);
+			viewer.enableProjection();
+
+			assertEquals("World", viewer.getVisibleDocument().get());
+
+			viewer.getDocument().replace(documentContent.indexOf("rld"), 0, "---");
+
+			assertEquals("Wo---rld", viewer.getVisibleDocument().get());
+		} finally {
+			shell.dispose();
+		}
+	}
+
+	@Test
+	public void testRemoveVisibleRegionEnd() throws BadLocationException {
+		testReplaceVisibleRegionEnd("");
+	}
+
+	@Test
+	public void testReplaceVisibleRegionEnd() throws BadLocationException {
+		testReplaceVisibleRegionEnd("---");
+	}
+
+
+	private void testReplaceVisibleRegionEnd(String toReplaceWith) throws BadLocationException {
+		Shell shell= new Shell();
+		shell.setLayout(new FillLayout());
+		TestProjectionViewer viewer= new TestProjectionViewer(shell, null, null, false, SWT.NONE);
+		String documentContent= """
+				Hello
+				World
+				123
+				456
+				""";
+		Document document= new Document(documentContent);
+		viewer.setDocument(document, new AnnotationModel());
+		int secondLineStart= documentContent.indexOf("World");
+		int secondLineEnd= documentContent.indexOf('\n', secondLineStart);
+
+		shell.setVisible(true);
+
+		try {
+			viewer.setVisibleRegion(secondLineStart, secondLineEnd - secondLineStart);
+			viewer.enableProjection();
+
+			assertEquals("World", viewer.getVisibleDocument().get());
+
+			viewer.getDocument().replace(documentContent.indexOf("d\n1"), 3, toReplaceWith);
+
+			assertEquals("Worl" + toReplaceWith, viewer.getVisibleDocument().get());
+		} finally {
+			shell.dispose();
+		}
+	}
+
+	@Test
+	public void testRemoveVisibleRegionStart() throws BadLocationException {
+		testReplaceVisibleRegionStart("");
+	}
+
+	@Test
+	public void testReplaceVisibleRegionStart() throws BadLocationException {
+		testReplaceVisibleRegionStart("---");
+	}
+
+
+	private void testReplaceVisibleRegionStart(String toReplaceWith) throws BadLocationException {
+		Shell shell= new Shell();
+		shell.setLayout(new FillLayout());
+		TestProjectionViewer viewer= new TestProjectionViewer(shell, null, null, false, SWT.NONE);
+		String documentContent= """
+				Hello
+				World
+				123
+				456
+				""";
+		Document document= new Document(documentContent);
+		viewer.setDocument(document, new AnnotationModel());
+		int secondLineStart= documentContent.indexOf("World");
+		int secondLineEnd= documentContent.indexOf('\n', secondLineStart);
+
+		shell.setVisible(true);
+
+		try {
+			viewer.setVisibleRegion(secondLineStart, secondLineEnd - secondLineStart);
+			viewer.enableProjection();
+
+			assertEquals("World", viewer.getVisibleDocument().get());
+
+			viewer.getDocument().replace(documentContent.indexOf("o\nW"), 3, toReplaceWith);
+
+			assertEquals(toReplaceWith + "orld", viewer.getVisibleDocument().get());
+		} finally {
+			shell.dispose();
+		}
+	}
+
+	@Test
+	public void testVisibleRegionEndsWithWhitespace() {
+		Shell shell= new Shell();
+		shell.setLayout(new FillLayout());
+		TestProjectionViewer viewer= new TestProjectionViewer(shell, null, null, false, SWT.NONE);
+		String documentContent= """
+				Hello
+				World\t\t
+				123
+				456
+				""";
+		Document document= new Document(documentContent);
+		viewer.setDocument(document, new AnnotationModel());
+		int secondLineStart= documentContent.indexOf("World");
+		int secondLineTextEnd= documentContent.indexOf('\n', secondLineStart);
+		int secondLineEnd= documentContent.indexOf('\n', secondLineStart);
+
+		shell.setVisible(true);
+
+		try {
+			viewer.setVisibleRegion(secondLineStart, secondLineEnd - secondLineStart);
+			viewer.enableProjection();
+
+			assertEquals("World\t\t", viewer.getVisibleDocument().get());
+
+			viewer.setVisibleRegion(secondLineStart, secondLineTextEnd - secondLineStart);
+
+			assertEquals("World\t\t\n", viewer.getVisibleDocument().get());
+
+
+		} finally {
+			shell.dispose();
+		}
+	}
+
+	@Test
+	public void testRemoveEntireVisibleRegion() throws BadLocationException {
+		Shell shell= new Shell();
+		shell.setLayout(new FillLayout());
+		TestProjectionViewer viewer= new TestProjectionViewer(shell, null, null, false, SWT.NONE);
+		String documentContent= """
+				Hello
+				World
+				123
+				456
+				""";
+		Document document= new Document(documentContent);
+		viewer.setDocument(document, new AnnotationModel());
+		int secondLineStart= documentContent.indexOf("World");
+		int secondLineEnd= documentContent.indexOf('\n', secondLineStart);
+		viewer.setVisibleRegion(secondLineStart, secondLineEnd - secondLineStart);
+		viewer.enableProjection();
+		shell.setVisible(true);
+		try {
+			document.replace(secondLineStart, secondLineEnd - secondLineStart, "");
+			assertEquals("", viewer.getVisibleDocument().get());
+			assertEquals(new Region(secondLineStart, 0), viewer.getVisibleRegion());
 		} finally {
 			shell.dispose();
 		}


### PR DESCRIPTION
This is my attempt to fix #3073 in order to implement https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2264

### Description

`ProjectionViewer` currently cannot use visible regions and projections together (except by calling `enableProjections()` after `setVisibleRegions` in which case it will show a wrong region). This PR changes the implementation of visible regions to collapse everything outside the visible region.

### Note

This PR does not allow collapsing or expanding any projection/folding regions outside of the declared _visible region_ (e.g. by other code modifying the document in some way or if a projection region is partially in the visible region).

Aside from that, this implementation has the following effect: If `setVisibleRegion` is called with a region that is fully collapsed, the editor is basically empty. If another behavior is desired, it would be good to know what the better behavior is.

### testing with JDT

To test this with JDT as requested in https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2264, do the following:
- Create a workspace with eclipse.platform.ui and JDT-UI set up (I did so by creating a Target Platform and added whatever I thought was necessary until I no longer got any errors but I have no idea how to properly do that)
- Use the changes in eclipse.platform.ui
- Apply https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2302 with JDT-UI:
- Create an "Eclipse Application" run configuration with this version of Eclipse Platform and the patched version of JDT-UI and start it
- Enable Window > Preferences > Java > Editor > "Only show the selected Java Element"
- Make sure folding is enabled at Window > Preferences > Java > Editor > Folding
- Open a Java class
- Select elements in the outline and observe that only the "selected element" is shown in the editor and folding still works (whether it's normal folding, custom folding regions, "Extended Folding", etc shouldn't make a difference)
![image](https://github.com/user-attachments/assets/b05a8771-fb38-44cb-a85a-59f5df857daa)
- If "Enhanced Folding" is active, make sure that https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2410 is available as well
