### PR TITLE
Migrate org.eclipse.search.tests from JUnit 4 to JUnit 5

### DIFF
--- a/tests/org.eclipse.search.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.search.tests/META-INF/MANIFEST.MF
@@ -18,10 +18,12 @@ Require-Bundle:
  org.eclipse.jface.text;bundle-version="[3.24.200,4.0.0)",
  org.eclipse.ui.editors;bundle-version="[3.17.100,4.0.0)",
  org.eclipse.ltk.core.refactoring;bundle-version="[3.14.100,4.0.0)",
- org.junit;bundle-version="4.13.2"
+ org.hamcrest;bundle-version="3.0.0"
 Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.extension;version="[5.14.0,6.0.0)",
  org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
- org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
+ org.opentest4j
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/AllFileSearchTests.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/AllFileSearchTests.java
@@ -13,10 +13,8 @@
  *******************************************************************************/
 package org.eclipse.search.tests.filesearch;
 
-import org.junit.ClassRule;
-
-import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 @Suite
 @SelectClasses({
@@ -29,6 +27,4 @@ import org.junit.platform.suite.api.SelectClasses;
 		SortingTest.class
 })
 public class AllFileSearchTests {
-	@ClassRule
-	public static JUnitSourceSetup fgJUnitSource= new JUnitSourceSetup();
 }

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/AnnotationManagerTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/AnnotationManagerTest.java
@@ -13,16 +13,16 @@
  *******************************************************************************/
 package org.eclipse.search.tests.filesearch;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import java.util.Iterator;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
@@ -59,10 +59,10 @@ public class AnnotationManagerTest {
 
 	private final AnnotationTypeLookup fAnnotationTypeLookup= EditorsUI.getAnnotationTypeLookup();
 
-	@ClassRule
-	public static JUnitSourceSetup fgJUnitSource= new JUnitSourceSetup();
+	@RegisterExtension
+	static JUnitSourceSetup fgJUnitSource= new JUnitSourceSetup();
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		SearchTestUtil.ensureWelcomePageClosed();
 		EditorAnnotationManager.debugSetHighlighterType(EditorAnnotationManager.HIGHLIGHTER_ANNOTATION);
@@ -72,7 +72,7 @@ public class AnnotationManagerTest {
 		fQuery2= new FileSearchQuery("Test", false, true, scope); //$NON-NLS-1$
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		InternalSearchUI.getInstance().removeAllQueries();
 		fQuery1= null;
@@ -104,7 +104,7 @@ public class AnnotationManagerTest {
 				Match[] matches= result.getMatches(file);
 				for (int j= 0; j < matches.length; j++) {
 					Position position= new Position(matches[j].getOffset(), matches[j].getLength());
-					assertTrue("position not found at: "+j, positions.remove(position)); //$NON-NLS-1$
+					assertTrue(positions.remove(position), "position not found at: "+j); //$NON-NLS-1$
 				}
 				assertEquals(0, positions.size());
 

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/FileCharSequenceTests.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/FileCharSequenceTests.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.search.tests.filesearch;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.core.runtime.CoreException;
 
@@ -38,12 +38,12 @@ public class FileCharSequenceTests {
 
 	private IProject fProject;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		fProject= ResourceHelper.createProject("my-project"); //$NON-NLS-1$
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		ResourceHelper.deleteProject("my-project"); //$NON-NLS-1$
 	}
@@ -114,23 +114,23 @@ public class FileCharSequenceTests {
 
 	private void assertEquals(String desc, CharSequence actual, CharSequence expected) {
 		for (int i= 0; i < expected.length(); i++) {
-			Assert.assertEquals(desc + " - forward " + i, expected.charAt(i), actual.charAt(i));
+			Assertions.assertEquals(expected.charAt(i), actual.charAt(i), desc + " - forward " + i);
 		}
-		Assert.assertEquals(desc + " - length", expected.length(), actual.length());
+		Assertions.assertEquals(expected.length(), actual.length(), desc + " - length");
 		for (int i= expected.length() - 1; i >= 0; i--) {
-			Assert.assertEquals(desc + " - backward " + i, expected.charAt(i), actual.charAt(i));
+			Assertions.assertEquals(expected.charAt(i), actual.charAt(i), desc + " - backward " + i);
 		}
 		for (int i= 0; i < expected.length(); i+= 567) {
-			Assert.assertEquals(desc + " - forward - steps" + i, expected.charAt(i), actual.charAt(i));
+			Assertions.assertEquals(expected.charAt(i), actual.charAt(i), desc + " - forward - steps" + i);
 		}
 		for (int i= 0; i < expected.length(); i+= FileCharSequenceProvider.BUFFER_SIZE) {
-			Assert.assertEquals(desc + " - forward - buffersize" + i, expected.charAt(i), actual.charAt(i));
+			Assertions.assertEquals(expected.charAt(i), actual.charAt(i), desc + " - forward - buffersize" + i);
 		}
 
 		assertOutOfBound(desc + "access at length", actual, expected.length());
 		assertOutOfBound(desc + "access at -1", actual, -1);
 
-		Assert.assertEquals(desc + " - length", actual.toString(), expected.toString());
+		Assertions.assertEquals(expected.toString(), actual.toString(), desc + " - length");
 	}
 
 
@@ -140,7 +140,7 @@ public class FileCharSequenceTests {
 		} catch (IndexOutOfBoundsException e) {
 			return;
 		}
-		assertFalse(message, true);
+		assertFalse(true, message);
 	}
 
 

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/FileSearchTests.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/FileSearchTests.java
@@ -15,7 +15,8 @@
  *******************************************************************************/
 package org.eclipse.search.tests.filesearch;
 
-import static org.junit.Assert.assertEquals;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.lang.reflect.Field;
@@ -24,10 +25,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.eclipse.core.runtime.ContributorFactorySimple;
 import org.eclipse.core.runtime.CoreException;
@@ -120,17 +121,17 @@ public class FileSearchTests {
 
 	}
 
-	@ClassRule
-	public static JUnitSourceSetup fgJUnitSource= new JUnitSourceSetup();
+	@RegisterExtension
+	static JUnitSourceSetup fgJUnitSource= new JUnitSourceSetup();
 
 	private IProject fProject;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception{
 		fProject= ResourceHelper.createProject("my-project"); //$NON-NLS-1$
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		ResourceHelper.deleteProject("my-project"); //$NON-NLS-1$
 	}
@@ -161,7 +162,7 @@ public class FileSearchTests {
 		TextSearchEngine.create().search(scope, collector, searchPattern, null);
 
 		TestResult[] results= collector.getResults();
-		assertEquals("Number of total results", 4, results.length);
+		assertEquals(4, results.length, "Number of total results");
 
 		assertMatches(results, 2, file1, buf.toString(), "hello");
 		assertMatches(results, 2, file2, buf.toString(), "hello");
@@ -194,7 +195,7 @@ public class FileSearchTests {
 		TextSearchEngine.create().search(scope, collector, searchPattern, null);
 
 		TestResult[] results= collector.getResults();
-		assertEquals("Number of total results", 6, results.length);
+		assertEquals(6, results.length, "Number of total results");
 	}
 
 	@Test
@@ -224,7 +225,7 @@ public class FileSearchTests {
 		TextSearchEngine.create().search(scope, collector, searchPattern, null);
 
 		TestResult[] results= collector.getResults();
-		assertEquals("Number of total results", 4, results.length);
+		assertEquals(4, results.length, "Number of total results");
 	}
 
 	@Test
@@ -262,7 +263,7 @@ public class FileSearchTests {
 			TextSearchEngine.create().search(scope, collector, searchPattern, null);
 
 			TestResult[] results= collector.getResults();
-			assertEquals("Number of total results", 748, results.length);
+			assertEquals(748, results.length, "Number of total results");
 			long end= System.currentTimeMillis();
 			System.out.println("time= " + (end - start));
 		} finally {
@@ -309,20 +310,20 @@ public class FileSearchTests {
 			Pattern searchPattern= PatternConstructor.createPattern("h?ll", false, true, false, false);
 			collector.reset();
 			engine.search(scope, collector, searchPattern, null);
-			assertEquals("Number of partial-word results", 22, collector.getNumberOfResults());
+			assertEquals(22, collector.getNumberOfResults(), "Number of partial-word results");
 		}
 		{
 			// wildcards, whole word = true: match only nothing and non-word chars before and after
 			Pattern searchPattern= PatternConstructor.createPattern("h?ll", false, true, false, true);
 			collector.reset();
 			engine.search(scope, collector, searchPattern, null);
-			assertEquals("Number of whole-word results", 10, collector.getNumberOfResults());
+			assertEquals(10, collector.getNumberOfResults(), "Number of whole-word results");
 		}
 		// regexp, whole word = false: match all lines
 		Pattern searchPattern= PatternConstructor.createPattern("h[eio]ll", true, true, false, false);
 		collector.reset();
 		engine.search(scope, collector, searchPattern, null);
-		assertEquals("Number of partial-word results", 22, collector.getNumberOfResults());
+		assertEquals(22, collector.getNumberOfResults(), "Number of partial-word results");
 	}
 
 	@Test
@@ -354,7 +355,7 @@ public class FileSearchTests {
 			TextSearchEngine.create().search(scope, collector, searchPattern, null);
 
 			TestResult[] results= collector.getResults();
-			assertEquals("Number of total results", 4, results.length);
+			assertEquals(4, results.length, "Number of total results");
 
 			assertMatches(results, 2, file1, buf.toString(), "hello");
 			assertMatches(results, 2, file2, buf.toString(), "hello");
@@ -510,39 +511,39 @@ public class FileSearchTests {
 		String[] fileNamePatterns= { "*" };
 
 		TestResult[] results= performSearch(collector, fileNamePatterns, searchPattern);
-		assertEquals("Number of total results", 4, results.length);
+		assertEquals(4, results.length, "Number of total results");
 
 		fileNamePatterns= new String[] { "*.x" };
 		results= performSearch(collector, fileNamePatterns, searchPattern);
-		assertEquals("Number of total results", 2, results.length);
+		assertEquals(2, results.length, "Number of total results");
 
 		fileNamePatterns= new String[] { "*.x", "*.y*" };
 		results= performSearch(collector, fileNamePatterns, searchPattern);
-		assertEquals("Number of total results", 3, results.length);
+		assertEquals(3, results.length, "Number of total results");
 
 		fileNamePatterns= new String[] { "!*.x" };
 		results= performSearch(collector, fileNamePatterns, searchPattern);
-		assertEquals("Number of total results", 2, results.length);
+		assertEquals(2, results.length, "Number of total results");
 
 		fileNamePatterns= new String[] { "!*.x", "!*.y" };
 		results= performSearch(collector, fileNamePatterns, searchPattern);
-		assertEquals("Number of total results", 1, results.length);
+		assertEquals(1, results.length, "Number of total results");
 
 		fileNamePatterns= new String[] { "*", "!*.y" };
 		results= performSearch(collector, fileNamePatterns, searchPattern);
-		assertEquals("Number of total results", 3, results.length);
+		assertEquals(3, results.length, "Number of total results");
 
 		fileNamePatterns= new String[] { "*", "!*.*" };
 		results= performSearch(collector, fileNamePatterns, searchPattern);
-		assertEquals("Number of total results", 0, results.length);
+		assertEquals(0, results.length, "Number of total results");
 
 		fileNamePatterns= new String[] { "*.x", "*.y*", "!*.y" };
 		results= performSearch(collector, fileNamePatterns, searchPattern);
-		assertEquals("Number of total results", 2, results.length);
+		assertEquals(2, results.length, "Number of total results");
 
 		fileNamePatterns= new String[] { "file*", "!*.x*", "!*.y" };
 		results= performSearch(collector, fileNamePatterns, searchPattern);
-		assertEquals("Number of total results", 1, results.length);
+		assertEquals(1, results.length, "Number of total results");
 	}
 
 	private TestResult[] performSearch(TestResultCollector collector, String[] fileNamePatterns, Pattern searchPattern) {
@@ -610,7 +611,7 @@ public class FileSearchTests {
 				TextSearchEngine.create().search(scope, collector, searchPattern, null);
 
 				TestResult[] results= collector.getResults();
-				assertEquals("Number of total results", 1, results.length);
+				assertEquals(1, results.length, "Number of total results");
 
 				assertMatches(results, 1, textfile, "text hello", "hello");
 				assertMatches(results, 0, binaryfile, "binary hello", "hello");
@@ -625,10 +626,10 @@ public class FileSearchTests {
 		for (TestResult curr : results) {
 			if (file.equals(curr.resource)) {
 				k++;
-				assertEquals("Wrong positions", string, fileContent.substring(curr.offset, curr.offset + curr.length));
+				assertEquals(string, fileContent.substring(curr.offset, curr.offset + curr.length), "Wrong positions");
 			}
 		}
-		assertEquals("Number of results in file", expectedCount, k);
+		assertEquals(expectedCount, k, "Number of results in file");
 	}
 
 

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/JUnitSourceSetup.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/JUnitSourceSetup.java
@@ -13,16 +13,16 @@
  *******************************************************************************/
 package org.eclipse.search.tests.filesearch;
 
-import org.junit.rules.ExternalResource;
-
-import org.eclipse.core.runtime.CoreException;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 
 import org.eclipse.search.tests.ResourceHelper;
 
-public class JUnitSourceSetup extends ExternalResource {
+public class JUnitSourceSetup implements BeforeAllCallback, AfterAllCallback {
 
 	public static final String STANDARD_PROJECT_NAME= "JUnitSource";
 
@@ -42,7 +42,7 @@ public class JUnitSourceSetup extends ExternalResource {
 	}
 
 	@Override
-	public void before() throws Exception {
+	public void beforeAll(ExtensionContext context) throws Exception {
 		IProject project= ResourcesPlugin.getWorkspace().getRoot().getProject(fProjectName);
 		if (!project.exists()) { // allow nesting of JUnitSetups
 			fProject= ResourceHelper.createJUnitSourceProject(fProjectName);
@@ -50,13 +50,9 @@ public class JUnitSourceSetup extends ExternalResource {
 	}
 
 	@Override
-	public void after() /*throws Exception (but JUnit4 API is stupid...)*/ {
+	public void afterAll(ExtensionContext context) throws Exception {
 		if (fProject != null) { // delete only by the setup who created the project
-			try {
-				ResourceHelper.deleteProject(fProjectName);
-			} catch (CoreException e) {
-				throw new AssertionError(e); // workaround stupid JUnit4 API
-			}
+			ResourceHelper.deleteProject(fProjectName);
 			fProject= null;
 		}
 	}

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/LineAnnotationManagerTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/LineAnnotationManagerTest.java
@@ -20,10 +20,10 @@ import static org.hamcrest.Matchers.hasItem;
 import java.util.ArrayList;
 import java.util.Iterator;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
@@ -52,10 +52,10 @@ public class LineAnnotationManagerTest {
 	private LineBasedFileSearch fLineQuery;
 	private final AnnotationTypeLookup fAnnotationTypeLookup= EditorsUI.getAnnotationTypeLookup();
 
-	@ClassRule
-	public static JUnitSourceSetup fgJUnitSource= new JUnitSourceSetup();
+	@RegisterExtension
+	static JUnitSourceSetup fgJUnitSource= new JUnitSourceSetup();
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		EditorAnnotationManager.debugSetHighlighterType(EditorAnnotationManager.HIGHLIGHTER_ANNOTATION);
 
@@ -65,7 +65,7 @@ public class LineAnnotationManagerTest {
 		fLineQuery= new LineBasedFileSearch(scope, false, true, "Test");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		InternalSearchUI.getInstance().removeAllQueries();
 		fLineQuery= null;

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/PositionTrackerTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/PositionTrackerTest.java
@@ -13,13 +13,14 @@
  *******************************************************************************/
 package org.eclipse.search.tests.filesearch;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeFalse;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.eclipse.core.runtime.jobs.Job;
 
@@ -51,10 +52,12 @@ import org.eclipse.search2.internal.ui.InternalSearchUI;
 public class PositionTrackerTest {
 	FileSearchQuery fQuery1;
 
-	@ClassRule
+	@RegisterExtension
+	static JUnitSourceSetup fgJUnitSource= new JUnitSourceSetup();
+
 	public static JUnitSourceSetup junitSource= new JUnitSourceSetup();
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		String[] fileNamePatterns= { "*.java" };
 		FileTextSearchScope scope= FileTextSearchScope.newWorkspaceScope(fileNamePatterns, false);
@@ -79,7 +82,7 @@ public class PositionTrackerTest {
 
 	@Test
 	public void testInsertInsideMatch() throws Exception {
-		assumeFalse("test fails on Mac, see https://github.com/eclipse-platform/eclipse.platform.ui/issues/882", Util.isMac());
+		assumeFalse(Util.isMac(), "test fails on Mac, see https://github.com/eclipse-platform/eclipse.platform.ui/issues/882");
 		NewSearchUI.runQueryInForeground(null, fQuery1);
 		FileSearchResult result= (FileSearchResult) fQuery1.getSearchResult();
 		Object[] elements= result.getElements();
@@ -102,14 +105,14 @@ public class PositionTrackerTest {
 			IDocument doc= fb.getDocument();
 
 			for (Match matche : matches) {
-				assertNotNull("null match for file: " + file, matche);
+				assertNotNull(matche, "null match for file: " + file);
 				Position currentPosition = InternalSearchUI.getInstance().getPositionTracker().getCurrentPosition(matche);
-				assertNotNull("null position for match: " + matche, currentPosition);
+				assertNotNull(currentPosition, "null position for match: " + matche);
 				doc.replace(currentPosition.offset + 1, 0, "Test");
 			}
 			for (Match matche : matches) {
 				Position currentPosition = InternalSearchUI.getInstance().getPositionTracker().getCurrentPosition(matche);
-				assertNotNull("null position for match: " + matche, currentPosition);
+				assertNotNull(currentPosition, "null position for match: " + matche);
 				String text= doc.get(currentPosition.offset, currentPosition.length);
 				StringBuilder buf= new StringBuilder();
 				buf.append(text.charAt(0));
@@ -137,7 +140,7 @@ public class PositionTrackerTest {
 
 			for (int i= 0; i < originalStarts.length; i++) {
 				Position currentPosition= InternalSearchUI.getInstance().getPositionTracker().getCurrentPosition(matches[i]);
-				assertNotNull("null position for match: " + matches[i], currentPosition);
+				assertNotNull(currentPosition, "null position for match: " + matches[i]);
 				assertEquals(originalStarts[i] + "Test".length(), currentPosition.getOffset());
 
 			}

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/ResultUpdaterTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/ResultUpdaterTest.java
@@ -13,23 +13,22 @@
  *******************************************************************************/
 package org.eclipse.search.tests.filesearch;
 
-import static org.junit.Assert.*;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 
+import org.eclipse.search.internal.ui.text.FileSearchQuery;
+import org.eclipse.search.tests.ResourceHelper;
 import org.eclipse.search.ui.NewSearchUI;
 import org.eclipse.search.ui.text.AbstractTextSearchResult;
 import org.eclipse.search.ui.text.FileTextSearchScope;
-
-import org.eclipse.search.internal.ui.text.FileSearchQuery;
-
-import org.eclipse.search.tests.ResourceHelper;
 
 public class ResultUpdaterTest {
 	private FileSearchQuery fQuery1;
@@ -38,7 +37,7 @@ public class ResultUpdaterTest {
 
 	private static final String PROJECT_TO_MODIFY= "ModifiableProject";
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// create a own project to make modifications
 		fProject= ResourceHelper.createJUnitSourceProject(PROJECT_TO_MODIFY);
@@ -49,7 +48,7 @@ public class ResultUpdaterTest {
 		fQuery1= new FileSearchQuery("Test", false, true, scope);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		ResourceHelper.deleteProject(PROJECT_TO_MODIFY);
 	}

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/SearchResultPageTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/SearchResultPageTest.java
@@ -14,13 +14,14 @@
 
 package org.eclipse.search.tests.filesearch;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Item;
@@ -47,10 +48,10 @@ import org.eclipse.search.ui.text.Match;
 public class SearchResultPageTest {
 	FileSearchQuery fQuery1;
 
-	@ClassRule
-	public static JUnitSourceSetup fgJUnitSource= new JUnitSourceSetup();
+	@RegisterExtension
+	static JUnitSourceSetup fgJUnitSource= new JUnitSourceSetup();
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		SearchTestUtil.ensureWelcomePageClosed();
 		String[] fileNamePatterns= { "*.java" };
@@ -60,7 +61,7 @@ public class SearchResultPageTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void testBasicDisplay() throws Exception {
 		NewSearchUI.runQueryInForeground(null, fQuery1);
 		ISearchResultViewPart view= NewSearchUI.getSearchResultView();
@@ -86,7 +87,7 @@ public class SearchResultPageTest {
 
 
 	@Test
-	@Ignore // checkElementDisplay(..) misses cases where one line contains multiple matches
+	@Disabled // checkElementDisplay(..) misses cases where one line contains multiple matches
 	public void testRemoveTreeMatches() throws Exception {
 		NewSearchUI.runQueryInForeground(null, fQuery1);
 		ISearchResultViewPart view= NewSearchUI.getSearchResultView();

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/SortingTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/SortingTest.java
@@ -13,16 +13,17 @@
  *******************************************************************************/
 package org.eclipse.search.tests.filesearch;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.eclipse.search.internal.ui.text.FileSearchQuery;
 import org.eclipse.search.ui.NewSearchUI;
@@ -33,10 +34,10 @@ import org.eclipse.search.ui.text.Match;
 public class SortingTest {
 	FileSearchQuery fQuery1;
 
-	@ClassRule
-	public static JUnitSourceSetup fgJUnitSource= new JUnitSourceSetup();
+	@RegisterExtension
+	static JUnitSourceSetup fgJUnitSource= new JUnitSourceSetup();
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		String[] fileNamePatterns= { "*.java" };
 		FileTextSearchScope scope= FileTextSearchScope.newWorkspaceScope(fileNamePatterns, false);
@@ -60,20 +61,20 @@ public class SortingTest {
 		}
 		// now remove them and readd them in reverse order
 		result.removeAll();
-		assertEquals("removed all matches", 0, result.getMatchCount());
+		assertEquals(0, result.getMatchCount(), "removed all matches");
 
 		for (int i= allMatches.size()-1; i >= 0; i--) {
 			result.addMatch(allMatches.get(i));
 		}
 
-		assertEquals("Test that all matches have been added again", result.getMatchCount(), originalMatchCount);
+		assertEquals(result.getMatchCount(), originalMatchCount, "Test that all matches have been added again");
 
 		// now check that they're ordered by position.
 		for (Object element : elements) {
 			Match[] matches = result.getMatches(element);
-			assertTrue("has matches", matches.length > 0);
+			assertTrue(matches.length > 0, "has matches");
 			for (int j= 1; j < matches.length; j++) {
-				assertTrue("order problem", isLessOrEqual(matches[j-1], matches[j]));
+				assertTrue(isLessOrEqual(matches[j - 1], matches[j]), "order problem");
 			}
 		}
 	}


### PR DESCRIPTION
This commit migrates the org.eclipse.search.tests bundle from JUnit 4 to JUnit 5, including all test files and the necessary dependency updates.

Changes:
- Updated imports from org.junit.* to org.junit.jupiter.api.*
- Replaced @Before/@After with @BeforeEach/@AfterEach annotations
- Replaced Assert with Assertions for all assertion methods
- Updated test annotations from @Test (JUnit 4) to @Test (JUnit 5)
- Migrated JUnitSourceSetup from @Rule to @RegisterExtension
- Updated assertions to use JUnit 5 style (message parameter last)

MANIFEST.MF updates:
- Removed JUnit 4 dependency (org.junit;bundle-version="4.13.2")
- Added org.hamcrest;bundle-version="3.0.0" for matcher support
- Added JUnit 5 Import-Package entries:
  - org.junit.jupiter.api;version="[5.14.0,6.0.0)"
  - org.junit.jupiter.api.extension;version="[5.14.0,6.0.0)"
  - org.junit.jupiter.api.function;version="[5.14.0,6.0.0)"
  - org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
  - org.opentest4j (required for Assumptions.assumeFalse() in PositionTrackerTest)

Files migrated:
- AllFileSearchTests.java
- AnnotationManagerTest.java
- FileCharSequenceTests.java
- FileSearchTests.java
- JUnitSourceSetup.java
- LineAnnotationManagerTest.java
- PositionTrackerTest.java
- ResultUpdaterTest.java
- SearchResultPageTest.java
- SortingTest.java

Note: The org.opentest4j import was critical to fix compilation - it provides TestAbortedException used by JUnit 5's Assumptions API (specifically assumeFalse() in PositionTrackerTest.java:85).

Verification:
- Compilation succeeds with 0 errors
- Tests compile and run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)