### PR TITLE
Fixed copy/paste error for WizardDialog.isModal()

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/WizardDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/WizardDialog.java
@@ -370,7 +370,7 @@ public class WizardDialog extends TitleAreaDialog implements IWizardContainer2, 
 	 */
 	public boolean isModal() {
 		return (getShellStyle() & SWT.PRIMARY_MODAL) == SWT.PRIMARY_MODAL
-				|| (getShellStyle() & SWT.PRIMARY_MODAL) == SWT.APPLICATION_MODAL;
+				|| (getShellStyle() & SWT.APPLICATION_MODAL) == SWT.APPLICATION_MODAL;
 	}
 
 	/**


### PR DESCRIPTION
Regression from https://github.com/eclipse-platform/eclipse.platform.ui/pull/243

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3150