### PR TITLE
Add filter text support in Templates part in preference pages

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/templates/TemplatesMessages.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/templates/TemplatesMessages.java
@@ -126,6 +126,7 @@ final class TemplatesMessages extends NLS {
 	public static String TemplatesPage_remove_title_single;
 	public static String TemplatesPage_remove_title_multi;
 	public static String TemplatesView_no_templates;
+	public static String TemplatePreferencePage_filterText;
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, TemplatesMessages.class);

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/templates/TemplatesMessages.properties
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/templates/TemplatesMessages.properties
@@ -64,6 +64,8 @@ TemplatePreferencePage_question_create_new_button_rename= Rename Existing
 
 TemplatePreferencePage_preview=Previe&w:
 
+TemplatePreferencePage_filterText=type filter text
+
 # edit template dialog
 EditTemplateDialog_error_noname=Template name cannot be empty.
 EditTemplateDialog_error_adjacent_variables=Template pattern has adjacent variables.


### PR DESCRIPTION
This creates a filter text to the Templates preference pages for providing filtering option. This change adds a filter text field to the Templates page UI. This introduces filtering across multiple templates such as Java, Ant, and Run/Debug template preference pages.


https://github.com/user-attachments/assets/4edbdbc5-815a-497e-b1fe-991d2001d419


