### PR TITLE
Improve ImageBasedFrame scaling

### DIFF
--- a/bundles/org.eclipse.e4.ui.widgets/src/org/eclipse/e4/ui/widgets/ImageBasedFrame.java
+++ b/bundles/org.eclipse.e4.ui.widgets/src/org/eclipse/e4/ui/widgets/ImageBasedFrame.java
@@ -14,6 +14,8 @@
  ******************************************************************************/
 package org.eclipse.e4.ui.widgets;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ControlEvent;
 import org.eclipse.swt.events.ControlListener;
@@ -24,6 +26,7 @@ import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.ToolBar;
 
 
@@ -66,9 +69,19 @@ public class ImageBasedFrame extends Canvas {
 			ImageBasedFrame frame = (ImageBasedFrame) event.widget;
 			frame.setCursor(null);
 		});
+
 		toWrap.addListener(SWT.ZoomChanged, event -> {
-			toWrap.pack(true);
-			setFramedControlLocation();
+			final AtomicReference<Listener> scaleOnParentResize = new AtomicReference<>();
+			scaleOnParentResize.set(e -> {
+				if (isDisposed()) {
+					return;
+				}
+				toWrap.pack(true);
+				setFramedControlLocation();
+				parent.layout();
+				parent.removeListener(SWT.Resize, scaleOnParentResize.get());
+			});
+			parent.addListener(SWT.Resize, scaleOnParentResize.get());
 		});
 
 		addMouseMoveListener(e -> {


### PR DESCRIPTION
With both Async and Sync DPI scaling, ImageBasedFrame scales itself on ZoomChanged event to pack the control to wrap in it. However, with the current approach of scaling on DPI_CHANGED it works fine as it only receives the event after the children have been resized. However, since ImageBasedFrame is a Control wrapped inside a Canvas, those widgets are already scaled implicitly and there's no need to pack them on ZoomChanged event but rather when a Resize event is received at the parent, allowing the ImageBasedFrame to only recalibrate its size when the parent is resizing.

This approach moves the responsibility of handling ZoomChanged event from outside SWT for ImageBasedFrame and also provides a possibility to scale it properly when the scaling is Async, i.e. the children might not have scaled when ZoomChanged is received.

###How to test
Simply A/B testing with master to check if the toolbar images scale properly since they are all wrapped in ImageBasedFrames, especially the perspective switcher in the top right.

Before:
<img width="122" height="35" alt="image" src="https://github.com/user-attachments/assets/ca27cd06-0279-4dc6-aadd-4e98c39c9272" />

After: 
<img width="125" height="30" alt="image" src="https://github.com/user-attachments/assets/40a806a7-dbab-4018-aaac-fc9323765820" />


This PR improves the state of https://github.com/eclipse-platform/eclipse.platform.swt/pull/2520, although not dependent on it. Must be merged before it.