### PR TITLE
Check if platform is running

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/ObjectContributorManager.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/ObjectContributorManager.java
@@ -658,7 +658,7 @@ public abstract class ObjectContributorManager implements IExtensionChangeHandle
 	 * collection of objects.
 	 */
 	private List getCommonClasses(List objects, List commonAdapters) {
-		if (objects == null || objects.isEmpty()) {
+		if (objects == null || objects.isEmpty() || !Platform.isRunning()) {
 			return null;
 		}
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/statushandlers/StatusManager.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/statushandlers/StatusManager.java
@@ -141,7 +141,9 @@ public class StatusManager {
 
 	private StatusManager() {
 		statusManagerLogListener = new StatusManagerLogListener();
-		Platform.addLogListener(statusManagerLogListener);
+		if (Platform.isRunning()) {
+			Platform.addLogListener(statusManagerLogListener);
+		}
 	}
 
 	private AbstractStatusHandler getStatusHandler() {


### PR DESCRIPTION
Currently it can happen that the platform is already shut down (e.g. very fast unit test) and then we see ugly exceptions in the log.

This now first check if the platform is actually running before access it.