### PR TITLE
Migrate org.eclipse.ui.editors.tests from JUnit4 to JUnit5

### DIFF
--- a/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
@@ -26,6 +26,8 @@ Require-Bundle:
  org.eclipse.ui;bundle-version="3.119.100",
  org.eclipse.ui.tests.harness;bundle-version="1.8.0",
  org.mockito.mockito-core;bundle-version="5.12.0"
+Import-Package: org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Bundle-ActivationPolicy: lazy

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/EditorsTestSuite.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/EditorsTestSuite.java
@@ -15,9 +15,8 @@
  ************************************************************************************************/
 package org.eclipse.ui.editors.tests;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
 import org.eclipse.jface.text.tests.codemining.CodeMiningTest;
 
@@ -33,8 +32,8 @@ import org.eclipse.ui.texteditor.stickyscroll.StickyLineTest;
  *
  * @since 3.0
  */
-@RunWith(Suite.class)
-@SuiteClasses({
+@Suite
+@SelectClasses({
 		ChainedPreferenceStoreTest.class,
 		DocumentProviderRegistryTest.class,
 		EncodingChangeTests.class,
@@ -60,5 +59,5 @@ import org.eclipse.ui.texteditor.stickyscroll.StickyLineTest;
 		CodeMiningTest.class,
 })
 public class EditorsTestSuite {
-	// see @SuiteClasses
+	// see @SelectClasses
 }


### PR DESCRIPTION
- Convert @RunWith(Suite.class) to @Suite
- Convert @Suite.SuiteClasses to @SelectClasses
- Update imports from org.junit.runners to org.junit.platform.suite.api
- Add org.junit.jupiter.api and org.junit.platform.suite.api to Import-Package