### PR TITLE
Ignore ALT_GR when considering to hide content assists

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/CompletionProposalPopup.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/CompletionProposalPopup.java
@@ -1408,7 +1408,8 @@ class CompletionProposalPopup implements IContentAssistListener {
 					break;
 
 				default :
-					if (e.keyCode != SWT.CAPS_LOCK && e.keyCode != SWT.MOD1 && e.keyCode != SWT.MOD2 && e.keyCode != SWT.MOD3 && e.keyCode != SWT.MOD4) {
+					// On Linux ALT_GR is the level3 switch (at least on the US-INTL layout), when using 'include "level3(YOURKEY)"' in the xkb file
+					if (e.keyCode != SWT.CAPS_LOCK && e.keyCode != SWT.MOD1 && e.keyCode != SWT.MOD2 && e.keyCode != SWT.MOD3 && e.keyCode != SWT.MOD4 && e.keyCode != SWT.ALT_GR) {
 						hide();
 					}
 					return true;

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/ContextInformationPopup.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/ContextInformationPopup.java
@@ -801,7 +801,8 @@ class ContextInformationPopup implements IContentAssistListener {
 					break;
 
 				default :
-					if (e.keyCode != SWT.CAPS_LOCK && e.keyCode != SWT.MOD1 && e.keyCode != SWT.MOD2 && e.keyCode != SWT.MOD3 && e.keyCode != SWT.MOD4) {
+					// On Linux ALT_GR is the level3 switch (at least on the US-INTL layout), when using 'include "level3(YOURKEY)"' in the xkb file
+					if (e.keyCode != SWT.CAPS_LOCK && e.keyCode != SWT.MOD1 && e.keyCode != SWT.MOD2 && e.keyCode != SWT.MOD3 && e.keyCode != SWT.MOD4 && e.keyCode != SWT.ALT_GR) {
 						hideContextSelector();
 					}
 					return true;
@@ -844,7 +845,8 @@ class ContextInformationPopup implements IContentAssistListener {
 					validateContextInformation();
 					break;
 				default:
-					if (e.keyCode != SWT.CAPS_LOCK && e.keyCode != SWT.MOD1 && e.keyCode != SWT.MOD2 && e.keyCode != SWT.MOD3 && e.keyCode != SWT.MOD4) {
+					// On Linux ALT_GR is the level3 switch (at least on the US-INTL layout), when using 'include "level3(YOURKEY)"' in the xkb file
+					if (e.keyCode != SWT.CAPS_LOCK && e.keyCode != SWT.MOD1 && e.keyCode != SWT.MOD2 && e.keyCode != SWT.MOD3 && e.keyCode != SWT.MOD4 && e.keyCode != SWT.ALT_GR) {
 						hideContextInfoPopup(true);
 					}
 					break;


### PR DESCRIPTION
On Linux ALT_GR is the level3 switch (at least on the US-INTL layout), when using 'include "level3(YOURKEY)"' in the xkb file. Pressing it should leave the content assist open.

I've remapped Caps-Lock as the level3 switch and changed the keyboard layout, so I can use CapsLock-h/j/k/l instead of the arrow keys. This works in all applications I use on my Gnome desktop, except for the eclipse autocomplete popups, which is quite annoying as I'm using eclipse as my main IDE for backend development.