### PR TITLE
Migrate org.eclipse.ui.tests.browser from JUnit4 to JUnit5

### DIFF
--- a/tests/org.eclipse.ui.tests.browser/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.browser/META-INF/MANIFEST.MF
@@ -9,6 +9,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.junit,
  org.eclipse.ui,
  org.eclipse.ui.browser
+Import-Package: org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Bundle-ActivationPolicy: lazy
 Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tests/org.eclipse.ui.tests.browser/src/org/eclipse/ui/tests/browser/internal/AllTests.java
+++ b/tests/org.eclipse.ui.tests.browser/src/org/eclipse/ui/tests/browser/internal/AllTests.java
@@ -14,11 +14,11 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.browser.internal;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 		ExistenceTestCase.class, InternalBrowserViewTestCase.class, InternalBrowserEditorTestCase.class,
 		// ExternalBrowserTestCase.class);
 		DialogsTestCase.class, PreferencesTestCase.class, TestInput.class, ToolbarBrowserTestCase.class,


### PR DESCRIPTION
- Convert @RunWith(Suite.class) to @Suite
- Convert @Suite.SuiteClasses to @SelectClasses
- Update imports from org.junit.runners to org.junit.platform.suite.api
- Add org.junit.jupiter.api and org.junit.platform.suite.api to Import-Package