### PR TITLE
Use a separate ExecutorService in AsyncCompletionProposalPopup

### DIFF
--- a/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.text
-Bundle-Version: 3.28.200.qualifier
+Bundle-Version: 3.29.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -40,4 +40,6 @@ Require-Bundle:
 Import-Package: com.ibm.icu.text
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.jface.text
+Bundle-Activator: org.eclipse.jface.text.Activator
+Bundle-ActivationPolicy: lazy
 Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/Activator.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/Activator.java
@@ -1,0 +1,68 @@
+package org.eclipse.jface.text;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+/**
+ * @since 3.29
+ */
+public class Activator implements BundleActivator {
+	/**
+	 * The identifier of the descriptor of this plugin in plugin.xml.
+	 */
+	public static final String ID= "org.eclipse.jface.text"; //$NON-NLS-1$
+
+	private static Activator activator;
+
+	private ExecutorService executor;
+
+	@Override
+	public void start(BundleContext context) {
+		activator= this;
+	}
+
+	@Override
+	public void stop(BundleContext context) {
+		activator= null;
+		if (executor != null) {
+			executor.shutdownNow();
+			executor= null;
+		}
+	}
+
+	public static ExecutorService getExecutor() {
+		activator.createExecutor();
+		return activator.executor;
+	}
+
+	private void createExecutor() {
+		if (activator.executor != null)
+			return;
+
+		executor= new ThreadPoolExecutor(
+				Runtime.getRuntime().availableProcessors(),
+				Runtime.getRuntime().availableProcessors(),
+				3L, TimeUnit.SECONDS,
+				new LinkedBlockingQueue<>(),
+				new ThreadFactory() {
+					AtomicInteger count= new AtomicInteger(1);
+
+					@Override
+					public Thread newThread(Runnable r) {
+						// Name the threads numerically for better debugging.
+						Thread t= new Thread(r, ID + "-worker-" + count.getAndIncrement()); //$NON-NLS-1$
+
+						// No need to keep the JVM running just because of the completion proposals
+						t.setDaemon(true);
+						return t;
+					}
+				});
+	}
+}


### PR DESCRIPTION
> [!TIP]
> I'm targeting this PR for M1 so I'll keep it drafted. **Feel free to review and test anyway**.

## What it does
Use a dedicated `ExecutorService` in `AsyncCompletionProposalPopup` so that canceling the futures works as expected.

Before this PR, the method `AsyncCompletionProposalPopup.cancelFutures()` did not stop running futures, more precisely: it didn't stop the `computationFutures`. This was because the common pool was being used.

This PR introduces a dedicated executor service (with its own pool) that can be shut down immediately when the completion popup is closed.

## How to test
- Check out this PR and also these other 2:
  - (Mandatory) https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4302
  - (Optional: avoids flooding the console with exceptions): https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2425
- Add this delay in `Parser::parse`, inside [this `for(;;)` - loop](https://github.com/eclipse-jdt/eclipse.jdt.core/blob/43ac9cab64c667686ac9af41479d87dd40078fcf/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java#L11607) (right at the beginning):

```java
if (Thread.currentThread().getName().contains("org.eclipse.jface.text")) // ... ThreadPoolExecutor		
{
	try {
		System.out.println("Parsing...");
		Thread.sleep(500);
	} catch (InterruptedException e) {
		// Interrupt again so that the actual interruption mechanism (the if below) is triggered
		Thread.currentThread().interrupt();
		System.out.println("Interrupted during sleep!");
	}
}
```
- Start the workbench and start some autocompletion
- Cancel the autocompletion by clicking outside the popup or by pressing the `esc`-key

### Expected outcome
- If you added the delay in `Parser::parse` then you should see this in the output, several times: `Parsing...`
- After pressing `esc`, you should see no more occurrences of `Parsing...` in the console and you should see `Interrupted during sleep!`