### PR TITLE
Propagate the ViewMenu Tooltip from the E4 model to the UI

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
@@ -908,12 +908,21 @@ public class StackRenderer extends LazyStackRenderer {
 		// We need to modify the 'exclude' bit based on if the menuTB is
 		// visible or not
 		RowData rd = (RowData) menuTB.getLayoutData();
+		ToolItem item = menuTB.getItem(0);
 		if (needsMenu) {
-			menuTB.getItem(0).setData(THE_PART_KEY, part);
+			item.setData(THE_PART_KEY, part);
 			rd.exclude = false;
+			String tooltip = viewMenu.getTooltip();
+			if (tooltip == null) {
+				tooltip = viewMenu.getLabel();
+			}
+			if (tooltip == null) {
+				tooltip = SWTRenderersMessages.viewMenu;
+			}
+			item.setToolTipText(tooltip);
 			menuTB.setVisible(true);
 		} else {
-			menuTB.getItem(0).setData(THE_PART_KEY, null);
+			item.setData(THE_PART_KEY, null);
 			rd.exclude = true;
 			menuTB.setVisible(false);
 		}


### PR DESCRIPTION
Currently all `ViewMenus` have the same tooltip "View Menu" even if there is a name or tooltip defined in the E4 Model. This is because the constant string is set once and never updated.

This now properly reads the values from the model and falls back to the old one if nothing is specified.

Assume we have the following in the Model Editor:
<img width="1508" height="725" alt="grafik" src="https://github.com/user-attachments/assets/d30dd587-37b8-4ff1-968a-4926060e15d1" />

## Before

<img width="551" height="474" alt="grafik" src="https://github.com/user-attachments/assets/461c809e-6b07-475e-9c78-68ec464e9d42" />

## After

<img width="531" height="473" alt="grafik" src="https://github.com/user-attachments/assets/ea3808db-302e-4bf1-b618-38e84fb91c2f" />

-----

Beside from that I think "View Menu" is a very bad default here, and I checked that actually all views in Eclipse currently show this tooltip. A better default will probably be "Show additional options and action" or similar.