### PR TITLE
Replace try-catch with assertThrows in org.eclipse.ui.tests

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/Bug42616Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/Bug42616Test.java
@@ -14,7 +14,7 @@
 package org.eclipse.ui.tests.api;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.ui.internal.WorkbenchPlugin;
@@ -31,14 +31,8 @@ public class Bug42616Test {
 
 	@Test
 	public void testErrorCondition() {
-		try {
-			WorkbenchPlugin.createExtension(null, null);
-			fail("createExtension with nulls succeeded");
-		} catch (CoreException e) {
-			// ensure that exception has a root cause.
-			assertNotNull("Cause is null", e.getStatus().getException());
-		} catch (Throwable t) {
-			fail("Throwable not wrapped in core exception.");
-		}
+		CoreException e = assertThrows(CoreException.class, () -> WorkbenchPlugin.createExtension(null, null));
+		// ensure that exception has a root cause.
+		assertNotNull("Cause is null", e.getStatus().getException());
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetManagerTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.ui.tests.api;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 
@@ -301,11 +302,8 @@ public class IWorkingSetManagerTest extends UITestCase {
 		fWorkingSetManager.addWorkingSet(fWorkingSet);
 		assertArrayEquals(new IWorkingSet[] { fWorkingSet }, fWorkingSetManager.getWorkingSets());
 
-		try {
-			fWorkingSetManager.addWorkingSet(fWorkingSet);
-			fail("Added the same set twice");
-		} catch (RuntimeException exception) {
-		}
+		assertThrows("added same set twice", RuntimeException.class,
+				() -> fWorkingSetManager.addWorkingSet(fWorkingSet));
 		assertArrayEquals(new IWorkingSet[] { fWorkingSet }, fWorkingSetManager.getWorkingSets());
 
 		IWorkingSet workingSet2 = fWorkingSetManager.createWorkingSet(

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/XMLMementoTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/XMLMementoTest.java
@@ -15,7 +15,7 @@ package org.eclipse.ui.tests.api;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -51,20 +51,10 @@ public class XMLMementoTest {
 	 */
 	@Test
 	public void testCreateReadRootReaderExceptionCases() {
-		try {
-			XMLMemento.createReadRoot(new StringReader("Invalid format"));
-			fail("should throw WorkbenchException because of invalid format");
-		} catch (WorkbenchException e) {
-			// expected
-		}
-		try {
-			XMLMemento.createReadRoot(new StringReader(
-					"<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>"));
-			fail("should throw WorkbenchException because there is no element");
-		} catch (WorkbenchException e) {
-			// expected
-		}
-		try {
+		assertThrows(WorkbenchException.class, () -> XMLMemento.createReadRoot(new StringReader("Invalid format")));
+		assertThrows("no exception even though there is noe element", WorkbenchException.class,
+				() -> XMLMemento.createReadRoot(new StringReader("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>")));
+		assertThrows(WorkbenchException.class, () ->
 			XMLMemento.createReadRoot(new Reader() {
 
 				@Override
@@ -77,11 +67,7 @@ public class XMLMementoTest {
 						throws IOException {
 					throw new IOException();
 				}
-			});
-			fail("should throw WorkbenchException because of IOException");
-		} catch (WorkbenchException e) {
-			// expected
-		}
+		}));
 	}
 
 	@Test
@@ -113,29 +99,14 @@ public class XMLMementoTest {
 
 	@Test
 	public void testSpacesInRootAreIllegal() {
-		try {
-			XMLMemento.createWriteRoot("with space");
-			fail("should fail");
-		} catch (Exception e) {
-			// expected
-		}
+		assertThrows(Exception.class, () -> XMLMemento.createWriteRoot("with space"));
 	}
 
 	@Test
 	public void testSpacesInKeysAreIllegal() {
 		XMLMemento memento = XMLMemento.createWriteRoot("foo");
-		try {
-			memento.createChild("with space", "bar");
-			fail("should fail");
-		} catch (Exception e) {
-			// expected
-		}
-		try {
-			memento.putString("with space", "bar");
-			fail("should fail");
-		} catch (Exception e) {
-			// expected
-		}
+		assertThrows(Exception.class, () -> memento.createChild("with space", "bar"));
+		assertThrows(Exception.class, () -> memento.putString("with space", "bar"));
 	}
 
 	@Test
@@ -508,12 +479,7 @@ public class XMLMementoTest {
 
 		for (final String key : illegalKeys) {
 			XMLMemento memento = XMLMemento.createWriteRoot("foo");
-			try {
-				memento.putString(key, "some string");
-				fail("putString with illegal key should fail");
-			} catch (Exception ex) {
-				// expected
-			}
+			assertThrows("should fail with illegal key", Exception.class, () -> memento.putString(key, "some string"));
 		}
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/ActionDelegateProxyTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/ActionDelegateProxyTest.java
@@ -18,8 +18,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -104,12 +104,7 @@ public class ActionDelegateProxyTest {
 		IHandlerService service = window.getService(IHandlerService.class);
 		assertFalse(EditorActionDelegate.executed);
 		EditorActionDelegate.part = null;
-		try {
-			service.executeCommand(STAY_COMMAND, null);
-			fail("the command is not yet handled");
-		} catch (NotHandledException e) {
-			// good
-		}
+		assertThrows(NotHandledException.class, () -> service.executeCommand(STAY_COMMAND, null));
 		assertFalse(EditorActionDelegate.executed);
 		assertNull(EditorActionDelegate.part);
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandCallbackTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandCallbackTest.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.ui.tests.commands;
 
+import static org.junit.Assert.assertThrows;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -156,16 +158,8 @@ public class CommandCallbackTest extends UITestCase {
 	public void testNoParametersNoCallbacks() throws Exception {
 		ParameterizedCommand pc1 = new ParameterizedCommand(cmd1, null);
 		ParameterizedCommand pc2 = new ParameterizedCommand(cmd1, null);
-		try {
-			commandService.registerElementForCommand(pc1, null);
-			fail("Callback should not register");
-		} catch (NotDefinedException e) {
-		}
-		try {
-			commandService.registerElementForCommand(pc2, null);
-			fail("Callback 2 should not register");
-		} catch (NotDefinedException e) {
-		}
+		assertThrows(NotDefinedException.class, () -> commandService.registerElementForCommand(pc1, null));
+		assertThrows(NotDefinedException.class, () -> commandService.registerElementForCommand(pc2, null));
 
 		commandService.refreshElements(CMD1_ID + ".1", null);
 		assertEquals(0, cmd1Handler.callbacks);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandParameterTypeTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandParameterTypeTest.java
@@ -17,8 +17,10 @@ package org.eclipse.ui.tests.commands;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.IParameter;
@@ -61,17 +63,8 @@ public class CommandParameterTypeTest {
 	 */
 	@Test
 	public void testSubtractTypeError() {
-		try {
-			// try to pass a Boolean instead of an Integer
-			testSubtract(Integer.valueOf(3), Boolean.FALSE, 3);
-			fail("expected ParameterValueConversionException");
-		}
-		catch (ParameterValueConversionException ex) {
-			// passed
-		}
-		catch (Exception ex) {
-			fail("expected ParameterValueConversionException");
-		}
+		// try to pass a Boolean instead of an Integer
+		assertThrows(ParameterValueConversionException.class, () -> testSubtract(Integer.valueOf(3), Boolean.FALSE, 3));
 	}
 
 	/**
@@ -127,22 +120,14 @@ public class CommandParameterTypeTest {
 		ICommandService commandService = getCommandService();
 		ParameterType type = commandService.getParameterType(TYPE);
 
-		Object converted = null;
+		AtomicReference<Object> converted = new AtomicReference<>();
 		if (expectFail) {
-			try {
-				converted = type.getValueConverter().convertToObject(value);
-				fail("expected ParameterValueConversionException");
-			} catch (ParameterValueConversionException ex) {
-				// passed
-				return;
-			} catch (Exception ex) {
-				fail("expected ParameterValueConversionException");
-			}
+			assertThrows(ParameterValueConversionException.class,
+					() -> converted.set(type.getValueConverter().convertToObject(value)));
 		} else {
-			converted = type.getValueConverter().convertToObject(value);
+			converted.set(type.getValueConverter().convertToObject(value));
+			assertEquals(Integer.valueOf(expected), converted.get());
 		}
-
-		assertEquals(Integer.valueOf(expected), converted);
 	}
 
 	/**
@@ -163,21 +148,14 @@ public class CommandParameterTypeTest {
 		ICommandService commandService = getCommandService();
 		ParameterType type = commandService.getParameterType(TYPE);
 
-		String converted = null;
+		AtomicReference<Object> converted = new AtomicReference<>();
 		if (expectFail) {
-			try {
-				converted = type.getValueConverter().convertToString(value);
-				fail("expected ParameterValueConversionException");
-			} catch (ParameterValueConversionException ex) {
-				// passed
-				return;
-			} catch (Exception ex) {
-				fail("expected ParameterValueConversionException");
-			}
+			assertThrows(ParameterValueConversionException.class,
+					() -> converted.set(type.getValueConverter().convertToString(value)));
 		} else {
-			converted = type.getValueConverter().convertToString(value);
+			converted.set(type.getValueConverter().convertToString(value));
+			assertEquals(expected, converted.get());
 		}
-		assertEquals(expected, converted);
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandSerializationTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandSerializationTest.java
@@ -15,8 +15,8 @@ package org.eclipse.ui.tests.commands;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Map;
 
@@ -293,27 +293,13 @@ public class CommandSerializationTest {
 	private void expectSerializationException(String serializedParameterizedCommand) {
 		ICommandService commandService = getCommandService();
 
-		try {
-			commandService.deserialize(serializedParameterizedCommand);
-			fail("expected SerializationException");
-		} catch (SerializationException ex) {
-			// passed
-		} catch (NotDefinedException ex) {
-			fail("expected SerializationException");
-		}
+		assertThrows(SerializationException.class, () -> commandService.deserialize(serializedParameterizedCommand));
 	}
 
 	private void expectNotDefinedException(String serializedParameterizedCommand) {
 		ICommandService commandService = getCommandService();
 
-		try {
-			commandService.deserialize(serializedParameterizedCommand);
-			fail("expected NotDefinedException");
-		} catch (SerializationException ex) {
-			fail("expected NotDefinedException");
-		} catch (NotDefinedException ex) {
-			// passed
-		}
+		assertThrows(NotDefinedException.class, () -> commandService.deserialize(serializedParameterizedCommand));
 	}
 
 	private ICommandService getCommandService() {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/HandlerActivationTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/HandlerActivationTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.commands;
 
+import static org.junit.Assert.assertThrows;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -240,15 +242,8 @@ public class HandlerActivationTest extends UITestCase {
 
 	@Test
 	public void testExceptionThrowingHandler(){
-
-		try {
-			handlerService.executeCommand("org.eclipse.ui.tests.command.handlerException", null);
-			fail("An exception should be thrown for this handler");
-		} catch (Exception e) {
-			if(!(e instanceof ExecutionException)) {
-				fail("Unexpected exception while executing command", e);
-			}
-		}
+		assertThrows(ExecutionException.class,
+				() -> handlerService.executeCommand("org.eclipse.ui.tests.command.handlerException", null));
 	}
 
 
@@ -419,24 +414,14 @@ public class HandlerActivationTest extends UITestCase {
 				CMD_ID, handler));
 		Command cmd = commandService.getCommand(CMD_ID);
 		ParameterizedCommand pcmd = new ParameterizedCommand(cmd, null);
-		try {
-			handlerService.executeCommand(pcmd, null);
-			fail("this should not be executable");
-		} catch (NotEnabledException e) {
-			// good
-		}
+		assertThrows(NotEnabledException.class, () -> handlerService.executeCommand(pcmd, null));
 		assertFalse(cmd.isEnabled());
 		window.getActivePage().showView(IPageLayout.ID_OUTLINE);
 		IEvaluationContext outlineContext = handlerService.createContextSnapshot(false);
 		handlerService.executeCommand(pcmd, null);
 		assertTrue(cmd.isEnabled());
 
-		try {
-			handlerService.executeCommandInContext(pcmd, null, oldContext);
-			fail("this should not be executable");
-		} catch (NotEnabledException e) {
-			// good
-		}
+		assertThrows(NotEnabledException.class, () -> handlerService.executeCommandInContext(pcmd, null, oldContext));
 
 		assertTrue(cmd.isEnabled());
 		handlerService.executeCommandInContext(pcmd, null, outlineContext);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/ModalContextCrashTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/ModalContextCrashTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.concurrency;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import java.lang.reflect.InvocationTargetException;
@@ -33,13 +34,8 @@ public class ModalContextCrashTest {
 	@Test
 	public void testCrash() throws Exception {
 		IRunnableWithProgress operation = new CrashingRunnable();
-		try{
-			PlatformUI.getWorkbench().getActiveWorkbenchWindow().run(true, false, operation);
-			fail("Should have an invocation target exception");
-		}
-		catch (InvocationTargetException e){
-			//We should get this
-		}
+		assertThrows(InvocationTargetException.class,
+				() -> PlatformUI.getWorkbench().getActiveWorkbenchWindow().run(true, false, operation));
 		if (Thread.interrupted()) {
 			fail("Thread was interrupted at end of test");
 		}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicSupportTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicSupportTests.java
@@ -16,7 +16,7 @@ package org.eclipse.ui.tests.dynamicplugins;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
@@ -93,13 +93,7 @@ public class DynamicSupportTests {
 		ReferenceQueue<Object> queue = new ReferenceQueue<>();
 		WeakReference<Object> ref = new WeakReference<>(o1, queue);
 		o1 = null;
-		try {
-			LeakTests.checkRef(queue, ref);
-			fail("Shouldn't have enqueued the ref");
-		}
-		catch (Throwable e) {
-			//wont be enqueued
-		}
+		assertThrows(Throwable.class, () -> LeakTests.checkRef(queue, ref));
 		Object [] results = tracker.getObjects(e1);
 		assertNotNull(results);
 		assertEquals(1, results.length);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/BindingManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/BindingManagerTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -132,12 +133,7 @@ public final class BindingManagerTest {
 		contextManager.setActiveContextIds(activeContextIds);
 
 		// Try to add a null binding.
-		try {
-			bindingManager.addBinding(null);
-			fail("It should not be possible to add a null binding");
-		} catch (final NullPointerException e) {
-			// Success.
-		}
+		assertThrows(NullPointerException.class, () -> bindingManager.addBinding(null));
 
 		// Try to add a binding that should become active.
 		final Binding binding = new TestBinding("conflict1", "na", "na", null,
@@ -699,12 +695,7 @@ public final class BindingManagerTest {
 		// SELECT UNDEFINED
 		final String schemeId = "schemeId";
 		final Scheme scheme = bindingManager.getScheme(schemeId);
-		try {
-			bindingManager.setActiveScheme(scheme);
-			fail("Cannot activate an undefined scheme");
-		} catch (final NotDefinedException e) {
-			// Success
-		}
+		assertThrows(NotDefinedException.class, () -> bindingManager.setActiveScheme(scheme));
 
 		// SELECT DEFINED
 		scheme.define("name", "description", null);
@@ -836,12 +827,7 @@ public final class BindingManagerTest {
 		contextManager.setActiveContextIds(activeContextIds);
 
 		// SET TO NULL
-		try {
-			bindingManager.setLocale(null);
-			fail("Cannot set the locale to null");
-		} catch (final NullPointerException e) {
-			// Success
-		}
+		assertThrows(NullPointerException.class, () -> bindingManager.setLocale(null));
 
 		// SET TO SOMETHING
 		final String commandId = "commandId";
@@ -880,12 +866,7 @@ public final class BindingManagerTest {
 		contextManager.setActiveContextIds(activeContextIds);
 
 		// SET TO NULL
-		try {
-			bindingManager.setPlatform(null);
-			fail("Cannot set the platform to null");
-		} catch (final NullPointerException e) {
-			// Success
-		}
+		assertThrows(NullPointerException.class, () -> bindingManager.setPlatform(null));
 
 		// SET TO SOMETHING
 		final String commandId = "commandId";

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/NewPropertySheetHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/NewPropertySheetHandlerTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.propertysheet;
 
+import static org.junit.Assert.assertThrows;
+
 import java.util.HashMap;
 
 import org.eclipse.core.commands.Command;
@@ -179,12 +181,7 @@ public class NewPropertySheetHandlerTest extends AbstractPropertySheetTest {
 	public final void testGetShowInContextWithNoActivePart() {
 		hideAndAssertNoParts();
 
-		try {
-			testNewPropertySheetHandler.getShowInContext(getExecutionEvent());
-		} catch (ExecutionException e) {
-			return;
-		}
-		fail("Expected ExecutionException due to no active part");
+		assertThrows(ExecutionException.class, () -> testNewPropertySheetHandler.getShowInContext(getExecutionEvent()));
 	}
 
 	/**
@@ -193,17 +190,11 @@ public class NewPropertySheetHandlerTest extends AbstractPropertySheetTest {
 	 * .
 	 */
 	@Test
-	public final void testFindPropertySheetWithoutActivePart()
-			throws PartInitException {
+	public final void testFindPropertySheetWithoutActivePart() {
 		hideAndAssertNoParts();
 
-		try {
-			testNewPropertySheetHandler.findPropertySheet(getExecutionEvent(),
-					new PropertyShowInContext(null, StructuredSelection.EMPTY));
-		} catch (ExecutionException e) {
-			return;
-		}
-		fail("Expected ExecutionException due to no active part");
+		assertThrows(ExecutionException.class, () -> testNewPropertySheetHandler.findPropertySheet(getExecutionEvent(),
+				new PropertyShowInContext(null, StructuredSelection.EMPTY)));
 	}
 
 	/**


### PR DESCRIPTION
Replaces several usages of try-catch statements to validate if an exception was thrown by assertThrows statements.