### PR TITLE
Cleanup and re-enable zoom tests

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ActivateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ActivateTest.java
@@ -14,14 +14,12 @@
 package org.eclipse.ui.tests.zoom;
 
 import org.eclipse.ui.IWorkbenchPart;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public abstract class ActivateTest extends ZoomTestCase {
 
 	public abstract IWorkbenchPart getStackedPart1();
 	public abstract IWorkbenchPart getStackedPart2();
-	public abstract IWorkbenchPart getUnstackedPart();
 
 	/**
 	 * <p>Test: Zoom a part and activate it</p>
@@ -55,24 +53,6 @@ public abstract class ActivateTest extends ZoomTestCase {
 
 		assertZoomed(stacked2);
 		assertActive(stacked2);
-	}
-
-	/**
-	 * <p>Test: Zoom a view than activate a view in a different stack</p>
-	 * <p>Expected result: page unzooms</p>
-	 */
-	@Test
-	@Ignore
-	public void testActivateOtherStack() {
-		// We allow an editor to be activated *without* unzooming
-//        IWorkbenchPart stacked1 = getStackedPart1();
-//        IWorkbenchPart unstacked = getUnstackedPart();
-//
-//        zoom(stacked1);
-//        page.activate(unstacked);
-//
-//        assertZoomed(null);
-//        assertActive(unstacked);
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/CloseTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/CloseTest.java
@@ -26,78 +26,6 @@ public abstract class CloseTest extends ZoomTestCase {
 
 	public abstract IWorkbenchPart getStackedPart1();
 	public abstract IWorkbenchPart getStackedPart2();
-	public abstract IWorkbenchPart getUnstackedPart();
-
-	/**
-	 * <p>Test: Zoom a part and hide an inactive fast view</p>
-	 * <p>Expected result: Part remains zoomed</p>
-	 */
-	@Test
-	public void testCloseInactiveFastView() {
-		IWorkbenchPart zoomPart = getStackedPart1();
-
-		zoom(zoomPart);
-		close(fastView);
-
-		assertZoomed(zoomPart);
-		assertActive(zoomPart);
-	}
-
-	/**
-	 * <p>Test: Zoom a part, activate a fast view, then hide the fast view</p>
-	 * <p>Expected result: Part remains zoomed</p>
-	 */
-	@Test
-	public void testCloseActiveFastView() {
-		IWorkbenchPart zoomPart = getStackedPart1();
-
-		zoom(zoomPart);
-		page.activate(fastView);
-		close(fastView);
-
-		assertZoomed(zoomPart);
-		assertActive(zoomPart);
-	}
-
-	/**
-	 * <p>Test: Activate an unstacked view, zoom and activate a stacked part, then close the active part.</p>
-	 * <p>Expected result: Stack remains zoomed, another part in the zoomed stack is active</p>
-	 * <p>Note: This ensures that when the active part is closed, it will try to activate a part that
-	 *    doesn't affect the zoom even if something else was activated more recently.</p>
-	 */
-	@Test
-	public void testCloseZoomedStackedPartAfterActivatingView() {
-		IWorkbenchPart zoomPart = getStackedPart1();
-		IWorkbenchPart otherStackedPart = getStackedPart2();
-		IWorkbenchPart unstackedPart = unstackedView;
-
-		page.activate(unstackedPart);
-		zoom(zoomPart);
-		close(zoomPart);
-
-		assertZoomed(otherStackedPart);
-		assertActive(otherStackedPart);
-	}
-
-	/**
-	 * <p>Test: Activate an unstacked editor, zoom and activate a stacked part, then close the active part.</p>
-	 * <p>Expected result: Stack remains zoomed, another part in the zoomed stack is active</p>
-	 * <p>Note: This ensures that when the active part is closed, it will try to activate a part that
-	 *    doesn't affect the zoom even if something else was activated more recently.</p>
-	 */
-	@Test
-	public void testCloseZoomedStackedPartAfterActivatingEditor() {
-		IWorkbenchPart zoomPart = getStackedPart1();
-		IWorkbenchPart otherStackedPart = getStackedPart2();
-		IWorkbenchPart unstackedPart = editor3;
-
-		page.activate(unstackedPart);
-		zoom(zoomPart);
-		close(zoomPart);
-
-		assertZoomed(otherStackedPart);
-		assertActive(otherStackedPart);
-	}
 
 	/**
 	 * <p>Test: Activate an unstacked editor, activate a stacked part, then close the active part.</p>
@@ -116,25 +44,6 @@ public abstract class CloseTest extends ZoomTestCase {
 
 		assertZoomed(null);
 		assertActive(unstackedPart);
-	}
-
-	/**
-	 * <p>Test: Zoom an unstacked part and close it.</p>
-	 * <p>Expected result: The page is unzoomed and the previously active part becomes active</p>
-	 * <p>Note: This ensures that the activation list is used if there is nothing available
-	 *    in the currently zoomed stack.</p>
-	 */
-	@Test
-	public void testCloseZoomedUnstackedPartAfterActivatingEditor() {
-		IWorkbenchPart previousActive = editor1;
-		IWorkbenchPart zoomedPart = getUnstackedPart();
-
-		page.activate(previousActive);
-		zoom(zoomedPart);
-		close(zoomedPart);
-
-		assertZoomed(null);
-		assertActive(previousActive);
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/OpenEditorTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/OpenEditorTest.java
@@ -31,23 +31,6 @@ public class OpenEditorTest extends ZoomTestCase {
 	}
 
 	/**
-	 * <p>Test: Open a new editor while a view is zoomed. Do not force activation.</p>
-	 * <p>Expected result: the page remains zoomed, the view is active</p>
-	 *
-	 * <p>Note: the expected result changed intentionally on 05/04/18</p>
-	 */
-	@Test
-	public void testOpenNewEditorWhileViewZoomed() {
-		close(editor1);
-
-		zoom(stackedView1);
-		openEditor(file1, false);
-
-		assertZoomed(stackedView1);
-		assertActive(stackedView1);
-	}
-
-	/**
 	 * <p>Test: Zoom an editor then open a new editor in the same stack. Do not force activation.</p>
 	 * <p>Expected result: the new editor is zoomed and active</p>
 	 */
@@ -59,47 +42,6 @@ public class OpenEditorTest extends ZoomTestCase {
 		openEditor(file2, false);
 		Assert.assertTrue(isZoomed(editor2));
 		Assert.assertTrue(page.getActivePart() == editor2);
-	}
-
-	/**
-	 * <p>Test: Open an existing editor while a view is zoomed. Do not force activation.</p>
-	 * <p>Expected result: the page remains zoomed, the view is active</p>
-	 */
-	@Test
-	public void testOpenExistingEditorWhileViewZoomed() {
-		zoom(stackedView1);
-		openEditor(file1, false);
-
-		assertZoomed(stackedView1);
-		assertActive(stackedView1);
-	}
-
-	/**
-	 * <p>Test: Open an existing editor while a view is zoomed. Use the activate-on-open mode.</p>
-	 * <p>Expected result: the page is unzoomed, the view is active</p>
-	 */
-	@Test
-	public void testOpenAndActivateExistingEditorWhileViewZoomed() {
-		zoom(stackedView1);
-		openEditor(file1, true);
-
-		assertZoomed(null);
-		assertActive(editor1);
-	}
-
-	/**
-	 * <p>Test: Open a new editor while a view is zoomed. Use the activate-on-open mode.</p>
-	 * <p>Expected result: the page is unzoomed, the view is active</p>
-	 */
-	@Test
-	public void testOpenAndActivateNewEditorWhileViewZoomed() {
-		close(editor1);
-
-		zoom(stackedView1);
-		openEditor(file1, true);
-
-		assertZoomed(null);
-		assertActive(editor1);
 	}
 
 	/**
@@ -127,32 +69,6 @@ public class OpenEditorTest extends ZoomTestCase {
 		openEditor(file2, true);
 
 		assertZoomed(editor2);
-		assertActive(editor2);
-	}
-
-	/**
-	 * <p>Test: Zoom an editor then open an existing editor in a different stack. Do not force activation.</p>
-	 * <p>Expected result: the page remains zoomed and the original editor is active</p>
-	 */
-	@Test
-	public void testOpenExistingEditorInOtherStack() {
-		zoom(editor3);
-		openEditor(file2, false);
-
-		assertZoomed(editor3);
-		assertActive(editor3);
-	}
-
-	/**
-	 * <p>Test: Zoom an editor then open an existing editor in a different stack. Use the activate-on-open mode.</p>
-	 * <p>Expected result: the page is unzoomed and the new editor and active</p>
-	 */
-	@Test
-	public void testOpenAndActivateExistingEditorInOtherStack() {
-		zoom(editor3);
-		openEditor(file2, true);
-
-		assertZoomed(null);
 		assertActive(editor2);
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ShowViewTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ShowViewTest.java
@@ -14,36 +14,12 @@
 package org.eclipse.ui.tests.zoom;
 
 
-import static org.junit.Assert.assertTrue;
-
-import org.eclipse.e4.ui.model.application.ui.MUIElement;
-import org.eclipse.e4.ui.model.application.ui.basic.MPartStack;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class ShowViewTest extends ZoomTestCase {
-
-	/**
-	 * <p>
-	 * Test: Zoom a view, create a new view in the same stack using the
-	 * IWorkbenchPage.VIEW_VISIBLE flag
-	 * </p>
-	 * <p>
-	 * Expected result: the new view is zoomed and active
-	 * </p>
-	 */
-	@Test
-	@Ignore("Commented out until the (possible) ambiguity in bug 91775 is resolved")
-	public void testCreateViewAndMakeVisibleInZoomedStack() {
-		zoom(stackedView1);
-		IViewPart newPart = showRegularView(ZoomPerspectiveFactory.STACK1_PLACEHOLDER1, IWorkbenchPage.VIEW_VISIBLE);
-
-		Assert.assertTrue(page.getActivePart() == newPart);
-		Assert.assertTrue(isZoomed(newPart));
-	}
 
 	/**
 	 * <p>Test: Zoom a view, create a new view in the same stack using the
@@ -60,72 +36,6 @@ public class ShowViewTest extends ZoomTestCase {
 
 		Assert.assertTrue(page.getActivePart() == newPart);
 		Assert.assertTrue(isZoomed(newPart));
-	}
-
-	/**
-	 * <p>Test: Zoom a view, create a new view in a different stack using the
-	 *    IWorkbenchPage.VIEW_CREATE flag and bring it to front using page.bringToTop</p>
-	 * <p>Expected result: no change in zoom or activation. The newly created view is obscured by the zoom,
-	 *    but will be the top view in its (currently invisible) stack.</p>
-	 */
-	@Test
-	public void testCreateViewAndBringToTopInOtherStack() {
-		zoom(unstackedView);
-		IViewPart newPart = showRegularView(ZoomPerspectiveFactory.STACK1_PLACEHOLDER1, IWorkbenchPage.VIEW_CREATE);
-		page.bringToTop(newPart);
-		Assert.assertTrue(page.getActivePart() == unstackedView);
-
-		// Ensure no change to zoom
-		Assert.assertTrue(isZoomed(unstackedView));
-
-		// Ensure that the new part was brought to the top of the stack
-		MUIElement partParent = getPartParent(unstackedView);
-		assertTrue(partParent instanceof MPartStack);
-
-		MPartStack stack = (MPartStack) partParent;
-		Assert.assertTrue(stack.getSelectedElement() == getPartModel(unstackedView));
-	}
-
-	/**
-	 * <p>Test: Zoom a view, create a new view in a different stack using the
-	 *    IWorkbenchPage.VIEW_VISIBLE flag</p>
-	 * <p>Expected result: no change in zoom or activation. The newly created view is obscured by the zoom,
-	 *    but will be the top view in its (currently invisible) stack.</p>
-	 */
-	@Test
-	public void testCreateViewAndMakeVisibleInOtherStack() {
-		zoom(unstackedView);
-		IViewPart newPart = showRegularView(ZoomPerspectiveFactory.STACK1_PLACEHOLDER1, IWorkbenchPage.VIEW_VISIBLE);
-		Assert.assertTrue(page.getActivePart() == unstackedView);
-
-		// Ensure no change to zoom
-		Assert.assertTrue(isZoomed(unstackedView));
-
-		// Ensure that the new part was brought to the top of the stack
-		MUIElement partParent = getPartParent(newPart);
-		assertTrue(partParent instanceof MPartStack);
-
-		MPartStack stack = (MPartStack) partParent;
-		Assert.assertTrue(stack.getSelectedElement() == getPartModel(newPart));
-	}
-	/**
-	 * <p>Test: Zoom an editor, create a new view using the IWorkbenchPage.VIEW_VISIBLE mode</p>
-	 * <p>Expected result: No change to zoom or activation. The new view was brought to the top
-	 *    of its stack.</p>
-	 */
-	@Test
-	public void testCreateViewAndMakeVisibleWhileEditorZoomed() {
-		zoom(editor1);
-		IViewPart newPart = showRegularView(ZoomPerspectiveFactory.STACK1_PLACEHOLDER1, IWorkbenchPage.VIEW_VISIBLE);
-		Assert.assertTrue(isZoomed());
-		Assert.assertTrue(page.getActivePart() == editor1);
-
-		// Ensure that the new part was brought to the top of the stack
-		MUIElement partParent = getPartParent(newPart);
-		assertTrue(partParent instanceof MPartStack);
-
-		MPartStack stack = (MPartStack) partParent;
-		Assert.assertTrue(stack.getSelectedElement() == getPartModel(newPart));
 	}
 
 	/**
@@ -159,20 +69,6 @@ public class ShowViewTest extends ZoomTestCase {
 
 	/**
 	 * <p>Test: Zoom a view, create a new view in a different stack using the
-	 *    IWorkbenchPage.VIEW_ACTIVATE flag</p>
-	 * <p>Expected result: the page is unzoomed and the new view is active</p>
-	 */
-	@Test
-	public void testCreateViewAndActivateInOtherStack() {
-		zoom(unstackedView);
-		IViewPart newPart = showRegularView(ZoomPerspectiveFactory.STACK1_PLACEHOLDER1, IWorkbenchPage.VIEW_ACTIVATE);
-
-		assertZoomed(null);
-		assertActive(newPart);
-	}
-
-	/**
-	 * <p>Test: Zoom a view, create a new view in a different stack using the
 	 *    IWorkbenchPage.VIEW_CREATE flag</p>
 	 * <p>Expected result: No change to zoom or activation. The newly created view is hidden</p>
 	 */
@@ -183,19 +79,6 @@ public class ShowViewTest extends ZoomTestCase {
 
 		assertZoomed(unstackedView);
 		assertActive(unstackedView);
-	}
-
-	/**
-	 * <p>Test: Zoom an editor, create a new view using the IWorkbenchPage.VIEW_ACTIVATE mode</p>
-	 * <p>Expected result: the page is unzoomed and the new view is active</p>
-	 */
-	@Test
-	public void testCreateViewAndActivateWhileEditorZoomed() {
-		zoom(editor1);
-		IViewPart newPart = showRegularView(ZoomPerspectiveFactory.STACK1_PLACEHOLDER1, IWorkbenchPage.VIEW_ACTIVATE);
-
-		assertZoomed(null);
-		assertActive(newPart);
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomPerspectiveFactory.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomPerspectiveFactory.java
@@ -28,6 +28,7 @@ public class ZoomPerspectiveFactory implements IPerspectiveFactory {
 	public static final String STACK1_PLACEHOLDER1 = IPageLayout.ID_PROP_SHEET;
 	public static final String STACK1_VIEW3 = IPageLayout.ID_TASK_LIST;
 	public static final String FASTVIEW1 = IPageLayout.ID_BOOKMARKS;
+	public static final String UNSTACKED_VIEW1 = IPageLayout.ID_PROGRESS_VIEW;
 
 	@Override
 	public void createInitialLayout(IPageLayout layout) {
@@ -40,5 +41,6 @@ public class ZoomPerspectiveFactory implements IPerspectiveFactory {
 		folder.addPlaceholder(STACK1_PLACEHOLDER1);
 		folder.addView(STACK1_VIEW3);
 
+		layout.addView(UNSTACKED_VIEW1, IPageLayout.TOP, 0.5f, IPageLayout.ID_EDITOR_AREA);
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomTestCase.java
@@ -44,8 +44,6 @@ import org.junit.Before;
 import org.junit.Rule;
 
 public class ZoomTestCase {
-//    protected static final String view2Id = IPageLayout.ID_OUTLINE;
-
 	@Rule
 	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
@@ -65,7 +63,6 @@ public class ZoomTestCase {
 	protected IViewPart stackedView1;
 	protected IViewPart stackedView2;
 	protected IViewPart unstackedView;
-	protected IViewPart fastView;
 
 	private IFile file3;
 
@@ -91,15 +88,12 @@ public class ZoomTestCase {
 					MockEditorPart.ID2);
 			editor3 = page.openEditor(new FileEditorInput(file3),
 					MockEditorPart.ID2);
-
-//            DragOperations
-//        		.drag(editor3, new EditorAreaDropTarget(new ExistingWindowProvider(window), SWT.RIGHT), false);
 		} catch (CoreException e) {
 		}
 
 		stackedView1 = findView(ZoomPerspectiveFactory.STACK1_VIEW1);
 		stackedView2 = findView(ZoomPerspectiveFactory.STACK1_VIEW2);
-//        fastView = findView(ZoomPerspectiveFactory.FASTVIEW1);
+		unstackedView = findView(ZoomPerspectiveFactory.UNSTACKED_VIEW1);
 	}
 
 	// zooms the given part

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomTestSuite.java
@@ -13,14 +13,12 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.zoom;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 /**
  * A test suite to test the zooming behavior of Eclipse.
  */
-@Ignore
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
 	ZoomedViewActivateTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomedEditorCloseTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomedEditorCloseTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.ui.tests.zoom;
 
 import org.eclipse.ui.IWorkbenchPart;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -30,34 +29,6 @@ public class ZoomedEditorCloseTest extends CloseTest {
 	@Override
 	public IWorkbenchPart getStackedPart2() {
 		return editor2;
-	}
-
-	@Override
-	public IWorkbenchPart getUnstackedPart() {
-		return editor3;
-	}
-
-	/**
-	 * <p>Test: Activate a view, then zoom an unstacked editor and close it.</p>
-	 * <p>Expected result: The previously active Editor becomes active and unzoomed</p>
-	 * <p>Note: This ensures that the activation list is used if there is nothing available
-	 *    in the currently zoomed stack. It also ensures that activation never moves from
-	 *    an editor to a view when an editor is closed.</p>
-	 */
-	@Test
-	@Ignore
-	public void testCloseZoomedUnstackedEditorAfterActivatingView() {
-		System.out.println("Bogus test: we don't unsoom in this case");
-//        IWorkbenchPart previousActive = stackedView1;
-//        IWorkbenchPart zoomedPart = editor3;
-//
-//        page.activate(editor1);
-//        page.activate(previousActive);
-//        zoom(zoomedPart);
-//        close(zoomedPart);
-//
-//        assertZoomed(null);
-//        assertActive(editor1);
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomedViewActivateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomedViewActivateTest.java
@@ -14,8 +14,6 @@
 package org.eclipse.ui.tests.zoom;
 
 import org.eclipse.ui.IWorkbenchPart;
-import org.junit.Ignore;
-import org.junit.Test;
 
 /**
  * @since 3.1
@@ -32,24 +30,4 @@ public class ZoomedViewActivateTest extends ActivateTest {
 		return stackedView2;
 	}
 
-	@Override
-	public IWorkbenchPart getUnstackedPart() {
-		return unstackedView;
-	}
-
-	/**
-	 * <p>Test: Zoom a view then activate an editor</p>
-	 * <p>Expected result: page unzooms</p>
-	 */
-	@Test
-	@Ignore
-	public void testActivateEditor() {
-		// We allow an editor to be activated *without* unzooming
-
-//        zoom(stackedView1);
-//        page.activate(editor1);
-//
-//        assertZoomed(null);
-//        assertActive(editor1);
-	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomedViewCloseTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomedViewCloseTest.java
@@ -31,7 +31,6 @@ public class ZoomedViewCloseTest extends CloseTest {
 		return stackedView2;
 	}
 
-	@Override
 	public IWorkbenchPart getUnstackedPart() {
 		return unstackedView;
 	}
@@ -54,41 +53,61 @@ public class ZoomedViewCloseTest extends CloseTest {
 	}
 
 	/**
-	 * <p>Test: Zoom an unstacked view and close it.</p>
-	 * <p>Expected result: The previously active part becomes active and unzoomed</p>
-	 * <p>Note: This ensures that the activation list is used if there is nothing available
-	 *    in the currently zoomed stack.</p>
+	 * <p>
+	 * Test: Activate an unstacked view, zoom and activate a stacked part, then
+	 * close the active part.
+	 * </p>
+	 * <p>
+	 * Expected result: Stack remains zoomed, another part in the zoomed stack is
+	 * active
+	 * </p>
+	 * <p>
+	 * Note: This ensures that when the active part is closed, it will try to
+	 * activate a part that doesn't affect the zoom even if something else was
+	 * activated more recently.
+	 * </p>
 	 */
 	@Test
-	public void testCloseZoomedUnstackedViewAfterActivatingView() {
-		IWorkbenchPart previousActive = stackedView1;
-		IWorkbenchPart zoomedPart = getUnstackedPart();
+	public void testCloseZoomedStackedPartAfterActivatingView() {
+		IWorkbenchPart zoomPart = getStackedPart1();
+		IWorkbenchPart otherStackedPart = getStackedPart2();
+		IWorkbenchPart unstackedPart = getUnstackedPart();
 
-		page.activate(previousActive);
-		zoom(zoomedPart);
-		close(zoomedPart);
+		page.activate(unstackedPart);
+		zoom(zoomPart);
+		close(zoomPart);
 
-		assertZoomed(null);
-		assertActive(previousActive);
+		assertZoomed(otherStackedPart);
+		assertActive(otherStackedPart);
 	}
 
 	/**
-	 * <p>Test: Activate an unstacked view, activate a stacked part, then close the active part.</p>
-	 * <p>Expected result: The unstacked part becomes active</p>
-	 * <p>Note: This isn't really a zoom test, but it ensures that activation
-	 *    will move between stacks when there is no zoom.</p>
+	 * <p>
+	 * Test: Activate an unstacked editor, zoom and activate a stacked part, then
+	 * close the active part.
+	 * </p>
+	 * <p>
+	 * Expected result: Stack remains zoomed, another part in the zoomed stack is
+	 * active
+	 * </p>
+	 * <p>
+	 * Note: This ensures that when the active part is closed, it will try to
+	 * activate a part that doesn't affect the zoom even if something else was
+	 * activated more recently.
+	 * </p>
 	 */
 	@Test
-	public void testCloseUnzoomedStackedViewAfterActivatingView() {
-		IWorkbenchPart activePart = getStackedPart1();
-		IWorkbenchPart unstackedPart = unstackedView;
+	public void testCloseZoomedStackedPartAfterActivatingEditor() {
+		IWorkbenchPart zoomPart = getStackedPart1();
+		IWorkbenchPart otherStackedPart = getStackedPart2();
+		IWorkbenchPart unstackedPart = getUnstackedPart();
 
 		page.activate(unstackedPart);
-		page.activate(activePart);
-		close(activePart);
+		zoom(zoomPart);
+		close(zoomPart);
 
-		// Ensure that the other part in the zoomed stack is now zoomed and active
-		assertZoomed(null);
-		assertActive(unstackedPart);
+		assertZoomed(otherStackedPart);
+		assertActive(otherStackedPart);
 	}
+
 }

--- a/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse UI Tests
 Bundle-SymbolicName: org.eclipse.ui.tests; singleton:=true
-Bundle-Version: 3.15.2100.qualifier
+Bundle-Version: 3.15.2200.qualifier
 Eclipse-BundleShape: dir
 Bundle-Activator: org.eclipse.ui.tests.TestPlugin
 Bundle-Vendor: Eclipse.org


### PR DESCRIPTION
This re-enables the ZoomTestSuite to execute tests for the parts of the zooming behavior in workbench pages that is actually implemented. This covers the toggleZoom functionality, which allows to maximize part stacks. However, some behavior has never been implemented at all or not in the way the tests currently describe it. This particularly includes different activation behavior depending on the zoom state when new views are opened. Thus, those tests are removed, as the current behavior has been accepted for a long time.

In summary, this changes does:
- enable ZoomTestSuite
- restore unstacked view in zoom tests with the progress view (was removed when navigator view was removed)
- remove tests related to fast view
- remove tests not fitting to actual and well-established behavior