### PR TITLE
Added guards to safely handle cases when Display is null or disposed.

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPlugin.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1175,15 +1175,25 @@ public class WorkbenchPlugin extends AbstractUIPlugin {
 	 */
 	public static Shell getSplashShell(Display display)
 			throws NumberFormatException, IllegalArgumentException {
+		if (display == null || display.isDisposed()) {
+			return null;
+		}
 		Shell splashShell = (Shell) display.getData(DATA_SPLASH_SHELL);
-		if (splashShell != null)
+		if (splashShell != null) {
+			if (splashShell.isDisposed()) {
+				return null;
+			}
 			return splashShell;
+		}
 
 		String splashHandle = System.getProperty(PROP_SPLASH_HANDLE);
 		if (splashHandle == null) {
 			return null;
 		}
 
+		if (display.isDisposed()) {
+			return null;
+		}
 		splashShell = Shell.internal_new(display, Long.parseLong(splashHandle));
 
 		display.setData(DATA_SPLASH_SHELL, splashShell);

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/services/WorkbenchSourceProvider.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/services/WorkbenchSourceProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2015 IBM Corporation and others.
+ * Copyright (c) 2009, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -403,7 +403,16 @@ public class WorkbenchSourceProvider extends AbstractSourceProvider implements I
 	}
 
 	private IWorkbenchWindow getActiveWindow() {
-		final Shell newActiveShell = workbench.getDisplay().getActiveShell();
+		Display display = workbench.getDisplay();
+		if (display == null || display.isDisposed()) {
+			return null;
+		}
+
+		final Shell newActiveShell = display.getActiveShell();
+		if (newActiveShell == null || newActiveShell.isDisposed()) {
+			return null;
+		}
+
 		final IContextService contextService = workbench.getService(IContextService.class);
 		if (contextService != null) {
 			final int shellType = contextService.getShellType(newActiveShell);


### PR DESCRIPTION
getActiveWindow()
getSplashShell(Display display)

- Added guards to safely handle cases where the Display is null or disposed.
- Prevents SWTException: Widget is disposed when querying the active shell during shutdown avoiding crashes.

These changes make both methods more robust during application startup and shutdown, eliminating crashes caused by accessing disposed SWT resources.

Raised this pr as discussed in -> https://github.com/eclipse-platform/eclipse.platform.ui/pull/3232#issuecomment-3253487291