### PR TITLE
Remove obsolete fail statements in org.eclipse.ui.tests.navigator

### DIFF
--- a/tests/org.eclipse.ui.tests.navigator/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.navigator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundlename
 Bundle-SymbolicName: org.eclipse.ui.tests.navigator;singleton:=true
-Bundle-Version: 3.8.100.qualifier
+Bundle-Version: 3.8.200.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/ActionProviderTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/ActionProviderTest.java
@@ -17,7 +17,6 @@ package org.eclipse.ui.tests.navigator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -69,7 +68,7 @@ public class ActionProviderTest extends NavigatorTestBase {
 	}
 
 	@Test
-	public void testOverride() {
+	public void testOverride() throws CoreException {
 		_contentService.bindExtensions(
 				new String[] { TEST_CONTENT_ACTION_PROVIDER }, false);
 		_contentService.getActivationService().activateExtensions(
@@ -79,12 +78,7 @@ public class ActionProviderTest extends NavigatorTestBase {
 
 		refreshViewer();
 
-		IStructuredSelection sel = null;
-		try {
-			sel = new StructuredSelection(((IContainer) _p2.members()[1]).members()[0]);
-		} catch (CoreException e) {
-			fail("Should not throw an exception");
-		}
+		IStructuredSelection sel = new StructuredSelection(((IContainer) _p2.members()[1]).members()[0]);
 		_viewer.setSelection(sel);
 
 		if (SLEEP_LONG)
@@ -112,14 +106,9 @@ public class ActionProviderTest extends NavigatorTestBase {
 	}
 
 	@Test
-	public void testAppearsBefore() {
+	public void testAppearsBefore() throws CoreException {
 
-		IStructuredSelection sel = null;
-		try {
-			sel = new StructuredSelection(((IContainer) _p2.members()[1]).members()[0]);
-		} catch (CoreException e) {
-			fail("Should not throw an exception");
-		}
+		IStructuredSelection sel = new StructuredSelection(((IContainer) _p2.members()[1]).members()[0]);
 		_viewer.setSelection(sel);
 
 		MenuManager mm = new MenuManager();

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/DecorationSchedulerRaceConditionTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/DecorationSchedulerRaceConditionTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.ui.tests.navigator;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 import java.util.concurrent.Semaphore;
 
@@ -81,7 +80,7 @@ public class DecorationSchedulerRaceConditionTest extends NavigatorTestBase {
 
 	@Override
 	@Before
-	public void setUp() {
+	public void setUp() throws CoreException {
 		super.setUp();
 
 		_contentService.bindExtensions(new String[] { COMMON_NAVIGATOR_RESOURCE_EXT }, true);
@@ -89,20 +88,10 @@ public class DecorationSchedulerRaceConditionTest extends NavigatorTestBase {
 
 		p1Project = ResourcesPlugin.getWorkspace().getRoot().getProject(TestWorkspace.P1_PROJECT_NAME);
 		p2Project = ResourcesPlugin.getWorkspace().getRoot().getProject(TestWorkspace.P2_PROJECT_NAME);
-		try {
-			p1Project.setSessionProperty(DecorationSchedulerRaceConditionTestDecorator.DECO_PROP, DECORATION_TEXT_1);
-		} catch (CoreException e) {
-			e.printStackTrace();
-			fail("Exception caught: " + e);
-		}
+		p1Project.setSessionProperty(DecorationSchedulerRaceConditionTestDecorator.DECO_PROP, DECORATION_TEXT_1);
 
 		IDecoratorManager manager = PlatformUI.getWorkbench().getDecoratorManager();
-		try {
-			manager.setEnabled("org.eclipse.ui.tests.navigator.bug417255Decorator", true);
-		} catch (CoreException e) {
-			e.printStackTrace();
-			fail("Exception caught: " + e);
-		}
+		manager.setEnabled("org.eclipse.ui.tests.navigator.bug417255Decorator", true);
 
 		waitForP1Decoration.waitForCondition(Display.getCurrent(), TIMEOUT_DECORATOR); // wait for decorator to run
 		DisplayHelper.sleep(Display.getCurrent(), TIMEOUT_UPDATE_JOB); // wait for update job following decoration to

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/DnDTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/DnDTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.viewers.StructuredSelection;
@@ -32,26 +31,12 @@ import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.eclipse.ui.tests.harness.util.SWTEventHelper;
 import org.eclipse.ui.tests.navigator.extension.TestDragAssistant;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 public class DnDTest extends NavigatorTestBase {
 
 	public DnDTest() {
 		_navigatorInstanceId = TEST_VIEWER;
-	}
-
-	@Override
-	@Before
-	public void setUp() {
-		super.setUp();
-	}
-
-	@Override
-	@After
-	public void tearDown() {
-		super.tearDown();
 	}
 
 	@Test
@@ -90,7 +75,7 @@ public class DnDTest extends NavigatorTestBase {
 	// CommonDragAdapterAssistant
 	// to perform clean up after drag has finished
 	@Test
-	public void testResourceDrag() {
+	public void testResourceDrag() throws PartInitException {
 		_viewer.expandToLevel(_p1, 3);
 
 		IFile file = _p1.getFolder("f1").getFile("file1.txt");
@@ -102,12 +87,7 @@ public class DnDTest extends NavigatorTestBase {
 		// used
 		IWorkbenchPage activePage = PlatformUI.getWorkbench()
 				.getActiveWorkbenchWindow().getActivePage();
-		TextEditor editorPart = null;
-		try {
-			editorPart = (TextEditor) IDE.openEditor(activePage, file);
-		} catch (PartInitException e) {
-			fail("Should not throw an exception");
-		}
+		TextEditor editorPart = (TextEditor) IDE.openEditor(activePage, file);
 
 		Control end = editorPart.getAdapter(Control.class);
 
@@ -127,7 +107,7 @@ public class DnDTest extends NavigatorTestBase {
 
 	// bug 264323 [CommonNavigator] CommonDragAdapterAssistant should be allowed to opt out of a drag
 	@Test
-	public void testDragOptOut() {
+	public void testDragOptOut() throws PartInitException {
 		_viewer.expandToLevel(_p1, 3);
 
 		IFile file = _p1.getFolder("f1").getFile("file1.txt");
@@ -139,12 +119,7 @@ public class DnDTest extends NavigatorTestBase {
 		// used
 		IWorkbenchPage activePage = PlatformUI.getWorkbench()
 				.getActiveWorkbenchWindow().getActivePage();
-		TextEditor editorPart = null;
-		try {
-			editorPart = (TextEditor) IDE.openEditor(activePage, file);
-		} catch (PartInitException e) {
-			fail("Should not throw an exception");
-		}
+		TextEditor editorPart = (TextEditor) IDE.openEditor(activePage, file);
 
 		Control end = editorPart.getAdapter(Control.class);
 

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/EvaluationCacheTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/EvaluationCacheTest.java
@@ -15,6 +15,7 @@ package org.eclipse.ui.tests.navigator;
 
 import java.util.ArrayList;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.ui.internal.navigator.VisibilityAssistant;
 import org.eclipse.ui.internal.navigator.extensions.EvaluationCache;
 import org.eclipse.ui.internal.navigator.extensions.NavigatorContentDescriptor;
@@ -37,7 +38,7 @@ public class EvaluationCacheTest extends NavigatorTestBase {
 	}
 
 	@Override
-	public void setUp() {
+	public void setUp() throws CoreException {
 		super.setUp();
 		INavigatorViewerDescriptor mockViewerDescript = new TestNavigatorViewerDescriptor();
 		INavigatorActivationService mockActivationService = new TestNavigatorActivationService();

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/GoBackForwardsTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/GoBackForwardsTest.java
@@ -76,7 +76,7 @@ public class GoBackForwardsTest extends UITestCase {
 	}
 
 	@Test
-	public void testNavigationHistoryNavigation() {
+	public void testNavigationHistoryNavigation() throws PartInitException {
 		IIntroPart introPart = PlatformUI.getWorkbench().getIntroManager().getIntro();
 		PlatformUI.getWorkbench().getIntroManager().closeIntro(introPart);
 
@@ -91,39 +91,33 @@ public class GoBackForwardsTest extends UITestCase {
 
 		openGenericEditor(editorInput);
 
-		if (!processEventsUntil(genericEditorNoSelection, 1000)) {
-			fail("Timeout during navigation." + getStateDetails());
-		}
+		assertTrue("Timeout during navigation." + getStateDetails(),
+				processEventsUntil(genericEditorNoSelection, 1000));
 
 		selectInGenericEditor(editorInput);
 
-		if (!processEventsUntil(genericEditorSelection, 1000)) {
-			fail("Timeout during navigation." + getStateDetails());
-		}
+		assertTrue("Timeout during navigation." + getStateDetails(),
+				processEventsUntil(genericEditorSelection, 1000));
 
 		openTextEditor(editorInput);
 
-		if (!processEventsUntil(textEditorNoSelection, 1000)) {
-			fail("Timeout during navigation." + getStateDetails());
-		}
+		assertTrue("Timeout during navigation." + getStateDetails(),
+				processEventsUntil(textEditorNoSelection, 1000));
 
 		selectInTextEditor(editorInput);
 
-		if (!processEventsUntil(textEditorSelection, 1000)) {
-			fail("Timeout during navigation." + getStateDetails());
-		}
+		assertTrue("Timeout during navigation." + getStateDetails(),
+				processEventsUntil(textEditorSelection, 1000));
 
 		openGenericEditor(editorInput);
 
-		if (!processEventsUntil(genericEditorSelection, 1000)) {
-			fail("Timeout during navigation." + getStateDetails());
-		}
+		assertTrue("Timeout during navigation." + getStateDetails(),
+				processEventsUntil(genericEditorSelection, 1000));
 
 		openTextEditor(editorInput);
 
-		if (!processEventsUntil(textEditorSelection, 1000)) {
-			fail("Timeout during navigation." + getStateDetails());
-		}
+		assertTrue("Timeout during navigation." + getStateDetails(),
+				processEventsUntil(textEditorSelection, 1000));
 
 		// Navigate backward from text editor to editor
 		goBackward(EditorTestHelper.getActiveWorkbenchWindow(), genericEditorSelection);
@@ -184,58 +178,38 @@ public class GoBackForwardsTest extends UITestCase {
 		};
 	}
 
-	private void openGenericEditor(IEditorInput editorInput) {
-		try {
-			EditorTestHelper.getActivePage().openEditor(editorInput, GENERIC_EDITOR_ID, true,
-					IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
-		} catch (PartInitException e) {
-			fail("Should not throw an exception");
-		}
+	private void openGenericEditor(IEditorInput editorInput) throws PartInitException {
+		EditorTestHelper.getActivePage().openEditor(editorInput, GENERIC_EDITOR_ID, true,
+				IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
 	}
 
-	private void selectInGenericEditor(IEditorInput editorInput) {
-		try {
-			AbstractTextEditor editor = (AbstractTextEditor) EditorTestHelper.getActivePage().openEditor(editorInput,
-					GENERIC_EDITOR_ID, true, IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
-			editor.selectAndReveal(10, 5);
-		} catch (PartInitException e) {
-			fail("Should not throw an exception");
-		}
+	private void selectInGenericEditor(IEditorInput editorInput) throws PartInitException {
+		AbstractTextEditor editor = (AbstractTextEditor) EditorTestHelper.getActivePage().openEditor(editorInput,
+				GENERIC_EDITOR_ID, true, IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
+		editor.selectAndReveal(10, 5);
 	}
 
-	private void selectInTextEditor(IEditorInput editorInput) {
-		try {
-			AbstractTextEditor editor = (AbstractTextEditor) EditorTestHelper.getActivePage().openEditor(editorInput,
-					TEXT_EDITOR_ID, true, IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
-			editor.selectAndReveal(10, 5);
-		} catch (PartInitException e) {
-			fail("Should not throw an exception");
-		}
+	private void selectInTextEditor(IEditorInput editorInput) throws PartInitException {
+		AbstractTextEditor editor = (AbstractTextEditor) EditorTestHelper.getActivePage().openEditor(editorInput,
+				TEXT_EDITOR_ID, true, IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
+		editor.selectAndReveal(10, 5);
 	}
 
-	private void openTextEditor(IEditorInput editorInput) {
-		try {
-			EditorTestHelper.getActivePage().openEditor(editorInput, TEXT_EDITOR_ID, true,
-					IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
-		} catch (PartInitException e) {
-			fail("Should not throw an exception");
-		}
+	private void openTextEditor(IEditorInput editorInput) throws PartInitException {
+		EditorTestHelper.getActivePage().openEditor(editorInput, TEXT_EDITOR_ID, true,
+				IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
 	}
 
 	private void goForward(IWorkbenchWindow window, Condition condition) {
 		NavigationHistoryAction action = new NavigationHistoryAction(window, true);
 		action.run();
-		if (!processEventsUntil(condition, 1000)) {
-			fail("Timeout during navigation.");
-		}
+		assertTrue("Timeout during navigation.", processEventsUntil(condition, 1000));
 	}
 
 	private void goBackward(IWorkbenchWindow window, Condition condition) {
 		NavigationHistoryAction action = new NavigationHistoryAction(window, false);
 		action.run();
-		if (!processEventsUntil(condition, 1000)) {
-			fail("Timeout during navigation.");
-		}
+		assertTrue("Timeout during navigation.", processEventsUntil(condition, 1000));
 	}
 
 	private String getActiveEditorId() {

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/NavigatorTestBase.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/NavigatorTestBase.java
@@ -182,19 +182,16 @@ public class NavigatorTestBase {
 	}
 
 	@Before
-	public void setUp() {
+	public void setUp() throws CoreException {
 
 		if (_navigatorInstanceId == null) {
 			throw new RuntimeException("Set the _navigatorInstanceId in the constructor");
 		}
 
 		// Easier if this is not around when not needed
-		if (!_navigatorInstanceId.equals(ProjectExplorer.VIEW_ID))
-			try {
-				EditorTestHelper.showView(ProjectExplorer.VIEW_ID, false);
-			} catch (PartInitException e) {
-				fail("Should not throw an exception");
-			}
+		if (!_navigatorInstanceId.equals(ProjectExplorer.VIEW_ID)) {
+			EditorTestHelper.showView(ProjectExplorer.VIEW_ID, false);
+		}
 
 		TestContentProviderPipelined.resetTest();
 		TestContentProviderResource.resetTest();
@@ -217,14 +214,10 @@ public class NavigatorTestBase {
 			_expectedChildren.add(_project.getFile(".classpath")); //$NON-NLS-1$
 			_expectedChildren.add(_project.getFile("model.properties")); //$NON-NLS-1$
 
-			try {
-				_p1 = ResourcesPlugin.getWorkspace().getRoot().getProject("p1");
-				_p1.open(null);
-				_p2 = ResourcesPlugin.getWorkspace().getRoot().getProject("p2");
-				_p2.open(null);
-			} catch (CoreException e) {
-				fail("Should not throw an exception");
-			}
+			_p1 = ResourcesPlugin.getWorkspace().getRoot().getProject("p1");
+			_p1.open(null);
+			_p2 = ResourcesPlugin.getWorkspace().getRoot().getProject("p2");
+			_p2.open(null);
 
 			_projectCount = 3;
 		}
@@ -270,12 +263,8 @@ public class NavigatorTestBase {
 		fail("The condition '" + description + "' was never met");
 	}
 
-	protected void showNavigator() {
-		try {
-			EditorTestHelper.showView(_navigatorInstanceId, true);
-		} catch (PartInitException e) {
-			fail("Should not throw an exception");
-		}
+	protected void showNavigator() throws PartInitException {
+		EditorTestHelper.showView(_navigatorInstanceId, true);
 
 		IWorkbenchWindow activeWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 		IWorkbenchPage activePage = activeWindow.getActivePage();
@@ -286,24 +275,16 @@ public class NavigatorTestBase {
 	}
 
 	@After
-	public void tearDown() {
+	public void tearDown() throws CoreException {
 		clearAll();
 		// Hide it, we want a new one each time
-		try {
-			EditorTestHelper.showView(_navigatorInstanceId, false);
-		} catch (PartInitException e) {
-			fail("Should not throw an exception");
-		}
+		EditorTestHelper.showView(_navigatorInstanceId, false);
 	}
 
-	protected void clearAll() {
+	protected void clearAll() throws CoreException {
 		IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
 		for (IProject project : projects) {
-			try {
-				FileUtil.delete(project);
-			} catch (CoreException e) {
-				fail("Should not throw an exception");
-			}
+			FileUtil.delete(project);
 		}
 	}
 

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/PerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/PerformanceTest.java
@@ -25,7 +25,6 @@ import java.text.DecimalFormat;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -36,8 +35,6 @@ import org.eclipse.ui.navigator.ICommonViewerMapper;
 import org.eclipse.ui.navigator.resources.ProjectExplorer;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.eclipse.ui.tests.harness.util.EditorTestHelper;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -56,19 +53,7 @@ public class PerformanceTest extends NavigatorTestBase {
 		_initTestData = false;
 	}
 
-	@Override
-	@Before
-	public void setUp() {
-		super.setUp();
-	}
-
-	@Override
-	@After
-	public void tearDown() {
-		super.tearDown();
-	}
-
-	protected void createProjects() {
+	protected void createProjects() throws InterruptedException {
 		Job createJob = new Job("Create projects") {
 
 			@Override
@@ -94,11 +79,7 @@ public class PerformanceTest extends NavigatorTestBase {
 
 		createJob.setRule(ResourcesPlugin.getWorkspace().getRoot());
 		createJob.schedule();
-		try {
-			createJob.join();
-		} catch (InterruptedException e) {
-			fail("Should not throw an exception");
-		}
+		createJob.join();
 
 		assertEquals(createJob.getResult(), Status.OK_STATUS);
 
@@ -113,7 +94,7 @@ public class PerformanceTest extends NavigatorTestBase {
 		assertEquals(_numProjects, numOfProjects);
 	}
 
-	protected void deleteProjects() {
+	protected void deleteProjects() throws InterruptedException {
 		Job deleteJob = new Job("Delete Projects") {
 
 			@Override
@@ -135,18 +116,14 @@ public class PerformanceTest extends NavigatorTestBase {
 
 		deleteJob.setRule(ResourcesPlugin.getWorkspace().getRoot());
 		deleteJob.schedule();
-		try {
-			deleteJob.join();
-		} catch (InterruptedException e) {
-			fail("Should not throw an exception");
-		}
+		deleteJob.join();
 
 		assertEquals(deleteJob.getResult(), Status.OK_STATUS);
 
 		DisplayHelper.runEventLoop(Display.getCurrent(), 10);
 	}
 
-	protected void createFiles(final IProject project, final int startNumber)
+	protected void createFiles(final IProject project, final int startNumber) throws InterruptedException
  {
 		Job createJob = new Job("Create Files") {
 
@@ -169,11 +146,8 @@ public class PerformanceTest extends NavigatorTestBase {
 
 		createJob.setRule(ResourcesPlugin.getWorkspace().getRoot());
 		createJob.schedule();
-		try {
-			createJob.join();
-		} catch (InterruptedException e) {
-			fail("Should not throw an exception");
-		}
+		createJob.join();
+
 		assertEquals(createJob.getResult(), Status.OK_STATUS);
 	}
 
@@ -204,18 +178,14 @@ public class PerformanceTest extends NavigatorTestBase {
 
 	// bug 159828 deleting large number of projects takes too long
 	@Test
-	public void testCreateAndDeleteProjects() {
+	public void testCreateAndDeleteProjects() throws PartInitException, InterruptedException {
 
 		_numProjects = 100;
 
 		createProjects();
 
 		// Hide it
-		try {
-			EditorTestHelper.showView(_navigatorInstanceId, false);
-		} catch (PartInitException e) {
-			fail("Should not throw an exception");
-		}
+		EditorTestHelper.showView(_navigatorInstanceId, false);
 
 		long start = System.currentTimeMillis();
 		deleteProjects();
@@ -281,7 +251,7 @@ public class PerformanceTest extends NavigatorTestBase {
 				+ (System.currentTimeMillis() - start));
 	}
 
-	protected void createFilesForProjects() {
+	protected void createFilesForProjects() throws InterruptedException {
 		for (int i = 0; i < _numProjects; i++) {
 			String name = _df.format(i);
 			IProject p1 = ResourcesPlugin.getWorkspace().getRoot().getProject(
@@ -306,12 +276,7 @@ public class PerformanceTest extends NavigatorTestBase {
 		final IProject p1 = ResourcesPlugin.getWorkspace().getRoot()
 				.getProject("p000");
 
-		try {
-			p1.close(null);
-		} catch (CoreException e) {
-			fail("Should not throw an exception");
-
-		}
+		p1.close(null);
 
 		long start = System.currentTimeMillis();
 		_viewer.setMapper(null);

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/jst/JstPipelineTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/jst/JstPipelineTest.java
@@ -24,6 +24,7 @@ import java.util.function.Predicate;
 
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.viewers.StructuredSelection;
@@ -43,7 +44,7 @@ public class JstPipelineTest extends NavigatorTestBase {
 
 	@Override
 	@Before
-	public void setUp() {
+	public void setUp() throws CoreException {
 		super.setUp();
 
 		WebJavaContentProvider.staticInit(_contentService.getContentExtensionById(COMMON_NAVIGATOR_JAVA_EXT)

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/FoldersAsProjectsContributionTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/FoldersAsProjectsContributionTest.java
@@ -15,7 +15,6 @@ package org.eclipse.ui.tests.navigator.resources;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -82,7 +81,7 @@ public final class FoldersAsProjectsContributionTest {
 
 	@Test
 	@Ignore
-	public void alreadyAdded() {
+	public void alreadyAdded() throws IOException, CoreException {
 		IProject outer = ResourcesPlugin.getWorkspace().getRoot().getProject("foldersasprojects.alreadyAdded.outer");
 		IProject inner1 = ResourcesPlugin.getWorkspace().getRoot().getProject("foldersasprojects.alreadyAdded.inner1");
 		IProject inner2 = ResourcesPlugin.getWorkspace().getRoot().getProject("foldersasprojects.alreadyAdded.inner2");
@@ -94,8 +93,6 @@ public final class FoldersAsProjectsContributionTest {
 			createProject(root, outer);
 			createProject(new Path(root.getAbsolutePath()).append(inner1.getName()).toFile(), inner1);
 			createProject(new Path(root.getAbsolutePath()).append(inner2.getName()).toFile(), inner2);
-		} catch (CoreException | IOException e) {
-			fail(NLS.bind("Required projects can not be created due to: {0}", e.getMessage()));
 		} finally {
 			Job.getJobManager().endRule(rule);
 		}
@@ -117,7 +114,7 @@ public final class FoldersAsProjectsContributionTest {
 
 	@Test
 	@Ignore
-	public void notYetImported() {
+	public void notYetImported() throws IOException, CoreException {
 		IProject outer = ResourcesPlugin.getWorkspace().getRoot().getProject("foldersasprojects.notYetImported.outer");
 		IProject inner1 = ResourcesPlugin.getWorkspace().getRoot()
 				.getProject("foldersasprojects.notYetImported.inner1");
@@ -133,8 +130,6 @@ public final class FoldersAsProjectsContributionTest {
 			createProject(new Path(root.getAbsolutePath()).append(inner2.getName()).toFile(), inner2);
 			inner1.delete(false, true, new NullProgressMonitor());
 			inner2.delete(false, true, new NullProgressMonitor());
-		} catch (CoreException | IOException e) {
-			fail(NLS.bind("Required projects can not be created due to: {0}", e.getMessage()));
 		} finally {
 			Job.getJobManager().endRule(rule);
 		}
@@ -152,7 +147,7 @@ public final class FoldersAsProjectsContributionTest {
 	}
 
 	@Test
-	public void ambiguity() {
+	public void ambiguity() throws CoreException, IOException {
 		IProject outer = ResourcesPlugin.getWorkspace().getRoot().getProject("foldersasprojects.ambiguity.outer");
 		IProject inner1 = ResourcesPlugin.getWorkspace().getRoot().getProject("foldersasprojects.ambiguity.inner1");
 		IProject inner2 = ResourcesPlugin.getWorkspace().getRoot().getProject("foldersasprojects.ambiguity.inner2");
@@ -165,8 +160,6 @@ public final class FoldersAsProjectsContributionTest {
 			createProject(new Path(root.getAbsolutePath()).append(inner1.getName()).toFile(), inner1);
 			createProject(new Path(root.getAbsolutePath()).append(inner2.getName()).toFile(), inner2);
 			inner1.delete(false, true, new NullProgressMonitor());
-		} catch (CoreException | IOException e) {
-			fail(NLS.bind("Required projects can not be created due to: {0}", e.getMessage()));
 		} finally {
 			Job.getJobManager().endRule(rule);
 		}
@@ -232,25 +225,20 @@ public final class FoldersAsProjectsContributionTest {
 		actual.open(new NullProgressMonitor());
 	}
 
-	private void ensureDescriptionsExist(IProject outer, IProject inner1, IProject inner2) {
+	private void ensureDescriptionsExist(IProject outer, IProject inner1, IProject inner2) throws IOException {
 		ensureFileExists(outer.getFolder(inner1.getName()).getFile(IProjectDescription.DESCRIPTION_FILE_NAME),
 				inner1.getName());
 		ensureFileExists(outer.getFolder(inner2.getName()).getFile(IProjectDescription.DESCRIPTION_FILE_NAME),
 				inner2.getName());
 	}
 
-	private void ensureFileExists(IFile description, String name) {
+	private void ensureFileExists(IFile description, String name) throws IOException {
 		if (description.exists()) {
 			return;
 		}
 		// If project description does not exist after creation (for whatever reason),
 		// create it explicitly with empty content
-		try {
-			Files.createFile(Paths.get(description.getLocationURI()));
-		} catch (IOException e) {
-			fail(String.format("Can't explicitly create project description due to: %s %s", e.getClass().getName(),
-					e.getMessage()));
-		}
+		Files.createFile(Paths.get(description.getLocationURI()));
 		assertTrue(String.format("Project description for %s does not exist", name), description.exists());
 	}
 

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/ResourceMgmtActionProviderTests.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/ResourceMgmtActionProviderTests.java
@@ -48,7 +48,7 @@ public final class ResourceMgmtActionProviderTests extends NavigatorTestBase {
 
 	@Override
 	@Before
-	public void setUp() {
+	public void setUp() throws CoreException {
 		super.setUp();
 		manager = new MenuManager();
 		manager.add(new GroupMarker(ICommonMenuConstants.GROUP_BUILD));
@@ -90,83 +90,71 @@ public final class ResourceMgmtActionProviderTests extends NavigatorTestBase {
 	/**
 	 * Test for 'open project' that doesn't have a builder attached - all but
 	 * 'build' &amp; 'open project' should be enabled
+	 *
+	 * @throws CoreException
 	 */
 	@Test
-	public void testFillContextMenu_openProjectNoBuilderSelection() {
+	public void testFillContextMenu_openProjectNoBuilderSelection() throws CoreException {
 		IProject openProj = ResourcesPlugin.getWorkspace().getRoot().getProject("Test");
 		boolean autoBuildInitialState = ResourcesPlugin.getWorkspace().getDescription().isAutoBuilding();
 
-		try {
-			if (!autoBuildInitialState) {
-				// we want to enable auto-building for this test to guarantee that the 'build'
-				// menu option isn't shown
-				IWorkspaceDescription wsd = ResourcesPlugin.getWorkspace().getDescription();
-				wsd.setAutoBuilding(true);
-				ResourcesPlugin.getWorkspace().setDescription(wsd);
-			}
-			openProj.open(null);
-		} catch (CoreException e) {
-			fail(e.getClass().getSimpleName() + " thrown: " + e.getLocalizedMessage());
+		if (!autoBuildInitialState) {
+			// we want to enable auto-building for this test to guarantee that the 'build'
+			// menu option isn't shown
+			IWorkspaceDescription wsd = ResourcesPlugin.getWorkspace().getDescription();
+			wsd.setAutoBuilding(true);
+			ResourcesPlugin.getWorkspace().setDescription(wsd);
 		}
+		openProj.open(null);
 		ResourceMgmtActionProvider provider = provider(openProj);
 		provider.fillContextMenu(manager);
 		checkMenuHasCorrectContributions(false, true, false, true, true);
 
 		if (!autoBuildInitialState) {
 			// clean-up: reset autobuild since we changed it
-			try {
-				IWorkspaceDescription wsd = ResourcesPlugin.getWorkspace().getDescription();
-				wsd.setAutoBuilding(false);
-				ResourcesPlugin.getWorkspace().setDescription(wsd);
-			} catch (CoreException e) {
-				fail(e.getClass().getSimpleName() + " thrown: " + e.getLocalizedMessage());
-			}
+			IWorkspaceDescription wsd = ResourcesPlugin.getWorkspace().getDescription();
+			wsd.setAutoBuilding(false);
+			ResourcesPlugin.getWorkspace().setDescription(wsd);
 		}
 	}
 
 	/**
 	 * Test for 'open project' that doesn't have a builder attached - only 'open
 	 * project' should be disabled
+	 *
+	 * @throws CoreException
 	 */
 	@Test
-	public void testFillContextMenu_openProjectWithBuilderSelection() {
+	public void testFillContextMenu_openProjectWithBuilderSelection() throws CoreException {
 		IProject openProj = ResourcesPlugin.getWorkspace().getRoot().getProject("Test");
 		IWorkspaceDescription wsd = ResourcesPlugin.getWorkspace().getDescription();
 		boolean autobuildInitialState = wsd.isAutoBuilding();
 		boolean hasNoInitialBuildCommands = false;
 		IProjectDescription desc = null;
-		try {
-			if (autobuildInitialState) {
-				wsd.setAutoBuilding(false);
-				ResourcesPlugin.getWorkspace().setDescription(wsd);
-			}
-			openProj.open(null);
-			desc = openProj.getDescription();
-			if (desc.getBuildSpec().length == 0) {
-				hasNoInitialBuildCommands = true;
-				ICommand cmd = desc.newCommand();
-				desc.setBuildSpec(new ICommand[] { cmd });
-				openProj.setDescription(desc, null);
-			}
-		} catch (CoreException e) {
-			fail(e.getClass().getSimpleName() + " thrown: " + e.getLocalizedMessage());
+		if (autobuildInitialState) {
+			wsd.setAutoBuilding(false);
+			ResourcesPlugin.getWorkspace().setDescription(wsd);
+		}
+		openProj.open(null);
+		desc = openProj.getDescription();
+		if (desc.getBuildSpec().length == 0) {
+			hasNoInitialBuildCommands = true;
+			ICommand cmd = desc.newCommand();
+			desc.setBuildSpec(new ICommand[] { cmd });
+			openProj.setDescription(desc, null);
 		}
 		ResourceMgmtActionProvider provider = provider(openProj);
 		provider.fillContextMenu(manager);
 		checkMenuHasCorrectContributions(true, true, false, true, true);
-		try {
-			// clean-up where needed: reset autobuild if we changed it & remove
-			// the build config if we added it
-			if (autobuildInitialState) {
-				wsd.setAutoBuilding(true);
-				ResourcesPlugin.getWorkspace().setDescription(wsd);
-			}
-			if (desc != null && hasNoInitialBuildCommands) {
-				desc.setBuildSpec(new ICommand[0]);
-				openProj.setDescription(desc, null);
-			}
-		} catch (CoreException e) {
-			fail(e.getClass().getSimpleName() + " thrown: " + e.getLocalizedMessage());
+		// clean-up where needed: reset autobuild if we changed it & remove
+		// the build config if we added it
+		if (autobuildInitialState) {
+			wsd.setAutoBuilding(true);
+			ResourcesPlugin.getWorkspace().setDescription(wsd);
+		}
+		if (desc != null && hasNoInitialBuildCommands) {
+			desc.setBuildSpec(new ICommand[0]);
+			openProj.setDescription(desc, null);
 		}
 	}
 


### PR DESCRIPTION
Several test methods in org.eclipse.ui.tests.navigator catch exceptions to then simply fail with the message of that same exception. With this change, the test methods are adapted to directly throw those exceptions so simplify the test implementation and remove obsolete fail statements.