### PR TITLE
Move static utility functionality from UITestCase to UITestUtil

### DIFF
--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/AbstratGenericEditorTest.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/AbstratGenericEditorTest.java
@@ -14,6 +14,9 @@
 package org.eclipse.ui.genericeditor.tests;
 
 import static org.eclipse.ui.tests.harness.util.DisplayHelper.runEventLoop;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.forceActive;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.waitForJobs;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -34,7 +37,6 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor;
 import org.eclipse.ui.intro.IIntroPart;
 import org.eclipse.ui.part.FileEditorInput;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 
 /**
  * Closes intro, create {@link #project}, create {@link #file} and open {@link #editor}; and clean up.
@@ -59,9 +61,9 @@ public class AbstratGenericEditorTest {
 		project.create(null);
 		project.open(null);
 		project.setDefaultCharset(StandardCharsets.UTF_8.name(), null);
-		UITestCase.waitForJobs(100, 5000);
+		waitForJobs(100, 5000);
 		window= PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-		UITestCase.forceActive(window.getShell());
+		forceActive(window.getShell());
 		createAndOpenFile();
 	 }
 
@@ -128,4 +130,13 @@ public class AbstratGenericEditorTest {
 			runEventLoop(PlatformUI.getWorkbench().getDisplay(),0);
 		}
 	}
+
+	public static void waitAndDispatch(long milliseconds) {
+		long timeout = milliseconds; //ms
+		long start = System.currentTimeMillis();
+		while (start + timeout > System.currentTimeMillis()) {
+			processEvents();
+		}
+	}
+
 }

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/CloseTestWindowsRule.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/CloseTestWindowsRule.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.ui.tests.harness.util;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,9 +45,9 @@ public class CloseTestWindowsRule extends ExternalResource {
 	@Override
 	protected void after() {
 		removeWindowListener();
-		UITestCase.processEvents();
+		processEvents();
 		closeAllTestWindows();
-		UITestCase.processEvents();
+		processEvents();
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/DialogCheck.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/DialogCheck.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.harness.util;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -83,7 +84,7 @@ public class DialogCheck {
 		dialog.setBlockOnOpen(false);
 		dialog.open();
 		Shell shell = dialog.getShell();
-		UITestCase.processEvents();
+		processEvents();
 		try {
 			verifyCompositeText(shell);
 		} finally {

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
@@ -16,26 +16,14 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.harness.util;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceMemento;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.IWorkbenchPage;
-import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.WorkbenchException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -53,16 +41,6 @@ import junit.framework.TestCase;
  * windows when the tearDown method is called.
  */
 public abstract class UITestCase extends TestCase {
-
-	/**
-	 * Returns the workbench page input to use for newly created windows.
-	 *
-	 * @return the page input to use for newly created windows
-	 * @since 3.1
-	 */
-	public static IAdaptable getPageInput() {
-		return ResourcesPlugin.getWorkspace().getRoot();
-	}
 
 	/**
 	 * Rule to close windows opened during the test case, manually called to remain
@@ -98,57 +76,6 @@ public abstract class UITestCase extends TestCase {
 
 	public UITestCase(String testName) {
 		super(testName);
-	}
-
-	/**
-	 * Fails the test due to the given throwable.
-	 */
-	public static void fail(String message, Throwable e) {
-		// If the exception is a CoreException with a multistatus
-		// then print out the multistatus so we can see all the info.
-		if (e instanceof CoreException) {
-			IStatus status = ((CoreException) e).getStatus();
-			write(status, 0);
-		} else
-			e.printStackTrace();
-		throw new AssertionError(message, e);
-	}
-
-	private static void indent(OutputStream output, int indent) {
-		for (int i = 0; i < indent; i++)
-			try {
-				output.write("\t".getBytes());
-			} catch (IOException e) {
-				// ignore
-			}
-	}
-
-	private static void write(IStatus status, int indent) {
-		PrintStream output = System.out;
-		indent(output, indent);
-		output.println("Severity: " + status.getSeverity());
-
-		indent(output, indent);
-		output.println("Plugin ID: " + status.getPlugin());
-
-		indent(output, indent);
-		output.println("Code: " + status.getCode());
-
-		indent(output, indent);
-		output.println("Message: " + status.getMessage());
-
-		if (status.getException() != null) {
-			indent(output, indent);
-			output.print("Exception: ");
-			status.getException().printStackTrace(output);
-		}
-
-		if (status.isMultiStatus()) {
-			IStatus[] children = status.getChildren();
-			for (IStatus child : children) {
-				write(child, indent + 1);
-			}
-		}
 	}
 
 	/**
@@ -233,207 +160,11 @@ public abstract class UITestCase extends TestCase {
 		closeTestWindows.after();
 	}
 
-	public static void processEvents() {
-		Display display = PlatformUI.getWorkbench().getDisplay();
-		if (display != null)
-			while (display.readAndDispatch())
-				;
-	}
-
-	/**
-	 * Utility for waiting until the execution of jobs of any family has
-	 * finished or timeout is reached. If no jobs are running, the method waits
-	 * given minimum wait time. While this method is waiting for jobs, UI events
-	 * are processed.
-	 *
-	 * @param minTimeMs
-	 *            minimum wait time in milliseconds
-	 * @param maxTimeMs
-	 *            maximum wait time in milliseconds
-	 */
-	public static void waitForJobs(long minTimeMs, long maxTimeMs) {
-		if (maxTimeMs < minTimeMs) {
-			throw new IllegalArgumentException("Max time is smaller as min time!");
-		}
-		final long start = System.currentTimeMillis();
-		while (System.currentTimeMillis() - start < minTimeMs) {
-			processEvents();
-			sleep(10);
-		}
-		while (!Job.getJobManager().isIdle() && System.currentTimeMillis() - start < maxTimeMs) {
-			processEvents();
-			sleep(10);
-		}
-	}
-
-	/**
-	 * Pauses execution of the current thread
-	 */
-	protected static void sleep(long millis) {
-		try {
-			Thread.sleep(millis);
-		} catch (InterruptedException e) {
-			return;
-		}
-	}
-
-	/**
-	 * Tries to make given shell active.
-	 *
-	 * <p>
-	 * Note: the method runs at least 1000 milliseconds to make sure the active
-	 * window is really active, see
-	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=417258#c27
-	 *
-	 * @param shell
-	 *            non null
-	 * @return true if the given shell is active for the current display
-	 */
-	public static boolean forceActive(Shell shell) {
-		Display display = PlatformUI.getWorkbench().getDisplay();
-		Shell[] shells = display.getShells();
-		for (Shell s : shells) {
-			if (s.isVisible()) {
-				s.setMinimized(true);
-			}
-			processEvents();
-		}
-		waitForJobs(200, 3000);
-		for (Shell s : shells) {
-			if (s.isVisible()) {
-				s.setMinimized(false);
-			}
-			processEvents();
-		}
-		waitForJobs(200, 3000);
-		shell.setVisible(false);
-		processEvents();
-		shell.setMinimized(true);
-		processEvents();
-		waitForJobs(200, 3000);
-		shell.setVisible(true);
-		processEvents();
-		shell.setMinimized(false);
-		processEvents();
-		shell.forceActive();
-		processEvents();
-		shell.forceFocus();
-		processEvents();
-		waitForJobs(400, 3000);
-		return display.getActiveShell() == shell;
-	}
-
-	public static interface Condition {
-		public boolean compute();
-	}
-
-	/**
-	 *
-	 * @param condition
-	 *            , or null if this should only wait
-	 * @param timeout
-	 *            , -1 if forever
-	 * @return true if successful, false if time out or interrupted
-	 */
-	public static boolean processEventsUntil(Condition condition, long timeout) {
-		long startTime = System.currentTimeMillis();
-		Display display = PlatformUI.getWorkbench().getDisplay();
-		while (condition == null || !condition.compute()) {
-			if (timeout != -1
-					&& System.currentTimeMillis() - startTime > timeout) {
-				return false;
-			}
-			while (display.readAndDispatch())
-				;
-			try {
-				Thread.sleep(20);
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/**
-	 * Open a test window with the empty perspective.
-	 */
-	public static IWorkbenchWindow openTestWindow() {
-		return openTestWindow(EmptyPerspective.PERSP_ID);
-	}
-
-	/**
-	 * Open a test window with the provided perspective.
-	 */
-	public static IWorkbenchWindow openTestWindow(String perspectiveId) {
-		try {
-			IWorkbenchWindow window = PlatformUI.getWorkbench().openWorkbenchWindow(
-					perspectiveId, getPageInput());
-			waitOnShell(window.getShell());
-			return window;
-		} catch (WorkbenchException e) {
-			fail("Problem opening test window", e);
-			return null;
-		}
-	}
-
-	/**
-	 * Try and process events until the new shell is the active shell. This may
-	 * never happen, so time out after a suitable period.
-	 *
-	 * @param shell
-	 *            the shell to wait on
-	 * @since 3.2
-	 */
-	private static void waitOnShell(Shell shell) {
-		processEvents();
-		waitForJobs(100, 5000);
-	}
-
 	/**
 	 * Close all test windows.
 	 */
 	public void closeAllTestWindows() {
 		closeTestWindows.closeAllTestWindows();
-	}
-
-	/**
-	 * Open a test page with the empty perspective in a window.
-	 */
-	public IWorkbenchPage openTestPage(IWorkbenchWindow win) {
-		IWorkbenchPage[] pages = openTestPage(win, 1);
-		if (pages != null) {
-			return pages[0];
-		}
-		return null;
-	}
-
-	/**
-	 * Open "n" test pages with the empty perspective in a window.
-	 */
-	public IWorkbenchPage[] openTestPage(IWorkbenchWindow win, int pageTotal) {
-		try {
-			IWorkbenchPage[] pages = new IWorkbenchPage[pageTotal];
-			IAdaptable input = getPageInput();
-
-			for (int i = 0; i < pageTotal; i++) {
-				pages[i] = win.openPage(EmptyPerspective.PERSP_ID, input);
-			}
-			return pages;
-		} catch (WorkbenchException e) {
-			fail("Problem opening test page", e);
-			return null;
-		}
-	}
-
-	/**
-	 * Close all pages within a window.
-	 */
-	public void closeAllPages(IWorkbenchWindow window) {
-		IWorkbenchPage[] pages = window.getPages();
-		for (IWorkbenchPage page : pages) {
-			page.close();
-		}
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestUtil.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestUtil.java
@@ -1,0 +1,280 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vector Informatik and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ui.tests.harness.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.WorkbenchException;
+
+public final class UITestUtil {
+
+	private UITestUtil() {
+	}
+
+	/**
+	 * Returns the workbench page input to use for newly created windows.
+	 *
+	 * @return the page input to use for newly created windows
+	 */
+	public static IAdaptable getPageInput() {
+		return ResourcesPlugin.getWorkspace().getRoot();
+	}
+
+	/**
+	 * Open a test window with the empty perspective.
+	 */
+	public static IWorkbenchWindow openTestWindow() {
+		return openTestWindow(EmptyPerspective.PERSP_ID);
+	}
+
+	/**
+	 * Open a test window with the provided perspective.
+	 */
+	public static IWorkbenchWindow openTestWindow(String perspectiveId) {
+		try {
+			IWorkbenchWindow window = PlatformUI.getWorkbench().openWorkbenchWindow(perspectiveId, getPageInput());
+			waitOnShell(window.getShell());
+			return window;
+		} catch (WorkbenchException e) {
+			fail("Problem opening test window", e);
+			return null;
+		}
+	}
+
+	/**
+	 * Fails the test due to the given throwable.
+	 */
+	private static void fail(String message, Throwable e) {
+		// If the exception is a CoreException with a multistatus
+		// then print out the multistatus so we can see all the info.
+		if (e instanceof CoreException) {
+			IStatus status = ((CoreException) e).getStatus();
+			write(status, 0);
+		} else
+			e.printStackTrace();
+		throw new AssertionError(message, e);
+	}
+
+	private static void indent(OutputStream output, int indent) {
+		for (int i = 0; i < indent; i++)
+			try {
+				output.write("\t".getBytes());
+			} catch (IOException e) {
+				// ignore
+			}
+	}
+
+	private static void write(IStatus status, int indent) {
+		PrintStream output = System.out;
+		indent(output, indent);
+		output.println("Severity: " + status.getSeverity());
+
+		indent(output, indent);
+		output.println("Plugin ID: " + status.getPlugin());
+
+		indent(output, indent);
+		output.println("Code: " + status.getCode());
+
+		indent(output, indent);
+		output.println("Message: " + status.getMessage());
+
+		if (status.getException() != null) {
+			indent(output, indent);
+			output.print("Exception: ");
+			status.getException().printStackTrace(output);
+		}
+
+		if (status.isMultiStatus()) {
+			IStatus[] children = status.getChildren();
+			for (IStatus child : children) {
+				write(child, indent + 1);
+			}
+		}
+	}
+
+	/**
+	 * Open "n" test pages with the empty perspective in a window.
+	 */
+	public static IWorkbenchPage[] openTestPage(IWorkbenchWindow win, int pageTotal) {
+		try {
+			IWorkbenchPage[] pages = new IWorkbenchPage[pageTotal];
+			IAdaptable input = getPageInput();
+
+			for (int i = 0; i < pageTotal; i++) {
+				pages[i] = win.openPage(EmptyPerspective.PERSP_ID, input);
+			}
+			return pages;
+		} catch (WorkbenchException e) {
+			fail("Problem opening test page", e);
+			return null;
+		}
+	}
+
+	/**
+	 * Open a test page with the empty perspective in a window.
+	 */
+	public static IWorkbenchPage openTestPage(IWorkbenchWindow win) {
+		IWorkbenchPage[] pages = openTestPage(win, 1);
+		if (pages != null) {
+			return pages[0];
+		}
+		return null;
+	}
+
+	/**
+	 * Close all pages within a window.
+	 */
+	public static void closeAllPages(IWorkbenchWindow window) {
+		IWorkbenchPage[] pages = window.getPages();
+		for (IWorkbenchPage page : pages) {
+			page.close();
+		}
+	}
+
+	public static void processEvents() {
+		Display display = PlatformUI.getWorkbench().getDisplay();
+		if (display != null)
+			while (display.readAndDispatch())
+				;
+	}
+
+	/**
+	 *
+	 * @param condition , or null if this should only wait
+	 * @param timeout   , -1 if forever
+	 * @return true if successful, false if time out or interrupted
+	 */
+	public static boolean processEventsUntil(Condition condition, long timeout) {
+		long startTime = System.currentTimeMillis();
+		Display display = PlatformUI.getWorkbench().getDisplay();
+		while (condition == null || !condition.compute()) {
+			if (timeout != -1 && System.currentTimeMillis() - startTime > timeout) {
+				return false;
+			}
+			while (display.readAndDispatch())
+				;
+			try {
+				Thread.sleep(20);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public static interface Condition {
+		public boolean compute();
+	}
+
+	/**
+	 * Utility for waiting until the execution of jobs of any family has finished or
+	 * timeout is reached. If no jobs are running, the method waits given minimum
+	 * wait time. While this method is waiting for jobs, UI events are processed.
+	 *
+	 * @param minTimeMs minimum wait time in milliseconds
+	 * @param maxTimeMs maximum wait time in milliseconds
+	 */
+	public static void waitForJobs(long minTimeMs, long maxTimeMs) {
+		if (maxTimeMs < minTimeMs) {
+			throw new IllegalArgumentException("Max time is smaller as min time!");
+		}
+		final long start = System.currentTimeMillis();
+		while (System.currentTimeMillis() - start < minTimeMs) {
+			processEvents();
+			sleep(10);
+		}
+		while (!Job.getJobManager().isIdle() && System.currentTimeMillis() - start < maxTimeMs) {
+			processEvents();
+			sleep(10);
+		}
+	}
+	/**
+	 * Pauses execution of the current thread
+	 */
+	private static void sleep(long millis) {
+		try {
+			Thread.sleep(millis);
+		} catch (InterruptedException e) {
+			return;
+		}
+	}
+
+	/**
+	 * Tries to make given shell active.
+	 *
+	 * <p>
+	 * Note: the method runs at least 1000 milliseconds to make sure the active
+	 * window is really active, see
+	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=417258#c27
+	 *
+	 * @param shell non null
+	 * @return true if the given shell is active for the current display
+	 */
+	public static boolean forceActive(Shell shell) {
+		Display display = PlatformUI.getWorkbench().getDisplay();
+		Shell[] shells = display.getShells();
+		for (Shell s : shells) {
+			if (s.isVisible()) {
+				s.setMinimized(true);
+			}
+			processEvents();
+		}
+		waitForJobs(200, 3000);
+		for (Shell s : shells) {
+			if (s.isVisible()) {
+				s.setMinimized(false);
+			}
+			processEvents();
+		}
+		waitForJobs(200, 3000);
+		shell.setVisible(false);
+		processEvents();
+		shell.setMinimized(true);
+		processEvents();
+		waitForJobs(200, 3000);
+		shell.setVisible(true);
+		processEvents();
+		shell.setMinimized(false);
+		processEvents();
+		shell.forceActive();
+		processEvents();
+		shell.forceFocus();
+		processEvents();
+		waitForJobs(400, 3000);
+		return display.getActiveShell() == shell;
+	}
+
+	/**
+	 * Try and process events until the new shell is the active shell. This may
+	 * never happen, so time out after a suitable period.
+	 *
+	 * @param shell the shell to wait on
+	 * @since 3.2
+	 */
+	static void waitOnShell(Shell shell) {
+		processEvents();
+		waitForJobs(100, 5000);
+	}
+
+}

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/GoBackForwardsTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/GoBackForwardsTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.navigator;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEventsUntil;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -35,6 +38,7 @@ import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.tests.harness.util.EditorTestHelper;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.eclipse.ui.tests.harness.util.UITestUtil.Condition;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
 import org.eclipse.ui.texteditor.TextSelectionNavigationLocation;
 import org.junit.Assert;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ComboViewerRefreshTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ComboViewerRefreshTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jface.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.jface.viewers.ComboViewer;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.swt.widgets.Shell;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FastTableViewerRefreshTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FastTableViewerRefreshTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.swt.widgets.TableItem;
 
 public class FastTableViewerRefreshTest extends TableViewerRefreshTest {

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FastTreeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FastTreeTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.util.ArrayList;
 import java.util.Collection;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FileImageDescriptorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FileImageDescriptorTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jface.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListPopulationTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListPopulationTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jface.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListViewerRefreshTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListViewerRefreshTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jface.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.jface.viewers.ListViewer;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.swt.widgets.Shell;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ProgressMonitorDialogPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ProgressMonitorDialogPerformanceTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jface.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.swt.widgets.Display;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/SWTTreeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/SWTTreeTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ShrinkingTreeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ShrinkingTreeTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.test.performance.Dimension;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TableViewerRefreshTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TableViewerRefreshTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jface.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.ViewerComparator;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TreeAddTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TreeAddTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.util.ArrayList;
 import java.util.Collection;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TreeViewerRefreshTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TreeViewerRefreshTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jface.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.widgets.Shell;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/EditorSwitchTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/EditorSwitchTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.util.Arrays;
 import java.util.Collection;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/LabelProviderTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/LabelProviderTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.util.Arrays;
 import java.util.Collection;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseEditorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseEditorTest.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.ui.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.util.Arrays;
 import java.util.Collection;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenClosePerspectiveTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenClosePerspectiveTest.java
@@ -16,6 +16,8 @@
 package org.eclipse.ui.tests.performance;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseViewTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseViewTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.test.performance.Dimension;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseWindowTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseWindowTest.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.ui.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.util.Arrays;
 import java.util.Collection;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenMultipleEditorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenMultipleEditorTest.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.ui.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.util.Arrays;
 import java.util.Collection;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/PerspectiveSwitchTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/PerspectiveSwitchTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.util.Arrays;
 import java.util.Collection;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProblemsViewPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProblemsViewPerformanceTest.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.ui.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProgressReportingTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProgressReportingTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.performance;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import java.lang.reflect.InvocationTargetException;
 
 import org.eclipse.core.runtime.OperationCanceledException;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ComputeSizeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ComputeSizeTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.performance.layout;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/EditorWidgetFactory.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/EditorWidgetFactory.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.performance.layout;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.getPageInput;
 import static org.junit.Assert.assertNotNull;
 
 import org.eclipse.core.resources.IFile;
@@ -29,7 +30,6 @@ import org.eclipse.ui.WorkbenchException;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.EditorSite;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.eclipse.ui.tests.performance.UIPerformanceTestSetup;
 
 
@@ -68,7 +68,7 @@ public class EditorWidgetFactory extends TestWidgetFactory {
 	public void init() throws WorkbenchException {
 
 		// Open an editor in a new window.
-		window = PlatformUI.getWorkbench().openWorkbenchWindow(EmptyPerspective.PERSP_ID, UITestCase.getPageInput());
+		window = PlatformUI.getWorkbench().openWorkbenchWindow(EmptyPerspective.PERSP_ID, getPageInput());
 		IWorkbenchPage activePage = window.getActivePage();
 		assertNotNull(activePage);
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/LayoutTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/LayoutTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.performance.layout;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.util.Geometry;
 import org.eclipse.swt.graphics.Point;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/PerspectiveWidgetFactory.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/PerspectiveWidgetFactory.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.performance.layout;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.getPageInput;
 import static org.junit.Assert.assertNotNull;
 
 import org.eclipse.swt.graphics.Point;
@@ -21,7 +22,6 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.WorkbenchException;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 
 
 /**
@@ -44,7 +44,7 @@ public class PerspectiveWidgetFactory extends TestWidgetFactory {
 	@Override
 	public void init() throws WorkbenchException {
 		// open the perspective in a new window
-		window = PlatformUI.getWorkbench().openWorkbenchWindow(perspectiveId, UITestCase.getPageInput());
+		window = PlatformUI.getWorkbench().openWorkbenchWindow(perspectiveId, getPageInput());
 		IWorkbenchPage page = window.getActivePage();
 		assertNotNull(page);
 	}

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ResizeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ResizeTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.performance.layout;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ViewWidgetFactory.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ViewWidgetFactory.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.performance.layout;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.getPageInput;
 import static org.junit.Assert.assertNotNull;
 
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
@@ -26,7 +27,6 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.WorkbenchException;
 import org.eclipse.ui.internal.ViewSite;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.eclipse.ui.tests.performance.BasicPerformanceTest;
 
 
@@ -58,7 +58,7 @@ public class ViewWidgetFactory extends TestWidgetFactory {
 	@Override
 	public void init() throws WorkbenchException {
 		// open the view in a new window
-		window = PlatformUI.getWorkbench().openWorkbenchWindow(EmptyPerspective.PERSP_ID, UITestCase.getPageInput());
+		window = PlatformUI.getWorkbench().openWorkbenchWindow(EmptyPerspective.PERSP_ID, getPageInput());
 		IWorkbenchPage page = window.getActivePage();
 		assertNotNull(page);
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/activities/MenusTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/activities/MenusTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ui.tests.activities;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -30,7 +31,6 @@ import org.eclipse.ui.menus.IContributionRoot;
 import org.eclipse.ui.menus.IMenuService;
 import org.eclipse.ui.services.IServiceLocator;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -89,7 +89,7 @@ public class MenusTest {
 
 	@Before
 	public void doSetUp() throws Exception {
-		window = UITestCase.openTestWindow();
+		window = openTestWindow();
 		enabledActivities = window.getWorkbench().getActivitySupport()
 				.getActivityManager().getEnabledActivityIds();
 		service = window.getService(IMenuService.class);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/AdaptableDecoratorTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/AdaptableDecoratorTestCase.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.adaptable;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -32,7 +33,6 @@ import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.decorators.DecoratorDefinition;
 import org.eclipse.ui.internal.decorators.DecoratorManager;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -158,7 +158,7 @@ public class AdaptableDecoratorTestCase implements ILabelProviderListener {
 	 * Shows the Adapted Resource Navigator in a new test window.
 	 */
 	protected void showAdaptedNav() throws PartInitException {
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 		window.getActivePage().showView(ADAPTED_NAVIGATOR_ID);
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/Bug407422Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/Bug407422Test.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -32,7 +33,6 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -46,7 +46,7 @@ public class Bug407422Test {
 
 	@Test
 	public void test() throws CoreException {
-		final IWorkbenchWindow window = UITestCase.openTestWindow();
+		final IWorkbenchWindow window = openTestWindow();
 		final IWorkbenchPage page = window.getActivePage();
 		final String EDITOR_ID = "org.eclipse.ui.DefaultTextEditor";
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IActionBarsTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IActionBarsTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
-import static org.eclipse.ui.tests.harness.util.UITestCase.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IActionDelegateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IActionDelegateTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -22,7 +23,6 @@ import java.util.Arrays;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,7 +41,7 @@ public abstract class IActionDelegateTest {
 
 	@Before
 	public void doSetUp() throws Exception {
-		fWindow = UITestCase.openTestWindow();
+		fWindow = openTestWindow();
 		fPage = fWindow.getActivePage();
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IActionFilterTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IActionFilterTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IAggregateWorkingSetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IAggregateWorkingSetTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.waitForJobs;
 import static org.junit.Assert.assertArrayEquals;
 
 import java.lang.reflect.Field;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IDeprecatedWorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IDeprecatedWorkbenchPageTest.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.getPageInput;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestPage;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorActionBarContributorTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorActionBarContributorTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.ui.IWorkbenchPage;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorMatchingStrategyTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorMatchingStrategyTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.ui.IEditorPart;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorPartTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorPartTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPageLayoutTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPageLayoutTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
 import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Test;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPageListenerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPageListenerTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.ui.IPageListener;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPageServiceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPageServiceTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.getPageInput;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.ui.IPageListener;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPartServiceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPartServiceTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.ui.IEditorInput;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPerspectiveListenerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPerspectiveListenerTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.ui.IPerspectiveDescriptor;
 import org.eclipse.ui.IPerspectiveListener;
 import org.eclipse.ui.IWorkbench;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/ISelectionServiceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/ISelectionServiceTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.ISelectionListener;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPageTest.java
@@ -16,6 +16,12 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.forceActive;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.getPageInput;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestPage;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.waitForJobs;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPartSiteTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPartSiteTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPartTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPartTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.tests.harness.util.CallHistory;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPartTestableTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPartTestableTests.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import java.util.HashSet;
 import java.util.Set;
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchTest.java
@@ -14,6 +14,9 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.getPageInput;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchWindowTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchWindowTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.closeAllPages;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestPage;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertThrows;
 
 import org.eclipse.core.resources.ResourcesPlugin;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetManagerTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThrows;
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/SaveablesListTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/SaveablesListTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestPage;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/SelectionListenerFactoryTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/SelectionListenerFactoryTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -35,7 +36,6 @@ import org.eclipse.ui.SelectionListenerFactory.ISelectionModel;
 import org.eclipse.ui.SelectionListenerFactory.Predicates;
 import org.eclipse.ui.tests.SelectionProviderView;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -59,7 +59,7 @@ public class SelectionListenerFactoryTest implements ISelectionListener {
 
 	@Before
 	public void doSetUp() throws Exception {
-		fWindow = UITestCase.openTestWindow();
+		fWindow = openTestWindow();
 		fPage = fWindow.getActivePage();
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/StickyViewTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/StickyViewTest.java
@@ -14,6 +14,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.ui.IEditorPart;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/UIJobTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/UIJobTest.java
@@ -14,6 +14,8 @@
 package org.eclipse.ui.tests.api;
 
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/ArbitraryPropertyTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/ArbitraryPropertyTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api.workbenchpart;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -28,7 +29,6 @@ import org.eclipse.ui.IViewReference;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,7 +49,7 @@ public class ArbitraryPropertyTest {
 
 	@Before
 	public void doSetUp() throws Exception {
-		window = UITestCase.openTestWindow();
+		window = openTestWindow();
 		page = window.getActivePage();
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/Bug543609Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/Bug543609Test.java
@@ -13,13 +13,13 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api.workbenchpart;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.eclipse.ui.tests.session.ViewWithState;
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,7 +36,7 @@ public class Bug543609Test {
 
 	@Before
 	public void doSetUp() throws Exception {
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 		fPage = window.getActivePage();
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/DependencyInjectionViewTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/DependencyInjectionViewTest.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.ui.tests.api.workbenchpart;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -28,7 +30,6 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,7 +46,7 @@ public class DependencyInjectionViewTest {
 
 	@Test
 	public void testDependencyInjectionLifecycle() throws Exception {
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 		IWorkbenchPage page = window.getActivePage();
 		IViewPart v = page.showView(DependencyInjectionView.ID);
 		assertTrue(v instanceof DependencyInjectionView);
@@ -72,7 +73,7 @@ public class DependencyInjectionViewTest {
 
 		assertEquals(expectedDisposeCallOrder, view.disposeCallOrder);
 
-		UITestCase.processEvents();
+		processEvents();
 
 
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/LifecycleViewTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/LifecycleViewTest.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.ui.tests.api.workbenchpart;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/OverriddenTitleTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/OverriddenTitleTest.java
@@ -14,6 +14,8 @@
 package org.eclipse.ui.tests.api.workbenchpart;
 
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.ui.IPropertyListener;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart2;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/RawIViewPartTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/RawIViewPartTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api.workbenchpart;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.ui.IPropertyListener;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/ViewPartTitleTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/ViewPartTitleTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.api.workbenchpart;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.ui.IPropertyListener;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart2;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/ActionDelegateProxyTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/ActionDelegateProxyTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.commands;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -37,7 +39,6 @@ import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.tests.api.workbenchpart.MenuContributionHarness;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,7 +58,7 @@ public class ActionDelegateProxyTest {
 
 	@Test
 	public void testViewDelegate() throws Exception {
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 		IWorkbenchPage page = window.getActivePage();
 		assertNull(page.findView(VIEW_ID));
 		IViewPart view = page.showView(VIEW_ID);
@@ -87,7 +88,7 @@ public class ActionDelegateProxyTest {
 
 	@Test
 	public void testWWActionDelegate() throws Exception {
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 		window.getActivePage().showActionSet(DELEGATE_ACTION_SET_ID);
 		IHandlerService service = window.getService(IHandlerService.class);
 		assertFalse(SimplyGoActionDelegate.executed);
@@ -99,7 +100,7 @@ public class ActionDelegateProxyTest {
 
 	@Test
 	public void testEditorActionDelegate() throws Exception {
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 		window.getActivePage().closeAllEditors(false);
 		IHandlerService service = window.getService(IHandlerService.class);
 		assertFalse(EditorActionDelegate.executed);
@@ -128,7 +129,7 @@ public class ActionDelegateProxyTest {
 		assertEquals(editor2, EditorActionDelegate.part);
 
 		window.getActivePage().activate(editor1);
-		UITestCase.processEvents();
+		processEvents();
 		service.executeCommand(STAY_COMMAND, null);
 		assertTrue(EditorActionDelegate.executed);
 		assertEquals(editor1, EditorActionDelegate.part);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandCallbackTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandCallbackTest.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.ui.tests.commands;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertThrows;
 
 import java.util.HashMap;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandEnablementTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandEnablementTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ui.tests.commands;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -68,7 +69,6 @@ import org.eclipse.ui.menus.UIElement;
 import org.eclipse.ui.services.IEvaluationService;
 import org.eclipse.ui.services.ISourceProviderService;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -648,7 +648,7 @@ public class CommandEnablementTest {
 	// Related bugs possibly breaking this: 382839, 394336
 	@Test
 	public void testEnablementForLocalContext() throws Exception {
-		UITestCase.openTestWindow("org.eclipse.ui.resourcePerspective");
+		openTestWindow("org.eclipse.ui.resourcePerspective");
 		activation1 = handlerService.activateHandler(CMD1_ID, contextHandler,
 				new ActiveContextExpression(CONTEXT_TEST1,
 						new String[] { ISources.ACTIVE_CONTEXT_NAME }));

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/HandlerActivationTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/HandlerActivationTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ui.tests.commands;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertThrows;
 
 import java.util.HashMap;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/WorkbenchStateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/WorkbenchStateTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.commands;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertSame;
 
 import java.util.Collection;
@@ -35,7 +36,6 @@ import org.eclipse.ui.contexts.IContextActivation;
 import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.handlers.RegistryToggleState;
 import org.eclipse.ui.menus.IMenuService;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.eclipse.ui.tests.menus.HandlerWithStateMock;
 import org.junit.After;
 import org.junit.Assert;
@@ -75,7 +75,7 @@ public class WorkbenchStateTest {
 
 	@Before
 	public final void before() {
-		testWindow = UITestCase.openTestWindow();
+		testWindow = openTestWindow();
 		IViewPart view = testWindow.getActivePage().findView(VIEW_ID);
 		Assert.assertNull(view);
 		Assert.assertFalse(

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/SyncExecWhileUIThreadWaitsForLock.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/SyncExecWhileUIThreadWaitsForLock.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.ui.tests.concurrency;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEventsUntil;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.waitForJobs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -35,7 +38,6 @@ import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.views.log.AbstractEntry;
 import org.eclipse.ui.internal.views.log.LogEntry;
 import org.eclipse.ui.internal.views.log.LogView;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,7 +57,7 @@ public class SyncExecWhileUIThreadWaitsForLock {
 
 	@Before
 	public void setUp() throws Exception {
-		UITestCase.processEvents();
+		processEvents();
 		reportedErrors = new ArrayList<>();
 		listener = (status, plugin) -> reportedErrors.add(status);
 		activePage = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
@@ -65,14 +67,14 @@ public class SyncExecWhileUIThreadWaitsForLock {
 			shouldClose = true;
 			logView = (LogView) activePage.showView(viewId);
 		}
-		UITestCase.processEvents();
+		processEvents();
 		WorkbenchPlugin.log("Log for test: init log view");
-		UITestCase.waitForJobs(100, 10000);
+		waitForJobs(100, 10000);
 		WorkbenchPlugin.getDefault().getLog().addLogListener(listener);
 
 		logView.handleClear();
-		UITestCase.waitForJobs(100, 10000);
-		UITestCase.processEventsUntil(() -> logView.getElements().length == 0, 30000);
+		waitForJobs(100, 10000);
+		processEventsUntil(() -> logView.getElements().length == 0, 30000);
 	}
 
 	@After
@@ -150,8 +152,8 @@ public class SyncExecWhileUIThreadWaitsForLock {
 		assertEquals("Unexpected child status count reported: " + Arrays.toString(status.getChildren()), 2,
 				status.getChildren().length);
 
-		UITestCase.processEvents();
-		UITestCase.processEventsUntil(() -> logView.getElements().length > 0, 30000);
+		processEvents();
+		processEventsUntil(() -> logView.getElements().length > 0, 30000);
 		AbstractEntry[] elements = logView.getElements();
 		List<AbstractEntry> list = Arrays.asList(elements).stream()
 				.filter(x -> ((LogEntry) x).getMessage().startsWith("To avoid deadlock")).toList();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/contexts/Bug74990Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/contexts/Bug74990Test.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.contexts;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertTrue;
 
 import org.eclipse.ui.IViewPart;
@@ -24,7 +25,6 @@ import org.eclipse.ui.contexts.EnabledSubmission;
 import org.eclipse.ui.contexts.IContext;
 import org.eclipse.ui.contexts.IWorkbenchContextSupport;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -67,7 +67,7 @@ public final class Bug74990Test {
 			/*
 			 * Open a window with the MockViewPart, and make sure it now enabled.
 			 */
-			final IWorkbenchPage page = UITestCase.openTestWindow().getActivePage();
+			final IWorkbenchPage page = openTestWindow().getActivePage();
 			final IViewPart openedView = page.showView("org.eclipse.ui.tests.api.MockViewPart");
 			page.activate(openedView);
 			while (fWorkbench.getDisplay().readAndDispatch()) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/contexts/PartContextTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/contexts/PartContextTest.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.contexts;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
-import static org.eclipse.ui.tests.harness.util.UITestCase.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -33,7 +33,7 @@ import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.tests.api.MockViewPart;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.eclipse.ui.tests.harness.util.UITestUtil;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -110,7 +110,7 @@ public class PartContextTest {
 		checkActiveContext(globalService, WINDOW_CONTEXT_ID, false);
 
 		IWorkbenchWindow window = openTestWindow();
-		assertTrue(UITestCase.forceActive(window.getShell()));
+		assertTrue(UITestUtil.forceActive(window.getShell()));
 
 		IContextService localService = window
 				.getService(IContextService.class);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ExportFileSystemOperationTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ExportFileSystemOperationTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.datatransfer;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.net.URI;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportArchiveOperationTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportArchiveOperationTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.datatransfer;
 
-import static org.eclipse.ui.tests.harness.util.UITestCase.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingArchiveProjectFilterTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingArchiveProjectFilterTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.ui.tests.datatransfer;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 
 import java.io.IOException;
 import java.net.URL;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingProjectsWizardTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingProjectsWizardTest.java
@@ -20,7 +20,7 @@ import static org.eclipse.jface.dialogs.IMessageProvider.WARNING;
 import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.eclipse.ui.tests.datatransfer.ImportTestUtils.restoreWorkspaceConfiguration;
 import static org.eclipse.ui.tests.datatransfer.ImportTestUtils.setWorkspaceAutoBuild;
-import static org.eclipse.ui.tests.harness.util.UITestCase.processEvents;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportOperationTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportOperationTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.datatransfer;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/SmartImportTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/SmartImportTests.java
@@ -17,6 +17,9 @@ package org.eclipse.ui.tests.datatransfer;
 import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.eclipse.ui.tests.datatransfer.ImportTestUtils.restoreWorkspaceConfiguration;
 import static org.eclipse.ui.tests.datatransfer.ImportTestUtils.setWorkspaceAutoBuild;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEventsUntil;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.waitForJobs;
 
 import java.io.CharArrayReader;
 import java.io.CharArrayWriter;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ActionSetTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ActionSetTests.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.Collection;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicContributionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicContributionTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicInvalidContributionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicInvalidContributionTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
 import org.junit.Test;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicInvalidControlContributionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicInvalidControlContributionTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
 import org.junit.Test;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicTestCase.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/EditorTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/EditorTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/IntroTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/IntroTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertThrows;
 
 import java.lang.ref.ReferenceQueue;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ObjectContributionTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ObjectContributionTests.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import java.util.HashSet;
 import java.util.Random;
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/PerspectiveTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/PerspectiveTests.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.ui.IPerspectiveDescriptor;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ViewTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ViewTests.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertThrows;
 
 import java.lang.ref.ReferenceQueue;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/WorkingSetTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/WorkingSetTests.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.dynamicplugins;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IAdaptable;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/ActionExpressionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/ActionExpressionTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.internal;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/Bug41931Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/Bug41931Test.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ui.tests.internal;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
@@ -30,7 +31,6 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.WorkbenchPage;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -56,7 +56,7 @@ public class Bug41931Test {
 	@Test
 	public void testBringToTop() throws CoreException {
 		// Open a window.
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 
 		// Create a test project.

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/Bug540297WorkbenchPageFindViewTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/Bug540297WorkbenchPageFindViewTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.internal;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.junit.Assert.assertEquals;
 
 import org.eclipse.swt.SWT;
@@ -27,7 +29,6 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.ViewPart;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -75,7 +76,7 @@ public class Bug540297WorkbenchPageFindViewTest {
 	@Before
 	public void doSetUp() throws Exception {
 		firstWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-		secondWindow = UITestCase.openTestWindow();
+		secondWindow = openTestWindow();
 
 		firstWindowActivePage = firstWindow.getActivePage();
 		secondWindowActivePage = secondWindow.getActivePage();
@@ -89,7 +90,7 @@ public class Bug540297WorkbenchPageFindViewTest {
 		prepareWorkbenchPageForTest(firstWindowActivePage);
 		prepareWorkbenchPageForTest(secondWindowActivePage);
 
-		UITestCase.processEvents();
+		processEvents();
 	}
 
 	private void prepareWorkbenchPageForTest(IWorkbenchPage page) {
@@ -112,7 +113,7 @@ public class Bug540297WorkbenchPageFindViewTest {
 		firstWindowActivePage.resetPerspective();
 		firstWindowActivePage.closePerspective(inactivePerspective, false, false);
 		firstWindowActivePage.closePerspective(activePerspective, false, false);
-		UITestCase.processEvents();
+		processEvents();
 	}
 
 	/**
@@ -213,7 +214,7 @@ public class Bug540297WorkbenchPageFindViewTest {
 	private static void setPerspective(IWorkbenchPage page, IPerspectiveDescriptor perspective) {
 		page.setPerspective(perspective);
 		page.resetPerspective();
-		UITestCase.processEvents();
+		processEvents();
 	}
 
 	private static void showAndHideView(IWorkbenchPage page) throws Exception {
@@ -223,13 +224,13 @@ public class Bug540297WorkbenchPageFindViewTest {
 
 	private static void showView(IWorkbenchPage page) throws Exception {
 		page.showView(MyViewPart.ID);
-		UITestCase.processEvents();
+		processEvents();
 	}
 
 	private static void hideView(IWorkbenchPage page) throws Exception {
 		IViewPart view = page.findView(MyViewPart.ID);
 		page.hideView(view);
-		UITestCase.processEvents();
+		processEvents();
 	}
 
 	private IPerspectiveDescriptor getPerspetiveDescriptor(String perspectiveId) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/Bug549139Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/Bug549139Test.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.internal;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.waitForJobs;
 import static org.junit.Assert.assertNotEquals;
 
 import java.io.ByteArrayInputStream;
@@ -35,7 +36,6 @@ import org.eclipse.jface.viewers.TreeSelection;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.actions.CloseResourceAction;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -86,7 +86,7 @@ public class Bug549139Test extends ResourceActionTest {
 			boolean force = true;
 			testProject.delete(force, new NullProgressMonitor());
 		}
-		UITestCase.waitForJobs(0, 30_000);
+		waitForJobs(0, 30_000);
 	}
 
 	/**
@@ -117,7 +117,7 @@ public class Bug549139Test extends ResourceActionTest {
 		closeAction.selectionChanged(selection);
 		closeAction.run();
 		processUIEvents();
-		UITestCase.waitForJobs(0, 30_000);
+		waitForJobs(0, 30_000);
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/Bug78470Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/Bug78470Test.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ui.tests.internal;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -30,7 +31,6 @@ import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.ViewPart;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Test;
 
 public class Bug78470Test {
@@ -113,7 +113,7 @@ public class Bug78470Test {
 					}
 				});
 		workbench.showPerspective(MyPerspective.ID, activeWorkbenchWindow);
-		UITestCase.processEvents();
+		processEvents();
 		Thread.sleep(2000);
 		assertTrue("view was not made visible", partVisibleExecuted);
 		assertNotNull(activePage.findView(MyViewPart.ID2));

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/EditorActionBarsTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/EditorActionBarsTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.internal;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.action.CoolBarManager;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/SWTBotWorkbenchResetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/SWTBotWorkbenchResetTest.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.ui.tests.internal;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/TextHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/TextHandlerTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.internal;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.junit.Assume.assumeFalse;
 
 import org.eclipse.core.runtime.Platform;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/TextSelectionActionExpressionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/TextSelectionActionExpressionTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.internal;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.action.IContributionItem;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbenchSiteProgressServiceModelTagsTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbenchSiteProgressServiceModelTagsTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.internal;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.services.events.IEventBroker;
 import org.eclipse.e4.ui.internal.workbench.swt.CSSConstants;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbenchWindowSubordinateSourcesTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbenchWindowSubordinateSourcesTests.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.ui.tests.internal;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.core.expressions.EqualsExpression;
 import org.eclipse.core.expressions.EvaluationResult;
 import org.eclipse.core.expressions.IEvaluationContext;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/intro/IntroTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/intro/IntroTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.intro;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IPerspectiveDescriptor;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/intro/IntroTest2.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/intro/IntroTest2.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.intro;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.IPerspectiveDescriptor;
 import org.eclipse.ui.IViewPart;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug36537Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug36537Test.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ui.tests.keys;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertFalse;
 
 import java.util.ArrayList;
@@ -29,7 +30,6 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.keys.IBindingService;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -49,7 +49,7 @@ public class Bug36537Test {
 	 */
 	@Test
 	public void testForRedundantKeySequenceBindings() {
-		final IWorkbenchWindow window = UITestCase.openTestWindow();
+		final IWorkbenchWindow window = openTestWindow();
 		final IWorkbench workbench = window.getWorkbench();
 		final IBindingService bindingService = workbench.getAdapter(IBindingService.class);
 		final Binding[] bindings = bindingService.getBindings();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug40023Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug40023Test.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ui.tests.keys;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertTrue;
 
 import java.io.FileNotFoundException;
@@ -33,7 +34,6 @@ import org.eclipse.ui.internal.Workbench;
 import org.eclipse.ui.internal.keys.BindingService;
 import org.eclipse.ui.keys.IBindingService;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -90,7 +90,7 @@ public class Bug40023Test {
 	public void testCheckOnCheckbox() throws CoreException, CommandException,
 			FileNotFoundException, IOException, ParseException {
 		// Open a window to run the test.
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 		Workbench workbench = (Workbench) window.getWorkbench();
 
 		// Set up a key binding for "Lock Toolbars".

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43321Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43321Test.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ui.tests.keys;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -36,7 +37,6 @@ import org.eclipse.ui.internal.keys.BindingService;
 import org.eclipse.ui.keys.IBindingService;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
 import org.junit.Rule;
 import org.junit.Test;
@@ -65,7 +65,7 @@ public class Bug43321Test {
 	@Test
 	public void testNoCheckOnNonCheckbox() throws CommandException,
 			CoreException, ParseException {
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 		IProject testProject = FileUtil.createProject("TestProject"); //$NON-NLS-1$
 		IFile textFile = testProject.getFile("A.txt"); //$NON-NLS-1$
 		String contents = "A blurb"; //$NON-NLS-1$

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug44460Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug44460Test.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ui.tests.keys;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -43,7 +44,6 @@ import org.eclipse.ui.internal.keys.BindingService;
 import org.eclipse.ui.internal.keys.WorkbenchKeyboard;
 import org.eclipse.ui.keys.IBindingService;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -71,7 +71,7 @@ public class Bug44460Test {
 	@Test
 	public void testCtrlShiftT() throws CommandException, CoreException {
 		// Open a new test window.
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 
 		// Open a new Java project, with a new class.
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug53489Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug53489Test.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ui.tests.keys;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -30,7 +31,6 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.tests.harness.util.AutomationUtil;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,7 +54,7 @@ public class Bug53489Test {
 	 */
 	@Test
 	public void testDoubleDelete() throws Exception {
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject testProject = workspace.getRoot().getProject("DoubleDeleteestProject"); //$NON-NLS-1$
 		testProject.create(null);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/largefile/LargeFileLimitsPreferenceHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/largefile/LargeFileLimitsPreferenceHandlerTest.java
@@ -57,7 +57,7 @@ import org.eclipse.ui.internal.LargeFileLimitsPreferenceHandler.FileLimit;
 import org.eclipse.ui.internal.LargeFileLimitsPreferenceHandler.LargeFileEditorSelectionDialog;
 import org.eclipse.ui.internal.LargeFileLimitsPreferenceHandler.PromptForEditor;
 import org.eclipse.ui.part.FileEditorInput;
-import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.eclipse.ui.tests.harness.util.UITestUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -461,7 +461,7 @@ public class LargeFileLimitsPreferenceHandlerTest {
 	}
 
 	private static void waitForJobs() {
-		UITestCase.waitForJobs(250, 2_000);
+		UITestUtil.waitForJobs(250, 2_000);
 	}
 
 	private static void setDefaultPreferences() {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/leaks/LeakTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/leaks/LeakTests.java
@@ -15,6 +15,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.leaks;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.lang.ref.PhantomReference;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/Bug231304Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/Bug231304Test.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ui.tests.menus;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertEquals;
 
 import org.eclipse.jface.action.IContributionItem;
@@ -24,7 +25,6 @@ import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.menus.IMenuService;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -40,7 +40,7 @@ public class Bug231304Test {
 
 	@Test
 	public void testToolTip() throws Exception {
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 		IMenuService menus = window.getService(IMenuService.class);
 		ToolBarManager manager = new ToolBarManager();
 		try {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/Bug264804Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/Bug264804Test.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.menus;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -31,7 +33,6 @@ import org.eclipse.ui.internal.PopupMenuExtender;
 import org.eclipse.ui.tests.api.ListElement;
 import org.eclipse.ui.tests.api.ListView;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -46,7 +47,7 @@ public class Bug264804Test {
 
 	@Test
 	public void testPopup() throws Exception {
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 
 		ListView part = (ListView) window.getActivePage().showView(
 				"org.eclipse.ui.tests.api.IActionFilterTest1");
@@ -72,7 +73,7 @@ public class Bug264804Test {
 			// contextMenu.setVisible(true);
 			Event e = new Event();
 			e.widget = contextMenu;
-			UITestCase.processEvents();
+			processEvents();
 			contextMenu.notifyListeners(SWT.Show, e);
 
 			find("org.eclipse.ui.file.close", manager.getItems());
@@ -82,7 +83,7 @@ public class Bug264804Test {
 			// to run
 			contextMenu.notifyListeners(SWT.Hide, e);
 			contextMenu.notifyListeners(SWT.Show, e);
-			UITestCase.processEvents();
+			processEvents();
 
 			find("org.eclipse.ui.file.close", manager.getItems());
 		} finally {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/Bug410426Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/Bug410426Test.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.menus;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -29,7 +30,6 @@ import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.menus.IMenuService;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Rule;
 import org.junit.Test;
 import org.osgi.service.log.LogListener;
@@ -45,7 +45,7 @@ public class Bug410426Test {
 
 	@Test
 	public void testToolbarContributionFromFactoryVisibility() throws Exception {
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 		IMenuService menus = window.getService(IMenuService.class);
 		ToolBarManager manager = new ToolBarManager();
 
@@ -96,7 +96,7 @@ public class Bug410426Test {
 
 	@Test
 	public void testNoClassCastExceptionForMenuManagerToolbarContribution() throws Exception {
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 		IMenuService menus = window.getService(IMenuService.class);
 		ToolBarManager manager = new ToolBarManager();
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/DynamicMenuTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/DynamicMenuTest.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.ui.tests.menus;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.swt.SWT;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/MenuPopulationTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/MenuPopulationTest.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.ui.tests.menus;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEventsUntil;
+
 import java.lang.reflect.Field;
 
 import org.eclipse.core.runtime.IStatus;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/MenuTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/MenuTestCase.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.menus;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.core.commands.contexts.Context;
 import org.eclipse.e4.ui.workbench.renderers.swt.HandledContributionItem;
 import org.eclipse.jface.action.IContributionItem;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/MenuVisibilityTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/MenuVisibilityTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.menus;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import java.util.Collections;
 
 import org.eclipse.core.commands.ExecutionEvent;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/ShowViewMenuTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/ShowViewMenuTest.java
@@ -13,6 +13,8 @@
  ******************************************************************************/
 package org.eclipse.ui.tests.menus;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.internal.ShowViewMenu;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multieditor/AbstractMultiEditorTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multieditor/AbstractMultiEditorTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.multieditor;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -48,7 +49,6 @@ import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.part.MultiEditorInput;
 import org.eclipse.ui.tests.TestPlugin;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -78,7 +78,7 @@ public class AbstractMultiEditorTest {
 	public void testBug317102() throws Throwable {
 		final String[] simpleFiles = { TEST01_TXT, TEST03_ETEST };
 
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 		WorkbenchPage page = (WorkbenchPage) window.getActivePage();
 
 		IProject testProject = findOrCreateProject(PROJECT_NAME);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multieditor/MultiEditorTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multieditor/MultiEditorTest.java
@@ -14,7 +14,7 @@
 package org.eclipse.ui.tests.multieditor;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
-import static org.eclipse.ui.tests.harness.util.UITestCase.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageEditorPartTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageEditorPartTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.multipageeditor;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.internal.ErrorEditorPart;
 import org.eclipse.ui.internal.part.NullEditorInput;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageEditorSelectionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageEditorSelectionTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.multipageeditor;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.io.ByteArrayInputStream;
 
 import org.eclipse.core.resources.IFile;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageKeyBindingTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageKeyBindingTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.multipageeditor;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import java.io.ByteArrayInputStream;
 
 import org.eclipse.core.resources.IFile;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiVariablePageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiVariablePageTest.java
@@ -14,6 +14,8 @@
 package org.eclipse.ui.tests.multipageeditor;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collection;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/navigator/AbstractNavigatorTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/navigator/AbstractNavigatorTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.navigator;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import java.io.ByteArrayInputStream;
 
 import org.eclipse.core.resources.IFile;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/operations/WorkbenchOperationStressTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/operations/WorkbenchOperationStressTests.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.operations;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.operations.IOperationHistory;
 import org.eclipse.core.commands.operations.IUndoContext;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ViewerItemsLimitTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ViewerItemsLimitTest.java
@@ -14,6 +14,9 @@
 package org.eclipse.ui.tests.preferences;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEventsUntil;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.waitForJobs;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressContantsTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressContantsTest.java
@@ -15,9 +15,9 @@
 
 package org.eclipse.ui.tests.progress;
 
-import static org.eclipse.ui.tests.harness.util.UITestCase.processEvents;
-import static org.eclipse.ui.tests.harness.util.UITestCase.processEventsUntil;
-import static org.eclipse.ui.tests.harness.util.UITestCase.waitForJobs;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEventsUntil;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.waitForJobs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressTestCase.java
@@ -14,7 +14,8 @@
 
 package org.eclipse.ui.tests.progress;
 
-import static org.eclipse.ui.tests.harness.util.UITestCase.processEvents;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.concurrent.TimeUnit;
@@ -29,7 +30,6 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.internal.progress.FinishedJobs;
 import org.eclipse.ui.internal.progress.ProgressView;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -44,7 +44,7 @@ public abstract class ProgressTestCase {
 
 	@Before
 	public void doSetUp() throws Exception {
-		window = UITestCase.openTestWindow("org.eclipse.ui.resourcePerspective");
+		window = openTestWindow("org.eclipse.ui.resourcePerspective");
 
 		// Remove progress info items before running the tests to prevent random
 		// failings

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressViewTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressViewTests.java
@@ -14,8 +14,8 @@
 
 package org.eclipse.ui.tests.progress;
 
-import static org.eclipse.ui.tests.harness.util.UITestCase.processEvents;
-import static org.eclipse.ui.tests.harness.util.UITestCase.processEventsUntil;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEventsUntil;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/AbstractPropertySheetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/AbstractPropertySheetTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.propertysheet;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IContributionItem;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/MultiInstancePropertySheetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/MultiInstancePropertySheetTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.propertysheet;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.lang.reflect.Field;
 
 import org.eclipse.core.resources.IProject;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/NewPropertySheetHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/NewPropertySheetHandlerTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.ui.tests.propertysheet;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.junit.Assert.assertThrows;
 
 import java.util.HashMap;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/PropertySheetAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/PropertySheetAuto.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.propertysheet;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertArrayEquals;
 
 import java.util.ArrayList;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/ContentMatchesTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/ContentMatchesTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.ui.tests.quickaccess;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -26,7 +27,6 @@ import org.eclipse.ui.internal.quickaccess.QuickAccessContents;
 import org.eclipse.ui.internal.quickaccess.QuickAccessDialog;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -48,7 +48,7 @@ public class ContentMatchesTest {
 
 	@Before
 	public void doSetUp() throws Exception {
-		IWorkbenchWindow window = UITestCase.openTestWindow();
+		IWorkbenchWindow window = openTestWindow();
 		dialog = new QuickAccessDialog(window, null);
 		quickAccessContents = dialog.getQuickAccessContents();
 		dialog.open();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.ui.tests.quickaccess;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEventsUntil;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -47,7 +49,6 @@ import org.eclipse.ui.internal.quickaccess.QuickAccessDialog;
 import org.eclipse.ui.internal.quickaccess.QuickAccessMessages;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -87,7 +88,7 @@ public class QuickAccessDialogTest {
 	public void setUp() throws Exception {
 		Arrays.stream(Display.getDefault().getShells()).filter(isQuickAccessShell).forEach(Shell::close);
 		dialogSettings = new DialogSettings("QuickAccessDialogTest" + System.currentTimeMillis());
-		activeWorkbenchWindow = UITestCase.openTestWindow();
+		activeWorkbenchWindow = openTestWindow();
 		QuickAccessDialog warmupDialog = new QuickAccessDialog(activeWorkbenchWindow, null);
 		warmupDialog.open();
 		warmupDialog.close();
@@ -133,7 +134,7 @@ public class QuickAccessDialogTest {
 		assertEquals("Quick access table should be empty", 0, table.getItemCount());
 
 		text.setText("T");
-		UITestCase.processEventsUntil(() -> table.getItemCount() > 1, TIMEOUT);
+		processEventsUntil(() -> table.getItemCount() > 1, TIMEOUT);
 		int oldCount = table.getItemCount();
 		assertTrue("Not enough quick access items for simple filter", oldCount > 3);
 		assertTrue("Too many quick access items for size of table", oldCount < MAXIMUM_NUMBER_OF_ELEMENTS);
@@ -212,7 +213,7 @@ public class QuickAccessDialogTest {
 
 		// Set a filter to get some items
 		text.setText("T");
-		UITestCase.processEventsUntil(() -> table.getItemCount() > 1, TIMEOUT);
+		processEventsUntil(() -> table.getItemCount() > 1, TIMEOUT);
 		final int defaultCount = table.getItemCount();
 		assertTrue("Not enough quick access items for simple filter", defaultCount > 3);
 		assertTrue("Too many quick access items for size of table", defaultCount < MAXIMUM_NUMBER_OF_ELEMENTS);
@@ -222,21 +223,21 @@ public class QuickAccessDialogTest {
 				.getService(IHandlerService.class);
 		// Run the handler to turn on show all
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
-		UITestCase.processEventsUntil(() -> table.getItemCount() != defaultCount, TIMEOUT);
+		processEventsUntil(() -> table.getItemCount() != defaultCount, TIMEOUT);
 		final int allCount = table.getItemCount();
 		assertTrue("Turning on show all should display more items", allCount > defaultCount);
 		assertEquals("Turning on show all should not change the top item", oldFirstItemText, table.getItem(0).getText(1));
 
 		// Run the handler to turn off show all
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
-		UITestCase.processEventsUntil(() -> table.getItemCount() != allCount, TIMEOUT);
+		processEventsUntil(() -> table.getItemCount() != allCount, TIMEOUT);
 		// Note: The table count may one off from the old count because of shell resizing (scroll bars being added then removed)
 		assertTrue("Turning off show all should limit items shown", table.getItemCount() < allCount);
 		assertEquals("Turning off show all should not change the top item", oldFirstItemText, table.getItem(0).getText(1));
 
 		// Run the handler to turn on show all
 		handlerService.executeCommand("org.eclipse.ui.window.quickAccess", null); //$NON-NLS-1$
-		UITestCase.processEventsUntil(() -> table.getItemCount() == allCount, TIMEOUT);
+		processEventsUntil(() -> table.getItemCount() == allCount, TIMEOUT);
 		assertEquals("Turning on show all twice shouldn't change the items", allCount, table.getItemCount());
 		assertEquals("Turning on show all twice shouldn't change the top item", oldFirstItemText, table.getItem(0).getText(1));
 
@@ -247,7 +248,7 @@ public class QuickAccessDialogTest {
 		text = dialog.getQuickAccessContents().getFilterText();
 		Table newTable = dialog.getQuickAccessContents().getTable();
 		text.setText("T");
-		UITestCase.processEventsUntil(() -> newTable.getItemCount() > 1, TIMEOUT);
+		processEventsUntil(() -> newTable.getItemCount() > 1, TIMEOUT);
 		// Note: The table count may one off from the old count because of shell resizing (scroll bars being added then removed)
 		assertTrue("Show all should be turned off when the shell is closed and reopened",
 				newTable.getItemCount() < allCount);
@@ -268,7 +269,7 @@ public class QuickAccessDialogTest {
 		firstTable.select(0);
 		activateCurrentElement(dialog);
 		assertNotEquals(0, dialogSettings.getArray("orderedElements").length);
-		UITestCase.processEventsUntil(
+		processEventsUntil(
 				() -> activeWorkbenchWindow.getActivePage() != null
 						&& activeWorkbenchWindow.getActivePage().getActivePart() != null
 						&& quickAccessElementText
@@ -287,7 +288,7 @@ public class QuickAccessDialogTest {
 		enterPressed.widget = dialog.getQuickAccessContents().getFilterText();
 		enterPressed.keyCode = SWT.CR;
 		enterPressed.widget.notifyListeners(SWT.KeyDown, enterPressed);
-		UITestCase.processEventsUntil(() -> enterPressed.widget.isDisposed(), 500);
+		processEventsUntil(() -> enterPressed.widget.isDisposed(), 500);
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/ContributedServiceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/ContributedServiceTest.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.ui.tests.services;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -35,7 +36,6 @@ import org.eclipse.ui.services.IDisposable;
 import org.eclipse.ui.services.IServiceLocator;
 import org.eclipse.ui.services.IServiceScopes;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -176,7 +176,7 @@ public class ContributedServiceTest {
 
 	@Test
 	public void testWorkbenchServiceFactory() throws Exception {
-		IWorkbenchWindow window = UITestCase.openTestWindow("org.eclipse.ui.resourcePerspective");
+		IWorkbenchWindow window = openTestWindow("org.eclipse.ui.resourcePerspective");
 		IProgressService progress = window.getService(IProgressService.class);
 		assertNotNull(progress);
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/EditorSourceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/EditorSourceTest.java
@@ -15,6 +15,9 @@
 
 package org.eclipse.ui.tests.services;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.util.Objects;
 
 import org.eclipse.core.expressions.EvaluationResult;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/EvaluationServiceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/EvaluationServiceTest.java
@@ -16,6 +16,10 @@
 package org.eclipse.ui.tests.services;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.forceActive;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.waitForJobs;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/WorkbenchSiteProgressServiceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/WorkbenchSiteProgressServiceTest.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.ui.tests.services;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/StatusDialogManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/StatusDialogManagerTest.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.ui.tests.statushandlers;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -69,7 +70,6 @@ import org.eclipse.ui.statushandlers.StatusManager.INotificationListener;
 import org.eclipse.ui.statushandlers.WorkbenchErrorHandler;
 import org.eclipse.ui.statushandlers.WorkbenchStatusDialogManager;
 import org.eclipse.ui.tests.concurrency.FreezeMonitor;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -608,10 +608,10 @@ public class StatusDialogManagerTest {
 	}
 
 	private void processRemainingUiEvents() {
-		UITestCase.processEvents();
+		processEvents();
 		int count = 0;
 		while (count < 3 && (StatusDialogUtil.getStatusShell() != null)) {
-			UITestCase.processEvents();
+			processEvents();
 			count++;
 		}
 	}
@@ -619,7 +619,7 @@ public class StatusDialogManagerTest {
 	private void assertStatusShellOpen() {
 		int count = 0;
 		while (count < 42 && (StatusDialogUtil.getStatusShell() == null)) {
-			UITestCase.processEvents();
+			processEvents();
 			count++;
 		}
 		assertNotNull("Status shell was not shown!", StatusDialogUtil.getStatusShell());
@@ -1171,7 +1171,7 @@ public class StatusDialogManagerTest {
 			postUnblockingTask();
 
 			// Allow the blocking dialog to be shown
-			UITestCase.processEvents();
+			processEvents();
 			StatusManager.getManager().removeListener(listener);
 		}
 		assertFalse("Job should successfully finish", semaphore.hasQueuedThreads());

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/StatusDialogUtil.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/StatusDialogUtil.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.ui.tests.statushandlers;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.waitForJobs;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -25,7 +27,6 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.Widget;
 import org.eclipse.ui.internal.WorkbenchMessages;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 
 /**
  * This class parses the structure of the Shell and finds necessary widgets.
@@ -60,7 +61,7 @@ public class StatusDialogUtil {
 	}
 
 	public static Shell getStatusShell(){
-		UITestCase.waitForJobs(100, 1000);
+		waitForJobs(100, 1000);
 		return getStatusShellImmediately();
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/WizardsStatusHandlingTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/WizardsStatusHandlingTestCase.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.statushandlers;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -36,7 +37,6 @@ import org.eclipse.ui.internal.dialogs.ExportWizard;
 import org.eclipse.ui.statushandlers.StatusAdapter;
 import org.eclipse.ui.statushandlers.StatusManager;
 import org.eclipse.ui.tests.SwtLeakTestWatcher;
-import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -106,14 +106,14 @@ public class WizardsStatusHandlingTestCase {
 
 	@Test
 	public void testWizardWithNoDefaultContructor() throws Exception {
-		UITestCase.processEvents();
+		processEvents();
 
 		final CustomWizardDialog dialog = exportWizard();
 		try {
 			dialog.setBlockOnOpen(false);
 			dialog.open();
 
-			UITestCase.processEvents();
+			processEvents();
 
 			// selecting FaultyExportWizard
 			IWizardPage currenPage = dialog.getCurrentPage();
@@ -126,7 +126,7 @@ public class WizardsStatusHandlingTestCase {
 				if (table.getItem(i).getText().equals(FAULTY_WIZARD_NAME)) {
 					table.select(i);
 					table.notifyListeners(SWT.Selection, new Event());
-					UITestCase.processEvents();
+					processEvents();
 					break;
 				}
 			}
@@ -136,7 +136,7 @@ public class WizardsStatusHandlingTestCase {
 
 			dialog.nextPressed2();
 
-			UITestCase.processEvents();
+			processEvents();
 			assertStatusAdapter(TestStatusHandler.getLastHandledStatusAdapter());
 			assertEquals(TestStatusHandler.getLastHandledStyle(), StatusManager.SHOW);
 		} finally {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomTestCase.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.zoom;
 
+import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;


### PR DESCRIPTION
The UITestCase currently contains a bunch of static utility functionality. Since UITestCase is a leftover from JUnit 3 times where test cases were defined in inheritance hierarchies, this class is about to be removed. In order to prepare for that, this moves the utility functions to a separate UITestUtil class. This also includes making some methods static that were effectively static before.

This contributes to the goal of getting rid of the JUnit 3 hierarchy around `UITestCase`. 