### PR TITLE
MultipageEditorPart check for tab disposal when getting Editor

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/part/MultiPageEditorPart.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/part/MultiPageEditorPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -648,11 +648,8 @@ public abstract class MultiPageEditorPart extends EditorPart implements IPageCha
 	 */
 	protected IEditorPart getEditor(int pageIndex) {
 		Item item = getItem(pageIndex);
-		if (item != null) {
-			Object data = item.getData();
-			if (data instanceof IEditorPart) {
-				return (IEditorPart) data;
-			}
+		if (item != null && !item.isDisposed() && item.getData() instanceof IEditorPart ep) {
+			return ep;
 		}
 		return null;
 	}


### PR DESCRIPTION
Getting an editor of a MultpageEditorPart during disposal of the editor led to dispose exceptions as getEditor is accessing an Item's data without checking for disposal. This happened for example when during shutdown the Web-kit widget is sending SWT events. (see https://github.com/eclipse-4diac/4diac-ide/issues/1808 for details). By checking for disposal of the item. This issue is prevent.