### PR TITLE
disable redrawing when setting visible region to prevent flickering

### DIFF
--- a/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionViewer.java
+++ b/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -767,6 +767,8 @@ public class ProjectionViewer extends SourceViewer implements ITextViewerExtensi
 		if (document == null) {
 			return;
 		}
+		int topIndex= redraws() ? getTopIndex() : -1;
+		setRedraw(false);
 		try {
 			// If the visible region changes, make sure collapsed regions outside of the old visible regions are expanded
 			// and collapse everything outside the new visible region
@@ -782,6 +784,8 @@ public class ProjectionViewer extends SourceViewer implements ITextViewerExtensi
 		} catch (BadLocationException e) {
 			ILog log= ILog.of(getClass());
 			log.log(new Status(IStatus.WARNING, getClass(), IStatus.OK, null, e));
+		} finally {
+			setRedraw(true, topIndex);
 		}
 	}
 


### PR DESCRIPTION
When `setVisibleRegion` is repeatedly [called with projection regions enabled](https://github.com/eclipse-platform/eclipse.platform.ui/pull/3074), it first expands everything outside of the old visible region and then collapses everything inside the new visible region. This can result in Eclipse showing unwanted text for a fraction of a second.

Without this change:

[recording with flickering](https://github.com/user-attachments/assets/c25211aa-e9cb-4a49-bbfa-23cfa9168fcc)

With this change:

[recording without flickering](https://github.com/user-attachments/assets/e11873e3-c25d-47dc-8a1d-3810e22b257d)

(I made the recordings with https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2302 active to get the visible regions logic in JDT)


I don't think an automated test is reasonable for this but I can try to provide a way to reproduce this manually without JDT if necessary.