### PR TITLE
FormText.paint(): don't pass (0,0) to Image on Linux

### DIFF
--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/FormText.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/FormText.java
@@ -1555,7 +1555,14 @@ public class FormText extends Canvas {
 		gc.setForeground(getForeground());
 		gc.setBackground(getBackground());
 		Point size = getSize();
-		repaint(gc, 0, 0, size.x, size.y);
+		Rectangle paintBounds;
+		if (size.x == 0 && size.y == 0) {
+			// avoids crash on image creation with (0,0) image size
+			paintBounds = new Rectangle(e.x, e.y, e.width, e.height);
+		} else {
+			paintBounds = new Rectangle(0, 0, size.x, size.y);
+		}
+		repaint(gc, paintBounds.x, paintBounds.y, paintBounds.width, paintBounds.height);
 	}
 
 	private void repaint(GC gc, int x, int y, int width, int height) {


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3087