### PR TITLE
Migrate org.eclipse.ltk.core.refactoring.tests from JUnit4 to JUnit5

### DIFF
--- a/tests/org.eclipse.ltk.core.refactoring.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.ltk.core.refactoring.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ltk.core.refactoring.tests; singleton:=true
-Bundle-Version: 3.10.600.qualifier
+Bundle-Version: 3.10.700.qualifier
 Bundle-Activator: org.eclipse.ltk.core.refactoring.tests.RefactoringCoreTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
@@ -26,4 +26,5 @@ Require-Bundle:
  org.eclipse.core.tests.harness
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
-Import-Package: org.junit.jupiter.api
+Import-Package: org.junit.jupiter.api,
+ org.junit.platform.suite.api

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/AllTests.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/AllTests.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ltk.core.refactoring.tests;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 import org.eclipse.ltk.core.refactoring.tests.history.RefactoringHistoryTests;
 import org.eclipse.ltk.core.refactoring.tests.participants.ParticipantTests;
@@ -22,8 +22,8 @@ import org.eclipse.ltk.core.refactoring.tests.resource.ResourceRefactoringTests;
 import org.eclipse.ltk.core.refactoring.tests.resource.ResourceRefactoringUndoTests;
 import org.eclipse.ltk.core.refactoring.tests.scripting.RefactoringScriptingTests;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	RefactoringContextTest.class,
 	ParticipantTests.class,
 	RefactoringHistoryTests.class,

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/history/RefactoringHistoryTests.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/history/RefactoringHistoryTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.ltk.core.refactoring.tests.history;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	RefactoringHistorySerializationTests.class,
 	RefactoringHistoryServiceTests.class
 })

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/participants/ParticipantTests.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/participants/ParticipantTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.ltk.core.refactoring.tests.participants;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	FailingParticipantTests.class,
 	SharedTextChangeTests.class,
 	CancelingParticipantTests.class,

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/scripting/RefactoringScriptingTests.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/scripting/RefactoringScriptingTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.ltk.core.refactoring.tests.scripting;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	RefactoringScriptApplicationTests.class
 })
 public class RefactoringScriptingTests {


### PR DESCRIPTION
- Convert @RunWith(Suite.class) to @Suite
- Convert @Suite.SuiteClasses to @SelectClasses
- Update imports from org.junit.runners to org.junit.platform.suite.api
- Add org.junit.jupiter.api and org.junit.platform.suite.api to Import-Package