### PR TITLE
Fix race condition in DecoratorAdaptableTests by adding event loop processing

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/decorators/DecoratorAdaptableTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/decorators/DecoratorAdaptableTests.java
@@ -25,6 +25,7 @@ import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.decorators.DecorationResult;
 import org.eclipse.ui.internal.decorators.DecoratorManager;
 import org.eclipse.ui.internal.decorators.LightweightDecoratorManager;
+import org.eclipse.ui.tests.harness.util.UITestUtil;
 import org.eclipse.ui.tests.menus.ObjectContributionClasses;
 import org.junit.After;
 import org.junit.Before;
@@ -63,6 +64,10 @@ public class DecoratorAdaptableTests {
 		PlatformUI.getWorkbench().getDecoratorManager().setEnabled(TestUnadaptableDecoratorContributor.ID, true);
 		PlatformUI.getWorkbench().getDecoratorManager().setEnabled(TestResourceDecoratorContributor.ID, true);
 		PlatformUI.getWorkbench().getDecoratorManager().setEnabled(TestResourceMappingDecoratorContributor.ID, true);
+
+		// Process all pending UI events to ensure decorator enablement has completed
+		// This prevents race conditions where decorators may not be fully registered yet
+		UITestUtil.processEvents();
 	}
 
 	@After
@@ -71,6 +76,9 @@ public class DecoratorAdaptableTests {
 		PlatformUI.getWorkbench().getDecoratorManager().setEnabled(TestUnadaptableDecoratorContributor.ID, false);
 		PlatformUI.getWorkbench().getDecoratorManager().setEnabled(TestResourceDecoratorContributor.ID, false);
 		PlatformUI.getWorkbench().getDecoratorManager().setEnabled(TestResourceMappingDecoratorContributor.ID, false);
+
+		// Process all pending UI events to ensure clean state for next test
+		UITestUtil.processEvents();
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Fixes #868

This PR fixes a race condition in `DecoratorAdaptableTests` that was causing intermittent test failures with the error:
> "Adaptable test 1 has failed for object org.eclipse.ui.tests.menus.ObjectContributionClasses$A@..."

## Problem
The tests were experiencing intermittent failures due to a race condition. After enabling decorators in the `@Before` method using `setEnabled()`, the decorator manager schedules asynchronous updates that may not have completed before the test assertions ran.

## Solution
This PR applies the same pattern used to fix other race conditions in Eclipse UI tests (like the recent fix for `MMenuItemTest` in a988d0872d):

1. Added import for `UITestUtil` which provides event loop processing utilities
2. Added `UITestUtil.processEvents()` after decorator enablement in `@Before` to ensure all pending UI events are processed
3. Added `UITestUtil.processEvents()` in `@After` to ensure a clean state for subsequent tests

The `processEvents()` method processes all pending events in the Display event queue, ensuring that decorator registration and enablement updates have completed before the test proceeds.

## Test Plan
- [x] Successfully ran all 3 tests in `DecoratorAdaptableTests`:
  - `testAdaptables`
  - `testNonAdaptableContributions`
  - `testContributorResourceAdapter`
- [x] Ran tests multiple times to verify consistency
- [x] All tests passed with no failures or errors

## Related Changes
This fix follows the same pattern as other recent race condition fixes in the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)