### PR TITLE
Migrate org.eclipse.search.tests from JUnit4 to JUnit5

### DIFF
--- a/tests/org.eclipse.search.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.search.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search.tests;singleton:=true
-Bundle-Version: 3.11.800.qualifier
+Bundle-Version: 3.11.900.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.search.core.tests;x-internal:=true,
@@ -19,6 +19,8 @@ Require-Bundle:
  org.eclipse.jface.text;bundle-version="[3.24.200,4.0.0)",
  org.eclipse.ui.editors;bundle-version="[3.17.100,4.0.0)",
  org.eclipse.ltk.core.refactoring;bundle-version="[3.14.100,4.0.0)"
+Import-Package: org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/core/tests/AllSearchModelTests.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/core/tests/AllSearchModelTests.java
@@ -13,16 +13,15 @@
  *******************************************************************************/
 package org.eclipse.search.core.tests;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
-@RunWith(Suite.class)
-@SuiteClasses({
+@Suite
+@SelectClasses({
 		QueryManagerTest.class,
 		TestSearchResult.class,
 		LineConversionTest.class
 })
 public class AllSearchModelTests {
-	// see @SuiteClasses
+	// see @SelectClasses
 }

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/AllSearchTests.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/AllSearchTests.java
@@ -13,19 +13,18 @@
  *******************************************************************************/
 package org.eclipse.search.tests;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
 import org.eclipse.search.core.tests.AllSearchModelTests;
 import org.eclipse.search.tests.filesearch.AllFileSearchTests;
 
-@RunWith(Suite.class)
-@SuiteClasses({
+@Suite
+@SelectClasses({
 		AllFileSearchTests.class,
 		AllSearchModelTests.class,
 		TextSearchRegistryTest.class
 })
 public class AllSearchTests {
-	// see @SuiteClasses
+	// see @SelectClasses
 }

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/AllFileSearchTests.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/AllFileSearchTests.java
@@ -14,12 +14,12 @@
 package org.eclipse.search.tests.filesearch;
 
 import org.junit.ClassRule;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
 
-@RunWith(Suite.class)
-@SuiteClasses({
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+
+@Suite
+@SelectClasses({
 		AnnotationManagerTest.class,
 		FileSearchTests.class,
 		LineAnnotationManagerTest.class,


### PR DESCRIPTION
- Convert @RunWith(Suite.class) to @Suite
- Convert @Suite.SuiteClasses to @SelectClasses
- Update imports from org.junit.runners to org.junit.platform.suite.api
- Add org.junit.jupiter.api and org.junit.platform.suite.api to Import-Package