### PR TITLE
Show ProgressMonitorJobsDialog after delay in ProgressManager.run

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressManager.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressManager.java
@@ -971,8 +971,9 @@ public class ProgressManager extends ProgressProvider implements IProgressServic
 			// Backward compatible code.
 			final ProgressMonitorJobsDialog dialog = new ProgressMonitorJobsDialog(
 					ProgressManagerUtil.getDefaultParent());
-			if (shouldRunInBackground()) {
-				dialog.setOpenOnRun(false);
+			dialog.setOpenOnRun(false);
+			if (!shouldRunInBackground()) {
+				scheduleProgressMonitorJob(dialog);
 			}
 			dialog.run(fork, cancelable, runnable);
 			return;


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.ui/pull/3147#issuecomment-3317608807

Schedule the progress dialog to appear after a delay if the preference "Always run in background" is set to `false`

<img width="707" height="131" alt="image" src="https://github.com/user-attachments/assets/d8c27e92-afc4-4b94-be49-6556bb0bc40d" />
