### PR TITLE
Remove obsolete exception handling in tests

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.performance/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Performance Plug-in
 Bundle-SymbolicName: org.eclipse.ui.tests.performance;singleton:=true
-Bundle-Version: 1.6.400.qualifier
+Bundle-Version: 1.6.500.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.core.tests.harness,

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FileImageDescriptorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FileImageDescriptorTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.jface.tests.performance;
 
-import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -70,12 +69,7 @@ public class FileImageDescriptorTest extends BasicPerformanceTest {
 
 				for (URL file : files) {
 					startMeasuring();
-					try {
-						descriptor = ImageDescriptor.createFromFile(missing, FileLocator.toFileURL(file).getFile());
-					} catch (IOException e) {
-						fail(e.getLocalizedMessage(), e);
-						continue;
-					}
+					descriptor = ImageDescriptor.createFromFile(missing, FileLocator.toFileURL(file).getFile());
 
 					for (int j = 0; j < 10; j++) {
 						Image image = descriptor.createImage();

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ProgressMonitorDialogPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ProgressMonitorDialogPerformanceTest.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.jface.tests.performance;
 
-import java.lang.reflect.InvocationTargetException;
-
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.swt.widgets.Display;
@@ -80,11 +78,7 @@ public class ProgressMonitorDialogPerformanceTest extends BasicPerformanceTest {
 			}
 		};
 
-		try {
-			dialog.run(false, true, runnable);
-		} catch (InvocationTargetException | InterruptedException e) {
-			fail(e.getMessage(), e);
-		}
+		dialog.run(false, true, runnable);
 
 		commitMeasurements();
 		assertPerformance();

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/BasicPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/BasicPerformanceTest.java
@@ -26,6 +26,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.test.performance.Dimension;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.function.ThrowingRunnable;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
@@ -221,7 +222,7 @@ public abstract class BasicPerformanceTest extends UITestCase {
 	 *
 	 * @since 3.1
 	 */
-	public static void exercise(Runnable runnable) throws CoreException {
+	public static void exercise(ThrowingRunnable runnable) throws CoreException {
 		exercise(runnable, 3, 100, 4000);
 	}
 
@@ -231,7 +232,7 @@ public abstract class BasicPerformanceTest extends UITestCase {
 	 *
 	 * @since 3.1
 	 */
-	public static void exercise(Runnable runnable,
+	public static void exercise(ThrowingRunnable runnable,
 			int minIterations,
 			int maxIterations, int maxTime) throws CoreException {
 		long startTime = System.currentTimeMillis();
@@ -240,7 +241,7 @@ public abstract class BasicPerformanceTest extends UITestCase {
 
 			try {
 				runnable.run();
-			} catch (Exception e) {
+			} catch (Throwable e) {
 				throw new CoreException(new Status(IStatus.ERROR,
 						FrameworkUtil.getBundle(BasicPerformanceTest.class)
 								.getSymbolicName(), IStatus.OK,


### PR DESCRIPTION
Let the tests throw the exceptions instead to be handled by the JUnit framework. The adapted places do not throw CoreExceptions that would require additional handling for proper formatting.