### PR TITLE
Move trace information from UITestCase to CloseTestWindowsRule

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
@@ -66,16 +66,6 @@ public abstract class UITestCase extends TestCase {
 	}
 
 	/**
-	 * Outputs a trace message to the trace output device, if enabled.
-	 * By default, trace messages are sent to <code>System.out</code>.
-	 *
-	 * @param msg the trace message
-	 */
-	protected void trace(String msg) {
-		System.out.println(msg);
-	}
-
-	/**
 	 * Simple implementation of setUp. Subclasses are prevented from overriding this
 	 * method to maintain logging consistency. doSetUp() should be overridden
 	 * instead.
@@ -88,9 +78,9 @@ public abstract class UITestCase extends TestCase {
 	@Override
 	public final void setUp() throws Exception {
 		super.setUp();
-		closeTestWindows.before();
 		String name = runningTest != null ? runningTest : this.getName();
-		trace(TestRunLogUtil.formatTestStartMessage(name));
+		closeTestWindows.setTestName(name);
+		closeTestWindows.before();
 		doSetUp();
 	}
 
@@ -116,8 +106,6 @@ public abstract class UITestCase extends TestCase {
 	@After
 	@Override
 	public final void tearDown() throws Exception {
-		String name = runningTest != null ? runningTest : this.getName();
-		trace(TestRunLogUtil.formatTestFinishedMessage(name));
 		doTearDown();
 		closeTestWindows.after();
 	}


### PR DESCRIPTION
The tracing information for UI tests (test name printed at start/end of each test to stdout) is the only remaining functionality of UITestCase. When the CloseTestWindowsRule has been extracted out of this test case, the test classes that have been adapted to only use that rule miss that tracing information since this.

This change moves the tracing to the CloseTestWindowsRule as the central test rule for UI-related tests. This implicitly readds the tracing information to tests that use the rule.
With this change, the inheritance to UITestCase can simply be replaced with the use of the CloseWindowsTestRule in all plain JUnit 4 tests.