### PR TITLE
Remove commented out code that does not serve as documentation

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/sac/CSSDocumentHandlerImpl.java
+++ b/bundles/org.eclipse.e4.ui.css.core/src/org/eclipse/e4/ui/css/core/impl/sac/CSSDocumentHandlerImpl.java
@@ -91,7 +91,6 @@ public class CSSDocumentHandlerImpl implements ExtendedDocumentHandler {
 		if (!getNodeStack().empty()) {
 			((CSSRuleListImpl) getNodeStack().peek()).add(ir);
 		} else {
-			// _getNodeStack().push(ir);
 			nodeRoot = ir;
 		}
 	}
@@ -100,10 +99,6 @@ public class CSSDocumentHandlerImpl implements ExtendedDocumentHandler {
 	public void namespaceDeclaration(String prefix, String uri)
 			throws CSSException {
 		//TODO replace with eclipse logging
-		//		if (logger.isDebugEnabled()) {
-		//			logger.debug("Declare namespace [prefix=" + prefix + ", uri=" + uri
-		//					+ "]");
-		//		}
 	}
 
 	@Override
@@ -116,7 +111,6 @@ public class CSSDocumentHandlerImpl implements ExtendedDocumentHandler {
 		if (!getNodeStack().empty()) {
 			((CSSRuleListImpl) getNodeStack().peek()).add(ir);
 		} else {
-			// _getNodeStack().push(ir);
 			nodeRoot = ir;
 		}
 	}
@@ -125,27 +119,12 @@ public class CSSDocumentHandlerImpl implements ExtendedDocumentHandler {
 	public void startMedia(SACMediaList media) throws CSSException {
 
 		ignore = true;
-		//		// Create the media rule and add it to the rule list
-		//		CSSMediaRuleImpl mr = new CSSMediaRuleImpl(parentStyleSheet, null,
-		//				new MediaListImpl(media));
-		//		if (!getNodeStack().empty()) {
-		//			((CSSRuleListImpl) getNodeStack().peek()).add(mr);
-		//		}
-		//
-		//		// Create the rule list
-		//		CSSRuleListImpl rules = new CSSRuleListImpl();
-		//		mr.setRuleList(rules);
-		//		getNodeStack().push(mr);
-		//		getNodeStack().push(rules);
 	}
 
 	@Override
 	public void endMedia(SACMediaList media) throws CSSException {
 
 		ignore = false;
-		//		// Pop the rule list and media rule nodes
-		//		getNodeStack().pop();
-		//		nodeRoot = getNodeStack().pop();
 	}
 
 	@Override
@@ -176,26 +155,11 @@ public class CSSDocumentHandlerImpl implements ExtendedDocumentHandler {
 	@Override
 	public void startFontFace() throws CSSException {
 		ignore = true;
-		//		// Create the font face rule and add it to the rule list
-		//		CSSFontFaceRuleImpl fontFaceRule = new CSSFontFaceRuleImpl(
-		//				parentStyleSheet, null);
-		//		if (!getNodeStack().empty()) {
-		//			((CSSRuleListImpl) getNodeStack().peek()).add(fontFaceRule);
-		//		}
-		//
-		//		// Create the style declaration
-		//		CSSStyleDeclarationImpl decl = new CSSStyleDeclarationImpl(fontFaceRule);
-		//		fontFaceRule.setStyle(decl);
-		//		getNodeStack().push(fontFaceRule);
-		//		getNodeStack().push(decl);
 	}
 
 	@Override
 	public void endFontFace() throws CSSException {
 		ignore = false;
-		//		// Pop both the style declaration and the font face rule nodes
-		//		getNodeStack().pop();
-		//		nodeRoot = getNodeStack().pop();
 	}
 
 	@Override

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/SelectionProcessor.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/SelectionProcessor.java
@@ -294,33 +294,6 @@ public final class SelectionProcessor {
 					TextEdit replace= new ReplaceEdit(region.getOffset(), region.getLength(), string);
 					root.addChild(replace);
 				}
-	//			while (lastDelim != -1) {
-	//				// more stuff to insert
-	//				String string;
-	//				Match m= delimiterMatcher.indexOf(replacement, lastDelim);
-	//				if (m == null) {
-	//					string= replacement.substring(lastDelim);
-	//					lastDelim= -1;
-	//				} else {
-	//					string= replacement.substring(lastDelim, m.getOffset());
-	//					lastDelim= m.getOffset() + m.getText().length();
-	//				}
-	//				endLine++;
-	//				TextEdit edit;
-	//				if (endLine < fDocument.getNumberOfLines()) {
-	//					edit= createReplaceEdit(endLine, visualStartColumn, visualEndColumn, string, delete);
-	//				} else {
-	//					// insertion reaches beyond the last line
-	//					int insertLocation= root.getExclusiveEnd();
-	//					int spaces= visualStartColumn;
-	//					char[] array= new char[spaces];
-	//					Arrays.fill(array, ' ');
-	//					string= TextUtilities.getDefaultLineDelimiter(fDocument) + String.valueOf(array) + string;
-	//					edit= new InsertEdit(insertLocation, string);
-	//					insertLocation+= string.length();
-	//				}
-	//				root.addChild(edit);
-	//			}
 				return root;
 			}
 		}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerContentGenerator.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerContentGenerator.java
@@ -758,9 +758,7 @@ public class MarkerContentGenerator {
 		if (forceUpdate || updateNeededForSelection(newElements)) {
 			internalUpdateSelectedElements(newElements);
 			// See comments below and Bug 296695
-			// if (contentChanged()) {
 			requestMarkerUpdate();
-			// }
 		}
 	}
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkersChangeListener.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkersChangeListener.java
@@ -40,8 +40,6 @@ class MarkersChangeListener implements IResourceChangeListener {
 	private String[] listeningTypes;
 	private boolean receiving;
 
-	//private static final int UPDATE_TEST_CHECK_LIMIT = 1500;
-
 	// The time the build started. A -1 indicates no build in progress.
 	private long preBuildTime;
 
@@ -130,9 +128,6 @@ class MarkersChangeListener implements IResourceChangeListener {
 			if(!hasApplicableTypes(event)){
 				return;
 			}
-			// if (!needsUpdate(event)) {
-			// return;
-			// }
 
 			if (!builder.isIncremental()) {
 				builder.getUpdateScheduler().scheduleUpdate();
@@ -157,13 +152,6 @@ class MarkersChangeListener implements IResourceChangeListener {
 	 */
 	void setReceivingChange(boolean receiving) {
 		this.receiving = receiving;
-	}
-
-	/**
-	 * Markers have not changed
-	 */
-	private void handleNoMarkerChange() {
-		//view.indicateUpdating(null, true, false);
 	}
 
 	/**
@@ -218,10 +206,7 @@ class MarkersChangeListener implements IResourceChangeListener {
 			MarkerUpdate update = new MarkerUpdate(added, removed, changed);
 			builder.incrementalUpdate(update);
 			builder.getUpdateScheduler().scheduleUpdate();
-		} else {
-			handleNoMarkerChange();
 		}
-		return;
 	}
 
 	/**
@@ -253,155 +238,6 @@ class MarkersChangeListener implements IResourceChangeListener {
 		}
 		return false;
 	}
-
-//	/**
-//	 * Note: This has been left commented out for further
-//	 * investigation(*),instead we we use the above for just checking types.
-//	 * This may invoke contributed code; as a field filter can be contributed.
-//	 * But again in such a case, the view would be a contributed as well.And, it
-//	 * is the responsibility of the field filter code to ensure the select
-//	 * method of filter remains fast.
-//	 *
-//	 */
-//	private boolean needsUpdate(IResourceChangeEvent event) {
-//		IMarkerDelta[] markerDeltas = event.findMarkerDeltas(null, true);
-//		MarkerEntry[] presentEntries = builder.getClonedMarkers().getClone()
-//				.getMarkerEntryArray();
-//		int deltaCount = markerDeltas.length;
-//		if (deltaCount == 0) {
-//			return false;
-//		}
-//		String[] types = listeningTypes;
-//		if (hasMarkerRemoval(presentEntries, null)) {
-//			return true;
-//		}
-//		int maxTestCount = deltaCount > UPDATE_TEST_CHECK_LIMIT ? UPDATE_TEST_CHECK_LIMIT
-//				: deltaCount;
-//
-//		for (int i = 0; i < markerDeltas.length; i++) {
-//			String typeId = markerDeltas[i].getType();
-//			if (!hasApplicableTypes(types, typeId)) {
-//				continue;
-//			}
-//			if (presentEntries == null || presentEntries.length == 0) {
-//				return true;
-//			}
-//			int kind = markerDeltas[i].getKind();
-//			IMarker marker = markerDeltas[i].getMarker();
-//			MarkerEntry markerEntry = new MarkerEntry(marker);
-//			if (affectsCurrentState(presentEntries, markerEntry, kind)) {
-//				return true;
-//			}
-//			if (i >= maxTestCount - 1) {
-//				return true;
-//			}
-//		}
-//		return false;
-//	}
-//
-//	/**
-//	 * Check if a marker change, removal, or addition is of interest to the
-//	 * view.
-//	 *
-//	 * <ul>
-//	 * <li>Set the MarkerEntry to be stale, if discovered at any point of time
-//	 * of its use.This will greatly speed up lot of parts of the view.</li>
-//	 * <li>Instead of testing all marker changes, test only upto a maximum limit
-//	 * beyond which we schedule an update anyway.</li>
-//	 *
-//	 * </ul>
-//	 *
-//	 * @param marker
-//	 * @param kind
-//	 */
-//	private boolean affectsCurrentState(MarkerEntry[] presentEntries,
-//			MarkerEntry marker, int kind) {
-//		switch (kind) {
-//		case IResourceDelta.REMOVED: {
-//			return hasMarkerRemoval(presentEntries, marker);
-//		}
-//		case IResourceDelta.ADDED: {
-//			return hasMarkerAdditionsofInterest(presentEntries, marker);
-//		}
-//		case IResourceDelta.CHANGED: {
-//			return hasMarkerChanges(presentEntries, marker);
-//		}
-//		default: {
-//			return false;
-//		}
-//		}
-//	}
-//
-//	/**
-//	 * Returns whether or not the given marker addition is of interest to the
-//	 * view.
-//	 *
-//	 * @param presentEntries
-//	 *            current marker entries
-//	 * @param marker
-//	 *            the marker entry
-//	 * @return <code>true</code> if build is needed <code>false</code> if no
-//	 *         update needed
-//	 */
-//	private boolean hasMarkerAdditionsofInterest(MarkerEntry[] presentEntries,
-//			MarkerEntry marker) {
-//		MarkerContentGenerator generator = builder.getGenerator();
-//		if (generator.select(marker)) {
-//			return true;
-//		}
-//		return false;
-//	}
-//
-//	/**
-//	 * Returns whether or not markers were removed from the view.
-//	 *
-//	 * @param presentEntriest
-//	 *            current marker entries
-//	 * @param marker
-//	 *            the marker entry
-//	 * @return <code>true</code> if build is needed <code>false</code> if no
-//	 *         update needed
-//	 */
-//	private boolean hasMarkerRemoval(MarkerEntry[] presentEntriest,
-//			MarkerEntry marker) {
-//		for (int i = 0; i < presentEntriest.length; i++) {
-//			if (presentEntriest[i].getStaleState()
-//					|| presentEntriest[i].getMarker() == null) {
-//				return true;
-//			}
-//			if (marker != null) {
-//				if (presentEntriest[i].getMarker().equals(marker.getMarker())) {
-//					return false;
-//				}
-//			}
-//		}
-//		return false;
-//	}
-//
-//	/**
-//	 * Returns whether or not markers were removed from the view.
-//	 *
-//	 * @param presentEntriest
-//	 *            current marker entries
-//	 * @param marker
-//	 *            the marker entry
-//	 * @return <code>true</code> if build is needed <code>false</code> if no
-//	 *         update needed
-//	 */
-//	private boolean hasMarkerChanges(MarkerEntry[] presentEntriest,
-//			MarkerEntry marker) {
-//		MarkerContentGenerator generator = builder.getGenerator();
-//		if (generator.select(marker)) {
-//			return true;
-//		}
-//		for (int i = 0; i < presentEntriest.length; i++) {
-//			if (presentEntriest[i].getMarker().equals(marker.getMarker())) {
-//				return true;
-//			}
-//
-//		}
-//		return false;
-//	}
 
 	/**
 	 * We are in a pre-build state.
@@ -604,31 +440,6 @@ class MarkerUpdateScheduler {
 		view.cancelQueuedUpdates();
 	}
 
-	///**
-	// * Indicate the status message on UI.
-	// *
-	// * @param messsage
-	// *            the status to display
-	// */
-	//void indicateStatus(String messsage) {
-	//	indicateStatus(messsage, false);
-	//}
-	////See Bug 294303
-	///**
-	// * Indicate the status message on UI.
-	// *
-	// * @param messsage
-	// *            the status to display
-	// * @param updateUI
-	// *            <code>true</code> update label to show changing status
-	// */
-	//void indicateStatus(String messsage, boolean updateUI) {
-	// //See Bug 294303
-	//	view.indicateUpdating(messsage != null ? messsage
-	//			: MarkerMessages.MarkerView_queueing_updates, updateUI);
-	//}
-
-
 	/**
 	 * //Fix for Bug 294959.There is another patch(more exhaustive in terms
 	 * of possibilities to cover) on the bug in which we keep scheduling
@@ -709,12 +520,6 @@ class MarkerUpdateScheduler {
 						go(delay, cancelable);
 					}
 				} else {
-					//long diff =timeB4Update-currentTime;
-					//if (diff <= AFTER_MARGIN && diff >= 0) {
-					//	go(0L, false);
-					//} else {
-					//	go(LONG_DELAY, cancelable);
-					//}
 					go(LONG_DELAY, cancelable);
 				}
 			} else {

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/HeapStatus.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/HeapStatus.java
@@ -303,9 +303,6 @@ public class HeapStatus extends Composite {
 		menuMgr.add(new ClearMarkAction());
 		menuMgr.add(new ShowMaxAction());
 		menuMgr.add(new CloseHeapStatusAction());
-//        if (isKyrsoftViewAvailable()) {
-//        	menuMgr.add(new ShowKyrsoftViewAction());
-//        }
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIDialogs.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIDialogs.java
@@ -95,25 +95,6 @@ public class UIDialogs {
 	@Test
 	@Ignore("CustomizePerspectiveDialog not implemented")
 	public void testEditActionSetsDialog() {
-//        Dialog dialog;
-//        Object persp = null;
-//        //Test perspective: use current perspective of test case
-//        try { /*
-//         * fixme: should try to get current perspective, or default;
-//         * currently only
-//         */
-//            WorkbenchWindow window = (WorkbenchWindow) getWorkbench().getActiveWorkbenchWindow();
-//            persp = new Perspective((PerspectiveDescriptor) getWorkbench()
-//                    .getPerspectiveRegistry().getPerspectives()[0],
-//                    (WorkbenchPage) window.getActivePage());
-//            dialog = window.createCustomizePerspectiveDialog(persp);
-//        } catch (WorkbenchException e) {
-//            dialog = null;
-//        }
-//        DialogCheck.assertDialog(dialog);
-//        if (persp != null) {
-//            persp.dispose();
-//        }
 	}
 
 	@Test
@@ -184,14 +165,6 @@ public class UIDialogs {
 	@Test
 	@Ignore("PerspectiveRegistry.getCustomPersp not implemented")
 	public void testLoadNotExistingPerspective() {
-//    	final String fakePerspectivID = "fakeperspetive";
-//		PerspectiveRegistry reg = (PerspectiveRegistry) WorkbenchPlugin
-//				.getDefault().getPerspectiveRegistry();
-//		try {
-//			reg.getCustomPersp(fakePerspectivID);
-//		} catch (WorkbenchException e) {
-//			assertTrue(e.getStatus().getMessage().indexOf(fakePerspectivID) != -1);
-//		}
 	}
 
 	@Test


### PR DESCRIPTION
This commit removes commented out code (dead code) from multiple files across the codebase. The commented code was no longer serving any documentation purpose and only added clutter.

Changes include:

Bundles:
- MarkersChangeListener.java: Removed 150+ lines of commented method implementations (needsUpdate, affectsCurrentState, etc.) and related helper methods that were left for "further investigation"
- MarkerContentGenerator.java: Removed commented if statement
- SelectionProcessor.java: Removed 27-line commented while loop block in multi-text selection paste handling
- CSSDocumentHandlerImpl.java: Removed multiple commented code blocks in startMedia, endMedia, startFontFace, endFontFace methods
- HeapStatus.java: Removed commented Kyrsoft view availability check

Tests:
- UIDialogs.java: Removed commented test implementations in testEditActionSetsDialog and testLoadNotExistingPerspective

All removed code was identified as dead code that doesn't serve documentation purposes. Version control history preserves this code if needed for future reference.