### PR TITLE
Migrate org.eclipse.jface.tests.databinding from JUnit4 to JUnit5

### DIFF
--- a/tests/org.eclipse.jface.tests.databinding/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.tests.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.tests.databinding
-Bundle-Version: 1.12.700.qualifier
+Bundle-Version: 1.12.800.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.databinding;bundle-version="[1.3.0,2.0.0)",
@@ -15,6 +15,8 @@ Require-Bundle: org.eclipse.core.databinding;bundle-version="[1.3.0,2.0.0)",
  org.eclipse.jface.databinding,
  org.eclipse.jface.tests.databinding.conformance,
  org.eclipse.core.databinding.property
+Import-Package: org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.jface.tests.databinding

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/jface/tests/databinding/BindingTestSuite.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/jface/tests/databinding/BindingTestSuite.java
@@ -188,12 +188,12 @@ import org.eclipse.jface.tests.internal.databinding.viewers.ObservableCollection
 import org.eclipse.jface.tests.internal.databinding.viewers.ViewerElementMapTest;
 import org.eclipse.jface.tests.internal.databinding.viewers.ViewerElementSetTest;
 import org.eclipse.jface.tests.internal.databinding.viewers.ViewerElementWrapperTest;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
 
-@RunWith(Suite.class)
-@SuiteClasses({ AbstractObservableListTest.class, AbstractObservableMapTest.class, AbstractObservableTest.class,
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+
+@Suite
+@SelectClasses({ AbstractObservableListTest.class, AbstractObservableMapTest.class, AbstractObservableTest.class,
 		AbstractObservableValueTest.class, AbstractStringToNumberValidatorTest.class, AbstractVetoableValueTest.class,
 		AggregateValidationStatusTest.class, AnonymousBeanValuePropertyTest.class, AnonymousPojoValuePropertyTest.class,
 		BeanPropertiesTest.class,

--- a/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/jface/tests/databinding/scenarios/BindingScenariosTestSuite.java
+++ b/tests/org.eclipse.jface.tests.databinding/src/org/eclipse/jface/tests/databinding/scenarios/BindingScenariosTestSuite.java
@@ -14,10 +14,8 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.databinding.scenarios;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
-
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
 /**
  * To run this test suite, right-click and select "Run As JUnit Plug-in Test".
@@ -26,8 +24,8 @@ import org.junit.runners.Suite.SuiteClasses;
  * Mode" as the application to run. You can also run this class as an SWT
  * application.
  */
-@RunWith(Suite.class)
-@SuiteClasses({ ButtonControlScenario.class, ComboScenarios.class, ComboUpdatingTest.class, ComboViewerScenario.class,
+@Suite
+@SelectClasses({ ButtonControlScenario.class, ComboScenarios.class, ComboUpdatingTest.class, ComboViewerScenario.class,
 		CustomConverterScenarios.class, CustomScenarios.class, ListViewerScenario.class, MasterDetailScenarios.class,
 		NewTableScenarios.class, NPETestScenario.class, PropertyScenarios.class, SpinnerControlScenario.class,
 		TableScenarios.class, TextControlScenario.class })


### PR DESCRIPTION
- Convert @RunWith(Suite.class) to @Suite
- Convert @Suite.SuiteClasses to @SelectClasses
- Update imports from org.junit.runners to org.junit.platform.suite.api
- Add org.junit.jupiter.api and org.junit.platform.suite.api to Import-Package