### PR TITLE
Replace obsolete BasicPerformanceTest superclass with utility class

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.performance/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Performance Plug-in
 Bundle-SymbolicName: org.eclipse.ui.tests.performance;singleton:=true
-Bundle-Version: 1.6.500.qualifier
+Bundle-Version: 1.6.600.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.core.tests.harness,

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/CollatorPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/CollatorPerformanceTest.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 import org.eclipse.jface.util.Policy;
-import org.eclipse.ui.tests.performance.BasicPerformanceTest;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.tests.performance.UIPerformanceTestRule;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -27,7 +27,7 @@ import org.junit.Test;
 /**
  * @since 3.5
  */
-public class CollatorPerformanceTest extends BasicPerformanceTest {
+public class CollatorPerformanceTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ComboViewerRefreshTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ComboViewerRefreshTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
 import org.eclipse.jface.viewers.ComboViewer;
 import org.eclipse.jface.viewers.StructuredViewer;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FastTableViewerRefreshTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FastTableViewerRefreshTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
 import org.eclipse.swt.widgets.TableItem;
 import org.junit.Test;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FastTreeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FastTreeTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FileImageDescriptorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FileImageDescriptorTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
 import java.net.URL;
 import java.util.ArrayList;
@@ -25,7 +26,9 @@ import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.ui.tests.performance.BasicPerformanceTest;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
@@ -34,7 +37,10 @@ import org.osgi.framework.FrameworkUtil;
  * ComboViewerRefreshTest is a test of refreshes of difference size in the combo
  * viewer.
  */
-public class FileImageDescriptorTest extends BasicPerformanceTest {
+public class FileImageDescriptorTest extends PerformanceTestCaseJunit4 {
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	protected static final String IMAGES_DIRECTORY = "/icons/imagetests";
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListPopulationTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListPopulationTest.java
@@ -15,20 +15,26 @@
 package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.List;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.tests.performance.BasicPerformanceTest;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
  * The ListPopulationTest is the test for simple
  * SWT lists.
  */
-public class ListPopulationTest extends BasicPerformanceTest {
+public class ListPopulationTest extends PerformanceTestCaseJunit4 {
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	List list;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListViewerRefreshTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListViewerRefreshTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
 import org.eclipse.jface.viewers.ListViewer;
 import org.eclipse.jface.viewers.StructuredViewer;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ProgressMonitorDialogPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ProgressMonitorDialogPerformanceTest.java
@@ -20,18 +20,23 @@ import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.tests.performance.BasicPerformanceTest;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.eclipse.ui.tests.performance.UIPerformanceTestRule;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
  * @since 3.3
  */
-public class ProgressMonitorDialogPerformanceTest extends BasicPerformanceTest {
+public class ProgressMonitorDialogPerformanceTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	/**
 	 * Test the time for doing a refresh.

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/SWTTreeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/SWTTreeTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.swt.SWT;
@@ -22,10 +23,15 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
-import org.eclipse.ui.tests.performance.BasicPerformanceTest;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.junit.Rule;
 import org.junit.Test;
 
-public class SWTTreeTest extends BasicPerformanceTest {
+public class SWTTreeTest extends PerformanceTestCaseJunit4 {
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	Shell browserShell;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ShrinkingTreeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ShrinkingTreeTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
 import org.eclipse.core.runtime.CoreException;
 import org.junit.Test;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TableViewerRefreshTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TableViewerRefreshTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jface.viewers.TableViewer;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TreeAddTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/TreeAddTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jface.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ViewerTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ViewerTest.java
@@ -21,18 +21,23 @@ import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.tests.performance.BasicPerformanceTest;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.eclipse.ui.tests.performance.UIPerformanceTestRule;
 import org.junit.After;
 import org.junit.ClassRule;
+import org.junit.Rule;
 
 /**
  * The LinearViewerTest is a test that tests viewers.
  */
-public abstract class ViewerTest extends BasicPerformanceTest {
+public abstract class ViewerTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	Shell browserShell;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/CommandsPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/CommandsPerformanceTest.java
@@ -35,9 +35,12 @@ import org.eclipse.jface.bindings.keys.KeySequence;
 import org.eclipse.jface.bindings.keys.KeyStroke;
 import org.eclipse.jface.bindings.keys.ParseException;
 import org.eclipse.jface.util.Util;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -50,10 +53,13 @@ import org.junit.Test;
  *
  * @since 3.1
  */
-public final class CommandsPerformanceTest extends BasicPerformanceTest {
+public final class CommandsPerformanceTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	/**
 	 * <p>

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/EditorSwitchTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/EditorSwitchTest.java
@@ -16,6 +16,7 @@ package org.eclipse.ui.tests.performance;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestRule.getTestProject;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.waitForBackgroundJobs;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -23,10 +24,13 @@ import java.util.Collection;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -36,10 +40,13 @@ import org.junit.runners.Parameterized.Parameters;
  * Test editor switching.
  */
 @RunWith(Parameterized.class)
-public class EditorSwitchTest extends BasicPerformanceTest {
+public class EditorSwitchTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	private final String extension1;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/GenerateIdentifiersTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/GenerateIdentifiersTest.java
@@ -15,18 +15,25 @@
 package org.eclipse.ui.tests.performance;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.activities.IActivityManager;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
  * @since 3.1
  */
-public class GenerateIdentifiersTest extends BasicPerformanceTest {
+public class GenerateIdentifiersTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	private static final int count = 10000;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/LabelProviderTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/LabelProviderTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.ui.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -46,9 +47,12 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -60,10 +64,13 @@ import org.junit.runners.Parameterized.Parameters;
  * @since 3.5
  */
 @RunWith(Parameterized.class)
-public class LabelProviderTest extends BasicPerformanceTest {
+public class LabelProviderTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	private static class CountryEntry {
 		private final String name;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseEditorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseEditorTest.java
@@ -17,6 +17,7 @@ package org.eclipse.ui.tests.performance;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestRule.getTestProject;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -24,22 +25,28 @@ import java.util.Collection;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.test.performance.Dimension;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
-public class OpenCloseEditorTest extends BasicPerformanceTest {
+public class OpenCloseEditorTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	private final String extension;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenClosePerspectiveTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenClosePerspectiveTest.java
@@ -18,6 +18,7 @@ package org.eclipse.ui.tests.performance;
 import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,6 +31,7 @@ import org.eclipse.core.commands.NotHandledException;
 import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.test.performance.Dimension;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.IPerspectiveDescriptor;
 import org.eclipse.ui.IPerspectiveRegistry;
 import org.eclipse.ui.IViewReference;
@@ -39,18 +41,23 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.internal.WorkbenchPlugin;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
-public class OpenClosePerspectiveTest extends BasicPerformanceTest {
+public class OpenClosePerspectiveTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	private final String id;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseViewTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseViewTest.java
@@ -15,14 +15,18 @@ package org.eclipse.ui.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.waitForBackgroundJobs;
 
 import java.util.Collection;
 
 import org.eclipse.test.performance.Dimension;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -35,10 +39,13 @@ import org.junit.runners.Parameterized.Parameters;
  * The views are shown in an empty perspective.
  */
 @RunWith(Parameterized.class)
-public class OpenCloseViewTest extends BasicPerformanceTest {
+public class OpenCloseViewTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	@Parameters(name = "{index}: {0}")
 	public static Collection<Object[]> data() {

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseWindowTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseWindowTest.java
@@ -16,23 +16,30 @@ package org.eclipse.ui.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
-public class OpenCloseWindowTest extends BasicPerformanceTest {
+public class OpenCloseWindowTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	private final String id;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenMultipleEditorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenMultipleEditorTest.java
@@ -22,11 +22,14 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -36,10 +39,13 @@ import org.junit.runners.Parameterized.Parameters;
  * @since 3.1
  */
 @RunWith(Parameterized.class)
-public class OpenMultipleEditorTest extends BasicPerformanceTest {
+public class OpenMultipleEditorTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	private final String extension;
 	private final boolean closeAll;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/PerspectiveSwitchTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/PerspectiveSwitchTest.java
@@ -16,6 +16,7 @@ package org.eclipse.ui.tests.performance;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestRule.getTestProject;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -24,6 +25,7 @@ import java.util.Collection;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.IPerspectiveDescriptor;
 import org.eclipse.ui.IPerspectiveRegistry;
 import org.eclipse.ui.IWorkbenchPage;
@@ -31,7 +33,9 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.WorkbenchException;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.WorkbenchPlugin;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -41,10 +45,13 @@ import org.junit.runners.Parameterized.Parameters;
  * Test perspective switching.
  */
 @RunWith(Parameterized.class)
-public class PerspectiveSwitchTest extends BasicPerformanceTest {
+public class PerspectiveSwitchTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	private final String id1;
 	private final String id2;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProblemsViewPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProblemsViewPerformanceTest.java
@@ -26,11 +26,14 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.eclipse.ui.tests.performance.parts.PerformanceProblemsView;
 import org.eclipse.ui.texteditor.MarkerUtilities;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -38,7 +41,10 @@ import org.junit.Test;
  *
  * @since 3.2
  */
-public class ProblemsViewPerformanceTest extends BasicPerformanceTest {
+public class ProblemsViewPerformanceTest extends PerformanceTestCaseJunit4 {
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	private final String EMPTY_PERSPECTIVE_ID = "org.eclipse.ui.tests.harness.util.EmptyPerspective";
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProgressReportingTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProgressReportingTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.ui.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -22,10 +23,12 @@ import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.IPreferenceConstants;
 import org.eclipse.ui.internal.WorkbenchPlugin;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -36,10 +39,13 @@ import org.junit.Test;
  * Verifies the performance of progress reporting APIs in various contexts which
  * offer progress monitoring.
  */
-public class ProgressReportingTest extends BasicPerformanceTest {
+public class ProgressReportingTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	/**
 	 * Number of iterations to run for the inner loop in these tests. This

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/UIPerformanceTestUtil.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/UIPerformanceTestUtil.java
@@ -11,7 +11,6 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-
 package org.eclipse.ui.tests.performance;
 
 import org.eclipse.core.runtime.CoreException;
@@ -20,22 +19,52 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
 import org.junit.function.ThrowingRunnable;
 import org.osgi.framework.FrameworkUtil;
 
-/**
- * Baseclass for simple performance tests.
- *
- * @since 3.1
- */
-public abstract class BasicPerformanceTest extends PerformanceTestCaseJunit4 {
+public final class UIPerformanceTestUtil {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	private UIPerformanceTestUtil() {
+
+	}
+
+	/**
+	 * Exercises the given runnable until either the given number of iterations
+	 * or the given amount of time has elapsed, whatever occurs first.
+	 */
+	public static void exercise(ThrowingRunnable runnable,
+			int minIterations,
+			int maxIterations, int maxTime) throws CoreException {
+		long startTime = System.currentTimeMillis();
+
+		for (int counter = 0; counter < maxIterations; counter++) {
+
+			try {
+				runnable.run();
+			} catch (Throwable e) {
+				throw new CoreException(new Status(IStatus.ERROR,
+						FrameworkUtil.getBundle(UIPerformanceTestUtil.class)
+								.getSymbolicName(), IStatus.OK,
+						"An exception occurred", e));
+			}
+
+			long curTime = System.currentTimeMillis();
+			if (curTime - startTime > maxTime && counter >= minIterations - 1) {
+				break;
+			}
+		}
+	}
+
+	/**
+	 * Runs the given runnable until either 100 iterations or 4s has elapsed.
+	 * Runs a minimum of 3 times.
+	 *
+	 * @since 3.1
+	 */
+	public static void exercise(ThrowingRunnable runnable) throws CoreException {
+		exercise(runnable, 3, 100, 4000);
+	}
 
 	public static void waitForBackgroundJobs() {
 
@@ -68,43 +97,5 @@ public abstract class BasicPerformanceTest extends PerformanceTestCaseJunit4 {
 		}
 	}
 
-	/**
-	 * Runs the given runnable until either 100 iterations or 4s has elapsed.
-	 * Runs a minimum of 3 times.
-	 *
-	 * @since 3.1
-	 */
-	public static void exercise(ThrowingRunnable runnable) throws CoreException {
-		exercise(runnable, 3, 100, 4000);
-	}
-
-	/**
-	 * Exercises the given runnable until either the given number of iterations
-	 * or the given amount of time has elapsed, whatever occurs first.
-	 *
-	 * @since 3.1
-	 */
-	public static void exercise(ThrowingRunnable runnable,
-			int minIterations,
-			int maxIterations, int maxTime) throws CoreException {
-		long startTime = System.currentTimeMillis();
-
-		for (int counter = 0; counter < maxIterations; counter++) {
-
-			try {
-				runnable.run();
-			} catch (Throwable e) {
-				throw new CoreException(new Status(IStatus.ERROR,
-						FrameworkUtil.getBundle(BasicPerformanceTest.class)
-								.getSymbolicName(), IStatus.OK,
-						"An exception occurred", e));
-			}
-
-			long curTime = System.currentTimeMillis();
-			if (curTime - startTime > maxTime && counter >= minIterations - 1) {
-				break;
-			}
-		}
-	}
 
 }

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ComputeSizeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ComputeSizeTest.java
@@ -19,8 +19,10 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.WorkbenchException;
-import org.eclipse.ui.tests.performance.BasicPerformanceTest;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -28,7 +30,10 @@ import org.junit.Test;
  *
  * @since 3.1
  */
-public class ComputeSizeTest extends BasicPerformanceTest {
+public class ComputeSizeTest extends PerformanceTestCaseJunit4 {
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	private final TestWidgetFactory widgetFactory;
 	private final int xIterations = 10;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/LayoutTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/LayoutTest.java
@@ -20,8 +20,10 @@ import org.eclipse.jface.util.Geometry;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.WorkbenchException;
-import org.eclipse.ui.tests.performance.BasicPerformanceTest;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -30,7 +32,10 @@ import org.junit.Test;
  *
  * @since 3.1
  */
-public class LayoutTest extends BasicPerformanceTest {
+public class LayoutTest extends PerformanceTestCaseJunit4 {
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	private final TestWidgetFactory widgetFactory;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ResizeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ResizeTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.ui.tests.performance.layout;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.waitForBackgroundJobs;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -24,12 +25,14 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.test.performance.Dimension;
+import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.WorkbenchException;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
-import org.eclipse.ui.tests.performance.BasicPerformanceTest;
 import org.eclipse.ui.tests.performance.UIPerformanceTestRule;
 import org.eclipse.ui.tests.performance.ViewPerformanceUtil;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -42,10 +45,13 @@ import org.junit.runners.Parameterized.Parameters;
  * @since 3.1
  */
 @RunWith(Parameterized.class)
-public class ResizeTest extends BasicPerformanceTest {
+public class ResizeTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+
+	@Rule
+	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	private static String RESOURCE_PERSPID = "org.eclipse.ui.resourcePerspective";
 	// Note: to test perspective switching properly, we need perspectives with lots

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ViewWidgetFactory.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ViewWidgetFactory.java
@@ -14,6 +14,7 @@
 package org.eclipse.ui.tests.performance.layout;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.getPageInput;
+import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.waitForBackgroundJobs;
 import static org.junit.Assert.assertNotNull;
 
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
@@ -27,7 +28,6 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.WorkbenchException;
 import org.eclipse.ui.internal.ViewSite;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
-import org.eclipse.ui.tests.performance.BasicPerformanceTest;
 
 
 /**
@@ -64,7 +64,7 @@ public class ViewWidgetFactory extends TestWidgetFactory {
 
 		IViewPart part = page.showView(viewId, null, IWorkbenchPage.VIEW_ACTIVATE);
 
-		BasicPerformanceTest.waitForBackgroundJobs();
+		waitForBackgroundJobs();
 
 		ctrl = getControl(part);
 


### PR DESCRIPTION
The BasicPerformanceTest only serves as a utility class for its subclasses. This change removes the class from the inheritance hierarchy and makes a propery utility class out of it.

This prepares for a possible subsequent migration to JUnit 5.