### PR TITLE
hide projection annotations outside of the current visible region

### DIFF
--- a/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionAnnotation.java
+++ b/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionAnnotation.java
@@ -73,6 +73,8 @@ public class ProjectionAnnotation extends Annotation implements IAnnotationPrese
 	/** Indicates whether this annotation should be painted as range */
 	private boolean fIsRangeIndication= false;
 
+	private boolean hidden= false;
+
 	/**
 	 * Creates a new expanded projection annotation.
 	 */
@@ -115,6 +117,9 @@ public class ProjectionAnnotation extends Annotation implements IAnnotationPrese
 
 	@Override
 	public void paint(GC gc, Canvas canvas, Rectangle rectangle) {
+		if (hidden) {
+			return;
+		}
 		Image image= getImage(canvas.getDisplay());
 		if (image != null) {
 			ImageUtilities.drawImage(image, gc, canvas, rectangle, SWT.CENTER, SWT.TOP);
@@ -126,6 +131,10 @@ public class ProjectionAnnotation extends Annotation implements IAnnotationPrese
 				drawRangeIndication(gc, canvas, rectangle);
 			}
 		}
+	}
+
+	void setHidden(boolean hidden) {
+		this.hidden= hidden;
 	}
 
 	@Override

--- a/tests/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
@@ -30,6 +30,7 @@ Import-Package: org.mockito,
  org.mockito.invocation,
  org.mockito.stubbing,
  org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
  org.junit.jupiter.params;version="[5.14.0,6.0.0)",
  org.junit.jupiter.params.provider;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)"


### PR DESCRIPTION
In #3074, I prevented collapsing and expanding projection regions that overlap with parts of the file outside of the current visible region.

However, this does not prevent the projection annotation from being shown in the editor. This PR changes that behavior and ensures these annotations (that cannot be collapsed or expanded) cannot be shown.

To prevent showing empty "files" in the editor which cannot be expanded, I also changed the code for setting the visible region to expand any surrounding or "bordering" projection regions.

### manual Testing

This can be tested by setting up an editor with content similar to the following:
```java

visible_region_start

projection_start

visible_region_end

projection_end

```

If the visible region is configured from `visible_region_start` to `visible_region_end` and a projection annotation is created between `projection_start` and `projection_end` (in both cases, these texts are inclusive), there is an annotation at `projection_start` which cannot be collapsed.

If I figure out how to test whether an annotation is drawn, I can provide a proper test case.

Here is a test case for manual inspection:
```java
	@Test
	public void testProjectionRegionsShownOnlyInVisibleRegion() throws BadLocationException, InterruptedException {
		Shell shell= new Shell(Display.getCurrent());
		shell.setLayout(new FillLayout());
		TestProjectionViewer viewer= new TestProjectionViewer(shell, null, null, true, SWT.ALL);
                // This should hide the folding annotation
		String documentContent= """

				visible_region_start

				projection_start

				visible_region_end

				projection_end

				""";

                // This should show it
//		String documentContent= """
//
//				visible_region_start
//
//				projection_start
//
//				projection_end
//
//				visible_region_end
//
//
//				""";
		Document document= new Document(documentContent);
		viewer.setDocument(document, new AnnotationModel());
		int visibleRegionStart = documentContent.indexOf("visible_region_start");
		int visibleRegionEnd = documentContent.indexOf("\n", documentContent.indexOf("visible_region_end"))+1;

		int projectionStart= documentContent.indexOf("projection_start");
		int projectionEnd= documentContent.indexOf("\n", documentContent.indexOf("projection_end")) + 1;

		viewer.setVisibleRegion(visibleRegionStart, visibleRegionEnd - visibleRegionStart);
		viewer.enableProjection();
		ProjectionAnnotation annotation= new ProjectionAnnotation();
		viewer.getProjectionAnnotationModel().addAnnotation(annotation, new Position(projectionStart, projectionEnd - projectionStart));
		shell.setVisible(true);
		Canvas canvas= new Canvas(shell, SWT.ALL);
		try {
			canvas.addPaintListener(new PaintListener() {

				@Override
				public void paintControl(PaintEvent e) {
					annotation.paint(e.gc, canvas, new Rectangle(e.x, e.y, e.width, e.height));
				}
			});

			Display display= shell.getDisplay();
			while (!shell.isDisposed()) {
				if (!display.readAndDispatch()) {
					display.sleep();
				}
			}
		} finally {
			canvas.dispose();
			shell.dispose();
		}
	}
```

This is what it should look like:
<img width="1201" height="697" alt="image" src="https://github.com/user-attachments/assets/53f1b618-0482-435f-95e2-a3b045ac82db" />

With the other version (or without this change), there is a projection annotation shown on the right:
<img width="1201" height="697" alt="image" src="https://github.com/user-attachments/assets/a6130cb5-f6aa-49eb-baf1-46903e74bebb" />

I also added automated tests for it.


### JDT example (for context)

More or less https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2302#issuecomment-3423803023, this can be seen with JDT using https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2302 by enabling Window > Preferences > Java > Editor > Only show the selected Java Element as well as Window > Preferences > Java > Editor > Folding > Enable folding of custom regions

Open a Java file with the following code (adapted from https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2302#issuecomment-3423803023):
```java
public class SomeClass {
    // region

    void a() {

    }

    void b() {

    }

    // endregion
}
```

When selecting `a()` in the editor, it only shows
```java
    // region

    void a() {

    }
```
Without this PR, the `// region` has a folding annotation on the right which cannot be used. With this PR, this region is used. However, it is still present when the whole class is shown.