### PR TITLE
Remove document listener from document on handleDispose()

### DIFF
--- a/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionViewer.java
+++ b/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionViewer.java
@@ -1480,6 +1480,12 @@ public class ProjectionViewer extends SourceViewer implements ITextViewerExtensi
 	@Override
 	protected void handleDispose() {
 		fWasProjectionEnabled= false;
+		if (fUpdateDocumentListener != null) {
+			IDocument document= getDocument();
+			if (document != null) {
+				document.removeDocumentListener(fUpdateDocumentListener);
+			}
+		}
 		super.handleDispose();
 	}
 


### PR DESCRIPTION
UpdateDocumentListener is added to document but not always removed in ProjectionViewer, regression introduced by commit
https://github.com/eclipse-platform/eclipse.platform.ui/commit/1848058a52102b5deff39427365e56fe882656b3

This fixes only one possible leak, where a single document was used in ProjectionViewer, to unblock JDT UI tests.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2532