### PR TITLE
Migrate org.eclipse.core.filebuffers.tests from JUnit4 to JUnit5

### DIFF
--- a/tests/org.eclipse.core.filebuffers.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.core.filebuffers.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.core.filebuffers.tests;singleton:=true
-Bundle-Version: 3.13.500.qualifier
+Bundle-Version: 3.13.600.qualifier
 Bundle-Activator: org.eclipse.core.filebuffers.tests.FileBuffersTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName
@@ -15,6 +15,8 @@ Require-Bundle:
  org.eclipse.core.filebuffers;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.text;bundle-version="[3.5.0,4.0.0)",
  org.junit;bundle-version="4.12.0"
+Import-Package: org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.core.filebuffers.tests

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersTestSuite.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersTestSuite.java
@@ -15,18 +15,16 @@
 
 package org.eclipse.core.filebuffers.tests;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
-
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
 /**
  * Test Suite for org.eclipse.core.filebuffers.
  *
  * @since 3.0
  */
-@RunWith(Suite.class)
-@SuiteClasses({ FileBufferCreation.class,
+@Suite
+@SelectClasses({ FileBufferCreation.class,
 		FileBuffersForWorkspaceFiles.class,
 		FileBuffersForExternalFiles.class,
 		FileBuffersForLinkedFiles.class,
@@ -42,5 +40,5 @@ import org.junit.runners.Suite.SuiteClasses;
 		ResourceTextFileManagerDocCreationTests.class
 })
 public class FileBuffersTestSuite {
-	// see @SuiteClasses
+	// see @SelectClasses
 }


### PR DESCRIPTION
- Convert @RunWith(Suite.class) to @Suite
- Convert @Suite.SuiteClasses to @SelectClasses
- Update imports from org.junit.runners to org.junit.platform.suite.api
- Add org.junit.jupiter.api and org.junit.platform.suite.api to Import-Package