### PR TITLE
Fix artifact lines in Forms UI Section headers #3381

### DIFF
--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/FormImages.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/FormImages.java
@@ -315,7 +315,7 @@ public class FormImages {
 			Color color2 = new Color(device, fRGBs[1]);
 			final ImageGcDrawer imageGcDrawer = (gc, width, height) -> {
 				gc.setBackground(color1);
-				gc.fillRectangle(0, 0, width, width);
+				gc.fillRectangle(0, 0, width, height);
 				gc.setForeground(color2);
 				gc.setBackground(color1);
 				gc.fillGradientRectangle(0, fMarginHeight + 2, 1, fTheight - 2, true);


### PR DESCRIPTION
Section headers show artifacts lines because a previous change accidentally changed the operation for filling the background to use a height of 1 instead of the actual height to be filled.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3381

### Before
<img width="715" height="459" alt="image" src="https://github.com/user-attachments/assets/18e2678e-4b71-4920-9945-382bb7340b27" />

### After
<img width="711" height="464" alt="image" src="https://github.com/user-attachments/assets/de36aa85-9eb4-4ba8-bfaa-3bb41d49d022" />
