### PR TITLE
Add Split Editor shortcuts to editor tab context menu

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/internal/workbench/renderers/swt/SWTRenderersMessages.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/internal/workbench/renderers/swt/SWTRenderersMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2015 IBM Corporation and others.
+ * Copyright (c) 2010, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -37,6 +37,10 @@ public class SWTRenderersMessages extends NLS {
 	public static String menuDetach;
 
 	public static String viewMenu;
+
+	public static String splitEditorH;
+
+	public static String splitEditorV;
 
 	static {
 		// load message values from bundle file

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/internal/workbench/renderers/swt/messages.properties
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/internal/workbench/renderers/swt/messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-#  Copyright (c) 2010, 2015 IBM Corporation and others.
+#  Copyright (c) 2010, 2025 IBM Corporation and others.
 #
 #  This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License 2.0
@@ -27,3 +27,5 @@ menuCloseRight = Close Tabs to the &Right
 menuCloseLeft = Close Tabs to the &Left
 menuDetach= &Detach
 viewMenu = View Menu
+splitEditorH = Split Editor in Horizontal
+splitEditorV = Split Editor in Vertical

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
@@ -34,7 +34,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
+import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.e4.core.commands.ECommandService;
+import org.eclipse.e4.core.commands.EHandlerService;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.core.di.extensions.Preference;
@@ -1535,8 +1538,14 @@ public class StackRenderer extends LazyStackRenderer {
 				new MenuItem(menu, SWT.SEPARATOR);
 
 				createMenuItem(menu, SWTRenderersMessages.menuCloseAll, e -> closeSiblingParts(menu, false));
+
+				new MenuItem(menu, SWT.SEPARATOR);
+
 			}
 		}
+
+		createMenuItem(menu, SWTRenderersMessages.splitEditorH, e -> splitEditor(part.getContext(), true));
+		createMenuItem(menu, SWTRenderersMessages.splitEditorV, e -> splitEditor(part.getContext(), false));
 
 		if (isDetachable(part)) {
 			if (closeableElements > 0) {
@@ -1952,5 +1961,13 @@ public class StackRenderer extends LazyStackRenderer {
 		}
 		return Arrays.stream(parent.getChildren()).filter(child -> id.equals(child.getData(ID)))
 				.filter(type::isInstance).map(type::cast).findFirst().orElse(null);
+	}
+
+	private void splitEditor(IEclipseContext ctx, boolean isHorizontal) {
+		ECommandService commandService = ctx.get(ECommandService.class);
+		EHandlerService handlerService = ctx.get(EHandlerService.class);
+		Map<String, String> param = Map.of("Splitter.isHorizontal", String.valueOf(isHorizontal)); //$NON-NLS-1$
+		ParameterizedCommand command = commandService.createCommand("org.eclipse.ui.window.splitEditor", param); //$NON-NLS-1$
+		handlerService.executeHandler(command);
 	}
 }


### PR DESCRIPTION
This PR introduces context menu entries for the Split Editor feature (Horizontal & Vertical) in the editor tab’s menu. Making it easier for new users to access.

<img width="347" height="244" alt="image" src="https://github.com/user-attachments/assets/2902cd6d-cbfd-463f-a35d-7c3844f8e533" />

<br>

https://github.com/user-attachments/assets/e8ece2c8-36af-4477-b248-0da985e29a66


Fixes : https://github.com/eclipse-platform/eclipse.platform.ui/issues/3166