### PR TITLE
Limit monitor-specific scaling to supported autoscale modes

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchMessages.java
@@ -36,6 +36,12 @@ public class WorkbenchMessages extends NLS {
 
 	public static String RescaleAtRuntimeDescription;
 
+	public static String RescaleAtRuntimeDisabledDescription;
+
+	public static String RescaleAtRuntimeIncompatibilityTitle;
+
+	public static String RescaleAtRuntimeIncompatibilityDescription;
+
 	public static String RescaleAtRuntimeEnabled;
 
 	public static String RescaleAtRuntimeSettingChangeWarningTitle;

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
@@ -53,6 +53,7 @@ import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.fieldassist.ControlDecoration;
 import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
+import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.jface.viewers.ArrayContentProvider;
@@ -65,7 +66,9 @@ import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.internal.DPIUtil;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -222,7 +225,15 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 				.getBoolean(IWorkbenchPreferenceConstants.RESCALING_AT_RUNTIME, true);
 		rescaleAtRuntime = createCheckButton(parent, WorkbenchMessages.RescaleAtRuntimeEnabled,
 				initialStateRescaleAtRuntime);
-		rescaleAtRuntime.setToolTipText(WorkbenchMessages.RescaleAtRuntimeDescription);
+		if (!DPIUtil.isSetupCompatibleToMonitorSpecificScaling()) {
+			rescaleAtRuntime.setEnabled(false);
+			Font font = parent.getFont();
+			Composite note = createNoteComposite(font, parent, WorkbenchMessages.Preference_note,
+					WorkbenchMessages.RescaleAtRuntimeDisabledDescription);
+			note.setLayoutData(GridDataFactory.swtDefaults().span(2, 1).create());
+		} else {
+			rescaleAtRuntime.setToolTipText(WorkbenchMessages.RescaleAtRuntimeDescription);
+		}
 	}
 
 	private void createThemeIndependentComposits(Composite comp) {

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
@@ -503,7 +503,10 @@ ThemeChangeWarningTitle = Theme Changed
 RescaleAtRuntimeSettingChangeWarningTitle = DPI Setting Changed
 RescaleAtRuntimeSettingChangeWarningText = Restart for the DPI setting changes to take effect
 RescaleAtRuntimeDescription = Activating this option will dynamically scale all windows according to the monitor they are currently in
+RescaleAtRuntimeDisabledDescription = Incompatible value for system property "swt.autoScale" is defined
 RescaleAtRuntimeEnabled = Use monitor-specific UI &scaling
+RescaleAtRuntimeIncompatibilityTitle = Monitor-Specific Scaling Deactivated
+RescaleAtRuntimeIncompatibilityDescription = Monitor-specific scaling is currently active but an incompatible "swt.autoScale" value is defined. For this reason, monitor-specific scaling has been disabled. Please review your auto-scaling configuration.
 # --- Workbench -----
 WorkbenchPreference_openMode=Open mode
 WorkbenchPreference_doubleClick=D&ouble click


### PR DESCRIPTION
These changes have following affects:

- Upon starting eclipse product when monitor-specific scaling is set with unsupported autoscale mode, it will show a error dialog and application won't start.
- User won't be able to enable monitor-specific scaling from appearance page if unsupported autoscale mode is set from property or ini file.
- User can then either force the unsupported autoscale mode with monitor specific-scaling by setting swt.autoScale.force to true or switch to supported autoscale mode.

### Testing

___

**Scenario#1:** Starting application with  `-Dswt.autoScale=int200`

Result: App should start (if monitor-specific scaling is not checked in Appearance page), but option to turn on monitor-specific scaling in **Appearance** page should be disabled.

<img width="615" height="433" alt="image" src="https://github.com/user-attachments/assets/44cab437-06b6-4e94-98d6-edc9344e7291" />

___

**Scenario#2:** Starting application with  `-Dswt.autoScale=int200` and  `-Dswt.autoScale.updateOnRuntime=true`

Result: App will start, user will see an error dialog stating the incompatibility of an option and monitor specific-scaling will be disabled.

<img width="842" height="252" alt="image" src="https://github.com/user-attachments/assets/76affe0b-cf91-4b9b-8d18-7b392513f6d7" />

___

**Scenario#3:** Starting application with  `-Dswt.autoScale=int200` and  `-Dswt.autoScale.updateOnRuntime=true` 
 and `-Dswt.autoScale.force=true`

Result: makes more sense with swt applications. if user really wants to use other scaling mode with monitor-specific scaling.

```
import org.eclipse.swt.widgets.*;

public class AutoScaleSnippet {

public static void main (String [] args) {
	System.setProperty("swt.autoScale.updateOnRuntime", "true");
	System.setProperty("swt.autoScale", "int200");
	System.setProperty("swt.autoScale.force", "true");
	Display display = new Display ();
	Shell shell = new Shell(display);
	shell.setText("Autoscale snippet");
	shell.open ();
	while (!shell.isDisposed ()) {
		if (!display.readAndDispatch ()) display.sleep ();
	}
	display.dispose ();
}
```
___

**Scenario#4:** Starting application with  `-Dswt.autoScale=quarter` 

Result: App should start, and user should be able to turn on/off the monitor-specific scaling in **Appearance** page.

<img width="1513" height="853" alt="image" src="https://github.com/user-attachments/assets/9c0e2cd3-9701-4ce1-b2d3-116162a779f0" />

___

**Note: following is the list of allowed autoscale values to be paired with monitor-specific scaling: ["false", "quarter", "exact"]** or ***any concrete zoom value e.g. 225***

### Dependency

- [x] Requires: https://github.com/eclipse-platform/eclipse.platform.swt/pull/2709