### PR TITLE
Optional filter text autocomplete support in chevron pop up

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/internal/workbench/renderers/swt/AbstractTableInformationControl.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/internal/workbench/renderers/swt/AbstractTableInformationControl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2018 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.e4.ui.internal.workbench.renderers.swt;
 
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.e4.ui.workbench.swt.internal.copy.SearchPattern;
 import org.eclipse.e4.ui.workbench.swt.internal.copy.WorkbenchSWTMessages;
 import org.eclipse.jface.preference.JFacePreferences;
@@ -25,6 +27,8 @@ import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.MouseListener;
@@ -312,6 +316,19 @@ public abstract class AbstractTableInformationControl {
 		return fTableViewer;
 	}
 
+	private TableItem suggestCompletionFromTable(String inputText) {
+		if (inputText == null || inputText.isEmpty()) {
+			return null;
+		}
+		String lowerCaseText = inputText.toLowerCase();
+		for (TableItem item : fTableViewer.getTable().getItems()) {
+			if (item.getText().toLowerCase().startsWith(lowerCaseText)) {
+				return item;
+			}
+		}
+		return null;
+	}
+
 	protected Text createFilterText(Composite parent) {
 		fFilterText = new Text(parent, SWT.NONE);
 
@@ -371,16 +388,56 @@ public abstract class AbstractTableInformationControl {
 		setBackgroundColor(background);
 	}
 
-	private void installFilter() {
+	private void chevronAutocompleteBehavior() {
 		fFilterText.setMessage(WorkbenchSWTMessages.FilteredTree_FilterMessage);
 		fFilterText.setText(""); //$NON-NLS-1$
+		setMatcherString(""); //$NON-NLS-1$
+		fTableViewer.refresh();
 
-		fFilterText.addModifyListener(e -> {
-			String text = ((Text) e.widget).getText();
-			setMatcherString(text);
+		fFilterText.addKeyListener(new KeyAdapter() {
+			@Override
+			public void keyReleased(KeyEvent e) {
+				int cursor = fFilterText.getSelection().x;
+				String input = fFilterText.getText().substring(0, cursor);
+				setMatcherString(input);
+				fTableViewer.refresh();
+
+				if (e.keyCode == SWT.BS || e.keyCode == SWT.DEL || !Character.isLetterOrDigit(e.character))
+					return;
+
+				TableItem suggested = suggestCompletionFromTable(input);
+				if (suggested != null && suggested.getText().length() > input.length()) {
+					String suggestion = suggested.getText();
+					fFilterText.setText(suggestion);
+					fFilterText.setSelection(input.length(), suggestion.length());
+					fTableViewer.setSelection(new StructuredSelection(suggested.getData()), true);
+				}
+			}
 		});
 	}
 
+	private void normalFilterBehavior() {
+		fFilterText.setMessage(WorkbenchSWTMessages.FilteredTree_FilterMessage);
+		fFilterText.setText(""); //$NON-NLS-1$
+		fFilterText.addModifyListener(e -> {
+			String text = ((Text) e.widget).getText();
+			setMatcherString(text);
+			fTableViewer.refresh();
+		});
+	}
+
+	private void installFilter() {
+		if (isAutocompleteEnabled()) {
+			chevronAutocompleteBehavior();
+		} else {
+			normalFilterBehavior();
+		}
+	}
+
+	private boolean isAutocompleteEnabled() {
+		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode("org.eclipse.ui.workbench"); //$NON-NLS-1$
+		return prefs.getBoolean("ENABLE_AUTOCOMPLETE_IN_CHEVRON", false); //$NON-NLS-1$
+	}
 	/**
 	 * The string matcher has been modified. The default implementation
 	 * refreshes the view and selects the first matched element

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2020 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -467,6 +467,11 @@ public class WorkbenchMessages extends NLS {
 	public static String PreferenceExportWarning_message;
 	public static String PreferenceExportWarning_continue;
 	public static String PreferenceExportWarning_applyAndContinue;
+
+	public static String Preference_Enable_Autocomplete_ChevronPopUp;
+	public static String Preference_Autocomplete;
+
+	public static String Preference_Enable_Autocomplete_ChevronPopUp_ToolTip;
 
 	// --- Workbench ---
 	public static String WorkbenchPreference_allowInplaceEditingButton;

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/WorkbenchPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/WorkbenchPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -80,6 +80,8 @@ public class WorkbenchPreferencePage extends PreferencePage implements IWorkbenc
 
 	private Button showInlineRenameButton;
 
+	private Button enableAutocompleteButton;
+
 	protected static int MAX_SAVE_INTERVAL = 9999;
 	protected static int MAX_VIEW_LIMIT = 1_000_000;
 
@@ -112,6 +114,7 @@ public class WorkbenchPreferencePage extends PreferencePage implements IWorkbenc
 		createStickyCyclePref(composite);
 		createHeapStatusPref(composite);
 		createLargeViewLimitPref(composite);
+		createAutocompletePref(composite);
 	}
 
 	/**
@@ -388,6 +391,15 @@ public class WorkbenchPreferencePage extends PreferencePage implements IWorkbenc
 		return WorkbenchPlugin.getDefault().getPreferenceStore();
 	}
 
+	protected void createAutocompletePref(Composite parent) {
+		enableAutocompleteButton = new Button(parent, SWT.CHECK);
+		enableAutocompleteButton.setText(WorkbenchMessages.Preference_Enable_Autocomplete_ChevronPopUp);
+		enableAutocompleteButton.setToolTipText(WorkbenchMessages.Preference_Enable_Autocomplete_ChevronPopUp_ToolTip);
+		IPreferenceStore store = getPreferenceStore();
+		boolean enabled = store.getBoolean(WorkbenchMessages.Preference_Autocomplete);
+		enableAutocompleteButton.setSelection(enabled);
+	}
+
 	/**
 	 * @see IWorkbenchPreferencePage
 	 */
@@ -423,6 +435,7 @@ public class WorkbenchPreferencePage extends PreferencePage implements IWorkbenc
 		showUserDialogButton.setSelection(store.getDefaultBoolean(IPreferenceConstants.RUN_IN_BACKGROUND));
 		showHeapStatusButton.setSelection(
 				PrefUtil.getAPIPreferenceStore().getDefaultBoolean(IWorkbenchPreferenceConstants.SHOW_MEMORY_MONITOR));
+		enableAutocompleteButton.setSelection(store.getDefaultBoolean(WorkbenchMessages.Preference_Autocomplete));
 
 		String defaultRenameMode = store.getDefaultString(IWorkbenchPreferenceConstants.RESOURCE_RENAME_MODE);
 		renameModeInline = !IWorkbenchPreferenceConstants.RESOURCE_RENAME_MODE_DIALOG.equals(defaultRenameMode);
@@ -446,6 +459,7 @@ public class WorkbenchPreferencePage extends PreferencePage implements IWorkbenc
 		store.setValue(IPreferenceConstants.RUN_IN_BACKGROUND, showUserDialogButton.getSelection());
 		store.setValue(IPreferenceConstants.WORKBENCH_SAVE_INTERVAL, saveInterval.getIntValue());
 		store.setValue(IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT, largeViewLimit.getIntValue());
+		store.setValue(WorkbenchMessages.Preference_Autocomplete, enableAutocompleteButton.getSelection());
 
 		String renameModeValue = IWorkbenchPreferenceConstants.RESOURCE_RENAME_MODE_INLINE;
 		if (!renameModeInline) {

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
@@ -409,6 +409,9 @@ PreferenceExportWarning_title = Possible Unapplied Changes
 PreferenceExportWarning_message = If you changed preferences and want to export them, ensure you click 'Apply and Continue' before the export.
 PreferenceExportWarning_continue = &Continue
 PreferenceExportWarning_applyAndContinue = &Apply and Continue
+Preference_Enable_Autocomplete_ChevronPopUp = Enable autocomplete option in chevron popup
+Preference_Enable_Autocomplete_ChevronPopUp_ToolTip = Enable autocomplete option to complete text as you type in the chevron popup
+Preference_Autocomplete=ENABLE_AUTOCOMPLETE_IN_CHEVRON
 
 # --- Workbench ---
 WorkbenchPreference_allowInplaceEditingButton = Allow in-place &system editors


### PR DESCRIPTION
Refs : https://github.com/eclipse-platform/eclipse.platform.ui/issues/194

This PR address one of the feature suggestion in https://github.com/eclipse-platform/eclipse.platform.ui/issues/194.

This PR includes an autocomplete feature in the chevron popup filter, making it easier to navigate when too many editors are opened in the workbench. As the user types, matching editor names are suggested in the filter text area and the remaining part is auto-filled, improving speed and efficiency in locating editors.

This enhancement is implemented as an optional feature for the filter text in chevron pop up ie, users can enable or disable the autocomplete option based on their preference. A checkbox option to enable and disable the autocomplete behaviour is given in the **`Eclipse -> Settings -> General`** page. The feature is controlled through a new preference flag, **`ENABLE_AUTOCOMPLETE_IN_CHEVRON`**, stored under `org.eclipse.ui.workbench`. Users can enable or disable autocomplete in the Workbench Preferences, and when disabled, the chevron shows the normal standard filtering behaviour.

Key changes:

1. Introduced a new optional autocomplete behaviour in the chevron popup to provide suggestions and auto completion.
2. Normal text filtering is still available.
3. Added a **`checkbox`** in Preference page to let users enable or disable the autocomplete option depending upon their preference. 
4. By default the option is disabled, but if the feature is to be enabled it can be done via `Eclipse -> Settings -> General -> Enable autocomplete option in chevron popup`


https://github.com/user-attachments/assets/5c9183b7-ee77-474b-8cad-b8d5e97dde3e