### PR TITLE
Fix flaky HoverTest.testEnabledWhenHover() race condition

### DIFF
--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/HoverTest.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/HoverTest.java
@@ -33,6 +33,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
@@ -80,7 +81,13 @@ public class HoverTest extends AbstratGenericEditorTest {
 		assertNotNull(findControl(shell, StyledText.class, AlrightyHoverProvider.LABEL));
 		assertNull(findControl(shell, StyledText.class, WorldHoverProvider.LABEL));
 
+		// Capture the first shell and its display to wait for disposal
+		Shell firstShell = shell;
+		Display display = firstShell.getDisplay();
 		cleanFileAndEditor();
+		// Wait for the hover shell to be disposed after editor cleanup
+		DisplayHelper.waitForCondition(display, 3000, () -> firstShell.isDisposed());
+
 		EnabledPropertyTester.setEnabled(false);
 		createAndOpenFile("enabledWhen.txt", "bar 'bar'");
 		shell= getHoverShell(info, triggerCompletionAndRetrieveInformationControlManager(), true);


### PR DESCRIPTION
## Summary
Fixes the random failure in `HoverTest.testEnabledWhenHover()` by ensuring the hover shell from the first test part is fully disposed before the second part begins.

## Root Cause
The test has two parts that test hover behavior with different `EnabledPropertyTester` states:
1. First part: `setEnabled(true)` - shows one hover
2. Second part: `setEnabled(false)` - shows a different hover

The race condition occurred because:
- After the first hover was verified, `cleanFileAndEditor()` was called
- However, the hover shell from the first part might not be fully disposed yet
- When the second hover was triggered, `getHoverShell()` would timeout waiting for the new hover shell (line 175 in the stack trace)

## Fix
Added explicit waiting for the first hover shell to be disposed:
1. Capture a reference to the first hover shell before cleanup
2. Call `cleanFileAndEditor()` as before  
3. Use `DisplayHelper.waitForCondition()` to wait up to 3000ms for the shell to be disposed
4. Only then proceed with the second part of the test

This ensures complete state reset between the two test phases.

## Pattern
This fix follows the same pattern used in other recent flaky test fixes in this repository:
- ProgressContantsTest.testKeepOneProperty (#370)
- ProgressViewTests.testItemOrder (#195)

Both use condition-based waiting with `DisplayHelper.waitForCondition()` to ensure proper cleanup between test phases rather than relying on timing.

## Test Plan
Due to environment issues, I was unable to run the full test suite locally. However, the fix follows established patterns from recent successful flaky test fixes in this repository.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/926

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>