### PR TITLE
Deprecate IWorkbenchPage#zoomOut() for removal

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/IWorkbenchPage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/IWorkbenchPage.java
@@ -1051,7 +1051,13 @@ public interface IWorkbenchPage extends IPartService, ISelectionService {
 	 * does nothing.
 	 *
 	 * @since 3.2
+	 *
+	 * @deprecated this method has never been implemented; use
+	 *             {@link #toggleZoom(IWorkbenchPartReference)} to toggle between
+	 *             maximized and non-maximized state instead of explicitly zooming
+	 *             out
 	 */
+	@Deprecated(forRemoval = true, since = "2025-12")
 	void zoomOut();
 
 	/**

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPage.java
@@ -1810,22 +1810,11 @@ public class WorkbenchPage implements IWorkbenchPage {
 	}
 
 	/**
-	 * Forces all perspectives on the page to zoom out.
-	 */
-	public void unzoomAllPerspectives() {
-		// TODO compat: we have no min/max behaviour
-	}
-
-	/**
 	 * Cleanup.
 	 */
 	public void dispose() {
 		legacyWindow = null;
 		largeFileLimitsPreferenceHandler.dispose();
-// // Always unzoom
-		// if (isZoomed()) {
-		// zoomOut();
-		// }
 		//
 		// // makeActiveEditor(null);
 		// // makeActive(null);
@@ -4350,7 +4339,7 @@ public class WorkbenchPage implements IWorkbenchPage {
 
 	@Override
 	public void zoomOut() {
-		// TODO compat: what does the zoom do?
+		// to be removed once interface method is removed
 	}
 
 	@Override


### PR DESCRIPTION
The method IWorkbenchPage#zoomOut() has never been implemented in the sole interface implementation WorkbenchPage. All existing consumers rely on the #toogleZoom() implementation. This change thus deprecates the method for removal, as it has never been implemented and required and will unlikely ever get implemented.

The related functionality of WorkbenchPage#unzoomAllPerspective() is also unused, and since it's internal this change just removes it.

See https://github.com/eclipse-platform/eclipse.platform.ui/pull/3215#issuecomment-3218305271 and https://github.com/eclipse-platform/eclipse.platform.ui/pull/3215#issuecomment-3224348852.