### PR TITLE
Fix race condition in NestedResourcesTests.testProjectHierarchy

### DIFF
--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/NestedResourcesTests.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/resources/NestedResourcesTests.java
@@ -81,19 +81,29 @@ public class NestedResourcesTests {
 		testProjects.add(projectABA);
 		testProjects.add(projectABB);
 
+		// Wait for NestedProjectManager to process all resource changes
+		assertTrue("NestedProjectManager did not update children for projectA",
+				DisplayHelper.waitForCondition(Display.getDefault(), TIMEOUT,
+						() -> NestedProjectManager.getInstance().getDirectChildrenProjects(projectA).length == 1));
+
 		IProject[] childrenOfProjectA = NestedProjectManager.getInstance().getDirectChildrenProjects(projectA);
-		Assert.assertEquals(1, childrenOfProjectA.length);
 		Assert.assertEquals(projectAB, childrenOfProjectA[0]);
 		Assert.assertNull(NestedProjectManager.getInstance().getMostDirectOpenContainer(projectA));
 
+		// Wait for NestedProjectManager to process projectAAA
+		assertTrue("NestedProjectManager did not update children for folderAA",
+				DisplayHelper.waitForCondition(Display.getDefault(), TIMEOUT,
+						() -> NestedProjectManager.getInstance().getDirectChildrenProjects(folderAA).length == 1));
+
 		IProject[] childrenOfFolderAA = NestedProjectManager.getInstance().getDirectChildrenProjects(folderAA);
-		Assert.assertEquals(1, childrenOfFolderAA.length);
 		Assert.assertEquals("aaa", childrenOfFolderAA[0].getName());
 		Assert.assertEquals(folderAA,
 				NestedProjectManager.getInstance().getMostDirectOpenContainer(childrenOfFolderAA[0]));
 
-		IProject[] childrenOfProjectAB = NestedProjectManager.getInstance().getDirectChildrenProjects(projectAB);
-		Assert.assertEquals(2, childrenOfProjectAB.length);
+		// Wait for NestedProjectManager to process both projectABA and projectABB
+		assertTrue("NestedProjectManager did not update children for projectAB",
+				DisplayHelper.waitForCondition(Display.getDefault(), TIMEOUT,
+						() -> NestedProjectManager.getInstance().getDirectChildrenProjects(projectAB).length == 2));
 	}
 
 	@Test


### PR DESCRIPTION
This commit fixes the intermittent test failure reported in GitHub issue #196 where testProjectHierarchy randomly fails with "expected:<2> but was:<1>" at line 96 (now line 111).

Root cause:
The NestedProjectManager uses an asynchronous IResourceChangeListener that responds to POST_CHANGE events to update its internal project hierarchy map (locationsToProjects). When projects are created and opened in rapid succession, the test may query getDirectChildrenProjects() before the manager has finished processing all resource change events, leading to incomplete results.

The specific failure occurred at the assertion checking that projectAB has 2 children (projectABA and projectABB). The test would sometimes only see 1 child because the second project's creation event hadn't been processed yet.

Solution:
Added DisplayHelper.waitForCondition() calls at three critical synchronization points to wait for NestedProjectManager to process all resource changes before making assertions:

1. Wait for projectA to show 1 child (projectAB)
2. Wait for folderAA to show 1 child (projectAAA)
3. Wait for projectAB to show 2 children (projectABA and projectABB)

This approach follows the same pattern already used successfully in the testProblemDecoration() method in the same test file (lines 161-188), which also waits for asynchronous marker updates to propagate.

The 2-second timeout (TIMEOUT constant) provides sufficient time for event processing while still failing quickly if assertions are genuinely incorrect.

Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/issues/196

🤖 Generated with [Claude Code](https://claude.com/claude-code)