### PR TITLE
Remove obsolete fail statements in org.eclipse.ui.tests

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/AdaptableDecoratorTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/AdaptableDecoratorTestCase.java
@@ -15,7 +15,6 @@
 package org.eclipse.ui.tests.adaptable;
 
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 
@@ -89,11 +88,7 @@ public class AdaptableDecoratorTestCase implements ILabelProviderListener {
 	@After
 	public void doTearDown() throws Exception {
 		if (testProject != null) {
-			try {
-				testProject.delete(true, null);
-			} catch (CoreException e) {
-				fail(e.toString());
-			}
+			testProject.delete(true, null);
 			testProject = null;
 			testFolder = null;
 			testFile = null;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IActionBarsTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IActionBarsTest.java
@@ -18,10 +18,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
+import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.NotEnabledException;
 import org.eclipse.core.commands.NotHandledException;
+import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.IStatusLineManager;
@@ -210,7 +211,8 @@ public class IActionBarsTest {
 			assertTrue(quit.hasRun);
 		}
 
-	private void runMatchingCommand(IWorkbenchWindow window, String actionId) {
+		private void runMatchingCommand(IWorkbenchWindow window, String actionId)
+				throws ExecutionException, NotDefinedException {
 		IHandlerService hs = window.getService(IHandlerService.class);
 		IActionCommandMappingService ms = window.getService(IActionCommandMappingService.class);
 		String commandId = ms.getCommandId(actionId);
@@ -220,8 +222,6 @@ public class IActionBarsTest {
 		} catch (NotHandledException | NotEnabledException e) {
 			// this is not a failure, just a condition to be checked by
 			// the test
-		} catch (Exception e) {
-			fail("Failed to run " + commandId);
 		}
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPageTest.java
@@ -1283,11 +1283,7 @@ public class IWorkbenchPageTest extends UITestCase {
 	@Test
 	public void testHideViewWithPart() throws Throwable {
 		// test that nothing bad happens with a null parameter
-		try {
-			fActivePage.hideView((IViewPart) null);
-		} catch (RuntimeException e) {
-			fail(e.getMessage());
-		}
+		fActivePage.hideView((IViewPart) null);
 
 		IViewPart view = fActivePage.showView(MockViewPart.ID3);
 
@@ -1299,11 +1295,7 @@ public class IWorkbenchPageTest extends UITestCase {
 	@Test
 	public void testHideViewWithReference() throws Throwable {
 		// test that nothing bad happens with a null parameter
-		try {
-			fActivePage.hideView((IViewReference) null);
-		} catch (RuntimeException e) {
-			fail(e.getMessage());
-		}
+		fActivePage.hideView((IViewReference) null);
 
 		IViewPart view = fActivePage.showView(MockViewPart.ID4);
 		IViewReference ref = fActivePage.findViewReference(MockViewPart.ID4);
@@ -2133,22 +2125,18 @@ public class IWorkbenchPageTest extends UITestCase {
 	}
 
 	/**
-	 * Test opening a perspective with placeholders for multi instance views.
-	 * The placeholders are added at top level (not in any folder).
+	 * Test opening a perspective with placeholders for multi instance views. The
+	 * placeholders are added at top level (not in any folder).
+	 *
+	 * @throws WorkbenchException
 	 *
 	 * @since 3.1
 	 */
 	@Test
 	@Ignore
-	public void testOpenPerspectiveWithMultiViewPlaceholdersAtTopLevel() {
+	public void testOpenPerspectiveWithMultiViewPlaceholdersAtTopLevel() throws WorkbenchException {
 
-		try {
-			fWin.getWorkbench().showPerspective(
-					PerspectiveWithMultiViewPlaceholdersAtTopLevel.PERSP_ID,
-					fWin);
-		} catch (WorkbenchException e) {
-			fail("Unexpected WorkbenchException: " + e);
-		}
+		fWin.getWorkbench().showPerspective(PerspectiveWithMultiViewPlaceholdersAtTopLevel.PERSP_ID, fWin);
 
 //		ArrayList partIds = facade.getPerspectivePartIds(fActivePage, null);
 		// FIXME: No implementation for facade.getPerspectivePartIds()
@@ -2160,26 +2148,20 @@ public class IWorkbenchPageTest extends UITestCase {
 	}
 
 	/**
-	 * Test opening a perspective with placeholders for multi instance views.
-	 * The placeholders are added in a placeholder folder. This is a regression
-	 * test for bug 72383 [Perspectives] Placeholder folder error with multiple
-	 * instance views
+	 * Test opening a perspective with placeholders for multi instance views. The
+	 * placeholders are added in a placeholder folder. This is a regression test for
+	 * bug 72383 [Perspectives] Placeholder folder error with multiple instance
+	 * views
+	 *
+	 * @throws WorkbenchException
 	 *
 	 * @since 3.1
 	 */
 	@Test
 	@Ignore
-	public void testOpenPerspectiveWithMultiViewPlaceholdersInPlaceholderFolder() {
+	public void testOpenPerspectiveWithMultiViewPlaceholdersInPlaceholderFolder() throws WorkbenchException {
 
-		try {
-			fWin
-					.getWorkbench()
-					.showPerspective(
-							PerspectiveWithMultiViewPlaceholdersInPlaceholderFolder.PERSP_ID,
-							fWin);
-		} catch (WorkbenchException e) {
-			fail("Unexpected WorkbenchException: " + e);
-		}
+		fWin.getWorkbench().showPerspective(PerspectiveWithMultiViewPlaceholdersInPlaceholderFolder.PERSP_ID, fWin);
 
 //		ArrayList partIds = facade.getPerspectivePartIds(fActivePage,"placeholderFolder");
 
@@ -2192,23 +2174,17 @@ public class IWorkbenchPageTest extends UITestCase {
 	}
 
 	/**
-	 * Test opening a perspective with placeholders for multi instance views.
-	 * The placeholders are added at top level (not in any folder).
+	 * Test opening a perspective with placeholders for multi instance views. The
+	 * placeholders are added at top level (not in any folder).
+	 *
+	 * @throws WorkbenchException
 	 *
 	 * @since 3.1
 	 */
 	@Test
 	@Ignore
-	public void testOpenPerspectiveWithMultiViewPlaceholdersInFolder() {
-		try {
-			fWin
-					.getWorkbench()
-					.showPerspective(
-							PerspectiveWithMultiViewPlaceholdersInFolder.PERSP_ID,
-							fWin);
-		} catch (WorkbenchException e) {
-			fail("Unexpected WorkbenchException: " + e);
-		}
+	public void testOpenPerspectiveWithMultiViewPlaceholdersInFolder() throws WorkbenchException {
+		fWin.getWorkbench().showPerspective(PerspectiveWithMultiViewPlaceholdersInFolder.PERSP_ID, fWin);
 
 //		ArrayList partIds = facade.getPerspectivePartIds(fActivePage,"folder");
 
@@ -2570,20 +2546,19 @@ public class IWorkbenchPageTest extends UITestCase {
 	 * Tests that relative view is correctly shown if visible parameter specified.
 	 * See bug 538199 - perspectiveExtension: visible="false" not honored when
 	 * relative view does not exist
+	 *
+	 * @throws WorkbenchException
 	 */
 	@Test
-	public void testRelativeViewVisibility() {
+	public void testRelativeViewVisibility() throws WorkbenchException {
 		processEvents();
 
 		fActivePage.closeAllPerspectives(true, false);
 		IPerspectiveRegistry reg = fWorkbench.getPerspectiveRegistry();
 		IPerspectiveDescriptor testPerspective = reg.findPerspectiveWithId(PerspectiveViewsBug538199.ID);
 		fActivePage.setPerspective(testPerspective);
-		try {
-			fWin.getWorkbench().showPerspective(PerspectiveViewsBug538199.ID, fWin);
-		} catch (WorkbenchException e) {
-			fail("Unexpected WorkbenchException: " + e);
-		}
+		fWin.getWorkbench().showPerspective(PerspectiveViewsBug538199.ID, fWin);
+
 		processEvents();
 		IWorkbenchPage activePage = fWin.getActivePage();
 
@@ -2605,12 +2580,14 @@ public class IWorkbenchPageTest extends UITestCase {
 	}
 
 	/**
-	 * Regression test for Bug 76285 [Presentations] Folder tab does not
-	 * indicate current view. Tests that, when switching between perspectives,
-	 * the remembered old part correctly handles multi-view instances.
+	 * Regression test for Bug 76285 [Presentations] Folder tab does not indicate
+	 * current view. Tests that, when switching between perspectives, the remembered
+	 * old part correctly handles multi-view instances.
+	 *
+	 * @throws PartInitException
 	 */
 	@Test
-	public void testBug76285() {
+	public void testBug76285() throws PartInitException {
 		IWorkbenchPage page = fActivePage;
 		IPerspectiveDescriptor originalPersp = page.getPerspective();
 		IPerspectiveDescriptor resourcePersp = PlatformUI.getWorkbench()
@@ -2622,12 +2599,7 @@ public class IWorkbenchPageTest extends UITestCase {
 		int n = 5;
 		IViewPart[] views = new IViewPart[n];
 		for (int i = 0; i < n; ++i) {
-			try {
-				views[i] = page.showView(MockViewPart.IDMULT, Integer
-						.toString(i), IWorkbenchPage.VIEW_CREATE);
-			} catch (PartInitException e) {
-				fail(e.getMessage());
-			}
+			views[i] = page.showView(MockViewPart.IDMULT, Integer.toString(i), IWorkbenchPage.VIEW_CREATE);
 		}
 		assertEquals(5, page.getViews().length);
 		for (int i = 0; i < n; ++i) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetTest.java
@@ -306,15 +306,10 @@ public class IWorkingSetTest extends UITestCase {
 		fWorkingSet.saveState(m);
 		BadElementFactory.shouldFailOnCreateElement = true;
 		IWorkingSet copy = new WorkingSet(fWorkingSet.getName(), fWorkingSet.getId(), m) {};
-		try {
-			assertFalse(BadElementFactory.elementCreationAttemptedWhileShouldFail);
-			IAdaptable [] elements = copy.getElements();
-			assertTrue(BadElementFactory.elementCreationAttemptedWhileShouldFail);
-			assertEquals("Element array should be empty", 0, elements.length);
-		}
-		catch (RuntimeException e) {
-			fail("Error getting elements for broken factory", e);
-		}
+		assertFalse(BadElementFactory.elementCreationAttemptedWhileShouldFail);
+		IAdaptable[] elements = copy.getElements();
+		assertTrue(BadElementFactory.elementCreationAttemptedWhileShouldFail);
+		assertEquals("Element array should be empty", 0, elements.length);
 	}
 
 	/**
@@ -328,12 +323,8 @@ public class IWorkingSetTest extends UITestCase {
 		IMemento m = XMLMemento.createWriteRoot("ws");
 		BadElementFactory.BadElementInstance.shouldSaveFail = true;
 		assertFalse(BadElementFactory.BadElementInstance.saveAttemptedWhileShouldFail);
-		try {
-			fWorkingSet.saveState(m);
-			assertTrue(BadElementFactory.BadElementInstance.saveAttemptedWhileShouldFail);
-		} catch (RuntimeException e) {
-			fail("Error saving elements for broken persistable", e);
-		}
+		fWorkingSet.saveState(m);
+		assertTrue(BadElementFactory.BadElementInstance.saveAttemptedWhileShouldFail);
 	}
 
 	public static class Foo implements IAdaptable {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/StickyViewTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/StickyViewTest.java
@@ -54,76 +54,67 @@ public class StickyViewTest extends UITestCase {
 	}
 
 	@Test
-	public void testStackPlacementRight() {
+	public void testStackPlacementRight() throws PartInitException {
 		testStackPlacement("Right");
 	}
 
 	@Test
-	public void testStackPlacementLeft() {
+	public void testStackPlacementLeft() throws PartInitException {
 		testStackPlacement("Left");
 	}
 
 	@Test
-	public void testStackPlacementTop() {
+	public void testStackPlacementTop() throws PartInitException {
 		testStackPlacement("Top");
 	}
 
 	@Test
-	public void testStackPlacementBottom() {
+	public void testStackPlacementBottom() throws PartInitException {
 		testStackPlacement("Bottom");
 	}
 
 	/**
 	 * Tests to ensure that sticky views are opened in the same stack.
+	 *
+	 * @throws PartInitException
 	 */
-	private void testStackPlacement(String location) {
-		try {
-			IViewPart part1 = page
-					.showView("org.eclipse.ui.tests.api.StickyView" + location
-							+ "1");
-			assertNotNull(part1);
-			IViewPart part2 = page
-					.showView("org.eclipse.ui.tests.api.StickyView" + location
-							+ "2");
-			assertNotNull(part2);
-			IViewPart[] stack = page.getViewStack(part1);
+	private void testStackPlacement(String location) throws PartInitException {
+		IViewPart part1 = page.showView("org.eclipse.ui.tests.api.StickyView" + location + "1");
+		assertNotNull(part1);
+		IViewPart part2 = page.showView("org.eclipse.ui.tests.api.StickyView" + location + "2");
+		assertNotNull(part2);
+		IViewPart[] stack = page.getViewStack(part1);
 
-			assertTrue(ViewUtils.findInStack(stack, part1));
-			assertTrue(ViewUtils.findInStack(stack, part2));
-
-		} catch (PartInitException e) {
-			fail(e.getMessage());
-		}
-
+		assertTrue(ViewUtils.findInStack(stack, part1));
+		assertTrue(ViewUtils.findInStack(stack, part2));
 	}
 
 	/**
-	 * Tests to ensure that all views in a stack with a known sticky view are also sticky.
+	 * Tests to ensure that all views in a stack with a known sticky view are also
+	 * sticky.
+	 *
+	 * @throws PartInitException
 	 */
 	@Test
-	public void testStackContents() {
-		try {
-			IViewPart part1 = page
-					.showView("org.eclipse.ui.tests.api.StickyViewRight1");
-			assertNotNull(part1);
+	public void testStackContents() throws PartInitException {
+		IViewPart part1 = page.showView("org.eclipse.ui.tests.api.StickyViewRight1");
+		assertNotNull(part1);
 
-			IViewPart[] stack = page.getViewStack(part1);
+		IViewPart[] stack = page.getViewStack(part1);
 
-			for (IViewPart element : stack) {
-				assertTrue(element.getTitle(), ViewUtils.isSticky(element));
-			}
-		} catch (PartInitException e) {
-			fail(e.getMessage());
+		for (IViewPart element : stack) {
+			assertTrue(element.getTitle(), ViewUtils.isSticky(element));
 		}
 	}
 
 	/**
-	 * Tests whether the moveable flag is being picked up and honoured
-	 * from the XML.
+	 * Tests whether the moveable flag is being picked up and honoured from the XML.
+	 *
+	 * @throws PartInitException
 	 */
 	@Test
 	@Ignore
-	public void XXXtestClosableFlag() {
+	public void XXXtestClosableFlag() throws PartInitException {
 		//explicit closeable = true
 		testCloseable("org.eclipse.ui.tests.api.StickyViewRight1", true);
 		//explicit closeable = false
@@ -134,7 +125,7 @@ public class StickyViewTest extends UITestCase {
 
 	@Test
 	@Ignore
-	public void XXXtestMoveableFlag() {
+	public void XXXtestMoveableFlag() throws PartInitException {
 		//explicit closeable = true
 		testMoveable("org.eclipse.ui.tests.api.StickyViewRight1", true);
 		//explicit closeable = false
@@ -146,89 +137,74 @@ public class StickyViewTest extends UITestCase {
 	/**
 	 * Tests whether a sticky view with the given id is moveable or not.
 	 *
-	 * @param id the id
+	 * @param id          the id
 	 * @param expectation the expected moveable state
+	 * @throws PartInitException
 	 */
-	private void testMoveable(String id, boolean expectation) {
-		try {
-			IViewPart part = page.showView(id);
-			assertNotNull(part);
-			assertTrue(ViewUtils.isSticky(part));
+	private void testMoveable(String id, boolean expectation) throws PartInitException {
+		IViewPart part = page.showView(id);
+		assertNotNull(part);
+		assertTrue(ViewUtils.isSticky(part));
 
-			//tests to ensure that the XML was read correctly
-			IStickyViewDescriptor[] descs = PlatformUI.getWorkbench()
-					.getViewRegistry().getStickyViews();
-			for (IStickyViewDescriptor desc : descs) {
-				if (desc.getId().equals(id)) {
-					assertEquals(expectation, desc.isMoveable());
-				}
+		// tests to ensure that the XML was read correctly
+		IStickyViewDescriptor[] descs = PlatformUI.getWorkbench().getViewRegistry().getStickyViews();
+		for (IStickyViewDescriptor desc : descs) {
+			if (desc.getId().equals(id)) {
+				assertEquals(expectation, desc.isMoveable());
 			}
-
-			// tests to ensure that the property is being honoured by the perspective
-			assertEquals(expectation, ViewUtils.isMoveable(part));
-		} catch (PartInitException e) {
-			fail(e.getMessage());
 		}
+
+		// tests to ensure that the property is being honoured by the perspective
+		assertEquals(expectation, ViewUtils.isMoveable(part));
 	}
 
 	/**
 	 * Tests whether a sticky view with the given id is closeable or not.
 	 *
-	 * @param id the id
+	 * @param id          the id
 	 * @param expectation the expected closeable state
+	 * @throws PartInitException
 	 */
-	private void testCloseable(String id, boolean expectation) {
-		try {
-			IViewPart part = page.showView(id);
-			assertNotNull(part);
-			assertTrue(ViewUtils.isSticky(part));
+	private void testCloseable(String id, boolean expectation) throws PartInitException {
+		IViewPart part = page.showView(id);
+		assertNotNull(part);
+		assertTrue(ViewUtils.isSticky(part));
 
-			//tests to ensure that the XML was read correctly
-			IStickyViewDescriptor[] descs = PlatformUI.getWorkbench()
-					.getViewRegistry().getStickyViews();
-			for (IStickyViewDescriptor desc : descs) {
-				if (desc.getId().equals(id)) {
-					assertEquals(expectation, desc.isCloseable());
-				}
+		// tests to ensure that the XML was read correctly
+		IStickyViewDescriptor[] descs = PlatformUI.getWorkbench().getViewRegistry().getStickyViews();
+		for (IStickyViewDescriptor desc : descs) {
+			if (desc.getId().equals(id)) {
+				assertEquals(expectation, desc.isCloseable());
 			}
-
-			// tests to ensure that the property is being honoured by the perspective
-			assertEquals(expectation, ViewUtils.isCloseable(part));
-		} catch (PartInitException e) {
-			fail(e.getMessage());
 		}
+
+		// tests to ensure that the property is being honoured by the perspective
+		assertEquals(expectation, ViewUtils.isCloseable(part));
 	}
 
 	/**
 	 * Sticky views should remain after perspective reset.
+	 *
+	 * @throws PartInitException
 	 */
 	@Test
-	public void testPerspectiveReset() {
-		try {
-			page.showView("org.eclipse.ui.tests.api.StickyViewRight1");
-			page.resetPerspective();
-			assertNotNull(page
-					.findView("org.eclipse.ui.tests.api.StickyViewRight1"));
-		} catch (PartInitException e) {
-			fail(e.getMessage());
-		}
+	public void testPerspectiveReset() throws PartInitException {
+		page.showView("org.eclipse.ui.tests.api.StickyViewRight1");
+		page.resetPerspective();
+		assertNotNull(page.findView("org.eclipse.ui.tests.api.StickyViewRight1"));
 	}
 
 	/**
 	 * Tests that a sticky view is opened in successive perspectives.
+	 *
+	 * @throws PartInitException
 	 */
 	@Test
-	public void testPerspectiveOpen() {
-		try {
-			page.showView("org.eclipse.ui.tests.api.StickyViewRight1");
-			page.setPerspective(WorkbenchPlugin.getDefault()
-					.getPerspectiveRegistry().findPerspectiveWithId(
-							"org.eclipse.ui.tests.api.SessionPerspective"));
-			assertNotNull(page
-					.findView("org.eclipse.ui.tests.api.StickyViewRight1"));
-		} catch (PartInitException e) {
-			fail(e.getMessage());
-		}
+	public void testPerspectiveOpen() throws PartInitException {
+		page.showView("org.eclipse.ui.tests.api.StickyViewRight1");
+		page.setPerspective(WorkbenchPlugin.getDefault().getPerspectiveRegistry()
+				.findPerspectiveWithId("org.eclipse.ui.tests.api.SessionPerspective"));
+		assertNotNull(page.findView("org.eclipse.ui.tests.api.StickyViewRight1"));
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/Bug_262032.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/Bug_262032.java
@@ -15,7 +15,6 @@ package org.eclipse.ui.tests.concurrency;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -49,27 +48,26 @@ public class Bug_262032 {
 	volatile boolean concurrentAccess = false;
 
 	/**
-	 * Threads: UI(+asyncExec), j
-	 * Locks: lock, IDRule
+	 * Threads: UI(+asyncExec), j Locks: lock, IDRule
 	 * <p>
-	 * j holds identity Rule
-	 * ui tries to acquire rule =&gt; block and performs asyncMessages
-	 * asyncExec run and acquire()s lock
-	 * j then attempts to acquire lock.
+	 * j holds identity Rule ui tries to acquire rule =&gt; block and performs
+	 * asyncMessages asyncExec run and acquire()s lock j then attempts to acquire
+	 * lock.
 	 * <p>
-	 * Deadlock manager believes that UI is waiting for IDrule while holding
-	 * lock, and Job holds IDRule while attempting lock.  Scheduling rules
-	 * are never released by the Deadlock detector, so the lock is yielded!
+	 * Deadlock manager believes that UI is waiting for IDrule while holding lock,
+	 * and Job holds IDRule while attempting lock. Scheduling rules are never
+	 * released by the Deadlock detector, so the lock is yielded!
 	 * <p>
-	 * The expectation is that when threads are 'waiting' they're sat
-	 * in the ordered lock acquire which can give the locks safely to whoever
-	 * is deemed to need it.  In this case that's not true as the UI
-	 * is running an async exec.
+	 * The expectation is that when threads are 'waiting' they're sat in the ordered
+	 * lock acquire which can give the locks safely to whoever is deemed to need it.
+	 * In this case that's not true as the UI is running an async exec.
 	 * <p>
 	 * The result is concurrent running in a locked region.
+	 *
+	 * @throws InterruptedException
 	 */
 	@Test
-	public void testBug262032() {
+	public void testBug262032() throws InterruptedException {
 		final ILock lock = Job.getJobManager().newLock();
 		final TestBarrier2 tb1 = new TestBarrier2(-1);
 
@@ -112,13 +110,9 @@ public class Bug_262032 {
 		Job.getJobManager().beginRule(identityRule, null);
 		Job.getJobManager().endRule(identityRule);
 
-		try {
-			j.join();
-			tb1.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
-			assertEquals(Status.OK_STATUS, j.getResult());
-		} catch (InterruptedException e) {
-			fail(e.getMessage());
-		}
+		j.join();
+		tb1.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
+		assertEquals(Status.OK_STATUS, j.getResult());
 	}
 
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/NoFreezeWhileWaitingForRuleTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/NoFreezeWhileWaitingForRuleTest.java
@@ -15,7 +15,6 @@ package org.eclipse.ui.tests.concurrency;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -75,7 +74,7 @@ public class NoFreezeWhileWaitingForRuleTest {
 	}
 
 	@Test
-	public void testWaiting() {
+	public void testWaiting() throws InterruptedException {
 		// If you want to see the blocking uncomment the following line:
 		// Job.getJobManager().setProgressProvider(null);
 		Display display = Display.getDefault();
@@ -93,7 +92,7 @@ public class NoFreezeWhileWaitingForRuleTest {
 			blockingJob.join();
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
-			fail(e.getMessage());
+			throw e;
 		}
 		assertFalse("Timeout reached, blocking occurred!", ruleMonitor.isCanceled());
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ExportFileSystemOperationTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ExportFileSystemOperationTest.java
@@ -78,22 +78,15 @@ public class ExportFileSystemOperationTest extends UITestCase implements
 		setUpData();
 	}
 
-	private void setUpData(){
-		try{
-			for (String directoryName : directoryNames) {
-				IFolder folder = project.getFolder(directoryName);
-				folder.create(false, true, new NullProgressMonitor());
-				for (String fileName : fileNames) {
-					IFile file = folder.getFile(fileName);
-					String contents =
-						directoryName + ", " + fileName;
-					file.create(new ByteArrayInputStream(contents.getBytes()),
-						true, new NullProgressMonitor());
-				}
+	private void setUpData() throws CoreException {
+		for (String directoryName : directoryNames) {
+			IFolder folder = project.getFolder(directoryName);
+			folder.create(false, true, new NullProgressMonitor());
+			for (String fileName : fileNames) {
+				IFile file = folder.getFile(fileName);
+				String contents = directoryName + ", " + fileName;
+				file.create(new ByteArrayInputStream(contents.getBytes()), true, new NullProgressMonitor());
 			}
-		}
-		catch(Exception e){
-			fail(e.toString());
 		}
 	}
 
@@ -107,10 +100,7 @@ public class ExportFileSystemOperationTest extends UITestCase implements
 		}
 		try {
 			project.delete(true, true, null);
-		} catch (CoreException e) {
-			fail(e.toString());
-		}
-		finally{
+		} finally {
 			project = null;
 			localDirectory = null;
 		}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingArchiveProjectFilterTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingArchiveProjectFilterTest.java
@@ -124,12 +124,7 @@ public class ImportExistingArchiveProjectFilterTest extends UITestCase {
 		IViewPart navigator = page.showView(IPageLayout.ID_PROJECT_EXPLORER);
 		assertNotNull("failed to open project explorer", navigator);
 
-		ProjectExplorer projectExplorer = null;
-		try {
-			projectExplorer = (ProjectExplorer) navigator;
-		} catch (ClassCastException e) {
-			fail(e.getMessage());
-		}
+		ProjectExplorer projectExplorer = (ProjectExplorer) navigator;
 		// Check project explorer for visibility of res folder for which resource filter
 		// is applied to hide on import
 		TreeViewer treeViewer = projectExplorer.getCommonViewer();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportOperationTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportOperationTest.java
@@ -111,10 +111,7 @@ public class ImportOperationTest extends UITestCase implements IOverwriteQuery {
 			project.delete(true, true, null);
 			File topDirectory = new File(localDirectory);
 			FileSystemHelper.clear(topDirectory);
-		} catch (CoreException e) {
-			fail(e.toString());
-		}
-		finally{
+		} finally {
 			project = null;
 			localDirectory = null;
 		}
@@ -194,21 +191,17 @@ public class ImportOperationTest extends UITestCase implements IOverwriteQuery {
 		operation.setCreateContainerStructure(false);
 		openTestWindow().run(true, true, operation);
 
-		try {
-			IPath path = IPath.fromOSString(localDirectory);
-			IResource targetFolder = project.findMember(path.lastSegment());
+		IPath path = IPath.fromOSString(localDirectory);
+		IResource targetFolder = project.findMember(path.lastSegment());
 
-			assertTrue("Import failed", targetFolder instanceof IContainer);
+		assertTrue("Import failed", targetFolder instanceof IContainer);
 
-			IResource[] resources = ((IContainer) targetFolder).members();
-			assertEquals("Import failed to import all directories",
-					directoryNames.length, resources.length);
-			for (IResource resource : resources) {
-				assertTrue("Import failed", resource instanceof IContainer);
-				verifyFolder((IContainer) resource);
-			}
-		} catch (CoreException e) {
-			fail(e.toString());
+		IResource[] resources = ((IContainer) targetFolder).members();
+		assertEquals("Import failed to import all directories",
+				directoryNames.length, resources.length);
+		for (IResource resource : resources) {
+			assertTrue("Import failed", resource instanceof IContainer);
+			verifyFolder((IContainer) resource);
 		}
 	}
 
@@ -245,46 +238,38 @@ public class ImportOperationTest extends UITestCase implements IOverwriteQuery {
 	 * Verifies that all files were imported.
 	 *
 	 * @param folderCount number of folders that were imported
+	 * @throws CoreException
 	 */
-	private void verifyFiles(int folderCount) {
-		try {
-			IPath path = IPath.fromOSString(localDirectory);
-			IResource targetFolder = project.findMember(path.makeRelative());
+	private void verifyFiles(int folderCount) throws CoreException {
+		IPath path = IPath.fromOSString(localDirectory);
+		IResource targetFolder = project.findMember(path.makeRelative());
 
-			assertTrue("Import failed", targetFolder instanceof IContainer);
+		assertTrue("Import failed", targetFolder instanceof IContainer);
 
-			IResource[] resources = ((IContainer) targetFolder).members();
-			assertEquals("Import failed to import all directories",
-					folderCount, resources.length);
-			for (IResource resource : resources) {
-				assertTrue("Import failed", resource instanceof IContainer);
-				verifyFolder((IContainer) resource);
-			}
-		} catch (CoreException e) {
-			fail(e.toString());
+		IResource[] resources = ((IContainer) targetFolder).members();
+		assertEquals("Import failed to import all directories", folderCount, resources.length);
+		for (IResource resource : resources) {
+			assertTrue("Import failed", resource instanceof IContainer);
+			verifyFolder((IContainer) resource);
 		}
 	}
 
 	/**
 	 * Verifies that all files were imported into the specified folder.
+	 *
+	 * @throws CoreException
 	 */
-	private void verifyFolder(IContainer folder) {
-		try {
-			IResource[] files = folder.members();
-			assertEquals("Import failed to import all files", fileNames.length,
-					files.length);
-			for (String fileName : fileNames) {
-				int k;
-				for (k = 0; k < files.length; k++) {
-					if (fileName.equals(files[k].getName())) {
-						break;
-					}
+	private void verifyFolder(IContainer folder) throws CoreException {
+		IResource[] files = folder.members();
+		assertEquals("Import failed to import all files", fileNames.length, files.length);
+		for (String fileName : fileNames) {
+			int k;
+			for (k = 0; k < files.length; k++) {
+				if (fileName.equals(files[k].getName())) {
+					break;
 				}
-				assertTrue("Import failed to import file " + fileName,
-						k < fileNames.length);
 			}
-		} catch (CoreException e) {
-			fail(e.toString());
+			assertTrue("Import failed to import file " + fileName, k < fileNames.length);
 		}
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/decorators/DecoratorCacheTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/decorators/DecoratorCacheTest.java
@@ -54,7 +54,7 @@ public class DecoratorCacheTest extends AbstractNavigatorTest {
 	}
 
 	@Test
-	public void testDecoratorCacheIsDisposed() {
+	public void testDecoratorCacheIsDisposed() throws CoreException {
 
 		Display fDisplay = Display.getCurrent();
 		if (fDisplay == null) {
@@ -66,11 +66,7 @@ public class DecoratorCacheTest extends AbstractNavigatorTest {
 		StructuredViewer fViewer = createViewer(fShell);
 		fViewer.setUseHashlookup(true);
 
-		try {
-			createTestFile();
-		} catch (CoreException e) {
-			fail(e.getLocalizedMessage(), e);
-		}
+		createTestFile();
 		fViewer.setInput(testFile);
 		fShell.open();
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/DeprecatedUIWizardsAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/DeprecatedUIWizardsAuto.java
@@ -125,13 +125,9 @@ public class DeprecatedUIWizardsAuto {
 	 */
 	@After
 	public void tearDown() throws Exception {
-		try {
-			if (project != null) {
-				project.delete(true, true, null);
-				project = null;
-			}
-		} catch (CoreException e) {
-			fail(e.toString());
+		if (project != null) {
+			project.delete(true, true, null);
+			project = null;
 		}
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIWizardsAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIWizardsAuto.java
@@ -133,13 +133,9 @@ public class UIWizardsAuto {
 	 */
 	@After
 	public void tearDown() throws Exception {
-		try {
-			if (project != null) {
-				project.delete(true, true, null);
-				project = null;
-			}
-		} catch (CoreException e) {
-			fail(e.toString());
+		if (project != null) {
+			project.delete(true, true, null);
+			project = null;
 		}
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/EditorTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/EditorTests.java
@@ -65,7 +65,7 @@ public class EditorTests extends DynamicTestCase {
 	}
 
 	@Test
-	public void testEditorClosure() throws CoreException {
+	public void testEditorClosure() throws CoreException, IllegalArgumentException, InterruptedException {
 		IWorkbenchWindow window = openTestWindow(IDE.RESOURCE_PERSPECTIVE_ID);
 		IFile file = getFile();
 		getBundle();
@@ -77,11 +77,7 @@ public class EditorTests extends DynamicTestCase {
 		part = null; //null the reference
 
 		removeBundle();
-		try {
-			LeakTests.checkRef(queue, ref);
-		} catch (Exception e) {
-			fail(e.getMessage());
-		}
+		LeakTests.checkRef(queue, ref);
 
 		assertEquals(0, window.getActivePage().getEditors().length);
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/IntroTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/IntroTests.java
@@ -49,7 +49,7 @@ public class IntroTests extends DynamicTestCase {
 	}
 
 	@Test
-	public void testIntroClosure() {
+	public void testIntroClosure() throws IllegalArgumentException, InterruptedException {
 		getBundle();
 		Workbench workbench = Workbench.getInstance();
 		IntroDescriptor testDesc = (IntroDescriptor) WorkbenchPlugin
@@ -63,16 +63,13 @@ public class IntroTests extends DynamicTestCase {
 		assertNotNull(intro);
 		intro = null; //null the reference
 		removeBundle();
-		try {
-			LeakTests.checkRef(queue, ref);
-		} catch (Exception e) {
-			fail(e.getMessage());
-		}
+		LeakTests.checkRef(queue, ref);
+
 		assertNull(workbench.getIntroManager().getIntro());
 	}
 
 	@Test
-	public void testIntroProperties() {
+	public void testIntroProperties() throws CoreException {
 		IIntroRegistry registry = WorkbenchPlugin.getDefault().getIntroRegistry();
 		assertNull(registry.getIntroForProduct(PRODUCT_ID));
 		assertNull(registry.getIntro(INTRO_ID));
@@ -80,12 +77,7 @@ public class IntroTests extends DynamicTestCase {
 		assertNotNull(registry.getIntroForProduct(PRODUCT_ID));
 		IIntroDescriptor desc = registry.getIntro(INTRO_ID);
 		assertNotNull(desc);
-		try {
-			testIntroProperties(desc);
-		}
-		catch (CoreException e) {
-			fail(e.getMessage());
-		}
+		testIntroProperties(desc);
 		removeBundle();
 		assertNull(registry.getIntro(INTRO_ID));
 		assertNull(registry.getIntroForProduct(PRODUCT_ID));

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/StatusHandlerTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/StatusHandlerTests.java
@@ -53,9 +53,12 @@ public class StatusHandlerTests extends DynamicTestCase {
 	/**
 	 * Tests to ensure that the status handlers are removed when the plugin is
 	 * unloaded.
+	 *
+	 * @throws InterruptedException
+	 * @throws IllegalArgumentException
 	 */
 	@Test
-	public void testStatusHandlerRemoval() throws CoreException {
+	public void testStatusHandlerRemoval() throws CoreException, IllegalArgumentException, InterruptedException {
 		getBundle();
 
 		StatusHandlerDescriptor statusHandlerDescriptor1 = StatusHandlerRegistry
@@ -79,12 +82,8 @@ public class StatusHandlerTests extends DynamicTestCase {
 
 		removeBundle();
 
-		try {
-			LeakTests.checkRef(queue, ref);
-			LeakTests.checkRef(queue2, ref2);
-		} catch (Exception e) {
-			fail(e.getMessage());
-		}
+		LeakTests.checkRef(queue, ref);
+		LeakTests.checkRef(queue2, ref2);
 
 		assertNull(StatusHandlerRegistry.getDefault().getHandlerDescriptor(
 				STATUS_HANDLER_ID1));
@@ -93,9 +92,12 @@ public class StatusHandlerTests extends DynamicTestCase {
 	/**
 	 * Tests to ensure that the status handlers are removed when the plugin is
 	 * unloaded.
+	 *
+	 * @throws InterruptedException
+	 * @throws IllegalArgumentException
 	 */
 	@Test
-	public void testStatusHandlerRemoval2() throws CoreException {
+	public void testStatusHandlerRemoval2() throws CoreException, IllegalArgumentException, InterruptedException {
 		getBundle();
 
 		ReferenceQueue<StatusHandlerDescriptor> queue = new ReferenceQueue<>();
@@ -132,12 +134,8 @@ public class StatusHandlerTests extends DynamicTestCase {
 
 		removeBundle();
 
-		try {
-			LeakTests.checkRef(queue, ref);
-			LeakTests.checkRef(queue2, ref2);
-		} catch (Exception e) {
-			fail(e.getMessage());
-		}
+		LeakTests.checkRef(queue, ref);
+		LeakTests.checkRef(queue2, ref2);
 
 		assertNull(StatusHandlerRegistry.getDefault().getHandlerDescriptor(
 				STATUS_HANDLER_ID1));
@@ -146,9 +144,12 @@ public class StatusHandlerTests extends DynamicTestCase {
 	/**
 	 * Tests to ensure that the status handlers are removed when the plugin is
 	 * unloaded. Checks if the default product handlers are handled correctly.
+	 *
+	 * @throws InterruptedException
+	 * @throws IllegalArgumentException
 	 */
 	@Test
-	public void testProductBindingRemoval() throws CoreException {
+	public void testProductBindingRemoval() throws CoreException, IllegalArgumentException, InterruptedException {
 		getBundle();
 
 		ReferenceQueue<StatusHandlerDescriptor> queue = new ReferenceQueue<>();
@@ -173,12 +174,8 @@ public class StatusHandlerTests extends DynamicTestCase {
 
 		removeBundle();
 
-		try {
-			LeakTests.checkRef(queue, ref);
-			LeakTests.checkRef(queue2, ref2);
-		} catch (Exception e) {
-			fail(e.getMessage());
-		}
+		LeakTests.checkRef(queue, ref);
+		LeakTests.checkRef(queue2, ref2);
 
 		assertNull(StatusHandlerRegistry.getDefault().getHandlerDescriptor(
 				STATUS_HANDLER_ID1));

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ViewTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ViewTests.java
@@ -51,7 +51,7 @@ public class ViewTests extends DynamicTestCase {
 	}
 
 	@Test
-	public void testViewClosure() throws CoreException {
+	public void testViewClosure() throws CoreException, IllegalArgumentException, InterruptedException {
 		IWorkbenchWindow window = openTestWindow(IDE.RESOURCE_PERSPECTIVE_ID);
 		getBundle();
 
@@ -64,11 +64,7 @@ public class ViewTests extends DynamicTestCase {
 		part = null; //null the reference
 
 		removeBundle();
-		try {
-			LeakTests.checkRef(queue, ref);
-		} catch (Exception e) {
-			fail(e.getMessage());
-		}
+		LeakTests.checkRef(queue, ref);
 
 		assertNull(window.getActivePage().findView(VIEW_ID1));
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/e4/CloseAllHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/e4/CloseAllHandlerTest.java
@@ -99,9 +99,11 @@ public class CloseAllHandlerTest {
 	 * Scenario 3: a mix of an open compatibility layer type editor *and* an E4
 	 * style part contribution which is tagged as representing an 'editor' are both
 	 * closed via the handler (and the enablement of handler is checked).
+	 *
+	 * @throws PartInitException
 	 */
 	@Test
-	public void testCloseMixedEditorTypes() {
+	public void testCloseMixedEditorTypes() throws PartInitException {
 		EHandlerService handlerService = application.getContext().get(EHandlerService.class);
 		ECommandService commandService = application.getContext().get(ECommandService.class);
 
@@ -119,11 +121,7 @@ public class CloseAllHandlerTest {
 		assertNotNull("Active workbench window not found.", window);
 
 		IFileEditorInput input = new DummyFileEditorInput();
-		try {
-			window.getActivePage().openEditor(input, TEST_COMPATIBILITY_LAYER_EDITOR_ID);
-		} catch (PartInitException e) {
-			fail("Test Compatibility Editor could not be opened.  Further testing cannot complete.");
-		}
+		window.getActivePage().openEditor(input, TEST_COMPATIBILITY_LAYER_EDITOR_ID);
 
 		// verify the close all handler is enabled now (since a dummy compatibility
 		// layer editor has been opened)
@@ -170,11 +168,8 @@ public class CloseAllHandlerTest {
 		// which represents an editor, and verify they are *both* closed when we invoked
 		// the close all editors handler
 		dummyPart = createAndOpenE4Part(partDescriptor);
-		try {
-			window.getActivePage().openEditor(input, TEST_COMPATIBILITY_LAYER_EDITOR_ID);
-		} catch (PartInitException e) {
-			fail("Test Compatibility Editor could not be opened.  Further testing cannot complete.");
-		}
+		window.getActivePage().openEditor(input, TEST_COMPATIBILITY_LAYER_EDITOR_ID);
+
 		compatEditor = window.getActivePage().findEditor(input);
 		assertNotNull(compatEditor);
 		dummyPart = partService.findPart(DUMMY_E4_PART_ID);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/encoding/EncodingTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/encoding/EncodingTestCase.java
@@ -14,10 +14,8 @@
 package org.eclipse.ui.tests.encoding;
 
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.nio.charset.Charset;
-import java.nio.charset.IllegalCharsetNameException;
 import java.util.List;
 
 import org.eclipse.ui.WorkbenchEncoding;
@@ -38,12 +36,7 @@ public class EncodingTestCase {
 		List<String> encodings = WorkbenchEncoding.getDefinedEncodings();
 
 		for (String encoding : encodings) {
-			try {
-				assertTrue("Unsupported charset " + encoding, Charset.isSupported(encoding));
-
-			} catch (IllegalCharsetNameException e) {
-				fail("Unsupported charset " + encoding);
-			}
+			assertTrue("Unsupported charset " + encoding, Charset.isSupported(encoding));
 		}
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/EditorActionBarsTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/EditorActionBarsTest.java
@@ -233,22 +233,14 @@ public class EditorActionBarsTest extends UITestCase {
 		// Test a cool bar with a single separator
 		CoolBarManager coolBarManager = new CoolBarManager();
 		coolBarManager.add(new Separator(CoolBarManager.USER_SEPARATOR));
-		try {
-			coolBarManager.createControl(fWindow.getShell());
-			coolBarManager.update(true);
-		} catch (ArrayIndexOutOfBoundsException e) {
-			fail("Exception updating cool bar with a single separator");
-		}
+		coolBarManager.createControl(fWindow.getShell());
+		coolBarManager.update(true);
 
 		// Test a cool bar with multiple separators
 		CoolBarManager coolBarManager2 = new CoolBarManager();
 		coolBarManager2.add(new Separator(CoolBarManager.USER_SEPARATOR));
-		try {
-			coolBarManager2.createControl(fWindow.getShell());
-			coolBarManager2.update(true);
-		} catch (ArrayIndexOutOfBoundsException e) {
-			fail("Exception updating cool bar with multiple separators");
-		}
+		coolBarManager2.createControl(fWindow.getShell());
+		coolBarManager2.update(true);
 	}
 }
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbenchWindowSubordinateSourcesTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbenchWindowSubordinateSourcesTests.java
@@ -55,7 +55,7 @@ public class WorkbenchWindowSubordinateSourcesTests extends UITestCase {
 	}
 
 	@Test
-	public void testIsCoolbarVisible() {
+	public void testIsCoolbarVisible() throws CoreException {
 		IEvaluationService service = window.getService(IEvaluationService.class);
 		IEvaluationContext context = service.getCurrentState();
 
@@ -65,23 +65,14 @@ public class WorkbenchWindowSubordinateSourcesTests extends UITestCase {
 		EqualsExpression test = new EqualsExpression(current ? Boolean.TRUE
 				: Boolean.FALSE);
 		with.add(test);
-
-		try {
-			assertEquals(EvaluationResult.TRUE, with.evaluate(context));
-		} catch (CoreException e) {
-			fail(e.getMessage());
-		}
+		assertEquals(EvaluationResult.TRUE, with.evaluate(context));
 
 		window.setCoolBarVisible(!current);
-		try {
-			assertEquals(EvaluationResult.FALSE, with.evaluate(context));
-		} catch (CoreException e) {
-			fail(e.getMessage());
-		}
+		assertEquals(EvaluationResult.FALSE, with.evaluate(context));
 	}
 
 	@Test
-	public void testIsStatusLineVisible() {
+	public void testIsStatusLineVisible() throws CoreException {
 		IEvaluationService service = window.getService(IEvaluationService.class);
 		IEvaluationContext context = service.getCurrentState();
 
@@ -90,23 +81,14 @@ public class WorkbenchWindowSubordinateSourcesTests extends UITestCase {
 		boolean current = window.getStatusLineVisible();
 		EqualsExpression test = new EqualsExpression(current ? Boolean.TRUE : Boolean.FALSE);
 		with.add(test);
-
-		try {
-			assertEquals(EvaluationResult.TRUE, with.evaluate(context));
-		} catch (CoreException e) {
-			fail(e.getMessage());
-		}
+		assertEquals(EvaluationResult.TRUE, with.evaluate(context));
 
 		window.setStatusLineVisible(!current);
-		try {
-			assertEquals(EvaluationResult.FALSE, with.evaluate(context));
-		} catch (CoreException e) {
-			fail(e.getMessage());
-		}
+		assertEquals(EvaluationResult.FALSE, with.evaluate(context));
 	}
 
 	@Test
-	public void testIsPerspectiveBarVisible() {
+	public void testIsPerspectiveBarVisible() throws CoreException {
 		IEvaluationService service = window.getService(IEvaluationService.class);
 		IEvaluationContext context = service.getCurrentState();
 
@@ -115,19 +97,10 @@ public class WorkbenchWindowSubordinateSourcesTests extends UITestCase {
 		boolean current = window.getPerspectiveBarVisible();
 		EqualsExpression test = new EqualsExpression(current ? Boolean.TRUE : Boolean.FALSE);
 		with.add(test);
-
-		try {
-			assertEquals(EvaluationResult.TRUE, with.evaluate(context));
-		} catch (CoreException e) {
-			fail(e.getMessage());
-		}
+		assertEquals(EvaluationResult.TRUE, with.evaluate(context));
 
 		window.setPerspectiveBarVisible(!current);
-		try {
-			assertEquals(EvaluationResult.FALSE, with.evaluate(context));
-		} catch (CoreException e) {
-			fail(e.getMessage());
-		}
+		assertEquals(EvaluationResult.FALSE, with.evaluate(context));
 	}
 
 	private static class PerspectiveL implements IPropertyChangeListener {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/BindingManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/BindingManagerTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -687,11 +686,13 @@ public final class BindingManagerTest {
 
 	/**
 	 * Verifies that selecting an undefimned scheme doesn't work. Verifies that
-	 * selecting a scheme works. Verifies that undefining scheme removes it as
-	 * the active scheme.
+	 * selecting a scheme works. Verifies that undefining scheme removes it as the
+	 * active scheme.
+	 *
+	 * @throws NotDefinedException
 	 */
 	@Test
-	public void testSetActiveScheme() {
+	public void testSetActiveScheme() throws NotDefinedException {
 		// SELECT UNDEFINED
 		final String schemeId = "schemeId";
 		final Scheme scheme = bindingManager.getScheme(schemeId);
@@ -699,13 +700,9 @@ public final class BindingManagerTest {
 
 		// SELECT DEFINED
 		scheme.define("name", "description", null);
-		try {
-			bindingManager.setActiveScheme(scheme);
-			assertSame("The schemes should match", scheme,
+		bindingManager.setActiveScheme(scheme);
+		assertSame("The schemes should match", scheme,
 					bindingManager.getActiveScheme());
-		} catch (final NotDefinedException e) {
-			fail("Should be able to activate a scheme");
-		}
 
 		// UNDEFINE SELECTED
 		scheme.undefine();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43321Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43321Test.java
@@ -15,7 +15,6 @@
 package org.eclipse.ui.tests.keys;
 
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
@@ -91,10 +90,6 @@ public class Bug43321Test {
 				.getGlobalActionHandler(ActionFactory.COPY.getId());
 		assertTrue("Non-checkbox menu item is checked.", !action.isChecked()); //$NON-NLS-1$
 
-		try {
-			FileUtil.deleteProject(testProject);
-		} catch (CoreException e) {
-			fail(e.toString());
-		}
+		FileUtil.deleteProject(testProject);
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/MarkersViewColumnSizeTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/MarkersViewColumnSizeTest.java
@@ -48,7 +48,7 @@ public class MarkersViewColumnSizeTest extends UITestCase {
 
 
 	@Test
-	public void testColumnCreate() {
+	public void testColumnCreate() throws PartInitException {
 		IWorkbenchWindow window = PlatformUI.getWorkbench()
 				.getActiveWorkbenchWindow();
 		if (window == null) {
@@ -59,21 +59,14 @@ public class MarkersViewColumnSizeTest extends UITestCase {
 			fail("Could not get a workbench page");
 		}
 
-		MarkersTestMarkersView problemView;
-		try {
-			problemView = (MarkersTestMarkersView) page
-					.showView("org.eclipse.ui.tests.markerTests");
-		} catch (PartInitException e) {
-			fail(e.getLocalizedMessage());
-			return;
-		}
+		MarkersTestMarkersView problemView = (MarkersTestMarkersView) page.showView("org.eclipse.ui.tests.markerTests");
 
 		problemView.setColumnWidths(100);
 
 	}
 
 	@Test
-	public void testColumnRestore() {
+	public void testColumnRestore() throws PartInitException {
 		IWorkbenchWindow window = PlatformUI.getWorkbench()
 				.getActiveWorkbenchWindow();
 		if (window == null) {
@@ -84,14 +77,7 @@ public class MarkersViewColumnSizeTest extends UITestCase {
 			fail("Could not get a workbench page");
 		}
 
-		MarkersTestMarkersView problemView;
-		try {
-			problemView = (MarkersTestMarkersView) page
-					.showView("org.eclipse.ui.tests.markerTests");
-		} catch (PartInitException e) {
-			fail(e.getLocalizedMessage());
-			return;
-		}
+		MarkersTestMarkersView problemView = (MarkersTestMarkersView) page.showView("org.eclipse.ui.tests.markerTests");
 
 		assertTrue("Column sizes not restored", problemView
 				.checkColumnSizes(100));

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/ResourceMappingMarkersTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/ResourceMappingMarkersTest.java
@@ -46,28 +46,15 @@ public class ResourceMappingMarkersTest extends AbstractNavigatorTest {
 	}
 
 	@Test
-	public void testResourceMappings() {
+	public void testResourceMappings() throws PartInitException {
 		IWorkbenchWindow window = PlatformUI.getWorkbench()
 				.getActiveWorkbenchWindow();
 		IWorkbenchPage page = window.getActivePage();
-		ResourceMappingTestView view;
+		ResourceMappingTestView view = (ResourceMappingTestView) page
+				.showView("org.eclipse.ui.tests.resourceMappingView");
 
-		try {
-			view = (ResourceMappingTestView) page
-					.showView("org.eclipse.ui.tests.resourceMappingView");
-		} catch (PartInitException e) {
-			fail(e.getLocalizedMessage());
-			return;
-		}
-
-		final MarkersTestMarkersView problemView;
-		try {
-			problemView = (MarkersTestMarkersView) page
-					.showView("org.eclipse.ui.tests.markerTests");
-		} catch (PartInitException e) {
-			fail(e.getLocalizedMessage());
-			return;
-		}
+		final MarkersTestMarkersView problemView = (MarkersTestMarkersView) page
+				.showView("org.eclipse.ui.tests.markerTests");
 
 		IMarker marker=view.addMarkerToFirstProject();
 		assertNotNull("Marker creation failed", marker);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/navigator/AbstractNavigatorTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/navigator/AbstractNavigatorTest.java
@@ -81,11 +81,7 @@ public abstract class AbstractNavigatorTest extends UITestCase {
 	@Override
 	protected void doTearDown() throws Exception {
 		if (testProject != null) {
-			try {
-				testProject.delete(true, null);
-			} catch (CoreException e) {
-				fail(e.toString());
-			}
+			testProject.delete(true, null);
 			testProject = null;
 			testFolder = null;
 			testFile = null;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/operations/OperationsAPITest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/operations/OperationsAPITest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.operations.AbstractOperation;
@@ -272,12 +271,8 @@ public class OperationsAPITest {
 		// IllegalStateException upon trying to open a composite.  If cleanup
 		// after the above exception is done, then we shouldn't get an
 		// IllegalStateException.
-		try {
-			history.openOperation(new TriggeredOperations(op3, history), IOperationHistory.EXECUTE);
-			history.closeOperation(true, true, IOperationHistory.EXECUTE);
-		} catch (IllegalStateException e) {
-			fail("IllegalStateException - trying to open an operation before a close");
-		}
+		history.openOperation(new TriggeredOperations(op3, history), IOperationHistory.EXECUTE);
+		history.closeOperation(true, true, IOperationHistory.EXECUTE);
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/FontPreferenceTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/FontPreferenceTestCase.java
@@ -16,7 +16,6 @@ package org.eclipse.ui.tests.preferences;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -138,9 +137,11 @@ public class FontPreferenceTestCase {
 	/**
 	 * The test added to assess results of accessing FontRegistry from a non-UI
 	 * thread. See bug 230360.
+	 *
+	 * @throws InterruptedException
 	 */
 	@Test
-	public void testNonUIThreadFontAccess() {
+	public void testNonUIThreadFontAccess() throws InterruptedException {
 		// create a separate font registry to avoid contaminating other tests
 		final FontRegistry fontRegistry = new FontRegistry("org.eclipse.jface.resource.jfacefonts"); //$NON-NLS-1$
 		// pre-calculate the default font; calling it in worker thread will only cause SWTException
@@ -170,8 +171,6 @@ public class FontPreferenceTestCase {
 			job.schedule();
 			job.join();
 			assertTrue(errorLogged[0]);
-		} catch (InterruptedException e) {
-			fail("Worker thread was interrupted in the FontRegistry access test");
 		} finally {
 			Policy.setLog(logger);
 		}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/MultiInstancePropertySheetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/MultiInstancePropertySheetTest.java
@@ -159,12 +159,8 @@ public class MultiInstancePropertySheetTest extends AbstractPropertySheetTest {
 	@Test
 	public void testAllowsMultiple() throws PartInitException {
 		activePage.showView(IPageLayout.ID_PROP_SHEET);
-		try {
-			activePage.showView(IPageLayout.ID_PROP_SHEET, "aSecondaryId",
-					IWorkbenchPage.VIEW_ACTIVATE);
-		} catch (PartInitException e) {
-			fail(e.getMessage());
-		}
+		activePage.showView(IPageLayout.ID_PROP_SHEET, "aSecondaryId",
+				IWorkbenchPage.VIEW_ACTIVATE);
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/session/NonRestorablePropertySheetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/session/NonRestorablePropertySheetTest.java
@@ -58,12 +58,7 @@ public class NonRestorablePropertySheetTest extends TestCase {
 		assertTrue(part instanceof PropertySheet);
 
 		for (int j = 0; j < 3; j++) {
-			try {
-				page.showView(IPageLayout.ID_PROP_SHEET, "#" + j,
-						IWorkbenchPage.VIEW_ACTIVATE);
-			} catch (PartInitException e) {
-				fail(e.getMessage());
-			}
+			page.showView(IPageLayout.ID_PROP_SHEET, "#" + j, IWorkbenchPage.VIEW_ACTIVATE);
 		}
 		assertTrue(countPropertySheetViews(page) == 4);
 	}


### PR DESCRIPTION
Several test methods in org.eclipse.ui.tests catch exceptions to then simply fail with the message of that same exception. With this change, the test methods are adapted to directly throw those exceptions so simplify the test implementation and remove obsolete fail statements.