### PR TITLE
Updated setBlockOnOpen documentation

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/window/Window.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/window/Window.java
@@ -832,7 +832,7 @@ public abstract class Window implements IShellProvider {
 
 	/**
 	 * Sets whether the <code>open</code> method should block until the window
-	 * closes.
+	 * closes. (May display different behavior depending on the operating system.)
 	 *
 	 * @param shouldBlock
 	 *            <code>true</code> if the <code>open</code> method should


### PR DESCRIPTION
SWT Radio-Buttons resets radio-button selection after opening and closing FileChooser from same dialog #1599

Updated the documentation for the setBlockOnOpen function. The function seems to display different behaviors based upon the operating system being used to reproduce Issue #1599. On MacOS reproducing the issue passes all test cases while Windows OS  fails.

Co-authored-by: Alejandro Navarro alexnavarro57@gmail.com

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/1599#issuecomment-3020465643