### PR TITLE
Enable dropping files onto labels containing ImageView in the workbench

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 IBM Corporation and others.
+ * Copyright (c) 2008, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -87,6 +87,8 @@ import org.eclipse.swt.custom.CTabFolder2Adapter;
 import org.eclipse.swt.custom.CTabFolder2Listener;
 import org.eclipse.swt.custom.CTabFolderEvent;
 import org.eclipse.swt.custom.CTabItem;
+import org.eclipse.swt.dnd.DND;
+import org.eclipse.swt.dnd.DropTarget;
 import org.eclipse.swt.events.ControlEvent;
 import org.eclipse.swt.events.ControlListener;
 import org.eclipse.swt.events.MouseAdapter;
@@ -719,6 +721,11 @@ public class StackRenderer extends LazyStackRenderer {
 		if (PartStackUtil.isEditorStack(element)) {
 			createOnboardingControls(tabFolder);
 			initializeOnboardingInformationInEditorStack(tabFolder);
+			int drop = DND.DROP_COPY | DND.DROP_MOVE | DND.DROP_LINK;
+			// Bug: eclipse-platform/eclipse.platform.swt/issues/649
+			Composite dropZone = new Composite(tabFolder, SWT.NONE);// additional Composite/child to support dropping
+			new Label(dropZone, SWT.NONE);
+			new DropTarget(dropZone, drop);
 		}
 		tabFolder.setMRUVisible(getMRUValue());
 

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRendererTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRendererTest.java
@@ -417,7 +417,7 @@ public class StackRendererTest {
 		Composite uiContainer = (Composite) ((StackRenderer) partStack.getRenderer()).getUIContainer(partStack);
 		CTabFolder tabFolder = (CTabFolder) ((Composite) uiContainer.getChildren()[0]).getChildren()[0];
 		assertNotNull(tabFolder.getChildren());
-		assertEquals(3, tabFolder.getChildren().length);
+		assertEquals(4, tabFolder.getChildren().length);
 
 		Composite outerOnboardingComposite = (Composite) tabFolder.getChildren()[2];
 		Rectangle expected = new Rectangle(StackRenderer.ONBOARDING_SPACING, StackRenderer.ONBOARDING_TOP_SPACING,
@@ -526,7 +526,7 @@ public class StackRendererTest {
 		Composite uiContainer = (Composite) ((StackRenderer) partStack.getRenderer()).getUIContainer(partStack);
 		CTabFolder tabFolder = (CTabFolder) ((Composite) uiContainer.getChildren()[0]).getChildren()[0];
 		assertNotNull(tabFolder.getChildren());
-		assertEquals(3, tabFolder.getChildren().length);
+		assertEquals(4, tabFolder.getChildren().length);
 
 		Composite outerOnboardingComposite = (Composite) tabFolder.getChildren()[2];
 		Rectangle expected = new Rectangle(StackRenderer.ONBOARDING_SPACING, StackRenderer.ONBOARDING_TOP_SPACING,


### PR DESCRIPTION
Dropping a file onto the top of an image wasn't possible on a label containing an imageView. The issue was previously fixed via https://github.com/eclipse-platform/eclipse.platform.swt/pull/713. However, in the workbench image, dropping was yet to be configured.

The issue is now resolved by calling a DropTarget on the image label . It sets additional DropTarget on the tabFolder via composite label.

Fixes :https://github.com/eclipse-platform/eclipse.platform.swt/issues/649


