### PR TITLE
Remove unused method

### DIFF
--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/text/TextSearchPage.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/text/TextSearchPage.java
@@ -643,13 +643,6 @@ public class TextSearchPage extends DialogPage implements ISearchPage, IReplaceP
 		return false;
 	}
 
-//	private void loadFilePatternDefaults() {
-//		SearchMatchInformationProviderRegistry registry= SearchPlugin.getDefault().getSearchMatchInformationProviderRegistry();
-//		String[] defaults= registry.getDefaultFilePatterns();
-//		fExtensions.setItems(defaults);
-//		fExtensions.setText(defaults[0]);
-//	}
-
 	private String insertEscapeChars(String text) {
 		if (text == null || text.equals("")) { //$NON-NLS-1$
 			return ""; //$NON-NLS-1$


### PR DESCRIPTION
The `loadFilePatternDefaults()` method has been commented out since 2006 and is no longer referenced or used anywhere in the codebase. Hence removing it as a part of cleanup.