### PR TITLE
Remove setUp/tearDown overwrites in UI performance tests

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ViewerTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ViewerTest.java
@@ -23,6 +23,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.tests.performance.BasicPerformanceTest;
 import org.eclipse.ui.tests.performance.UIPerformanceTestRule;
+import org.junit.After;
 import org.junit.ClassRule;
 
 /**
@@ -83,9 +84,8 @@ public abstract class ViewerTest extends BasicPerformanceTest {
 		};
 	}
 
-	@Override
-	protected void doTearDown() throws Exception {
-		super.doTearDown();
+	@After
+	public final void closeBrowserShell() throws Exception {
 		if(browserShell!= null){
 			browserShell.close();
 			browserShell = null;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/BasicPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/BasicPerformanceTest.java
@@ -27,8 +27,6 @@ import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.function.ThrowingRunnable;
 import org.osgi.framework.Bundle;
@@ -88,26 +86,6 @@ public abstract class BasicPerformanceTest extends PerformanceTestCaseJunit4 {
 	 */
 	private boolean shouldLocallyTag() {
 		return tagAsSummary;
-	}
-
-	@Override
-	@Before
-	public void setUp() throws Exception {
-		super.setUp();
-		doSetUp();
-	}
-
-	protected void doSetUp() throws Exception {
-	}
-
-	@Override
-	@After
-	public void tearDown() throws Exception {
-		doTearDown();
-		super.tearDown();
-	}
-
-	protected void doTearDown() throws Exception {
 	}
 
 	protected IProject getProject() {

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/CommandsPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/CommandsPerformanceTest.java
@@ -35,6 +35,8 @@ import org.eclipse.jface.bindings.keys.KeySequence;
 import org.eclipse.jface.bindings.keys.KeyStroke;
 import org.eclipse.jface.bindings.keys.ParseException;
 import org.eclipse.jface.util.Util;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -176,10 +178,8 @@ public final class CommandsPerformanceTest extends BasicPerformanceTest {
 	 * @throws NotDefinedException
 	 *             If something went wrong initializing the active scheme.
 	 */
-	@Override
-	protected final void doSetUp() throws NotDefinedException, Exception {
-		super.doSetUp();
-
+	@Before
+	public final void setUpBindings() throws NotDefinedException, Exception {
 		/*
 		 * The constants to use in creating the various objects. The platform
 		 * locale count must be greater than or equal to the number of deletion
@@ -346,12 +346,11 @@ public final class CommandsPerformanceTest extends BasicPerformanceTest {
 		bindingManager.setBindings(bindings);
 	}
 
-	@Override
-	protected final void doTearDown() throws Exception {
+	@After
+	public final void clearBindings() throws Exception {
 		bindingManager = null;
 		commandManager = null;
 		contextManager = null;
-		super.doTearDown();
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/LabelProviderTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/LabelProviderTest.java
@@ -46,6 +46,8 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -244,10 +246,8 @@ public class LabelProviderTest extends BasicPerformanceTest {
 		return viewer;
 	}
 
-	@Override
-	protected void doSetUp() throws Exception {
-		super.doSetUp();
-
+	@Before
+	public final void prepareShellUp() throws Exception {
 		Display display = Display.getCurrent();
 		if (display == null)
 			display = new Display();
@@ -266,9 +266,8 @@ public class LabelProviderTest extends BasicPerformanceTest {
 		fShell.open();
 	}
 
-	@Override
-	protected void doTearDown() throws Exception {
-		super.doTearDown();
+	@After
+	public final void closeShell() throws Exception {
 		if (fShell != null) {
 			fShell.close();
 			fShell = null;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProgressReportingTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProgressReportingTest.java
@@ -28,6 +28,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.IPreferenceConstants;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -82,10 +83,9 @@ public class ProgressReportingTest extends BasicPerformanceTest {
 	private volatile boolean isDone;
 	private Display display;
 
-	@Override
-	protected void doSetUp() throws Exception {
+	@Before
+	public final void storeDisplay() throws Exception {
 		this.display = Display.getCurrent();
-		super.doSetUp();
 	}
 
 	private void setRunInBackground(boolean newRunInBackgroundSetting) {


### PR DESCRIPTION
Define separate `@Before`/`@After` methods instead.