### PR TITLE
Paint Whole FormText to Avoid Rendering Artifacts

### DIFF
--- a/bundles/org.eclipse.ui.forms/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.forms/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.ui.forms;singleton:=true
-Bundle-Version: 3.13.500.qualifier
+Bundle-Version: 3.13.600.qualifier
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.forms,

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/FormText.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/FormText.java
@@ -1554,7 +1554,8 @@ public class FormText extends Canvas {
 		ensureBoldFontPresent(getFont());
 		gc.setForeground(getForeground());
 		gc.setBackground(getBackground());
-		repaint(gc, e.x, e.y, e.width, e.height);
+		Point size = getSize();
+		repaint(gc, 0, 0, size.x, size.y);
 	}
 
 	private void repaint(GC gc, int x, int y, int width, int height) {


### PR DESCRIPTION
This PR updates the painting logic of FormText to render the entire content every time, rather than in segments. Painting in parts—particularly during scrolling—can introduce precision loss when using fractional (e.g., 1.25x, 1.75x) scaling factors. This may result in skipped pixels and visual glitches in the UI.

**How to test:**
From a fresh installation and clean workspace:

- Ensure that "monitor-specific scaling" is enabled
- Set primary monitor zoom to 175%
- Open any forms editor, e.g., by creating a plug-in project and opening the manifest
- Scroll inside the forms editors
- It is easiest to reproduce when scrolling slowly, such as when dragging the scrollbar with the mouse.

**Before:**
![image](https://github.com/user-attachments/assets/06362b18-466b-4af4-a199-01afe3e053f3)

**After:**
![image](https://github.com/user-attachments/assets/fb81107d-5e5c-4fb5-aad2-9de58f16d783) 

Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/issues/2997