### PR TITLE
Revert "Sync maximized flag from the shell size with the application model"

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/WBWRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/WBWRenderer.java
@@ -534,11 +534,8 @@ public class WBWRenderer extends SWTPartRenderer {
 				@Override
 				public void controlResized(ControlEvent e) {
 					// Don't store the maximized size in the model
-					// But set the maximized tag so that the user can access the current state
 					if (shell.getMaximized()) {
-						me.getTags().add(ShellMaximizedTag);
-					} else {
-						me.getTags().remove(ShellMaximizedTag);
+						return;
 					}
 
 					try {


### PR DESCRIPTION
This reverts commit ebfb7ec36cd3a6b9dc4b208f6824d639fcbacade as it introduces regression

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3227