### PR TITLE
Migrate org.eclipse.jface.tests.notifications from JUnit 4 to JUnit 5

### DIFF
--- a/tests/org.eclipse.jface.tests.notifications/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.tests.notifications/META-INF/MANIFEST.MF
@@ -4,12 +4,12 @@ Bundle-Name: Jface notifications tests
 Bundle-SymbolicName: org.eclipse.jface.tests.notifications
 Bundle-Vendor: Eclipse.org
 Bundle-Version: 0.2.0.qualifier
-Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+Import-Package: org.hamcrest,
+ org.junit.jupiter.api;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Automatic-Module-Name: org.eclipse.jface.notifications.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.junit,
- org.eclipse.jface.notifications;bundle-version="0.4.0",
+Require-Bundle: org.eclipse.jface.notifications;bundle-version="0.4.0",
  org.eclipse.swt,
  org.eclipse.jface,
  org.eclipse.ui.forms,

--- a/tests/org.eclipse.jface.tests.notifications/src/org/eclipse/jface/tests/notifications/NotificationPopupTest.java
+++ b/tests/org.eclipse.jface.tests.notifications/src/org/eclipse/jface/tests/notifications/NotificationPopupTest.java
@@ -39,25 +39,25 @@ import org.eclipse.swt.widgets.Text;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("restriction")
-public class NotificationPopupTest {
+class NotificationPopupTest {
 
 	private Display display;
 	private Builder builder;
 	private Shell shell;
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	void setUp() {
 		this.display = Display.getDefault();
 		this.builder = NotificationPopup.forDisplay(this.display);
 	}
 
-	@After
-	public void tearDown() {
+	@AfterEach
+	void tearDown() {
 		if (shell != null) {
 			shell.close();
 			shell.dispose();
@@ -70,7 +70,7 @@ public class NotificationPopupTest {
 	}
 
 	@Test
-	public void createsWithTextAndTitle() {
+	void createsWithTextAndTitle() {
 		NotificationPopup notication = this.builder.text("This is a test").title("Hello World", false).delay(1).build();
 		notication.open();
 		List<Control> controls = getNotificationPopupControls(notication);
@@ -81,7 +81,7 @@ public class NotificationPopupTest {
 	}
 
 	@Test
-	public void createsWithCloseButton() {
+	void createsWithCloseButton() {
 		NotificationPopup notication = this.builder.text("This is a test").title("Hello World", true).delay(1).build();
 		notication.open();
 		List<Control> controls = getNotificationPopupControls(notication);
@@ -91,7 +91,7 @@ public class NotificationPopupTest {
 	}
 
 	@Test
-	public void createsWithTextContent() {
+	void createsWithTextContent() {
 		Text[] text = new Text[1];
 		NotificationPopup notication = this.builder.title("Hello World", false).content(parent -> {
 			text[0] = new Text(parent, SWT.NONE);
@@ -107,7 +107,7 @@ public class NotificationPopupTest {
 	}
 
 	@Test
-	public void createsWithTitleContent() {
+	void createsWithTitleContent() {
 		Text[] text = new Text[1];
 		NotificationPopup notication = this.builder.title(parent -> {
 			text[0] = new Text(parent, SWT.NONE);
@@ -122,7 +122,7 @@ public class NotificationPopupTest {
 	}
 
 	@Test
-	public void createsForShell() {
+	void createsForShell() {
 		shell = WidgetFactory.shell(SWT.NONE).create(display);
 		this.builder = NotificationPopup.forShell(shell);
 


### PR DESCRIPTION
This commit migrates the org.eclipse.jface.tests.notifications test bundle from JUnit 4 to JUnit 5.

Changes:
- Updated imports from org.junit.* to org.junit.jupiter.api.*
- Replaced @Before with @BeforeEach
- Replaced @After with @AfterEach
- Changed test class from public to package-private (JUnit 5 best practice)
- Changed all test methods from public to package-private
- Removed org.junit dependency from MANIFEST.MF
- Added org.hamcrest Import-Package (previously provided by org.junit bundle)

Test Results:
- All 5 tests passing (10 total including suite execution)
- Compilation successful
- No functional changes to test logic

Files modified:
- NotificationPopupTest.java

🤖 Generated with [Claude Code](https://claude.com/claude-code)