### PR TITLE
Expand the filtered page tree by default

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/FilteredPreferenceDialog.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/FilteredPreferenceDialog.java
@@ -308,6 +308,11 @@ public abstract class FilteredPreferenceDialog extends PreferenceDialog implemen
 	public void showOnly(String[] filteredIds) {
 		if (!hasAtMostOnePage()) {
 			filteredTree.addFilter(new PreferenceNodeFilter(filteredIds));
+
+			// expand the tree to level 2 if there is only one parent node
+			if (getTreeViewer().getTree().getItems().length == 1) {
+				getTreeViewer().expandToLevel(2);
+			}
 		}
 	}
 


### PR DESCRIPTION
- If the opened filtered preference dialog contains only one root page, expand it to level two.

A follow up for https://github.com/eclipse-platform/eclipse.platform.ui/discussions/3149