### PR TITLE
Remove document listener from *old* document on setDocument()

### DIFF
--- a/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionViewer.java
+++ b/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionViewer.java
@@ -400,6 +400,7 @@ public class ProjectionViewer extends SourceViewer implements ITextViewerExtensi
 		}
 
 		if (fProjectionAnnotationModel != null) {
+			removeDocumentUpdateListener();
 			wasProjectionEnabled= removeProjectionAnnotationModel(getVisualAnnotationModel()) != null;
 			fProjectionAnnotationModel= null;
 		}
@@ -411,6 +412,15 @@ public class ProjectionViewer extends SourceViewer implements ITextViewerExtensi
 		}
 
 
+	}
+
+	private void removeDocumentUpdateListener() {
+		if (fUpdateDocumentListener != null) {
+			IDocument document= getDocument();
+			if (document != null) {
+				document.removeDocumentListener(fUpdateDocumentListener);
+			}
+		}
 	}
 
 	@Override
@@ -554,10 +564,7 @@ public class ProjectionViewer extends SourceViewer implements ITextViewerExtensi
 				super.setVisibleRegion(fVisibleRegionDuringProjection.getOffset(), fVisibleRegionDuringProjection.getLength());
 				fVisibleRegionDuringProjection= null;
 			}
-			IDocument document= getDocument();
-			if (document != null) {
-				document.removeDocumentListener(fUpdateDocumentListener);
-			}
+			removeDocumentUpdateListener();
 		}
 	}
 
@@ -1480,12 +1487,7 @@ public class ProjectionViewer extends SourceViewer implements ITextViewerExtensi
 	@Override
 	protected void handleDispose() {
 		fWasProjectionEnabled= false;
-		if (fUpdateDocumentListener != null) {
-			IDocument document= getDocument();
-			if (document != null) {
-				document.removeDocumentListener(fUpdateDocumentListener);
-			}
-		}
+		removeDocumentUpdateListener();
 		super.handleDispose();
 	}
 


### PR DESCRIPTION
UpdateDocumentListener is added to document but not always removed in ProjectionViewer, regression introduced by commit https://github.com/eclipse-platform/eclipse.platform.ui/commit/1848058a52102b5deff39427365e56fe882656b3

This fixes remaining possible leak, where *multiple* documents were used in ProjectionViewer.

See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2532