### PR TITLE
Remove unnecessary disablement of CloseTestWindowsRule in leak test

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
@@ -154,12 +154,4 @@ public abstract class UITestCase extends TestCase {
 		closeTestWindows.after();
 	}
 
-	/**
-	 * Set whether the window listener will manage opening and closing of created windows.
-	 */
-	protected void manageWindows(boolean manage) {
-		closeTestWindows.setEnabled(manage);
-	}
-
-
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/leaks/LeakTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/leaks/LeakTests.java
@@ -285,25 +285,17 @@ public class LeakTests extends UITestCase {
 
 	@Test
 	public void testSimpleWindowLeak() throws Exception {
-		// turn off window management so that we dont have a reference to our
-		// new
-		// window in the listener
-		manageWindows(false);
-		try {
-			ReferenceQueue queue = new ReferenceQueue();
-			IWorkbenchWindow newWindow = openTestWindow();
+		ReferenceQueue queue = new ReferenceQueue();
+		IWorkbenchWindow newWindow = openTestWindow();
 
-			assertNotNull(newWindow);
-			Reference ref = createReference(queue, newWindow);
-			try {
-				newWindow.close();
-				newWindow = null;
-				checkRef(queue, ref);
-			} finally {
-				ref.clear();
-			}
+		assertNotNull(newWindow);
+		Reference ref = createReference(queue, newWindow);
+		try {
+			newWindow.close();
+			newWindow = null;
+			checkRef(queue, ref);
 		} finally {
-			manageWindows(true);
+			ref.clear();
 		}
 	}
 


### PR DESCRIPTION
UITestCase provides a method to disable window tracking of the CloseTestWindowsRule, which is only used at a single place that does not even require it.

This change removes the methods and the according usage.

This contributes to the goal of getting rid of the JUnit 3 hierarchy around `UITestCase`.