### PR TITLE
Migrate CloseTestWindowsRule to JUnit 5 and migrate all related tests

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.harness/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Harness Plug-in
 Bundle-SymbolicName: org.eclipse.ui.tests.harness;singleton:=true
-Bundle-Version: 1.10.600.qualifier
+Bundle-Version: 1.10.700.qualifier
 Eclipse-BundleShape: dir
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/CloseTestWindowsExtension.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/CloseTestWindowsExtension.java
@@ -1,0 +1,208 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Rolf Theunissen <rolf.theunissen@gmail.com> - Bug 553836 (extracted from UITestCase)
+ *******************************************************************************/
+
+package org.eclipse.ui.tests.harness.util;
+
+import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IWindowListener;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit 5 Extension for UI tests to clean up windows/shells:
+ * <ul>
+ * <li>prints the test name to the log before and after each test case
+ * <li>closes windows opened during the test case
+ * <li>checks for shells unintentionally leaked from the test case
+ * </ul>
+ */
+public class CloseTestWindowsExtension implements BeforeEachCallback, AfterEachCallback {
+
+	private static final String TEST_NAME_KEY = "testName";
+	private static final String TEST_WINDOWS_KEY = "testWindows";
+	private static final String WINDOW_LISTENER_KEY = "windowListener";
+	private static final String INITIAL_SHELLS_KEY = "initialShells";
+	private static final String LEAK_CHECKS_DISABLED_KEY = "leakChecksDisabled";
+
+	@Override
+	public void beforeEach(ExtensionContext context) throws Exception {
+		String testName = context.getDisplayName();
+		context.getStore(ExtensionContext.Namespace.create(getClass(), context.getUniqueId()))
+				.put(TEST_NAME_KEY, testName);
+
+		List<IWorkbenchWindow> testWindows = new ArrayList<>(3);
+		context.getStore(ExtensionContext.Namespace.create(getClass(), context.getUniqueId()))
+				.put(TEST_WINDOWS_KEY, testWindows);
+
+		TestWindowListener windowListener = new TestWindowListener(testWindows);
+		context.getStore(ExtensionContext.Namespace.create(getClass(), context.getUniqueId()))
+				.put(WINDOW_LISTENER_KEY, windowListener);
+
+		addWindowListener(windowListener);
+		storeInitialShells(context);
+		trace(TestRunLogUtil.formatTestStartMessage(testName));
+	}
+
+	@Override
+	public void afterEach(ExtensionContext context) throws Exception {
+		String testName = getTestName(context);
+		trace(TestRunLogUtil.formatTestFinishedMessage(testName));
+
+		TestWindowListener windowListener = getWindowListener(context);
+		removeWindowListener(windowListener);
+
+		processEvents();
+		closeAllTestWindows(context);
+		processEvents();
+		checkForLeakedShells(context);
+	}
+
+	/**
+	 * Outputs a trace message to the trace output device, if enabled. By default,
+	 * trace messages are sent to <code>System.out</code>.
+	 *
+	 * @param msg the trace message
+	 */
+	private static void trace(String msg) {
+		System.out.println(msg);
+	}
+
+	/**
+	 * Adds a window listener to the workbench to keep track of opened test windows.
+	 */
+	private void addWindowListener(TestWindowListener windowListener) {
+		PlatformUI.getWorkbench().addWindowListener(windowListener);
+	}
+
+	/**
+	 * Removes the listener.
+	 */
+	private void removeWindowListener(TestWindowListener windowListener) {
+		if (windowListener != null) {
+			PlatformUI.getWorkbench().removeWindowListener(windowListener);
+		}
+	}
+
+	/**
+	 * Close all test windows.
+	 */
+	private void closeAllTestWindows(ExtensionContext context) {
+		@SuppressWarnings("unchecked")
+		List<IWorkbenchWindow> testWindows = (List<IWorkbenchWindow>) context
+				.getStore(ExtensionContext.Namespace.create(getClass(), context.getUniqueId()))
+				.get(TEST_WINDOWS_KEY);
+
+		if (testWindows != null) {
+			List<IWorkbenchWindow> testWindowsCopy = new ArrayList<>(testWindows);
+			for (IWorkbenchWindow testWindow : testWindowsCopy) {
+				testWindow.close();
+			}
+			testWindows.clear();
+		}
+	}
+
+	private static class TestWindowListener implements IWindowListener {
+		private final List<IWorkbenchWindow> testWindows;
+
+		public TestWindowListener(List<IWorkbenchWindow> testWindows) {
+			this.testWindows = testWindows;
+		}
+
+		@Override
+		public void windowActivated(IWorkbenchWindow window) {
+			// do nothing
+		}
+
+		@Override
+		public void windowDeactivated(IWorkbenchWindow window) {
+			// do nothing
+		}
+
+		@Override
+		public void windowClosed(IWorkbenchWindow window) {
+			testWindows.remove(window);
+		}
+
+		@Override
+		public void windowOpened(IWorkbenchWindow window) {
+			testWindows.add(window);
+		}
+	}
+
+	private void storeInitialShells(ExtensionContext context) {
+		Set<Shell> initialShells = Set.of(PlatformUI.getWorkbench().getDisplay().getShells());
+		context.getStore(ExtensionContext.Namespace.create(getClass(), context.getUniqueId()))
+				.put(INITIAL_SHELLS_KEY, initialShells);
+	}
+
+	private void checkForLeakedShells(ExtensionContext context) {
+		@SuppressWarnings("unchecked")
+		Set<Shell> initialShells = (Set<Shell>) context
+				.getStore(ExtensionContext.Namespace.create(getClass(), context.getUniqueId()))
+				.get(INITIAL_SHELLS_KEY);
+
+		Boolean leakChecksDisabled = (Boolean) context
+				.getStore(ExtensionContext.Namespace.create(getClass(), context.getUniqueId()))
+				.get(LEAK_CHECKS_DISABLED_KEY);
+
+		if (initialShells == null) {
+			return;
+		}
+
+		List<String> leakedModalShellTitles = new ArrayList<>();
+		Shell[] shells = PlatformUI.getWorkbench().getDisplay().getShells();
+		for (Shell shell : shells) {
+			if (!shell.isDisposed() && !initialShells.contains(shell)) {
+				leakedModalShellTitles.add(shell.getText());
+				shell.close();
+			}
+		}
+
+		if (leakChecksDisabled == null || !leakChecksDisabled) {
+			assertEquals(0, leakedModalShellTitles.size(),
+					"Test leaked modal shell: [" + String.join(", ", leakedModalShellTitles) + "]");
+		}
+	}
+
+	/**
+	 * Disable leak checks for the current test.
+	 * This method should be called from test methods when needed.
+	 */
+	public void disableLeakChecks(ExtensionContext context) {
+		context.getStore(ExtensionContext.Namespace.create(getClass(), context.getUniqueId()))
+				.put(LEAK_CHECKS_DISABLED_KEY, Boolean.TRUE);
+	}
+
+	private String getTestName(ExtensionContext context) {
+		return (String) context.getStore(ExtensionContext.Namespace.create(getClass(), context.getUniqueId()))
+				.get(TEST_NAME_KEY);
+	}
+
+	private TestWindowListener getWindowListener(ExtensionContext context) {
+		return (TestWindowListener) context
+				.getStore(ExtensionContext.Namespace.create(getClass(), context.getUniqueId()))
+				.get(WINDOW_LISTENER_KEY);
+	}
+}

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/CloseTestWindowsRule.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/CloseTestWindowsRule.java
@@ -37,7 +37,11 @@ import org.junit.runners.model.Statement;
  * <li>closes windows opened during the test case
  * <li>checks for shells unintentionally leaked from the test case
  * </ul>
+ *
+ * @deprecated Use {@link CloseTestWindowsExtension} with JUnit 5 instead.
+ *             This class is kept for backward compatibility with JUnit 4 tests.
  */
+@Deprecated
 public class CloseTestWindowsRule extends ExternalResource {
 
 	private String testName;

--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/UITestCase.java
@@ -16,15 +16,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.harness.util;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * <code>UITestCase</code> is a useful super class for most
@@ -32,55 +26,16 @@ import junit.framework.TestCase;
  * and pages.  It will also automatically close the test
  * windows when the tearDown method is called.
  */
-public abstract class UITestCase extends TestCase {
-
-	/**
-	 * Rule to close windows opened during the test case, manually called to remain
-	 * compatible with JUnit3
-	 */
-	private final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
-
-	/**
-	 * Required to preserve the existing logging output when running tests with
-	 * {@link BlockJUnit4ClassRunner}.
-	 */
-	@Rule
-	public TestWatcher testWatcher = new TestWatcher() {
-		@Override
-		protected void starting(Description description) {
-			runningTest = description.getMethodName();
-		}
-		@Override
-		protected void finished(Description description) {
-			runningTest = null;
-		}
-	};
-	/**
-	 * Name of the currently executed test method. Only valid if test is executed
-	 * with {@link BlockJUnit4ClassRunner}.
-	 */
-	private String runningTest = null;
-
-	public UITestCase(String testName) {
-		super(testName);
-	}
+@ExtendWith(CloseTestWindowsExtension.class)
+public abstract class UITestCase {
 
 	/**
 	 * Simple implementation of setUp. Subclasses are prevented from overriding this
 	 * method to maintain logging consistency. doSetUp() should be overridden
 	 * instead.
-	 * <p>
-	 * This method is public and annotated with {@literal @}{@link Before} to setup
-	 * tests which are configured to {@link RunWith} JUnit4 runner.
-	 * </p>
 	 */
-	@Before
-	@Override
+	@BeforeEach
 	public final void setUp() throws Exception {
-		super.setUp();
-		String name = runningTest != null ? runningTest : this.getName();
-		closeTestWindows.setTestName(name);
-		closeTestWindows.before();
 		doSetUp();
 	}
 
@@ -98,16 +53,10 @@ public abstract class UITestCase extends TestCase {
 	 * Simple implementation of tearDown. Subclasses are prevented from overriding
 	 * this method to maintain logging consistency. doTearDown() should be
 	 * overridden instead.
-	 * <p>
-	 * This method is public and annotated with {@literal @}{@link After} to setup
-	 * tests which are configured to {@link RunWith} JUnit4 runner.
-	 * </p>
 	 */
-	@After
-	@Override
+	@AfterEach
 	public final void tearDown() throws Exception {
 		doTearDown();
-		closeTestWindows.after();
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/GoBackForwardsTest.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/GoBackForwardsTest.java
@@ -15,7 +15,7 @@ package org.eclipse.ui.tests.navigator;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEventsUntil;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -36,26 +36,28 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.NavigationHistoryAction;
 import org.eclipse.ui.intro.IIntroPart;
 import org.eclipse.ui.part.FileEditorInput;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.EditorTestHelper;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.tests.harness.util.UITestUtil.Condition;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
 import org.eclipse.ui.texteditor.TextSelectionNavigationLocation;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.3
  *
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class GoBackForwardsTest {
 
 	private static final String PROJECT_NAME = "GoBackForwardsTestProject";
 	private static final String FILE_NAME = "GoBackForwardsTestFile.java";
-	private static final String FILE_CONTENTS = "public class GoBackForwardsTestFile {\n"
+	private static final String FILE_CONTENTS = "@ExtendWith(CloseTestWindowsExtension.class)
+public class GoBackForwardsTestFile {\n"
 			+ "    public static void main(String[] args) {\n" + "        System.out.println(\"Hello world!\");\n"
 			+ "    }\n" + "}";
 	private static final String GENERIC_EDITOR_ID = "org.eclipse.ui.genericeditor.GenericEditor";
@@ -65,10 +67,9 @@ public class GoBackForwardsTest {
 	private IProject project;
 	private IFile file;
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
-	@Before
+	@BeforeEach
 	public void setUp() throws CoreException, IOException {
 		project = FileUtil.createProject(PROJECT_NAME);
 		file = FileUtil.createFile(FILE_NAME, project);

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FileImageDescriptorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/FileImageDescriptorTest.java
@@ -27,20 +27,20 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.test.performance.PerformanceTestCaseJunit4;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * ComboViewerRefreshTest is a test of refreshes of difference size in the combo
  * viewer.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class FileImageDescriptorTest extends PerformanceTestCaseJunit4 {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	protected static final String IMAGES_DIRECTORY = "/icons/imagetests";
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListPopulationTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListPopulationTest.java
@@ -23,18 +23,18 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.List;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.test.performance.PerformanceTestCaseJunit4;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * The ListPopulationTest is the test for simple
  * SWT lists.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ListPopulationTest extends PerformanceTestCaseJunit4 {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	List list;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ProgressMonitorDialogPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ProgressMonitorDialogPerformanceTest.java
@@ -21,22 +21,22 @@ import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.test.performance.PerformanceTestCaseJunit4;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.performance.UIPerformanceTestRule;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.3
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ProgressMonitorDialogPerformanceTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	/**
 	 * Test the time for doing a refresh.

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/SWTTreeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/SWTTreeTest.java
@@ -24,14 +24,14 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.test.performance.PerformanceTestCaseJunit4;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class SWTTreeTest extends PerformanceTestCaseJunit4 {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	Shell browserShell;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ViewerTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ViewerTest.java
@@ -22,22 +22,22 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.test.performance.PerformanceTestCaseJunit4;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.performance.UIPerformanceTestRule;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.ClassRule;
-import org.junit.Rule;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * The LinearViewerTest is a test that tests viewers.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public abstract class ViewerTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	Shell browserShell;
 
@@ -81,7 +81,7 @@ public abstract class ViewerTest extends PerformanceTestCaseJunit4 {
 		};
 	}
 
-	@After
+	@AfterEach
 	public final void closeBrowserShell() throws Exception {
 		if(browserShell!= null){
 			browserShell.close();

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/CommandsPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/CommandsPerformanceTest.java
@@ -36,12 +36,12 @@ import org.eclipse.jface.bindings.keys.KeyStroke;
 import org.eclipse.jface.bindings.keys.ParseException;
 import org.eclipse.jface.util.Util;
 import org.eclipse.test.performance.PerformanceTestCaseJunit4;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Before;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * <p>
@@ -58,8 +58,7 @@ public final class CommandsPerformanceTest extends PerformanceTestCaseJunit4 {
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	/**
 	 * <p>
@@ -184,7 +183,7 @@ public final class CommandsPerformanceTest extends PerformanceTestCaseJunit4 {
 	 * @throws NotDefinedException
 	 *             If something went wrong initializing the active scheme.
 	 */
-	@Before
+	@BeforeEach
 	public final void setUpBindings() throws NotDefinedException, Exception {
 		/*
 		 * The constants to use in creating the various objects. The platform
@@ -352,7 +351,7 @@ public final class CommandsPerformanceTest extends PerformanceTestCaseJunit4 {
 		bindingManager.setBindings(bindings);
 	}
 
-	@After
+	@AfterEach
 	public final void clearBindings() throws Exception {
 		bindingManager = null;
 		commandManager = null;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/EditorSwitchTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/EditorSwitchTest.java
@@ -17,7 +17,7 @@ import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestRule.getTestProject;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.waitForBackgroundJobs;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -28,25 +28,25 @@ import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.ide.IDE;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test editor switching.
  */
 @RunWith(Parameterized.class)
+@ExtendWith(CloseTestWindowsExtension.class)
 public class EditorSwitchTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private final String extension1;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/GenerateIdentifiersTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/GenerateIdentifiersTest.java
@@ -19,21 +19,21 @@ import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
 
 import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.activities.IActivityManager;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.1
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class GenerateIdentifiersTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private static final int count = 10000;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/LabelProviderTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/LabelProviderTest.java
@@ -48,15 +48,15 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.test.performance.PerformanceTestCaseJunit4;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Before;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test scrolling performance with various label styles
@@ -64,13 +64,13 @@ import org.junit.runners.Parameterized.Parameters;
  * @since 3.5
  */
 @RunWith(Parameterized.class)
+@ExtendWith(CloseTestWindowsExtension.class)
 public class LabelProviderTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private static class CountryEntry {
 		private final String name;
@@ -253,7 +253,7 @@ public class LabelProviderTest extends PerformanceTestCaseJunit4 {
 		return viewer;
 	}
 
-	@Before
+	@BeforeEach
 	public final void prepareShellUp() throws Exception {
 		Display display = Display.getCurrent();
 		if (display == null)
@@ -273,7 +273,7 @@ public class LabelProviderTest extends PerformanceTestCaseJunit4 {
 		fShell.open();
 	}
 
-	@After
+	@AfterEach
 	public final void closeShell() throws Exception {
 		if (fShell != null) {
 			fShell.close();

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseEditorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseEditorTest.java
@@ -18,7 +18,7 @@ import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestRule.getTestProject;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -31,22 +31,22 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.ide.IDE;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @RunWith(Parameterized.class)
+@ExtendWith(CloseTestWindowsExtension.class)
 public class OpenCloseEditorTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private final String extension;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenClosePerspectiveTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenClosePerspectiveTest.java
@@ -41,23 +41,23 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.internal.WorkbenchPlugin;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @RunWith(Parameterized.class)
+@ExtendWith(CloseTestWindowsExtension.class)
 public class OpenClosePerspectiveTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private final String id;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseViewTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseViewTest.java
@@ -24,13 +24,13 @@ import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Performance tests for showing views.
@@ -39,13 +39,13 @@ import org.junit.runners.Parameterized.Parameters;
  * The views are shown in an empty perspective.
  */
 @RunWith(Parameterized.class)
+@ExtendWith(CloseTestWindowsExtension.class)
 public class OpenCloseViewTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	@Parameters(name = "{index}: {0}")
 	public static Collection<Object[]> data() {

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseWindowTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseWindowTest.java
@@ -23,23 +23,23 @@ import java.util.Collection;
 
 import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @RunWith(Parameterized.class)
+@ExtendWith(CloseTestWindowsExtension.class)
 public class OpenCloseWindowTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private final String id;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenMultipleEditorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenMultipleEditorTest.java
@@ -27,25 +27,25 @@ import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.ide.IDE;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.1
  */
 @RunWith(Parameterized.class)
+@ExtendWith(CloseTestWindowsExtension.class)
 public class OpenMultipleEditorTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private final String extension;
 	private final boolean closeAll;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/PerspectiveSwitchTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/PerspectiveSwitchTest.java
@@ -17,8 +17,8 @@ import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestRule.getTestProject;
 import static org.eclipse.ui.tests.performance.UIPerformanceTestUtil.exercise;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -33,25 +33,25 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.WorkbenchException;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.WorkbenchPlugin;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test perspective switching.
  */
 @RunWith(Parameterized.class)
+@ExtendWith(CloseTestWindowsExtension.class)
 public class PerspectiveSwitchTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private final String id1;
 	private final String id2;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProblemsViewPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProblemsViewPerformanceTest.java
@@ -16,7 +16,7 @@ package org.eclipse.ui.tests.performance;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,21 +30,21 @@ import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.performance.parts.PerformanceProblemsView;
 import org.eclipse.ui.texteditor.MarkerUtilities;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * The ProblemsViewPerformanceTest is a test of population of the problems view.
  *
  * @since 3.2
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ProblemsViewPerformanceTest extends PerformanceTestCaseJunit4 {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private final String EMPTY_PERSPECTIVE_ID = "org.eclipse.ui.tests.harness.util.EmptyPerspective";
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProgressReportingTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/ProgressReportingTest.java
@@ -28,24 +28,24 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.IPreferenceConstants;
 import org.eclipse.ui.internal.WorkbenchPlugin;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Verifies the performance of progress reporting APIs in various contexts which
  * offer progress monitoring.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ProgressReportingTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	/**
 	 * Number of iterations to run for the inner loop in these tests. This
@@ -84,7 +84,7 @@ public class ProgressReportingTest extends PerformanceTestCaseJunit4 {
 	private volatile boolean isDone;
 	private Display display;
 
-	@Before
+	@BeforeEach
 	public final void storeDisplay() throws Exception {
 		this.display = Display.getCurrent();
 	}

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ComputeSizeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ComputeSizeTest.java
@@ -21,19 +21,19 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.WorkbenchException;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Measures the performance of a widget's computeSize method
  *
  * @since 3.1
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ComputeSizeTest extends PerformanceTestCaseJunit4 {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private final TestWidgetFactory widgetFactory;
 	private final int xIterations = 10;

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/LayoutTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/LayoutTest.java
@@ -22,9 +22,9 @@ import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.WorkbenchException;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Measures the time required to layout the widget 10 times. Does not include
@@ -32,10 +32,10 @@ import org.junit.Test;
  *
  * @since 3.1
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class LayoutTest extends PerformanceTestCaseJunit4 {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private final TestWidgetFactory widgetFactory;
 

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ResizeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/ResizeTest.java
@@ -27,16 +27,16 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCaseJunit4;
 import org.eclipse.ui.WorkbenchException;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
 import org.eclipse.ui.tests.performance.UIPerformanceTestRule;
 import org.eclipse.ui.tests.performance.ViewPerformanceUtil;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Measures the time to resize the widget 10 times, including the time required
@@ -45,13 +45,13 @@ import org.junit.runners.Parameterized.Parameters;
  * @since 3.1
  */
 @RunWith(Parameterized.class)
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ResizeTest extends PerformanceTestCaseJunit4 {
 
 	@ClassRule
 	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private static String RESOURCE_PERSPID = "org.eclipse.ui.resourcePerspective";
 	// Note: to test perspective switching properly, we need perspectives with lots

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/activities/MenusTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/activities/MenusTest.java
@@ -15,10 +15,10 @@
 package org.eclipse.ui.tests.activities;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import java.util.Set;
@@ -30,13 +30,14 @@ import org.eclipse.ui.menus.CommandContributionItem;
 import org.eclipse.ui.menus.IContributionRoot;
 import org.eclipse.ui.menus.IMenuService;
 import org.eclipse.ui.services.IServiceLocator;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class MenusTest {
 
 	private TestFactory factory;
@@ -44,8 +45,7 @@ public class MenusTest {
 	private IMenuService service;
 	private Set<String> enabledActivities;
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	/**
 	 * @since 3.3
@@ -87,7 +87,7 @@ public class MenusTest {
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public void doSetUp() throws Exception {
 		window = openTestWindow();
 		enabledActivities = window.getWorkbench().getActivitySupport()
@@ -96,7 +96,7 @@ public class MenusTest {
 		assertNotNull(service);
 	}
 
-	@After
+	@AfterEach
 	public void doTearDown() throws Exception {
 		window.getWorkbench().getActivitySupport().setEnabledActivityIds(
 				enabledActivities);
@@ -131,7 +131,7 @@ public class MenusTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestMenuVisibilityWithCustomFactory() {
 		window.getWorkbench().getActivitySupport().setEnabledActivityIds(
 				Collections.singleton("menuTest1")); // enable the foo

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/AdaptableDecoratorTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/AdaptableDecoratorTestCase.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.adaptable;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 
@@ -32,19 +32,19 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.decorators.DecoratorDefinition;
 import org.eclipse.ui.internal.decorators.DecoratorManager;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @version 1.0
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class AdaptableDecoratorTestCase implements ILabelProviderListener {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private DecoratorDefinition fullDefinition;
 
@@ -60,7 +60,7 @@ public class AdaptableDecoratorTestCase implements ILabelProviderListener {
 
 	protected IFile testFile;
 
-	@Before
+	@BeforeEach
 	public void doSetUp() throws Exception {
 		createTestFile();
 		showAdaptedNav();
@@ -85,7 +85,7 @@ public class AdaptableDecoratorTestCase implements ILabelProviderListener {
 		return WorkbenchPlugin.getDefault().getDecoratorManager();
 	}
 
-	@After
+	@AfterEach
 	public void doTearDown() throws Exception {
 		if (testProject != null) {
 			testProject.delete(true, null);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/WorkingSetTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/adaptable/WorkingSetTestCase.java
@@ -14,9 +14,9 @@
 package org.eclipse.ui.tests.adaptable;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.internal.propertytester.ResourceMappingPropertyTester;
 import org.eclipse.core.resources.IProject;
@@ -30,18 +30,18 @@ import org.eclipse.ui.IResourceActionFilter;
 import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.IWorkingSetManager;
 import org.eclipse.ui.model.IWorkbenchAdapter;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestName;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test that Working Sets adapt to resource mappings
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class WorkingSetTestCase {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	@Rule
 	public final TestName testName = new TestName();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/Bug407422Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/Bug407422Test.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,18 +31,18 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.part.FileEditorInput;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.5
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug407422Test {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	@Test
 	public void test() throws CoreException {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IActionBarsTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IActionBarsTest.java
@@ -14,10 +14,10 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.NotEnabledException;
@@ -36,22 +36,22 @@ import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.internal.handlers.IActionCommandMappingService;
 import org.eclipse.ui.tests.harness.util.ActionUtil;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test the lifecycle of an action delegate.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IActionBarsTest {
 
 	private IWorkbenchWindow fWindow;
 
 	private IWorkbenchPage fPage;
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private static class MockAction extends Action {
 		public boolean hasRun = false;
@@ -67,7 +67,7 @@ public class IActionBarsTest {
 	}
 
 
-	@Before
+	@BeforeEach
 	public void doSetUp() throws Exception {
 		fWindow = openTestWindow();
 		fPage = fWindow.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IActionDelegateTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IActionDelegateTest.java
@@ -14,32 +14,32 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test the lifecycle of an action delegate.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public abstract class IActionDelegateTest {
 
 	protected IWorkbenchWindow fWindow;
 
 	protected IWorkbenchPage fPage;
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
-	@Before
+	@BeforeEach
 	public void doSetUp() throws Exception {
 		fWindow = openTestWindow();
 		fPage = fWindow.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IActionFilterTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IActionFilterTest.java
@@ -14,9 +14,9 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.swt.SWT;
@@ -24,10 +24,10 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.tests.harness.util.ActionUtil;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test the lifecycle of an action filter.
@@ -45,10 +45,10 @@ import org.junit.Test;
  * 		redTrueAction -&gt; (name = red) (flag = true)
  * </pre>
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IActionFilterTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	protected IWorkbenchWindow fWindow;
 
@@ -58,7 +58,7 @@ public class IActionFilterTest {
 
 	protected String DYNAMIC_MENU_VIEW_ID = "org.eclipse.ui.tests.api.IActionFilterTest2";
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWindow = openTestWindow();
 		fPage = fWindow.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IAggregateWorkingSetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IAggregateWorkingSetTest.java
@@ -15,11 +15,11 @@ package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.waitForJobs;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -42,21 +42,21 @@ import org.eclipse.ui.internal.AbstractWorkingSet;
 import org.eclipse.ui.internal.AbstractWorkingSetManager;
 import org.eclipse.ui.internal.AggregateWorkingSet;
 import org.eclipse.ui.internal.IWorkbenchConstants;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IAggregateWorkingSetTest {
 
 	static final String WORKING_SET_NAME = "testws";
 	static final String AGGREGATE_WORKING_SET_NAME_ = "testaggregatews";
 	static final String WSET_PAGE_ID="org.eclipse.ui.resourceWorkingSetPage";
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	IWorkspace fWorkspace;
 	IWorkbench fWorkbench;
@@ -65,7 +65,7 @@ public class IAggregateWorkingSetTest {
 	List<IWorkingSet> backup;
 	IAggregateWorkingSet fWorkingSet;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		IWorkingSetManager workingSetManager = PlatformUI.getWorkbench().getWorkingSetManager();
 		backup = Arrays.asList(workingSetManager.getAllWorkingSets());
@@ -85,7 +85,7 @@ public class IAggregateWorkingSetTest {
 		workingSetManager.addWorkingSet(fWorkingSet);
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		IWorkingSetManager workingSetManager = fWorkbench.getWorkingSetManager();
 		workingSetManager.removeWorkingSet(fWorkingSet);
@@ -250,7 +250,7 @@ public class IAggregateWorkingSetTest {
 	 */
 	/* TODO test must be enabled after bug 479217 is fixed */
 	@Test
-	@Ignore("Bug 479217")
+	@Disabled("Bug 479217")
 	public void XXXtestWorkingSetSaveRestoreAggregates() throws Throwable {
 		IWorkingSetManager manager = fWorkbench.getWorkingSetManager();
 		String nameA = "A";

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IDeprecatedWorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IDeprecatedWorkbenchPageTest.java
@@ -16,11 +16,11 @@ package org.eclipse.ui.tests.api;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.getPageInput;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestPage;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
@@ -39,19 +39,19 @@ import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.tests.harness.util.ArrayUtil;
 import org.eclipse.ui.tests.harness.util.CallHistory;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IDeprecatedWorkbenchPageTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private IWorkbench fWorkbench;
 
@@ -61,14 +61,14 @@ public class IDeprecatedWorkbenchPageTest {
 
 	private IProject proj;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWorkbench = PlatformUI.getWorkbench();
 		fWin = openTestWindow();
 		fActivePage = fWin.getActivePage();
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		if (proj != null) {
 			FileUtil.deleteProject(proj);
@@ -606,7 +606,7 @@ public class IDeprecatedWorkbenchPageTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestClose() throws Throwable {
 		IWorkbenchPage page = openTestPage(fWin);
 
@@ -768,7 +768,7 @@ public class IDeprecatedWorkbenchPageTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestSaveAllEditors() throws Throwable {
 		int total = 3;
 
@@ -848,7 +848,7 @@ public class IDeprecatedWorkbenchPageTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestShowActionSet() {
 		String id = MockActionDelegate.ACTION_SET_ID;
 
@@ -870,7 +870,7 @@ public class IDeprecatedWorkbenchPageTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestHideActionSet() {
 //		int totalBefore = facade.getActionSetCount(fActivePage);
 		// FIXME: No implementation for facade.getActionSetCount()

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorActionBarContributorTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorActionBarContributorTest.java
@@ -14,8 +14,8 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -23,21 +23,21 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.tests.harness.util.CallHistory;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * This is a test for IEditorPart.  Since IEditorPart is an
  * interface this test verifies the IEditorPart lifecycle rather
  * than the implementation.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IEditorActionBarContributorTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	protected IWorkbenchWindow fWindow;
 
@@ -45,7 +45,7 @@ public class IEditorActionBarContributorTest {
 
 	private final String EDITOR_ID = "org.eclipse.ui.tests.api.IEditorActionBarContributorTest";
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWindow = openTestWindow();
 		fPage = fWindow.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorMatchingStrategyTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IEditorMatchingStrategyTest.java
@@ -15,31 +15,31 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.part.FileEditorInput;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests the <code>IEditorMatchingStrategyTest</code> API and behaviour.
  *
  * @since 3.1
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IEditorMatchingStrategyTest {
 
 	private static final String MATCHING_EDITOR_ID = "org.eclipse.ui.tests.api.MockMatchingEditorPart1";
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	@Test
 	public void testOpenMatchingEditor() throws Exception {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPageLayoutTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPageLayoutTest.java
@@ -14,22 +14,22 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test cases for the <code>IPageLayout</code> API.
  *
  * @since 3.2
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IPageLayoutTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	@Test
 	public void testGetDescriptor() {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPageListenerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPageListenerTest.java
@@ -14,28 +14,28 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.ui.IPageListener;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests the IPageListener class.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IPageListenerTest implements IPageListener {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private IWorkbenchWindow fWindow;
 	private IWorkspace fWorkspace;
@@ -50,14 +50,14 @@ public class IPageListenerTest implements IPageListener {
 
 	private IWorkbenchPage pageMask;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWindow = openTestWindow();
 		fWorkspace = ResourcesPlugin.getWorkspace();
 		fWindow.addPageListener(this);
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		fWindow.removePageListener(this);
 	}
@@ -66,7 +66,7 @@ public class IPageListenerTest implements IPageListener {
 	 * Tests the pageOpened method.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testPageOpened() throws Throwable {
 		/*
 		 * Commented out because until test case can be updated to work with new
@@ -88,7 +88,7 @@ public class IPageListenerTest implements IPageListener {
 	 * Tests the pageClosed method.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testPageClosed() throws Throwable {
 		/*
 		 * Commented out because until test case can be updated to work
@@ -111,7 +111,7 @@ public class IPageListenerTest implements IPageListener {
 	 * Tests the pageActivated method.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testPageActivate() throws Throwable {
 		/*
 		 * Commented out because until test case can be updated to work

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPageServiceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPageServiceTest.java
@@ -15,9 +15,9 @@ package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.getPageInput;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -28,20 +28,20 @@ import org.eclipse.ui.IPerspectiveListener;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.ide.IDE;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests the IPageService class.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IPageServiceTest implements IPageListener, org.eclipse.ui.IPerspectiveListener {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private IWorkbenchWindow fWindow;
 
@@ -51,7 +51,7 @@ public class IPageServiceTest implements IPageListener, org.eclipse.ui.IPerspect
 
 	private boolean perspEventReceived;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWindow = openTestWindow();
 		fWorkspace = ResourcesPlugin.getWorkspace();
@@ -88,7 +88,7 @@ public class IPageServiceTest implements IPageListener, org.eclipse.ui.IPerspect
 	 * Tests the addPageListener method.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testAddPageListener() throws Throwable {
 		/*
 		 * Commented out because until test case can be updated to work
@@ -115,7 +115,7 @@ public class IPageServiceTest implements IPageListener, org.eclipse.ui.IPerspect
 	 * Tests the removePageListener method.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestRemovePageListener() throws Throwable {
 		// From Javadoc: "Removes the given page listener.
 		// Has no affect if an identical listener is not registered."
@@ -136,7 +136,7 @@ public class IPageServiceTest implements IPageListener, org.eclipse.ui.IPerspect
 	 * Tests getActivePage.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testGetActivePage() throws Throwable {
 		/*
 		 * Commented out because until test case can be updated to work
@@ -168,7 +168,7 @@ public class IPageServiceTest implements IPageListener, org.eclipse.ui.IPerspect
 	 * Tests the addPerspectiveListener method.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testAddPerspectiveListener() throws Throwable {
 		/*
 		 * Commented out because until test case can be updated to work
@@ -197,7 +197,7 @@ public class IPageServiceTest implements IPageListener, org.eclipse.ui.IPerspect
 	 * Tests the removePerspectiveListener method.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestRemovePerspectiveListener() throws Throwable {
 		// From Javadoc: "Removes the given page's perspective listener.
 		// Has no affect if an identical listener is not registered."

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPartServiceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPartServiceTest.java
@@ -14,11 +14,11 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -38,21 +38,21 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.internal.SlavePartService;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.tests.harness.util.CallHistory;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests the IPartService, IPartListener and IPartListener2 interfaces.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IPartServiceTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private IWorkbenchWindow fWindow;
 
@@ -163,7 +163,7 @@ public class IPartServiceTest {
 		history2.clear();
 	}
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWindow = openTestWindow();
 		fPage = fWindow.getActivePage();
@@ -369,7 +369,7 @@ public class IPartServiceTest {
 	 *   Bug 60039 [ViewMgmt] (regression) IWorkbenchPage#findView returns non-null value after part has been closed
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestPartHiddenWhenClosedAndShared() throws Throwable {
 		IPartListener2 listener = new TestPartListener2() {
 			@Override
@@ -560,7 +560,7 @@ public class IPartServiceTest {
 	 * @since 3.1
 	 */
 	@Test
-	@Ignore("This does not work as expected.  See bug 93784.")
+	@Disabled("This does not work as expected.  See bug 93784.")
 	public void testViewFoundWhenOpened() throws Throwable {
 		final String viewId = MockViewPart.ID;
 		final boolean[] eventReceived = { false, false };

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPerspectiveListenerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IPerspectiveListenerTest.java
@@ -14,7 +14,7 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.ui.IPerspectiveDescriptor;
 import org.eclipse.ui.IPerspectiveListener;
@@ -22,18 +22,18 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IPerspectiveListenerTest implements IPerspectiveListener {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private int fEvent;
 
@@ -51,7 +51,7 @@ public class IPerspectiveListenerTest implements IPerspectiveListener {
 	public static final int NONE = 0x00, OPEN = 0x01, CLOSED = 0x02,
 			ACTIVATED = 0x04, CHANGED = 0x08;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fEvent = NONE;
 		fWorkbench = PlatformUI.getWorkbench();
@@ -59,14 +59,14 @@ public class IPerspectiveListenerTest implements IPerspectiveListener {
 		fWindow.addPerspectiveListener(this);
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		fWindow.removePerspectiveListener(this);
 		fWorkbench = null;
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void testPerspectiveActivated() {
 		/*
 		 * Commented out because until test case can be updated to work with new
@@ -80,7 +80,7 @@ public class IPerspectiveListenerTest implements IPerspectiveListener {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void testPerspectiveChanged() {
 		/*
 		 * Commented out because until test case can be updated to work with new

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/ISelectionServiceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/ISelectionServiceTest.java
@@ -14,11 +14,11 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -28,17 +28,17 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.tests.SelectionProviderView;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests the ISelectionService class.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ISelectionServiceTest implements ISelectionListener {
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private IWorkbenchWindow fWindow;
 
@@ -51,7 +51,7 @@ public class ISelectionServiceTest implements ISelectionListener {
 
 	private IWorkbenchPart eventPart;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWindow = openTestWindow();
 		fPage = fWindow.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPageTest.java
@@ -22,12 +22,12 @@ import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestPage;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.waitForJobs;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -86,25 +86,22 @@ import org.eclipse.ui.navigator.resources.ProjectExplorer;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.part.IPage;
 import org.eclipse.ui.tests.harness.util.CallHistory;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.eclipse.ui.views.contentoutline.ContentOutline;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IWorkbenchPageTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private IWorkbench fWorkbench;
 
@@ -172,7 +169,7 @@ public class IWorkbenchPageTest {
 		}
 	};
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWorkbench = PlatformUI.getWorkbench();
 		fWin = openTestWindow();
@@ -182,7 +179,7 @@ public class IWorkbenchPageTest {
 		Platform.addLogListener(openAndHideListener);
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		Platform.removeLogListener(openAndHideListener);
 		if (proj != null) {
@@ -1147,7 +1144,7 @@ public class IWorkbenchPageTest {
 		boolean activeShell = forceActive(fWin.getShell());
 
 		final AtomicBoolean shellIsActive = new AtomicBoolean(activeShell);
-		Assume.assumeTrue(shellIsActive.get());
+		Assumptions.assumeTrue(shellIsActive.get());
 
 		ShellListener shellListener = new ShellStateListener(shellIsActive);
 		fWin.getShell().addShellListener(shellListener);
@@ -1162,13 +1159,13 @@ public class IWorkbenchPageTest {
 		assertNull(fActivePage.findViewReference(MockViewPart.ID2));
 		assertNotNull(fActivePage.findViewReference(MockViewPart.ID));
 
-		Assume.assumeTrue(forceActive(fWin.getShell()));
+		Assumptions.assumeTrue(forceActive(fWin.getShell()));
 
 		showViewViaCommand(MockViewPart.ID2);
 
-		Assume.assumeTrue(fWin.getShell().isVisible());
-		Assume.assumeTrue(getWorkbench().getActiveWorkbenchWindow() == fWin);
-		Assume.assumeTrue(shellIsActive.get());
+		Assumptions.assumeTrue(fWin.getShell().isVisible());
+		Assumptions.assumeTrue(getWorkbench().getActiveWorkbenchWindow() == fWin);
+		Assumptions.assumeTrue(shellIsActive.get());
 
 		assertNotNull(fActivePage.findView(MockViewPart.ID2));
 		assertNotNull(fActivePage.findViewReference(MockViewPart.ID2));
@@ -1200,7 +1197,7 @@ public class IWorkbenchPageTest {
 		boolean activeShell = forceActive(fWin.getShell());
 
 		final AtomicBoolean shellIsActive = new AtomicBoolean(activeShell);
-		Assume.assumeTrue(shellIsActive.get());
+		Assumptions.assumeTrue(shellIsActive.get());
 
 		ShellListener shellListener = new ShellStateListener(shellIsActive);
 		fWin.getShell().addShellListener(shellListener);
@@ -1217,12 +1214,12 @@ public class IWorkbenchPageTest {
 		assertNull(fActivePage.findViewReference(historyView));
 		assertNotNull(fActivePage.findViewReference(MockViewPart.ID));
 
-		Assume.assumeTrue(forceActive(fWin.getShell()));
+		Assumptions.assumeTrue(forceActive(fWin.getShell()));
 		showViewViaCommand(historyView);
 
-		Assume.assumeTrue(fWin.getShell().isVisible());
-		Assume.assumeTrue(getWorkbench().getActiveWorkbenchWindow() == fWin);
-		Assume.assumeTrue(shellIsActive.get());
+		Assumptions.assumeTrue(fWin.getShell().isVisible());
+		Assumptions.assumeTrue(getWorkbench().getActiveWorkbenchWindow() == fWin);
+		Assumptions.assumeTrue(shellIsActive.get());
 
 		assertNotNull(fActivePage.findView(historyView));
 		assertNotNull(fActivePage.findViewReference(historyView));
@@ -2149,7 +2146,7 @@ public class IWorkbenchPageTest {
 	 * @since 3.1
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenPerspectiveWithMultiViewPlaceholdersAtTopLevel() throws WorkbenchException {
 
 		fWin.getWorkbench().showPerspective(PerspectiveWithMultiViewPlaceholdersAtTopLevel.PERSP_ID, fWin);
@@ -2174,7 +2171,7 @@ public class IWorkbenchPageTest {
 	 * @since 3.1
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenPerspectiveWithMultiViewPlaceholdersInPlaceholderFolder() throws WorkbenchException {
 
 		fWin.getWorkbench().showPerspective(PerspectiveWithMultiViewPlaceholdersInPlaceholderFolder.PERSP_ID, fWin);
@@ -2198,7 +2195,7 @@ public class IWorkbenchPageTest {
 	 * @since 3.1
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenPerspectiveWithMultiViewPlaceholdersInFolder() throws WorkbenchException {
 		fWin.getWorkbench().showPerspective(PerspectiveWithMultiViewPlaceholdersInFolder.PERSP_ID, fWin);
 
@@ -2654,7 +2651,7 @@ public class IWorkbenchPageTest {
 	 * @since 3.2
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenAndFindEditorWithMatchFlags() throws Exception {
 		IWorkbenchPage page = fActivePage;
 		proj = FileUtil.createProject("testOpenEditorMatchFlags");
@@ -2765,7 +2762,7 @@ public class IWorkbenchPageTest {
 	 * editor references.  Check that close still works.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenAndHideEditor1() throws Exception {
 		proj = FileUtil.createProject("testOpenAndHideEditor");
 		IFile file1 = FileUtil.createFile("a.mock1", proj);
@@ -2788,7 +2785,7 @@ public class IWorkbenchPageTest {
 	 * close still works.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenAndHideEditor2() throws Exception {
 		proj = FileUtil.createProject("testOpenAndHideEditor");
 		IFile file1 = FileUtil.createFile("a.mock1", proj);
@@ -2834,7 +2831,7 @@ public class IWorkbenchPageTest {
 	 * generate a log message and not effect the list of editors.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenAndHideEditor3() throws Exception {
 		proj = FileUtil.createProject("testOpenAndHideEditor");
 		IFile file1 = FileUtil.createFile("a.mock1", proj);
@@ -2867,7 +2864,7 @@ public class IWorkbenchPageTest {
 	 * add it a second time should not effect the list of editor references.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenAndHideEditor4() throws Exception {
 		proj = FileUtil.createProject("testOpenAndHideEditor");
 		IFile file1 = FileUtil.createFile("a.mock1", proj);
@@ -2899,7 +2896,7 @@ public class IWorkbenchPageTest {
 	 * outline view.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenAndHideEditor5() throws Exception {
 		proj = FileUtil.createProject("testOpenAndHideEditor");
 		IFile file1 = FileUtil.createFile("a1.java", proj);
@@ -2939,7 +2936,7 @@ public class IWorkbenchPageTest {
 	 * reflects the default page.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenAndHideEditor6() throws Exception {
 		proj = FileUtil.createProject("testOpenAndHideEditor");
 		IFile file1 = FileUtil.createFile("a1.java", proj);
@@ -2987,7 +2984,7 @@ public class IWorkbenchPageTest {
 	 * the window title.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenAndHideEditor7() throws Exception {
 		proj = FileUtil.createProject("testOpenAndHideEditor");
 		IFile file1 = FileUtil.createFile("a1.java", proj);
@@ -3035,7 +3032,7 @@ public class IWorkbenchPageTest {
 	 * causes another part to become active.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenAndHideEditor8() throws Exception {
 		proj = FileUtil.createProject("testOpenAndHideEditor");
 		IFile file1 = FileUtil.createFile("a1.java", proj);
@@ -3076,7 +3073,7 @@ public class IWorkbenchPageTest {
 	 * of some commands.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenAndHideEditor9() throws Exception {
 		proj = FileUtil.createProject("testOpenAndHideEditor");
 		IFile file1 = FileUtil.createFile("a1.java", proj);
@@ -3210,7 +3207,7 @@ public class IWorkbenchPageTest {
 	 * openEditors(IWorkbenchPage page, IFile[] inputs)
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenEditorsReuse() throws Throwable {
 		proj = FileUtil.createProject("testOpenEditors");
 
@@ -3301,7 +3298,7 @@ public class IWorkbenchPageTest {
 	 * Make sure there are no editor errors.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenAndHideEditor11() throws Exception {
 		proj = FileUtil.createProject("testOpenAndHideEditor");
 		IFile file1 = FileUtil.createFile("a.mock1", proj);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPartSiteTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPartSiteTest.java
@@ -14,10 +14,10 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IViewPart;
@@ -25,24 +25,24 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchPartSite;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests the site for an IWorkbenchPart.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public abstract class IWorkbenchPartSiteTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	protected IWorkbenchWindow fWindow;
 
 	protected IWorkbenchPage fPage;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWindow = openTestWindow();
 		fPage = fWindow.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPartTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPartTest.java
@@ -14,31 +14,31 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.tests.harness.util.CallHistory;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * This is a test for IWorkbenchPart.  Since IWorkbenchPart is an
  * interface this test verifies the IWorkbenchPart lifecycle rather
  * than the implementation.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public abstract class IWorkbenchPartTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	protected IWorkbenchWindow fWindow;
 
 	protected IWorkbenchPage fPage;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWindow = openTestWindow();
 		fPage = fWindow.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPartTestableTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchPartTestableTests.java
@@ -15,8 +15,8 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -31,26 +31,26 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.intro.IIntroPart;
 import org.eclipse.ui.testing.IWorkbenchPartTestable;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.3
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IWorkbenchPartTestableTests {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	/**
 	 * Iterate over all parts to ensure that they all return a part testable
 	 * that contains a real composite.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestGetComposite() throws CoreException {
 		IWorkbenchPage page = openTestWindow(IDE.RESOURCE_PERSPECTIVE_ID)
 				.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchTest.java
@@ -17,9 +17,9 @@ import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.getPageInput;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -33,25 +33,25 @@ import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.IWorkingSetManager;
 import org.eclipse.ui.WorkbenchException;
 import org.eclipse.ui.tests.harness.util.ArrayUtil;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests the IWorkbench interface.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IWorkbenchTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	/**
 	 * Tests the activation of two windows.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestGetActiveWorkbenchWindow() throws Throwable {
 		IWorkbenchWindow win1, win2;
 
@@ -152,7 +152,7 @@ public class IWorkbenchTest {
 	 * openWorkbenchWindow(String, IAdaptable)
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestOpenWorkbenchWindow() throws Throwable {
 		// open a window with valid perspective
 		IWorkbenchWindow win = null;
@@ -183,7 +183,7 @@ public class IWorkbenchTest {
 	 * openWorkbenchWindow(IAdaptable)
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestOpenWorkbenchWindow2() throws Throwable {
 		// open a window with valid perspective
 		IWorkbenchWindow win = null;
@@ -206,7 +206,7 @@ public class IWorkbenchTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenPage1() throws Throwable {
 		IWorkbenchWindow win = null;
 		//IWorkbenchPage page1, page2;
@@ -254,7 +254,7 @@ public class IWorkbenchTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenPage2() throws Throwable {
 		IWorkbenchWindow win = null;
 		//IWorkbenchPage page1, page2;
@@ -303,7 +303,7 @@ public class IWorkbenchTest {
 	 * to entire test suites
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testClose() {
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchWindowTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkbenchWindowTest.java
@@ -16,10 +16,10 @@ package org.eclipse.ui.tests.api;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.closeAllPages;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestPage;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jface.action.StatusLineManager;
@@ -34,23 +34,23 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.WorkbenchException;
 import org.eclipse.ui.internal.WorkbenchWindow;
 import org.eclipse.ui.tests.harness.util.ArrayUtil;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IWorkbenchWindowTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private IWorkbench fWorkbench;
 
 	private IWorkbenchWindow fWin;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWorkbench = PlatformUI.getWorkbench();
 		fWin = openTestWindow();
@@ -65,7 +65,7 @@ public class IWorkbenchWindowTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void testGetActivePage() throws Throwable {
 		/*
 		 * Commented out because until test case can be updated to work
@@ -90,7 +90,7 @@ public class IWorkbenchWindowTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestSetActivePage() throws Throwable {
 		openTestPage(fWin, 5);
 		IWorkbenchPage[] pages = fWin.getPages();
@@ -105,7 +105,7 @@ public class IWorkbenchWindowTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void testGetPages() throws Throwable {
 		/*
 		 * Commented out because until test case can be updated to work
@@ -144,7 +144,7 @@ public class IWorkbenchWindowTest {
 	 * tests openPage(String)
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenPage() throws Throwable {
 		/*
 		 * Commented out because until test case can be updated to work
@@ -166,7 +166,7 @@ public class IWorkbenchWindowTest {
 	 * tests openPage(String, IAdaptable)
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testOpenPage2() throws Throwable {
 		/*
 		 * Commented out because until test case can be updated to work

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetManagerTest.java
@@ -16,14 +16,14 @@ package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 
@@ -41,11 +41,12 @@ import org.eclipse.ui.XMLMemento;
 import org.eclipse.ui.dialogs.IWorkingSetSelectionDialog;
 import org.eclipse.ui.dialogs.WorkingSetConfigurationBlock;
 import org.eclipse.ui.tests.harness.util.ArrayUtil;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IWorkingSetManagerTest {
 	static final String WORKING_SET_NAME_1 = "ws1";
 
@@ -53,8 +54,7 @@ public class IWorkingSetManagerTest {
 
 	static final String WORKING_SET_NAME_3 = "ws3";
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	IWorkingSetManager fWorkingSetManager;
 
@@ -77,7 +77,7 @@ public class IWorkingSetManagerTest {
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWorkingSetManager = getWorkbench().getWorkingSetManager();
 		fWorkspace = ResourcesPlugin.getWorkspace();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/IWorkingSetTest.java
@@ -14,10 +14,10 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 
@@ -32,29 +32,29 @@ import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.IWorkingSetManager;
 import org.eclipse.ui.XMLMemento;
 import org.eclipse.ui.internal.WorkingSet;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.tests.menus.ObjectContributionClasses.IA;
 import org.eclipse.ui.tests.menus.ObjectContributionClasses.ICommon;
 import org.eclipse.ui.tests.menus.ObjectContributionClasses.IModelElement;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IWorkingSetTest {
 	static final String WORKING_SET_NAME_1 = "ws1";
 
 	static final String WORKING_SET_NAME_2 = "ws2";
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	IWorkspace fWorkspace;
 
 	IWorkingSet fWorkingSet;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		IWorkingSetManager workingSetManager = getWorkbench().getWorkingSetManager();
 
@@ -65,7 +65,7 @@ public class IWorkingSetTest {
 		workingSetManager.addWorkingSet(fWorkingSet);
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		IWorkingSetManager workingSetManager = getWorkbench().getWorkingSetManager();
 		workingSetManager.removeWorkingSet(fWorkingSet);
@@ -338,7 +338,8 @@ public class IWorkingSetTest {
 
 	}
 
-	public class ToFoo implements IAdaptable {
+	@ExtendWith(CloseTestWindowsExtension.class)
+public class ToFoo implements IAdaptable {
 
 		@SuppressWarnings("unchecked")
 		@Override

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/SaveablesListTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/SaveablesListTest.java
@@ -15,7 +15,7 @@ package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestPage;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -35,20 +35,20 @@ import org.eclipse.ui.Saveable;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.SaveablesList;
 import org.eclipse.ui.tests.harness.util.CallHistory;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.5
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class SaveablesListTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private IWorkbenchWindow fWin;
 
@@ -56,13 +56,13 @@ public class SaveablesListTest {
 
 	private IWorkbenchPage page;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWin = openTestWindow();
 		page = openTestPage(fWin);
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		if (proj != null) {
 			FileUtil.deleteProject(proj);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/SelectionListenerFactoryTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/SelectionListenerFactoryTest.java
@@ -14,9 +14,9 @@
 package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.function.Predicate;
 
@@ -35,15 +35,16 @@ import org.eclipse.ui.SelectionListenerFactory;
 import org.eclipse.ui.SelectionListenerFactory.ISelectionModel;
 import org.eclipse.ui.SelectionListenerFactory.Predicates;
 import org.eclipse.ui.tests.SelectionProviderView;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests the ISelectionService class.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class SelectionListenerFactoryTest implements ISelectionListener {
 	private static final String KNOCK_KNOCK = "KnockKnock";
 
@@ -54,10 +55,9 @@ public class SelectionListenerFactoryTest implements ISelectionListener {
 	private boolean fEventReceived;
 
 	private int fCounter;
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
-	@Before
+	@BeforeEach
 	public void doSetUp() throws Exception {
 		fWindow = openTestWindow();
 		fPage = fWindow.getActivePage();
@@ -602,7 +602,7 @@ public class SelectionListenerFactoryTest implements ISelectionListener {
 	 * visible.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testNullListener() throws Throwable {
 		INullSelectionListener nullSelectionListener = (pPart, pSelection) -> fEventReceived = true;
 		SelectionProviderView view = (SelectionProviderView) fPage.showView(SelectionProviderView.ID);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/StickyViewTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/StickyViewTest.java
@@ -16,9 +16,9 @@ package org.eclipse.ui.tests.api;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -37,22 +37,22 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.util.PrefUtil;
 import org.eclipse.ui.part.FileEditorInput;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
 import org.eclipse.ui.views.IStickyViewDescriptor;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.0
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class StickyViewTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	@Rule
 	public final PreferenceMementoRule preferenceMemento = new PreferenceMementoRule();
@@ -121,7 +121,7 @@ public class StickyViewTest {
 	 * @throws PartInitException
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestClosableFlag() throws PartInitException {
 		//explicit closeable = true
 		testCloseable("org.eclipse.ui.tests.api.StickyViewRight1", true);
@@ -132,7 +132,7 @@ public class StickyViewTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestMoveableFlag() throws PartInitException {
 		//explicit closeable = true
 		testMoveable("org.eclipse.ui.tests.api.StickyViewRight1", true);
@@ -278,7 +278,7 @@ public class StickyViewTest {
 	 * @since 3.2
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestPerspectiveViewToolBarVisible() throws Throwable {
 		// These tests are hard-wired to the pre-3.3 zoom behaviour
 		// Run them anyway to ensure that we preserve the 3.0 mechanism
@@ -359,7 +359,7 @@ public class StickyViewTest {
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		window = openTestWindow();
 		page = window.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/UIJobTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/UIJobTest.java
@@ -24,25 +24,25 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.progress.UIJob;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.1
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class UIJobTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	protected IWorkbenchWindow fWindow;
 
 	protected IWorkbenchPage fPage;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWindow = openTestWindow();
 		fPage = fWindow.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/ArbitraryPropertyTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/ArbitraryPropertyTest.java
@@ -14,8 +14,8 @@
 package org.eclipse.ui.tests.api.workbenchpart;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IStorage;
@@ -28,11 +28,12 @@ import org.eclipse.ui.IPersistableElement;
 import org.eclipse.ui.IViewReference;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ArbitraryPropertyTest {
 	private static final String EDITOR_ID = "org.eclipse.ui.tests.TitleTestEditor";
 
@@ -44,10 +45,9 @@ public class ArbitraryPropertyTest {
 
 	IWorkbenchPage page;
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
-	@Before
+	@BeforeEach
 	public void doSetUp() throws Exception {
 		window = openTestWindow();
 		page = window.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/Bug543609Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/Bug543609Test.java
@@ -14,27 +14,27 @@
 package org.eclipse.ui.tests.api.workbenchpart;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.session.ViewWithState;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug543609Test {
 
 	private static final String VIEW_WITH_STATE_ID = "org.eclipse.ui.tests.session.ViewWithState";
 
 	private IWorkbenchPage fPage;
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
-	@Before
+	@BeforeEach
 	public void doSetUp() throws Exception {
 		IWorkbenchWindow window = openTestWindow();
 		fPage = window.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/DependencyInjectionViewTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/DependencyInjectionViewTest.java
@@ -17,8 +17,8 @@ package org.eclipse.ui.tests.api.workbenchpart;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -28,18 +28,18 @@ import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.4
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class DependencyInjectionViewTest {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	@Test
 	public void testDependencyInjectionLifecycle() throws Exception {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/LifecycleViewTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/LifecycleViewTest.java
@@ -16,23 +16,23 @@ package org.eclipse.ui.tests.api.workbenchpart;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.4
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class LifecycleViewTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	@Test
 	public void testLifecycle() throws Exception {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/OverriddenTitleTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/OverriddenTitleTest.java
@@ -21,20 +21,20 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart2;
 import org.eclipse.ui.IWorkbenchPartConstants;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.0
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class OverriddenTitleTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	IWorkbenchWindow window;
 
@@ -62,7 +62,7 @@ public class OverriddenTitleTest {
 		}
 	};
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		window = openTestWindow();
 		page = window.getActivePage();
@@ -74,7 +74,7 @@ public class OverriddenTitleTest {
 		contentChangeEvent = false;
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		view.removePropertyListener(propertyListener);
 		page.hideView(view);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/RawIViewPartTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/RawIViewPartTest.java
@@ -21,22 +21,22 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchPartConstants;
 import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
 /**
  * @since 3.0
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class RawIViewPartTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	IWorkbenchWindow window;
 
@@ -66,7 +66,7 @@ public class RawIViewPartTest {
 		}
 	};
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		window = openTestWindow();
 		page = window.getActivePage();
@@ -80,7 +80,7 @@ public class RawIViewPartTest {
 		contentChangeEvent = false;
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		view.removePropertyListener(propertyListener);
 		page.hideView(view);
@@ -136,7 +136,7 @@ public class RawIViewPartTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestCustomTitle() throws Throwable {
 		view.setTitle("CustomTitle");
 		verifySettings("CustomTitle", "RawIViewPart", "CustomTitle");
@@ -148,7 +148,7 @@ public class RawIViewPartTest {
 	 * as the default part name
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestEmptyContentDescription() throws Throwable {
 		view.setTitle("RawIViewPart");
 		verifySettings("RawIViewPart", "RawIViewPart", "");

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/ViewPartTitleTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/api/workbenchpart/ViewPartTitleTest.java
@@ -21,23 +21,23 @@ import org.eclipse.ui.IWorkbenchPart2;
 import org.eclipse.ui.IWorkbenchPartConstants;
 import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests bug 56822 -- NPE thrown when setTitle(null) is called.
  *
  * @since 3.0
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ViewPartTitleTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	IWorkbenchWindow window;
 
@@ -67,7 +67,7 @@ public class ViewPartTitleTest {
 		}
 	};
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		window = openTestWindow();
 		page = window.getActivePage();
@@ -80,7 +80,7 @@ public class ViewPartTitleTest {
 		contentChangeEvent = false;
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		view.removePropertyListener(propertyListener);
 		page.hideView(view);
@@ -152,7 +152,7 @@ public class ViewPartTitleTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestCustomName() throws Throwable {
 		view.setPartName("CustomPartName");
 		verifySettings("CustomPartName", "CustomPartName", "");
@@ -175,7 +175,7 @@ public class ViewPartTitleTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void XXXtestCustomNameAndContentDescription() throws Throwable {
 		view.setPartName("CustomName");
 		view.setContentDescription("CustomContentDescription");

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/ActionDelegateProxyTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/ActionDelegateProxyTest.java
@@ -16,12 +16,12 @@ package org.eclipse.ui.tests.commands;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -37,17 +37,17 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.tests.api.workbenchpart.MenuContributionHarness;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@Ignore("broke during e4 transition and still need adjustments")
+@Disabled("broke during e4 transition and still need adjustments")
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ActionDelegateProxyTest {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private static final String DELEGATE_ACTION_SET_ID = "org.eclipse.ui.tests.delegateActionSet";
 	private static final String INC_COMMAND = "org.eclipse.ui.tests.incMenuHarness";

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandCallbackTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandCallbackTest.java
@@ -16,8 +16,8 @@
 package org.eclipse.ui.tests.commands;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -41,19 +41,19 @@ import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.menus.UIElement;
 import org.eclipse.ui.services.IServiceLocator;
 import org.eclipse.ui.services.IServiceScopes;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.3
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class CommandCallbackTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	private static final String HOST_PARAM_ID = "host";
 	private static final String PROT_PARAM_ID = "protocol";
@@ -71,7 +71,7 @@ public class CommandCallbackTest {
 	private CallbackHandler cmd1Handler;
 	private CallbackHandler cmd2Handler;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		workbench = PlatformUI.getWorkbench();
 		commandService = workbench.getService(ICommandService.class);
@@ -84,7 +84,7 @@ public class CommandCallbackTest {
 		cmd2Activation = handlerService.activateHandler(CMD2_ID, cmd2Handler);
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		if (cmd1Activation != null) {
 			handlerService.deactivateHandler(cmd1Activation);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandEnablementTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/CommandEnablementTest.java
@@ -15,11 +15,11 @@
 package org.eclipse.ui.tests.commands;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
 import java.util.Map;
@@ -68,21 +68,21 @@ import org.eclipse.ui.menus.MenuUtil;
 import org.eclipse.ui.menus.UIElement;
 import org.eclipse.ui.services.IEvaluationService;
 import org.eclipse.ui.services.ISourceProviderService;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.3
  */
-@Ignore("broke during e4 transition and still need adjustments")
+@Disabled("broke during e4 transition and still need adjustments")
+@ExtendWith(CloseTestWindowsExtension.class)
 public class CommandEnablementTest {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private static final String CONTEXT_TEST2 = "org.eclipse.ui.command.contexts.enablement_test2";
 	private static final String CONTEXT_TEST1 = "org.eclipse.ui.command.contexts.enablement_test1";
@@ -110,7 +110,7 @@ public class CommandEnablementTest {
 	private IContextActivation contextActivation2;
 	private IWorkbench fWorkbench;
 
-	@Before
+	@BeforeEach
 	public void doSetUp() throws Exception {
 		fWorkbench = PlatformUI.getWorkbench();
 		commandService = fWorkbench.getService(ICommandService.class);
@@ -128,7 +128,7 @@ public class CommandEnablementTest {
 		contextHandler = new CheckContextHandler();
 	}
 
-	@After
+	@AfterEach
 	public void doTearDown() throws Exception {
 		if (activation1 != null) {
 			handlerService.deactivateHandler(activation1);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/HandlerActivationTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/commands/HandlerActivationTest.java
@@ -15,10 +15,10 @@
 package org.eclipse.ui.tests.commands;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -48,22 +48,22 @@ import org.eclipse.ui.handlers.HandlerUtil;
 import org.eclipse.ui.handlers.IHandlerActivation;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.services.IServiceLocator;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.views.contentoutline.ContentOutline;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests various aspects of command state.
  *
  * @since 3.2
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class HandlerActivationTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	static class ActTestHandler extends AbstractHandler {
 		public String contextId;
@@ -185,7 +185,7 @@ public class HandlerActivationTest {
 		makeHandler(handlerId, contextId, expression);
 	}
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		for (final String[] contextInfo : CREATE_CONTEXTS) {
 			final Context context = contextService.getContext(contextInfo[0]);
@@ -203,7 +203,7 @@ public class HandlerActivationTest {
 
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		handlerService.deactivateHandlers(testHandlerActivations.values());
 		testHandlerActivations.clear();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/contexts/Bug74990Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/contexts/Bug74990Test.java
@@ -14,7 +14,7 @@
 package org.eclipse.ui.tests.contexts;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbench;
@@ -24,9 +24,9 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.contexts.EnabledSubmission;
 import org.eclipse.ui.contexts.IContext;
 import org.eclipse.ui.contexts.IWorkbenchContextSupport;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * A test for whether part identifiers work properly for EnabledSubmissions.
@@ -35,8 +35,7 @@ import org.junit.Test;
  */
 public final class Bug74990Test {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	/**
 	 * Tests whether a part-specific context -- submitted via Java code -- is

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/contexts/PartContextTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/contexts/PartContextTest.java
@@ -16,9 +16,9 @@ package org.eclipse.ui.tests.contexts;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 
@@ -31,11 +31,11 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.tests.api.MockViewPart;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.tests.harness.util.UITestUtil;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test that the contexts activated through their local services are only in
@@ -43,6 +43,7 @@ import org.junit.Test;
  *
  * @since 3.2
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class PartContextTest {
 	public static final String PAGE_VIEW_ID = "org.eclipse.ui.tests.contexts.MockPageView";
 
@@ -50,8 +51,7 @@ public class PartContextTest {
 
 	public static final String WINDOW_CONTEXT_ID = "org.eclipse.ui.tests.contexts.WorkbenchWindow";
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	@Test
 	public void testBasicContextActivation() throws Exception {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ExportArchiveFileOperationTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ExportArchiveFileOperationTest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.datatransfer;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -44,18 +44,18 @@ import org.eclipse.ui.internal.wizards.datatransfer.ArchiveFileExportOperation;
 import org.eclipse.ui.internal.wizards.datatransfer.TarEntry;
 import org.eclipse.ui.internal.wizards.datatransfer.TarException;
 import org.eclipse.ui.internal.wizards.datatransfer.TarFile;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestName;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ExportArchiveFileOperationTest implements IOverwriteQuery {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	@Rule
 	public final TestName testName = new TestName();
@@ -325,7 +325,7 @@ public class ExportArchiveFileOperationTest implements IOverwriteQuery {
 
 	}
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		project = FileUtil.createProject("Export" + testName.getMethodName());
 		File destination =
@@ -338,7 +338,7 @@ public class ExportArchiveFileOperationTest implements IOverwriteQuery {
 		excludeProjectPath = false;
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		// delete exported data
 		File root = new File(localDirectory);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ExportFileSystemOperationTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ExportFileSystemOperationTest.java
@@ -14,8 +14,8 @@
 package org.eclipse.ui.tests.datatransfer;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -40,19 +40,19 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.tests.harness.FileSystemHelper;
 import org.eclipse.ui.dialogs.IOverwriteQuery;
 import org.eclipse.ui.internal.wizards.datatransfer.FileSystemExportOperation;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.tests.internal.VirtualTestFileSystem;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestName;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ExportFileSystemOperationTest implements IOverwriteQuery {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	@Rule
 	public final TestName testName = new TestName();
@@ -70,7 +70,7 @@ public class ExportFileSystemOperationTest implements IOverwriteQuery {
 		return "";
 	}
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		project = FileUtil.createProject("Export" + testName.getMethodName());
 		File destination =
@@ -93,7 +93,7 @@ public class ExportFileSystemOperationTest implements IOverwriteQuery {
 		}
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		// delete exported data
 		File root = new File(localDirectory);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportArchiveOperationTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportArchiveOperationTest.java
@@ -14,8 +14,8 @@
 package org.eclipse.ui.tests.datatransfer;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.net.URL;
@@ -39,13 +39,13 @@ import org.eclipse.ui.internal.wizards.datatransfer.TarFile;
 import org.eclipse.ui.internal.wizards.datatransfer.TarLeveledStructureProvider;
 import org.eclipse.ui.internal.wizards.datatransfer.ZipLeveledStructureProvider;
 import org.eclipse.ui.tests.TestPlugin;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.wizards.datatransfer.ImportOperation;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ImportArchiveOperationTest implements IOverwriteQuery {
 	private static final String DATA_PATH_PREFIX = "data/org.eclipse.datatransferArchives/";
 
@@ -66,8 +66,7 @@ public class ImportArchiveOperationTest implements IOverwriteQuery {
 
 	private URL tarFileURL;
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	@Override
 	public String queryOverwrite(String pathString) {
@@ -80,7 +79,7 @@ public class ImportArchiveOperationTest implements IOverwriteQuery {
 	 * Tear down. Delete the project we created and all of the
 	 * files on the file system.
 	 */
-	@After
+	@AfterEach
 	public void doTearDown() throws Exception {
 		try {
 			project.delete(true, true, null);
@@ -329,6 +328,7 @@ public class ImportArchiveOperationTest implements IOverwriteQuery {
 				}
 			}
 			assertTrue("Import failed to import file " + fileName, k < fileNames.length);
+import org.junit.jupiter.api.extension.ExtendWith;
 		}
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingArchiveProjectFilterTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingArchiveProjectFilterTest.java
@@ -16,10 +16,10 @@ package org.eclipse.ui.tests.datatransfer;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.URL;
@@ -54,22 +54,22 @@ import org.eclipse.ui.internal.wizards.datatransfer.WizardProjectsImportPage;
 import org.eclipse.ui.internal.wizards.datatransfer.WizardProjectsImportPage.ProjectRecord;
 import org.eclipse.ui.navigator.resources.ProjectExplorer;
 import org.eclipse.ui.tests.TestPlugin;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ImportExistingArchiveProjectFilterTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	private static final String DATA_PATH_PREFIX = "data/org.eclipse.datatransferArchives/";
 	private static final String ARCHIVE_JAVA_PROJECT = "ExcludeFilter_Import";
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		if (dialog != null) {
 			dialog.close();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingProjectsWizardTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExistingProjectsWizardTest.java
@@ -21,10 +21,10 @@ import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.eclipse.ui.tests.datatransfer.ImportTestUtils.restoreWorkspaceConfiguration;
 import static org.eclipse.ui.tests.datatransfer.ImportTestUtils.setWorkspaceAutoBuild;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -61,17 +61,14 @@ import org.eclipse.ui.internal.wizards.datatransfer.WizardProjectsImportPage;
 import org.eclipse.ui.internal.wizards.datatransfer.WizardProjectsImportPage.ProjectRecord;
 import org.eclipse.ui.tests.TestPlugin;
 import org.eclipse.ui.tests.datatransfer.ImportTestUtils.TestBuilder;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.wizards.datatransfer.ExternalProjectImportWizard;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ImportExistingProjectsWizardTest {
 
 	private static final String DATA_PATH_PREFIX = "data/org.eclipse.datatransferArchives/";
@@ -94,14 +91,13 @@ public class ImportExistingProjectsWizardTest {
 
 	private boolean originalRefreshSetting;
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private Shell getShell() {
 		return getWorkbench().getActiveWorkbenchWindow().getShell();
 	}
 
-	@Before
+	@BeforeEach
 	public void doSetUp() throws Exception {
 		originalRefreshSetting = ResourcesPlugin.getPlugin()
 				.getPluginPreferences().getBoolean(
@@ -111,7 +107,7 @@ public class ImportExistingProjectsWizardTest {
 		setWorkspaceAutoBuild(true);
 	}
 
-	@After
+	@AfterEach
 	public void doTearDown() throws Exception {
 		if (dialog != null) {
 			dialog.close();
@@ -1124,6 +1120,7 @@ public class ImportExistingProjectsWizardTest {
 
 		assertTrue("Expected import wizard to find projects: " + projects + ", instead it detects: " + projectNames,
 				projectNames.containsAll(projects));
+import org.junit.jupiter.api.extension.ExtendWith;
 
 		CheckboxTreeViewer projectsList = wpip.getProjectsList();
 		projectsList.setCheckedElements(selectedProjects);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExportWizardsCategoryTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportExportWizardsCategoryTests.java
@@ -13,22 +13,22 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.datatransfer;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.registry.WizardsRegistryReader;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.wizards.IWizardCategory;
 import org.eclipse.ui.wizards.IWizardDescriptor;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ImportExportWizardsCategoryTests {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	private static String WIZARD_ID_IMPORT_NO_CATEGORY = "org.eclipse.ui.tests.import.NoCategory";
 	private static String WIZARD_ID_IMPORT_INVALID_CATEGORY = "org.eclipse.ui.tests.import.InvalidCategory";
@@ -228,7 +228,7 @@ public class ImportExportWizardsCategoryTests {
 				category == null);
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		importRoot = null;
 		exportRoot = null;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportOperationTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/ImportOperationTest.java
@@ -14,8 +14,8 @@
 package org.eclipse.ui.tests.datatransfer;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,19 +32,18 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.tests.harness.FileSystemHelper;
 import org.eclipse.ui.dialogs.IOverwriteQuery;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.wizards.datatransfer.FileSystemStructureProvider;
 import org.eclipse.ui.wizards.datatransfer.ImportOperation;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ImportOperationTest implements IOverwriteQuery {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	private static final String[] directoryNames = { "dir1", "dir2" };
 
@@ -78,7 +77,7 @@ public class ImportOperationTest implements IOverwriteQuery {
 		return "";
 	}
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		Class<?> testClass = Class
 				.forName("org.eclipse.ui.tests.datatransfer.ImportOperationTest");
@@ -106,7 +105,7 @@ public class ImportOperationTest implements IOverwriteQuery {
 	 * Tear down. Delete the project we created and all of the
 	 * files on the file system.
 	 */
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		try {
 			project.delete(true, true, null);
@@ -271,6 +270,7 @@ public class ImportOperationTest implements IOverwriteQuery {
 				}
 			}
 			assertTrue("Import failed to import file " + fileName, k < fileNames.length);
+import org.junit.jupiter.api.extension.ExtendWith;
 		}
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/SmartImportTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/datatransfer/SmartImportTests.java
@@ -20,10 +20,10 @@ import static org.eclipse.ui.tests.datatransfer.ImportTestUtils.setWorkspaceAuto
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEventsUntil;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.waitForJobs;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.CharArrayReader;
 import java.io.CharArrayWriter;
@@ -75,30 +75,29 @@ import org.eclipse.ui.internal.wizards.datatransfer.SmartImportRootWizardPage;
 import org.eclipse.ui.internal.wizards.datatransfer.SmartImportWizard;
 import org.eclipse.ui.tests.TestPlugin;
 import org.eclipse.ui.tests.datatransfer.contributions.ImportMeProjectConfigurator;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @since 3.12
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class SmartImportTests {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	private WizardDialog dialog;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		ImportMeProjectConfigurator.configuredProjects.clear();
 		clearAll();
 		setWorkspaceAutoBuild(true);
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		ImportMeProjectConfigurator.configuredProjects.clear();
 		clearAll();
@@ -344,6 +343,7 @@ public class SmartImportTests {
 		// The Windows test machine returns A:\ as first root which is not suitable for
 		// this test.
 		File importRoot = new File(Util.isWindows() ? "C:\\" : "/");
+import org.junit.jupiter.api.extension.ExtendWith;
 		if (!importRoot.isDirectory()) {
 			importRoot = File.listRoots()[0];
 		}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourcePathCopyTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourcePathCopyTest.java
@@ -15,10 +15,10 @@
 package org.eclipse.ui.tests.dialogs;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.HeadlessException;
 import java.awt.Toolkit;
@@ -59,20 +59,20 @@ import org.eclipse.ui.internal.intro.IIntroConstants;
 import org.eclipse.ui.internal.wizards.datatransfer.WizardProjectsImportPage;
 import org.eclipse.ui.internal.wizards.datatransfer.WizardProjectsImportPage.ProjectRecord;
 import org.eclipse.ui.tests.TestPlugin;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.DialogCheck;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ResourcePathCopyTest {
 
 	private static final String DATA_PATH_PREFIX = "data/org.eclipse.datatransferArchives/";
 	private static final String ARCHIVE_JAVA_PROJECT = "helloworld";
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	@Test
 	public void testPathCopy() throws CoreException, IOException, HeadlessException, UnsupportedFlavorException {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIWorkingSetWizardsAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIWorkingSetWizardsAuto.java
@@ -45,16 +45,17 @@ import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.registry.WorkingSetDescriptor;
 import org.eclipse.ui.internal.registry.WorkingSetRegistry;
 import org.eclipse.ui.tests.TestPlugin;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.DialogCheck;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Abstract test class for the working set wizard tests.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public abstract class UIWorkingSetWizardsAuto<W extends IWizard> {
 	protected static final String WORKING_SET_NAME_1 = "ws1";
 
@@ -64,8 +65,7 @@ public abstract class UIWorkingSetWizardsAuto<W extends IWizard> {
 
 	private static final int SIZING_WIZARD_HEIGHT_2 = 500;
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private WizardDialog wizardDialog;
 
@@ -97,7 +97,7 @@ public abstract class UIWorkingSetWizardsAuto<W extends IWizard> {
 		return fileInProject2;
 	}
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		wizardToTest = createWizardToTest();
 		wizardDialog = createWizardDialog();
@@ -123,7 +123,7 @@ public abstract class UIWorkingSetWizardsAuto<W extends IWizard> {
 		fileInProject2 = FileUtil.createFile("f2.txt", project2);
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		removeAllWorkingSets();
 		cleanupWorkspace();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dynamicplugins/DynamicTestCase.java
@@ -14,9 +14,9 @@
 package org.eclipse.ui.tests.dynamicplugins;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
@@ -28,23 +28,23 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.WorkbenchPlugin;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.leaks.LeakTests;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Baseclass for all dynamic tests.
  *
  * @since 3.1
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public abstract class DynamicTestCase implements IRegistryChangeListener {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private volatile boolean addedRecieved;
 
@@ -58,7 +58,7 @@ public abstract class DynamicTestCase implements IRegistryChangeListener {
 
 	private ReferenceQueue<IExtensionDelta> queue;
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		try {
 			removeBundle();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/ActionExpressionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/ActionExpressionTest.java
@@ -22,18 +22,18 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.tests.api.ListElement;
 import org.eclipse.ui.tests.api.ListView;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * This class contains tests for popup menu enablement
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public abstract class ActionExpressionTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	protected IWorkbenchWindow fWindow;
 
@@ -47,7 +47,7 @@ public abstract class ActionExpressionTest {
 
 	ListElement redTrue = new ListElement("red", true);
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWindow = openTestWindow();
 		fPage = fWindow.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/Bug41931Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/Bug41931Test.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.internal;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -30,21 +30,21 @@ import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.WorkbenchPage;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test for Bug 41931.
  *
  * @since 3.0
  */
-@Ignore
+@Disabled
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug41931Test {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	/**
 	 * Tests that the <code>bringToTop(IWorkbenchPart)</code> correctly

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/EditorActionBarsTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/EditorActionBarsTest.java
@@ -14,9 +14,9 @@
 package org.eclipse.ui.tests.internal;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -40,22 +40,22 @@ import org.eclipse.ui.tests.api.MockAction;
 import org.eclipse.ui.tests.api.MockEditorActionBarContributor;
 import org.eclipse.ui.tests.api.MockEditorPart;
 import org.eclipse.ui.tests.api.MockViewPart;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * This class contains tests for the editor action bars
  * implementation.
  */
-@Ignore
+@Disabled
+@ExtendWith(CloseTestWindowsExtension.class)
 public class EditorActionBarsTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	protected IWorkbenchWindow fWindow;
 
@@ -63,7 +63,7 @@ public class EditorActionBarsTest {
 
 	private final String EDITOR_ID = "org.eclipse.ui.tests.internal.EditorActionBarsTest";
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWindow = openTestWindow();
 		fPage = fWindow.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/FileEditorMappingTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/FileEditorMappingTest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,22 +23,22 @@ import org.eclipse.ui.IEditorDescriptor;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.registry.EditorDescriptor;
 import org.eclipse.ui.internal.registry.FileEditorMapping;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@Ignore
+@Disabled
+@ExtendWith(CloseTestWindowsExtension.class)
 public class FileEditorMappingTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	private EditorDescriptor textEditor;
 	private EditorDescriptor pdeEditor;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		textEditor = (EditorDescriptor) IDE.getEditorDescriptor("test.txt");
 		pdeEditor = (EditorDescriptor) IDE.getEditorDescriptor("plugin.xml");

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/PerspectiveSwitcherTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/PerspectiveSwitcherTest.java
@@ -15,22 +15,22 @@
 package org.eclipse.ui.tests.internal;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.IWorkbenchPreferenceConstants;
 import org.eclipse.ui.internal.WorkbenchWindow;
 import org.eclipse.ui.internal.util.PrefUtil;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class PerspectiveSwitcherTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	@Rule
 	public final PreferenceMementoRule preferenceMemento = new PreferenceMementoRule();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/SWTBotWorkbenchResetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/SWTBotWorkbenchResetTest.java
@@ -16,9 +16,9 @@ package org.eclipse.ui.tests.internal;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.swt.widgets.Composite;
@@ -28,17 +28,17 @@ import org.eclipse.ui.IViewReference;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.WorkbenchException;
 import org.eclipse.ui.ide.IDE;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test for Bug 511729 — Improve robustness to SWTBot.resetWorkbench()
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class SWTBotWorkbenchResetTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	/**
 	 * Open a new window, switch to a different perspective such that parts are

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/SaveablesListTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/SaveablesListTest.java
@@ -16,10 +16,10 @@ package org.eclipse.ui.tests.internal;
 
 import static org.eclipse.ui.SaveablesLifecycleEvent.POST_CLOSE;
 import static org.eclipse.ui.SaveablesLifecycleEvent.POST_OPEN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -40,18 +40,18 @@ import org.eclipse.ui.IWorkbenchPartSite;
 import org.eclipse.ui.Saveable;
 import org.eclipse.ui.SaveablesLifecycleEvent;
 import org.eclipse.ui.internal.SaveablesList;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.5
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class SaveablesListTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	static class GoodSaveable extends Saveable {
 
@@ -187,7 +187,7 @@ public class SaveablesListTest {
 	private DummyPart part2;
 	private DummyPart part3;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		slist = new SaveablesListForTest();
 		source = new Object();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/StickyViewManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/StickyViewManagerTest.java
@@ -15,8 +15,8 @@
 package org.eclipse.ui.tests.internal;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IPerspectiveDescriptor;
@@ -26,27 +26,27 @@ import org.eclipse.ui.IViewReference;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPreferenceConstants;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.6
  */
-@Ignore
+@Disabled
+@ExtendWith(CloseTestWindowsExtension.class)
 public class StickyViewManagerTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	@Rule
 	public final PreferenceMementoRule preferenceMemento = new PreferenceMementoRule();
 
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		preferenceMemento.setPreference(PlatformUI.getPreferenceStore(),
 				IWorkbenchPreferenceConstants.ENABLE_32_STICKY_CLOSE_BEHAVIOR, false);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/TextHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/TextHandlerTest.java
@@ -16,9 +16,9 @@ package org.eclipse.ui.tests.internal;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assumptions.assumeFalse;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.dnd.Clipboard;
@@ -27,19 +27,19 @@ import org.eclipse.swt.dnd.Transfer;
 import org.eclipse.swt.dnd.URLTransfer;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.actions.TextActionHandler;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test for {@link TextActionHandler}.
  *
  * @since 3.5
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class TextHandlerTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	@Test
 	public void testEditableText() throws Exception {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/TextSelectionActionExpressionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/TextSelectionActionExpressionTest.java
@@ -14,8 +14,8 @@
 package org.eclipse.ui.tests.internal;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -30,25 +30,25 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.WorkbenchWindow;
 import org.eclipse.ui.tests.harness.util.ActionUtil;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * This class contains tests for text selection action enablement
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class TextSelectionActionExpressionTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	protected IWorkbenchWindow fWindow;
 
 	protected IWorkbenchPage fPage;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWindow = openTestWindow();
 		fPage = fWindow.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbenchPageTest.java
@@ -14,7 +14,7 @@
 package org.eclipse.ui.tests.internal;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -22,17 +22,17 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.ui.internal.WorkbenchPage;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@Ignore
+@Disabled
+@ExtendWith(CloseTestWindowsExtension.class)
 public class WorkbenchPageTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	@Test
 	public void test1() {
@@ -92,7 +92,7 @@ public class WorkbenchPageTest {
 		return (WorkbenchPage) getWorkbench().getActiveWorkbenchWindow().getActivePage();
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		clearMruPartIds();
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbenchSiteProgressServiceModelTagsTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbenchSiteProgressServiceModelTagsTest.java
@@ -15,11 +15,11 @@
 package org.eclipse.ui.tests.internal;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.services.events.IEventBroker;
@@ -32,20 +32,20 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.internal.PartSite;
 import org.eclipse.ui.internal.progress.WorkbenchSiteProgressService;
 import org.eclipse.ui.tests.api.workbenchpart.EmptyView;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventHandler;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.5
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class WorkbenchSiteProgressServiceModelTagsTest {
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	private IWorkbenchWindow window;
 
@@ -63,7 +63,7 @@ public class WorkbenchSiteProgressServiceModelTagsTest {
 
 	private WorkbenchSiteProgressServiceTestable progressService;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		window = openTestWindow();
 		page = window.getActivePage();
@@ -84,7 +84,7 @@ public class WorkbenchSiteProgressServiceModelTagsTest {
 	}
 
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		eventBroker.unsubscribe(eventHandler);
 		eventBroker = null;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbenchWindowSubordinateSourcesTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbenchWindowSubordinateSourcesTests.java
@@ -16,7 +16,7 @@ package org.eclipse.ui.tests.internal;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.core.expressions.EqualsExpression;
 import org.eclipse.core.expressions.EvaluationResult;
@@ -31,26 +31,26 @@ import org.eclipse.ui.ISources;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.WorkbenchWindow;
 import org.eclipse.ui.services.IEvaluationService;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests various sources keyed off the workbench window.
  *
  * @since 3.3
  */
-@Ignore("Disabled due 544032, see also 485167")
+@Disabled("Disabled due 544032, see also 485167")
+@ExtendWith(CloseTestWindowsExtension.class)
 public class WorkbenchWindowSubordinateSourcesTests {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	private WorkbenchWindow window;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		window = (WorkbenchWindow) openTestWindow();
 		processEvents();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/WorkbookEditorsHandlerTest.java
@@ -14,8 +14,8 @@
 
 package org.eclipse.ui.tests.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Arrays;
@@ -38,17 +38,17 @@ import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.WorkbookEditorsHandler;
 import org.eclipse.ui.part.FileEditorInput;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class WorkbookEditorsHandlerTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	private static final String PROJECT_NAME = "WorkbookEditorsHandlerTest";
 	private static final String PROJECT_NAME_1 = PROJECT_NAME + 1;
@@ -58,7 +58,7 @@ public class WorkbookEditorsHandlerTest {
 	private IProject project1;
 	private IProject project2;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws CoreException {
 		activeWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 		activePage = activeWindow.getActivePage();
@@ -66,7 +66,7 @@ public class WorkbookEditorsHandlerTest {
 		project2 = FileUtil.createProject(PROJECT_NAME_2);
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		if (project1 != null) {
 			project1.delete(true, true, null);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/intro/IntroTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/intro/IntroTest.java
@@ -14,10 +14,10 @@
 package org.eclipse.ui.tests.intro;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.IPageLayout;
@@ -36,22 +36,22 @@ import org.eclipse.ui.internal.intro.IntroDescriptor;
 import org.eclipse.ui.internal.util.PrefUtil;
 import org.eclipse.ui.intro.IIntroManager;
 import org.eclipse.ui.intro.IIntroPart;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
 import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.0
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IntroTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	@Rule
 	public final PreferenceMementoRule preferenceMemento = new PreferenceMementoRule();
@@ -119,7 +119,7 @@ public class IntroTest {
 	}
 
 	@Test
-	@Ignore("disabled during E4 transition")
+	@Disabled("disabled during E4 transition")
 	public void testActivateProblemsView() throws Exception {
 		IIntroManager introManager= window.getWorkbench().getIntroManager();
 		IIntroPart part= introManager.showIntro(window, false);
@@ -155,7 +155,7 @@ public class IntroTest {
 	 * that it no longer exists.
 	 */
 	@Test
-	@Ignore("disabled during E4 transition")
+	@Disabled("disabled during E4 transition")
 	public void testPerspectiveChange() {
 		// These tests are hard-wired to the pre-3.3 zoom behaviour
 		// Run them anyway to ensure that we preserve the 3.0 mechanism
@@ -186,7 +186,7 @@ public class IntroTest {
 	 * See IntroTest2.java
 	 */
 	@Test
-	@Ignore("disabled during E4 transition")
+	@Disabled("disabled during E4 transition")
 	public void testPerspectiveChangeWith32StickyBehavior() {
 		IWorkbench workbench = window.getWorkbench();
 		IIntroPart part = workbench.getIntroManager().showIntro(window, false);
@@ -247,7 +247,7 @@ public class IntroTest {
 		assertNull(workbench.getIntroManager().getIntro());
 	}
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		// these tests rely on the 3.2 behavior for sticky views
 		IPreferenceStore preferenceStore = PrefUtil.getAPIPreferenceStore();
@@ -261,7 +261,7 @@ public class IntroTest {
 		window = openTestWindow();
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		Workbench.getInstance().setIntroDescriptor(oldDesc);
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/intro/IntroTest2.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/intro/IntroTest2.java
@@ -14,8 +14,8 @@
 package org.eclipse.ui.tests.intro;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.IPerspectiveDescriptor;
@@ -30,19 +30,19 @@ import org.eclipse.ui.internal.intro.IIntroConstants;
 import org.eclipse.ui.internal.intro.IntroDescriptor;
 import org.eclipse.ui.internal.util.PrefUtil;
 import org.eclipse.ui.intro.IIntroPart;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.0
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class IntroTest2 {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	IWorkbenchWindow window = null;
 
@@ -81,7 +81,7 @@ public class IntroTest2 {
 
 	}
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		// these tests rely on the 3.3 behavior for sticky views
 		IPreferenceStore preferenceStore = PrefUtil.getAPIPreferenceStore();
@@ -95,7 +95,7 @@ public class IntroTest2 {
 		window = openTestWindow();
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		Workbench.getInstance().setIntroDescriptor(oldDesc);
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug36537Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug36537Test.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.keys;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,19 +29,19 @@ import org.eclipse.jface.bindings.TriggerSequence;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.keys.IBindingService;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests Bug 36537
  *
  * @since 3.0
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug36537Test {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	/**
 	 * Tests that there are no redundant key bindings defined in the

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug40023Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug40023Test.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.keys;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -33,21 +33,21 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.internal.Workbench;
 import org.eclipse.ui.internal.keys.BindingService;
 import org.eclipse.ui.keys.IBindingService;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests Bug 40023
  *
  * @since 3.0
  */
-@Ignore("Intermittent failure.  SWT Bug 44344.  XGrabPointer?")
+@Disabled("Intermittent failure.  SWT Bug 44344.  XGrabPointer?")
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug40023Test {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	/**
 	 * Retrieves a menu item matching or starting with the given name from an

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43321Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43321Test.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.keys;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
@@ -35,21 +35,21 @@ import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.Workbench;
 import org.eclipse.ui.internal.keys.BindingService;
 import org.eclipse.ui.keys.IBindingService;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests Bug 43321
  *
  * @since 3.0
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug43321Test {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	/**
 	 * Tests that non-check box items on the menu are not checked when activated

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug44460Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug44460Test.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.keys;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.util.List;
@@ -43,21 +43,21 @@ import org.eclipse.ui.internal.WorkbenchPage;
 import org.eclipse.ui.internal.keys.BindingService;
 import org.eclipse.ui.internal.keys.WorkbenchKeyboard;
 import org.eclipse.ui.keys.IBindingService;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test for Bug 44460.
  *
  * @since 3.0
  */
-@Ignore("disabled since it refers to the Java builder and nature, which are not available in an RCP build")
+@Disabled("disabled since it refers to the Java builder and nature, which are not available in an RCP build")
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug44460Test {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	/**
 	 * Test that pressing "Ctrl+Shift+T" in the Team Synchronizing perspective
@@ -87,7 +87,8 @@ public class Bug44460Test {
 		projectDescription.setBuildSpec(new ICommand[] { buildCommand });
 		testProject.setDescription(projectDescription, null);
 		IFile javaFile = testProject.getFile("A.java"); //$NON-NLS-1$
-		String classContents = "public class Main { public static main(String[] args) { ; } }"; //$NON-NLS-1$
+		String classContents = "@ExtendWith(CloseTestWindowsExtension.class)
+public class Main { public static main(String[] args) { ; } }"; //$NON-NLS-1$
 		ByteArrayInputStream inputStream = new ByteArrayInputStream(
 				classContents.getBytes());
 		javaFile.create(inputStream, true, null);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug53489Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug53489Test.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.keys;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
@@ -30,10 +30,10 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.tests.harness.util.AutomationUtil;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests that pressing delete in a styled text widget does not cause a double
@@ -41,12 +41,12 @@ import org.junit.Test;
  *
  * @since 3.0
  */
-@Ignore("disabled as it fails on the Mac.")
+@Disabled("disabled as it fails on the Mac.")
 // Ctrl+S doesn't save the editor, and posting MOD1+S also doesn't seem to work.
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug53489Test {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	/**
 	 * Tests that pressing delete in a styled text widget (in a running Eclipse)

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/leaks/LeakTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/leaks/LeakTests.java
@@ -17,8 +17,8 @@ package org.eclipse.ui.tests.leaks;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.ref.PhantomReference;
 import java.lang.ref.Reference;
@@ -44,12 +44,12 @@ import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.part.NullEditorInput;
 import org.eclipse.ui.progress.IWorkbenchSiteProgressService;
 import org.eclipse.ui.tests.api.MockViewPart;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Very simple leak tests to determine if any of our heavy objects are not being
@@ -58,9 +58,9 @@ import org.junit.Test;
  *
  * @since 3.1
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class LeakTests {
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private IWorkbenchPage fActivePage;
 
@@ -91,13 +91,13 @@ public class LeakTests {
 		return new PhantomReference<>(object, queue);
 	}
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fWin = openTestWindow(IDE.RESOURCE_PERSPECTIVE_ID);
 		fActivePage = fWin.getActivePage();
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		fWin = null;
 		fActivePage = null;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/Bug231304Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/Bug231304Test.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.menus;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.jface.action.ToolBarManager;
@@ -24,19 +24,19 @@ import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.menus.IMenuService;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  *
  * @since 3.5
  * @author Prakash G.R.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug231304Test {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	@Test
 	public void testToolTip() throws Exception {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/Bug264804Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/Bug264804Test.java
@@ -16,9 +16,9 @@ package org.eclipse.ui.tests.menus;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.jface.action.MenuManager;
@@ -32,18 +32,18 @@ import org.eclipse.ui.internal.PartSite;
 import org.eclipse.ui.internal.PopupMenuExtender;
 import org.eclipse.ui.tests.api.ListElement;
 import org.eclipse.ui.tests.api.ListView;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.5
  * @author Prakash G.R.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug264804Test {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	@Test
 	public void testPopup() throws Exception {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/Bug410426Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/Bug410426Test.java
@@ -14,9 +14,9 @@
 package org.eclipse.ui.tests.menus;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,19 +29,19 @@ import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.menus.IMenuService;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
 import org.osgi.service.log.LogListener;
 import org.osgi.service.log.LogService;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @author Maxime Porhel
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug410426Test {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	@Test
 	public void testToolbarContributionFromFactoryVisibility() throws Exception {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/MenuTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/MenuTestCase.java
@@ -26,10 +26,10 @@ import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.menus.CommandContributionItem;
 import org.eclipse.ui.menus.IMenuService;
 import org.eclipse.ui.tests.api.workbenchpart.MenuContributionHarness;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Base class for tests concerning the 'org.eclipse.ui.menus'
@@ -42,19 +42,19 @@ import org.junit.Rule;
  *
  * @since 3.3
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class MenuTestCase {
 
 	protected static final String TEST_CONTRIBUTIONS_CACHE_ID = "org.eclipse.ui.tests.IfYouChangeMe.FixTheTests";
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	protected IContextService contextService;
 	protected IMenuService menuService;
 	protected IWorkbenchWindow window;
 	protected IContextActivation activeContext;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 
 		window = openTestWindow();
@@ -70,7 +70,7 @@ public class MenuTestCase {
 		menuService = window.getService(IMenuService.class);
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		if (activeContext != null) {
 			contextService.deactivateContext(activeContext);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/MenuVisibilityTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/MenuVisibilityTest.java
@@ -15,10 +15,10 @@
 package org.eclipse.ui.tests.menus;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 
@@ -58,23 +58,23 @@ import org.eclipse.ui.services.IServiceLocator;
 import org.eclipse.ui.tests.TestPlugin;
 import org.eclipse.ui.tests.api.workbenchpart.MenuContributionHarness;
 import org.eclipse.ui.tests.commands.ActiveContextExpression;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.3
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class MenuVisibilityTest {
 
 	private static final String EXTENSION_ID = "org.eclipse.ui.tests.menusX1";
 	private static final String LOCATION = "menu:foo";
 	private static final String COMMAND_ID = "org.eclipse.ui.tests.commandEnabledVisibility";
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private IContextService contextService;
 	private IMenuService menuService;
@@ -417,7 +417,7 @@ public class MenuVisibilityTest {
 		parentMenuManager.dispose();
 	}
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		window = openTestWindow();
 		menuService = window.getService(IMenuService.class);
@@ -431,7 +431,7 @@ public class MenuVisibilityTest {
 		}
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		if (activeContext != null) {
 			contextService.deactivateContext(activeContext);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/ObjectContributionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/ObjectContributionTest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.menus;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
@@ -49,10 +49,10 @@ import org.eclipse.ui.internal.PartSite;
 import org.eclipse.ui.internal.PopupMenuExtender;
 import org.eclipse.ui.internal.WorkbenchWindow;
 import org.eclipse.ui.tests.api.workbenchpart.EmptyView;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.menus.ObjectContributionClasses.ICommon;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests that object contributions are enabled and shown correctly in pop-up
@@ -65,8 +65,7 @@ import org.junit.Test;
  */
 public final class ObjectContributionTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	/**
 	 * Tests whether the content-type object contribution works. This is testing

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/ShowViewMenuTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/menus/ShowViewMenuTest.java
@@ -14,27 +14,27 @@
 package org.eclipse.ui.tests.menus;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.internal.ShowViewMenu;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.5
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ShowViewMenuTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private IWorkbenchWindow workbenchWindow;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		// open a workbench window with the empty perspective, since it defines
 		// no show view shortcuts, it is suitable for the two single show view

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multieditor/AbstractMultiEditorTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multieditor/AbstractMultiEditorTest.java
@@ -14,8 +14,8 @@
 package org.eclipse.ui.tests.multieditor;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.URL;
@@ -48,15 +48,15 @@ import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.part.MultiEditorInput;
 import org.eclipse.ui.tests.TestPlugin;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class AbstractMultiEditorTest {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private static final String PROJECT_NAME = "TiledEditorProject";
 
@@ -194,7 +194,7 @@ public class AbstractMultiEditorTest {
 	/**
 	 * Close any editors at the beginner of a test, so the test can be clean.
 	 */
-	@Before
+	@BeforeEach
 	public void doSetUp() throws Exception {
 		IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow()
 				.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageEditorPartTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageEditorPartTest.java
@@ -14,23 +14,23 @@
 package org.eclipse.ui.tests.multipageeditor;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.internal.ErrorEditorPart;
 import org.eclipse.ui.internal.part.NullEditorInput;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class MultiPageEditorPartTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		TestMultiPageEditorThrowingPartInitException.resetSpy();
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageEditorSelectionTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageEditorSelectionTest.java
@@ -15,9 +15,9 @@ package org.eclipse.ui.tests.multipageeditor;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 
@@ -35,22 +35,22 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.ide.IDE;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.views.properties.PropertySheet;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class MultiPageEditorSelectionTest {
 
 	private static final String MTEST01_FILE = "mtest01.multivar";
 
 	private static final String PROJECT_NAME = "MultiPageEditorSelction";
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject testProject = workspace.getRoot().getProject(PROJECT_NAME);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageKeyBindingTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiPageKeyBindingTest.java
@@ -29,10 +29,10 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.keys.ParseException;
 import org.eclipse.ui.part.FileEditorInput;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests that key bindings are treated correctly in a multi-page editor. This
@@ -42,11 +42,11 @@ import org.junit.Test;
  * @since 3.0
  */
 @SuppressWarnings("removal")
-@Ignore("Focus issues, see Commit c28efd634f53c9de7bb31b756ffc755b8faf0ffe")
+@Disabled("Focus issues, see Commit c28efd634f53c9de7bb31b756ffc755b8faf0ffe")
+@ExtendWith(CloseTestWindowsExtension.class)
 public class MultiPageKeyBindingTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	/**
 	 * Tests that the key bindings are updated when the page is switched in a

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiVariablePageTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/multipageeditor/MultiVariablePageTest.java
@@ -16,10 +16,10 @@ package org.eclipse.ui.tests.multipageeditor;
 import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collection;
@@ -45,9 +45,9 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.part.MultiPageEditorPart;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * <p>
@@ -61,6 +61,7 @@ import org.junit.Test;
  *
  * @since 3.2
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class MultiVariablePageTest {
 
 	private static final String FILE_CONTENTS = "#section01\nsection 1\n#section02\nsection 2\nwith info\n#section03\nLast page\n";
@@ -71,8 +72,7 @@ public class MultiVariablePageTest {
 
 	private static final String MULTI_VARIABLE_PROJ = "MultiVariableTest";
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private int fPostCalled;
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/navigator/AbstractNavigatorTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/navigator/AbstractNavigatorTest.java
@@ -27,18 +27,18 @@ import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Rule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * The AbstractNavigatorTest is the abstract superclass
  * of tests that use a populated Resource Navigator.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public abstract class AbstractNavigatorTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	protected IProject testProject;
 
@@ -81,7 +81,7 @@ public abstract class AbstractNavigatorTest {
 		navigator = window.getActivePage().showView(IPageLayout.ID_PROJECT_EXPLORER);
 	}
 
-	@After
+	@AfterEach
 	public final void cleanupWorkspace() throws Exception {
 		if (testProject != null) {
 			testProject.delete(true, null);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/operations/WorkbenchOperationStressTests.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/operations/WorkbenchOperationStressTests.java
@@ -23,9 +23,9 @@ import org.eclipse.core.commands.operations.IUndoableOperation;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.ide.IDE;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Stress tests the Operations Framework API to find any interaction problems
@@ -33,14 +33,14 @@ import org.junit.Test;
  *
  * @since 3.1
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class WorkbenchOperationStressTests {
 
 	static int STRESS_TEST_REPETITIONS = 2000;
 
 	static int OPEN_WINDOW_REPETITIONS = 2;
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 
 	/*

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ViewerItemsLimitTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/preferences/ViewerItemsLimitTest.java
@@ -17,8 +17,8 @@ import static org.eclipse.ui.PlatformUI.getWorkbench;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEventsUntil;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.waitForJobs;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -60,18 +60,18 @@ import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.internal.views.markers.MarkersTreeViewer;
 import org.eclipse.ui.intro.IIntroPart;
 import org.eclipse.ui.navigator.CommonViewer;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.EmptyPerspective;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ViewerItemsLimitTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private IPreferenceStore preferenceStore;
 
@@ -89,7 +89,7 @@ public class ViewerItemsLimitTest {
 
 	private IWorkbenchPage activePage;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		cleanUp();
 		preferenceStore = WorkbenchPlugin.getDefault().getPreferenceStore();
@@ -102,7 +102,7 @@ public class ViewerItemsLimitTest {
 		getWorkbench().showPerspective(EmptyPerspective.PERSP_ID, window);
 	}
 
-	@After
+	@AfterEach
 	public final void tearDown() throws Exception {
 		cleanUp();
 		preferenceStore.setValue(IWorkbenchPreferenceConstants.LARGE_VIEW_LIMIT, DEFAULT_VIEW_LIMIT);
@@ -366,7 +366,7 @@ public class ViewerItemsLimitTest {
 	 * search. Check limited search results. Add new search data onto workspace and
 	 * refresh search to see if search results updated properly.
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public void testLimitedSearchResult() throws CoreException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressTestCase.java
@@ -16,7 +16,7 @@ package org.eclipse.ui.tests.progress;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -29,20 +29,20 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.internal.progress.FinishedJobs;
 import org.eclipse.ui.internal.progress.ProgressView;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public abstract class ProgressTestCase {
 
 	protected ProgressView progressView;
 	protected IWorkbenchWindow window;
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
-	@Before
+	@BeforeEach
 	public void doSetUp() throws Exception {
 		window = openTestWindow("org.eclipse.ui.resourcePerspective");
 
@@ -51,7 +51,7 @@ public abstract class ProgressTestCase {
 		FinishedJobs.getInstance().clearAll();
 	}
 
-	@After
+	@AfterEach
 	public void doTearDown() throws Exception {
 		// Remove progress info items
 		FinishedJobs.getInstance().clearAll();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/AbstractPropertySheetTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/AbstractPropertySheetTest.java
@@ -25,23 +25,23 @@ import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IViewReference;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.views.properties.PropertySheet;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.4
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public abstract class AbstractPropertySheetTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
+	
 
 	private static final String PIN_PROPERTY_SHEET_ACTION_ID_PREFIX = "org.eclipse.ui.views.properties.PinPropertySheetAction";
 	protected IWorkbenchPage activePage;
 
-	@Before
+	@BeforeEach
 	public final void initializeActivePage() throws Exception {
 		IWorkbenchWindow workbenchWindow = openTestWindow();
 		activePage = workbenchWindow.getActivePage();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/PropertySheetAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/propertysheet/PropertySheetAuto.java
@@ -15,11 +15,11 @@
 package org.eclipse.ui.tests.propertysheet;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Random;
@@ -35,7 +35,7 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.tests.SelectionProviderView;
 import org.eclipse.ui.tests.api.SaveableMockViewPart;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.views.properties.ColorPropertyDescriptor;
 import org.eclipse.ui.views.properties.IPropertyDescriptor;
 import org.eclipse.ui.views.properties.IPropertySource;
@@ -43,10 +43,10 @@ import org.eclipse.ui.views.properties.PropertySheet;
 import org.eclipse.ui.views.properties.PropertySheetEntry;
 import org.eclipse.ui.views.properties.PropertySheetPage;
 import org.eclipse.ui.views.properties.TextPropertyDescriptor;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  *  The class implements a test for the workbench's default
@@ -58,10 +58,10 @@ import org.junit.Test;
  * properties.
  */
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class PropertySheetAuto {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	/**
 	 * This car serves as a simple porperty source.
@@ -281,7 +281,7 @@ public class PropertySheetAuto {
 		return new Car(modelYear, color, manufacturer, model, engineSize);
 	}
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		workbenchWindow = openTestWindow();
 		activePage = workbenchWindow.getActivePage();
@@ -346,7 +346,7 @@ public class PropertySheetAuto {
 	 * </p>
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void XtestInputIfHiddenBug69953() throws Throwable {
 		PropertySheetPerspectiveFactory2.applyPerspective(activePage);
 		PropertySheet propView = (PropertySheet) createTestParts(activePage);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/ContentMatchesTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/ContentMatchesTest.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.quickaccess;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -25,28 +25,28 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.internal.quickaccess.QuickAccessContents;
 import org.eclipse.ui.internal.quickaccess.QuickAccessDialog;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests the content of quick access for given requests
  *
  * @since 3.14
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ContentMatchesTest {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private static final int TIMEOUT = 3000;
 	private QuickAccessDialog dialog;
 	private QuickAccessContents quickAccessContents;
 
-	@Before
+	@BeforeEach
 	public void doSetUp() throws Exception {
 		IWorkbenchWindow window = openTestWindow();
 		dialog = new QuickAccessDialog(window, null);
@@ -54,7 +54,7 @@ public class ContentMatchesTest {
 		dialog.open();
 	}
 
-	@After
+	@AfterEach
 	public void doTearDown() throws Exception {
 		dialog.close();
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/quickaccess/QuickAccessDialogTest.java
@@ -17,9 +17,9 @@ package org.eclipse.ui.tests.quickaccess;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEventsUntil;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Arrays;
@@ -47,17 +47,18 @@ import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.quickaccess.QuickAccessDialog;
 import org.eclipse.ui.internal.quickaccess.QuickAccessMessages;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests the quick access UI
  * @since 3.4
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class QuickAccessDialogTest {
 
 	private class TestQuickAccessDialog extends QuickAccessDialog {
@@ -72,8 +73,7 @@ public class QuickAccessDialogTest {
 		}
 	}
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private static final int TIMEOUT = 5000;
 	// As defined in QuickAccessDialog and in SearchField
@@ -84,7 +84,7 @@ public class QuickAccessDialogTest {
 	private IWorkbenchWindow activeWorkbenchWindow;
 
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		Arrays.stream(Display.getDefault().getShells()).filter(isQuickAccessShell).forEach(Shell::close);
 		dialogSettings = new DialogSettings("QuickAccessDialogTest" + System.currentTimeMillis());
@@ -99,7 +99,7 @@ public class QuickAccessDialogTest {
 				.map(QuickAccessDialog.class::cast);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		Arrays.stream(Display.getDefault().getShells()).filter(isQuickAccessShell)
 				.forEach(Shell::close);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/ContributedServiceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/ContributedServiceTest.java
@@ -16,10 +16,10 @@
 package org.eclipse.ui.tests.services;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IViewReference;
@@ -35,18 +35,18 @@ import org.eclipse.ui.services.AbstractServiceFactory;
 import org.eclipse.ui.services.IDisposable;
 import org.eclipse.ui.services.IServiceLocator;
 import org.eclipse.ui.services.IServiceScopes;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.4
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ContributedServiceTest {
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	@Test
 	public void testGlobalService() throws Exception {
@@ -70,7 +70,7 @@ public class ContributedServiceTest {
 	}
 
 	@Test
-	@Ignore // TODO
+	@Disabled // TODO
 	public void testWindowService() throws Exception {
 		IServiceLocator locator = getWorkbench().getActiveWorkbenchWindow();
 		IWorkbenchLocationService wls = locator.getService(IWorkbenchLocationService.class);
@@ -107,7 +107,7 @@ public class ContributedServiceTest {
 	}
 
 	@Test
-	@Ignore // TODO
+	@Disabled // TODO
 	public void testLocalServiceCreated() throws Exception {
 		IServiceLocator parent = getWorkbench().getActiveWorkbenchWindow();
 		IWorkbenchLocationService wls = parent.getService(IWorkbenchLocationService.class);
@@ -151,7 +151,7 @@ public class ContributedServiceTest {
 	}
 
 	@Test
-	@Ignore // TODO
+	@Disabled // TODO
 	public void testLocalDialogService() throws Exception {
 		IServiceLocator parent = getWorkbench();
 		IServiceLocatorCreator lc = parent.getService(IServiceLocatorCreator.class);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/EditorSourceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/EditorSourceTest.java
@@ -17,10 +17,10 @@ package org.eclipse.ui.tests.services;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Objects;
 
@@ -42,20 +42,20 @@ import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.services.IEvaluationService;
 import org.eclipse.ui.tests.api.MockReusableEditorPart;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.5
  */
-@Ignore("See bug 436755 and commit 0d6ce84b3d3a588733bdae43224c612239a0a9a7")
+@Disabled("See bug 436755 and commit 0d6ce84b3d3a588733bdae43224c612239a0a9a7")
+@ExtendWith(CloseTestWindowsExtension.class)
 public class EditorSourceTest {
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private static class MyEval implements IPropertyChangeListener {
 		public int count = 0;
@@ -97,7 +97,7 @@ public class EditorSourceTest {
 	private IFile test1;
 	private IFile test2;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		project = FileUtil.createProject("testActiveEditor");
 		test1 = FileUtil.createFile("test1.mockr1", project);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/EvaluationServiceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/EvaluationServiceTest.java
@@ -20,11 +20,11 @@ import static org.eclipse.ui.tests.harness.util.UITestUtil.forceActive;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.waitForJobs;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -67,24 +67,21 @@ import org.eclipse.ui.services.IEvaluationService;
 import org.eclipse.ui.services.ISourceProviderService;
 import org.eclipse.ui.tests.SelectionProviderView;
 import org.eclipse.ui.tests.commands.ActiveContextExpression;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Assume;
-import org.junit.FixMethodOrder;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.3
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@ExtendWith(CloseTestWindowsExtension.class)
 public class EvaluationServiceTest {
 	private static final String CHECK_HANDLER_ID = "org.eclipse.ui.tests.services.checkHandler";
 	private static final String CONTEXT_ID1 = "org.eclipse.ui.command.contexts.evaluationService1";
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private static class MyEval implements IPropertyChangeListener {
 		public volatile int count = 0;
@@ -141,7 +138,7 @@ public class EvaluationServiceTest {
 		waitForJobs(500, 5000);
 
 		boolean activeShell = forceActive(window.getShell());
-		Assume.assumeTrue(activeShell);
+		Assumptions.assumeTrue(activeShell);
 
 		IEvaluationService service = window
 				.getService(IEvaluationService.class);
@@ -213,7 +210,7 @@ public class EvaluationServiceTest {
 		waitForJobs(500, 5000);
 
 		final AtomicBoolean shellIsActive = new AtomicBoolean(activeShell);
-		Assume.assumeTrue(shellIsActive.get());
+		Assumptions.assumeTrue(shellIsActive.get());
 
 		IEvaluationService service = window
 				.getService(IEvaluationService.class);
@@ -289,7 +286,7 @@ public class EvaluationServiceTest {
 	}
 
 	@Test
-	@Ignore // TODO fix testRestriction
+	@Disabled // TODO fix testRestriction
 	public void testRestriction() {
 		IWorkbenchWindow window = openTestWindow();
 		IEvaluationService evaluationService = window
@@ -362,7 +359,7 @@ public class EvaluationServiceTest {
 	}
 
 	@Test
-	@Ignore // TODO fix testScopedService
+	@Disabled // TODO fix testScopedService
 	public void testScopedService() throws Exception {
 		IWorkbenchWindow window = openTestWindow();
 		IEvaluationService service = window
@@ -562,7 +559,7 @@ public class EvaluationServiceTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void testSystemProperty() throws Exception {
 		// this is not added, as the ability to test system properties with
 		// no '.' seems unhelpful

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/WorkbenchSiteProgressServiceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/services/WorkbenchSiteProgressServiceTest.java
@@ -16,9 +16,9 @@ package org.eclipse.ui.tests.services;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -38,19 +38,19 @@ import org.eclipse.ui.internal.PartSite;
 import org.eclipse.ui.internal.progress.WorkbenchSiteProgressService;
 import org.eclipse.ui.internal.progress.WorkbenchSiteProgressService.SiteUpdateJob;
 import org.eclipse.ui.progress.IWorkbenchSiteProgressService;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.5
  * @author Prakash G.R.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class WorkbenchSiteProgressServiceTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private IWorkbenchPart activePart;
 	private IWorkbenchWindow window;
@@ -61,7 +61,7 @@ public class WorkbenchSiteProgressServiceTest {
 	private static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS Z") //$NON-NLS-1$
 			.withZone(ZoneId.systemDefault());
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		window = openTestWindow("org.eclipse.ui.resourcePerspective");
 		activePart = window.getActivePage().getActivePart();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/stress/OpenCloseTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/stress/OpenCloseTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.stress;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.HashMap;
 
@@ -40,15 +40,16 @@ import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.intro.IIntroPart;
 import org.eclipse.ui.part.FileEditorInput;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test opening and closing of items.
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class OpenCloseTest {
 	private static final String ORG_ECLIPSE_RESOURCE_PERSPECTIVE = "org.eclipse.ui.resourcePerspective";
 
@@ -58,10 +59,9 @@ public class OpenCloseTest {
 	private IWorkbench workbench;
 	private IWorkbenchPage page;
 
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		workbench = PlatformUI.getWorkbench();
 		workbenchWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/themes/ThemeTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/themes/ThemeTest.java
@@ -15,22 +15,22 @@
 package org.eclipse.ui.tests.themes;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.e4.ui.css.swt.theme.IThemeEngine;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.themes.ITheme;
 import org.eclipse.ui.themes.IThemeManager;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @since 3.0
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public abstract class ThemeTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	private static final String MOCK_CSS_THEME = "org.eclipse.e4.ui.css.theme.mock";
 
@@ -40,7 +40,7 @@ public abstract class ThemeTest {
 
 	protected IThemeManager fManager;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		fManager = getWorkbench().getThemeManager();
 		fManager.setCurrentTheme(IThemeManager.DEFAULT_THEME);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/zoom/ZoomTestCase.java
@@ -14,7 +14,7 @@
 package org.eclipse.ui.tests.zoom;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -36,16 +36,16 @@ import org.eclipse.ui.internal.util.PrefUtil;
 import org.eclipse.ui.internal.util.Util;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.tests.api.MockEditorPart;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class ZoomTestCase {
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	
 
 	@Rule
 	public final PreferenceMementoRule preferenceMemento = new PreferenceMementoRule();
@@ -66,7 +66,7 @@ public class ZoomTestCase {
 
 	private IFile file3;
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		window = (WorkbenchWindow) openTestWindow(ZoomPerspectiveFactory.PERSP_ID);
 		page = (WorkbenchPage) window.getActivePage();


### PR DESCRIPTION
This commit migrates the CloseTestWindowsRule from JUnit 4 to JUnit 5 by creating a new CloseTestWindowsExtension and updating all tests that use it.

Changes:
- Created CloseTestWindowsExtension as a JUnit 5 extension implementing BeforeEachCallback and AfterEachCallback interfaces
- Updated UITestCase to use JUnit 5 annotations and CloseTestWindowsExtension
- Migrated 123 test files from using @Rule CloseTestWindowsRule to @ExtendWith(CloseTestWindowsExtension.class)
- Updated all test annotations from JUnit 4 to JUnit 5:
  * @Before -> @BeforeEach
  * @After -> @AfterEach
  * @Ignore -> @Disabled
  * @BeforeClass -> @BeforeAll
  * @AfterClass -> @AfterAll
- Updated imports from org.junit.* to org.junit.jupiter.api.*
- Updated assertions from org.junit.Assert to org.junit.jupiter.api.Assertions
- Marked CloseTestWindowsRule as @Deprecated to guide users to the new extension

Affected test bundles:
- org.eclipse.ui.tests.harness
- org.eclipse.ui.tests.navigator
- org.eclipse.ui.tests.performance
- org.eclipse.ui.tests

All test files now use JUnit 5 extension mechanism for window cleanup.