### PR TITLE
Fix race condition in ProgressContantsTest.testKeepOneProperty

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressContantsTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/progress/ProgressContantsTest.java
@@ -223,6 +223,8 @@ public class ProgressContantsTest extends ProgressTestCase {
 			errorJob.schedule();
 			processEventsUntil(() -> findProgressInfoItem(errorJob) != null, 3000);
 		}
+		// Wait for KEEPONE cleanup to stabilize at exactly 1 item
+		processEventsUntil(() -> countBelongingProgressItems(DummyFamilyJob.class) == 1, 3000);
 
 		assertEquals("Only one finished job should be kept in view", 1,
 				countBelongingProgressItems(DummyFamilyJob.class));
@@ -254,8 +256,8 @@ public class ProgressContantsTest extends ProgressTestCase {
 			errorJob.schedule();
 			processEventsUntil(() -> findProgressInfoItem(errorJob) != null, 3000);
 		}
-		// Additional event processing to ensure all KEEPONE logic has completed
-		processEvents();
+		// Wait for KEEPONE cleanup to stabilize at exactly 1 item
+		processEventsUntil(() -> countBelongingProgressItems(DummyFamilyJob.class) == 1, 5000);
 
 		assertEquals("Only one finished job should be kept in view", 1,
 				countBelongingProgressItems(DummyFamilyJob.class));


### PR DESCRIPTION
## Summary
Fixes the flaky `testKeepOneProperty` test that intermittently failed with `expected:<1> but was:<0>` due to a race condition.

## Problem
The test was asserting the KEEPONE property result before the async cleanup logic had completed. The previous fix (commit 39d028ea57) added an error job as a synchronization marker, but this wasn't sufficient as the cleanup can still be pending after the error job appears in the progress view.

## Solution
This fix adds explicit waits for the actual condition being tested: that exactly 1 item from the DummyFamilyJob family remains in the progress view. By using `processEventsUntil(() -> countBelongingProgressItems(DummyFamilyJob.class) == 1, timeout)`, we ensure the KEEPONE cleanup has fully stabilized before asserting.

## Changes
- Added explicit wait for count to stabilize at 1 in first test scenario (line 227)
- Added explicit wait for count to stabilize at 1 in second test scenario (line 260, where the failure occurred)
- Uses longer timeout (5000ms) for the more complex second scenario with 20 concurrent jobs

## Testing
Verified the fix by running the test 5 times consecutively - all passed successfully.

## Related
Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/runs/55056915330

🤖 Generated with [Claude Code](https://claude.com/claude-code)