### PR TITLE
Migrate org.eclipse.e4.ui.tests from JUnit4 to JUnit5

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
@@ -38,7 +38,9 @@ Export-Package: org.eclipse.e4.ui.tests.model.test,
 Bundle-ActivationPolicy: lazy
 Import-Package: jakarta.annotation,
  jakarta.inject,
- org.osgi.service.event
+ org.osgi.service.event,
+ org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.e4.ui.tests
 Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/UIAllTests.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/UIAllTests.java
@@ -56,15 +56,15 @@ import org.eclipse.e4.ui.workbench.renderers.swt.StackRendererTest;
 import org.eclipse.e4.ui.workbench.renderers.swt.TabStateHandlerTest;
 import org.eclipse.e4.ui.workbench.renderers.swt.ThemeDefinitionChangedHandlerTest;
 import org.eclipse.e4.ui.workbench.renderers.swt.ToolBarManagerRendererTest;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * All E4 UI-related tests
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 		StartupTestSuite.class,
 		UIEventTypesTest.class,
 		Bug299755Test.class,

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/StartupTestSuite.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/StartupTestSuite.java
@@ -15,11 +15,11 @@
 
 package org.eclipse.e4.ui.tests.application;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ EModelServiceTest.class, EModelServiceFindTest.class, EModelServicePerspectiveFindTest.class,
+@Suite
+@SelectClasses({ EModelServiceTest.class, EModelServiceFindTest.class, EModelServicePerspectiveFindTest.class,
 		EModelServiceInsertTest.class, EPartServiceTest.class, ESelectionServiceTest.class, EventBrokerTest.class,
 		HeadlessContactsDemoTest.class, HeadlessPhotoDemoTest.class, UIEventsTest.class,
 })


### PR DESCRIPTION
- Convert @RunWith(Suite.class) to @Suite
- Convert @Suite.SuiteClasses to @SelectClasses
- Update imports from org.junit.runners to org.junit.platform.suite.api
- Add org.junit.jupiter.api and org.junit.platform.suite.api to Import-Package