### PR TITLE
Remove fails for missing implementations in org.eclipse.ui.tests

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IDeprecatedWorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IDeprecatedWorkbenchPageTest.java
@@ -842,8 +842,7 @@ public class IDeprecatedWorkbenchPageTest extends UITestCase {
 		String id = MockActionDelegate.ACTION_SET_ID;
 
 //		int totalBefore = facade.getActionSetCount(fActivePage);
-		// FIXME: No implementation
-		fail("facade.getActionSetCount() had no implementation");
+		// FIXME: No implementation for facade.getActionSetCount()
 
 		fActivePage.showActionSet(id);
 
@@ -854,8 +853,7 @@ public class IDeprecatedWorkbenchPageTest extends UITestCase {
 		fActivePage.showActionSet(id);
 
 //		facade.assertActionSetId(fActivePage, id, false);
-		// FIXME: No implementation
-		fail("facade.assertActionSetId() had no implementation");
+		// FIXME: No implementation for facade.assertActionSetId()
 
 //		assertEquals(facade.getActionSetCount(fActivePage), totalBefore + 1);
 	}
@@ -864,9 +862,7 @@ public class IDeprecatedWorkbenchPageTest extends UITestCase {
 	@Ignore
 	public void XXXtestHideActionSet() {
 //		int totalBefore = facade.getActionSetCount(fActivePage);
-		// FIXME: No implementation
-
-		fail("facade.getActionSetCount() had no implementation");
+		// FIXME: No implementation for facade.getActionSetCount()
 
 		String id = MockWorkbenchWindowActionDelegate.SET_ID;
 		fActivePage.showActionSet(id);
@@ -876,7 +872,6 @@ public class IDeprecatedWorkbenchPageTest extends UITestCase {
 //		assertEquals(facade.getActionSetCount(fActivePage), totalBefore);
 
 //		facade.assertActionSetId(fActivePage, id, false);
-
-		fail("facade.assertActionSetId() had no implementation");
+		// FIXME: No implementation for facade.assertActionSetId()
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPageTest.java
@@ -2151,8 +2151,7 @@ public class IWorkbenchPageTest extends UITestCase {
 		}
 
 //		ArrayList partIds = facade.getPerspectivePartIds(fActivePage, null);
-		// FIXME: No implementation
-		fail("facade.getPerspectivePartIds() had no implementation");
+		// FIXME: No implementation for facade.getPerspectivePartIds()
 
 //		assertTrue(partIds.contains("*"));
 //		assertTrue(partIds.contains(MockViewPart.IDMULT));
@@ -2184,8 +2183,7 @@ public class IWorkbenchPageTest extends UITestCase {
 
 //		ArrayList partIds = facade.getPerspectivePartIds(fActivePage,"placeholderFolder");
 
-		// FIXME: No implementation
-		fail("facade.getPerspectivePartIds() had no implementation");
+		// FIXME: No implementation for facade.getPerspectivePartIds()
 
 //		assertTrue(partIds.contains("*"));
 //		assertTrue(partIds.contains(MockViewPart.IDMULT));
@@ -2214,8 +2212,7 @@ public class IWorkbenchPageTest extends UITestCase {
 
 //		ArrayList partIds = facade.getPerspectivePartIds(fActivePage,"folder");
 
-		// FIXME: No implementation
-		fail("facade.getPerspectivePartIds() had no implementation");
+		// FIXME: No implementation for facade.getPerspectivePartIds()
 
 //		assertTrue(partIds.contains("*"));
 //		assertTrue(partIds.contains(MockViewPart.IDMULT));

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/StickyViewTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/StickyViewTest.java
@@ -325,12 +325,10 @@ public class StickyViewTest extends UITestCase {
 
 
 //			assertTrue(facade.isViewPaneVisible(viewRef));
-			// FIXME: No implementation
-			fail("facade.isViewPaneVisible() had no implementation");
+			// FIXME: No implementation for facade.isViewPaneVisible()
 
 //			assertTrue(facade.isViewToolbarVisible(viewRef));
-			// FIXME: No implementation
-			fail("facade.isViewToolbarVisible() had no implementation");
+			// FIXME: No implementation for facade.isViewToolbarVisible()
 
 
 			// open the editor and zoom it.
@@ -341,24 +339,20 @@ public class StickyViewTest extends UITestCase {
 			IWorkbenchPartReference ref = page.getReference(editor);
 			page.toggleZoom(ref);
 //			assertFalse(facade.isViewPaneVisible(viewRef));
-			// FIXME: No implementation
-			fail("facade.isViewPaneVisible() had no implementation");
+			// FIXME: No implementation for facade.isViewPaneVisible()
 
 //			assertFalse(facade.isViewToolbarVisible(viewRef));
-			// FIXME: No implementation
-			fail("facade.isViewToolbarVisible() had no implementation");
+			// FIXME: No implementation facade.isViewToolbarVisible()
 
 
 			// switch to another perspective, and then switch back.
 			page.setPerspective(secondPerspective);
 
 //			assertFalse(facade.isViewPaneVisible(viewRef));
-			// FIXME: No implementation
-			fail("facade.isViewPaneVisible() had no implementation");
+			// FIXME: No implementation facade.isViewPaneVisible()
 
 //			assertFalse(facade.isViewToolbarVisible(viewRef));
-			// FIXME: No implementation
-			fail("facade.isViewToolbarVisible() had no implementation");
+			// FIXME: No implementation facade.isViewToolbarVisible()
 
 
 			page.setPerspective(perspective);
@@ -366,12 +360,10 @@ public class StickyViewTest extends UITestCase {
 
 			// both the view and the toolbar must be not visible
 //			assertFalse(facade.isViewPaneVisible(viewRef));
-			// FIXME: No implementation
-			fail("facade.isViewPaneVisible() had no implementation");
+			// FIXME: No implementation facade.isViewPaneVisible()
 
 //			assertFalse(facade.isViewToolbarVisible(viewRef));
-			// FIXME: No implementation
-			fail("facade.isViewToolbarVisible() had no implementation");
+			// FIXME: No implementation facade.isViewToolbarVisible()
 
 		} finally {
 			if (editor != null) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIDialogs.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIDialogs.java
@@ -16,8 +16,6 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dialogs;
 
-import static org.junit.Assert.fail;
-
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.e4.core.contexts.IEclipseContext;
@@ -97,7 +95,6 @@ public class UIDialogs {
 	@Test
 	@Ignore("CustomizePerspectiveDialog not implemented")
 	public void testEditActionSetsDialog() {
-		fail("CustomizePerspectiveDialog not implemented");
 //        Dialog dialog;
 //        Object persp = null;
 //        //Test perspective: use current perspective of test case
@@ -187,7 +184,6 @@ public class UIDialogs {
 	@Test
 	@Ignore("PerspectiveRegistry.getCustomPersp not implemented")
 	public void testLoadNotExistingPerspective() {
-		fail("PerspectiveRegistry.getCustomPersp not implemented");
 //    	final String fakePerspectivID = "fakeperspetive";
 //		PerspectiveRegistry reg = (PerspectiveRegistry) WorkbenchPlugin
 //				.getDefault().getPerspectiveRegistry();


### PR DESCRIPTION
Removes fail statements that only indicate missing method or test implementation where the test methods are disabled anyway.