### PR TITLE
StickyLine.getText() should not fail on not mapped widget lines

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -236,7 +236,8 @@ public class StickyScrollingControl {
 
 		List<StyleRange> stickyLinesStyleRanges= new ArrayList<>();
 		int stickyLineTextOffset= 0;
-		for (int i= 0; i < getNumberStickyLines(); i++) {
+		int stickyLinesCount = getNumberStickyLines();
+		for (int i = 0; i < stickyLinesCount; i++) {
 			IStickyLine stickyLine= stickyLines.get(i);
 			StyleRange[] ranges= stickyLine.getStyleRanges();
 			if (ranges != null) {

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/texteditor/stickyscroll/StickyLine.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/texteditor/stickyscroll/StickyLine.java
@@ -47,7 +47,11 @@ public class StickyLine implements IStickyLine {
 	public String getText() {
 		if (text == null) {
 			StyledText textWidget = sourceViewer.getTextWidget();
-			text = textWidget.getLine(getWidgetLineNumber());
+			int widgetLineNumber = getWidgetLineNumber();
+			if (widgetLineNumber < 0 || widgetLineNumber >= textWidget.getLineCount()) {
+				return ""; // return empty string if line number is invalid //$NON-NLS-1$
+			}
+			text = textWidget.getLine(widgetLineNumber);
 		}
 		return text;
 	}


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3085