### PR TITLE
Prepare UIPerformanceTestSuite for JUnit 4

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseViewTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseViewTest.java
@@ -16,10 +16,16 @@ package org.eclipse.ui.tests.performance;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 
+import java.util.Collection;
+
 import org.eclipse.test.performance.Dimension;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 /**
  * Performance tests for showing views.
@@ -27,7 +33,16 @@ import org.eclipse.ui.IWorkbenchWindow;
  * and a more complex view (Resource Navigator).
  * The views are shown in an empty perspective.
  */
+@RunWith(Parameterized.class)
 public class OpenCloseViewTest extends BasicPerformanceTest {
+
+	@Parameters(name = "{index}: {0}")
+	public static Collection<Object[]> data() {
+		return ViewPerformanceUtil.getAllTestableViewIds().stream().map(
+				id -> new Object[] { id, id.equals(ViewPerformanceUtil.PROJECT_EXPLORER) ? BasicPerformanceTest.GLOBAL
+						: BasicPerformanceTest.NONE })
+				.toList();
+	}
 
 	private final String viewId;
 
@@ -36,8 +51,8 @@ public class OpenCloseViewTest extends BasicPerformanceTest {
 		this.viewId = viewId;
 	}
 
-	@Override
-	protected void runTest() throws Throwable {
+	@Test
+	public void test() throws Throwable {
 		IWorkbenchWindow window = openTestWindow();
 		final IWorkbenchPage page = window.getActivePage();
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/UIPerformanceTestSuite.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/UIPerformanceTestSuite.java
@@ -38,7 +38,7 @@ public class UIPerformanceTestSuite extends FilteredTestSuite {
 		addTest(new JUnit4TestAdapter(OpenClosePerspectiveTest.class));
 		addTest(new JUnit4TestAdapter(PerspectiveSwitchTest.class));
 		addTest(new JUnit4TestAdapter(OpenCloseWindowTest.class));
-		addTest(new ViewPerformanceSuite());
+		addTest(new JUnit4TestAdapter(OpenCloseViewTest.class));
 		addTest(new JUnit4TestAdapter(OpenCloseEditorTest.class));
 		addTest(new JUnit4TestAdapter(OpenMultipleEditorTest.class));
 		addTest(new JUnit4TestAdapter(EditorSwitchTest.class));

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ViewPerformanceUtil.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ViewPerformanceUtil.java
@@ -14,58 +14,27 @@
 
 package org.eclipse.ui.tests.performance;
 
+import java.util.Collection;
 import java.util.HashSet;
 
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.tests.performance.layout.ResizeTest;
-import org.eclipse.ui.tests.performance.layout.ViewWidgetFactory;
 import org.eclipse.ui.views.IViewDescriptor;
-
-import junit.framework.Test;
-import junit.framework.TestSuite;
 
 /**
  * @since 3.1
  */
-public class ViewPerformanceSuite extends TestSuite {
+public final class ViewPerformanceUtil {
 
 	public static final String PROJECT_EXPLORER = "org.eclipse.ui.navigator.ProjectExplorer";
 
-	public static final String BASIC_PATH = "org.eclipse.ui";
+	private static final String BASIC_PATH = "org.eclipse.ui";
 
-	public static final String VIEWS_PATTERN = "org.eclipse.ui.views";
+	private static final String VIEWS_PATTERN = "org.eclipse.ui.views";
 
-	/**
-	 * Returns the suite. This is required to use the JUnit Launcher.
-	 */
-	public static Test suite() {
-		return new ViewPerformanceSuite();
+	private ViewPerformanceUtil() {
 	}
 
-	public ViewPerformanceSuite() {
-		addOpenCloseTests();
-		addResizeTests();
-	}
-
-	private void addOpenCloseTests() {
-		String[] ids = getAllTestableViewIds();
-
-		for (String id : ids) {
-			addTest(new OpenCloseViewTest(id,
-					id.equals(PROJECT_EXPLORER) ? BasicPerformanceTest.GLOBAL : BasicPerformanceTest.NONE));
-		}
-	}
-
-	private void addResizeTests() {
-		String[] ids = getAllTestableViewIds();
-
-		for (String id : ids) {
-			addTest(new ResizeTest(new ViewWidgetFactory(id)));
-		}
-
-	}
-
-	public static String[] getAllTestableViewIds() {
+	public static Collection<String> getAllTestableViewIds() {
 		HashSet<String> result = new HashSet<>();
 
 		IViewDescriptor[] descriptors = PlatformUI.getWorkbench().getViewRegistry().getViews();
@@ -83,6 +52,6 @@ public class ViewPerformanceSuite extends TestSuite {
 			}
 		}
 
-		return result.toArray(new String[result.size()]);
+		return result;
 	}
 }

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/WorkbenchPerformanceSuite.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/WorkbenchPerformanceSuite.java
@@ -14,27 +14,13 @@
 
 package org.eclipse.ui.tests.performance;
 
-import org.eclipse.ui.tests.harness.util.EmptyPerspective;
-import org.eclipse.ui.tests.performance.layout.PerspectiveWidgetFactory;
 import org.eclipse.ui.tests.performance.layout.ResizeTest;
 
+import junit.framework.JUnit4TestAdapter;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
 class WorkbenchPerformanceSuite extends TestSuite {
-
-	private static String RESOURCE_PERSPID = "org.eclipse.ui.resourcePerspective";
-	// Note: to test perspective switching properly, we need perspectives with lots
-	// of
-	// associated actions.
-	// NOTE - do not change the order of the IDs below. the PerspectiveSwitchTest
-	// has a
-	// fingerprint test for performance that releys on this not changing.
-	public static final String[] PERSPECTIVE_IDS = { EmptyPerspective.PERSP_ID2, UIPerformanceTestSetup.PERSPECTIVE1,
-			RESOURCE_PERSPID, "org.eclipse.jdt.ui.JavaPerspective", "org.eclipse.debug.ui.DebugPerspective" };
-
-	// Perspective ID to use for the resize window fingerprint test
-	public static String resizeFingerprintTest = RESOURCE_PERSPID;
 
 	/**
 	 * Returns the suite. This is required to use the JUnit Launcher.
@@ -44,15 +30,8 @@ class WorkbenchPerformanceSuite extends TestSuite {
 	}
 
 	public WorkbenchPerformanceSuite() {
-		addResizeScenarios();
+		addTest(new JUnit4TestAdapter(ResizeTest.class));
 	}
 
 
-	private void addResizeScenarios() {
-		for (String id : PERSPECTIVE_IDS) {
-			addTest(new ResizeTest(new PerspectiveWidgetFactory(id),
-					id.equals(resizeFingerprintTest) ? BasicPerformanceTest.LOCAL : BasicPerformanceTest.NONE,
-					"UI - Workbench Window Resize"));
-		}
-	}
 }

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ComputeSizeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ComputeSizeTest.java
@@ -21,6 +21,7 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.WorkbenchException;
 import org.eclipse.ui.tests.performance.BasicPerformanceTest;
+import org.junit.Test;
 
 /**
  * Measures the performance of a widget's computeSize method
@@ -39,8 +40,8 @@ public class ComputeSizeTest extends BasicPerformanceTest {
 		this.widgetFactory = widgetFactory;
 	}
 
-	@Override
-	protected void runTest() throws CoreException, WorkbenchException {
+	@Test
+	public void test() throws CoreException, WorkbenchException {
 
 		widgetFactory.init();
 		final Composite widget = widgetFactory.getControl();

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/LayoutTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/LayoutTest.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.WorkbenchException;
 import org.eclipse.ui.tests.performance.BasicPerformanceTest;
+import org.junit.Test;
 
 /**
  * Measures the time required to layout the widget 10 times. Does not include
@@ -50,8 +51,8 @@ public class LayoutTest extends BasicPerformanceTest {
 	/**
 	 * Run the test
 	 */
-	@Override
-	protected void runTest() throws CoreException, WorkbenchException {
+	@Test
+	public void test() throws CoreException, WorkbenchException {
 
 		widgetFactory.init();
 		final Composite widget = widgetFactory.getControl();

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/TestWidgetFactory.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/TestWidgetFactory.java
@@ -38,4 +38,9 @@ public abstract class TestWidgetFactory {
 	public abstract void done();
 	public abstract String getName();
 	public abstract Composite getControl() throws CoreException, WorkbenchException;
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }


### PR DESCRIPTION
Remove imperative setup of WorkbenchPerformanceTestSuite with JUnit 4 parameterization of the according test cases. This prepares for migrating the test classes from JUnit 3 to JUnit 4.