### PR TITLE
Remove WS_CARBON check

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/BindingPersistence.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/keys/BindingPersistence.java
@@ -519,7 +519,7 @@ public class BindingPersistence extends PreferencePersistence {
 	 * @param commandService            The command service for the workbench; must
 	 *                                  not be <code>null</code>.
 	 */
-	@SuppressWarnings("removal")
+
 	private static final void readBindingsFromRegistry(final IConfigurationElement[] configurationElements,
 			final int configurationElementCount, final BindingManager bindingManager,
 			final CommandManager commandService) {
@@ -608,12 +608,6 @@ public class BindingPersistence extends PreferencePersistence {
 
 			if (Util.WS_COCOA.equals(platform)) {
 				cocoaTempList.add(binding);
-			} else if (Util.WS_CARBON.equals(platform)) {
-				bindings.add(binding);
-				// temp work around ... simply honour the carbon
-				// bindings for cocoa.
-				cocoaTempList.add(new KeyBinding(keySequence, parameterizedCommand, schemeId, contextId, locale,
-						Util.WS_COCOA, null, Binding.SYSTEM));
 			} else {
 				bindings.add(binding);
 			}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/BindingPersistenceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/BindingPersistenceTest.java
@@ -173,10 +173,7 @@ public final class BindingPersistenceTest {
 				}
 			}
 		}
-		if (Util.WS_CARBON.equals(SWT.getPlatform())
-				|| Util.WS_COCOA.equals(SWT.getPlatform())) {
-			assertEquals(2, numAboutBindings);
-		} else {
+		if (Util.WS_COCOA.equals(SWT.getPlatform())) {
 			assertEquals(1, numAboutBindings);
 		}
 	}


### PR DESCRIPTION
This PR removes the only remaining WS_CARBON check from the codebase.The Carbon backend is no longer used or supported in SWT, as all modern macOS environments use the Cocoa backend (WS_COCOA). This check is now obsolete and can be removed. (https://github.com/eclipse-platform/eclipse.platform.ui/discussions/2964)