### PR TITLE
Migrate org.eclipse.ui.workbench.texteditor.tests from JUnit4 to JUnit5

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.workbench.texteditor.tests
-Bundle-Version: 3.14.900.qualifier
+Bundle-Version: 3.14.1000.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: 
@@ -23,4 +23,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.ui.workbench.texteditor.tests
 Import-Package: org.mockito,
- org.mockito.stubbing;version="5.5.0"
+ org.mockito.stubbing;version="5.5.0",
+ org.junit.jupiter.api,
+ org.junit.platform.suite.api

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/WorkbenchTextEditorTestSuite.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/WorkbenchTextEditorTestSuite.java
@@ -13,9 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
 import org.eclipse.ui.internal.findandreplace.FindReplaceLogicTest;
 import org.eclipse.ui.internal.findandreplace.overlay.FindReplaceOverlayTest;
@@ -27,14 +26,13 @@ import org.eclipse.ui.workbench.texteditor.tests.revisions.HunkComputerTest;
 import org.eclipse.ui.workbench.texteditor.tests.revisions.RangeTest;
 import org.eclipse.ui.workbench.texteditor.tests.rulers.RulerTestSuite;
 
-
 /**
  * Test Suite for org.eclipse.ui.workbench.texteditor.
  *
  * @since 3.0
  */
-@RunWith(Suite.class)
-@SuiteClasses({
+@Suite
+@SelectClasses({
 		HippieCompletionTest.class,
 		RangeTest.class,
 		ChangeRegionTest.class,
@@ -52,5 +50,5 @@ import org.eclipse.ui.workbench.texteditor.tests.rulers.RulerTestSuite;
 		FindReplaceLogicTest.class,
 })
 public class WorkbenchTextEditorTestSuite {
-	// see @SuiteClasses
+	// see @SelectClasses
 }

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/rulers/RulerTestSuite.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/rulers/RulerTestSuite.java
@@ -13,18 +13,16 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests.rulers;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
-
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
 /**
  * @since 3.0
  */
-@RunWith(Suite.class)
-@SuiteClasses({
+@Suite
+@SelectClasses({
 		DAGTest.class
 })
 public class RulerTestSuite {
-	// see @SuiteClasses
+	// see @SelectClasses
 }


### PR DESCRIPTION
- Convert @RunWith(Suite.class) to @Suite
- Convert @Suite.SuiteClasses to @SelectClasses
- Update imports from org.junit.runners to org.junit.platform.suite.api
- Add org.junit.jupiter.api and org.junit.platform.suite.api to Import-Package