### PR TITLE
Migrate org.eclipse.search.tests from JUnit 4 to JUnit 5

### DIFF
--- a/tests/org.eclipse.search.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.search.tests/META-INF/MANIFEST.MF
@@ -14,12 +14,13 @@ Require-Bundle:
  org.eclipse.search;bundle-version="[3.16.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.100,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.19.200,4.0.0)",
- org.junit;bundle-version="4.13.0",
  org.eclipse.ui.workbench.texteditor;bundle-version="[3.17.200,4.0.0)",
  org.eclipse.jface.text;bundle-version="[3.24.200,4.0.0)",
  org.eclipse.ui.editors;bundle-version="[3.17.100,4.0.0)",
- org.eclipse.ltk.core.refactoring;bundle-version="[3.14.100,4.0.0)"
+ org.eclipse.ltk.core.refactoring;bundle-version="[3.14.100,4.0.0)",
+ org.junit;bundle-version="4.13.2"
 Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/core/tests/AllSearchModelTests.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/core/tests/AllSearchModelTests.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.search.core.tests;
 
-import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 @Suite
 @SelectClasses({

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/core/tests/LineConversionTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/core/tests/LineConversionTest.java
@@ -14,14 +14,15 @@
 
 package org.eclipse.search.core.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -49,7 +50,7 @@ public class LineConversionTest {
 
 	private static final String LINE_THREE= "This is the third line";
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		IProject project= ResourcesPlugin.getWorkspace().getRoot().getProject("Test");
 		project.create(null);
@@ -58,7 +59,7 @@ public class LineConversionTest {
 		fFile.create(new ByteArrayInputStream(getFileContents().getBytes()), true, null);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		SearchPlugin.getActivePage().closeAllEditors(false);
 		fFile.getProject().delete(true, true, null);

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/core/tests/NullSearchResult.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/core/tests/NullSearchResult.java
@@ -15,11 +15,10 @@ package org.eclipse.search.core.tests;
 
 import org.eclipse.jface.resource.ImageDescriptor;
 
+import org.eclipse.search.internal.ui.text.FileSearchResult;
 import org.eclipse.search.ui.ISearchQuery;
 import org.eclipse.search.ui.text.IEditorMatchAdapter;
 import org.eclipse.search.ui.text.IFileMatchAdapter;
-
-import org.eclipse.search.internal.ui.text.FileSearchResult;
 
 public class NullSearchResult extends FileSearchResult { // inherit from FileSearchResult so a search result view can be found
 

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/core/tests/QueryManagerTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/core/tests/QueryManagerTest.java
@@ -13,10 +13,12 @@
  *******************************************************************************/
 package org.eclipse.search.core.tests;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.search.ui.IQueryListener;
 import org.eclipse.search.ui.ISearchQuery;

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/core/tests/TestSearchResult.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/core/tests/TestSearchResult.java
@@ -14,12 +14,14 @@
 package org.eclipse.search.core.tests;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.search.ui.ISearchQuery;
 import org.eclipse.search.ui.text.AbstractTextSearchResult;
@@ -60,9 +62,9 @@ public class TestSearchResult {
 		Match match3= new Match(object, 0, 2);
 		result.addMatch(match3);
 		Match[] matches= result.getMatches(object);
-		assertSame("matches[0]", matches[0], match3);
-		assertSame("matches[1]", matches[1], match2);
-		assertSame("matches[2]", matches[2], match1);
+		assertSame(matches[0], match3, "matches[0]");
+		assertSame(matches[1], match2, "matches[1]");
+		assertSame(matches[2], match1, "matches[2]");
 	}
 
 	@Test
@@ -80,9 +82,9 @@ public class TestSearchResult {
 		Match match3= new Match(object, 2, 2);
 		result.addMatch(match3);
 		Match[] matches= result.getMatches(object);
-		assertSame("matches[0]", matches[0], match1);
-		assertSame("matches[1]", matches[1], match2);
-		assertSame("matches[2]", matches[2], match3);
+		assertSame(matches[0], match1, "matches[0]");
+		assertSame(matches[1], match2, "matches[1]");
+		assertSame(matches[2], match3, "matches[2]");
 	}
 
 	@Test
@@ -98,8 +100,8 @@ public class TestSearchResult {
 		Match match2= new Match(object, 1, 0);
 		result.addMatch(match2);
 		Match[] matches= result.getMatches(object);
-		assertSame("matches[0]", matches[0], match2);
-		assertSame("matches[1]", matches[1], match1);
+		assertSame(matches[0], match2, "matches[0]");
+		assertSame(matches[1], match1, "matches[1]");
 	}
 
 	@Test

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/AllSearchTests.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/AllSearchTests.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.search.tests;
 
-import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 import org.eclipse.search.core.tests.AllSearchModelTests;
 import org.eclipse.search.tests.filesearch.AllFileSearchTests;

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/TestTextSearchEngine.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/TestTextSearchEngine.java
@@ -12,9 +12,11 @@ package org.eclipse.search.tests;
 
 import java.util.regex.Pattern;
 
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+
+import org.eclipse.core.resources.IFile;
+
 import org.eclipse.search.core.text.TextSearchEngine;
 import org.eclipse.search.core.text.TextSearchRequestor;
 import org.eclipse.search.core.text.TextSearchScope;

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/TextSearchRegistryTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/TextSearchRegistryTest.java
@@ -10,13 +10,15 @@
  *******************************************************************************/
 package org.eclipse.search.tests;
 
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 
+import org.junit.jupiter.api.Test;
+
 import org.eclipse.search.internal.core.text.TextSearchEngineRegistry;
 import org.eclipse.search.internal.ui.SearchPlugin;
-import org.junit.Test;
 
 public class TextSearchRegistryTest {
 


### PR DESCRIPTION
The tests in org.eclipse.search.tests.filesearch uses a JUnit4 rules, these will be migrated separately.