### PR TITLE
Remove useless p2.inf from o.e.e4.ui.workbench.renderers.swt.cocoa

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Eclipse-PlatformFilter: (osgi.ws=cocoa)
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.renderers.swt.cocoa;singleton:=true
-Bundle-Version: 0.14.400.qualifier
+Bundle-Version: 0.14.500.qualifier
 Bundle-Name: %fragmentName
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.e4.ui.workbench.renderers.swt;bundle-version="[0.10.0,1.0.0)"

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/META-INF/p2.inf
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt.cocoa/META-INF/p2.inf
@@ -1,5 +1,0 @@
-# ensure that the applicable implementation fragment gets installed (bug 361901)
-requires.0.namespace = org.eclipse.equinox.p2.iu
-requires.0.name = org.eclipse.swt.cocoa.macosx.x86_64
-#requires.0.range = [$version$,$version$]
-requires.0.filter = (&(osgi.os=macosx)(osgi.ws=cocoa)(osgi.arch=x86_64))


### PR DESCRIPTION
It was introduced via
https://github.com/eclipse-platform/eclipse.platform.ui/commit/d321fb9a33ced720c196d7a1aa1bee8d1dd3bd06 most likely to workaround org.eclipse.swt host not mandating dependency on the correct os/arch specific fragment. As SWT does that this is useless and just generates issues with maven publishing. Pointed out in eclipse-platform/eclipse.platform.releng.aggregator#3264 (comment)