### PR TITLE
Find/Replace Overlay: Restore cursor position when search input is cleared

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench.texteditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench.texteditor; singleton:=true
-Bundle-Version: 3.19.400.qualifier
+Bundle-Version: 3.19.500.qualifier
 Bundle-Activator: org.eclipse.ui.internal.texteditor.TextEditorPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogic.java
@@ -324,6 +324,9 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 	private boolean performSearch(boolean updateFromIncrementalBaseLocation) {
 		resetStatus();
 		if (findString.isEmpty()) {
+			if (isAvailableAndActive(SearchOptions.INCREMENTAL)) {
+				restoreSelectionIfEmpty();
+			}
 			return false;
 		}
 
@@ -336,6 +339,19 @@ public class FindReplaceLogic implements IFindReplaceLogic {
 			// we don't keep state in this dialog
 		}
 		return somethingFound;
+	}
+
+	/**
+	 * Restores the original caret/selection position when the search field becomes
+	 * empty.
+	 */
+	private void restoreSelectionIfEmpty() {
+		if (incrementalBaseLocation == null) {
+			return;
+		}
+		if (target instanceof IFindReplaceTargetExtension extension) {
+			extension.setSelection(incrementalBaseLocation.x, incrementalBaseLocation.y);
+		}
 	}
 
 	/**

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.workbench.texteditor.tests
-Bundle-Version: 3.14.1000.qualifier
+Bundle-Version: 3.14.1100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -833,6 +833,53 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.resetIncrementalBaseLocation();
 		findReplaceLogic.performSearch();
 		assertThat(textViewer.getSelectedRange(), is(new Point(5, 4)));
+		textViewer.setSelectedRange(7, 0);
+		findReplaceLogic.resetIncrementalBaseLocation();
+		findReplaceLogic.performSearch();
+		assertThat(textViewer.getSelectedRange(), is(new Point(10, 4)));
+		textViewer.setSelectedRange(10, 0);
+		findReplaceLogic.resetIncrementalBaseLocation();
+		findReplaceLogic.performSearch();
+		assertThat(textViewer.getSelectedRange(), is(new Point(10, 4)));
+		// Verify that after clearing the search, caret goes back to last active location
+		findReplaceLogic.setFindString("");
+		findReplaceLogic.performSearch();
+		assertThat(textViewer.getSelectedRange(), is(new Point(10, 4)));
+	}
+
+	@Test
+	public void testRestoreSelectionOnEmptyFindStringInIncrementalMode() {
+		String setupString= "test\ntest\ntest";
+		TextViewer textViewer= setupTextViewer(setupString);
+		textViewer.setSelectedRange(5, 0); // Set initial selection
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.activate(SearchOptions.FORWARD);
+		findReplaceLogic.activate(SearchOptions.WRAP);
+		findReplaceLogic.activate(SearchOptions.INCREMENTAL);
+
+		findReplaceLogic.resetIncrementalBaseLocation(); // Set base location
+		findReplaceLogic.setFindString("test");
+		assertThat(textViewer.getSelectedRange(), is(new Point(5, 4)));
+		findReplaceLogic.setFindString(""); // Clear the find string
+		assertThat(textViewer.getSelectedRange(), is(new Point(5, 0))); // Restored to base location
+	}
+
+	@Test
+	public void testNoRestoreOnEmptyFindStringWhenNotIncremental() {
+		String setupString= "test\ntest\ntest";
+		TextViewer textViewer= setupTextViewer(setupString);
+		textViewer.setSelectedRange(5, 0); // Set initial selection
+		IFindReplaceLogic findReplaceLogic= setupFindReplaceLogicObject(textViewer);
+		findReplaceLogic.activate(SearchOptions.FORWARD);
+		findReplaceLogic.activate(SearchOptions.WRAP);
+		// Do NOT activate incremental mode
+
+		findReplaceLogic.resetIncrementalBaseLocation();
+		findReplaceLogic.setFindString("test");
+		assertThat(textViewer.getSelectedRange(), is(new Point(5, 0)));
+		findReplaceLogic.setFindString(""); // Clear the find string
+		// Will not restore selection since incremental mode is not active
+		assertThat(textViewer.getSelectedRange(), is(new Point(5, 0))); // Remains unchanged
 	}
 
 	@Test
@@ -866,8 +913,8 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.setFindString("Te");
 		assertEquals(new Point(0, 2), findReplaceLogic.getTarget().getSelection());
 
-		findReplaceLogic.setFindString(""); // this clears the incremental search, but the "old search" still remains active
-		assertEquals(new Point(0, 2), findReplaceLogic.getTarget().getSelection());
+		findReplaceLogic.setFindString(""); // clears the incremental search input, restoring the caret to the base location
+		assertEquals(new Point(0, 0), findReplaceLogic.getTarget().getSelection());
 	}
 
 	@Test


### PR DESCRIPTION
Restores the editor caret to its original position when the Find/Replace overlay search field is cleared.

Fixes #1944 

This PR introduces logic to restore the original caret/selection position when the search input field becomes empty, but only when incremental search mode is active. This ensures consistent and expected behavior for users typing in the Find/Replace overlay.

Key Changes
1. Updated performSearch()
  - Added a conditional check for SearchOptions.INCREMENTAL when the find string is empty.
  - Calls restoreSelectionIfEmpty() to restore the selection only in incremental mode.
  
2. Added restoreSelectionIfEmpty() method
  - Restores the selection to incrementalBaseLocation if incremental mode is active and a valid base location exists.
  - Skips restoration when incremental mode is not active to avoid unexpected behavior in non-incremental searches.


Accordingly the below test cases are updated/added.
- testResetIncrementalBaseLocation()
- testRestoreSelectionOnEmptyFindStringInIncrementalMode()
- testNoRestoreOnEmptyFindStringWhenNotIncremental()
- testSetFindString_incrementalActive()

@HeikoKlare : 
Can you have a look into this when you get some time please.