### PR TITLE
Move ShellStateListener to only test class that uses it

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.harness/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Harness Plug-in
 Bundle-SymbolicName: org.eclipse.ui.tests.harness;singleton:=true
-Bundle-Version: 1.10.500.qualifier
+Bundle-Version: 1.10.600.qualifier
 Eclipse-BundleShape: dir
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
@@ -22,7 +22,6 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -31,8 +30,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceMemento;
-import org.eclipse.swt.events.ShellEvent;
-import org.eclipse.swt.events.ShellListener;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbench;
@@ -328,39 +325,6 @@ public abstract class UITestCase extends TestCase {
 		processEvents();
 		waitForJobs(400, 3000);
 		return display.getActiveShell() == shell;
-	}
-
-	public static class ShellStateListener implements ShellListener {
-		private final AtomicBoolean shellIsActive;
-
-		public ShellStateListener(AtomicBoolean shellIsActive) {
-			this.shellIsActive = shellIsActive;
-		}
-
-		@Override
-		public void shellIconified(ShellEvent e) {
-			shellIsActive.set(false);
-		}
-
-		@Override
-		public void shellDeiconified(ShellEvent e) {
-			shellIsActive.set(true);
-		}
-
-		@Override
-		public void shellDeactivated(ShellEvent e) {
-			shellIsActive.set(false);
-		}
-
-		@Override
-		public void shellClosed(ShellEvent e) {
-			shellIsActive.set(false);
-		}
-
-		@Override
-		public void shellActivated(ShellEvent e) {
-			shellIsActive.set(true);
-		}
 	}
 
 	public static interface Condition {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPageTest.java
@@ -37,6 +37,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.util.IPropertyChangeListener;
+import org.eclipse.swt.events.ShellEvent;
 import org.eclipse.swt.events.ShellListener;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
@@ -3332,4 +3333,38 @@ public class IWorkbenchPageTest extends UITestCase {
 
 		assertEquals(part, stack[0]);
 	}
+
+	private static class ShellStateListener implements ShellListener {
+		private final AtomicBoolean shellIsActive;
+
+		public ShellStateListener(AtomicBoolean shellIsActive) {
+			this.shellIsActive = shellIsActive;
+		}
+
+		@Override
+		public void shellIconified(ShellEvent e) {
+			shellIsActive.set(false);
+		}
+
+		@Override
+		public void shellDeiconified(ShellEvent e) {
+			shellIsActive.set(true);
+		}
+
+		@Override
+		public void shellDeactivated(ShellEvent e) {
+			shellIsActive.set(false);
+		}
+
+		@Override
+		public void shellClosed(ShellEvent e) {
+			shellIsActive.set(false);
+		}
+
+		@Override
+		public void shellActivated(ShellEvent e) {
+			shellIsActive.set(true);
+		}
+	}
+
 }


### PR DESCRIPTION
ShellStateListener is only used in a single test class, so move it there from the to-be-removed UITestCase.