### PR TITLE
Migrate org.eclipse.ui.tests.rcp from JUnit4 to JUnit5

### DIFF
--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/performance/RCPPerformanceTestSuite.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/performance/RCPPerformanceTestSuite.java
@@ -14,14 +14,14 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.rcp.performance;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * @since 3.1
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({PlatformUIPerfTest.class , EmptyWorkbenchPerfTest.class})
+@Suite
+@SelectClasses({PlatformUIPerfTest.class , EmptyWorkbenchPerfTest.class})
 public class RCPPerformanceTestSuite {
 
 }

--- a/tests/org.eclipse.ui.tests.rcp/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.rcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.tests.rcp; singleton:=true
-Bundle-Version: 3.6.600.qualifier
+Bundle-Version: 3.6.700.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,


### PR DESCRIPTION
- Convert @RunWith(Suite.class) to @Suite
- Convert @Suite.SuiteClasses to @SelectClasses
- Update imports from org.junit.runners to org.junit.platform.suite.api
- Add org.junit.jupiter.api and org.junit.platform.suite.api to Import-Package