### PR TITLE
Revert "Workaround for unexpected scrollbars in MultipleHyperlink"

### DIFF
--- a/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.text
-Bundle-Version: 3.29.0.qualifier
+Bundle-Version: 3.29.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/hyperlink/MultipleHyperlinkPresenter.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/hyperlink/MultipleHyperlinkPresenter.java
@@ -153,14 +153,6 @@ public class MultipleHyperlinkPresenter extends DefaultHyperlinkPresenter implem
 			fForegroundColor= foregroundColor;
 			fBackgroundColor= backgroundColor;
 			create();
-			getShell().addListener(SWT.ZoomChanged, event -> {
-				final Shell shell= getShell();
-				shell.getDisplay().asyncExec(() -> {
-					if (!shell.isDisposed()) {
-						shell.setSize(computeSizeHint());
-					}
-				});
-			});
 		}
 
 		@Override
@@ -228,13 +220,6 @@ public class MultipleHyperlinkPresenter extends DefaultHyperlinkPresenter implem
 			int width;
 			if (preferedSize.y - scrollBarHeight <= constraints.y) {
 				width= preferedSize.x - scrollBarWidth;
-				if (Util.isWin32()) {
-					/*
-					 * compensate rounding issue in windows
-					 * +1 for preferedSize and +1 for scrollBarWidth
-					 */
-					width+= 2;
-				}
 				fTable.getVerticalBar().setVisible(false);
 			} else {
 				width= Math.min(preferedSize.x, constraints.x);
@@ -243,13 +228,6 @@ public class MultipleHyperlinkPresenter extends DefaultHyperlinkPresenter implem
 			int height;
 			if (preferedSize.x - scrollBarWidth <= constraints.x) {
 				height= preferedSize.y - scrollBarHeight;
-				if (Util.isWin32()) {
-					/*
-					 * compensate rounding issue in windows
-					 * +1 for preferedSize and +1 for scrollBarHeight
-					 */
-					height+= 2;
-				}
 				fTable.getHorizontalBar().setVisible(false);
 			} else {
 				height= Math.min(preferedSize.y, constraints.y);


### PR DESCRIPTION
The workaround was introduced to resolved the unexpected scrollbars in MultiHyperLinks but later it was fixed as a result of fix in https://github.com/eclipse-platform/eclipse.platform.swt/commit/56379d5edf29a33b9b7cd4d639a921f2b2465820

### How to test
Use this Snippet and open it on a 225% monitor.

```
package test;

public class TestClass {
	public static void main(String[] args) {
		// TODO Auto-generated method stub
	}
}
```

Hover over main and press control key. 

### Result

I have tested it with primary monitor = 150% and secondary = 125, 150, 175, 200, 225, 250, 300. 

