### PR TITLE
Improve Quick Search Dialog UI

### DIFF
--- a/bundles/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/ui/QuickSearchDialog.java
+++ b/bundles/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/ui/QuickSearchDialog.java
@@ -58,6 +58,7 @@ import org.eclipse.jface.preference.PreferenceConverter;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.CursorLinePainter;
+import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.source.CompositeRuler;
@@ -1173,6 +1174,9 @@ public class QuickSearchDialog extends SelectionStatusDialog {
 							viewer.revealRange(rangeStart, rangeEnd - rangeStart);
 
 							var targetLineFirstMatch = getQuery().findFirst(document.get(item.getOffset(), contextLenght - (item.getOffset() - start)));
+							if (targetLineFirstMatch == null) {
+							    return; // nothing to refresh
+							}
 							int targetLineFirstMatchStart = item.getOffset() + targetLineFirstMatch.getOffset();
 							// sets caret position
 							viewer.setSelectedRange(targetLineFirstMatchStart, 0);
@@ -1289,6 +1293,10 @@ public class QuickSearchDialog extends SelectionStatusDialog {
 				//element is available in the list.
 				openButton.setEnabled(itemCount>0);
 			}
+			//Auto-select the first search result for preview to be shown.
+			if (itemCount >= 1 && list.getSelection().isEmpty()) {
+	            list.getTable().select(0);
+	        }
 			refreshDetails();
 		}
 	}
@@ -1484,6 +1492,14 @@ public class QuickSearchDialog extends SelectionStatusDialog {
 		} else {
 			//The QuickTextSearcher is already active update the query
 			this.searcher.setQuery(newFilter, force);
+			if(newFilter.getPatternString().trim().isEmpty()) {
+				//When pattern is cleared, clear the preview section
+				viewer.setDocument(new Document("")); //$NON-NLS-1$
+			    if (lineNumberColumn != null) {
+			        viewer.removeVerticalRulerColumn(lineNumberColumn);
+			        viewer.addVerticalRulerColumn(lineNumberColumn);
+			    }
+			}
 		}
 		if (progressJob!=null) {
 			progressJob.schedule();


### PR DESCRIPTION
This pr basically addresses the below issues

- [x] 1. When 1 or more search results exist, by default no entry is shown till user selects but now 1st entry is showed in preview section.
- [x] 2. After a search, when search pattern is cleared, the preview remains which is no more valid. Now the preview is cleared.

1. When there are 1 or more multiple search results, by default nothing is selected and shown in preview till user selects an entry. Now the 1st entry is shown by default.

Multiple search results
Before : 
<img width="886" height="608" alt="image" src="https://github.com/user-attachments/assets/5e98a57a-06d1-465d-959b-8b40dba24f0c" />


After : 
<img width="817" height="782" alt="image" src="https://github.com/user-attachments/assets/cec43127-1212-427a-9496-6119adbccd2a" />


1 Search result
Before : 
<img width="893" height="611" alt="image" src="https://github.com/user-attachments/assets/d113ad86-5796-445f-b24e-40a4ae1aa2b8" />

After : 
<img width="772" height="785" alt="image" src="https://github.com/user-attachments/assets/be0e63b8-4160-4966-84d8-8fccf05eb3cc" />



2. Now when the search pattern is cleared but preview section still showing up stale entries which are no more valid. Even the ruler section for the preview needs to be cleared.

Before : 
<img width="873" height="615" alt="image" src="https://github.com/user-attachments/assets/1a9e8ed2-3c9d-4236-adb7-aef5978a99cc" />

After : 
<img width="778" height="783" alt="image" src="https://github.com/user-attachments/assets/7101bad2-13b1-43e0-a2ed-96ad32cd927e" />

Please do let me know if you have any suggestions in the same context.