### PR TITLE
Stackoverflow fix in ImageDescriptor

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ImageDescriptor.java
@@ -424,30 +424,32 @@ public abstract class ImageDescriptor extends DeviceResourceDescriptor<Image> {
 	 */
 	public ImageData getImageData(int zoom) {
 		if (zoom == 100) {
-			return getImageData(100);
+			return getImageData();
 		}
 		return null;
 	}
 
 	/**
-	 * Creates and returns a new SWT <code>ImageData</code> object
-	 * for this image descriptor.
-	 * Note that each call returns a new SWT image data object.
+	 * Creates and returns a new SWT <code>ImageData</code> object for this image
+	 * descriptor. Note that each call returns a new SWT image data object.
 	 * <p>
-	 * This framework method is declared public so that it is
-	 * possible to request an image descriptor's image data without
-	 * creating an SWT image object.
+	 * This framework method is declared public so that it is possible to request an
+	 * image descriptor's image data without creating an SWT image object.
 	 * </p>
 	 * <p>
 	 * Returns <code>null</code> if the image data could not be created.
 	 * </p>
 	 * <p>
-	 * This method was abstract until 3.13. Clients should stop re-implementing
-	 * this method and should re-implement {@link #getImageData(int)} instead.
+	 * This method was abstract until 3.13. Clients should stop re-implementing this
+	 * method and should re-implement {@link #getImageData(int)} instead.
 	 * </p>
 	 *
 	 * @return a new image data or <code>null</code>
-	 * @deprecated Use {@link #getImageData(int)} instead.
+	 * @deprecated Replace with {@link #getImageData(int)} instead. <b>Note: Calling
+	 *             this method may result in stack overflow if subclass doesn't
+	 *             override either {@link #getImageData()} or
+	 *             {@link #getImageData(int)} to prevent endless cycle between the 2
+	 *             implementation in this class since 2017.</b>
 	 */
 	@Deprecated
 	public ImageData getImageData() {


### PR DESCRIPTION
Fixes getImageData(100) calling itself endlessly (introduced via https://github.com/eclipse-platform/eclipse.platform.ui/commit/c2fe1447c499d0de02b24e5bd07e18d559105e0e ) by reintroducing the bigger getImageData(100) and getImageData() endlessly (introduced in 2017 via
https://github.com/eclipse-platform/eclipse.platform.ui/commit/e6d12ca0ae4762273680dc65ae8eb6f211778acc ) that wasn't experienced thanks to the *happy accident* that it was asbtract method and all implementations before that had their own and every implementor since then most likely figured the endless loop while developing.
Enhanced documentation to mention that.