### PR TITLE
Add missing image to shared images and resolve resource leak 

### DIFF
--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.workbench; singleton:=true
-Bundle-Version: 3.136.100.qualifier
+Bundle-Version: 3.137.0.qualifier
 Bundle-Activator: org.eclipse.ui.internal.WorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/ISharedImages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/ISharedImages.java
@@ -835,6 +835,13 @@ public interface ISharedImages {
 	String IMG_OBJS_DND_TOFASTVIEW = "IMG_OBJS_DND_TOFASTVIEW"; //$NON-NLS-1$
 
 	/**
+	 * Identifies the default 'missing' image.
+	 *
+	 * @since 3.137
+	 */
+	String IMG_DEF_MISSING = "IMG_DEF_MISSING"; //$NON-NLS-1$
+
+	/**
 	 * Retrieves the specified image from the workbench plugin's image registry.
 	 * Note: The returned <code>Image</code> is managed by the workbench; clients
 	 * must <b>not</b> dispose of the returned image.

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchImages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchImages.java
@@ -117,6 +117,8 @@ public/* final */class WorkbenchImages {
 	 */
 	@SuppressWarnings("removal")
 	private static final void declareImages() {
+		declareImage(ISharedImages.IMG_DEF_MISSING, ImageDescriptor.getMissingImageDescriptor(), true);
+
 		// Overlays
 		declareImage(ISharedImages.IMG_DEC_FIELD_ERROR, PATH_OVERLAY + "error_ovr.svg", true); //$NON-NLS-1$
 		declareImage(ISharedImages.IMG_DEC_FIELD_WARNING, PATH_OVERLAY + "warning_ovr.svg", true); //$NON-NLS-1$

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPage.java
@@ -144,6 +144,7 @@ import org.eclipse.ui.ISaveablesLifecycleListener;
 import org.eclipse.ui.ISaveablesSource;
 import org.eclipse.ui.ISelectionListener;
 import org.eclipse.ui.ISelectionService;
+import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.IShowEditorInput;
 import org.eclipse.ui.ISources;
 import org.eclipse.ui.IViewPart;
@@ -4038,7 +4039,7 @@ public class WorkbenchPage implements IWorkbenchPage {
 			if (CompatibilityPart.COMPATIBILITY_VIEW_URI.equals(part.getContributionURI())
 					&& part.getIconURI() == null) {
 				part.getTransientData().put(IPresentationEngine.OVERRIDE_ICON_IMAGE_KEY,
-						ImageDescriptor.getMissingImageDescriptor().createImage());
+						ISharedImages.get().getImage(ISharedImages.IMG_DEF_MISSING));
 			}
 		}
 
@@ -4055,7 +4056,7 @@ public class WorkbenchPage implements IWorkbenchPage {
 		MPart part = modelService.createModelElement(MPart.class);
 		part.setElementId(ph.getElementId());
 		part.getTransientData().put(IPresentationEngine.OVERRIDE_ICON_IMAGE_KEY,
-				ImageDescriptor.getMissingImageDescriptor().createImage());
+				ISharedImages.get().getImage(ISharedImages.IMG_DEF_MISSING));
 		String label = (String) ph.getTransientData().get(IWorkbenchConstants.TAG_LABEL);
 		if (label != null) {
 			part.setLabel(label);


### PR DESCRIPTION
Currently, a shared image descriptor for a missing image is provided via the ImageDescriptor class. But images created for that descriptor still have to be maintained manually, e.g., by a resource manager or manual disposal. In some cases, this is not done correctly, leading to non-disposed resources.

This change adds a shared instance of the missing image that may be reused wherever needed. It is adopted for placeholders, which by now created missing images but never cleaned them up. That resource leak is resolved with the this change.

The proposal is driven by the following finding in an E3-based product:
```
java.lang.Error: SWT Resource was not properly disposed
	at org.eclipse.swt.graphics.Resource.initNonDisposeTracking(Resource.java:191)
	at org.eclipse.swt.graphics.Resource.<init>(Resource.java:124)
	at org.eclipse.swt.graphics.Image.<init>(Image.java:635)
	at org.eclipse.jface.resource.ImageDescriptor.createImage(ImageDescriptor.java:382)
	at org.eclipse.jface.resource.ImageDescriptor.createImage(ImageDescriptor.java:331)
	at org.eclipse.jface.resource.ImageDescriptor.createImage(ImageDescriptor.java:309)
	at org.eclipse.ui.internal.WorkbenchPage.handleNullRefPlaceHolders(WorkbenchPage.java:4049)
	at org.eclipse.ui.internal.WorkbenchPage.busySetPerspective(WorkbenchPage.java:3999)
	at org.eclipse.ui.internal.WorkbenchPage.lambda$12(WorkbenchPage.java:3969)
	at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:67)
	at org.eclipse.ui.internal.WorkbenchPage.setPerspective(WorkbenchPage.java:3969)
	at org.eclipse.ui.internal.Workbench.activate(Workbench.java:2990)
	at org.eclipse.ui.internal.Workbench.busyShowPerspective(Workbench.java:3031)
	at org.eclipse.ui.internal.Workbench.lambda$19(Workbench.java:3006)
	at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:67)
	at org.eclipse.ui.internal.Workbench.showPerspective(Workbench.java:3004)
	at org.eclipse.ui.internal.Workbench.showPerspective(Workbench.java:2979)
```