### PR TITLE
Simple fix for NPE in ProjectionViewer.resetVisibleRegion

### DIFF
--- a/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionViewer.java
+++ b/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionViewer.java
@@ -776,7 +776,9 @@ public class ProjectionViewer extends SourceViewer implements ITextViewerExtensi
 			expandOutsideCurrentVisibleRegion(document);
 			collapseOutsideOfNewVisibleRegion(start, end, document);
 			fConfiguredVisibleRegion= newVisibleRegion;
-			hideProjectionAnnotationsOutsideOfVisibleRegion();
+			if (fProjectionAnnotationModel != null) {
+				hideProjectionAnnotationsOutsideOfVisibleRegion();
+			}
 		} catch (BadLocationException e) {
 			ILog log= ILog.of(getClass());
 			log.log(new Status(IStatus.WARNING, getClass(), IStatus.OK, null, e));
@@ -887,10 +889,12 @@ public class ProjectionViewer extends SourceViewer implements ITextViewerExtensi
 			super.resetVisibleRegion();
 		}
 		fConfiguredVisibleRegion= null;
-		for (Iterator<Annotation> it= fProjectionAnnotationModel.getAnnotationIterator(); it.hasNext();) {
-			Annotation annotation= it.next();
-			if (annotation instanceof ProjectionAnnotation a) {
-				a.setHidden(false);
+		if (fProjectionAnnotationModel != null) {
+			for (Iterator<Annotation> it= fProjectionAnnotationModel.getAnnotationIterator(); it.hasNext();) {
+				Annotation annotation= it.next();
+				if (annotation instanceof ProjectionAnnotation a) {
+					a.setHidden(false);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Only fix for places changed in ce17c9e and related to NPE's on `fProjectionAnnotationModel`.

The code in `ProjectionViewer` in general assumes
`fProjectionAnnotationModel` to be non null in most places where it might access it. Probably this needs to be revisited.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3459