### PR TITLE
Add version constraints for JUnit 5 dependencies

### DIFF
--- a/tests/org.eclipse.core.filebuffers.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.core.filebuffers.tests/META-INF/MANIFEST.MF
@@ -15,8 +15,8 @@ Require-Bundle:
  org.eclipse.core.filebuffers;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.text;bundle-version="[3.5.0,4.0.0)",
  org.junit;bundle-version="4.12.0"
-Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.core.filebuffers.tests

--- a/tests/org.eclipse.e4.core.commands.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.core.commands.tests/META-INF/MANIFEST.MF
@@ -11,8 +11,8 @@ Require-Bundle: org.eclipse.core.commands,
 Import-Package: jakarta.inject;version="[2.0.0,3.0.0)",
  org.eclipse.e4.core.contexts,
  org.osgi.framework;version="[1.5.0,2.0.0)",
- org.junit.jupiter.api,
- org.junit.platform.suite.api
+ org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Eclipse-BundleShape: dir

--- a/tests/org.eclipse.e4.core.commands.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.core.commands.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.core.commands.tests;singleton:=true
-Bundle-Version: 0.14.500.qualifier
+Bundle-Version: 0.14.600.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.commands,
  org.eclipse.e4.core.commands,

--- a/tests/org.eclipse.e4.emf.xpath.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.emf.xpath.test/META-INF/MANIFEST.MF
@@ -10,9 +10,9 @@ Export-Package: org.eclipse.e4.emf.xpath.test.model.xpathtest,
  org.eclipse.e4.emf.xpath.test.model.xpathtest.impl,
  org.eclipse.e4.emf.xpath.test.model.xpathtest.util
 Import-Package: org.assertj.core.api;version="[3.27.0,4.0.0)",
- org.junit.jupiter.api,
- org.junit.jupiter.api.function,
- org.junit.platform.suite.api
+ org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Require-Bundle: org.eclipse.e4.ui.model.workbench,
  org.eclipse.e4.emf.xpath,
  org.eclipse.emf.ecore.xmi,

--- a/tests/org.eclipse.e4.ui.tests.css.core/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests.css.core/META-INF/MANIFEST.MF
@@ -14,8 +14,8 @@ Export-Package: org.eclipse.e4.ui.tests.css.core;x-internal:=true,
  org.eclipse.e4.ui.tests.css.core.parser;x-internal:=true,
  org.eclipse.e4.ui.tests.css.core.util;x-internal:=true
 Automatic-Module-Name: org.eclipse.e4.ui.tests.css.core
-Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api,
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
  org.w3c.css.sac;version="1.3.0"
 Bundle-Vendor: %Bundle-Vendor
 

--- a/tests/org.eclipse.e4.ui.tests.css.core/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests.css.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.e4.ui.tests.css.core
-Bundle-Version: 1.302.600.qualifier
+Bundle-Version: 1.302.700.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.swt,
  org.eclipse.e4.ui.css.core,

--- a/tests/org.eclipse.e4.ui.tests.css.swt/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.e4.ui.tests.css.swt; singleton:=true
-Bundle-Version: 0.12.800.qualifier
+Bundle-Version: 0.12.900.qualifier
 Require-Bundle: org.eclipse.e4.ui.css.core,
  org.eclipse.e4.ui.css.swt,
  org.eclipse.e4.ui.css.swt.theme;bundle-version="0.9.1",

--- a/tests/org.eclipse.e4.ui.tests.css.swt/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/META-INF/MANIFEST.MF
@@ -12,9 +12,9 @@ Require-Bundle: org.eclipse.e4.ui.css.core,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.eclipse.core.runtime;version="3.5.0",
- org.junit.jupiter.api;version="5.9.1",
- org.junit.jupiter.api.function,
- org.junit.platform.suite.api;version="1.9.1",
+ org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
  org.osgi.framework;version="[1.7.0,2.0.0)",
  org.osgi.service.event;version="[1.3.0,2.0.0)",
  org.w3c.css.sac;version="1.3.0"

--- a/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
@@ -39,8 +39,8 @@ Bundle-ActivationPolicy: lazy
 Import-Package: jakarta.annotation,
  jakarta.inject,
  org.osgi.service.event,
- org.junit.jupiter.api,
- org.junit.platform.suite.api
+ org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.e4.ui.tests
 Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/tests/org.eclipse.e4.ui.workbench.addons.swt.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.workbench.addons.swt.test/META-INF/MANIFEST.MF
@@ -10,10 +10,12 @@ Require-Bundle: org.eclipse.e4.core.commands;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.core.databinding.observable;bundle-version="[1.4.0,2.0.0)",
  org.eclipse.jface.databinding;bundle-version="[1.6.200,2.0.0)",
  org.eclipse.e4.ui.workbench.swt;bundle-version="[0.12.100,1.0.0)",
- org.mockito.mockito-core;bundle-version="5.15.2",
- junit-jupiter-params;bundle-version="5.11.4",
- junit-jupiter-api;bundle-version="5.11.4",
- junit-platform-suite-api;bundle-version="1.11.4"
+ org.mockito.mockito-core;bundle-version="5.15.2"
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.condition;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.params;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.params.provider;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-Vendor: %providerName
 Export-Package: org.eclipse.e4.ui.workbench.addons.minmax;x-internal:=true
 Automatic-Module-Name: org.eclipse.e4.ui.workbench.addons.swt.test

--- a/tests/org.eclipse.jface.tests.databinding/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.tests.databinding/META-INF/MANIFEST.MF
@@ -15,8 +15,8 @@ Require-Bundle: org.eclipse.core.databinding;bundle-version="[1.3.0,2.0.0)",
  org.eclipse.jface.databinding,
  org.eclipse.jface.tests.databinding.conformance,
  org.eclipse.core.databinding.property
-Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.jface.tests.databinding

--- a/tests/org.eclipse.jface.tests.notifications/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.tests.notifications/META-INF/MANIFEST.MF
@@ -4,8 +4,8 @@ Bundle-Name: Jface notifications tests
 Bundle-SymbolicName: org.eclipse.jface.tests.notifications
 Bundle-Vendor: Eclipse.org
 Bundle-Version: 0.2.0.qualifier
-Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Automatic-Module-Name: org.eclipse.jface.notifications.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit,

--- a/tests/org.eclipse.jface.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.tests/META-INF/MANIFEST.MF
@@ -12,8 +12,8 @@ Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.ui,
  org.eclipse.ui.tests.harness
 Import-Package: org.osgi.framework,
- org.junit.jupiter.api,
- org.junit.platform.suite.api
+ org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Export-Package: org.eclipse.jface.tests.fieldassist;x-internal:=true,
  org.eclipse.jface.tests.preferences;x-internal:=true,
  org.eclipse.jface.tests.viewers;x-internal:=true

--- a/tests/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
@@ -29,5 +29,5 @@ Automatic-Module-Name: org.eclipse.jface.text.tests
 Import-Package: org.mockito,
  org.mockito.invocation,
  org.mockito.stubbing,
- org.junit.jupiter.api,
- org.junit.platform.suite.api
+ org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"

--- a/tests/org.eclipse.ltk.core.refactoring.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/META-INF/MANIFEST.MF
@@ -26,5 +26,5 @@ Require-Bundle:
  org.eclipse.core.tests.harness
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
-Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"

--- a/tests/org.eclipse.ltk.ui.refactoring.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ltk.ui.refactoring.tests/META-INF/MANIFEST.MF
@@ -21,5 +21,5 @@ Require-Bundle:
  org.eclipse.text;bundle-version="[3.5.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
-Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"

--- a/tests/org.eclipse.search.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.search.tests/META-INF/MANIFEST.MF
@@ -19,8 +19,8 @@ Require-Bundle:
  org.eclipse.jface.text;bundle-version="[3.24.200,4.0.0)",
  org.eclipse.ui.editors;bundle-version="[3.17.100,4.0.0)",
  org.eclipse.ltk.core.refactoring;bundle-version="[3.14.100,4.0.0)"
-Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir

--- a/tests/org.eclipse.tests.urischeme/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.tests.urischeme/META-INF/MANIFEST.MF
@@ -6,8 +6,8 @@ Bundle-SymbolicName: org.eclipse.tests.urischeme
 Bundle-Version: 1.2.700.qualifier
 Bundle-Localization: plugin
 Fragment-Host: org.eclipse.urischeme;bundle-version="1.1.100"
-Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Automatic-Module-Name: org.eclipse.urischeme.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="[4.12.0,5.0.0)"

--- a/tests/org.eclipse.text.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.text.tests/META-INF/MANIFEST.MF
@@ -14,8 +14,8 @@ Require-Bundle:
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.text;bundle-version="[3.6.3,4.0.0)",
  org.junit;bundle-version="4.12.0"
-Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.text.tests

--- a/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
@@ -26,8 +26,8 @@ Require-Bundle:
  org.eclipse.ui;bundle-version="3.119.100",
  org.eclipse.ui.tests.harness;bundle-version="1.8.0",
  org.mockito.mockito-core;bundle-version="5.12.0"
-Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Bundle-ActivationPolicy: lazy

--- a/tests/org.eclipse.ui.genericeditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.genericeditor.tests/META-INF/MANIFEST.MF
@@ -21,11 +21,12 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.core.expressions,
  org.eclipse.ui.tests.harness;bundle-version="1.4.500",
  org.eclipse.test,
- junit-jupiter-api,
  org.hamcrest
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.ui.genericeditor.tests
 Require-Capability: eclipse.swt;filter:="(image.format=svg)"
-Import-Package: org.junit.platform.suite.api;version="[1.13.0,2.0.0)"
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.condition;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.13.0,2.0.0)"

--- a/tests/org.eclipse.ui.monitoring.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.monitoring.tests/META-INF/MANIFEST.MF
@@ -1,8 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
-Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-SymbolicName: org.eclipse.ui.monitoring.tests;singleton:=true
 Bundle-Vendor: %Bundle-Vendor

--- a/tests/org.eclipse.ui.tests.browser/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.browser/META-INF/MANIFEST.MF
@@ -9,8 +9,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.junit,
  org.eclipse.ui,
  org.eclipse.ui.browser
-Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Eclipse-BundleShape: dir
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tests/org.eclipse.ui.tests.forms/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.forms/META-INF/MANIFEST.MF
@@ -9,8 +9,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.forms,
  org.junit
 Bundle-Vendor: Eclipse.org
-Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.ui.tests.forms

--- a/tests/org.eclipse.ui.tests.navigator/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.navigator/META-INF/MANIFEST.MF
@@ -17,8 +17,8 @@ Require-Bundle: org.eclipse.core.resources,
  org.eclipse.jdt.ui,
  org.eclipse.ui.genericeditor
 Bundle-Vendor: Eclipse.org
-Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.ui.tests.navigator;x-internal:=true
 Eclipse-BundleShape: dir

--- a/tests/org.eclipse.ui.tests.performance/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.performance/META-INF/MANIFEST.MF
@@ -19,8 +19,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.e4.core.contexts,
  org.eclipse.ui.navigator,
  org.eclipse.ui.navigator.resources
-Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin

--- a/tests/org.eclipse.ui.tests.rcp/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.rcp/META-INF/MANIFEST.MF
@@ -10,9 +10,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.mockito.mockito-core,
  org.eclipse.test.performance,
  org.eclipse.ui.tests.harness
-Import-Package: org.junit.jupiter.api,
- org.junit.jupiter.api.function,
- org.junit.platform.suite.api,
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
  org.opentest4j
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tests/org.eclipse.ui.tests.views.properties.tabbed/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.views.properties.tabbed/META-INF/MANIFEST.MF
@@ -11,8 +11,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.views.properties.tabbed,
  org.eclipse.jface.text
 Bundle-Vendor: %Plugin.providerName
-Import-Package: org.junit.jupiter.api,
- org.junit.platform.suite.api
+Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.ui.tests.views.properties.tabbed,

--- a/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -48,8 +48,8 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="3.14.0",
 Import-Package: jakarta.annotation,
  jakarta.inject,
  org.osgi.service.event,
- org.junit.jupiter.api,
- org.junit.platform.suite.api
+ org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Eclipse-AutoStart: true
 Export-Package: org.eclipse.ui.tests.api,
  org.eclipse.ui.tests.menus

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
@@ -24,5 +24,5 @@ Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.ui.workbench.texteditor.tests
 Import-Package: org.mockito,
  org.mockito.stubbing;version="5.5.0",
- org.junit.jupiter.api,
- org.junit.platform.suite.api
+ org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)"


### PR DESCRIPTION
Also change JUnit 5 bundle requirements to package imports.

Required as JUnit 6 is available in target platform since
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3399

which makes GHA builds fail with "no tests found", such as in https://github.com/eclipse-platform/eclipse.platform.ui/actions/runs/18377868347/job/52356324874?pr=3387

For similar changes in PDE, compare for:
- https://github.com/eclipse-pde/eclipse.pde/pull/2004