### PR TITLE
Remove IPropertyChangeListener registration in dispose method of editor

### DIFF
--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.136.0.qualifier
+Bundle-Version: 3.136.100.qualifier
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/part/EditorPart.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/part/EditorPart.java
@@ -291,4 +291,12 @@ public abstract class EditorPart extends WorkbenchPart implements IEditorPart {
 		Assert.isTrue(site instanceof IEditorSite, "The site for an editor must be an IEditorSite"); //$NON-NLS-1$
 	}
 
+	@Override
+	public void dispose() {
+		if (compatibilityTitleListener != null) {
+			removePropertyListener(compatibilityTitleListener);
+			compatibilityTitleListener = null;
+		}
+		super.dispose();
+	}
 }

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/part/MultiPageEditorPart.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/part/MultiPageEditorPart.java
@@ -153,6 +153,8 @@ public abstract class MultiPageEditorPart extends EditorPart implements IPageCha
 
 	private ListenerList<IPageChangedListener> pageChangeListeners = new ListenerList<>(ListenerList.IDENTITY);
 
+	private org.eclipse.jface.util.IPropertyChangeListener propertyChangeListenerToUpdateContainer;
+
 	/**
 	 * Creates an empty multi-page editor with no pages and registers a
 	 * {@link PropertyChangeListener} to listen for changes to the editor's
@@ -160,11 +162,12 @@ public abstract class MultiPageEditorPart extends EditorPart implements IPageCha
 	 */
 	protected MultiPageEditorPart() {
 		super();
-		getAPIPreferenceStore().addPropertyChangeListener(event -> {
+		propertyChangeListenerToUpdateContainer = event -> {
 			if (isUpdateRequired(event)) {
 				updateContainer();
 			}
-		});
+		};
+		getAPIPreferenceStore().addPropertyChangeListener(propertyChangeListenerToUpdateContainer);
 	}
 
 	/**
@@ -526,6 +529,11 @@ public abstract class MultiPageEditorPart extends EditorPart implements IPageCha
 	 */
 	@Override
 	public void dispose() {
+		IPreferenceStore store = getAPIPreferenceStore();
+		if (propertyChangeListenerToUpdateContainer != null) {
+			store.removePropertyChangeListener(propertyChangeListenerToUpdateContainer);
+			propertyChangeListenerToUpdateContainer = null;
+		}
 		if (getSite() != null) {
 			deactivateSite(true, false);
 		}


### PR DESCRIPTION
The two classes `org.eclipse.ui.part.EditorPart` and `org.eclipse.ui.part.MultiPageEditorPart` currently register a property change listener in their constructors but fail to unregister it in their dispose() methods.

This oversight results in a memory leak: even after an editor is closed and no longer in use, the associated memory cannot be garbage collected because the listener remains registered. Over time, this can lead to increased memory consumption and degraded performance, especially in environments where editors are frequently opened and closed.

This change ensures that the property change listeners are properly removed during disposal, allowing the editor instances to be garbage collected as expected.

Here the steps to reproduce the problem scenario:
- Download the sample plugin [sample_editors.zip](https://github.com/user-attachments/files/22046839/sample_editors.zip) , extract the zip and import the project sample_editors to your workspace. The plugin contains a simple form editor registration with class `sample.SampleFormEditor` which allocates some amount of memory in the constructor. 
- Launch the target platform, create a project and a file with name `test.sampleform`. Open this file and the SampleFormEditor should be opened. The editor itself is empty and does not provide any meaningful content.
- Now close the editor and run the garbage collector multiple times (after enabling "Show heap status" in the preferences) by clicking on the trash icon in the taskbar of eclipse. One would now expect that the editor instance of SampleFormEditor can be garbage collected because the editor is no longer open and used. This is not the case and can be found out by running the eclipse memory analyzer.
- Download the eclipse memory analyzer from https://eclipse.dev/mat/ , install and run it.
- Acquire a Heap Dump of your running target platform containing the SampleFormEditor
- Open the histogram of the heap dump and search for class SampleFormEditor. The histogram shows that there exists one instance of the SampleFormEditor which consumes still some memory. By running context menu action "Merge Shortest Paths to GC Roots"->"exclude all phantom/weak/soft etc. references", you can find out the reason why the object cannot be garbage collected and which object still reference the SampleFormEditor.
Here a screenshot:
<img width="2184" height="802" alt="form_editor_not_garbage_collected" src="https://github.com/user-attachments/assets/2d6f372c-fd1e-4845-b34d-931b41159185" />
One can see in the stack that the SampleFormEditor instance is still referenced by the propertyChangeListener.

After applying the changes of this pull request, the reference is gone and the SampleFormEditor instance can be garbage collected after it is closed and no longer in use.