### PR TITLE
Remove no longer needed suppresswarnings in demo.cssbridge

### DIFF
--- a/examples/org.eclipse.e4.demo.cssbridge/src/org/eclipse/e4/demo/cssbridge/internal/core/DummyMailService.java
+++ b/examples/org.eclipse.e4.demo.cssbridge/src/org/eclipse/e4/demo/cssbridge/internal/core/DummyMailService.java
@@ -43,7 +43,6 @@ public class DummyMailService implements IMailService {
 		return mails;
 	}
 
-	@SuppressWarnings("serial")
 	private Map<FolderType, List<Mail>> getFolderTypeToMails() {
 		if (folderTypeToMails == null) {
 			folderTypeToMails = new HashMap<>() {
@@ -56,7 +55,6 @@ public class DummyMailService implements IMailService {
 		return folderTypeToMails;
 	}
 
-	@SuppressWarnings("serial")
 	private List<Mail> createDummyInboxFolderMails() {
 		return new ArrayList<>() {
 			{
@@ -101,7 +99,6 @@ public class DummyMailService implements IMailService {
 		};
 	}
 
-	@SuppressWarnings("serial")
 	private List<Mail> createDummySentFolderMails() {
 		return new ArrayList<>() {
 			{


### PR DESCRIPTION
Fixes warnings in I-build like
https://download.eclipse.org/eclipse/downloads/drops4/I20250722-1800/compilelogs/plugins/org.eclipse.e4.demo.cssbridge_1.3.0.v20241015-1729/@dot.html#OTHER_WARNINGS