### PR TITLE
Migrate org.eclipse.ui.tests from JUnit4 to JUnit5

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/internal/ide/DirectoryProposalContentAssistTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/internal/ide/DirectoryProposalContentAssistTestSuite.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.ide;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ DirectoryProposalContentAssistTest.class })
+@Suite
+@SelectClasses({ DirectoryProposalContentAssistTest.class })
 public class DirectoryProposalContentAssistTestSuite {
 
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/UiTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/UiTestSuite.java
@@ -58,14 +58,15 @@ import org.eclipse.ui.tests.stress.OpenCloseTest;
 import org.eclipse.ui.tests.systeminplaceeditor.OpenSystemInPlaceEditorTest;
 import org.eclipse.ui.tests.themes.ThemesTestSuite;
 import org.eclipse.ui.tests.zoom.ZoomTestSuite;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Test all areas of the UI.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	StartupTest.class,
 	UIAutomatedSuite.class,
 	ApiTestSuite.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/activities/ActivitiesTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/activities/ActivitiesTestSuite.java
@@ -14,14 +14,14 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.activities;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * The ActivitiesTestSuite class runs the activities' test suites.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	ImagesTest.class,
 	UtilTest.class,
 	StaticTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/AdaptableTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/AdaptableTestSuite.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.adaptable;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * The AdaptableTestSuite is the TestSuite for the
  * adaptable support in the UI.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	AdaptableDecoratorTestCase.class,
 	MarkerImageProviderTest.class,
 	WorkingSetTestCase.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/ApiTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/ApiTestSuite.java
@@ -25,11 +25,12 @@ import org.eclipse.ui.tests.e4.CloseAllHandlerTest;
 import org.eclipse.ui.tests.ide.api.FileEditorInputTest;
 import org.eclipse.ui.tests.ide.api.IDETest;
 import org.eclipse.ui.tests.ide.api.IDETest2;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({
 	 IPageLayoutTest.class,
 	 PlatformUITest.class,
 	 IWorkbenchTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandsTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandsTestSuite.java
@@ -14,14 +14,14 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.commands;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Tests for all areas of command support for the platform.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	CommandExecutionTest.class,
 	Bug73756Test.class,
 	Bug125792Test.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/ConcurrencyTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/ConcurrencyTestSuite.java
@@ -13,16 +13,16 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.concurrency;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * The suite of tests related to concurrency and deadlock.
  *
  * @since 3.1
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	ModalContextCrashTest.class,
 	NestedSyncExecDeadlockTest.class,
 	SyncExecWhileUIThreadWaitsForRuleTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/contexts/ContextsTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/contexts/ContextsTestSuite.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.contexts;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * The suite of tests related to the "org.eclipse.ui.contexts" extension point,
@@ -24,8 +24,8 @@ import org.junit.runners.Suite;
  *
  * @since 3.0
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	Bug74990Test.class,
 	Bug84763Test.class,
 	ExtensionTestCase.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/DataTransferTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/DataTransferTestSuite.java
@@ -16,11 +16,11 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.datatransfer;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	ImportOperationTest.class,
 	ImportArchiveOperationTest.class,
 	ExportFileSystemOperationTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/decorators/DecoratorsTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/decorators/DecoratorsTestSuite.java
@@ -14,11 +14,11 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.decorators;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	ExceptionDecoratorTestCase.class,
 	DecoratorTestCase.class,
 	LightweightDecoratorTestCase.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/FilteredResourcesSelectionDialogTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/FilteredResourcesSelectionDialogTestSuite.java
@@ -14,16 +14,16 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dialogs;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * The suite of tests for the FilteredResourcesSelectionDialog.
  *
  * @since 3.14
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	ResourceItemLabelTest.class,
 	ResourceInitialSelectionTest.class,
 	ResourceSelectionFilteringDialogTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIAutomatedSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIAutomatedSuite.java
@@ -15,11 +15,12 @@
 package org.eclipse.ui.tests.dialogs;
 
 import org.eclipse.ui.tests.compare.UIComparePreferencesAuto;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ UIDialogsAuto.class, DeprecatedUIDialogsAuto.class, UIWizardsAuto.class,
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({ UIDialogsAuto.class, DeprecatedUIDialogsAuto.class, UIWizardsAuto.class,
 		DeprecatedUIWizardsAuto.class, UIPreferencesAuto.class, UIComparePreferencesAuto.class,
 		DeprecatedUIPreferencesAuto.class, UIMessageDialogsAuto.class, UINewWorkingSetWizardAuto.class,
 		UIEditWorkingSetWizardAuto.class, SearchPatternAuto.class, InfixSearchPatternAuto.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIInteractiveSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIInteractiveSuite.java
@@ -14,14 +14,15 @@
 package org.eclipse.ui.tests.dialogs;
 
 import org.eclipse.ui.tests.compare.UIComparePreferences;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Test all areas of the UI.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	UIPreferences.class,
 	UIComparePreferences.class,
 	DeprecatedUIPreferences.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicPluginsTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicPluginsTestSuite.java
@@ -13,15 +13,14 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dynamicplugins;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
 /**
  * Test suite for dynamic plug-in support.
  */
-@RunWith(Suite.class)
-@SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		StatusHandlerTests.class, //
 		AcceleratorConfigurationsExtensionDynamicTest.class, //
 		AcceleratorScopesExtensionDynamicTest.class, //

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/encoding/EncodingTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/encoding/EncodingTestSuite.java
@@ -14,14 +14,14 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.encoding;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * The EncodingTestSuite is the suite for encoding tests.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
  EncodingTestCase.class
 })
 public class EncodingTestSuite {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/fieldassist/FieldAssistTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/fieldassist/FieldAssistTestSuite.java
@@ -15,14 +15,14 @@
 
 package org.eclipse.ui.tests.fieldassist;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Tests for the platform operations support.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	FieldAssistAPITest.class,
 	ComboContentAssistCommandAdapterTest.class,
 	TextContentAssistCommandAdapterTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/InternalTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/InternalTestSuite.java
@@ -30,11 +30,12 @@ import org.eclipse.ui.tests.markers.MarkerViewTests;
 import org.eclipse.ui.tests.markers.MarkerViewUtilTest;
 import org.eclipse.ui.tests.markers.ResourceMappingMarkersTest;
 import org.eclipse.ui.tests.markers.ScopeAreaTest;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({
 	EditorActionBarsTest.class,
 	ActionSetExpressionTest.class,
 	PopupMenuExpressionTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/intro/IntroTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/intro/IntroTestSuite.java
@@ -13,14 +13,14 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.intro;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * @since 3.0
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	IntroPartTest.class,
 	NoIntroPartTest.class,
 	IntroTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/KeysTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/KeysTestSuite.java
@@ -13,14 +13,14 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.keys;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Tests for all areas of the key support for the platform.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	BindingInteractionsTest.class,
 	BindingManagerTest.class,
 	DispatcherTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/leaks/LeaksTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/leaks/LeaksTestSuite.java
@@ -14,11 +14,11 @@
 
 package org.eclipse.ui.tests.leaks;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 		LeakTests.class,
 		Bug397302Tests.class,
 })

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/MenusTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/MenusTestSuite.java
@@ -14,15 +14,15 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.menus;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Tests for all code related to menus. This includes the
  * <code>popupMenus</code> extension point, and others.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 		DynamicToolbarTest.class,
 		ObjectContributionTest.class,
 		MenuVisibilityTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multieditor/MultiEditorTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multieditor/MultiEditorTestSuite.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.multieditor;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		AbstractMultiEditorTest.class, //
 		MultiEditorTest.class, //
 })

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageEditorTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageEditorTestSuite.java
@@ -13,16 +13,16 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.multipageeditor;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * The suite of tests for multi-page editors.
  *
  * @since 3.0
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	MultiEditorInputTest.class,
 	MultiPageEditorPartTest.class,
 	MultiVariablePageTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/navigator/NavigatorTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/navigator/NavigatorTestSuite.java
@@ -14,13 +14,12 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.navigator;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	NavigatorTest.class
 })
 public class NavigatorTestSuite  {
 }
-

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/operations/OperationsTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/operations/OperationsTestSuite.java
@@ -15,14 +15,14 @@
 
 package org.eclipse.ui.tests.operations;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Tests for the platform operations support.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	OperationsAPITest.class,
 	WorkbenchOperationHistoryTests.class,
 	MultiThreadedOperationsTests.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/PreferencesTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/PreferencesTestSuite.java
@@ -15,15 +15,16 @@
 package org.eclipse.ui.tests.preferences;
 
 import org.eclipse.ui.tests.propertyPages.PropertyPageEnablementTest;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Test suite for preferences.
  */
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	FontPreferenceTestCase.class,
 	DeprecatedFontPreferenceTestCase.class,
 	ScopedPreferenceStoreTestCase.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressTestSuite.java
@@ -15,8 +15,8 @@
 
 package org.eclipse.ui.tests.progress;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Test suite for the Progress View and related API
@@ -24,8 +24,8 @@ import org.junit.runners.Suite;
  * @since 3.6
  * @author Prakash G.R. (grprakash@in.ibm.com)
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	ProgressContantsTest.class,
 	ProgressViewTests.class,
 	JobInfoTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/PropertySheetTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/PropertySheetTestSuite.java
@@ -14,14 +14,14 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.propertysheet;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Test areas of the Property Sheet API.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	PropertyShowInContextTest.class,
 	MultiInstancePropertySheetTest.class,
 	ShowInPropertySheetTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessTestSuite.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.quickaccess;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ CamelUtilTest.class, QuickAccessDialogTest.class, ContentMatchesTest.class,
+@Suite
+@SelectClasses({ CamelUtilTest.class, QuickAccessDialogTest.class, ContentMatchesTest.class,
 		QuickAccessProvidersTest.class })
 public class QuickAccessTestSuite {
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/ServicesTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/ServicesTestSuite.java
@@ -15,15 +15,15 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.services;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Tests general to services.
  * @since 3.3
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	EvaluationServiceTest.class,
 	ContributedServiceTest.class,
 	WorkbenchSiteProgressServiceTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/StatusHandlingTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/StatusHandlingTestSuite.java
@@ -14,16 +14,16 @@
 
 package org.eclipse.ui.tests.statushandlers;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Tests the status handling facility
  *
  * @since 3.3
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	StatusDialogManagerTest.class,
 	LabelProviderWrapperTest.class,
 	SupportTrayTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/themes/ThemesTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/themes/ThemesTestSuite.java
@@ -14,14 +14,14 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.themes;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * @since 3.0
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	 ThemeAPITest.class,
 	 JFaceThemeTest.class,
 	 WorkbenchThemeChangedHandlerTest.class,

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomTestSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomTestSuite.java
@@ -13,14 +13,14 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.zoom;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * A test suite to test the zooming behavior of Eclipse.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+@Suite
+@SelectClasses({ //
 		ZoomedViewActivateTest.class, //
 		ZoomedEditorCloseTest.class, //
 		ZoomedViewCloseTest.class, //

--- a/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -47,7 +47,9 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="3.14.0",
  org.eclipse.emf.ecore
 Import-Package: jakarta.annotation,
  jakarta.inject,
- org.osgi.service.event
+ org.osgi.service.event,
+ org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Eclipse-AutoStart: true
 Export-Package: org.eclipse.ui.tests.api,
  org.eclipse.ui.tests.menus


### PR DESCRIPTION
- Convert @RunWith(Suite.class) to @Suite
- Convert @Suite.SuiteClasses to @SelectClasses
- Update imports from org.junit.runners to org.junit.platform.suite.api
- Add org.junit.jupiter.api and org.junit.platform.suite.api to Import-Package