### PR TITLE
Fix FormEditor.dispose() calling super.dispose() first

### DIFF
--- a/bundles/org.eclipse.ui.forms/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.forms/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.ui.forms;singleton:=true
-Bundle-Version: 3.13.600.qualifier
+Bundle-Version: 3.13.700.qualifier
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.forms,

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/editor/FormEditor.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/editor/FormEditor.java
@@ -400,7 +400,6 @@ public abstract class FormEditor extends MultiPageEditorPart  {
 	 */
 	@Override
 	public void dispose() {
-		super.dispose();
 		for (Object page : pages) {
 			if (page instanceof IFormPage) {
 				IFormPage fpage = (IFormPage) page;
@@ -417,6 +416,7 @@ public abstract class FormEditor extends MultiPageEditorPart  {
 			toolkit.dispose();
 			toolkit = null;
 		}
+		super.dispose();
 	}
 
 	/**


### PR DESCRIPTION
Common pattern for init/dispose, setup/teardown is that on init, super is called first and on dispose last.

This is always done this way to allow super class initialize whatever needed first and subclass work on that, and the dispose should always perform cleanup in the opposite direction. Otherwise super code might cleanup things that are still needed for the subclass to properly cleanup.

Probably related to
https://github.com/eclipse-pde/eclipse.pde/issues/1963