### PR TITLE
Migrate org.eclipse.jface.tests.notifications from JUnit4 to JUnit5

### DIFF
--- a/tests/org.eclipse.jface.tests.notifications/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.tests.notifications/META-INF/MANIFEST.MF
@@ -4,6 +4,8 @@ Bundle-Name: Jface notifications tests
 Bundle-SymbolicName: org.eclipse.jface.tests.notifications
 Bundle-Vendor: Eclipse.org
 Bundle-Version: 0.2.0.qualifier
+Import-Package: org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Automatic-Module-Name: org.eclipse.jface.notifications.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit,

--- a/tests/org.eclipse.jface.tests.notifications/src/org/eclipse/jface/tests/notifications/AllTests.java
+++ b/tests/org.eclipse.jface.tests.notifications/src/org/eclipse/jface/tests/notifications/AllTests.java
@@ -13,12 +13,11 @@
 
 package org.eclipse.jface.tests.notifications;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
-@RunWith(Suite.class)
-@SuiteClasses({ NotificationPopupTest.class })
+@Suite
+@SelectClasses({ NotificationPopupTest.class })
 public class AllTests {
 
 }


### PR DESCRIPTION
- Convert @RunWith(Suite.class) to @Suite
- Convert @Suite.SuiteClasses to @SelectClasses
- Update imports from org.junit.runners to org.junit.platform.suite.api
- Add org.junit.jupiter.api and org.junit.platform.suite.api to Import-Package