### PR TITLE
Do not fetch input eagerly if not required

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/e4/compatibility/CompatibilityEditor.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/e4/compatibility/CompatibilityEditor.java
@@ -59,9 +59,11 @@ public class CompatibilityEditor extends CompatibilityPart {
 	@Override
 	IWorkbenchPart createPart(WorkbenchPartReference reference) throws PartInitException {
 		IWorkbenchPart part = super.createPart(reference);
-		IEditorInput input = ((EditorReference) reference).getEditorInput();
-		if (input instanceof MultiEditorInput && part instanceof MultiEditor) {
-			createMultiEditorChildren(part, input);
+		if (part instanceof MultiEditor) {
+			IEditorInput input = ((EditorReference) reference).getEditorInput();
+			if (input instanceof MultiEditorInput) {
+				createMultiEditorChildren(part, input);
+			}
 		}
 		return part;
 	}


### PR DESCRIPTION
Currently CompatibilityEditor.createPart(WorkbenchPartReference) eagerly fetches the input just to then check if it is actually needed.

This now pulls out the check for MultiEditor out to only fetch the input if there is a demand for it.