### PR TITLE
Show ProgressMonitorJobsDialog after delay in ProgressManager.run

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressManager.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressManager.java
@@ -967,9 +967,10 @@ public class ProgressManager extends ProgressProvider implements IProgressServic
 	@Override
 	public void run(boolean fork, boolean cancelable, IRunnableWithProgress runnable)
 			throws InvocationTargetException, InterruptedException {
-		if (!fork || !cancelable) {
+		if (!shouldRunInBackground() && (!fork || !cancelable)) {
 			// Backward compatible code.
-			final ProgressMonitorJobsDialog dialog = new ProgressMonitorJobsDialog(null);
+			final ProgressMonitorJobsDialog dialog = new ProgressMonitorJobsDialog(
+					ProgressManagerUtil.getDefaultParent());
 			dialog.run(fork, cancelable, runnable);
 			return;
 		}


### PR DESCRIPTION
Avoids a "flickering" produced by showing the progress dialog and closing it immediately for short-running tasks, improving the UX.

Before this PR, calling either one of these 2 methods ...
- `PlatformUI.getWorkbench().getProgressService().run(...)`
- `PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActivePart().getSite().getAdapter(IWorkbenchSiteProgressService.class).run(...)`

... and passing `false` as the 1st and/or the 2nd parameter (`fork` / `cancelable`) ended up showing a `ProgressMonitorJobsDialog` immediately. On the other hand passing `true` to both parameters showed the dialog after a short delay of **800 ms**.

After this PR, the dialog is always shown after a delay of 800 ms.  

