### PR TITLE
Add API filters for removal of @noreference SWT classes

### DIFF
--- a/bundles/org.eclipse.jface/.settings/.api_filters
+++ b/bundles/org.eclipse.jface/.settings/.api_filters
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.jface" version="2">
+    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.swt.graphics.MonitorAwarePoint">
+        <filter id="305426566">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwarePoint"/>
+                <message_argument value="org.eclipse.jface_3.37.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.swt.graphics.MonitorAwareRectangle">
+        <filter id="305426566">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwareRectangle"/>
+                <message_argument value="org.eclipse.jface_3.37.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.ui/.settings/.api_filters
+++ b/bundles/org.eclipse.ui/.settings/.api_filters
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.ui" version="2">
+    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.swt.graphics.MonitorAwarePoint">
+        <filter id="305426566">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwarePoint"/>
+                <message_argument value="org.eclipse.ui_3.207.200"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.swt.graphics.MonitorAwareRectangle">
+        <filter id="305426566">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.graphics.MonitorAwareRectangle"/>
+                <message_argument value="org.eclipse.ui_3.207.200"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>


### PR DESCRIPTION
The classes MonitorAwarePoint and MonitorAwareRectangle have been removed from SWT. They were public inside an API package but marked as `@noreference` as they are not intended to be used as part of an API, which is why API tooling considers there removal a breaking API change. The bundles org.eclipse.ui and org.eclipse.jface reexport SWT packages, which is why API tooling also considers the removal as breaking API change of those bundles. This change adds according API filters.

Belongs to:
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2349