### PR TITLE
Fix "Widget is disposed" exception in VisibleLinesTracker

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/VisibleLinesTracker.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/VisibleLinesTracker.java
@@ -91,7 +91,7 @@ class VisibleLinesTracker implements PaintListener {
 	 */
 	static void track(ITextViewer viewer, Consumer<StyledText> handler) {
 		StyledText textWidget= viewer != null ? viewer.getTextWidget() : null;
-		if (textWidget == null) {
+		if (textWidget == null || textWidget.isDisposed()) {
 			return;
 		}
 		VisibleLinesTracker tracker= (VisibleLinesTracker) textWidget.getData(DATA_KEY);
@@ -111,7 +111,7 @@ class VisibleLinesTracker implements PaintListener {
 	 */
 	static void untrack(ITextViewer viewer, Consumer<StyledText> handler) {
 		StyledText textWidget= viewer != null ? viewer.getTextWidget() : null;
-		if (textWidget == null) {
+		if (textWidget == null || textWidget.isDisposed()) {
 			return;
 		}
 		VisibleLinesTracker tracker= (VisibleLinesTracker) textWidget.getData(DATA_KEY);


### PR DESCRIPTION
Fixes SWTException: "Widget is disposed" in VisibleLinesTracker.
```
org.eclipse.swt.SWTException: Widget is disposed
	at org.eclipse.swt.SWT.error(SWT.java:4946)
	at org.eclipse.swt.SWT.error(SWT.java:4861)
	at org.eclipse.swt.SWT.error(SWT.java:4832)
	at org.eclipse.swt.widgets.Widget.error(Widget.java:507)
	at org.eclipse.swt.widgets.Widget.checkWidget(Widget.java:426)
	at org.eclipse.swt.widgets.Widget.getData(Widget.java:601)
	at org.eclipse.jface.text.source.VisibleLinesTracker.untrack(VisibleLinesTracker.java:117)
	at org.eclipse.jface.text.source.AnnotationRulerColumn.handleDispose(AnnotationRulerColumn.java:491)
	at org.eclipse.jface.text.source.AnnotationRulerColumn.lambda$2(AnnotationRulerColumn.java:264)
	at org.eclipse.swt.widgets.TypedListener.handleEvent(TypedListener.java:161)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4362)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1214)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1238)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1219)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:896)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:930)
	at org.eclipse.swt.widgets.Canvas.releaseChildren(Canvas.java:166)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:903)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:930)
	at org.eclipse.swt.widgets.Canvas.releaseChildren(Canvas.java:166)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:903)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:930)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:903)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:930)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:903)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:930)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:903)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:930)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:903)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:930)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:903)
	at org.eclipse.swt.widgets.Composite.releaseChildren(Composite.java:930)
	at org.eclipse.swt.widgets.Widget.release(Widget.java:903)
	at org.eclipse.swt.widgets.Widget.dispose(Widget.java:485)
	at org.eclipse.e4.ui.workbench.renderers.swt.SWTPartRenderer.disposeWidget(SWTPartRenderer.java:186)
	at org.eclipse.e4.ui.workbench.renderers.swt.ContributedPartRenderer.disposeWidget(ContributedPartRenderer.java:284)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeRemoveGui(PartRenderingEngine.java:934)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:857)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.removeGui(PartRenderingEngine.java:841)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.subscribeTopicToBeRendered(PartRenderingEngine.java:184)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.e4.core.internal.di.MethodRequestor.execute(MethodRequestor.java:58)
	at org.eclipse.e4.core.di.internal.extensions.EventObjectSupplier$DIEventHandler.handleEvent(EventObjectSupplier.java:92)
	at org.eclipse.equinox.internal.event.EventHandlerWrapper.handleEvent(EventHandlerWrapper.java:206)
	at org.eclipse.equinox.internal.event.EventHandlerTracker.dispatchEvent(EventHandlerTracker.java:201)
	at org.eclipse.equinox.internal.event.EventHandlerTracker.dispatchEvent(EventHandlerTracker.java:1)
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)
	at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:151)
	at org.eclipse.equinox.internal.event.EventAdminImpl.dispatchEvent(EventAdminImpl.java:132)
	at org.eclipse.equinox.internal.event.EventAdminImpl.sendEvent(EventAdminImpl.java:73)
	at org.eclipse.equinox.internal.event.EventComponent.sendEvent(EventComponent.java:48)
	at org.eclipse.e4.ui.services.internal.events.EventBroker.send(EventBroker.java:55)
	at org.eclipse.e4.ui.internal.workbench.UIEventPublisher.notifyChanged(UIEventPublisher.java:60)
	at org.eclipse.emf.common.notify.impl.BasicNotifierImpl.eNotify(BasicNotifierImpl.java:424)
	at org.eclipse.e4.ui.model.application.ui.impl.UIElementImpl.setToBeRendered(UIElementImpl.java:316)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.hidePart(PartServiceImpl.java:1411)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.hidePart(PartServiceImpl.java:1341)
	at org.eclipse.e4.ui.workbench.renderers.swt.StackRenderer.closePart(StackRenderer.java:1378)
	at org.eclipse.e4.ui.workbench.renderers.swt.StackRenderer$2.mouseUp(StackRenderer.java:1209)
	at org.eclipse.swt.widgets.TypedListener.handleEvent(TypedListener.java:258)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4362)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1214)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:4160)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3748)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1151)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1042)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:678)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:583)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:185)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:219)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:149)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:115)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:467)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:298)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:627)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:575)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1431)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1403)
```