### PR TITLE
Move check for leaked shells to CloseTestWindowsRule

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
@@ -16,12 +16,6 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.harness.util;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
-import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.PlatformUI;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -45,8 +39,6 @@ public abstract class UITestCase extends TestCase {
 	 * compatible with JUnit3
 	 */
 	private final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
-
-	private Set<Shell> preExistingShells;
 
 	/**
 	 * Required to preserve the existing logging output when running tests with
@@ -97,11 +89,9 @@ public abstract class UITestCase extends TestCase {
 	public final void setUp() throws Exception {
 		super.setUp();
 		closeTestWindows.before();
-		this.preExistingShells = Set.of(PlatformUI.getWorkbench().getDisplay().getShells());
 		String name = runningTest != null ? runningTest : this.getName();
 		trace(TestRunLogUtil.formatTestStartMessage(name));
 		doSetUp();
-
 	}
 
 	/**
@@ -129,18 +119,7 @@ public abstract class UITestCase extends TestCase {
 		String name = runningTest != null ? runningTest : this.getName();
 		trace(TestRunLogUtil.formatTestFinishedMessage(name));
 		doTearDown();
-
-		// Check for shell leak.
-		List<String> leakedModalShellTitles = new ArrayList<>();
-		Shell[] shells = PlatformUI.getWorkbench().getDisplay().getShells();
-		for (Shell shell : shells) {
-			if (!shell.isDisposed() && !preExistingShells.contains(shell)) {
-				leakedModalShellTitles.add(shell.getText());
-				shell.close();
-			}
-		}
-		assertEquals("Test leaked modal shell: [" + String.join(", ", leakedModalShellTitles) + "]", 0,
-				leakedModalShellTitles.size());
+		closeTestWindows.after();
 	}
 
 	/**
@@ -151,7 +130,6 @@ public abstract class UITestCase extends TestCase {
 	 * Subclasses may extend.
 	 */
 	protected void doTearDown() throws Exception {
-		closeTestWindows.after();
 	}
 
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/stress/OpenCloseTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/stress/OpenCloseTest.java
@@ -118,6 +118,9 @@ public class OpenCloseTest {
 	 */
 	@Test
 	public void testOpenClosePerspective() {
+		// Reopening the perspective will create a new popup shell that would be
+		// detected as leak
+		closeTestWindows.disableLeakChecks();
 		ICommandService commandService = workbench.getService(ICommandService.class);
 		Command command = commandService.getCommand("org.eclipse.ui.window.closePerspective");
 
@@ -131,11 +134,11 @@ public class OpenCloseTest {
 
 		for (int index = 0; index < numIterations; index++) {
 			try {
-				PlatformUI.getWorkbench().showPerspective(ORG_ECLIPSE_RESOURCE_PERSPECTIVE, workbenchWindow);
 				try {
 					handlerService.executeCommand(pCommand, null);
 				} catch (ExecutionException | NotDefinedException | NotEnabledException | NotHandledException e1) {
 				}
+				PlatformUI.getWorkbench().showPerspective(ORG_ECLIPSE_RESOURCE_PERSPECTIVE, workbenchWindow);
 			} catch (WorkbenchException e) {
 				e.printStackTrace();
 			}
@@ -148,8 +151,6 @@ public class OpenCloseTest {
 	@Test
 	public void testOpenCloseView() throws WorkbenchException {
 		IViewPart consoleView;
-		IWorkbenchPage page = PlatformUI.getWorkbench().showPerspective(ORG_ECLIPSE_RESOURCE_PERSPECTIVE,
-				workbenchWindow);
 		for (int index = 0; index < numIterations; index++) {
 			consoleView = page.showView(IPageLayout.ID_MINIMAP_VIEW);
 			page.hideView(consoleView);


### PR DESCRIPTION
The UITestCase contains a leaked shell check that would be better places in a test rule and fits to the already existing CloseTestWindowsRule.

This change integrates the leaked shell check into the CloseTestWindowsRule.