### PR TITLE
Add ZoomChanged listener to MessageDialogue

### DIFF
--- a/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface;singleton:=true
-Bundle-Version: 3.38.100.qualifier
+Bundle-Version: 3.38.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface,

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/IconAndMessageDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/IconAndMessageDialog.java
@@ -24,6 +24,7 @@ import org.eclipse.swt.accessibility.AccessibleAdapter;
 import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
@@ -294,6 +295,38 @@ public abstract class IconAndMessageDialog extends Dialog {
 
 		return image[0];
 
+	}
+
+	@Override
+	protected void configureShell(Shell shell) {
+		super.configureShell(shell);
+		if (shouldRecomputeSizeOnDpiChange()) {
+			shell.addListener(SWT.ZoomChanged, e -> recomputeShellSize(shell));
+		}
+	}
+
+	/**
+	 * Default behavior: recompute size based on current shell keep the maximum
+	 * among the current bounds and the computed bounds
+	 *
+	 */
+	private void recomputeShellSize(Shell shell) {
+		Point newSize = shell.computeSize(SWT.DEFAULT, SWT.DEFAULT, false);
+		Rectangle currentBounds = shell.getBounds();
+		newSize.x = Math.max(currentBounds.width, newSize.x);
+		newSize.y = Math.max(currentBounds.height, newSize.y);
+		shell.setBounds(currentBounds.x, currentBounds.y, newSize.x, newSize.y);
+	}
+
+	/**
+	 * This flag should be set to true if the size of this dialogue has to be
+	 * recomputed on DPI change
+	 *
+	 * @return boolean
+	 * @since 3.38
+	 */
+	public boolean shouldRecomputeSizeOnDpiChange() {
+		return false;
 	}
 
 }


### PR DESCRIPTION
When a zoom change occurs, the OS automatically scales the window based on the scale factor. However, since fonts do not  always scale linearly, this can cause text in dialogues to be cut off.

This change adds a `ZoomChanged` listener to `MessageDialog`. When a `ZoomChanged` event is triggered, the shell size is recomputed so that the contents are fit properly and text is not clipped.

**Steps to reproduce**

Run the below snippet on setup with 100% primary monitor zoom and move it to 150% monitor

Use the VM arguments

```
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
```

```java
package org.eclipse.swt.snippets;

import org.eclipse.jface.dialogs.*;
import org.eclipse.jface.layout.*;
import org.eclipse.jface.preference.*;
import org.eclipse.jface.widgets.*;
import org.eclipse.swt.*;
import org.eclipse.swt.widgets.*;

public class SnippetTextOnlyDialog {

    public static void main(String[] args) {
        Display display = new Display();
        Shell shell = new Shell(display);

        // Main dialog
        MessageDialog dialog = new MessageDialog(shell,
            "Status Check",
            null,
            "the numbers one two three\nfour five six seven eight nine ten\nfour five six seven eight nine ten",
            MessageDialog.INFORMATION,
            0,
            IDialogConstants.PROCEED_LABEL,
            IDialogConstants.CANCEL_LABEL) {

            private Button proceedButton;

            @Override
            protected Control createCustomArea(Composite parent) {
                var radioButtonFactory = WidgetFactory.button(SWT.RADIO | SWT.WRAP);

                // First radio button
                Button option1 = radioButtonFactory
                    .text("the numbers one two three\nfour five six seven eight nine ten\nfour five six seven eight nine ten")
                    .create(parent);
                GridDataFactory.swtDefaults()
                    .hint(250, SWT.DEFAULT)
                    .indent(0, 5)
                    .applyTo(option1);

                // Second radio button
                Button option2 = radioButtonFactory
                		.text("the numbers one two three\nfour five six seven eight nine ten\nfour five six seven eight nine ten")
                    .create(parent);
                GridDataFactory.swtDefaults()
                .hint(250, SWT.DEFAULT)
                    .indent(0, 5)
                    .applyTo(option2);



                LinkFactory.newLink(SWT.WRAP)
                .text("the numbers one two three\nfour five six seven eight nine ten\nfour five six seven eight nine ten") // hardcoded text
                .onSelect(e -> {
                    PreferenceDialog dialog = new PreferenceDialog(
                            parent.getShell(),
                            new org.eclipse.jface.preference.PreferenceManager()
                    );
                    dialog.setBlockOnOpen(false);
                    dialog.open();
                    this.close();
                })
                .create(parent);
//

                return parent;
            }

            @Override
            protected int getShellStyle() {
                // Add RESIZE and MAX style bits
                return super.getShellStyle() | SWT.RESIZE | SWT.MAX;
            }

            @Override
            protected void createButtonsForButtonBar(Composite parent) {
                super.createButtonsForButtonBar(parent);
                proceedButton = getButton(0);
                proceedButton.setEnabled(false); // disabled by default
                getButton(1).forceFocus(); // focus Cancel instead of auto-selecting radio
            }
        };

        dialog.open();

        // Event loop
        while (!shell.isDisposed()) {
            if (!display.readAndDispatch()) {
                display.sleep();
            }
        }
        display.dispose();
    }
}
```

**Expected Behavior:**
With the changes in this PR and in [PR #2446](https://github.com/eclipse-platform/eclipse.platform.swt/pull/2446) , the dialog text should scale correctly and not be cut off when moving between monitors with different DPI settings.

**Actual Behavior (without changes):**
Text in the dialog is cut off on high-DPI monitors.

| Without Changes | With Changes |
|-----------------|--------------|
| ![Without changes](https://github.com/user-attachments/assets/4495dd10-4ac8-4154-ace8-72ee2553dcca) | ![With changes](https://github.com/user-attachments/assets/984d9994-325f-4733-b306-ec94714e2e04) |


Depends on https://github.com/eclipse-platform/eclipse.platform.swt/pull/2446