### PR TITLE
Don't log error if info for deleted marker is not found

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/texteditor/MarkerUtilities.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/texteditor/MarkerUtilities.java
@@ -31,6 +31,7 @@ import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceStatus;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -258,7 +259,11 @@ public final class MarkerUtilities {
 		try {
 			return marker.getType();
 		} catch (CoreException x) {
-			handleCoreException(x);
+			// check if the marker marker was deleted and an exception was thrown due to that
+			boolean deletedMarkerNotFound = x.getStatus().getCode() == IResourceStatus.MARKER_NOT_FOUND && !marker.exists();
+			if (!deletedMarkerNotFound) {
+				handleCoreException(x);
+			}
 		}
 		return null;
 	}


### PR DESCRIPTION
Its possible that a marker is deleted, while its info is being retrieved. This will produce a logged error such as: "Marker id 6922 not found.", while the caller continues working without the info.

In this case, the logged error is not necessary - the marker is gone, not being able to retrieve its info is expected behavior.

This change adjusts MarkerUtilities to not log an error for a not found Marker, if the marker is not existing at the time of catching the respective exception.

Fixes: #2219