### PR TITLE
Fix race condition in MMenuItemTest by adding event loop processing

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MMenuItemTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MMenuItemTest.java
@@ -763,6 +763,9 @@ public class MMenuItemTest {
 		activePart.getContext().set("key", "active");
 		inactivePart.getContext().set("key", "inactive");
 
+		// Ensure all pending UI events are processed before triggering the menu item
+		contextRule.spinEventLoop();
+
 		assertFalse(executed[0]);
 
 		Object widget1 = menuItem.getWidget();
@@ -835,6 +838,10 @@ public class MMenuItemTest {
 
 		activePart.getContext().set("key", "active");
 		inactivePart.getContext().set("key", "inactive");
+
+		// Ensure all pending UI events are processed before triggering the menu item
+		// This prevents race conditions where the handler may not be fully registered yet
+		contextRule.spinEventLoop();
 
 		assertFalse(executed[0]);
 		assertEquals(activePart, window.getContext().get(EPartService.class)


### PR DESCRIPTION
Fixes #1737

The test testElementHierarchyInContext_HandledItem was experiencing intermittent failures due to a race condition. After creating handler processing addons and activating parts, the handler registration may not have completed before the test triggered the menu item selection.

This commit adds calls to contextRule.spinEventLoop() in both testElementHierarchyInContext_DirectItem and
testElementHierarchyInContext_HandledItem to ensure all pending UI events are processed before triggering menu item selection. This is a standard pattern for preventing race conditions in Eclipse UI tests.

The spinEventLoop() method processes all pending events in the Display event queue, ensuring that handler registration and context updates have completed before the test proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)