### PR TITLE
Migrate org.eclipse.jface.tests from JUnit4 to JUnit5

### DIFF
--- a/tests/org.eclipse.jface.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.tests/META-INF/MANIFEST.MF
@@ -11,7 +11,9 @@ Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.core.runtime,
  org.eclipse.ui,
  org.eclipse.ui.tests.harness
-Import-Package: org.osgi.framework
+Import-Package: org.osgi.framework,
+ org.junit.jupiter.api,
+ org.junit.platform.suite.api
 Export-Package: org.eclipse.jface.tests.fieldassist;x-internal:=true,
  org.eclipse.jface.tests.preferences;x-internal:=true,
  org.eclipse.jface.tests.viewers;x-internal:=true

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/AllTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/AllTests.java
@@ -23,12 +23,12 @@ import org.eclipse.jface.tests.viewers.AllViewersTests;
 import org.eclipse.jface.tests.widgets.AllWidgetTests;
 import org.eclipse.jface.tests.window.AllWindowTests;
 import org.eclipse.jface.tests.wizards.WizardTestSuite;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
 
-@RunWith(Suite.class)
-@SuiteClasses({ AllActionTests.class, AllDialogTests.class, AllImagesTests.class, AllLabelProviderTests.class,
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+
+@Suite
+@SelectClasses({ AllActionTests.class, AllDialogTests.class, AllImagesTests.class, AllLabelProviderTests.class,
 		AllLayoutTests.class, AllPrefsTests.class, AllResourcesTests.class, AllViewersTests.class, AllWidgetTests.class,
 		AllWindowTests.class, DecoratingLabelProviderTests.class, FieldAssistTestSuite.class, WizardTestSuite.class })
 public class AllTests {

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/AllActionTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/AllActionTests.java
@@ -14,11 +14,12 @@
 package org.eclipse.jface.tests.action;
 
 import org.junit.runner.JUnitCore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ ContributionItemTest.class, ToolBarManagerTest.class, CoolBarManagerTest.class,
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({ ContributionItemTest.class, ToolBarManagerTest.class, CoolBarManagerTest.class,
 		MenuManagerTest.class })
 public class AllActionTests {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/AllDialogTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/AllDialogTests.java
@@ -14,11 +14,12 @@
 package org.eclipse.jface.tests.dialogs;
 
 import org.junit.runner.JUnitCore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ DialogTest.class, StatusDialogTest.class, DialogSettingsTest.class, InputDialogTest.class,
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({ DialogTest.class, StatusDialogTest.class, DialogSettingsTest.class, InputDialogTest.class,
 		TitleAreaDialogTest.class, SafeRunnableErrorTest.class, ProgressIndicatorStyleTest.class,
 		ProgressMonitorDialogTest.class, PlainMessageDialogTest.class })
 public class AllDialogTests {

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/fieldassist/FieldAssistTestSuite.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/fieldassist/FieldAssistTestSuite.java
@@ -14,14 +14,14 @@
 
 package org.eclipse.jface.tests.fieldassist;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * Tests for the platform operations support.
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ // disabled, see bug 275393...
+@Suite
+@SelectClasses({ // disabled, see bug 275393...
 		// TextFieldAssistTests.class, ComboFieldAssistTests.class,
 		ControlDecorationTests.class, FieldAssistAPITests.class })
 public class FieldAssistTestSuite {

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/AllImagesTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/AllImagesTests.java
@@ -15,11 +15,12 @@
 package org.eclipse.jface.tests.images;
 
 import org.junit.runner.JUnitCore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ ImageRegistryTest.class, ResourceManagerTest.class, FileImageDescriptorTest.class,
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({ ImageRegistryTest.class, ResourceManagerTest.class, FileImageDescriptorTest.class,
 		UrlImageDescriptorTest.class, DecorationOverlayIconTest.class, DeferredImageDescriptorTest.class })
 public class AllImagesTests {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/AllLabelProviderTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/AllLabelProviderTests.java
@@ -1,11 +1,10 @@
 package org.eclipse.jface.tests.labelProviders;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
-@RunWith(Suite.class)
-@SuiteClasses({ ColorAndFontLabelProviderTest.class, //
+@Suite
+@SelectClasses({ ColorAndFontLabelProviderTest.class, //
 		ColorAndFontViewerLabelProviderTest.class, //
 		ColumnLabelProviderLambdaTest.class, //
 		CompositeLabelProviderTableTest.class, //

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/DecoratingLabelProviderTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/labelProviders/DecoratingLabelProviderTests.java
@@ -14,11 +14,12 @@
 package org.eclipse.jface.tests.labelProviders;
 
 import org.junit.runner.JUnitCore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ CompositeLabelProviderTableTest.class, DecoratingLabelProviderTreePathTest.class,
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({ CompositeLabelProviderTableTest.class, DecoratingLabelProviderTreePathTest.class,
 		DecoratingLabelProviderTreeTest.class, ColorAndFontLabelProviderTest.class,
 		ColorAndFontViewerLabelProviderTest.class, DecoratingStyledCellLabelProviderTest.class,
 		IDecorationContextTest.class })

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/layout/AllLayoutTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/layout/AllLayoutTests.java
@@ -14,11 +14,12 @@
 package org.eclipse.jface.tests.layout;
 
 import org.junit.runner.JUnitCore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ GeometryTest.class, AbstractColumnLayoutTest.class, GridDataFactoryTest.class,
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({ GeometryTest.class, AbstractColumnLayoutTest.class, GridDataFactoryTest.class,
 		GridLayoutFactoryTest.class, TreeColumnLayoutTest.class })
 public class AllLayoutTests {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/preferences/AllPrefsTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/preferences/AllPrefsTests.java
@@ -14,11 +14,12 @@
 package org.eclipse.jface.tests.preferences;
 
 import org.junit.runner.JUnitCore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({ //
 		BooleanFieldEditorTest.class, //
 		StringFieldEditorTest.class, //
 		IntegerFieldEditorTest.class, //

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/resources/AllResourcesTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/resources/AllResourcesTests.java
@@ -15,11 +15,12 @@
 package org.eclipse.jface.tests.resources;
 
 import org.junit.runner.JUnitCore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ FontRegistryTest.class, JFaceResourcesTest.class })
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({ FontRegistryTest.class, JFaceResourcesTest.class })
 public class AllResourcesTests {
 
 	public static void main(String[] args) {

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/AllViewersTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/AllViewersTests.java
@@ -14,11 +14,12 @@
 package org.eclipse.jface.tests.viewers;
 
 import org.junit.runner.JUnitCore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ TreeSelectionTest.class, MultipleEqualElementsTreeViewerTest.class,
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({ TreeSelectionTest.class, MultipleEqualElementsTreeViewerTest.class,
 		LazySortedCollectionTest.class, TreeViewerTest.class, VirtualTreeViewerTest.class, SimpleTreeViewerTest.class,
 		SimpleTableViewerTest.class, SimpleVirtualLazyTreeViewerTest.class, VirtualLazyTreeViewerTest.class,
 		TableViewerTest.class, TreeViewerColumnTest.class, VirtualTableViewerTest.class,

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/AllWidgetTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/AllWidgetTests.java
@@ -10,12 +10,11 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
-@RunWith(Suite.class)
-@SuiteClasses({ TestUnitButtonFactory.class, //
+@Suite
+@SelectClasses({ TestUnitButtonFactory.class, //
 		TestUnitCompositeFactory.class, //
 		TestUnitControlFactory.class, //
 		TestUnitGroupFactory.class, //

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/window/AllWindowTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/window/AllWindowTests.java
@@ -15,11 +15,12 @@
 package org.eclipse.jface.tests.window;
 
 import org.junit.runner.JUnitCore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ //
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({ //
 		ApplicationWindowTest.class, //
 		WindowTest.class, //
 })

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/wizards/WizardTestSuite.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/wizards/WizardTestSuite.java
@@ -15,11 +15,12 @@
 package org.eclipse.jface.tests.wizards;
 
 import org.junit.runner.JUnitCore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({ ButtonAlignmentTest.class, WizardTest.class, WizardProgressMonitorTest.class })
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({ ButtonAlignmentTest.class, WizardTest.class, WizardProgressMonitorTest.class })
 public class WizardTestSuite {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
- Convert @RunWith(Suite.class) to @Suite
- Convert @Suite.SuiteClasses to @SelectClasses
- Update imports from org.junit.runners to org.junit.platform.suite.api
- Add org.junit.jupiter.api and org.junit.platform.suite.api to Import-Package