### PR TITLE
feat : Add global search result navigation shortcuts

### DIFF
--- a/bundles/org.eclipse.search/newsearch/org/eclipse/search2/internal/ui/basic/views/GlobalNextPrevSearchEntryHandler.java
+++ b/bundles/org.eclipse.search/newsearch/org/eclipse/search2/internal/ui/basic/views/GlobalNextPrevSearchEntryHandler.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse Foundation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eclipse Foundation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.search2.internal.ui.basic.views;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExecutableExtension;
+
+import org.eclipse.search.ui.ISearchResultPage;
+import org.eclipse.search.ui.ISearchResultViewPart;
+import org.eclipse.search.ui.NewSearchUI;
+import org.eclipse.search.ui.text.AbstractTextSearchViewPage;
+
+/**
+ * Global handler for navigating to next/previous search results without
+ * requiring focus on the Search view. Navigates directly through the active
+ * search result page, keeping focus in the editor throughout.
+ * <p>
+ * Configured via the {@code :next} or {@code :previous} data suffix in
+ * {@code plugin.xml}, e.g.:
+ * {@code defaultHandler="...GlobalNextPrevSearchEntryHandler:previous"}
+ * </p>
+ */
+public class GlobalNextPrevSearchEntryHandler extends AbstractHandler implements IExecutableExtension {
+
+	private boolean navigateNext = true;
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		ISearchResultViewPart viewPart = NewSearchUI.getSearchResultView();
+		if (viewPart == null) {
+			return null; // No search has been run yet
+		}
+		ISearchResultPage page = viewPart.getActivePage();
+		if (page instanceof AbstractTextSearchViewPage textPage) {
+			if (navigateNext) {
+				textPage.gotoNextMatch();
+			} else {
+				textPage.gotoPreviousMatch();
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public void setInitializationData(IConfigurationElement config, String propertyName, Object data)
+			throws CoreException {
+		navigateNext = !"previous".equals(data); //$NON-NLS-1$
+	}
+}

--- a/bundles/org.eclipse.search/plugin.properties
+++ b/bundles/org.eclipse.search/plugin.properties
@@ -83,3 +83,8 @@ textSearchQueryProvider="Text Search Query Provider"
 
 match_highlight.label= Match highlight background color
 match_highlight.description= The background color used to highlight matches in the Search view when colored labels are enabled.
+
+GlobalNextSearchEntryAction_label= Next Search Result
+GlobalNextSearchEntryAction_description= Navigate to the next search result from anywhere in the workbench without switching focus to the Search view
+GlobalPreviousSearchEntryAction_label= Previous Search Result
+GlobalPreviousSearchEntryAction_description= Navigate to the previous search result from anywhere in the workbench without switching focus to the Search view

--- a/bundles/org.eclipse.search/plugin.xml
+++ b/bundles/org.eclipse.search/plugin.xml
@@ -104,6 +104,20 @@
 			name="%command.performTextSearchFile.name" 
 			description="%command.performTextSearchFile.description"
 	    />
+		<command
+			categoryId="org.eclipse.ui.category.navigate"
+  			id="org.eclipse.search.ui.globalNextSearchEntry"
+			name="%GlobalNextSearchEntryAction_label"
+			description="%GlobalNextSearchEntryAction_description"
+			defaultHandler="org.eclipse.search2.internal.ui.basic.views.GlobalNextPrevSearchEntryHandler:next"
+	    />
+		<command
+			categoryId="org.eclipse.ui.category.navigate"
+  			id="org.eclipse.search.ui.globalPreviousSearchEntry"
+			name="%GlobalPreviousSearchEntryAction_label"
+			description="%GlobalPreviousSearchEntryAction_description"
+			defaultHandler="org.eclipse.search2.internal.ui.basic.views.GlobalNextPrevSearchEntryHandler:previous"
+	    />
 
 	</extension>
 	
@@ -162,6 +176,32 @@
             commandId="org.eclipse.search.ui.performTextSearchWorkspace"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M1+M3+T"/>
+		<key
+			commandId="org.eclipse.search.ui.globalNextSearchEntry"
+			contextId="org.eclipse.ui.contexts.window"
+			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+			sequence="ALT+.">
+		</key>
+		<key
+			commandId="org.eclipse.search.ui.globalNextSearchEntry"
+			contextId="org.eclipse.ui.contexts.window"
+			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+			platform="cocoa"
+			sequence="M1+M3+.">
+		</key>
+		<key
+			commandId="org.eclipse.search.ui.globalPreviousSearchEntry"
+			contextId="org.eclipse.ui.contexts.window"
+			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+			sequence="ALT+,">
+		</key>
+		<key
+			commandId="org.eclipse.search.ui.globalPreviousSearchEntry"
+			contextId="org.eclipse.ui.contexts.window"
+			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+			platform="cocoa"
+			sequence="M1+M3+,">
+		</key>
 	    
 	</extension>
 	

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/AllSearchTests.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/AllSearchTests.java
@@ -23,7 +23,9 @@ import org.eclipse.search.tests.filesearch.AllFileSearchTests;
 @SelectClasses({
 		AllFileSearchTests.class,
 		AllSearchModelTests.class,
-		TextSearchRegistryTest.class
+		TextSearchRegistryTest.class,
+		GlobalNextPrevSearchEntryHandlerTest.class,
+		GlobalNextPrevSearchEntryHandlerIntegrationTest.class
 })
 public class AllSearchTests {
 	// see @SelectClasses

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/GlobalNextPrevSearchEntryHandlerIntegrationTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/GlobalNextPrevSearchEntryHandlerIntegrationTest.java
@@ -1,0 +1,195 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse Foundation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eclipse Foundation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.search.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.runtime.jobs.IJobManager;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Table;
+
+import org.eclipse.jface.viewers.TableViewer;
+
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+
+import org.eclipse.search.internal.ui.text.FileSearchPage;
+import org.eclipse.search.internal.ui.text.FileSearchQuery;
+import org.eclipse.search.tests.filesearch.JUnitSourceSetup;
+import org.eclipse.search.ui.ISearchResultViewPart;
+import org.eclipse.search.ui.NewSearchUI;
+import org.eclipse.search.ui.text.AbstractTextSearchViewPage;
+import org.eclipse.search.ui.text.FileTextSearchScope;
+import org.eclipse.search2.internal.ui.basic.views.GlobalNextPrevSearchEntryHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Integration tests for {@link GlobalNextPrevSearchEntryHandler} that verify
+ * actual navigation behaviour against a real search result in the workbench.
+ *
+ * <p>The navigation logic in {@link AbstractTextSearchViewPage} tracks match
+ * position via an internal {@code fCurrentMatchIndex} field that is reset to
+ * {@code -1} only by the JFace selection-changed listener, not by raw SWT
+ * {@code table.setSelection()}. The tests here use the same approach as
+ * {@code SearchResultPageTest.testTableNavigation()}: start with the viewer
+ * selection at row 0 (leaving the internal match index at its initial value of
+ * 0), then navigate backwards to reliably arrive at the last element, and then
+ * navigate forwards to reliably arrive back at the first element.
+ * </p>
+ */
+public class GlobalNextPrevSearchEntryHandlerIntegrationTest {
+
+	@RegisterExtension
+	static JUnitSourceSetup fgJUnitSource = new JUnitSourceSetup();
+
+	private FileSearchPage fPage;
+	private Table fTable;
+	private GlobalNextPrevSearchEntryHandler fNextHandler;
+	private GlobalNextPrevSearchEntryHandler fPrevHandler;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		SearchTestUtil.ensureWelcomePageClosed();
+
+		String[] fileNamePatterns = { "*.java" }; //$NON-NLS-1$
+		FileTextSearchScope scope = FileTextSearchScope.newWorkspaceScope(fileNamePatterns, false);
+		FileSearchQuery query = new FileSearchQuery("Test", false, true, scope); //$NON-NLS-1$
+		NewSearchUI.runQueryInForeground(null, query);
+
+		ISearchResultViewPart viewPart = NewSearchUI.getSearchResultView();
+		assertNotNull(viewPart, "Search result view must be open after running a query");
+
+		fPage = (FileSearchPage) viewPart.getActivePage();
+		fPage.setLayout(AbstractTextSearchViewPage.FLAG_LAYOUT_FLAT);
+		fTable = ((TableViewer) fPage.getViewer()).getTable();
+		consumeEvents();
+
+		assertTrue(fTable.getItemCount() > 1,
+				"JUnit source project must produce at least 2 results for navigation tests");
+
+		fNextHandler = new GlobalNextPrevSearchEntryHandler();
+		// default is already "next" but be explicit
+		fNextHandler.setInitializationData(null, "command", "next"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		fPrevHandler = new GlobalNextPrevSearchEntryHandler();
+		fPrevHandler.setInitializationData(null, "command", "previous"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@AfterEach
+	public void tearDown() {
+		// Drain all pending UpdateUIJobs for this page so they don't fire during
+		// subsequent tests' consumeEvents() calls and corrupt their table state.
+		if (fPage != null) {
+			consumeEvents();
+		}
+		// Close any editors opened by showCurrentMatch() to leave the workbench clean.
+		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		if (window != null && window.getActivePage() != null) {
+			window.getActivePage().closeAllEditors(false);
+		}
+	}
+
+	/**
+	 * Going backward from the initial selection (row 0, internal match index 0)
+	 * decrements the match index to -1, which causes
+	 * {@link AbstractTextSearchViewPage#gotoPreviousMatch()} to wrap around to the
+	 * last result. Then going forward exhausts the last result's matches and wraps
+	 * back to the first result.
+	 *
+	 * <p>This mirrors the logic verified by
+	 * {@code SearchResultPageTest.testTableNavigation()}, but exercises the
+	 * handlers rather than direct page calls.
+	 * </p>
+	 */
+	@Test
+	public void testPreviousWrapsToLastThenNextWrapsToFirst() throws Exception {
+		// Start at the first element (initial state after query).
+		fTable.setSelection(0);
+		fTable.showSelection();
+		consumeEvents();
+
+		// Previous from initial match index (0) decrements to -1 → wraps to last.
+		fPrevHandler.execute(new ExecutionEvent());
+		consumeEvents();
+
+		assertEquals(fTable.getItemCount() - 1, fTable.getSelectionIndex(),
+				"previous handler should wrap from the first result to the last");
+
+		// Next from the last result's final match increments beyond the end → wraps
+		// to the first result.
+		fNextHandler.execute(new ExecutionEvent());
+		consumeEvents();
+
+		assertEquals(0, fTable.getSelectionIndex(),
+				"next handler should wrap from the last result to the first");
+	}
+
+	/**
+	 * Two independent handler instances must not share internal state. Configuring
+	 * one as "previous" must not affect one configured as "next".
+	 */
+	@Test
+	public void testNextAndPreviousHandlersAreIndependent() throws Exception {
+		// Sanity-check: the two handlers are distinct objects.
+		assertTrue(fNextHandler != fPrevHandler,
+				"next and previous handlers must be separate instances");
+
+		// Drive to last element via previous handler.
+		fTable.setSelection(0);
+		fTable.showSelection();
+		consumeEvents();
+		fPrevHandler.execute(new ExecutionEvent());
+		consumeEvents();
+		int lastIndex = fTable.getItemCount() - 1;
+		assertEquals(lastIndex, fTable.getSelectionIndex(),
+				"previous handler should reach last result");
+
+		// Drive back to first element via next handler.
+		fNextHandler.execute(new ExecutionEvent());
+		consumeEvents();
+		assertEquals(0, fTable.getSelectionIndex(),
+				"next handler should reach first result");
+	}
+
+	/**
+	 * Drains the SWT event queue and waits for all pending {@code UpdateUIJob}s
+	 * belonging to the current page to complete. This is necessary because
+	 * {@code UpdateUIJob} can reschedule itself with a 500 ms delay; a plain
+	 * {@code Display.readAndDispatch()} loop would not wait for those deferred
+	 * runs and could leave stale async work that pollutes subsequent tests.
+	 */
+	private void consumeEvents() {
+		IJobManager manager = Job.getJobManager();
+		// Drain immediately-queued display events first.
+		while (Display.getDefault().readAndDispatch()) {
+			// keep dispatching
+		}
+		// Then wait for all UpdateUIJobs that belong to this page to finish
+		// (they identify themselves via belongsTo(AbstractTextSearchViewPage.this)).
+		while (fPage != null && manager.find(fPage).length > 0) {
+			Display.getDefault().readAndDispatch();
+		}
+		// Final drain for any events triggered by the completed jobs.
+		while (Display.getDefault().readAndDispatch()) {
+			// keep dispatching
+		}
+	}
+}

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/GlobalNextPrevSearchEntryHandlerTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/GlobalNextPrevSearchEntryHandlerTest.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse Foundation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eclipse Foundation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.search.tests;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.search2.internal.ui.basic.views.GlobalNextPrevSearchEntryHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link GlobalNextPrevSearchEntryHandler}.
+ * <p>
+ * These tests cover configuration via {@code setInitializationData} and
+ * the no-op behaviour when no search results are available.
+ * For navigation behaviour with real search results see
+ * {@link GlobalNextPrevSearchEntryHandlerIntegrationTest}.
+ * </p>
+ */
+public class GlobalNextPrevSearchEntryHandlerTest {
+
+	private GlobalNextPrevSearchEntryHandler handler;
+
+	@BeforeEach
+	public void setUp() {
+		handler = new GlobalNextPrevSearchEntryHandler();
+	}
+
+	/**
+	 * When no search has been run the handler returns {@code null} silently rather
+	 * than throwing an exception.
+	 */
+	@Test
+	public void testExecuteReturnsNullWhenNoSearchResultViewIsOpen() throws Exception {
+		// Deliberately close any open search view so the handler finds nothing
+		SearchTestUtil.ensureSearchViewClosed();
+		Object result = handler.execute(new ExecutionEvent());
+		assertNull(result, "Handler should return null when no search result view is open");
+	}
+
+	/**
+	 * Configuring with {@code "previous"} must not throw and leaves the handler
+	 * ready to navigate backwards.
+	 */
+	@Test
+	public void testSetInitializationDataWithPrevious() throws CoreException {
+		handler.setInitializationData(null, "command", "previous"); //$NON-NLS-1$ //$NON-NLS-2$
+		// Direction verified behaviourally in GlobalNextPrevSearchEntryHandlerIntegrationTest
+	}
+
+	/**
+	 * Configuring with {@code "next"} must not throw; it is also the default.
+	 */
+	@Test
+	public void testSetInitializationDataWithNext() throws CoreException {
+		handler.setInitializationData(null, "command", "next"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	/**
+	 * A {@code null} data value must not throw; the handler defaults to navigate-next.
+	 */
+	@Test
+	public void testSetInitializationDataWithNullDefaultsToNext() throws CoreException {
+		handler.setInitializationData(null, null, null);
+		// No exception expected; direction defaults to next
+	}
+
+	/**
+	 * An unrecognised data value must not throw; the handler defaults to navigate-next.
+	 */
+	@Test
+	public void testSetInitializationDataWithUnknownValueDefaultsToNext() throws CoreException {
+		handler.setInitializationData(null, "command", "sideways"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+}

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/SearchTestUtil.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/SearchTestUtil.java
@@ -26,6 +26,8 @@ import org.eclipse.ui.ide.IDE;
 
 import org.eclipse.ui.editors.text.EditorsUI;
 
+import org.eclipse.search.ui.NewSearchUI;
+
 
 /**
  * Util class for search tests.
@@ -52,6 +54,26 @@ public class SearchTestUtil {
 
 	public static IEditorPart openTextEditor(IWorkbenchPage activePage, IFile openFile1) throws PartInitException {
 		return IDE.openEditor(activePage, openFile1, EditorsUI.DEFAULT_TEXT_EDITOR_ID, true);
+	}
+
+	/**
+	 * Hides the Search result view in the active workbench window page so that
+	 * {@link NewSearchUI#getSearchResultView()} returns {@code null}. Does nothing
+	 * if no such view is currently open.
+	 */
+	public static void ensureSearchViewClosed() {
+		IWorkbenchWindow activeWorkbenchWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		if (activeWorkbenchWindow == null) {
+			return;
+		}
+		IWorkbenchPage page = activeWorkbenchWindow.getActivePage();
+		if (page == null) {
+			return;
+		}
+		IViewPart searchView = page.findView(NewSearchUI.SEARCH_VIEW_ID);
+		if (searchView != null) {
+			page.hideView(searchView);
+		}
 	}
 
 }


### PR DESCRIPTION
Add global search result navigation shortcuts #3240 

Add ALT+. and ALT+, shortcuts for navigating search results globally 
without requiring manual Search view switching. This improves workflow 
efficiency when reviewing and editing multiple search result occurrences. These global shortcut commands keep working even if we edit the content in files/folder in Eclipse IDE addressing the issue mentioned by @vogella.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3240

**ALT+. Flow (Next Search Entry)**
```
User presses ALT+.
    ↓
plugin.xml: "ALT+. triggers globalNextSearchEntry command"
    ↓
plugin.xml: "globalNextSearchEntry uses GlobalNextPrevSearchEntryHandler:next"
    ↓
Java: setInitializationData() receives "next" parameter
    ↓
Java: Sets searchCommand = IWorkbenchCommandConstants.NAVIGATE_NEXT
    ↓
Java: execute() method runs three-command sequence:
    1. Show Search view
    2. Execute NAVIGATE_NEXT command
    3. Activate editor
```

**ALT+, Flow (Previous Search Entry)**
```
User presses ALT+,
    ↓
plugin.xml: "ALT+, triggers globalPreviousSearchEntry command"
    ↓
plugin.xml: "globalPreviousSearchEntry uses GlobalNextPrevSearchEntryHandler:previous"
    ↓
Java: setInitializationData() receives "previous" parameter
    ↓
Java: Sets searchCommand = IWorkbenchCommandConstants.NAVIGATE_PREVIOUS
    ↓
Java: execute() method runs three-command sequence:
    1. Show Search view
    2. Execute NAVIGATE_PREVIOUS command
    3. Activate editor
```