### PR TITLE
Replace obsolete usage of UITestCase#closeAllWindows()

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/CloseTestWindowsRule.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/CloseTestWindowsRule.java
@@ -70,7 +70,7 @@ public class CloseTestWindowsRule extends ExternalResource {
 	/**
 	 * Close all test windows.
 	 */
-	public void closeAllTestWindows() {
+	private void closeAllTestWindows() {
 		List<IWorkbenchWindow> testWindowsCopy = new ArrayList<>(testWindows);
 		for (IWorkbenchWindow testWindow : testWindowsCopy) {
 			testWindow.close();

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
@@ -155,13 +155,6 @@ public abstract class UITestCase extends TestCase {
 	}
 
 	/**
-	 * Close all test windows.
-	 */
-	public void closeAllTestWindows() {
-		closeTestWindows.closeAllTestWindows();
-	}
-
-	/**
 	 * Set whether the window listener will manage opening and closing of created windows.
 	 */
 	protected void manageWindows(boolean manage) {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchTest.java
@@ -141,7 +141,9 @@ public class IWorkbenchTest extends UITestCase {
 
 		assertEquals(wins.length, oldTotal + num);
 
-		closeAllTestWindows();
+		for (IWorkbenchWindow window : newWins) {
+			window.close();
+		}
 		wins = getWorkbench().getWorkbenchWindows();
 		assertEquals(wins.length, oldTotal);
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandCallbackTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandCallbackTest.java
@@ -418,7 +418,7 @@ public class CommandCallbackTest extends UITestCase {
 		try {
 			assertEquals(2, cmd1Handler.callbacks);
 			cmd1Handler.callbacks = 0;
-			closeAllTestWindows();
+			window.close();
 			commandService.refreshElements(CMD1_ID, null);
 			assertEquals(1, cmd1Handler.callbacks);
 		} finally {


### PR DESCRIPTION
Two tests unnecessarily employ functionality of a test rule to close all windows that have been opened throughout the test run. The windows to close are actually known to the tests and can directly be closed, such that the UITestCase does not need to expose the closing functionality of the test rule.

This change adapts the tests accordingly and removes the unnecessary method from UITestCase.

This contributes to the goal of getting rid of the JUnit 3 hierarchy around `UITestCase`.