### PR TITLE
Add a command to persist workbench state

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/PersistWorkbenchHandler.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/PersistWorkbenchHandler.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2025, Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ui.internal;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.ui.PlatformUI;
+
+public class PersistWorkbenchHandler extends AbstractHandler {
+
+	@Override
+	public Object execute(ExecutionEvent event) {
+		if (PlatformUI.getWorkbench() instanceof Workbench workbench) {
+			workbench.persist(false);
+			return IStatus.OK;
+		}
+		return IStatus.ERROR;
+	}
+
+}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
@@ -1216,7 +1216,7 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 	 *                 Will also skip saving the model to the disk since that is
 	 *                 done later in shutdown.
 	 */
-	private void persist(final boolean shutdown) {
+	void persist(final boolean shutdown) {
 		// persist editors that can be and possibly close the others
 		SafeRunner.run(new SafeRunnable() {
 			@Override

--- a/bundles/org.eclipse.ui.workbench/plugin.xml
+++ b/bundles/org.eclipse.ui.workbench/plugin.xml
@@ -26,5 +26,9 @@
             </with>
          </enabledWhen>
       </handler>
+      <handler
+            class="org.eclipse.ui.internal.PersistWorkbenchHandler"
+            commandId="org.eclipse.ui.persistWorkbenchState">
+      </handler>
    </extension>
 </plugin>

--- a/bundles/org.eclipse.ui/plugin.properties
+++ b/bundles/org.eclipse.ui/plugin.properties
@@ -293,6 +293,8 @@ command.up.description = Navigate up one level
 command.up.name = Up
 command.toggleCoolbar.name = Toggle Main Toolbar Visibility
 command.toggleCoolbar.description = Toggles the visibility of the window toolbar
+command.persistWorkbenchState.name = Persist workbench state
+command.persistWorkbenchState.description = Forces persistence of the current workbench state for potential future recovery 
 
 context.editingText.description = Editing Text Context
 context.editingText.name = Editing Text

--- a/bundles/org.eclipse.ui/plugin.xml
+++ b/bundles/org.eclipse.ui/plugin.xml
@@ -1437,6 +1437,12 @@
             id="org.eclipse.ui.toggleShowKeys"
             name="%command.showKeysToggle.name">
       </command>
+      <command
+            categoryId="org.eclipse.ui.category.window"
+            description="%command.persistWorkbenchState.description"
+            id="org.eclipse.ui.persistWorkbenchState"
+            name="%command.persistWorkbenchState.name">
+      </command>
    </extension>
    
    <extension


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3398

This command can be tried the following way:

Base

0. Start an IDE with this patch
1. Close some views
2. Kill the IDE (brutally, not with the nice "exit" button)
3. Restart: ❌ Closed views are here again

Diff

0. Start an IDE with this patch
1. Close some views
2. Ctrl+3 > "Persist workbench state"
3. Kill the IDE (brutally, not with the nice "exit" button)
4. Restart: ✔️ Closed views are not there