### PR TITLE
Migrate org.eclipse.ui.monitoring.tests from JUnit4 to JUnit5

### DIFF
--- a/tests/org.eclipse.ui.monitoring.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.monitoring.tests/META-INF/MANIFEST.MF
@@ -1,6 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
+Import-Package: org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-SymbolicName: org.eclipse.ui.monitoring.tests;singleton:=true
 Bundle-Vendor: %Bundle-Vendor

--- a/tests/org.eclipse.ui.monitoring.tests/src/org/eclipse/ui/internal/monitoring/MonitoringTestSuite.java
+++ b/tests/org.eclipse.ui.monitoring.tests/src/org/eclipse/ui/internal/monitoring/MonitoringTestSuite.java
@@ -14,16 +14,16 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.monitoring;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Test suite for {@code org.eclipse.ui.monitoring} plug-in.
  * The tests in {@link EventLoopMonitorThreadManualTests} are not included in this
  * suite due to their flakiness.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	EventLoopMonitorThreadTests.class,
 	FilterHandlerTests.class,
 	DefaultLoggerTests.class})


### PR DESCRIPTION
- Convert @RunWith(Suite.class) to @Suite
- Convert @Suite.SuiteClasses to @SelectClasses
- Update imports from org.junit.runners to org.junit.platform.suite.api
- Add org.junit.jupiter.api and org.junit.platform.suite.api to Import-Package