### PR TITLE
Code cleanup in AnnotationModel, AnnotationMap, Javadoc inherit adjustment

### DIFF
--- a/bundles/org.eclipse.text/src/org/eclipse/jface/text/source/AnnotationMap.java
+++ b/bundles/org.eclipse.text/src/org/eclipse/jface/text/source/AnnotationMap.java
@@ -21,6 +21,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.core.runtime.ILog;
+
 import org.eclipse.jface.text.Position;
 
 
@@ -54,11 +56,38 @@ class AnnotationMap implements IAnnotationMap {
 		fInternalMap= new HashMap<>(capacity);
 	}
 
+	/**
+	 * Sets the lock object for this object. Subsequent calls to specified methods of this object
+	 * are synchronized on this lock object. Which methods are synchronized is specified by the
+	 * implementer.
+	 * <p>
+	 * If the lock object is not explicitly set by this method, the annotation map uses its internal
+	 * lock object for synchronization.
+	 * </p>
+	 * 
+	 * <p>
+	 * <em>You should not override an existing lock object unless you own that lock object yourself.
+	 * Use the existing lock object instead.</em>
+	 * </p>
+	 *
+	 * @param lockObject the lock object. If <code>null</code> is given, internal lock object is
+	 *            used for locking.
+	 */
 	@Override
 	public synchronized void setLockObject(Object lockObject) {
+		if(fLockObject != null && fLockObject != lockObject) {
+			ILog log= ILog.of(AnnotationMap.class);
+			String message = "Attempt to override existing lock object of AnnotationMap."; //$NON-NLS-1$
+			log.warn(message, new IllegalStateException(message));
+		}
 		fLockObject= lockObject;
 	}
 
+	/**
+	 * Lock object used to synchronize concurrent access to the internal map data.
+	 * 
+	 * @return <b>never</b> returns null
+	 */
 	@Override
 	public synchronized Object getLockObject() {
 		if (fLockObject == null) {

--- a/bundles/org.eclipse.text/src/org/eclipse/jface/text/source/IAnnotationMap.java
+++ b/bundles/org.eclipse.text/src/org/eclipse/jface/text/source/IAnnotationMap.java
@@ -79,4 +79,28 @@ public interface IAnnotationMap extends Map<Annotation, Position>, ISynchronizab
 	 */
 	@Override
 	Collection<Position> values();
+	
+	/**
+	 * Implementers of this interface should <b>never</b> return null. Clients should use the lock
+	 * object in order to synchronize concurrent access to the implementer.
+	 * 
+	 * @return the lock object to be used, if no explicit lock object is set, internal one should
+	 *         be used, therefore never <code>null</code>
+	 */
+	@Override
+	Object getLockObject();
+	
+	/**
+	 * Sets the lock object for this object. Subsequent calls to specified methods of this object
+	 * are synchronized on this lock object. Which methods are synchronized is specified by the
+	 * implementer.
+	 * <p>
+	 * <em>You should not override an existing lock object unless you own that lock object yourself.
+	 * Use the existing lock object instead.</em>
+	 * </p>
+	 *
+	 * @param lockObject the lock object. Never <code>null</code>.
+	 */
+	@Override
+	void setLockObject(Object lockObject);
 }


### PR DESCRIPTION
- split of the PR: https://github.com/eclipse-platform/eclipse.platform.ui/pull/3397
- Removed dead code in AnnotationModel.cleanup because mapLock can't be null.
- Added new javadoc to IAnnotationMap.getLockObject()
- added assert.isLegal check to AnnotationMAp.setLockObject()