### PR TITLE
Force qualifier update for split packages of o.e.text and o.e.jface.text

### DIFF
--- a/bundles/org.eclipse.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.text
-Bundle-Version: 3.14.300.qualifier
+Bundle-Version: 3.14.400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.text/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.text/forceQualifierUpdate.txt
@@ -6,3 +6,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/16
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3190


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3190

This fixes five errors like this:
```
The package 'org.eclipse.jface.text 0.0.0' is jar-signed differently by the containing IUs
org.eclipse.jface.text 3.28.100.v20250730-1623
  {CN=Eclipse.org Foundation, Inc., O=Eclipse.org Foundation, Inc., L=Ottawa, ST=Ontario, from=2025-07-17, to=2026-07-16}
    {CN=DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1, O=DigiCert, Inc., from=2021-04-29, to=2036-04-28}
      {CN=DigiCert Trusted Root G4, OU=www.digicert.com, O=DigiCert Inc, from=2013-08-01, to=2038-01-15}
org.eclipse.text 3.14.300.v20250119-1501
  {CN=Eclipse.org Foundation, Inc., O=Eclipse.org Foundation, Inc., L=Ottawa, ST=Ontario, from=2024-07-22, to=2025-07-21}
    {CN=DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1, O=DigiCert, Inc., from=2021-04-29, to=2036-04-28}
      {CN=DigiCert Trusted Root G4, OU=www.digicert.com, O=DigiCert Inc, from=2013-08-01, to=2038-01-15}
```