### PR TITLE
UI component being attempted to be disposed in a non-ui thread.

### DIFF
--- a/bundles/org.eclipse.ui.navigator.resources/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.navigator.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.navigator.resources; singleton:=true
-Bundle-Version: 3.9.800.qualifier
+Bundle-Version: 3.9.900.qualifier
 Bundle-Activator: org.eclipse.ui.internal.navigator.resources.plugin.WorkbenchNavigatorPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/EditActionGroup.java
+++ b/bundles/org.eclipse.ui.navigator.resources/src/org/eclipse/ui/internal/navigator/resources/actions/EditActionGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2015 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,8 +18,10 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
 import org.eclipse.swt.dnd.Clipboard;
 import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.ISharedImages;
@@ -55,9 +57,22 @@ public class EditActionGroup extends ActionGroup {
 
 	@Override
 	public void dispose() {
-		if (clipboard != null) {
-			clipboard.dispose();
-			clipboard = null;
+		Display display = Display.getCurrent();
+		if (display != null && !display.isDisposed()) {
+			if (clipboard != null && !clipboard.isDisposed()) {
+				clipboard.dispose();
+				clipboard = null;
+			}
+		} else {
+			// Non-UI thread or display disposed
+			if (clipboard != null && !clipboard.isDisposed()) {
+				try {
+					clipboard.dispose();
+					clipboard = null;
+				} catch (SWTException e) {
+					// Log a message if required.
+				}
+			}
 		}
 		super.dispose();
 	}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/e4/compatibility/CompatibilityPart.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/e4/compatibility/CompatibilityPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2016 IBM Corporation and others.
+ * Copyright (c) 2010, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ import org.eclipse.e4.core.services.log.Logger;
 import org.eclipse.e4.ui.di.Focus;
 import org.eclipse.e4.ui.di.Persist;
 import org.eclipse.e4.ui.di.PersistState;
+import org.eclipse.e4.ui.di.UISynchronize;
 import org.eclipse.e4.ui.internal.workbench.Activator;
 import org.eclipse.e4.ui.internal.workbench.Policy;
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
@@ -418,9 +419,13 @@ public abstract class CompatibilityPart implements ISelectionChangedListener {
 	}
 
 	@PreDestroy
-	void destroy() {
+	void destroy(UISynchronize sync) {
 		if (!alreadyDisposed) {
-			invalidate();
+			sync.syncExec(() -> {
+				if (!alreadyDisposed) {
+					invalidate();
+				}
+			});
 		}
 
 		eventBroker.unsubscribe(widgetSetHandler);


### PR DESCRIPTION
Fixes #2316

As suggested tried fixing in destroy(), but looks like we need extra testing to ensure no shutdown regressions considering the below
- In shutdown, syncExec might block if the display is already disposed or unresponsive.
- EventBroker cleanup still runs in non-UI thread, which is fine. But we have 2 different parts happening - part disposed later, eventbroker unsubscribed immediately.

Note : I have no recreate to test this fix, can this be tested with the existing Unit Test infrastructure in place already?