### PR TITLE
Revert ImageBasedFrame zoom change listener

### DIFF
--- a/bundles/org.eclipse.e4.ui.widgets/src/org/eclipse/e4/ui/widgets/ImageBasedFrame.java
+++ b/bundles/org.eclipse.e4.ui.widgets/src/org/eclipse/e4/ui/widgets/ImageBasedFrame.java
@@ -14,8 +14,6 @@
  ******************************************************************************/
 package org.eclipse.e4.ui.widgets;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ControlEvent;
 import org.eclipse.swt.events.ControlListener;
@@ -26,8 +24,6 @@ import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Listener;
-import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.ToolBar;
 
 
@@ -70,20 +66,12 @@ public class ImageBasedFrame extends Canvas {
 			ImageBasedFrame frame = (ImageBasedFrame) event.widget;
 			frame.setCursor(null);
 		});
-
 		toWrap.addListener(SWT.ZoomChanged, event -> {
-			Shell shell = parent.getShell();
-			final AtomicReference<Listener> scaleOnParentResize = new AtomicReference<>();
-			scaleOnParentResize.set(e -> {
-				if (isDisposed()) {
-					return;
-				}
-				toWrap.pack(true);
-				setFramedControlLocation();
-				parent.layout();
-				shell.removeListener(SWT.Resize, scaleOnParentResize.get());
-			});
-			shell.addListener(SWT.Resize, scaleOnParentResize.get());
+			if (isDisposed()) {
+				return;
+			}
+			toWrap.pack(true);
+			setFramedControlLocation();
 		});
 
 		addMouseMoveListener(e -> {


### PR DESCRIPTION
This PR reverts the change to the zoom changed listener of the ImageBasedFrame. The async DPI change handling of the windows implementation does not need the complex event chaining anymore.

It is reverting the changes from 44f830b8bd43aa6a96046f77830d2a20b642cf62 and 2f6a390496172bccdcbc3e696d3e68601f639773 keeping only the disposal check

Is supposed to not cause regressions with https://github.com/eclipse-platform/eclipse.platform.swt/pull/2520