### PR TITLE
Re-enable test cases and move ignore from test suites to test classes

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/AcceleratorConfigurationsExtensionDynamicTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/AcceleratorConfigurationsExtensionDynamicTest.java
@@ -20,6 +20,7 @@ import org.eclipse.core.commands.common.NamedHandleObject;
 import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
 import org.eclipse.ui.keys.IBindingService;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -28,6 +29,7 @@ import org.junit.Test;
  *
  * @since 3.1.1
  */
+@Ignore("Bug 405296")
 public final class AcceleratorConfigurationsExtensionDynamicTest extends
 		DynamicTestCase {
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/AcceleratorScopesExtensionDynamicTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/AcceleratorScopesExtensionDynamicTest.java
@@ -20,6 +20,7 @@ import org.eclipse.core.commands.common.NamedHandleObject;
 import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -28,6 +29,7 @@ import org.junit.Test;
  *
  * @since 3.1.1
  */
+@Ignore("Bug 405296")
 public final class AcceleratorScopesExtensionDynamicTest extends
 		DynamicTestCase {
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ActionDefinitionsExtensionDynamicTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ActionDefinitionsExtensionDynamicTest.java
@@ -20,6 +20,7 @@ import org.eclipse.core.commands.common.NamedHandleObject;
 import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -28,6 +29,7 @@ import org.junit.Test;
  *
  * @since 3.1.1
  */
+@Ignore("Bug 405296")
 public final class ActionDefinitionsExtensionDynamicTest extends
 		DynamicTestCase {
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ActionSetTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ActionSetTests.java
@@ -37,12 +37,13 @@ import org.eclipse.ui.internal.WorkbenchWindow;
 import org.eclipse.ui.internal.registry.ActionSetRegistry;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
 import org.eclipse.ui.tests.leaks.LeakTests;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * Tests to ensure the addition of new action sets with dynamic plug-ins.
  */
-
+@Ignore("Bug 405296")
 public class ActionSetTests extends DynamicTestCase {
 
 	private static final String ACTION_SET_ID = "org.eclipse.newActionSet1.newActionSet1";

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ActivitySupportTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ActivitySupportTests.java
@@ -23,6 +23,7 @@ import org.eclipse.ui.activities.IActivity;
 import org.eclipse.ui.activities.ICategory;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
 import org.eclipse.ui.tests.harness.util.ImageTests;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class ActivitySupportTests extends DynamicTestCase {
@@ -43,6 +44,7 @@ public class ActivitySupportTests extends DynamicTestCase {
 	}
 
 	@Test
+	@Ignore("Bug 405296")
 	public void testActivityImages() {
 		IActivity baselineActivity = getWorkbench().getActivitySupport()
 				.getActivityManager().getActivity("someBogusActivityId");

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/BindingsExtensionDynamicTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/BindingsExtensionDynamicTest.java
@@ -26,6 +26,7 @@ import org.eclipse.jface.contexts.IContextIds;
 import org.eclipse.ui.IWorkbenchCommandConstants;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
 import org.eclipse.ui.keys.IBindingService;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -34,6 +35,7 @@ import org.junit.Test;
  *
  * @since 3.1.1
  */
+@Ignore("Bug 405296")
 public final class BindingsExtensionDynamicTest extends DynamicTestCase {
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/CommandsExtensionDynamicTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/CommandsExtensionDynamicTest.java
@@ -33,6 +33,7 @@ import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
 import org.eclipse.ui.keys.IBindingService;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -41,6 +42,7 @@ import org.junit.Test;
  *
  * @since 3.1.1
  */
+@Ignore("Bug 405296")
 public final class CommandsExtensionDynamicTest extends DynamicTestCase {
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ContextsExtensionDynamicTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ContextsExtensionDynamicTest.java
@@ -20,6 +20,7 @@ import org.eclipse.core.commands.common.NamedHandleObject;
 import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -28,6 +29,7 @@ import org.junit.Test;
  *
  * @since 3.1.1
  */
+@Ignore("Bug 405296")
 public final class ContextsExtensionDynamicTest extends DynamicTestCase {
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicContributionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicContributionTest.java
@@ -24,11 +24,13 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
 import org.eclipse.ui.internal.util.BundleUtility;
 import org.eclipse.ui.menus.IMenuService;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @since 3.5
  */
+@Ignore("Bug 405296")
 public class DynamicContributionTest extends DynamicTestCase {
 
 	@Test

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicInvalidContributionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicInvalidContributionTest.java
@@ -18,11 +18,13 @@ import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @since 3.5
  */
+@Ignore("Bug 405296")
 public class DynamicInvalidContributionTest extends DynamicTestCase {
 
 	@Test

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicInvalidControlContributionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicInvalidControlContributionTest.java
@@ -18,11 +18,13 @@ import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @since 3.8
  */
+ @Ignore("Bug 405296")
 public class DynamicInvalidControlContributionTest extends DynamicTestCase {
 
 	@Test

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicPluginsTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicPluginsTestSuite.java
@@ -13,46 +13,44 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
 
 /**
  * Test suite for dynamic plug-in support.
  */
 @RunWith(Suite.class)
-@Ignore("Bug 405296")
-@Suite.SuiteClasses({
-	StatusHandlerTests.class,
-	AcceleratorConfigurationsExtensionDynamicTest.class,
-	AcceleratorScopesExtensionDynamicTest.class,
-	ActionDefinitionsExtensionDynamicTest.class,
-	ActionSetTests.class,
-	ActivitySupportTests.class,
-	BindingsExtensionDynamicTest.class,
-	BrowserTests.class,
-	CommandsExtensionDynamicTest.class,
-	ContextsExtensionDynamicTest.class,
-	HandlersExtensionDynamicTest.class,
-	PreferencePageTests.class,
-	KeywordTests.class,
-	PropertyPageTests.class,
-	HelpSupportTests.class,
-	EncodingTests.class,
-	DecoratorTests.class,
-	StartupTests.class,
-	EditorTests.class,
-	IntroTests.class,
-	PerspectiveTests.class,
-	ViewTests.class,
-	NewWizardTests.class,
-	ObjectContributionTests.class,
-	WorkingSetTests.class,
-	DynamicSupportTests.class,
-	DynamicContributionTest.class,
-	DynamicInvalidContributionTest.class,
-	DynamicInvalidControlContributionTest.class,
+@SuiteClasses({ //
+		StatusHandlerTests.class, //
+		AcceleratorConfigurationsExtensionDynamicTest.class, //
+		AcceleratorScopesExtensionDynamicTest.class, //
+		ActionDefinitionsExtensionDynamicTest.class, //
+		ActionSetTests.class, //
+		ActivitySupportTests.class, //
+		BindingsExtensionDynamicTest.class, //
+		BrowserTests.class, //
+		CommandsExtensionDynamicTest.class, //
+		ContextsExtensionDynamicTest.class, //
+		HandlersExtensionDynamicTest.class, //
+		PreferencePageTests.class, //
+		KeywordTests.class, //
+		PropertyPageTests.class, //
+		HelpSupportTests.class, //
+		EncodingTests.class, //
+		DecoratorTests.class, //
+		StartupTests.class, //
+		EditorTests.class, //
+		IntroTests.class, //
+		PerspectiveTests.class, //
+		ViewTests.class, //
+		NewWizardTests.class, //
+		ObjectContributionTests.class, //
+		WorkingSetTests.class, //
+		DynamicSupportTests.class, //
+		DynamicContributionTest.class, //
+		DynamicInvalidContributionTest.class, //
+		DynamicInvalidControlContributionTest.class, //
 })
-
 public class DynamicPluginsTestSuite {
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/EditorTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/EditorTests.java
@@ -38,6 +38,7 @@ import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
 import org.eclipse.ui.tests.leaks.LeakTests;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -68,6 +69,7 @@ public class EditorTests extends DynamicTestCase {
 	}
 
 	@Test
+	@Ignore("Bug 405296")
 	public void testEditorClosure() throws CoreException, IllegalArgumentException, InterruptedException {
 		IWorkbenchWindow window = openTestWindow(IDE.RESOURCE_PERSPECTIVE_ID);
 		IFile file = getFile();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/HandlersExtensionDynamicTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/HandlersExtensionDynamicTest.java
@@ -21,6 +21,7 @@ import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.NotHandledException;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -29,6 +30,7 @@ import org.junit.Test;
  *
  * @since 3.1.1
  */
+@Ignore("Bug 405296")
 public final class HandlersExtensionDynamicTest extends DynamicTestCase {
 
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/IntroTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/IntroTests.java
@@ -33,11 +33,13 @@ import org.eclipse.ui.intro.IIntroPart;
 import org.eclipse.ui.tests.leaks.LeakTests;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @since 3.1
  */
+@Ignore("Bug 405296")
 public class IntroTests extends DynamicTestCase {
 
 	private static final String PRODUCT_ID = "org.eclipse.ui.tests.someProduct";

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/NewWizardTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/NewWizardTests.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 
+import org.eclipse.core.runtime.InvalidRegistryObjectException;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
 import org.eclipse.ui.wizards.IWizardDescriptor;
@@ -39,7 +40,7 @@ public class NewWizardTests extends DynamicTestCase {
 		assertNotNull(wizard);
 		testNewWizardProperties(wizard);
 		removeBundle();
-		assertNull(registry.findWizard(WIZARD_ID));
+		assertThrows(InvalidRegistryObjectException.class, () -> registry.findWizard(WIZARD_ID));
 		assertThrows(RuntimeException.class, () -> testNewWizardProperties(wizard));
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ObjectContributionTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ObjectContributionTests.java
@@ -35,11 +35,13 @@ import org.eclipse.ui.internal.ObjectActionContributorManager;
 import org.eclipse.ui.internal.PartSite;
 import org.eclipse.ui.internal.PopupMenuExtender;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @since 3.1
  */
+@Ignore("Bug 405296")
 public class ObjectContributionTests extends DynamicTestCase {
 
 	private static final String GROUP_ID = "#OC";

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/PerspectiveTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/PerspectiveTests.java
@@ -28,12 +28,14 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.WorkbenchWindow;
 import org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * Tests to check the addition of a new perspective once the perspective
  * registry is loaded.
  */
+@Ignore("Bug 405296")
 public class PerspectiveTests extends DynamicTestCase {
 
 	private static final String PERSPECTIVE_ID = "org.eclipse.newPerspective1.newPerspective1";

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/StatusHandlerTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/StatusHandlerTests.java
@@ -30,12 +30,14 @@ import org.eclipse.ui.statushandlers.AbstractStatusHandler;
 import org.eclipse.ui.statushandlers.StatusAdapter;
 import org.eclipse.ui.statushandlers.StatusManager;
 import org.eclipse.ui.tests.leaks.LeakTests;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * Tests to ensure the addition and removal of new status handlers with dynamic
  * plug-ins.
  */
+@Ignore("Bug 405296")
 public class StatusHandlerTests extends DynamicTestCase {
 
 	private static final String STATUS_HANDLER_ID1 = "org.eclipse.newStatusHandler1.newStatusHandler1";
@@ -145,6 +147,7 @@ public class StatusHandlerTests extends DynamicTestCase {
 	 * @throws IllegalArgumentException
 	 */
 	@Test
+	@Ignore("Bug 405296")
 	public void testProductBindingRemoval() throws CoreException, IllegalArgumentException, InterruptedException {
 		getBundle();
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ViewTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/ViewTests.java
@@ -38,11 +38,13 @@ import org.eclipse.ui.views.IStickyViewDescriptor;
 import org.eclipse.ui.views.IViewCategory;
 import org.eclipse.ui.views.IViewDescriptor;
 import org.eclipse.ui.views.IViewRegistry;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * Tests to ensure the addition of new views with dynamic plug-ins.
  */
+@Ignore("Bug 405296")
 public class ViewTests extends DynamicTestCase {
 
 	private static final String VIEW_ID1 = "org.eclipse.newView1.newView1";

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/intro/IntroTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/intro/IntroTest.java
@@ -41,6 +41,7 @@ import org.eclipse.ui.tests.harness.util.EmptyPerspective;
 import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -118,6 +119,7 @@ public class IntroTest {
 	}
 
 	@Test
+	@Ignore("disabled during E4 transition")
 	public void testActivateProblemsView() throws Exception {
 		IIntroManager introManager= window.getWorkbench().getIntroManager();
 		IIntroPart part= introManager.showIntro(window, false);
@@ -153,6 +155,7 @@ public class IntroTest {
 	 * that it no longer exists.
 	 */
 	@Test
+	@Ignore("disabled during E4 transition")
 	public void testPerspectiveChange() {
 		// These tests are hard-wired to the pre-3.3 zoom behaviour
 		// Run them anyway to ensure that we preserve the 3.0 mechanism
@@ -183,6 +186,7 @@ public class IntroTest {
 	 * See IntroTest2.java
 	 */
 	@Test
+	@Ignore("disabled during E4 transition")
 	public void testPerspectiveChangeWith32StickyBehavior() {
 		IWorkbench workbench = window.getWorkbench();
 		IIntroPart part = workbench.getIntroManager().showIntro(window, false);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/intro/IntroTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/intro/IntroTestSuite.java
@@ -13,14 +13,12 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.intro;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 /**
  * @since 3.0
  */
-@Ignore
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
 	IntroPartTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multieditor/MultiEditorTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multieditor/MultiEditorTest.java
@@ -62,6 +62,7 @@ import org.eclipse.ui.part.MultiEditorInput;
 import org.eclipse.ui.tests.TestPlugin;
 import org.eclipse.ui.tests.api.MockEditorPart;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -153,6 +154,7 @@ public class MultiEditorTest {
 	 * editor.
 	 */
 	@Test
+	@Ignore("deactivated during E4 transition")
 	public void testOpenTestFile() throws Throwable {
 		final String[] simpleFiles = { TEST01_TXT, TEST03_ETEST };
 
@@ -264,6 +266,7 @@ public class MultiEditorTest {
 	 *             on an error
 	 */
 	@Test
+	@Ignore("deactivated during E4 transition")
 	public void testTrackCoolBar() throws Throwable {
 		final String[] simpleFiles = { TEST01_TXT, TEST02_TXT,
 				TEST04_PROPERTIES, BUILD_XML, TEST03_ETEST };

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multieditor/MultiEditorTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multieditor/MultiEditorTestSuite.java
@@ -13,15 +13,13 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.multieditor;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-@Ignore
 @RunWith(Suite.class)
-@Suite.SuiteClasses({
-	AbstractMultiEditorTest.class,
-	MultiEditorTest.class,
+@Suite.SuiteClasses({ //
+		AbstractMultiEditorTest.class, //
+		MultiEditorTest.class, //
 })
 public class MultiEditorTestSuite {
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomTestSuite.java
@@ -20,12 +20,12 @@ import org.junit.runners.Suite;
  * A test suite to test the zooming behavior of Eclipse.
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({
-	ZoomedViewActivateTest.class,
-	ZoomedEditorCloseTest.class,
-	ZoomedViewCloseTest.class,
-	ShowViewTest.class,
-	OpenEditorTest.class,
+@Suite.SuiteClasses({ //
+		ZoomedViewActivateTest.class, //
+		ZoomedEditorCloseTest.class, //
+		ZoomedViewCloseTest.class, //
+		ShowViewTest.class, //
+		OpenEditorTest.class, //
 })
 public class ZoomTestSuite {
 }


### PR DESCRIPTION
Some test suite of org.eclipse.ui.tests are currently disabled/ignored. This will be impossible when migrating to JUnit 5. This change pushes down the ignore to either the included test classes or just some of the test methods of other methods of those test classes work fine. Thus, this also re-enables some tests that actually run fine.