### PR TITLE
Extract preference memento from UITestCase into TestRule

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/PreferenceMementoRule.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/PreferenceMementoRule.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vector Informatik and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ui.tests.harness.util;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferenceMemento;
+import org.junit.rules.ExternalResource;
+
+/**
+ * Preference helper to restore changed preference values after test run.
+ */
+public class PreferenceMementoRule extends ExternalResource {
+
+	private PreferenceMemento prefMemento;
+
+	@Override
+	protected void before() {
+		prefMemento = new PreferenceMemento();
+	}
+
+	@Override
+	protected void after() {
+		prefMemento.resetPreferences();
+	}
+
+	/**
+	 * Change a preference value for the associated test run. The preference will
+	 * automatically be reset to the value it had before starting when executing
+	 * {@link #after()}.
+	 *
+	 * @param <T>   preference value type. The type must have a corresponding
+	 *              {@link IPreferenceStore} setter.
+	 * @param store preference store to manipulate (must not be <code>null</code>)
+	 * @param name  preference to change
+	 * @param value new preference value
+	 * @throws IllegalArgumentException when setting a type which is not supported
+	 *                                  by {@link IPreferenceStore}
+	 *
+	 * @see IPreferenceStore#setValue(String, double)
+	 * @see IPreferenceStore#setValue(String, float)
+	 * @see IPreferenceStore#setValue(String, int)
+	 * @see IPreferenceStore#setValue(String, long)
+	 * @see IPreferenceStore#setValue(String, boolean)
+	 * @see IPreferenceStore#setValue(String, String)
+	 */
+	public <T> void setPreference(IPreferenceStore store, String name, T value) {
+		prefMemento.setValue(store, name, value);
+	}
+}

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
@@ -20,8 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.jface.preference.PreferenceMemento;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.junit.After;
@@ -49,9 +47,6 @@ public abstract class UITestCase extends TestCase {
 	private final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	private Set<Shell> preExistingShells;
-
-	/** Preference helper to restore changed preference values after test run. */
-	private final PreferenceMemento prefMemento = new PreferenceMemento();
 
 	/**
 	 * Required to preserve the existing logging output when running tests with
@@ -133,7 +128,6 @@ public abstract class UITestCase extends TestCase {
 	public final void tearDown() throws Exception {
 		String name = runningTest != null ? runningTest : this.getName();
 		trace(TestRunLogUtil.formatTestFinishedMessage(name));
-		prefMemento.resetPreferences();
 		doTearDown();
 
 		// Check for shell leak.
@@ -174,26 +168,5 @@ public abstract class UITestCase extends TestCase {
 		closeTestWindows.setEnabled(manage);
 	}
 
-	/**
-	 * Change a preference value for this test run. The preference will be reset to
-	 * its value before test started automatically on {@link #tearDown()}.
-	 *
-	 * @param <T>   preference value type. The type must have a corresponding
-	 *              {@link IPreferenceStore} setter.
-	 * @param store preference store to manipulate (must not be <code>null</code>)
-	 * @param name  preference to change
-	 * @param value new preference value
-	 * @throws IllegalArgumentException when setting a type which is not supported
-	 *                                  by {@link IPreferenceStore}
-	 *
-	 * @see IPreferenceStore#setValue(String, double)
-	 * @see IPreferenceStore#setValue(String, float)
-	 * @see IPreferenceStore#setValue(String, int)
-	 * @see IPreferenceStore#setValue(String, long)
-	 * @see IPreferenceStore#setValue(String, boolean)
-	 * @see IPreferenceStore#setValue(String, String)
-	 */
-	protected <T> void setPreference(IPreferenceStore store, String name, T value) {
-		prefMemento.setValue(store, name, value);
-	}
+
 }

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProgressReportingTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProgressReportingTest.java
@@ -27,6 +27,8 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.IPreferenceConstants;
 import org.eclipse.ui.internal.WorkbenchPlugin;
+import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
+import org.junit.Rule;
 
 /**
  * Verifies the performance of progress reporting APIs in various contexts which
@@ -64,6 +66,10 @@ public class ProgressReportingTest extends BasicPerformanceTest {
 	 * results during profiling.
 	 */
 	public static final int MAX_ITERATIONS = 100;
+
+	@Rule
+	public final PreferenceMementoRule preferenceMemento = new PreferenceMementoRule();
+
 	private volatile boolean isDone;
 	private Display display;
 
@@ -81,7 +87,8 @@ public class ProgressReportingTest extends BasicPerformanceTest {
 	}
 
 	private void setRunInBackground(boolean newRunInBackgroundSetting) {
-		setPreference(WorkbenchPlugin.getDefault().getPreferenceStore(), IPreferenceConstants.RUN_IN_BACKGROUND,
+		preferenceMemento.setPreference(WorkbenchPlugin.getDefault().getPreferenceStore(),
+				IPreferenceConstants.RUN_IN_BACKGROUND,
 				newRunInBackgroundSetting);
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/StickyViewTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/StickyViewTest.java
@@ -35,9 +35,11 @@ import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.util.PrefUtil;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.tests.harness.util.FileUtil;
+import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
 import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.eclipse.ui.views.IStickyViewDescriptor;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -47,6 +49,9 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class StickyViewTest extends UITestCase {
+
+	@Rule
+	public final PreferenceMementoRule preferenceMemento = new PreferenceMementoRule();
 
 	private IWorkbenchWindow window;
 
@@ -277,7 +282,8 @@ public class StickyViewTest extends UITestCase {
 	public void XXXtestPerspectiveViewToolBarVisible() throws Throwable {
 		// These tests are hard-wired to the pre-3.3 zoom behaviour
 		// Run them anyway to ensure that we preserve the 3.0 mechanism
-		setPreference(PrefUtil.getAPIPreferenceStore(), IWorkbenchPreferenceConstants.ENABLE_NEW_MIN_MAX, false);
+		preferenceMemento.setPreference(PrefUtil.getAPIPreferenceStore(),
+				IWorkbenchPreferenceConstants.ENABLE_NEW_MIN_MAX, false);
 
 		IPerspectiveDescriptor perspective = WorkbenchPlugin.getDefault()
 				.getPerspectiveRegistry().findPerspectiveWithId(

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/PerspectiveSwitcherTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/PerspectiveSwitcherTest.java
@@ -21,13 +21,18 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.IWorkbenchPreferenceConstants;
 import org.eclipse.ui.internal.WorkbenchWindow;
 import org.eclipse.ui.internal.util.PrefUtil;
+import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
 import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class PerspectiveSwitcherTest extends UITestCase {
+
+	@Rule
+	public final PreferenceMementoRule preferenceMemento = new PreferenceMementoRule();
 
 	public PerspectiveSwitcherTest() {
 		super(PerspectiveSwitcherTest.class.getSimpleName());
@@ -45,7 +50,8 @@ public class PerspectiveSwitcherTest extends UITestCase {
 		assertNotNull("We should have a perspective bar in the beginning", getPerspectiveSwitcher(window)); //$NON-NLS-1$
 
 		// turn off the 'Open Perspective' item
-		setPreference(apiPreferenceStore, IWorkbenchPreferenceConstants.SHOW_OPEN_ON_PERSPECTIVE_BAR, false);
+		preferenceMemento.setPreference(apiPreferenceStore, IWorkbenchPreferenceConstants.SHOW_OPEN_ON_PERSPECTIVE_BAR,
+				false);
 
 		// check that we still have a perspective bar
 		assertNotNull("The perspective bar should have been created successfully", getPerspectiveSwitcher(window)); //$NON-NLS-1$

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/StickyViewManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/StickyViewManagerTest.java
@@ -24,8 +24,10 @@ import org.eclipse.ui.IViewReference;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPreferenceConstants;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
 import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -37,14 +39,17 @@ import org.junit.runners.JUnit4;
 @Ignore
 public class StickyViewManagerTest extends UITestCase {
 
+	@Rule
+	public final PreferenceMementoRule preferenceMemento = new PreferenceMementoRule();
+
 	public StickyViewManagerTest() {
 		super(StickyViewManagerTest.class.getSimpleName());
 	}
 
 	@Override
 	protected void doSetUp() throws Exception {
-		setPreference(PlatformUI.getPreferenceStore(), IWorkbenchPreferenceConstants.ENABLE_32_STICKY_CLOSE_BEHAVIOR,
-				false);
+		preferenceMemento.setPreference(PlatformUI.getPreferenceStore(),
+				IWorkbenchPreferenceConstants.ENABLE_32_STICKY_CLOSE_BEHAVIOR, false);
 		super.doSetUp();
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/intro/IntroTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/intro/IntroTest.java
@@ -33,7 +33,9 @@ import org.eclipse.ui.internal.util.PrefUtil;
 import org.eclipse.ui.intro.IIntroManager;
 import org.eclipse.ui.intro.IIntroPart;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
+import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
 import org.eclipse.ui.tests.harness.util.UITestCase;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -43,6 +45,9 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class IntroTest extends UITestCase {
+
+	@Rule
+	public final PreferenceMementoRule preferenceMemento = new PreferenceMementoRule();
 
 	IWorkbenchWindow window = null;
 
@@ -149,7 +154,8 @@ public class IntroTest extends UITestCase {
 	public void testPerspectiveChange() {
 		// These tests are hard-wired to the pre-3.3 zoom behaviour
 		// Run them anyway to ensure that we preserve the 3.0 mechanism
-		setPreference(PrefUtil.getAPIPreferenceStore(), IWorkbenchPreferenceConstants.ENABLE_NEW_MIN_MAX, false);
+		preferenceMemento.setPreference(PrefUtil.getAPIPreferenceStore(),
+				IWorkbenchPreferenceConstants.ENABLE_NEW_MIN_MAX, false);
 
 		IWorkbench workbench = window.getWorkbench();
 		IIntroPart part = workbench.getIntroManager().showIntro(window, false);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomTestCase.java
@@ -36,11 +36,16 @@ import org.eclipse.ui.internal.util.Util;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.tests.api.MockEditorPart;
 import org.eclipse.ui.tests.harness.util.FileUtil;
+import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
 import org.eclipse.ui.tests.harness.util.UITestCase;
 import org.junit.Assert;
+import org.junit.Rule;
 
 public class ZoomTestCase extends UITestCase {
 //    protected static final String view2Id = IPageLayout.ID_OUTLINE;
+
+	@Rule
+	public final PreferenceMementoRule preferenceMemento = new PreferenceMementoRule();
 
 	protected WorkbenchWindow window;
 
@@ -74,7 +79,7 @@ public class ZoomTestCase extends UITestCase {
 
 		// These tests are hard-wired to the pre-3.3 zoom behaviour
 		// Run them anyway to ensure that we preserve the 3.0 mechanism
-		setPreference(apiStore, IWorkbenchPreferenceConstants.ENABLE_NEW_MIN_MAX, false);
+		preferenceMemento.setPreference(apiStore, IWorkbenchPreferenceConstants.ENABLE_NEW_MIN_MAX, false);
 
 		try {
 			project = FileUtil.createProject("IEditorPartTest"); //$NON-NLS-1$


### PR DESCRIPTION
The preference memento managed in UITestCase is only used in very specific test cases. In addition, the logic is integrated into the UITestCase superclass instead of encapsulating the concern into a dedicated TestRule.

This change encapsulates the preference memento into a separate TestRule and only instantiates that rule in those tests that require it.