### PR TITLE
Fix a typo in the CSS example

### DIFF
--- a/examples/org.eclipse.e4.demo.cssbridge/css/blue.css
+++ b/examples/org.eclipse.e4.demo.cssbridge/css/blue.css
@@ -11,17 +11,17 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
- 
+
 @import url("common.css");
 
 /* for IDs see the class: org.eclipse.e4.demo.cssbridge.ui.views.Theme.Shell */
 ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-background {
 	color: #eef5ff;
 }
-ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-seletion-foreground {
+ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-selection-foreground {
 	color: yellow;
 }
-ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-seletion-background {
+ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-selection-background {
 	color: #00a8ff;
 }
 ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-text-and-label-foreground {

--- a/examples/org.eclipse.e4.demo.cssbridge/css/green.css
+++ b/examples/org.eclipse.e4.demo.cssbridge/css/green.css
@@ -11,17 +11,17 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
- 
+
 @import url("common.css");
 
 /* for IDs see the class: org.eclipse.e4.demo.cssbridge.ui.views.Theme.Shell */
 ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-background {
 	color: #f4ffdd;
 }
-ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-seletion-foreground {
+ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-selection-foreground {
 	color: #b8f2ff;
 }
-ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-seletion-background {
+ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-selection-background {
 	color: #00871d;
 }
 ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-text-and-label-foreground {

--- a/examples/org.eclipse.e4.demo.cssbridge/css/red.css
+++ b/examples/org.eclipse.e4.demo.cssbridge/css/red.css
@@ -11,17 +11,17 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
- 
+
 @import url("common.css");
 
 /* for IDs see the class: org.eclipse.e4.demo.cssbridge.ui.views.Theme.Shell */
 ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-background {
 	color: #ffe0c4;
 }
-ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-seletion-foreground {
+ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-selection-foreground {
 	color: yellow;
 }
-ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-seletion-background {
+ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-selection-background {
 	color: #f8cd00;
 }
 ColorDefinition#org-eclipse-e4-demo-cssbridge-ui-views-theme-shell-text-and-label-foreground {

--- a/examples/org.eclipse.e4.demo.cssbridge/plugin.properties
+++ b/examples/org.eclipse.e4.demo.cssbridge/plugin.properties
@@ -21,8 +21,8 @@ org.eclipse.e4.demo.cssbridge.red.theme=Red theme
 
 org.eclipse.e4.demo.cssbridge.ui.views.Theme=CSS bridge demo theme
 org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.background=Shell background
-org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.seletion.foreground=Shell selection foreground
-org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.seletion.background=Shell selection background
+org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.selection.foreground=Shell selection foreground
+org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.selection.background=Shell selection background
 org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.text.and.label.foreground=Shell text and label foreground
 org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.link.foreground=Shell link foreground
 org.eclipse.e4.demo.cssbridge.ui.views.theme.foldersview.mailbox.name.font=FoldersView mailbox name font

--- a/examples/org.eclipse.e4.demo.cssbridge/plugin.xml
+++ b/examples/org.eclipse.e4.demo.cssbridge/plugin.xml
@@ -62,9 +62,9 @@
             description="%command.description.2"
             categoryId="org.eclipse.e4.demo.cssbridge.css.theme.switcher.category"
             id="org.eclipse.e4.demo.cssbridge.switch.to.red.css.theme">
-      </command>            
+      </command>
    </extension>
-   
+
    <extension
          id="product"
          point="org.eclipse.core.runtime.products">
@@ -81,8 +81,8 @@
          </property>
       </product>
    </extension>
-   
-   
+
+
    <!-- The CSS theme definition -->
    <extension point="org.eclipse.e4.ui.css.swt.theme">
       <theme
@@ -106,39 +106,39 @@
             label="%org.eclipse.e4.demo.cssbridge.red.theme">
       </theme>
    </extension>
-   
+
    <!-- The 3.x theme definition -->
    <extension point="org.eclipse.ui.themes">
       <themeElementCategory
             id="org.eclipse.e4.demo.cssbridge.ui.views.Theme"
             label="%org.eclipse.e4.demo.cssbridge.ui.views.Theme"/>
-            
+
       <!-- for IDs see the class: org.eclipse.e4.demo.cssbridge.ui.views.Shell -->
       <colorDefinition
-        	id="org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.seletion.foreground"
+        	id="org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.selection.foreground"
         	categoryId="org.eclipse.e4.demo.cssbridge.ui.views.Theme"
-        	label="%org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.seletion.foreground"
-        	value="COLOR_LIST_SELECTION_TEXT">       
+        	label="%org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.selection.foreground"
+        	value="COLOR_LIST_SELECTION_TEXT">
       </colorDefinition>
       <colorDefinition
-        	id="org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.seletion.background"
+        	id="org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.selection.background"
         	categoryId="org.eclipse.e4.demo.cssbridge.ui.views.Theme"
-        	label="%org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.seletion.background"
-        	value="COLOR_LIST_SELECTION">       
+        	label="%org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.selection.background"
+        	value="COLOR_LIST_SELECTION">
       </colorDefinition>
       <colorDefinition
         	id="org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.text.and.label.foreground"
         	categoryId="org.eclipse.e4.demo.cssbridge.ui.views.Theme"
         	label="%org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.text.and.label.foreground"
-        	value="COLOR_WIDGET_FOREGROUND">       
-      </colorDefinition>  
+        	value="COLOR_WIDGET_FOREGROUND">
+      </colorDefinition>
       <colorDefinition
         	id="org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.link.foreground"
         	categoryId="org.eclipse.e4.demo.cssbridge.ui.views.Theme"
         	label="%org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.link.foreground"
-        	value="COLOR_LINK_FOREGROUND">       
-      </colorDefinition>            
-                      
+        	value="COLOR_LINK_FOREGROUND">
+      </colorDefinition>
+
       <!-- for IDs see the class: org.eclipse.e4.demo.cssbridge.ui.views.Theme.FoldersView -->
       <fontDefinition
             id="org.eclipse.e4.demo.cssbridge.ui.views.theme.foldersview.mailbox.name.font"
@@ -150,9 +150,9 @@
         	id="org.eclipse.e4.demo.cssbridge.ui.views.theme.foldersview.mailbox.name.foreground"
         	categoryId="org.eclipse.e4.demo.cssbridge.ui.views.Theme"
         	label="%org.eclipse.e4.demo.cssbridge.ui.views.theme.foldersview.mailbox.name.foreground"
-        	value="COLOR_LIST_FOREGROUND">       
+        	value="COLOR_LIST_FOREGROUND">
       </colorDefinition>
-      
+
       <fontDefinition
             id="org.eclipse.e4.demo.cssbridge.ui.views.theme.foldersview.folder.type.font"
             categoryId="org.eclipse.e4.demo.cssbridge.ui.views.Theme"
@@ -163,9 +163,9 @@
         	id="org.eclipse.e4.demo.cssbridge.ui.views.theme.foldersview.folder.type.foreground"
         	categoryId="org.eclipse.e4.demo.cssbridge.ui.views.Theme"
         	label="%org.eclipse.e4.demo.cssbridge.ui.views.theme.foldersview.type.foreground"
-        	value="COLOR_LIST_FOREGROUND">       
+        	value="COLOR_LIST_FOREGROUND">
       </colorDefinition>
-      
+
       <!-- for IDs see the class: org.eclipse.e4.demo.cssbridge.ui.views.Theme.FolderPreviewView -->
       <fontDefinition
             id="org.eclipse.e4.demo.cssbridge.ui.views.theme.folderpreviewview.low.imp.mail.font"
@@ -177,9 +177,9 @@
         	id="org.eclipse.e4.demo.cssbridge.ui.views.theme.folderpreviewview.low.imp.mail.foreground"
         	categoryId="org.eclipse.e4.demo.cssbridge.ui.views.Theme"
         	label="%org.eclipse.e4.demo.cssbridge.ui.views.theme.folderpreviewview.low.imp.mail.foreground"
-        	value="COLOR_LIST_FOREGROUND">       
+        	value="COLOR_LIST_FOREGROUND">
       </colorDefinition>
-      
+
       <fontDefinition
             id="org.eclipse.e4.demo.cssbridge.ui.views.theme.folderpreviewview.normal.imp.mail.font"
             categoryId="org.eclipse.e4.demo.cssbridge.ui.views.Theme"
@@ -190,9 +190,9 @@
         	id="org.eclipse.e4.demo.cssbridge.ui.views.theme.folderpreviewview.normal.imp.mail.foreground"
         	categoryId="org.eclipse.e4.demo.cssbridge.ui.views.Theme"
         	label="%org.eclipse.e4.demo.cssbridge.ui.views.theme.folderpreviewview.normal.imp.mail.foreground"
-        	value="COLOR_LIST_FOREGROUND">       
+        	value="COLOR_LIST_FOREGROUND">
       </colorDefinition>
-      
+
       <fontDefinition
             id="org.eclipse.e4.demo.cssbridge.ui.views.theme.folderpreviewview.high.imp.mail.font"
             categoryId="org.eclipse.e4.demo.cssbridge.ui.views.Theme"
@@ -203,7 +203,7 @@
         	id="org.eclipse.e4.demo.cssbridge.ui.views.theme.folderpreviewview.high.imp.mail.foreground"
         	categoryId="org.eclipse.e4.demo.cssbridge.ui.views.Theme"
         	label="%org.eclipse.e4.demo.cssbridge.ui.views.theme.folderpreviewview.high.imp.mail.foreground"
-        	value="COLOR_LIST_FOREGROUND">       
+        	value="COLOR_LIST_FOREGROUND">
       </colorDefinition>
    </extension>
 

--- a/examples/org.eclipse.e4.demo.cssbridge/src/org/eclipse/e4/demo/cssbridge/ui/views/Theme.java
+++ b/examples/org.eclipse.e4.demo.cssbridge/src/org/eclipse/e4/demo/cssbridge/ui/views/Theme.java
@@ -24,8 +24,8 @@ public class Theme {
 
 	public interface Shell {
 		String BACKGROUND = "org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.background";
-		String SELECTION_FOREGROUND = "org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.seletion.foreground";
-		String SELECTION_BACKGROUND = "org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.seletion.background";
+		String SELECTION_FOREGROUND = "org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.selection.foreground";
+		String SELECTION_BACKGROUND = "org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.selection.background";
 		String TEXT_AND_LABEL_FOREGROUND = "org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.text.and.label.foreground";
 		String LINK_FOREGROUND = "org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.link.foreground";
 	}


### PR DESCRIPTION
It was misspelled everywhere, so it was not broken.