### PR TITLE
Don't increase scrollable size for zero width tables

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/layout/AbstractColumnLayout.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/layout/AbstractColumnLayout.java
@@ -254,7 +254,7 @@ public abstract class AbstractColumnLayout extends Layout {
 		int width = Math.max(0, area.width - trim);
 
 		if (width > 1)
-			layoutTableTree(table, width, area, tableWidth < area.width);
+			layoutTableTree(table, width, area, tableWidth > 0 && tableWidth < area.width);
 
 		// For the first time we need to relayout because Scrollbars are not
 		// calculate appropriately


### PR DESCRIPTION
This seem to fix StackOverflow on "Trust" table on Linux, see https://github.com/eclipse-equinox/p2/issues/946.

No idea how and if this affect everything else.