### PR TITLE
Avoid IllegalArgumentException if the line number mapping fails

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/texteditor/stickyscroll/StickyLine.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/texteditor/stickyscroll/StickyLine.java
@@ -57,16 +57,19 @@ public class StickyLine implements IStickyLine {
 		StyledText textWidget = sourceViewer.getTextWidget();
 		int widgetLineNumber = getWidgetLineNumber();
 
-		if (widgetLineNumber >= textWidget.getLineCount()) {
+		if (widgetLineNumber < 0 || widgetLineNumber >= textWidget.getLineCount()) {
 			return null;
 		}
-
-		int offsetAtLine = textWidget.getOffsetAtLine(getWidgetLineNumber());
-		StyleRange[] styleRanges = textWidget.getStyleRanges(offsetAtLine, getText().length());
-		for (StyleRange styleRange : styleRanges) {
-			styleRange.start = styleRange.start - offsetAtLine;
+		try {
+			int offsetAtLine = textWidget.getOffsetAtLine(widgetLineNumber);
+			StyleRange[] styleRanges = textWidget.getStyleRanges(offsetAtLine, getText().length());
+			for (StyleRange styleRange : styleRanges) {
+				styleRange.start = styleRange.start - offsetAtLine;
+			}
+			return styleRanges;
+		} catch (IllegalArgumentException e) {
+			return null; // in case of an invalid line number, return null
 		}
-		return styleRanges;
 	}
 
 	private int getWidgetLineNumber() {


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.ui/issues/3080 
See also https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2316