### PR TITLE
Move empty document range at EOF to start of removed range

### DIFF
--- a/bundles/org.eclipse.text/projection/org/eclipse/jface/text/projection/ProjectionDocument.java
+++ b/bundles/org.eclipse.text/projection/org/eclipse/jface/text/projection/ProjectionDocument.java
@@ -417,6 +417,9 @@ public class ProjectionDocument extends AbstractDocument {
 			if (fragment.getOffset() == offsetInMaster) {
 				fragment.setOffset(offsetInMaster + lengthInMaster);
 				fragment.setLength(fragment.getLength() - lengthInMaster);
+				if (fragment.getLength() == 0 && offsetInMaster != 0 && offsetInMaster + lengthInMaster == getMasterDocument().getLength()) {
+					fragment.setOffset(offsetInMaster);
+				}
 			} else {
 				// split fragment into three fragments, let position updater remove it
 

--- a/tests/org.eclipse.text.tests/projection/org/eclipse/text/tests/ProjectionDocumentTest.java
+++ b/tests/org.eclipse.text.tests/projection/org/eclipse/text/tests/ProjectionDocumentTest.java
@@ -27,6 +27,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DefaultLineTracker;
@@ -2651,5 +2652,40 @@ public class ProjectionDocumentTest {
 		} catch (BadLocationException e) {
 			assertTrue(false);
 		}
+	}
+
+	@Test
+	public void testFullDocumentRangeRemovedAtOnce() throws BadLocationException {
+		fSlaveDocument.addMasterDocumentRange(0, fMasterDocument.getLength());
+		fSlaveDocument.removeMasterDocumentRange(0, fMasterDocument.getLength());
+		Assertions.assertEquals("", fSlaveDocument.get());
+		Position[] fragments = fSlaveDocument.getFragments2();
+		Assertions.assertEquals(1, fragments.length);
+		Assertions.assertEquals(new Position(fMasterDocument.getLength(), 0), fragments[0]);
+	}
+
+	@Test
+	public void testFullDocumentRangeRemovedInTwoParts() throws BadLocationException {
+		fSlaveDocument.addMasterDocumentRange(0, fMasterDocument.getLength());
+		fSlaveDocument.removeMasterDocumentRange(0, 10);
+		Assertions.assertEquals(fMasterDocument.getLength() - 10, fSlaveDocument.getLength());
+		fSlaveDocument.removeMasterDocumentRange(10, fMasterDocument.getLength() - 10);
+		Assertions.assertEquals("", fSlaveDocument.get());
+		Position[] fragments = fSlaveDocument.getFragments2();
+		Assertions.assertEquals(1, fragments.length);
+		Assertions.assertEquals(new Position(10, 0), fragments[0]);
+	}
+
+	@Test
+	public void testRemovePartsOfDocument() throws BadLocationException {
+		fSlaveDocument.addMasterDocumentRange(0, fMasterDocument.getLength());
+		fSlaveDocument.removeMasterDocumentRange(0, 10);
+		Assertions.assertEquals(fMasterDocument.getLength() - 10, fSlaveDocument.getLength());
+		fSlaveDocument.removeMasterDocumentRange(10, fMasterDocument.getLength() - 20);
+		Assertions.assertEquals(fMasterDocument.get(fMasterDocument.getLength() - 10, 10),
+				fSlaveDocument.get());
+		Position[] fragments = fSlaveDocument.getFragments2();
+		Assertions.assertEquals(1, fragments.length);
+		Assertions.assertEquals(new Position(fMasterDocument.getLength() - 10, 10), fragments[0]);
 	}
 }


### PR DESCRIPTION
Because this part of the codebase isn't frequently modified, I'll try to describe this in a way that is reasonable to understand without being too familiar with these parts.

### Description of the change
`ProjectionViewer`/`ProjectionDocument` allows hiding ranges/regions within the document.
When a region is removed/hidden, it keeps an empty range which is used when e.g. typing text at that position (if there is no visible region left, it should still be possible to type new text).
Currently, this range is put at the end of the removed range causing typed letters to be inserted at the end of the last removed range.
This PR changes this behavior to put the zero-length range at the beginning of the "removed" range if the entire range is "removed" (from being visible) and the removed range ends at the end of the file (so if you remove the last part of the file and the part before the removed range is removed already).

The `offsetInMaster != 0 && offsetInMaster + lengthInMaster == getMasterDocument().getLength()` part of the condition is my attempt of not changing any behavior that is not wanted/keeping impact as low as possible:
- If the beginning of the file (or the whole file most likely) is hidden with a single call, it keeps the old behavior (it leaves the position for typing at the end of the range)
- It is only applicable when the end of the file is removed because someone hiding the last part of the file shouldn't want the user to continue typing at the end of the file.

### Reasoning

With my previous change in #3074, `ProjectionViewer#setVisibleRegion` is based on projection regions if projections are enabled (to allow using these two features together). This caused a regression (#3380) which resulted in setting an empty "visible region" to cause entered text appear at the end (failing `SegmentedModeTest#testSegmentation`).

### Other considerations
This doesn't fix the issue that (assuming projections are enabled for the editor) setting a visible region still allows editing text at the end of the file.

For example, if projections are enabled for the editor and `setVisibleRegion` is used to only show the `X` class, it is possible to type after the end of the `Y` class by moving the cursor to the very end:
```java
class X {

}

class Y {

}
```
The code responsible for that is in the `else` block but I wasn't (yet) able to make that work.

If this change is considered too risky/invasive (by changing behavior for people relying on removing the end region - though I have no idea why someone would rely on that), I can understand still reverting #3074 instead of merging this PR.

Also note that I cannot run the tests locally (I think because of the JUnit 6 issue).


Fixes #3380

