### PR TITLE
Remove workbench field and getter from UITestCase

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
@@ -32,7 +32,6 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceMemento;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
@@ -71,7 +70,6 @@ public abstract class UITestCase extends TestCase {
 	 */
 	private final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
-	protected IWorkbench fWorkbench;
 	private Set<Shell> preExistingShells;
 
 	/** Preference helper to restore changed preference values after test run. */
@@ -177,8 +175,7 @@ public abstract class UITestCase extends TestCase {
 	public final void setUp() throws Exception {
 		super.setUp();
 		closeTestWindows.before();
-		fWorkbench = PlatformUI.getWorkbench();
-		this.preExistingShells = Set.of(fWorkbench.getDisplay().getShells());
+		this.preExistingShells = Set.of(PlatformUI.getWorkbench().getDisplay().getShells());
 		String name = runningTest != null ? runningTest : this.getName();
 		trace(TestRunLogUtil.formatTestStartMessage(name));
 		doSetUp();
@@ -214,14 +211,13 @@ public abstract class UITestCase extends TestCase {
 
 		// Check for shell leak.
 		List<String> leakedModalShellTitles = new ArrayList<>();
-		Shell[] shells = fWorkbench.getDisplay().getShells();
+		Shell[] shells = PlatformUI.getWorkbench().getDisplay().getShells();
 		for (Shell shell : shells) {
 			if (!shell.isDisposed() && !preExistingShells.contains(shell)) {
 				leakedModalShellTitles.add(shell.getText());
 				shell.close();
 			}
 		}
-		fWorkbench = null;
 		assertEquals("Test leaked modal shell: [" + String.join(", ", leakedModalShellTitles) + "]", 0,
 				leakedModalShellTitles.size());
 	}
@@ -445,16 +441,6 @@ public abstract class UITestCase extends TestCase {
 	 */
 	protected void manageWindows(boolean manage) {
 		closeTestWindows.setEnabled(manage);
-	}
-
-	/**
-	 * Returns the workbench.
-	 *
-	 * @return the workbench
-	 * @since 3.1
-	 */
-	protected IWorkbench getWorkbench() {
-		return fWorkbench;
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/GenerateIdentifiersTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/GenerateIdentifiersTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.performance;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+
 import org.eclipse.ui.activities.IActivityManager;
 import org.junit.Test;
 
@@ -30,7 +32,7 @@ public class GenerateIdentifiersTest extends BasicPerformanceTest {
 
 	@Test
 	public void test() throws Throwable {
-		final IActivityManager activityManager = fWorkbench.getActivitySupport().getActivityManager();
+		final IActivityManager activityManager = getWorkbench().getActivitySupport().getActivityManager();
 
 		exercise(() -> {
 			// construct the Identifiers to test

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenClosePerspectiveTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenClosePerspectiveTest.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.ui.tests.performance;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -116,8 +118,7 @@ public class OpenClosePerspectiveTest extends BasicPerformanceTest {
 	private void closePerspective(IWorkbenchPage activePage) {
 		IPerspectiveDescriptor persp = activePage.getPerspective();
 
-		ICommandService commandService = fWorkbench
-				.getService(ICommandService.class);
+		ICommandService commandService = getWorkbench().getService(ICommandService.class);
 		Command command = commandService
 				.getCommand("org.eclipse.ui.window.closePerspective");
 
@@ -128,8 +129,7 @@ public class OpenClosePerspectiveTest extends BasicPerformanceTest {
 		ParameterizedCommand pCommand = ParameterizedCommand.generateCommand(
 				command, parameters);
 
-		IHandlerService handlerService = fWorkbench
-				.getService(IHandlerService.class);
+		IHandlerService handlerService = getWorkbench().getService(IHandlerService.class);
 		try {
 			handlerService.executeCommand(pCommand, null);
 		} catch (ExecutionException | NotDefinedException | NotEnabledException | NotHandledException e1) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/WorkingSetTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/WorkingSetTestCase.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.adaptable;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+
 import org.eclipse.core.internal.propertytester.ResourceMappingPropertyTester;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IAggregateWorkingSetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IAggregateWorkingSetTest.java
@@ -27,8 +27,10 @@ import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.ui.IAggregateWorkingSet;
 import org.eclipse.ui.IMemento;
+import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.IWorkingSetManager;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.XMLMemento;
 import org.eclipse.ui.internal.AbstractWorkingSet;
 import org.eclipse.ui.internal.AbstractWorkingSetManager;
@@ -47,6 +49,7 @@ public class IAggregateWorkingSetTest extends UITestCase {
 	static final String AGGREGATE_WORKING_SET_NAME_ = "testaggregatews";
 	static final String WSET_PAGE_ID="org.eclipse.ui.resourceWorkingSetPage";
 	IWorkspace fWorkspace;
+	IWorkbench fWorkbench;
 
 	IWorkingSet[] components;
 	List<IWorkingSet> backup;
@@ -59,11 +62,11 @@ public class IAggregateWorkingSetTest extends UITestCase {
 	@Override
 	protected void doSetUp() throws Exception {
 		super.doSetUp();
-		IWorkingSetManager workingSetManager = fWorkbench
-		.getWorkingSetManager();
+		IWorkingSetManager workingSetManager = PlatformUI.getWorkbench().getWorkingSetManager();
 		backup = Arrays.asList(workingSetManager.getAllWorkingSets());
 
 		fWorkspace = ResourcesPlugin.getWorkspace();
+		fWorkbench = PlatformUI.getWorkbench();
 		components = new IWorkingSet[4];
 		for (int i = 0; i < 4; i++) {
 			components[i] = workingSetManager.createWorkingSet(WORKING_SET_NAME
@@ -89,6 +92,7 @@ public class IAggregateWorkingSetTest extends UITestCase {
 				workingSetManager.removeWorkingSet(wset);
 			}
 		}
+		fWorkbench = null;
 		super.doTearDown();
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IDeprecatedWorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IDeprecatedWorkbenchPageTest.java
@@ -22,6 +22,7 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IPerspectiveDescriptor;
 import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
@@ -40,6 +41,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class IDeprecatedWorkbenchPageTest extends UITestCase {
 
+	private IWorkbench fWorkbench;
+
 	private IWorkbenchPage fActivePage;
 
 	private IWorkbenchWindow fWin;
@@ -53,6 +56,7 @@ public class IDeprecatedWorkbenchPageTest extends UITestCase {
 	@Override
 	protected void doSetUp() throws Exception {
 		super.doSetUp();
+		fWorkbench = PlatformUI.getWorkbench();
 		fWin = openTestWindow();
 		fActivePage = fWin.getActivePage();
 	}
@@ -64,6 +68,7 @@ public class IDeprecatedWorkbenchPageTest extends UITestCase {
 			FileUtil.deleteProject(proj);
 			proj = null;
 		}
+		fWorkbench = null;
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPerspectiveListenerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPerspectiveListenerTest.java
@@ -15,8 +15,10 @@ package org.eclipse.ui.tests.api;
 
 import org.eclipse.ui.IPerspectiveDescriptor;
 import org.eclipse.ui.IPerspectiveListener;
+import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
 import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Ignore;
@@ -28,6 +30,8 @@ import org.junit.runners.JUnit4;
 public class IPerspectiveListenerTest extends UITestCase implements
 		IPerspectiveListener {
 	private int fEvent;
+
+	private IWorkbench fWorkbench;
 
 	private IWorkbenchWindow fWindow;
 
@@ -49,6 +53,7 @@ public class IPerspectiveListenerTest extends UITestCase implements
 	protected void doSetUp() throws Exception {
 		super.doSetUp();
 		fEvent = NONE;
+		fWorkbench = PlatformUI.getWorkbench();
 		fWindow = openTestWindow();
 		fWindow.addPerspectiveListener(this);
 	}
@@ -56,6 +61,7 @@ public class IPerspectiveListenerTest extends UITestCase implements
 	@Override
 	protected void doTearDown() throws Exception {
 		fWindow.removePerspectiveListener(this);
+		fWorkbench = null;
 		super.doTearDown();
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPageTest.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -89,6 +91,8 @@ import org.junit.runners.MethodSorters;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class IWorkbenchPageTest extends UITestCase {
 
+	private IWorkbench fWorkbench;
+
 	private IWorkbenchPage fActivePage;
 
 	private IWorkbenchWindow fWin;
@@ -160,6 +164,7 @@ public class IWorkbenchPageTest extends UITestCase {
 	@Override
 	protected void doSetUp() throws Exception {
 		super.doSetUp();
+		fWorkbench = PlatformUI.getWorkbench();
 		fWin = openTestWindow();
 		fActivePage = fWin.getActivePage();
 		logStatus = null;
@@ -175,6 +180,7 @@ public class IWorkbenchPageTest extends UITestCase {
 			FileUtil.deleteProject(proj);
 			proj = null;
 		}
+		fWorkbench = null;
 	}
 
 	/**
@@ -836,7 +842,7 @@ public class IWorkbenchPageTest extends UITestCase {
 
 	@Test
 	public void testSetPerspective() throws Throwable {
-		IPerspectiveDescriptor per = PlatformUI.getWorkbench()
+		IPerspectiveDescriptor per = getWorkbench()
 				.getPerspectiveRegistry().findPerspectiveWithId(
 						EmptyPerspective.PERSP_ID);
 		fActivePage.setPerspective(per);
@@ -1152,7 +1158,7 @@ public class IWorkbenchPageTest extends UITestCase {
 		showViewViaCommand(MockViewPart.ID2);
 
 		Assume.assumeTrue(fWin.getShell().isVisible());
-		Assume.assumeTrue(PlatformUI.getWorkbench().getActiveWorkbenchWindow() == fWin);
+		Assume.assumeTrue(getWorkbench().getActiveWorkbenchWindow() == fWin);
 		Assume.assumeTrue(shellIsActive.get());
 
 		assertNotNull(fActivePage.findView(MockViewPart.ID2));
@@ -1206,7 +1212,7 @@ public class IWorkbenchPageTest extends UITestCase {
 		showViewViaCommand(historyView);
 
 		Assume.assumeTrue(fWin.getShell().isVisible());
-		Assume.assumeTrue(PlatformUI.getWorkbench().getActiveWorkbenchWindow() == fWin);
+		Assume.assumeTrue(getWorkbench().getActiveWorkbenchWindow() == fWin);
 		Assume.assumeTrue(shellIsActive.get());
 
 		assertNotNull(fActivePage.findView(historyView));
@@ -2591,7 +2597,7 @@ public class IWorkbenchPageTest extends UITestCase {
 	public void testBug76285() throws PartInitException {
 		IWorkbenchPage page = fActivePage;
 		IPerspectiveDescriptor originalPersp = page.getPerspective();
-		IPerspectiveDescriptor resourcePersp = PlatformUI.getWorkbench()
+		IPerspectiveDescriptor resourcePersp = getWorkbench()
 				.getPerspectiveRegistry().findPerspectiveWithId(
 						IDE.RESOURCE_PERSPECTIVE_ID);
 		// test requires switching between two different perspectives

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IAdaptable;
@@ -51,57 +53,57 @@ public class IWorkbenchTest extends UITestCase {
 		IWorkbenchWindow win1, win2;
 
 		// Test initial window.
-		win1 = fWorkbench.getActiveWorkbenchWindow();
+		win1 = getWorkbench().getActiveWorkbenchWindow();
 		assertNotNull(win1);
 
 		// Test open window.
 		win1 = openTestWindow();
-		assertEquals(win1, fWorkbench.getActiveWorkbenchWindow());
+		assertEquals(win1, getWorkbench().getActiveWorkbenchWindow());
 
 		// Test open second window.
 		win2 = openTestWindow();
-		assertEquals(win2, fWorkbench.getActiveWorkbenchWindow());
+		assertEquals(win2, getWorkbench().getActiveWorkbenchWindow());
 
 		// Test set focus.
 		win1.getShell().forceFocus();
 		processEvents();
-		assertEquals(win1, fWorkbench.getActiveWorkbenchWindow());
+		assertEquals(win1, getWorkbench().getActiveWorkbenchWindow());
 
 		// Test set focus.
 		win2.getShell().forceFocus();
 		processEvents();
-		assertEquals(win2, fWorkbench.getActiveWorkbenchWindow());
+		assertEquals(win2, getWorkbench().getActiveWorkbenchWindow());
 
 		// Cleanup in tearDown.
 	}
 
 	@Test
 	public void testGetEditorRegistry() throws Throwable {
-		IEditorRegistry reg = fWorkbench.getEditorRegistry();
+		IEditorRegistry reg = getWorkbench().getEditorRegistry();
 		assertNotNull(reg);
 	}
 
 	@Test
 	public void testGetPerspectiveRegistry() throws Throwable {
-		IPerspectiveRegistry reg = fWorkbench.getPerspectiveRegistry();
+		IPerspectiveRegistry reg = getWorkbench().getPerspectiveRegistry();
 		assertNotNull(reg);
 	}
 
 	@Test
 	public void testGetPrefereneManager() throws Throwable {
-		PreferenceManager mgr = fWorkbench.getPreferenceManager();
+		PreferenceManager mgr = getWorkbench().getPreferenceManager();
 		assertNotNull(mgr);
 	}
 
 	@Test
 	public void testGetSharedImages() throws Throwable {
-		ISharedImages img = fWorkbench.getSharedImages();
+		ISharedImages img = getWorkbench().getSharedImages();
 		assertNotNull(img);
 	}
 
 	@Test
 	public void testGetWorkingSetManager() throws Throwable {
-		IWorkingSetManager workingSetManager = fWorkbench
+		IWorkingSetManager workingSetManager = getWorkbench()
 				.getWorkingSetManager();
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 
@@ -110,7 +112,7 @@ public class IWorkbenchTest extends UITestCase {
 		IWorkingSet workingSet = workingSetManager.createWorkingSet("ws1",
 				new IAdaptable[] { workspace.getRoot() });
 		workingSetManager.addWorkingSet(workingSet);
-		workingSetManager = fWorkbench.getWorkingSetManager();
+		workingSetManager = getWorkbench().getWorkingSetManager();
 		assertEquals(1, workingSetManager.getWorkingSets().length);
 		assertEquals(workingSet, workingSetManager.getWorkingSets()[0]);
 
@@ -119,7 +121,7 @@ public class IWorkbenchTest extends UITestCase {
 
 	@Test
 	public void testGetWorkbenchWindows() throws Throwable {
-		IWorkbenchWindow[] wins = fWorkbench.getWorkbenchWindows();
+		IWorkbenchWindow[] wins = getWorkbench().getWorkbenchWindows();
 		assertEquals(ArrayUtil.checkNotNull(wins), true);
 		int oldTotal = wins.length;
 		int num = 3;
@@ -129,7 +131,7 @@ public class IWorkbenchTest extends UITestCase {
 			newWins[i] = openTestWindow();
 		}
 
-		wins = fWorkbench.getWorkbenchWindows();
+		wins = getWorkbench().getWorkbenchWindows();
 		for (int i = 0; i < num; i++) {
 			assertTrue(ArrayUtil.contains(wins, newWins[i]));
 		}
@@ -137,7 +139,7 @@ public class IWorkbenchTest extends UITestCase {
 		assertEquals(wins.length, oldTotal + num);
 
 		closeAllTestWindows();
-		wins = fWorkbench.getWorkbenchWindows();
+		wins = getWorkbench().getWorkbenchWindows();
 		assertEquals(wins.length, oldTotal);
 	}
 
@@ -150,9 +152,9 @@ public class IWorkbenchTest extends UITestCase {
 		// open a window with valid perspective
 		IWorkbenchWindow win = null;
 		try {
-			win = fWorkbench.openWorkbenchWindow(EmptyPerspective.PERSP_ID, getPageInput());
+			win = getWorkbench().openWorkbenchWindow(EmptyPerspective.PERSP_ID, getPageInput());
 			assertNotNull(win);
-			assertEquals(win, fWorkbench.getActiveWorkbenchWindow());
+			assertEquals(win, getWorkbench().getActiveWorkbenchWindow());
 			assertEquals(EmptyPerspective.PERSP_ID, win.getActivePage()
 					.getPerspective().getId());
 		} finally {
@@ -164,7 +166,7 @@ public class IWorkbenchTest extends UITestCase {
 		// open a window with invalid perspective. WorkbenchException is expected.
 		boolean exceptionOccured = false;
 		try {
-			win = fWorkbench.openWorkbenchWindow("afdasfdasf", getPageInput());
+			win = getWorkbench().openWorkbenchWindow("afdasfdasf", getPageInput());
 		} catch (WorkbenchException ex) {
 			exceptionOccured = true;
 		}
@@ -182,11 +184,11 @@ public class IWorkbenchTest extends UITestCase {
 		IWorkbenchWindow win = null;
 
 		try {
-			win = fWorkbench
+			win = getWorkbench()
 					.openWorkbenchWindow(getPageInput());
 			assertNotNull(win);
-			assertEquals(win, fWorkbench.getActiveWorkbenchWindow());
-			String defaultID = fWorkbench.getPerspectiveRegistry()
+			assertEquals(win, getWorkbench().getActiveWorkbenchWindow());
+			String defaultID = getWorkbench().getPerspectiveRegistry()
 					.getDefaultPerspective();
 			assertEquals(win.getActivePage().getPerspective().getId(),
 					defaultID);
@@ -205,42 +207,38 @@ public class IWorkbenchTest extends UITestCase {
 		//IWorkbenchPage page1, page2;
 		try {
 			/*
-			 * Commented out until test case can be updated to match new
-			 * implementation of single page per window
+			 * Commented out until test case can be updated to match new implementation of
+			 * single page per window
 			 *
-			 // Open test window.
-			 win = fWorkbench.openWorkbenchWindow(ResourcesPlugin.getWorkspace());
-			 assertNotNull(win);
-
-			 // Set platform pref for openPage.
-			 IPreferenceStore store = WorkbenchPlugin.getDefault().getPreferenceStore();
-			 store.setValue(IPreferenceConstants.REUSE_PERSPECTIVES,
-			 true);
-
-			 // Call openPage twice with the same input.
-			 // Verify that we get the same page back both times.
-			 page1 = fWorkbench.openPage(ResourcesPlugin.getWorkspace());
-			 assertNotNull(page1);
-			 page2 = fWorkbench.openPage(ResourcesPlugin.getWorkspace());
-			 assertNotNull(page2);
-			 assertEquals("Pages should be equal", page1, page2);
-
-			 // Reset platform pref for openPage.
-			 store.setValue(IPreferenceConstants.REUSE_PERSPECTIVES,
-			 false);
+			 * // Open test window. win =
+			 * getWorkbench().openWorkbenchWindow(ResourcesPlugin.getWorkspace());
+			 * assertNotNull(win);
+			 *
+			 * // Set platform pref for openPage. IPreferenceStore store =
+			 * WorkbenchPlugin.getDefault().getPreferenceStore();
+			 * store.setValue(IPreferenceConstants.REUSE_PERSPECTIVES, true);
+			 *
+			 * // Call openPage twice with the same input. // Verify that we get the same
+			 * page back both times. page1 =
+			 * getWorkbench().openPage(ResourcesPlugin.getWorkspace());
+			 * assertNotNull(page1); page2 =
+			 * getWorkbench().openPage(ResourcesPlugin.getWorkspace());
+			 * assertNotNull(page2); assertEquals("Pages should be equal", page1, page2);
+			 *
+			 * // Reset platform pref for openPage.
+			 * store.setValue(IPreferenceConstants.REUSE_PERSPECTIVES, false);
 			 */
 			// Call openPage twice with the same input.
 			// Verify that we get two different pages back.
 			/*
-			 * Commented out until Nick has time to update this
-			 * test case to match new implementation of openPage
-			 * otherwise this test always fails.
+			 * Commented out until Nick has time to update this test case to match new
+			 * implementation of openPage otherwise this test always fails.
 			 *
-			 page1 = fWorkbench.openPage(ResourcesPlugin.getWorkspace());
-			 assertNotNull(page1);
-			 page2 = fWorkbench.openPage(ResourcesPlugin.getWorkspace());
-			 assertNotNull(page2);
-			 assertTrue("Pages should be not equal", page1 != page2);
+			 * page1 = getWorkbench().openPage(ResourcesPlugin.getWorkspace());
+			 * assertNotNull(page1); page2 =
+			 * getWorkbench().openPage(ResourcesPlugin.getWorkspace());
+			 * assertNotNull(page2); assertTrue("Pages should be not equal", page1 !=
+			 * page2);
 			 */
 		} finally {
 			// Close test window.
@@ -257,40 +255,35 @@ public class IWorkbenchTest extends UITestCase {
 		//IWorkbenchPage page1, page2;
 		try {
 			/*
-			 * Commented out until test case can be updated to match new
-			 * implementation of single page per window
+			 * Commented out until test case can be updated to match new implementation of
+			 * single page per window
 			 *
-			 // Open test window.
-			 win = fWorkbench.openWorkbenchWindow(ResourcesPlugin.getWorkspace());
-			 assertNotNull(win);
-
-			 // Set platform pref for openPage.
-			 IPreferenceStore store = WorkbenchPlugin.getDefault().getPreferenceStore();
-			 store.setValue(IPreferenceConstants.REUSE_PERSPECTIVES,
-			 true);
-
-			 // Call openPage twice with the same input.
-			 // Verify that we get the same page back both times.
-			 page1 = fWorkbench.openPage(EmptyPerspective.PERSP_ID,
-			 ResourcesPlugin.getWorkspace(), 0);
-			 assertNotNull(page1);
-			 page2 = fWorkbench.openPage(IWorkbenchConstants.DEFAULT_LAYOUT_ID,
-			 ResourcesPlugin.getWorkspace(), 0);
-			 assertNotNull(page2);
-			 assertEquals("Pages should be equal", page1, page2);
-
-			 // Reset platform pref for openPage.
-			 store.setValue(IPreferenceConstants.REUSE_PERSPECTIVES,
-			 false);
-
-			 // Call openPage twice with the same input.
-			 // Verify that we get two different pages back.
-			 page1 = fWorkbench.openPage(EmptyPerspective.PERSP_ID,
-			 ResourcesPlugin.getWorkspace(), 0);
-			 assertNotNull(page1);
-			 page2 = fWorkbench.openPage(IWorkbenchConstants.DEFAULT_LAYOUT_ID,
-			 ResourcesPlugin.getWorkspace(), 0);
-			 assertTrue("Pages should be not equal", page1 != page2);
+			 * // Open test window. win =
+			 * getWorkbench().openWorkbenchWindow(ResourcesPlugin.getWorkspace());
+			 * assertNotNull(win);
+			 *
+			 * // Set platform pref for openPage. IPreferenceStore store =
+			 * WorkbenchPlugin.getDefault().getPreferenceStore();
+			 * store.setValue(IPreferenceConstants.REUSE_PERSPECTIVES, true);
+			 *
+			 * // Call openPage twice with the same input. // Verify that we get the same
+			 * page back both times. page1 =
+			 * getWorkbench().openPage(EmptyPerspective.PERSP_ID,
+			 * ResourcesPlugin.getWorkspace(), 0); assertNotNull(page1); page2 =
+			 * getWorkbench().openPage(IWorkbenchConstants.DEFAULT_LAYOUT_ID,
+			 * ResourcesPlugin.getWorkspace(), 0); assertNotNull(page2);
+			 * assertEquals("Pages should be equal", page1, page2);
+			 *
+			 * // Reset platform pref for openPage.
+			 * store.setValue(IPreferenceConstants.REUSE_PERSPECTIVES, false);
+			 *
+			 * // Call openPage twice with the same input. // Verify that we get two
+			 * different pages back. page1 =
+			 * getWorkbench().openPage(EmptyPerspective.PERSP_ID,
+			 * ResourcesPlugin.getWorkspace(), 0); assertNotNull(page1); page2 =
+			 * getWorkbench().openPage(IWorkbenchConstants.DEFAULT_LAYOUT_ID,
+			 * ResourcesPlugin.getWorkspace(), 0); assertTrue("Pages should be not equal",
+			 * page1 != page2);
 			 */
 		} finally {
 			// Close test window.

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchWindowTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchWindowTest.java
@@ -20,9 +20,11 @@ import org.eclipse.jface.action.StatusLineManager;
 import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchActionConstants;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.WorkbenchException;
 import org.eclipse.ui.internal.WorkbenchWindow;
 import org.eclipse.ui.tests.harness.util.ArrayUtil;
@@ -36,6 +38,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class IWorkbenchWindowTest extends UITestCase {
 
+	private IWorkbench fWorkbench;
+
 	private IWorkbenchWindow fWin;
 
 	public IWorkbenchWindowTest() {
@@ -45,6 +49,7 @@ public class IWorkbenchWindowTest extends UITestCase {
 	@Override
 	protected void doSetUp() throws Exception {
 		super.doSetUp();
+		fWorkbench = PlatformUI.getWorkbench();
 		fWin = openTestWindow();
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetManagerTest.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -74,7 +75,7 @@ public class IWorkingSetManagerTest extends UITestCase {
 	@Override
 	protected void doSetUp() throws Exception {
 		super.doSetUp();
-		fWorkingSetManager = fWorkbench.getWorkingSetManager();
+		fWorkingSetManager = getWorkbench().getWorkingSetManager();
 		fWorkspace = ResourcesPlugin.getWorkspace();
 		fWorkingSet = fWorkingSetManager.createWorkingSet(WORKING_SET_NAME_1,
 				new IAdaptable[] { fWorkspace.getRoot() });
@@ -371,8 +372,7 @@ public class IWorkingSetManagerTest extends UITestCase {
 	@Test
 	public void testRemoveWorkingSetAfterRename() throws Throwable {
 		/* get workingSetManager */
-		IWorkingSetManager workingSetManager =
-			fWorkbench.getWorkingSetManager();
+		IWorkingSetManager workingSetManager = getWorkbench().getWorkingSetManager();
 
 		workingSetManager.addWorkingSet(fWorkingSet);
 		String origName=fWorkingSet.getName();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.junit.Assert.assertArrayEquals;
 
 import java.util.Arrays;
@@ -54,8 +55,7 @@ public class IWorkingSetTest extends UITestCase {
 	@Override
 	protected void doSetUp() throws Exception {
 		super.doSetUp();
-		IWorkingSetManager workingSetManager = fWorkbench
-				.getWorkingSetManager();
+		IWorkingSetManager workingSetManager = getWorkbench().getWorkingSetManager();
 
 		fWorkspace = ResourcesPlugin.getWorkspace();
 		fWorkingSet = workingSetManager.createWorkingSet(WORKING_SET_NAME_1,
@@ -65,8 +65,7 @@ public class IWorkingSetTest extends UITestCase {
 	}
 	@Override
 	protected void doTearDown() throws Exception {
-		IWorkingSetManager workingSetManager = fWorkbench
-		.getWorkingSetManager();
+		IWorkingSetManager workingSetManager = getWorkbench().getWorkingSetManager();
 		workingSetManager.removeWorkingSet(fWorkingSet);
 		super.doTearDown();
 	}
@@ -157,8 +156,7 @@ public class IWorkingSetTest extends UITestCase {
 	@Test
 	public void testNoDuplicateWorkingSetName() throws Throwable {
 		/* get workingSetManager */
-		IWorkingSetManager workingSetManager = fWorkbench
-				.getWorkingSetManager();
+		IWorkingSetManager workingSetManager = getWorkbench().getWorkingSetManager();
 
 		/*
 		 * check that initially workingSetManager contains "fWorkingSet"
@@ -195,8 +193,7 @@ public class IWorkingSetTest extends UITestCase {
 	public void testNoDuplicateWorkingSetNamesDifferentLabels()
 			throws Throwable {
 		/* get workingSetManager */
-		IWorkingSetManager workingSetManager = fWorkbench
-				.getWorkingSetManager();
+		IWorkingSetManager workingSetManager = getWorkbench().getWorkingSetManager();
 		/*
 		 * check that initially workingSetManager contains "fWorkingSet"
 		 */

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandCallbackTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandCallbackTest.java
@@ -28,7 +28,9 @@ import org.eclipse.core.commands.Parameterization;
 import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.commands.IElementReference;
 import org.eclipse.ui.commands.IElementUpdater;
@@ -54,6 +56,7 @@ public class CommandCallbackTest extends UITestCase {
 	private static final String CMD1_ID = PREFIX + "cmd1";
 	private static final String CMD2_ID = PREFIX + "cmd2";
 
+	private IWorkbench workbench;
 	private ICommandService commandService;
 	private Command cmd1;
 	private Command cmd2;
@@ -70,12 +73,11 @@ public class CommandCallbackTest extends UITestCase {
 	@Override
 	protected void doSetUp() throws Exception {
 		super.doSetUp();
-		commandService = fWorkbench
-				.getService(ICommandService.class);
+		workbench = PlatformUI.getWorkbench();
+		commandService = workbench.getService(ICommandService.class);
 		cmd1 = commandService.getCommand(CMD1_ID);
 		cmd2 = commandService.getCommand(CMD2_ID);
-		handlerService = fWorkbench
-				.getService(IHandlerService.class);
+		handlerService = workbench.getService(IHandlerService.class);
 		cmd1Handler = new CallbackHandler();
 		cmd1Activation = handlerService.activateHandler(CMD1_ID, cmd1Handler);
 		cmd2Handler = new CallbackHandler();
@@ -92,6 +94,7 @@ public class CommandCallbackTest extends UITestCase {
 			handlerService.deactivateHandler(cmd2Activation);
 			cmd2Activation = null;
 		}
+		workbench = null;
 		super.doTearDown();
 	}
 
@@ -174,9 +177,9 @@ public class CommandCallbackTest extends UITestCase {
 		ParameterizedCommand pc2 = new ParameterizedCommand(cmd1, null);
 
 		IElementReference cr1 = commandService.registerElementForCommand(pc1,
-				new MyElement(fWorkbench));
+				new MyElement(workbench));
 		IElementReference cr2 = commandService.registerElementForCommand(pc2,
-				new MyElement(fWorkbench));
+				new MyElement(workbench));
 
 		try {
 			assertEquals(2, cmd1Handler.callbacks);
@@ -207,9 +210,9 @@ public class CommandCallbackTest extends UITestCase {
 						new Parameterization(parmProt, "http"),
 						new Parameterization(parmHost, "download.eclipse.org") });
 		IElementReference cr1 = commandService.registerElementForCommand(pc1,
-				new MyElement(fWorkbench));
+				new MyElement(workbench));
 		IElementReference cr2 = commandService.registerElementForCommand(pc2,
-				new MyElement(fWorkbench));
+				new MyElement(workbench));
 		try {
 
 			assertEquals(2, cmd2Handler.callbacks);
@@ -255,11 +258,11 @@ public class CommandCallbackTest extends UITestCase {
 						new Parameterization(parmProt, "http"),
 						new Parameterization(parmHost, "download.eclipse.org") });
 		IElementReference cr1 = commandService.registerElementForCommand(pc1,
-				new MyElement(fWorkbench));
+				new MyElement(workbench));
 		IElementReference cr2 = commandService.registerElementForCommand(pc2,
-				new MyElement(fWorkbench));
+				new MyElement(workbench));
 		IElementReference cr3 = commandService.registerElementForCommand(pc3,
-				new MyElement(fWorkbench));
+				new MyElement(workbench));
 		try {
 
 			assertEquals(3, cmd2Handler.callbacks);
@@ -317,15 +320,15 @@ public class CommandCallbackTest extends UITestCase {
 				new Parameterization[] { new Parameterization(parmProt, "ftp"),
 						new Parameterization(parmHost, "download.eclipse.org") });
 		IElementReference cr1 = commandService.registerElementForCommand(pc1,
-				new MyElement(fWorkbench));
+				new MyElement(workbench));
 		IElementReference cr2 = commandService.registerElementForCommand(pc2,
-				new MyElement(fWorkbench));
+				new MyElement(workbench));
 		IElementReference cr3 = commandService.registerElementForCommand(pc3,
-				new MyElement(fWorkbench));
+				new MyElement(workbench));
 		IElementReference cr4 = commandService.registerElementForCommand(pc4,
-				new MyElement(fWorkbench));
+				new MyElement(workbench));
 		IElementReference cr5 = commandService.registerElementForCommand(pc5,
-				new MyElement(fWorkbench));
+				new MyElement(workbench));
 		try {
 			assertEquals(5, cmd2Handler.callbacks);
 			Map<String, String> filter = new HashMap<>();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingArchiveProjectFilterTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingArchiveProjectFilterTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.datatransfer;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -41,7 +43,6 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.dialogs.ImportExportWizard;
 import org.eclipse.ui.internal.wizards.datatransfer.WizardProjectsImportPage;
@@ -187,6 +188,6 @@ public class ImportExistingArchiveProjectFilterTest extends UITestCase {
 	}
 
 	private Shell getShell() {
-		return PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+		return getWorkbench().getActiveWorkbenchWindow().getShell();
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/SmartImportTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/SmartImportTests.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.datatransfer;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.eclipse.ui.tests.datatransfer.ImportTestUtils.restoreWorkspaceConfiguration;
 import static org.eclipse.ui.tests.datatransfer.ImportTestUtils.setWorkspaceAutoBuild;
 
@@ -61,7 +62,6 @@ import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.IWorkingSetManager;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.FilteredTree;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.wizards.datatransfer.SmartImportRootWizardPage;
@@ -387,7 +387,7 @@ public class SmartImportTests extends UITestCase {
 
 	@Test
 	public void testInitialWorkingSets() throws Exception {
-		IWorkingSetManager workingSetManager = PlatformUI.getWorkbench().getWorkingSetManager();
+		IWorkingSetManager workingSetManager = getWorkbench().getWorkingSetManager();
 		IWorkingSet workingSet = workingSetManager.createWorkingSet("testWorkingSet", new IAdaptable[0]);
 		workingSet.setId("org.eclipse.ui.resourceWorkingSetPage");
 		workingSetManager.addWorkingSet(workingSet);
@@ -410,7 +410,7 @@ public class SmartImportTests extends UITestCase {
 
 	@Test
 	public void testChangedWorkingSets() throws Exception {
-		IWorkingSetManager workingSetManager = PlatformUI.getWorkbench().getWorkingSetManager();
+		IWorkingSetManager workingSetManager = getWorkbench().getWorkingSetManager();
 		IWorkingSet workingSet = workingSetManager.createWorkingSet("testWorkingSet", new IAdaptable[0]);
 		workingSet.setId("org.eclipse.ui.resourceWorkingSetPage");
 		workingSetManager.addWorkingSet(workingSet);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourcePathCopyTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourcePathCopyTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.dialogs;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+
 import java.awt.HeadlessException;
 import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
@@ -45,7 +47,6 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.dialogs.ImportExportWizard;
 import org.eclipse.ui.internal.dialogs.PropertyDialog;
@@ -107,7 +108,7 @@ public class ResourcePathCopyTest extends UITestCase {
 		assertNotNull("failed to open project explorer", navigator);
 
 		// for project selection
-		IWorkbenchPage activePage = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+		IWorkbenchPage activePage = getWorkbench().getActiveWorkbenchWindow().getActivePage();
 		IViewPart findView = activePage.findView(IPageLayout.ID_PROJECT_EXPLORER);
 		ISelectionProvider selectionProvider = findView.getSite().getSelectionProvider();
 		selectionProvider.setSelection(new StructuredSelection(workspaceProjects));

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIEditWorkingSetWizardAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIEditWorkingSetWizardAuto.java
@@ -14,8 +14,10 @@
 package org.eclipse.ui.tests.dialogs;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.ui.PlatformUI.getWorkbench;
 
 import java.util.List;
+
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceDescription;
@@ -102,7 +104,7 @@ public class UIEditWorkingSetWizardAuto extends UIWorkingSetWizardsAuto<WorkingS
 		/*
 		 * Test page state with preset page input
 		 */
-		IWorkingSetManager workingSetManager = fWorkbench.getWorkingSetManager();
+		IWorkingSetManager workingSetManager = getWorkbench().getWorkingSetManager();
 		IWorkingSet workingSet = workingSetManager.createWorkingSet(WORKING_SET_NAME_1,
 				new IAdaptable[] { getProject1(), getFileInProject2() });
 		getWizard().setSelection(workingSet);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UINewWorkingSetWizardAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UINewWorkingSetWizardAuto.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dialogs;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+
 import java.util.List;
 
 import org.eclipse.core.runtime.IAdaptable;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIWorkingSetWizardsAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIWorkingSetWizardsAuto.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dialogs;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -129,7 +131,7 @@ public abstract class UIWorkingSetWizardsAuto<W extends IWizard> extends UITestC
 	}
 
 	private void removeAllWorkingSets() {
-		IWorkingSetManager workingSetManager = fWorkbench.getWorkingSetManager();
+		IWorkingSetManager workingSetManager = getWorkbench().getWorkingSetManager();
 		IWorkingSet[] workingSets = workingSetManager.getWorkingSets();
 		for (IWorkingSet workingSet : workingSets) {
 			workingSetManager.removeWorkingSet(workingSet);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicInvalidContributionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicInvalidContributionTest.java
@@ -39,7 +39,7 @@ public class DynamicInvalidContributionTest extends DynamicTestCase {
 		// open another window, now that our invalid contribution is there, it
 		// should be parsed and loaded, this ensures the workbench window can
 		// still go up even if someone is contributing an invalid contribution
-		fWorkbench.openWorkbenchWindow(window.getActivePage().getPerspective().getId(), null);
+		getWorkbench().openWorkbenchWindow(window.getActivePage().getPerspective().getId(), null);
 	}
 
 	@Override

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicInvalidControlContributionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicInvalidControlContributionTest.java
@@ -39,7 +39,7 @@ public class DynamicInvalidControlContributionTest extends DynamicTestCase {
 		// open another window, now that our invalid contribution is there, it
 		// should be parsed and loaded, this ensures the workbench window can
 		// still go up even if someone is contributing an invalid contribution
-		fWorkbench.openWorkbenchWindow(window.getActivePage().getPerspective()
+		getWorkbench().openWorkbenchWindow(window.getActivePage().getPerspective()
 				.getId(), null);
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicTestCase.java
@@ -20,6 +20,8 @@ import org.eclipse.core.runtime.IExtensionDelta;
 import org.eclipse.core.runtime.IRegistryChangeEvent;
 import org.eclipse.core.runtime.IRegistryChangeListener;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.eclipse.ui.tests.leaks.LeakTests;
@@ -61,6 +63,10 @@ public abstract class DynamicTestCase extends UITestCase implements
 			Platform.getExtensionRegistry().removeRegistryChangeListener(this);
 			queue = null;
 		}
+	}
+
+	protected static final IWorkbench getWorkbench() {
+		return PlatformUI.getWorkbench();
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/PerspectiveSwitcherTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/PerspectiveSwitcherTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.internal;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.IWorkbenchPreferenceConstants;
@@ -39,7 +41,7 @@ public class PerspectiveSwitcherTest extends UITestCase {
 	public void testCreatePerspectiveSwithcerInToolbar() {
 		IPreferenceStore apiPreferenceStore = PrefUtil.getAPIPreferenceStore();
 
-		WorkbenchWindow window = (WorkbenchWindow) fWorkbench.getActiveWorkbenchWindow();
+		WorkbenchWindow window = (WorkbenchWindow) getWorkbench().getActiveWorkbenchWindow();
 		assertNotNull("We should have a perspective bar in the beginning", getPerspectiveSwitcher(window)); //$NON-NLS-1$
 
 		// turn off the 'Open Perspective' item

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/StickyViewManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/StickyViewManagerTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.internal;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+
 import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IPerspectiveDescriptor;
 import org.eclipse.ui.IPerspectiveRegistry;
@@ -54,8 +56,7 @@ public class StickyViewManagerTest extends UITestCase {
 	@Test
 	public void testMultipleStickyViewAcrossPerspectivesBug280656()
 			throws Exception {
-		IWorkbenchPage page = fWorkbench.getActiveWorkbenchWindow()
-				.getActivePage();
+		IWorkbenchPage page = getWorkbench().getActiveWorkbenchWindow().getActivePage();
 		// show a multi-instance view that has no secondary id
 		page.showView("org.eclipse.ui.tests.api.MockViewPartMultSticky", null,
 				IWorkbenchPage.VIEW_ACTIVATE);
@@ -63,7 +64,7 @@ public class StickyViewManagerTest extends UITestCase {
 		page.showView("org.eclipse.ui.tests.api.MockViewPartMultSticky",
 				"secondary", IWorkbenchPage.VIEW_ACTIVATE);
 
-		IPerspectiveRegistry registry = fWorkbench.getPerspectiveRegistry();
+		IPerspectiveRegistry registry = getWorkbench().getPerspectiveRegistry();
 		IPerspectiveDescriptor[] descriptors = registry.getPerspectives();
 
 		for (IPerspectiveDescriptor descriptor : descriptors) {
@@ -88,7 +89,7 @@ public class StickyViewManagerTest extends UITestCase {
 		// first we show the special test views
 		testMultipleStickyViewAcrossPerspectivesBug280656();
 
-		IWorkbenchPage page = fWorkbench.getActiveWorkbenchWindow()
+		IWorkbenchPage page = getWorkbench().getActiveWorkbenchWindow()
 				.getActivePage();
 		IViewReference primaryViewReference = page.findViewReference(
 				"org.eclipse.ui.tests.api.MockViewPartMultSticky", null);
@@ -99,7 +100,7 @@ public class StickyViewManagerTest extends UITestCase {
 		page.hideView(primaryViewReference);
 		page.hideView(secondaryViewReference);
 
-		IPerspectiveRegistry registry = fWorkbench.getPerspectiveRegistry();
+		IPerspectiveRegistry registry = getWorkbench().getPerspectiveRegistry();
 		IPerspectiveDescriptor[] descriptors = registry.getPerspectives();
 
 		for (IPerspectiveDescriptor descriptor : descriptors) {
@@ -121,15 +122,14 @@ public class StickyViewManagerTest extends UITestCase {
 	@Test
 	public void testRemovedMultipleStickyViewAcrossPerspectives2()
 			throws Exception {
-		IPerspectiveRegistry registry = fWorkbench.getPerspectiveRegistry();
+		IPerspectiveRegistry registry = getWorkbench().getPerspectiveRegistry();
 		// retrieve two different perspectives
 		IPerspectiveDescriptor resourcePerspectiveDescriptor = registry
 				.findPerspectiveWithId("org.eclipse.ui.resourcePerspective");
 		IPerspectiveDescriptor viewPerspectiveDescriptor = registry
 				.findPerspectiveWithId("org.eclipse.ui.tests.api.ViewPerspective");
 
-		IWorkbenchPage page = fWorkbench.getActiveWorkbenchWindow()
-				.getActivePage();
+		IWorkbenchPage page = getWorkbench().getActiveWorkbenchWindow().getActivePage();
 		page.setPerspective(resourcePerspectiveDescriptor);
 
 		// show some multi-instance sticky view instances

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbenchPageTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.internal;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -88,7 +90,7 @@ public class WorkbenchPageTest extends UITestCase {
 	}
 
 	private WorkbenchPage getWorkbenchPage() {
-		return (WorkbenchPage) fWorkbench.getActiveWorkbenchWindow().getActivePage();
+		return (WorkbenchPage) getWorkbench().getActiveWorkbenchWindow().getActivePage();
 	}
 
 	@Override

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageEditorSelectionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageEditorSelectionTest.java
@@ -100,7 +100,7 @@ public class MultiPageEditorSelectionTest extends UITestCase {
 		editor.updateSelection();
 
 		PropertySheet propertiewView = (PropertySheet) window.getActivePage().showView(IPageLayout.ID_PROP_SHEET);
-		processUiEvents();
+		processEvents();
 
 		Tree tree = (Tree) propertiewView.getCurrentPage().getControl();
 
@@ -130,8 +130,4 @@ public class MultiPageEditorSelectionTest extends UITestCase {
 		return part;
 	}
 
-	private void processUiEvents() {
-		while (fWorkbench.getDisplay().readAndDispatch()) {
-		}
-	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiVariablePageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiVariablePageTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.multipageeditor;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+
 import java.io.ByteArrayInputStream;
 import java.util.Collection;
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ViewerItemsLimitTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ViewerItemsLimitTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.preferences;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -49,7 +51,6 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPreferenceConstants;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.views.markers.MarkersTreeViewer;
 import org.eclipse.ui.intro.IIntroPart;
@@ -189,7 +190,7 @@ public class ViewerItemsLimitTest extends UITestCase {
 	}
 
 	private IWorkbenchWindow getActiveWindow() {
-		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		IWorkbenchWindow window = getWorkbench().getActiveWorkbenchWindow();
 		assertNotNull("Should get one window", window);
 		return window;
 	}
@@ -224,7 +225,7 @@ public class ViewerItemsLimitTest extends UITestCase {
 	}
 
 	private static IWorkbench closeIntro() {
-		IWorkbench workbench = PlatformUI.getWorkbench();
+		IWorkbench workbench = getWorkbench();
 		IIntroPart introPart = workbench.getIntroManager().getIntro();
 		if (introPart != null) {
 			workbench.getIntroManager().closeIntro(introPart);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/MultiInstancePropertySheetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/MultiInstancePropertySheetTest.java
@@ -430,7 +430,7 @@ public class MultiInstancePropertySheetTest extends AbstractPropertySheetTest {
 			}
 		}
 
-		processUiEvents();
+		processEvents();
 		// TODO this is required here because the default page is never properly
 		// disposed.
 		testPropertySheetPage.dispose();
@@ -517,7 +517,7 @@ public class MultiInstancePropertySheetTest extends AbstractPropertySheetTest {
 			}
 		}
 
-		processUiEvents();
+		processEvents();
 		// TODO this is required here because the default page is never properly
 		// disposed.
 		testPropertySheetPage.dispose();
@@ -559,7 +559,7 @@ public class MultiInstancePropertySheetTest extends AbstractPropertySheetTest {
 			}
 		}
 
-		processUiEvents();
+		processEvents();
 		// TODO this is required here because the default page is never properly
 		// disposed.
 		testPropertySheetPage.dispose();
@@ -575,7 +575,7 @@ public class MultiInstancePropertySheetTest extends AbstractPropertySheetTest {
 		// populate the 'Properties' view
 		contributingView.getSite().getSelectionProvider().setSelection(selection);
 
-		processUiEvents();
+		processEvents();
 
 		// show the 'Properties' view: it should pick up content from the only
 		// one relevant part: view with given id
@@ -605,11 +605,6 @@ public class MultiInstancePropertySheetTest extends AbstractPropertySheetTest {
 					currentPage instanceof PropertySheetPage);
 		}
 
-	}
-
-	private void processUiEvents() {
-		while (fWorkbench.getDisplay().readAndDispatch()) {
-		}
 	}
 
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/NewPropertySheetHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/NewPropertySheetHandlerTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ui.tests.propertysheet;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.junit.Assert.assertThrows;
 
 import java.util.HashMap;
@@ -155,7 +156,7 @@ public class NewPropertySheetHandlerTest extends AbstractPropertySheetTest {
 	}
 
 	void hideAndAssertNoParts() {
-		IWorkbenchWindow[] windows = fWorkbench.getWorkbenchWindows();
+		IWorkbenchWindow[] windows = getWorkbench().getWorkbenchWindows();
 		for (IWorkbenchWindow w : windows) {
 			IWorkbenchPage ap = w.getActivePage();
 			hideAndAssertNoParts(ap);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/EvaluationServiceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/EvaluationServiceTest.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.ui.tests.services;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -45,7 +47,6 @@ import org.eclipse.ui.ISources;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.contexts.IContextActivation;
 import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.handlers.IHandlerActivation;
@@ -95,7 +96,7 @@ public class EvaluationServiceTest extends UITestCase {
 
 	@Test
 	public void testBug334524() throws Exception {
-		IPerspectiveRegistry registry = PlatformUI.getWorkbench().getPerspectiveRegistry();
+		IPerspectiveRegistry registry = getWorkbench().getPerspectiveRegistry();
 		IPerspectiveDescriptor resourcePerspective = registry.findPerspectiveWithId("org.eclipse.ui.resourcePerspective");
 		IPerspectiveDescriptor javaPerspective = registry.findPerspectiveWithId("org.eclipse.jdt.ui.JavaPerspective");
 		String viewId = "org.eclipse.ui.tests.SelectionProviderView";
@@ -544,8 +545,7 @@ public class EvaluationServiceTest extends UITestCase {
 
 	@Test
 	public void testPlatformProperty() throws Exception {
-		IEvaluationService evaluationService = PlatformUI
-				.getWorkbench().getService(IEvaluationService.class);
+		IEvaluationService evaluationService = getWorkbench().getService(IEvaluationService.class);
 		TestExpression test = new TestExpression("org.eclipse.core.runtime",
 				"bundleState",
 				new Object[] { "org.eclipse.core.expressions" }, "ACTIVE", false);
@@ -561,8 +561,7 @@ public class EvaluationServiceTest extends UITestCase {
 		// this is not added, as the ability to test system properties with
 		// no '.' seems unhelpful
 		System.setProperty("isHere", "true");
-		IEvaluationService evaluationService = PlatformUI
-				.getWorkbench().getService(IEvaluationService.class);
+		IEvaluationService evaluationService = getWorkbench().getService(IEvaluationService.class);
 		TestExpression test = new TestExpression("org.eclipse.core.runtime",
 				"isHere",
 				new Object[] { "true" }, null, false);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/themes/JFaceThemeTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/themes/JFaceThemeTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.themes;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.junit.Assert.assertArrayEquals;
 
 import org.eclipse.jface.resource.ColorDescriptor;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/themes/ThemeTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/themes/ThemeTest.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.themes;
 
+import static org.eclipse.ui.PlatformUI.getWorkbench;
+
 import org.eclipse.e4.ui.css.swt.theme.IThemeEngine;
 import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.eclipse.ui.themes.ITheme;
@@ -39,14 +41,14 @@ public abstract class ThemeTest extends UITestCase {
 	@Override
 	protected void doSetUp() throws Exception {
 		super.doSetUp();
-		fManager = fWorkbench.getThemeManager();
+		fManager = getWorkbench().getThemeManager();
 		fManager.setCurrentTheme(IThemeManager.DEFAULT_THEME);
 
 		mockCSSTheme();
 	}
 
 	private void mockCSSTheme() {
-		IThemeEngine themeEngine = fWorkbench.getService(IThemeEngine.class);
+		IThemeEngine themeEngine = getWorkbench().getService(IThemeEngine.class);
 		org.eclipse.e4.ui.css.swt.theme.ITheme currentTheme = themeEngine.getActiveTheme();
 		if (currentTheme != null && !MOCK_CSS_THEME.equals(currentTheme.getId())) {
 			themeEngine.setTheme(MOCK_CSS_THEME, false);


### PR DESCRIPTION
The workbench can just be retrieved from PlatformUI and should not be unnecessarily stored in a to-be-removed abstract test class. This gets rid of the field by different means for different usage contexts:
- Replace unnecessary reimplementations of spinning the event loop
- Directly access the workbench via PlatformUI
- Store the field in the actual test class

This contributes to the goal of getting rid of the JUnit 3 hierarchy around `UITestCase`.