### PR TITLE
Add API filters for removed export of SVG package in SWT

### DIFF
--- a/bundles/org.eclipse.jface/.settings/.api_filters
+++ b/bundles/org.eclipse.jface/.settings/.api_filters
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.jface" version="2">
+    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.swt.svg.JSVGRasterizer">
+        <filter id="305426566">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.svg.JSVGRasterizer"/>
+                <message_argument value="org.eclipse.jface_3.38.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.ui/.settings/.api_filters
+++ b/bundles/org.eclipse.ui/.settings/.api_filters
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.ui" version="2">
+    <resource path="META-INF/MANIFEST.MF" type="org.eclipse.swt.svg.JSVGRasterizer">
+        <filter id="305426566">
+            <message_arguments>
+                <message_argument value="org.eclipse.swt.svg.JSVGRasterizer"/>
+                <message_argument value="org.eclipse.ui_3.207.300"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>


### PR DESCRIPTION
This is necessary once
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/2602

is merged. JFace and UI reexport SWT, such that the removal of a package export in SWT is effectively a breaking API change of these bundles. So this needs to be merged right after the SWT PR is merged.