### PR TITLE
Add support for nested problems display for hierarchical projects

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ExtendedMarkersView.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ExtendedMarkersView.java
@@ -24,11 +24,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.core.commands.operations.IUndoContext;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.Assert;
@@ -1642,16 +1645,35 @@ public class ExtendedMarkersView extends ViewPart {
 			}
 			// try to adapt them in resources and add it to the
 			// selectedElements
-			List<Object> selectedElements = new ArrayList<>();
+			Set<Object> selectedElements = new LinkedHashSet<>();
 			for (Object object : objectsToAdapt) {
 				Object resElement = MarkerResourceUtil.adapt2ResourceElement(object);
 				if (resElement != null) {
 					selectedElements.add(resElement);
 				}
 			}
+			if (isProjectNestingActive(part)) {
+				List<IProject> selectedProjects = selectedElements.stream().filter(IProject.class::isInstance)
+						.map(IProject.class::cast).toList();
+				if (!selectedProjects.isEmpty()) {
+					selectedElements.addAll(MarkerResourceUtil.getNestedChildProjects(selectedProjects));
+				}
+			}
 			MarkerContentGenerator gen = view.getGenerator();
 			gen.updateSelectedResource(selectedElements.toArray(), part == null);
 		}
+
+	}
+
+	/**
+	 * Check if project nesting is active for this marker view
+	 *
+	 * @param part the currently selected part
+	 * @return <code>true</code> if nesting should be performed, <code>false</code>
+	 *         otherwise
+	 */
+	protected boolean isProjectNestingActive(IWorkbenchPart part) {
+		return false;
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ProblemsView.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ProblemsView.java
@@ -17,9 +17,11 @@ import org.eclipse.core.commands.operations.IUndoContext;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.ide.undo.WorkspaceUndoUtil;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.ide.IDEInternalWorkbenchImages;
+import org.eclipse.ui.navigator.CommonNavigator;
 import org.eclipse.ui.views.markers.MarkerSupportView;
 import org.eclipse.ui.views.markers.internal.MarkerMessages;
 import org.eclipse.ui.views.markers.internal.MarkerSupportRegistry;
@@ -62,6 +64,16 @@ public class ProblemsView extends MarkerSupportView {
 	protected String getDeleteOperationName(IMarker[] markers) {
 		Assert.isLegal(markers.length > 0);
 		return markers.length == 1 ? MarkerMessages.deleteProblemMarker_operationName : MarkerMessages.deleteProblemMarkers_operationName;
+	}
+
+	@Override
+	protected boolean isProjectNestingActive(IWorkbenchPart part) {
+		if (part instanceof CommonNavigator navigator) {
+			return navigator.getNavigatorContentService().getActivationService().isNavigatorExtensionActive(
+					"org.eclipse.ui.navigator.resources.nested.nestedProjectContentProvider"); //$NON-NLS-1$
+
+		}
+		return false;
 	}
 
 }


### PR DESCRIPTION
Currently if one select in Project Explorer to display projects not only flat but hierarchical and choose the "Problems on selected Project" filtering (but other filters are affected as well) the following happens:

- We have Project `P` with nested projects `X`, `Y`, `Z`
- `Y` has a compile problem and `X` has warnings
- Now `P` shows a red icon because it has problems of type error inherited
- I select `P` but Problems View remains empty
- One has to first expand `P`, then locate `Y` and select it
- To see the warning I have to locate `X` and select it

so there is an inconsistency (`P` shows problems icon but problems view is empty) and an inconvenience (I need to select individual childs to see all problems/warnings on a parent of nested projects).

This now enhances the `ExtendedMarkersView` by a method `isProjectNestingActive` (returns false by default) to allow view extensions to decide if they want to enable discovery of nested projects or not. The `ProblemsView` is further enhanced to detect the situation and returns true for this particular case.

See also https://bugs.eclipse.org/bugs/show_bug.cgi?id=573535

## Before

<img width="920" height="622" alt="grafik" src="https://github.com/user-attachments/assets/dd17f8ae-2d43-4617-83a8-9d95e67f6cff" />


## After

<img width="1013" height="669" alt="grafik" src="https://github.com/user-attachments/assets/265bb23a-02a6-4d54-a2f0-818386a9f770" />
