### PR TITLE
Avoid drawing line break characters when rendering code minings

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationDrawingStrategy.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/InlinedAnnotationDrawingStrategy.java
@@ -478,7 +478,11 @@ class InlinedAnnotationDrawingStrategy implements IDrawingStrategy {
 						gc.setForeground(textWidget.getSelectionForeground());
 						gc.setBackground(textWidget.getSelectionBackground());
 					}
-					gc.drawString(hostCharacter, redrawnHostCharX, redrawnHostCharY, true);
+					String characterToBeDrawn= hostCharacter;
+					if ("\n".equals(characterToBeDrawn)) { //$NON-NLS-1$
+						characterToBeDrawn= ""; //$NON-NLS-1$
+					}
+					gc.drawString(characterToBeDrawn, redrawnHostCharX, redrawnHostCharY, true);
 				}
 				// END TO REMOVE
 			} else if (style != null && style.metrics != null && style.metrics.width != 0) {
@@ -569,7 +573,11 @@ class InlinedAnnotationDrawingStrategy implements IDrawingStrategy {
 					gc.setForeground(textWidget.getSelectionForeground());
 					gc.setBackground(textWidget.getSelectionBackground());
 				}
-				gc.drawString(Character.toString(hostCharacter), charBounds.x, charBounds.y + verticalDrawingOffset, true);
+				String characterToBeDrawn= Character.toString(hostCharacter);
+				if ("\n".equals(characterToBeDrawn)) { //$NON-NLS-1$
+					characterToBeDrawn= ""; //$NON-NLS-1$
+				}
+				gc.drawString(characterToBeDrawn, charBounds.x, charBounds.y + verticalDrawingOffset, true);
 				// END TO REMOVE
 			} else if (style != null && style.metrics != null && style.metrics.width != 0) {
 				// line content annotation had an , reset it


### PR DESCRIPTION
Fix rendering issue on linux where the line break character is drawn as part of the code mining.

<img width="785" height="429" alt="image" src="https://github.com/user-attachments/assets/54ef147a-2338-4f59-877b-ec14acc62f10" />
