### PR TITLE
Migrate org.eclipse.text.tests from JUnit4 to JUnit5

### DIFF
--- a/tests/org.eclipse.text.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.text.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.text.tests
-Bundle-Version: 3.14.900.qualifier
+Bundle-Version: 3.14.1000.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: 
@@ -14,6 +14,8 @@ Require-Bundle:
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.text;bundle-version="[3.6.3,4.0.0)",
  org.junit;bundle-version="4.12.0"
+Import-Package: org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.text.tests

--- a/tests/org.eclipse.text.tests/projection/org/eclipse/text/tests/ProjectionTestSuite.java
+++ b/tests/org.eclipse.text.tests/projection/org/eclipse/text/tests/ProjectionTestSuite.java
@@ -14,20 +14,18 @@
 
 package org.eclipse.text.tests;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
-
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
 /**
  *
  * @since 3.0
  */
-@RunWith(Suite.class)
-@SuiteClasses({
+@Suite
+@SelectClasses({
 		ProjectionDocumentTest.class,
 		ProjectionMappingTest.class
 })
 public class ProjectionTestSuite {
-	// see @SuiteClasses
+	// see @SelectClasses
 }

--- a/tests/org.eclipse.text.tests/src/org/eclipse/text/tests/EclipseTextTestSuite.java
+++ b/tests/org.eclipse.text.tests/src/org/eclipse/text/tests/EclipseTextTestSuite.java
@@ -14,21 +14,19 @@
  *******************************************************************************/
 package org.eclipse.text.tests;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
 import org.eclipse.text.tests.link.LinkTestSuite;
 import org.eclipse.text.tests.templates.TemplatesTestSuite;
-
 
 /**
  * Test Suite for org.eclipse.text.
  *
  * @since 3.0
  */
-@RunWith(Suite.class)
-@SuiteClasses({
+@Suite
+@SelectClasses({
 		MultiStringMatcherTest.class,
 		ConfigurableLineTrackerTest.class,
 		LineTrackerTest4.class,
@@ -51,5 +49,5 @@ import org.eclipse.text.tests.templates.TemplatesTestSuite;
 		TemplatesTestSuite.class
 })
 public class EclipseTextTestSuite {
-	// see @SuiteClasses
+	// see @SelectClasses
 }

--- a/tests/org.eclipse.text.tests/src/org/eclipse/text/tests/link/LinkTestSuite.java
+++ b/tests/org.eclipse.text.tests/src/org/eclipse/text/tests/link/LinkTestSuite.java
@@ -14,23 +14,21 @@
 
 package org.eclipse.text.tests.link;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
-
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
 /**
  * Test Suite org.eclipse.text.tests.link.
  *
  * @since 3.0
  */
-@RunWith(Suite.class)
-@SuiteClasses({
+@Suite
+@SelectClasses({
 		LinkedPositionGroupTest.class,
 		LinkedPositionTest.class,
 		InclusivePositionUpdaterTest.class,
 		LinkedModeModelTest.class
 })
 public class LinkTestSuite {
-	// see @SuiteClasses
+	// see @SelectClasses
 }

--- a/tests/org.eclipse.text.tests/src/org/eclipse/text/tests/templates/TemplatesTestSuite.java
+++ b/tests/org.eclipse.text.tests/src/org/eclipse/text/tests/templates/TemplatesTestSuite.java
@@ -16,19 +16,18 @@
 
 package org.eclipse.text.tests.templates;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
 /**
  * Test Suite for the org.eclipse.text plug-in
  */
-@RunWith(Suite.class)
-@SuiteClasses({
+@Suite
+@SelectClasses({
 		TemplateTranslatorTest.class,
 		TemplateVariablesWordSelectionTest.class,
 		GlobalTemplateVariablesDateTest.class
 })
 public class TemplatesTestSuite {
-	// see @SuiteClasses
+	// see @SelectClasses
 }


### PR DESCRIPTION
- Convert @RunWith(Suite.class) to @Suite
- Convert @Suite.SuiteClasses to @SelectClasses
- Update imports from org.junit.runners to org.junit.platform.suite.api
- Add org.junit.jupiter.api and org.junit.platform.suite.api to Import-Package