### PR TITLE
Centralize test project access for UI performance tests in test rule

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/BasicPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/BasicPerformanceTest.java
@@ -14,9 +14,6 @@
 
 package org.eclipse.ui.tests.performance;
 
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IWorkspace;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -48,8 +45,6 @@ public abstract class BasicPerformanceTest extends PerformanceTestCaseJunit4 {
 
 	@Rule
 	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
-
-	private IProject testProject;
 
 	final private boolean tagAsGlobalSummary;
 
@@ -86,15 +81,6 @@ public abstract class BasicPerformanceTest extends PerformanceTestCaseJunit4 {
 	 */
 	private boolean shouldLocallyTag() {
 		return tagAsSummary;
-	}
-
-	protected IProject getProject() {
-		if (testProject == null) {
-			IWorkspace workspace = ResourcesPlugin.getWorkspace();
-			testProject = workspace.getRoot().getProject(
-					UIPerformanceTestRule.PROJECT_NAME);
-		}
-		return testProject;
 	}
 
 	public void tagIfNecessary(String shortName, Dimension dimension) {

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/EditorSwitchTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/EditorSwitchTest.java
@@ -15,6 +15,7 @@ package org.eclipse.ui.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestRule.getTestProject;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -67,9 +68,9 @@ public class EditorSwitchTest extends BasicPerformanceTest {
 		// the initial time to open, just switching.
 		IWorkbenchWindow window = openTestWindow(UIPerformanceTestRule.PERSPECTIVE1);
 		final IWorkbenchPage activePage = window.getActivePage();
-		final IFile file1 = getProject().getFile("1." + extension1);
+		final IFile file1 = getTestProject().getFile("1." + extension1);
 		assertTrue(file1.exists());
-		final IFile file2 = getProject().getFile("1." + extension2);
+		final IFile file2 = getTestProject().getFile("1." + extension2);
 		assertTrue(file2.exists());
 		IDE.openEditor(activePage, file1, true);
 		IDE.openEditor(activePage, file2, true);

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseEditorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseEditorTest.java
@@ -16,6 +16,7 @@ package org.eclipse.ui.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestRule.getTestProject;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -56,7 +57,7 @@ public class OpenCloseEditorTest extends BasicPerformanceTest {
 
 	@Test
 	public void test() throws Throwable {
-		final IFile file = getProject().getFile("1." + extension);
+		final IFile file = getTestProject().getFile("1." + extension);
 		assertTrue(file.exists());
 
 		IWorkbenchWindow window = openTestWindow(UIPerformanceTestRule.PERSPECTIVE1);

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenMultipleEditorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenMultipleEditorTest.java
@@ -16,6 +16,7 @@ package org.eclipse.ui.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestRule.getTestProject;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -65,7 +66,7 @@ public class OpenMultipleEditorTest extends BasicPerformanceTest {
 		startMeasuring();
 
 		for (int i = 0; i < 100; i++) {
-			IFile file = getProject().getFile(i + "." + extension);
+			IFile file = getTestProject().getFile(i + "." + extension);
 			IDE.openEditor(activePage, file, true);
 			processEvents();
 		}

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/PerspectiveSwitchTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/PerspectiveSwitchTest.java
@@ -15,6 +15,7 @@ package org.eclipse.ui.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestRule.getTestProject;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -106,7 +107,7 @@ public class PerspectiveSwitchTest extends BasicPerformanceTest {
 
 		// IFile aFile = getProject().getFile("1." +
 		// EditorPerformanceSuite.EDITOR_FILE_EXTENSIONS[0]);
-		IFile aFile = getProject().getFile(activeEditor);
+		IFile aFile = getTestProject().getFile(activeEditor);
 		assertTrue(aFile.exists());
 
 		IDE.openEditor(page, aFile, true);

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/UIPerformanceTestRule.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/UIPerformanceTestRule.java
@@ -17,7 +17,6 @@ import java.io.ByteArrayInputStream;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.ui.IWorkbench;
@@ -57,16 +56,19 @@ public class UIPerformanceTestRule extends ExternalResource {
 	@Override
 	protected void after() {
 		try {
-			ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT_NAME).delete(true, null);
+			getTestProject().delete(true, null);
 		} catch (CoreException e) {
 			e.printStackTrace();
 		}
 	}
 
+	public static IProject getTestProject() {
+		return ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT_NAME);
+	}
+
 	private static void setUpProject() throws CoreException {
 		// Create a java project.
-		IWorkspace workspace = ResourcesPlugin.getWorkspace();
-		IProject testProject = workspace.getRoot().getProject(PROJECT_NAME);
+		IProject testProject = getTestProject();
 		testProject.create(null);
 		testProject.open(null);
 


### PR DESCRIPTION
Currently, the test project access in projects is scattered across multiple places. This centralizes the access at the UIPerformanceTestRule, which is responsible with creating and deleting the project anyway.