### PR TITLE
Avoid removal warning in AnimatorFactory due to java-doc reference

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/AnimatorFactory.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/AnimatorFactory.java
@@ -20,7 +20,7 @@ import org.eclipse.swt.widgets.Control;
 /**
  * Factory for control animators used by JFace to animate the display of an SWT
  * Control. Through the use of the method
- * {@link org.eclipse.jface.util.Policy#setAnimatorFactory(AnimatorFactory)}
+ * {@code org.eclipse.jface.util.Policy.setAnimatorFactory(AnimatorFactory)}
  * a new type of animator factory can be plugged into JFace.
  *
  * @since 3.2


### PR DESCRIPTION
Tonight's I-build failed with
```
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-compiler-plugin:5.0.1-SNAPSHOT:compile (default-compile) on project org.eclipse.jface: Compilation failure: Compilation failure: 
[ERROR] /home/jenkins/agent/workspace/Builds/I-build-4.38/cje-production/gitCache/eclipse.platform.releng.aggregator/eclipse.platform.ui/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/AnimatorFactory.java:[23] 
[ERROR] 	* {@link org.eclipse.jface.util.Policy#setAnimatorFactory(AnimatorFactory)}
[ERROR] 	                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[ERROR] Javadoc: The method setAnimatorFactory(AnimatorFactory) from the type Policy is deprecated
``` 

This is an attempt to fix https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3464