### PR TITLE
Simplify tagging of UI performance tests

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListViewerRefreshTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListViewerRefreshTest.java
@@ -19,7 +19,6 @@ import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import org.eclipse.jface.viewers.ListViewer;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.test.performance.Dimension;
 import org.junit.Test;
 
 /**
@@ -46,10 +45,6 @@ public class ListViewerRefreshTest extends ViewerTest {
 	 */
 	@Test
 	public void testRefresh() throws Throwable {
-
-		tagIfNecessary("JFace - Refresh 100 item ListViewer 10 times",
-				Dimension.ELAPSED_PROCESS);
-
 		openBrowser();
 
 		exercise(() -> {

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ProgressMonitorDialogPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ProgressMonitorDialogPerformanceTest.java
@@ -20,7 +20,6 @@ import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.test.performance.Dimension;
 import org.eclipse.ui.tests.performance.BasicPerformanceTest;
 import org.eclipse.ui.tests.performance.UIPerformanceTestRule;
 import org.junit.ClassRule;
@@ -39,10 +38,6 @@ public class ProgressMonitorDialogPerformanceTest extends BasicPerformanceTest {
 	 */
 	@Test
 	public void testLongNames() throws Throwable {
-
-		tagIfNecessary("JFace - 10000 element task name in progress dialog",
-				Dimension.ELAPSED_PROCESS);
-
 		Display display = Display.getCurrent();
 		if (display == null) {
 			display = new Display();

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ShrinkingTreeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ShrinkingTreeTest.java
@@ -16,7 +16,6 @@ package org.eclipse.jface.tests.performance;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.test.performance.Dimension;
 import org.junit.Test;
 
 /**
@@ -28,10 +27,6 @@ public class ShrinkingTreeTest extends TreeTest {
 
 	@Test
 	public void testTreeViewerRefresh() throws CoreException {
-
-		tagIfNecessary("JFace - Refresh from 1000 items to 100 items",
-				Dimension.ELAPSED_PROCESS);
-
 		openBrowser();
 //		int smallCount = 1;
 //		for (int i = 0; i < 3; i++) {

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TreeAddTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TreeAddTest.java
@@ -73,10 +73,6 @@ public class TreeAddTest extends TreeTest {
 	 */
 	@Test
 	public void testAddHundred() throws CoreException {
-
-		tagIfNecessary("JFace - Add 1000 items in 10 blocks to TreeViewer",
-				Dimension.ELAPSED_PROCESS);
-
 		doTestAdd(100, TEST_COUNT, false);
 	}
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ViewerTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ViewerTest.java
@@ -39,14 +39,6 @@ public abstract class ViewerTest extends BasicPerformanceTest {
 	public static int ITERATIONS = 100;
 	public static int MIN_ITERATIONS = 20;
 
-	public ViewerTest(int tagging) {
-		super(tagging);
-	}
-
-	public ViewerTest() {
-		super();
-	}
-
 	protected void openBrowser() {
 		Display display = Display.getCurrent();
 		if (display == null) {

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/BasicPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/BasicPerformanceTest.java
@@ -20,14 +20,11 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.junit.Rule;
 import org.junit.function.ThrowingRunnable;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 /**
@@ -37,60 +34,8 @@ import org.osgi.framework.FrameworkUtil;
  */
 public abstract class BasicPerformanceTest extends PerformanceTestCaseJunit4 {
 
-	public static final int NONE = 0;
-
-	public static final int LOCAL = 1;
-
-	public static final int GLOBAL = 2;
-
 	@Rule
 	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
-
-	final private boolean tagAsGlobalSummary;
-
-	final private boolean tagAsSummary;
-
-	public BasicPerformanceTest() {
-		this(NONE);
-		Bundle bundle = FrameworkUtil.getBundle(getClass());
-		BundleContext context = bundle != null ? bundle.getBundleContext() : null;
-		if (context == null) { // most likely run in a wrong launch mode
-			System.err.println("Unable to retrieve bundle context from BasicPerformanceTest; interactive mode is disabled");
-			return;
-		}
-	}
-
-	public BasicPerformanceTest(int tagging) {
-		tagAsGlobalSummary = ((tagging & GLOBAL) != 0);
-		tagAsSummary = ((tagging & LOCAL) != 0);
-	}
-
-	/**
-	 * Answers whether this test should be tagged globally.
-	 *
-	 * @return whether this test should be tagged globally
-	 */
-	private boolean shouldGloballyTag() {
-		return tagAsGlobalSummary;
-	}
-
-	/**
-	 * Answers whether this test should be tagged locally.
-	 *
-	 * @return whether this test should be tagged locally
-	 */
-	private boolean shouldLocallyTag() {
-		return tagAsSummary;
-	}
-
-	public void tagIfNecessary(String shortName, Dimension dimension) {
-		if (shouldGloballyTag()) {
-			tagAsGlobalSummary(shortName, dimension);
-		}
-		if (shouldLocallyTag()) {
-			tagAsSummary(shortName, dimension);
-		}
-	}
 
 	public static void waitForBackgroundJobs() {
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseEditorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseEditorTest.java
@@ -45,13 +45,11 @@ public class OpenCloseEditorTest extends BasicPerformanceTest {
 
 	@Parameters(name = "{index}: {0}")
 	public static Collection<Object[]> data() {
-		return Arrays.asList(new Object[][] { { "perf_basic", BasicPerformanceTest.NONE },
-				{ "perf_outline", BasicPerformanceTest.NONE }, { "java", BasicPerformanceTest.LOCAL } });
+		return Arrays.asList(new Object[][] { { "perf_basic" }, { "perf_outline" }, { "java" } });
 	}
 
 
-	public OpenCloseEditorTest(String extension, int tagging) {
-		super(tagging);
+	public OpenCloseEditorTest(String extension) {
 		this.extension = extension;
 	}
 
@@ -80,7 +78,9 @@ public class OpenCloseEditorTest extends BasicPerformanceTest {
 			stopMeasuring();
 		});
 
-		tagIfNecessary("UI - Open/Close Editor", Dimension.ELAPSED_PROCESS);
+		if (extension.equals("java")) {
+			tagAsSummary("UI - Open/Close Editor", Dimension.ELAPSED_PROCESS);
+		}
 		commitMeasurements();
 		assertPerformance();
 	}

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenClosePerspectiveTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenClosePerspectiveTest.java
@@ -56,16 +56,12 @@ public class OpenClosePerspectiveTest extends BasicPerformanceTest {
 
 	@Parameters(name = "{index}: {0}")
 	public static Collection<Object[]> data() {
-		return Arrays.asList(new Object[][] { { EmptyPerspective.PERSP_ID2, BasicPerformanceTest.NONE }, {
-				UIPerformanceTestRule.PERSPECTIVE1,
-				BasicPerformanceTest.LOCAL },
-				{ "org.eclipse.ui.resourcePerspective", BasicPerformanceTest.NONE },
-				{ "org.eclipse.jdt.ui.JavaPerspective", BasicPerformanceTest.NONE },
-				{ "org.eclipse.debug.ui.DebugPerspective", BasicPerformanceTest.NONE } });
+		return Arrays.asList(new Object[][] { { EmptyPerspective.PERSP_ID2 }, { UIPerformanceTestRule.PERSPECTIVE1 },
+				{ "org.eclipse.ui.resourcePerspective" }, { "org.eclipse.jdt.ui.JavaPerspective" },
+				{ "org.eclipse.debug.ui.DebugPerspective" } });
 	}
 
-	public OpenClosePerspectiveTest(String id, int tagging) {
-		super(tagging);
+	public OpenClosePerspectiveTest(String id) {
 		this.id = id;
 	}
 
@@ -103,7 +99,9 @@ public class OpenClosePerspectiveTest extends BasicPerformanceTest {
 			activePage.showView(i);
 		}
 
-		tagIfNecessary("UI - Open/Close " + perspective1.getLabel() + " Perspective", Dimension.ELAPSED_PROCESS);
+		if (id.equals(UIPerformanceTestRule.PERSPECTIVE1)) {
+			tagAsSummary("UI - Open/Close " + perspective1.getLabel() + " Perspective", Dimension.ELAPSED_PROCESS);
+		}
 
 		exercise(() -> {
 			processEvents();

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseViewTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseViewTest.java
@@ -42,16 +42,12 @@ public class OpenCloseViewTest extends BasicPerformanceTest {
 
 	@Parameters(name = "{index}: {0}")
 	public static Collection<Object[]> data() {
-		return ViewPerformanceUtil.getAllTestableViewIds().stream().map(
-				id -> new Object[] { id, id.equals(ViewPerformanceUtil.PROJECT_EXPLORER) ? BasicPerformanceTest.GLOBAL
-						: BasicPerformanceTest.NONE })
-				.toList();
+		return ViewPerformanceUtil.getAllTestableViewIds().stream().map(id -> new Object[] { id }).toList();
 	}
 
 	private final String viewId;
 
-	public OpenCloseViewTest(String viewId, int tagging) {
-		super(tagging);
+	public OpenCloseViewTest(String viewId) {
 		this.viewId = viewId;
 	}
 
@@ -66,7 +62,9 @@ public class OpenCloseViewTest extends BasicPerformanceTest {
 		waitForBackgroundJobs();
 		processEvents();
 
-		tagIfNecessary("UI - Open/Close " + view1.getTitle(), Dimension.ELAPSED_PROCESS);
+		if (viewId.equals(ViewPerformanceUtil.PROJECT_EXPLORER)) {
+			tagAsGlobalSummary("UI - Open/Close " + view1.getTitle(), Dimension.ELAPSED_PROCESS);
+		}
 
 		for (int j = 0; j < 100; j++) {
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseWindowTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseWindowTest.java
@@ -20,7 +20,6 @@ import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.eclipse.test.performance.Dimension;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
 import org.junit.ClassRule;
@@ -45,14 +44,11 @@ public class OpenCloseWindowTest extends BasicPerformanceTest {
 	}
 
 	public OpenCloseWindowTest(String id) {
-		super(BasicPerformanceTest.NONE);
 		this.id = id;
 	}
 
 	@Test
 	public void test() throws Throwable {
-		tagIfNecessary("UI - Open/Close Window", Dimension.ELAPSED_PROCESS);
-
 		exercise(() -> {
 			processEvents();
 			EditorTestHelper.calmDown(500, 30000, 500);

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenMultipleEditorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenMultipleEditorTest.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.test.performance.Dimension;
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -60,8 +59,6 @@ public class OpenMultipleEditorTest extends BasicPerformanceTest {
 	public void test() throws Throwable {
 		IWorkbenchWindow window = openTestWindow(UIPerformanceTestRule.PERSPECTIVE1);
 		IWorkbenchPage activePage = window.getActivePage();
-
-		tagIfNecessary("UI - Open Multiple Editors",Dimension.ELAPSED_PROCESS);
 
 		startMeasuring();
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/PerspectiveSwitchTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/PerspectiveSwitchTest.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.test.performance.Dimension;
 import org.eclipse.ui.IPerspectiveDescriptor;
 import org.eclipse.ui.IPerspectiveRegistry;
 import org.eclipse.ui.IWorkbenchPage;
@@ -111,8 +110,6 @@ public class PerspectiveSwitchTest extends BasicPerformanceTest {
 		assertTrue(aFile.exists());
 
 		IDE.openEditor(page, aFile, true);
-
-		tagIfNecessary("UI - Perspective Switch", Dimension.ELAPSED_PROCESS);
 
 		exercise(() -> {
 			processEvents();

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProblemsViewPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProblemsViewPerformanceTest.java
@@ -26,7 +26,6 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.test.performance.Dimension;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
@@ -62,9 +61,6 @@ public class ProblemsViewPerformanceTest extends BasicPerformanceTest {
 			fail();
 			return;
 		}
-
-		tagIfNecessary("UI - Problems View population",
-				Dimension.ELAPSED_PROCESS);
 
 		for (int i = 0; i < 100; i++) {
 			createMarkers();

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProgressReportingTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProgressReportingTest.java
@@ -22,7 +22,6 @@ import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.test.performance.Dimension;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.IPreferenceConstants;
@@ -32,7 +31,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 
 /**
  * Verifies the performance of progress reporting APIs in various contexts which
@@ -77,9 +75,6 @@ public class ProgressReportingTest extends BasicPerformanceTest {
 	@Rule
 	public final PreferenceMementoRule preferenceMemento = new PreferenceMementoRule();
 
-	@Rule
-	public final TestName testName = new TestName();
-
 	private volatile boolean isDone;
 	private Display display;
 
@@ -100,7 +95,6 @@ public class ProgressReportingTest extends BasicPerformanceTest {
 	 */
 	public void runAsyncTest(Runnable testContent) throws Exception {
 		final Display display = Display.getCurrent();
-		tagIfNecessary(testName.getMethodName(), Dimension.ELAPSED_PROCESS);
 		exercise(() -> {
 			startMeasuring();
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ResizeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ResizeTest.java
@@ -70,24 +70,25 @@ public class ResizeTest extends BasicPerformanceTest {
 
 	private final TestWidgetFactory widgetFactory;
 
+	private final boolean tagLocal;
+
 	@Parameters(name = "{index}: {0}")
 	public static Collection<Object[]> data() {
 		var configs = new ArrayList<Object[]>();
 		configs.addAll(PERSPECTIVE_IDS.stream()
-				.map(id -> new Object[] { new PerspectiveWidgetFactory(id),
-						id.equals(resizeFingerprintTest) ? BasicPerformanceTest.LOCAL : BasicPerformanceTest.NONE })
+				.map(id -> new Object[] { new PerspectiveWidgetFactory(id), id.equals(resizeFingerprintTest) })
 				.toList());
 		configs.addAll(ViewPerformanceUtil.getAllTestableViewIds().stream()
-				.map(id -> new Object[] { new ViewWidgetFactory(id), BasicPerformanceTest.NONE }).toList());
+				.map(id -> new Object[] { new ViewWidgetFactory(id), false }).toList());
 		return configs;
 	}
 
 	/**
 	 * Create a new instance of the receiver.
 	 */
-	public ResizeTest(TestWidgetFactory testWidgetFactory, int tagging) {
-		super(tagging);
+	public ResizeTest(TestWidgetFactory testWidgetFactory, boolean tagLocal) {
 		this.widgetFactory = testWidgetFactory;
+		this.tagLocal = tagLocal;
 	}
 
 	/**
@@ -95,7 +96,9 @@ public class ResizeTest extends BasicPerformanceTest {
 	 */
 	@Test
 	public void test() throws CoreException, WorkbenchException {
-		tagIfNecessary(tagString, Dimension.ELAPSED_PROCESS);
+		if (tagLocal) {
+			tagAsSummary(tagString, Dimension.ELAPSED_PROCESS);
+		}
 
 		widgetFactory.init();
 		final Composite widget = widgetFactory.getControl();


### PR DESCRIPTION
UI performance tests use the existing tagging capabilities very rarely. This removes the tagging calls where it does not have any effect anymore and in the remaining cases simplifies the tagging specification such that no utility functions in the common BasicPerformanceTest superclass is necessary anymore.
In addition, useless checks inside the BasicPerformanceTest constructor are removed, as they were only necessary for interactive execution mode that has already been removed.