### PR TITLE
Replace fail() calls in org.eclipse.ui.tests

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorRegistryTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorRegistryTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.List;
@@ -89,13 +88,13 @@ public class IEditorRegistryTest {
 	}
 
 	@After
-	public void tearDown() {
+	public void tearDown() throws CoreException {
 		if (proj != null) {
 			try {
 				FileUtil.deleteProject(proj);
 			} catch (CoreException e) {
 				TestPlugin.getDefault().getLog().log(e.getStatus());
-				fail();
+				throw e;
 			}
 		}
 	}
@@ -360,11 +359,7 @@ public class IEditorRegistryTest {
 
 		// removing the listener that is not registered yet should have no
 		// effect
-		try {
-			fReg.removePropertyListener(listener);
-		} catch (Throwable e) {
-			fail();
-		}
+		fReg.removePropertyListener(listener);
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchWindowTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchWindowTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.junit.Assert.assertThrows;
+
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jface.action.StatusLineManager;
 import org.eclipse.swt.custom.CLabel;
@@ -175,13 +177,10 @@ public class IWorkbenchWindowTest extends UITestCase {
 		}
 
 		// test openPage() fails
-		try {
-			page = fWin.openPage("*************", ResourcesPlugin.getWorkspace());
-			fail();
-		} catch (WorkbenchException ex) {
-		}
-
-		page.close();
+		assertThrows(WorkbenchException.class, () -> {
+			IWorkbenchPage p = fWin.openPage("*************", ResourcesPlugin.getWorkspace());
+			p.close();
+		});
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/AcceleratorConfigurationsExtensionDynamicTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/AcceleratorConfigurationsExtensionDynamicTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.junit.Assert.assertThrows;
+
 import org.eclipse.core.commands.common.NamedHandleObject;
 import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
@@ -72,40 +74,27 @@ public final class AcceleratorConfigurationsExtensionDynamicTest extends
 
 	/**
 	 * Tests whether the items defined in the extension point can be added and
-	 * removed dynamically. It tests that the data doesn't exist, and then loads
-	 * the extension. It tests that the data then exists, and unloads the
-	 * extension. It tests that the data then doesn't exist.
+	 * removed dynamically. It tests that the data doesn't exist, and then loads the
+	 * extension. It tests that the data then exists, and unloads the extension. It
+	 * tests that the data then doesn't exist.
+	 *
+	 * @throws NotDefinedException
 	 */
 	@Test
-	public final void testAcceleratorConfigurations() {
+	public final void testAcceleratorConfigurations() throws NotDefinedException {
 		final IBindingService service = getWorkbench().getAdapter(IBindingService.class);
-		NamedHandleObject namedHandleObject;
 
-		namedHandleObject = service.getScheme("monkey");
-		try {
-			namedHandleObject.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
+		NamedHandleObject namedHandleObject1 = service.getScheme("monkey");
+		assertThrows(NotDefinedException.class, () -> namedHandleObject1.getName());
 
 		getBundle();
 
-		namedHandleObject = service.getScheme("monkey");
-		try {
-			assertTrue("Monkey".equals(namedHandleObject.getName()));
-		} catch (final NotDefinedException e) {
-			fail();
-		}
+		NamedHandleObject namedHandleObject2 = service.getScheme("monkey");
+		assertTrue("Monkey".equals(namedHandleObject2.getName()));
 
 		removeBundle();
 
-		namedHandleObject = service.getScheme("monkey");
-		try {
-			namedHandleObject.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
+		NamedHandleObject namedHandleObject3 = service.getScheme("monkey");
+		assertThrows(NotDefinedException.class, () -> namedHandleObject3.getName());
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/AcceleratorScopesExtensionDynamicTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/AcceleratorScopesExtensionDynamicTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.junit.Assert.assertThrows;
+
 import org.eclipse.core.commands.common.NamedHandleObject;
 import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.ui.contexts.IContextService;
@@ -72,40 +74,26 @@ public final class AcceleratorScopesExtensionDynamicTest extends
 
 	/**
 	 * Tests whether the items defined in the extension point can be added and
-	 * removed dynamically. It tests that the data doesn't exist, and then loads
-	 * the extension. It tests that the data then exists, and unloads the
-	 * extension. It tests that the data then doesn't exist.
+	 * removed dynamically. It tests that the data doesn't exist, and then loads the
+	 * extension. It tests that the data then exists, and unloads the extension. It
+	 * tests that the data then doesn't exist.
+	 *
+	 * @throws NotDefinedException
 	 */
 	@Test
-	public final void testAcceleratorScopes() {
+	public final void testAcceleratorScopes() throws NotDefinedException {
 		final IContextService service = getWorkbench().getAdapter(IContextService.class);
-		NamedHandleObject namedHandleObject;
-
-		namedHandleObject = service.getContext("monkey");
-		try {
-			namedHandleObject.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
+		NamedHandleObject namedHandleObject1 = service.getContext("monkey");
+		assertThrows(NotDefinedException.class, () -> namedHandleObject1.getName());
 
 		getBundle();
 
-		namedHandleObject = service.getContext("monkey");
-		try {
-			assertTrue("Monkey".equals(namedHandleObject.getName()));
-		} catch (final NotDefinedException e) {
-			fail();
-		}
+		NamedHandleObject namedHandleObject2 = service.getContext("monkey");
+		assertTrue("Monkey".equals(namedHandleObject2.getName()));
 
 		removeBundle();
 
-		namedHandleObject = service.getContext("monkey");
-		try {
-			namedHandleObject.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
+		NamedHandleObject namedHandleObject3 = service.getContext("monkey");
+		assertThrows(NotDefinedException.class, () -> namedHandleObject3.getName());
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ActionDefinitionsExtensionDynamicTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ActionDefinitionsExtensionDynamicTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.junit.Assert.assertThrows;
+
 import org.eclipse.core.commands.common.NamedHandleObject;
 import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.ui.commands.ICommandService;
@@ -72,40 +74,27 @@ public final class ActionDefinitionsExtensionDynamicTest extends
 
 	/**
 	 * Tests whether the items defined in the extension point can be added and
-	 * removed dynamically. It tests that the data doesn't exist, and then loads
-	 * the extension. It tests that the data then exists, and unloads the
-	 * extension. It tests that the data then doesn't exist.
+	 * removed dynamically. It tests that the data doesn't exist, and then loads the
+	 * extension. It tests that the data then exists, and unloads the extension. It
+	 * tests that the data then doesn't exist.
+	 *
+	 * @throws NotDefinedException
 	 */
 	@Test
-	public final void testActionDefinitions() {
+	public final void testActionDefinitions() throws NotDefinedException {
 		final ICommandService service = getWorkbench().getAdapter(ICommandService.class);
-		NamedHandleObject namedHandleObject;
 
-		namedHandleObject = service.getCommand("monkey");
-		try {
-			namedHandleObject.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
+		NamedHandleObject namedHandleObject1 = service.getCommand("monkey");
+		assertThrows(NotDefinedException.class, () -> namedHandleObject1.getName());
 
 		getBundle();
 
-		namedHandleObject = service.getCommand("monkey");
-		try {
-			assertTrue("Monkey".equals(namedHandleObject.getName()));
-		} catch (final NotDefinedException e) {
-			fail();
-		}
+		NamedHandleObject namedHandleObject2 = service.getCommand("monkey");
+		assertTrue("Monkey".equals(namedHandleObject2.getName()));
 
 		removeBundle();
 
-		namedHandleObject = service.getCommand("monkey");
-		try {
-			namedHandleObject.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
+		NamedHandleObject namedHandleObject3 = service.getCommand("monkey");
+		assertThrows(NotDefinedException.class, () -> namedHandleObject3.getName());
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/BindingsExtensionDynamicTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/BindingsExtensionDynamicTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.junit.Assert.assertThrows;
+
 import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.jface.bindings.Binding;
 import org.eclipse.jface.bindings.Scheme;
@@ -76,19 +78,18 @@ public final class BindingsExtensionDynamicTest extends DynamicTestCase {
 
 	/**
 	 * Tests whether the items defined in the extension point can be added and
-	 * removed dynamically. It tests that the data doesn't exist, and then loads
-	 * the extension. It tests that the data then exists, and unloads the
-	 * extension. It tests that the data then doesn't exist.
+	 * removed dynamically. It tests that the data doesn't exist, and then loads the
+	 * extension. It tests that the data then exists, and unloads the extension. It
+	 * tests that the data then doesn't exist.
 	 *
-	 * @throws ParseException
-	 *             If "M1+W" can't be parsed by the extension point.
+	 * @throws ParseException      If "M1+W" can't be parsed by the extension point.
+	 * @throws NotDefinedException
 	 */
 	@Test
-	public void testBindings() throws ParseException {
+	public void testBindings() throws ParseException, NotDefinedException {
 		final IBindingService bindingService = getWorkbench().getAdapter(IBindingService.class);
 		final TriggerSequence triggerSequence = KeySequence.getInstance("M1+W");
 		Binding[] bindings;
-		Scheme scheme;
 		boolean found;
 
 		found = false;
@@ -113,13 +114,8 @@ public final class BindingsExtensionDynamicTest extends DynamicTestCase {
 			}
 		}
 		assertTrue(!found);
-		scheme = bindingService.getScheme("monkey");
-		try {
-			scheme.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
+		Scheme scheme1 = bindingService.getScheme("monkey");
+		assertThrows(NotDefinedException.class, () -> scheme1.getName());
 
 		getBundle();
 
@@ -145,12 +141,8 @@ public final class BindingsExtensionDynamicTest extends DynamicTestCase {
 			}
 		}
 		assertTrue(found);
-		scheme = bindingService.getScheme("monkey");
-		try {
-			assertTrue("Monkey".equals(scheme.getName()));
-		} catch (final NotDefinedException e) {
-			fail();
-		}
+		Scheme scheme2 = bindingService.getScheme("monkey");
+		assertTrue("Monkey".equals(scheme2.getName()));
 
 		removeBundle();
 
@@ -176,12 +168,7 @@ public final class BindingsExtensionDynamicTest extends DynamicTestCase {
 			}
 		}
 		assertTrue(!found);
-		scheme = bindingService.getScheme("monkey");
-		try {
-			scheme.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
+		Scheme scheme3 = bindingService.getScheme("monkey");
+		assertThrows(NotDefinedException.class, () -> scheme3.getName());
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/CommandsExtensionDynamicTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/CommandsExtensionDynamicTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.junit.Assert.assertThrows;
+
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
@@ -82,22 +84,23 @@ public final class CommandsExtensionDynamicTest extends DynamicTestCase {
 
 	/**
 	 * Tests whether the items defined in the extension point can be added and
-	 * removed dynamically. It tests that the data doesn't exist, and then loads
-	 * the extension. It tests that the data then exists, and unloads the
-	 * extension. It tests that the data then doesn't exist.
+	 * removed dynamically. It tests that the data doesn't exist, and then loads the
+	 * extension. It tests that the data then exists, and unloads the extension. It
+	 * tests that the data then doesn't exist.
 	 *
-	 * @throws ParseException
-	 *             If "M1+W" can't be parsed by the extension point.
+	 * @throws ParseException      If "M1+W" can't be parsed by the extension point.
+	 * @throws NotDefinedException
+	 * @throws NotHandledException
+	 * @throws ExecutionException
 	 */
 	@Test
-	public final void testCommands() throws ParseException {
+	public final void testCommands()
+			throws ParseException, NotDefinedException, ExecutionException, NotHandledException {
 		final IBindingService bindingService = getWorkbench().getAdapter(IBindingService.class);
 		final ICommandService commandService = getWorkbench().getAdapter(ICommandService.class);
 		final IContextService contextService = getWorkbench().getAdapter(IContextService.class);
 		final TriggerSequence triggerSequence = KeySequence.getInstance("M1+W");
-		NamedHandleObject namedHandleObject;
 		Binding[] bindings;
-		Command command;
 		boolean found;
 
 		assertTrue(!"monkey".equals(bindingService.getActiveScheme().getId()));
@@ -119,49 +122,20 @@ public final class CommandsExtensionDynamicTest extends DynamicTestCase {
 			}
 		}
 		assertTrue(!found);
-		namedHandleObject = bindingService.getScheme("monkey");
-		try {
-			namedHandleObject.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
-		namedHandleObject = commandService.getCategory("monkey");
-		try {
-			namedHandleObject.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
-		command = commandService.getCommand("monkey");
-		try {
-			command.execute(new ExecutionEvent());
-			fail();
-		} catch (final ExecutionException e) {
-			fail();
-		} catch (final NotHandledException e) {
-			assertTrue(true);
-		}
-		try {
-			command.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
-		namedHandleObject = contextService.getContext("context");
-		try {
-			namedHandleObject.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
-		namedHandleObject = contextService.getContext("scope");
-		try {
-			namedHandleObject.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
+		NamedHandleObject bindingMonkey1 = bindingService.getScheme("monkey");
+		assertThrows(NotDefinedException.class, () -> bindingMonkey1.getName());
+
+		NamedHandleObject categoryMonkey1 = commandService.getCategory("monkey");
+		assertThrows(NotDefinedException.class, () -> categoryMonkey1.getName());
+
+		Command command1 = commandService.getCommand("monkey");
+		assertThrows(NotHandledException.class, () -> command1.execute(new ExecutionEvent()));
+		assertThrows(NotDefinedException.class, () -> command1.getName());
+
+		NamedHandleObject contextContext1 = contextService.getContext("context");
+		assertThrows(NotDefinedException.class, () -> contextContext1.getName());
+		NamedHandleObject contextScope1 = contextService.getContext("scope");
+		assertThrows(NotDefinedException.class, () -> contextScope1.getName());
 
 		getBundle();
 
@@ -184,41 +158,17 @@ public final class CommandsExtensionDynamicTest extends DynamicTestCase {
 			}
 		}
 		assertTrue(found);
-		namedHandleObject = bindingService.getScheme("monkey");
-		try {
-			assertTrue("Monkey".equals(namedHandleObject.getName()));
-		} catch (final NotDefinedException e) {
-			fail();
-		}
-		command = commandService.getCommand("monkey");
-		try {
-			command.execute(new ExecutionEvent());
-		} catch (final ExecutionException | NotHandledException e) {
-			fail();
-		}
-		try {
-			assertEquals("Monkey", command.getName());
-		} catch (final NotDefinedException e) {
-			fail();
-		}
-		namedHandleObject = commandService.getCommand("monkey");
-		try {
-			assertTrue("Monkey".equals(namedHandleObject.getName()));
-		} catch (final NotDefinedException e) {
-			fail();
-		}
-		namedHandleObject = contextService.getContext("context");
-		try {
-			assertTrue("Monkey".equals(namedHandleObject.getName()));
-		} catch (final NotDefinedException e) {
-			fail();
-		}
-		namedHandleObject = contextService.getContext("scope");
-		try {
-			assertTrue("Monkey".equals(namedHandleObject.getName()));
-		} catch (final NotDefinedException e) {
-			fail();
-		}
+		NamedHandleObject bindingMonkey2 = bindingService.getScheme("monkey");
+		assertTrue("Monkey".equals(bindingMonkey2.getName()));
+		Command command2 = commandService.getCommand("monkey");
+		command2.execute(new ExecutionEvent());
+		assertEquals("Monkey", command2.getName());
+		NamedHandleObject commandMonkey2 = commandService.getCommand("monkey");
+		assertTrue("Monkey".equals(commandMonkey2.getName()));
+		NamedHandleObject contextContext2 = contextService.getContext("context");
+		assertTrue("Monkey".equals(contextContext2.getName()));
+		NamedHandleObject contextScope2 = contextService.getContext("scope");
+		assertTrue("Monkey".equals(contextScope2.getName()));
 
 		removeBundle();
 
@@ -241,49 +191,17 @@ public final class CommandsExtensionDynamicTest extends DynamicTestCase {
 			}
 		}
 		assertTrue(!found);
-		namedHandleObject = bindingService.getScheme("monkey");
-		try {
-			namedHandleObject.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
-		namedHandleObject = commandService.getCategory("monkey");
-		try {
-			namedHandleObject.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
-		command = commandService.getCommand("monkey");
-		try {
-			command.execute(new ExecutionEvent());
-			fail();
-		} catch (final ExecutionException e) {
-			fail();
-		} catch (final NotHandledException e) {
-			assertTrue(true);
-		}
-		try {
-			command.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
-		namedHandleObject = contextService.getContext("context");
-		try {
-			namedHandleObject.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
-		namedHandleObject = contextService.getContext("scope");
-		try {
-			namedHandleObject.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
+		NamedHandleObject bindingMonkey3 = bindingService.getScheme("monkey");
+		assertThrows(NotDefinedException.class, () -> bindingMonkey3.getName());
+		NamedHandleObject commandMonkey3 = commandService.getCommand("monkey");
+		assertThrows(NotDefinedException.class, () -> commandMonkey3.getName());
+		Command command3 = commandService.getCommand("monkey");
+		assertThrows(NotHandledException.class, () -> command3.execute(new ExecutionEvent()));
+		assertThrows(NotDefinedException.class, () -> command3.getName());
+		NamedHandleObject contextContext3 = contextService.getContext("context");
+		assertThrows(NotDefinedException.class, () -> contextContext3.getName());
+		NamedHandleObject contextScope3 = contextService.getContext("scope");
+		assertThrows(NotDefinedException.class, () -> contextScope3.getName());
 	}
 
 	@Test
@@ -295,28 +213,14 @@ public final class CommandsExtensionDynamicTest extends DynamicTestCase {
 		// till the handler is loaded, we assume it could be handled
 		// when its time to execute, we load the handler and throw the
 		// ExecutionException
-		try {
-			handlerService.executeCommand(
-					"org.eclipse.ui.tests.command.handlerLoadException", null);
-			fail("An exception should be thrown for this handler");
-		} catch (Exception e) {
-			if (!(e instanceof ExecutionException)) {
-				fail("Unexpected exception while executing command", e);
-			}
-		}
+		assertThrows(ExecutionException.class,
+				() -> handlerService.executeCommand("org.eclipse.ui.tests.command.handlerLoadException", null));
 
 		// afterwards, we know that the handler couldn't be loaded, so it can't
 		// be handled
 		// from now we always throw NotHandledException
-		try {
-			handlerService.executeCommand(
-					"org.eclipse.ui.tests.command.handlerLoadException", null);
-			fail("An exception should be thrown for this handler");
-		} catch (Exception e) {
-			if (!(e instanceof NotHandledException)) {
-				fail("Unexpected exception while executing command", e);
-			}
-		}
+		assertThrows(NotHandledException.class,
+				() -> handlerService.executeCommand("org.eclipse.ui.tests.command.handlerLoadException", null));
 
 		removeBundle();
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ContextsExtensionDynamicTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ContextsExtensionDynamicTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.junit.Assert.assertThrows;
+
 import org.eclipse.core.commands.common.NamedHandleObject;
 import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.ui.contexts.IContextService;
@@ -70,40 +72,27 @@ public final class ContextsExtensionDynamicTest extends DynamicTestCase {
 
 	/**
 	 * Tests whether the items defined in the extension point can be added and
-	 * removed dynamically. It tests that the data doesn't exist, and then loads
-	 * the extension. It tests that the data then exists, and unloads the
-	 * extension. It tests that the data then doesn't exist.
+	 * removed dynamically. It tests that the data doesn't exist, and then loads the
+	 * extension. It tests that the data then exists, and unloads the extension. It
+	 * tests that the data then doesn't exist.
+	 *
+	 * @throws NotDefinedException
 	 */
 	@Test
-	public final void testContexts() {
+	public final void testContexts() throws NotDefinedException {
 		final IContextService service = getWorkbench().getAdapter(IContextService.class);
-		NamedHandleObject namedHandleObject;
 
-		namedHandleObject = service.getContext("monkey");
-		try {
-			namedHandleObject.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
+		NamedHandleObject namedHandleObject1 = service.getContext("monkey");
+		assertThrows(NotDefinedException.class, () -> namedHandleObject1.getName());
 
 		getBundle();
 
-		namedHandleObject = service.getContext("monkey");
-		try {
-			assertTrue("Monkey".equals(namedHandleObject.getName()));
-		} catch (final NotDefinedException e) {
-			fail();
-		}
+		NamedHandleObject namedHandleObject2 = service.getContext("monkey");
+		assertTrue("Monkey".equals(namedHandleObject2.getName()));
 
 		removeBundle();
 
-		namedHandleObject = service.getContext("monkey");
-		try {
-			namedHandleObject.getName();
-			fail();
-		} catch (final NotDefinedException e) {
-			assertTrue(true);
-		}
+		NamedHandleObject namedHandleObject3 = service.getContext("monkey");
+		assertThrows(NotDefinedException.class, () -> namedHandleObject3.getName());
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/EditorTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/EditorTests.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.junit.Assert.assertThrows;
+
 import java.io.ByteArrayInputStream;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
@@ -104,12 +106,7 @@ public class EditorTests extends DynamicTestCase {
 
 		removeBundle();
 		assertNull(registry.findEditor(EDITOR_ID));
-		try {
-			testEditorProperties(desc);
-			fail();
-		}
-		catch (RuntimeException e) {
-		}
+		assertThrows(RuntimeException.class, () -> testEditorProperties(desc));
 	}
 
 	private void testEditorProperties(IEditorDescriptor desc) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/HandlersExtensionDynamicTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/HandlersExtensionDynamicTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.junit.Assert.assertThrows;
+
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
@@ -72,44 +74,28 @@ public final class HandlersExtensionDynamicTest extends DynamicTestCase {
 
 	/**
 	 * Tests whether the items defined in the extension point can be added and
-	 * removed dynamically. It tests that the data doesn't exist, and then loads
-	 * the extension. It tests that the data then exists, and unloads the
-	 * extension. It tests that the data then doesn't exist.
+	 * removed dynamically. It tests that the data doesn't exist, and then loads the
+	 * extension. It tests that the data then exists, and unloads the extension. It
+	 * tests that the data then doesn't exist.
+	 *
+	 * @throws NotHandledException
+	 * @throws ExecutionException
 	 */
 	@Test
-	public final void testHandlers() {
+	public final void testHandlers() throws ExecutionException, NotHandledException {
 		final ICommandService commandService = getWorkbench().getAdapter(ICommandService.class);
-		Command command;
 
-		command = commandService.getCommand("monkey");
-		try {
-			command.execute(new ExecutionEvent());
-			fail();
-		} catch (final ExecutionException e) {
-			fail();
-		} catch (final NotHandledException e) {
-			assertTrue(true);
-		}
+		Command command1 = commandService.getCommand("monkey");
+		assertThrows(NotHandledException.class, () -> command1.execute(new ExecutionEvent()));
 
 		getBundle();
 
-		command = commandService.getCommand("monkey");
-		try {
-			command.execute(new ExecutionEvent());
-		} catch (final ExecutionException | NotHandledException e) {
-			fail();
-		}
+		Command command2 = commandService.getCommand("monkey");
+		command2.execute(new ExecutionEvent());
 
 		removeBundle();
 
-		command = commandService.getCommand("monkey");
-		try {
-			command.execute(new ExecutionEvent());
-			fail();
-		} catch (final ExecutionException e) {
-			fail();
-		} catch (final NotHandledException e) {
-			assertTrue(true);
-		}
+		Command command3 = commandService.getCommand("monkey");
+		assertThrows(NotHandledException.class, () -> command3.execute(new ExecutionEvent()));
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/IntroTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/IntroTests.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.junit.Assert.assertThrows;
+
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 
@@ -40,7 +42,7 @@ public class IntroTests extends DynamicTestCase {
 	private static final String INTRO_ID = "org.eclipse.newIntro1.newIntro1";
 	private IntroDescriptor oldDesc;
 	private IWorkbenchWindow window;
-	
+
 
 	public IntroTests() {
 		super(IntroTests.class.getSimpleName());
@@ -87,15 +89,7 @@ public class IntroTests extends DynamicTestCase {
 		removeBundle();
 		assertNull(registry.getIntro(INTRO_ID));
 		assertNull(registry.getIntroForProduct(PRODUCT_ID));
-		try {
-			testIntroProperties(desc);
-			fail();
-		}
-		catch (CoreException e) {
-			fail(e.getMessage());
-		}
-		catch (RuntimeException e) {
-		}
+		assertThrows(RuntimeException.class, () -> testIntroProperties(desc));
 	}
 
 	private void testIntroProperties(IIntroDescriptor desc) throws CoreException {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/NewWizardTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/NewWizardTests.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.junit.Assert.assertThrows;
+
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
 import org.eclipse.ui.wizards.IWizardDescriptor;
@@ -43,13 +45,7 @@ public class NewWizardTests extends DynamicTestCase {
 		testNewWizardProperties(wizard);
 		removeBundle();
 		assertNull(registry.findWizard(WIZARD_ID));
-		try {
-			testNewWizardProperties(wizard);
-			fail();
-		}
-		catch (RuntimeException e) {
-			//no-op
-		}
+		assertThrows(RuntimeException.class, () -> testNewWizardProperties(wizard));
 	}
 
 	private void testNewWizardProperties(IWizardDescriptor wizard) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ViewTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ViewTests.java
@@ -13,8 +13,11 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.junit.Assert.assertThrows;
+
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.ui.IPageLayout;
@@ -82,13 +85,7 @@ public class ViewTests extends DynamicTestCase {
 		testViewProperties(desc);
 		removeBundle();
 		assertNull(registry.find(VIEW_ID2));
-		try {
-			testViewProperties(desc);
-			fail();
-		}
-		catch (RuntimeException e) {
-			// no-op
-		}
+		assertThrows(RuntimeException.class, () -> testViewProperties(desc));
 	}
 
 	@Test
@@ -103,13 +100,7 @@ public class ViewTests extends DynamicTestCase {
 		testViewProperties(desc);
 		removeBundle();
 		assertNull(registry.find(VIEW_ID1));
-		try {
-			testViewProperties(desc);
-			fail();
-		}
-		catch (RuntimeException e) {
-			// no-op
-		}
+		assertThrows(RuntimeException.class, () -> testViewProperties(desc));
 	}
 
 	@Test
@@ -123,15 +114,15 @@ public class ViewTests extends DynamicTestCase {
 		getBundle();
 
 		descs = registry.getStickyViews();
-		IStickyViewDescriptor desc = null;
+		AtomicReference<IStickyViewDescriptor> desc = new AtomicReference<>();
 		for (IStickyViewDescriptor desc2 : descs) {
 			if (VIEW_ID1.equals(desc2.getId())) {
-				desc = desc2;
+				desc.set(desc2);
 				break;
 			}
 		}
-		assertNotNull(desc);
-		testStickyViewProperties(desc);
+		assertNotNull(desc.get());
+		testStickyViewProperties(desc.get());
 		removeBundle();
 
 		descs = registry.getStickyViews();
@@ -139,13 +130,7 @@ public class ViewTests extends DynamicTestCase {
 			assertFalse(VIEW_ID1.equals(desc2.getId()));
 		}
 
-		try {
-			testStickyViewProperties(desc);
-			fail();
-		}
-		catch (RuntimeException e) {
-			// no-op
-		}
+		assertThrows(RuntimeException.class, () -> testStickyViewProperties(desc.get()));
 	}
 
 	private void testStickyViewProperties(IStickyViewDescriptor desc) {
@@ -175,14 +160,7 @@ public class ViewTests extends DynamicTestCase {
 		removeBundle();
 		assertNull(registry.find(VIEW_ID1));
 		assertNull(registry.findCategory(CATEGORY_ID));
-		try {
-			testCategoryProperties(category);
-			fail();
-		}
-		catch (RuntimeException e) {
-			// no-op
-		}
-
+		assertThrows(RuntimeException.class, () -> testCategoryProperties(category));
 	}
 
 	private void testCategoryProperties(IViewCategory desc) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/StatusDialogManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/StatusDialogManagerTest.java
@@ -20,8 +20,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
@@ -534,58 +534,49 @@ public class StatusDialogManagerTest {
 
 	@Test
 	public void testNullLabelProvider(){
-		try {
-			wsdm.setStatusListLabelProvider(null);
-			fail();
-		} catch (IllegalArgumentException iae){
-			assertTrue(true);
-		}
+		assertThrows(IllegalArgumentException.class, () -> wsdm.setStatusListLabelProvider(null));
 	}
 
 	//bug 235254
 	@Test
-	public void testNonNullLabelProvider(){
-		try {
-			final boolean [] called = new boolean[]{false};
-			wsdm.setStatusListLabelProvider(new ITableLabelProvider(){
+	public void testNonNullLabelProvider() {
+		final boolean[] called = new boolean[] { false };
+		wsdm.setStatusListLabelProvider(new ITableLabelProvider() {
 
-				@Override
-				public Image getColumnImage(Object element, int columnIndex) {
-					return null;
-				}
+			@Override
+			public Image getColumnImage(Object element, int columnIndex) {
+				return null;
+			}
 
-				@Override
-				public String getColumnText(Object element, int columnIndex) {
-					called[0] = true;
-					return "";
-				}
+			@Override
+			public String getColumnText(Object element, int columnIndex) {
+				called[0] = true;
+				return "";
+			}
 
-				@Override
-				public void addListener(ILabelProviderListener listener) {
+			@Override
+			public void addListener(ILabelProviderListener listener) {
 
-				}
+			}
 
-				@Override
-				public void dispose() {
+			@Override
+			public void dispose() {
 
-				}
+			}
 
-				@Override
-				public boolean isLabelProperty(Object element, String property) {
-					return false;
-				}
+			@Override
+			public boolean isLabelProperty(Object element, String property) {
+				return false;
+			}
 
-				@Override
-				public void removeListener(ILabelProviderListener listener) {
+			@Override
+			public void removeListener(ILabelProviderListener listener) {
 
-				}
+			}
 
-			});
-			wsdm.addStatusAdapter(createStatusAdapter(MESSAGE_1), true);
-			assertTrue(called[0]);
-		} catch (Exception e){
-			fail();
-		}
+		});
+		wsdm.addStatusAdapter(createStatusAdapter(MESSAGE_1), true);
+		assertTrue(called[0]);
 	}
 
 	/**
@@ -697,12 +688,7 @@ public class StatusDialogManagerTest {
 		WorkbenchStatusDialogManager wsdm = new WorkbenchStatusDialogManager(
 				IStatus.CANCEL, null);
 		StatusAdapter sa = createStatusAdapter(MESSAGE_1);
-		try {
-			wsdm.addStatusAdapter(sa, false);
-			assertTrue(true);
-		} catch (NullPointerException npe){
-			fail();
-		}
+		wsdm.addStatusAdapter(sa, false);
 	}
 
 	@Test
@@ -721,11 +707,7 @@ public class StatusDialogManagerTest {
 
 			}
 		});
-		try{
-			wsdm.addStatusAdapter(bomb, false);
-		} catch (Throwable t) {
-			fail("no exception should be thrown");
-		}
+		wsdm.addStatusAdapter(bomb, false);
 		assertTrue("Dialog should not display on failure",
 				StatusDialogUtil.getStatusShell() == null);
 		wsdm.addStatusAdapter(createStatusAdapter("normal one"), false);
@@ -736,12 +718,7 @@ public class StatusDialogManagerTest {
 	// checking if the statuses are correctly ignored.
 	@Test
 	public void testOKStatus1() {
-		try {
-			wsdm.addStatusAdapter(new StatusAdapter(Status.OK_STATUS), false);
-			assertTrue(true);
-		} catch (NullPointerException npe) {
-			fail();
-		}
+		wsdm.addStatusAdapter(new StatusAdapter(Status.OK_STATUS), false);
 		assertNull("Shell should not be created.", StatusDialogUtil
 				.getStatusShell());
 		wsdm.addStatusAdapter(createStatusAdapter(MESSAGE_1), false);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/systeminplaceeditor/OpenSystemInPlaceEditorTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/systeminplaceeditor/OpenSystemInPlaceEditorTest.java
@@ -15,7 +15,6 @@ package org.eclipse.ui.tests.systeminplaceeditor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -92,24 +91,19 @@ public class OpenSystemInPlaceEditorTest {
 		file.delete();
 	}
 
-	private IWorkbenchPage getWorkbenchPage() {
+	private IWorkbenchPage getWorkbenchPage() throws WorkbenchException {
 		IWorkbenchWindow window;
-		try {
-			if (PlatformUI.getWorkbench().getWorkbenchWindowCount() == 0) {
-				window = PlatformUI.getWorkbench().openWorkbenchWindow(null);
-			} else {
-				window = PlatformUI.getWorkbench().getWorkbenchWindows()[0];
-			}
-
-			IWorkbenchPage[] pages = window.getPages();
-			if (pages.length > 0) {
-				return pages[0];
-			}
-
-			return window.openPage(null);
-		} catch (WorkbenchException ex) {
-			fail();
-			return null;
+		if (PlatformUI.getWorkbench().getWorkbenchWindowCount() == 0) {
+			window = PlatformUI.getWorkbench().openWorkbenchWindow(null);
+		} else {
+			window = PlatformUI.getWorkbench().getWorkbenchWindows()[0];
 		}
+
+		IWorkbenchPage[] pages = window.getPages();
+		if (pages.length > 0) {
+			return pages[0];
+		}
+
+		return window.openPage(null);
 	}
 }


### PR DESCRIPTION
This replaces JUnit fail() calls in org.eclipse.ui.tests by various means:
- Replace exception catching and fail() statements with assertThrows()
- Remove exception catching and fail() statements by letting the test methods simply throw the exception