### PR TITLE
Fix LineNumberRuler for fixed zoom

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/LineNumberRulerColumn.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/LineNumberRulerColumn.java
@@ -624,6 +624,7 @@ public class LineNumberRulerColumn implements IVerticalRulerColumn {
 					fBuffer.dispose();
 					fBuffer= null;
 				}
+				layout(false);
 			});
 		});
 


### PR DESCRIPTION
This PR adds a layout call to the callback executed after a zoom change for the Canvas. If a fixed zoom is used and monitor specific scaling is active the font sizes will be correctly adapted after a zoom change, but the size of the Canvas is not, leading to cut off line numbers. Forcing a layout for this rare case of event will ensure a proper resizing.

### How to test

Start a runtime with
```
-Dswt.autoScale.updateOnRuntime=true
-Dswt.autoScale=150
```

on two monitors with different zoom than 150, best one bigger, one smaller and move a Text Editor with line numbers between the monitor.

**Before**
<img width="336" height="276" alt="Screenshot 2025-08-12 132002" src="https://github.com/user-attachments/assets/8d9b5bb1-4d5c-442e-8697-fa6a939ef2ed" />

**After**
<img width="308" height="434" alt="Screenshot 2025-08-12 132555" src="https://github.com/user-attachments/assets/6b839895-3084-4075-87de-ffb342f14bc6" />
