### PR TITLE
Avoid NPE on closing a Window while opening it #3242

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/window/Window.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/window/Window.java
@@ -794,6 +794,11 @@ public abstract class Window implements IShellProvider {
 		// open the window
 		shell.open();
 
+		// dialog may have been closed during the open() call, then just return
+		if (shell == null) {
+			return returnCode;
+		}
+
 		// run the event loop if specified
 		if (block) {
 			runEventLoop(shell);
@@ -812,9 +817,7 @@ public abstract class Window implements IShellProvider {
 	 * 				the shell
 	 */
 	private static void runEventLoop(Shell loopShell) {
-
-		Display display;
-		display = loopShell.getDisplay();
+		Display display = loopShell.getDisplay();
 
 		while (!loopShell.isDisposed()) {
 			try {

--- a/tests/org.eclipse.jface.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.jface.tests
-Bundle-Version: 1.4.1000.qualifier
+Bundle-Version: 1.4.1100.qualifier
 Automatic-Module-Name: org.eclipse.jface.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.12.0",

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/window/AllWindowTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/window/AllWindowTests.java
@@ -19,7 +19,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ ApplicationWindowTest.class })
+@Suite.SuiteClasses({ //
+		ApplicationWindowTest.class, //
+		WindowTest.class, //
+})
 public class AllWindowTests {
 
 	public static void main(String[] args) {

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/window/WindowTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/window/WindowTest.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jface.tests.window;
+
+import org.eclipse.jface.window.Window;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Shell;
+import org.junit.Test;
+
+public class WindowTest {
+
+	// See https://github.com/eclipse-platform/eclipse.platform.ui/issues/3242
+	@Test
+	public void testCloseDialogWhileOpening() throws Exception {
+		Window window = new Window((Shell) null) {
+		};
+		window.setBlockOnOpen(true);
+
+		Listener closeWindowListener = event -> window.close();
+		Display.getDefault().addFilter(SWT.Show, closeWindowListener);
+		try {
+			window.open();
+		} finally {
+			Display.getDefault().removeFilter(SWT.Show, closeWindowListener);
+			window.close();
+		}
+	}
+
+}


### PR DESCRIPTION
A Window may be closed while it's still processing it's open() call. One possibility is when attaching a listener that closes the Window to the SWT.Show event which is sent while open() is executed. Closing the Window also disposes the Window's shell, but the subsequent code assumes that shell to not be null.

This change adapts the Window#open() implementation to properly handle the case that the Window is already closed while opening it.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3242