### PR TITLE
Performance: Cache method calls in loops and optimize string concaten…

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/MenuManagerShowProcessor.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/MenuManagerShowProcessor.java
@@ -123,8 +123,8 @@ public class MenuManagerShowProcessor implements IMenuListener2 {
 	 * {@link MDynamicMenuContribution} application model elements
 	 */
 	private void processDynamicElements(MMenu menuModel, MenuManager menuManager) {
-		MMenuElement[] menuElements = menuModel.getChildren().toArray(
-				new MMenuElement[menuModel.getChildren().size()]);
+		List<MMenuElement> children = menuModel.getChildren();
+		MMenuElement[] menuElements = children.toArray(new MMenuElement[children.size()]);
 		for (MMenuElement currentMenuElement : menuElements) {
 
 			if (currentMenuElement instanceof MDynamicMenuContribution dmc) {
@@ -154,9 +154,9 @@ public class MenuManagerShowProcessor implements IMenuListener2 {
 				if (mel.size() > 0) {
 
 					int position = 0;
-					while (position < menuModel.getChildren().size()) {
-						if (currentMenuElement == menuModel.getChildren().get(
-								position)) {
+					children = menuModel.getChildren();
+					while (position < children.size()) {
+						if (currentMenuElement == children.get(position)) {
 							position++;
 							break;
 						}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPage.java
@@ -3423,16 +3423,18 @@ public class WorkbenchPage implements IWorkbenchPage {
 		// Hide placeholders for parts that exist in the 'global' areas
 		modelService.hideLocalPlaceholders(window, dummyPerspective);
 
-		int dCount = dummyPerspective.getChildren().size();
-		while (!dummyPerspective.getChildren().isEmpty()) {
-			MPartSashContainerElement dChild = dummyPerspective.getChildren().remove(0);
-			persp.getChildren().add(dChild);
+		List<MPartSashContainerElement> dummyChildren = dummyPerspective.getChildren();
+		List<MPartSashContainerElement> perspChildren = persp.getChildren();
+		int dCount = dummyChildren.size();
+		while (!dummyChildren.isEmpty()) {
+			MPartSashContainerElement dChild = dummyChildren.remove(0);
+			perspChildren.add(dChild);
 		}
 
-		while (persp.getChildren().size() > dCount) {
-			MUIElement child = persp.getChildren().get(0);
+		while (perspChildren.size() > dCount) {
+			MUIElement child = perspChildren.get(0);
 			child.setToBeRendered(false);
-			persp.getChildren().remove(0);
+			perspChildren.remove(0);
 		}
 
 		List<MWindow> existingDetachedWindows = new ArrayList<>();

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/registry/WizardsRegistryReader.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/registry/WizardsRegistryReader.java
@@ -76,14 +76,15 @@ public class WizardsRegistryReader extends RegistryReader {
 
 		CategoryNode(Category cat) {
 			category = cat;
-			path = ""; //$NON-NLS-1$
 			String[] categoryPath = category.getParentPath();
+			StringBuilder pathBuilder = new StringBuilder();
 			if (categoryPath != null) {
 				for (String parentPath : categoryPath) {
-					path += parentPath + '/';
+					pathBuilder.append(parentPath).append('/');
 				}
 			}
-			path += cat.getId();
+			pathBuilder.append(cat.getId());
+			path = pathBuilder.toString();
 		}
 
 		String getPath() {


### PR DESCRIPTION
Apply low-risk performance optimizations across multiple bundles.

After review, this PR contains only the legitimate performance improvements:

**Repeated method call caching:**
- MenuManagerShowProcessor: Cache menuModel.getChildren() to avoid repeated method calls in loop condition
- WorkbenchPage: Cache getChildren() results to avoid repeated method calls in loops

**String concatenation optimizations:**
- WizardsRegistryReader: Use StringBuilder for path construction in loop instead of repeated string concatenation

All changes are non-API breaking and maintain identical behavior while reducing unnecessary object allocations and method calls.

**Note:** Changes that provided no actual benefit (caching simple field accesses like List.size(), String.length(), or unnecessary variable extractions) have been removed.