### PR TITLE
Migrate org.eclipse.tests.urischeme from JUnit4 to JUnit5

### DIFF
--- a/tests/org.eclipse.tests.urischeme/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.tests.urischeme/META-INF/MANIFEST.MF
@@ -3,9 +3,11 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-Vendor: %Plugin.Providername
 Bundle-SymbolicName: org.eclipse.tests.urischeme
-Bundle-Version: 1.2.600.qualifier
+Bundle-Version: 1.2.700.qualifier
 Bundle-Localization: plugin
 Fragment-Host: org.eclipse.urischeme;bundle-version="1.1.100"
+Import-Package: org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Automatic-Module-Name: org.eclipse.urischeme.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="[4.12.0,5.0.0)"

--- a/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/suite/AllUnitTests.java
+++ b/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/suite/AllUnitTests.java
@@ -22,12 +22,12 @@ import org.eclipse.urischeme.internal.registration.TestUnitRegistrationMacOsX;
 import org.eclipse.urischeme.internal.registration.TestUnitRegistrationWindows;
 import org.eclipse.urischeme.internal.registration.TestUnitRegistryWriter;
 import org.eclipse.urischeme.internal.registration.TestUnitWinRegistry;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
 
-@RunWith(Suite.class)
-@SuiteClasses({ UriSchemeProcessorUnitTest.class, //
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+
+@Suite
+@SelectClasses({ UriSchemeProcessorUnitTest.class, //
 		TestUnitPlistFileWriter.class, //
 		TestUnitDesktopFileWriter.class, //
 		TestUnitRegistrationMacOsX.class, //


### PR DESCRIPTION
- Convert @RunWith(Suite.class) to @Suite
- Convert @Suite.SuiteClasses to @SelectClasses
- Update imports from org.junit.runners to org.junit.platform.suite.api
- Add org.junit.jupiter.api and org.junit.platform.suite.api to Import-Package