### PR TITLE
In Project Explorer, ensure "Select All" (Ctrl+A and menu) works reliably irrespective of first or subsequent selections.

### DIFF
--- a/bundles/org.eclipse.ui.navigator/plugin.xml
+++ b/bundles/org.eclipse.ui.navigator/plugin.xml
@@ -13,5 +13,16 @@
             id="org.eclipse.ui.navigator.PluginDropAction">
       </action>
    </extension> 
-   
+   <extension
+         point="org.eclipse.ui.handlers">
+	  <handler
+	        commandId="org.eclipse.ui.edit.selectAll"
+	        class="org.eclipse.ui.navigator.CommonNavigatorSelectAllHandler">
+	     <activeWhen>
+	         <with variable="activePart">
+                <instanceof value="org.eclipse.ui.navigator.CommonNavigator"/>
+	         </with>
+	     </activeWhen>
+	  </handler>
+   </extension>   
 </plugin>

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/navigator/CommonNavigator.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/navigator/CommonNavigator.java
@@ -16,6 +16,8 @@
  *******************************************************************************/
 package org.eclipse.ui.navigator;
 
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.PerformanceStats;
 import org.eclipse.core.runtime.SafeRunner;
@@ -29,18 +31,25 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IMemento;
+import org.eclipse.ui.IPartListener2;
 import org.eclipse.ui.ISaveablePart;
 import org.eclipse.ui.ISaveablesLifecycleListener;
 import org.eclipse.ui.ISaveablesSource;
 import org.eclipse.ui.IViewSite;
+import org.eclipse.ui.IWorkbenchCommandConstants;
+import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.Saveable;
 import org.eclipse.ui.SaveablesLifecycleEvent;
 import org.eclipse.ui.actions.ActionGroup;
+import org.eclipse.ui.handlers.IHandlerActivation;
+import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.internal.navigator.CommonNavigatorActionGroup;
 import org.eclipse.ui.internal.navigator.NavigatorContentService;
 import org.eclipse.ui.internal.navigator.NavigatorPlugin;
@@ -160,6 +169,8 @@ public class CommonNavigator extends ViewPart implements ISetSelectionTarget, IS
 
 	private LinkHelperService linkService;
 
+	private IPartListener2 partListener;
+
 	public CommonNavigator() {
 		super();
 	}
@@ -255,6 +266,47 @@ public class CommonNavigator extends ViewPart implements ISetSelectionTarget, IS
 			ColumnViewerToolTipSupport.enableFor(commonViewer);
 		}
 
+		// Immediate fallback: handle Ctrl+A at the Tree level
+		commonViewer.getTree().addKeyListener(new KeyAdapter() {
+			@Override
+			public void keyPressed(KeyEvent e) {
+				// MOD1 = Ctrl on Win/Linux, Command on macOS
+				if ((e.stateMask & SWT.MOD1) != 0 && (e.keyCode == 'a' || e.keyCode == 'A')) {
+					commonViewer.getTree().selectAll();
+					e.doit = false;
+				}
+			}
+		});
+
+		// Activate the 'Select All' command handler when the view is active
+		partListener = new IPartListener2() {
+			private IHandlerActivation activation;
+
+			@Override
+			public void partActivated(IWorkbenchPartReference ref) {
+				if (ref.getPart(false) == CommonNavigator.this) {
+					IHandlerService hs = getSite().getService(IHandlerService.class);
+					activation = hs.activateHandler(IWorkbenchCommandConstants.EDIT_SELECT_ALL, new AbstractHandler() {
+						@Override
+						public Object execute(ExecutionEvent event) {
+							commonViewer.getTree().selectAll();
+							return null;
+						}
+					});
+				}
+			}
+
+			@Override
+			public void partDeactivated(IWorkbenchPartReference ref) {
+				if (ref.getPart(false) == CommonNavigator.this && activation != null) {
+					IHandlerService hs = getSite().getService(IHandlerService.class);
+					hs.deactivateHandler(activation);
+					activation = null;
+				}
+			}
+		};
+		getSite().getPage().addPartListener(partListener);
+
 		stats.endRun();
 	}
 
@@ -308,13 +360,17 @@ public class CommonNavigator extends ViewPart implements ISetSelectionTarget, IS
 	 */
 	@Override
 	public void dispose() {
-		if (commonManager != null) {
-			commonManager.dispose();
+		try {
+			getSite().getPage().removePartListener(partListener);
+			if (commonManager != null) {
+				commonManager.dispose();
+			}
+			if (commonActionGroup != null) {
+				commonActionGroup.dispose();
+			}
+		} finally {
+			super.dispose();
 		}
-		if (commonActionGroup != null) {
-			commonActionGroup.dispose();
-		}
-		super.dispose();
 	}
 
 	/**

--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/navigator/CommonNavigatorSelectAllHandler.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/navigator/CommonNavigatorSelectAllHandler.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2003, 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.navigator;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.handlers.HandlerUtil;
+
+/**
+ * CommonNavigatorSelectAllHandler is the handler for the select all action.
+ *
+ * @since 3.14
+ *
+ */
+public class CommonNavigatorSelectAllHandler extends AbstractHandler {
+	@Override
+	public Object execute(ExecutionEvent event) {
+		IWorkbenchPart part = HandlerUtil.getActivePart(event);
+		if (part instanceof CommonNavigator navigator) {
+			navigator.getCommonViewer().getTree().selectAll();
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
Fixes #2739 

Description: 
In the Project Explorer, the "Edit > Select All" menu item and Ctrl+A shortcut did not work reliably when a single project was selected. Specifically, pressing Ctrl+A after selecting a project for the first time had no effect. Only after clicking another project did Ctrl+A begin to work as expected.

Details of the fix:
- Added a KeyListener to the Tree widget to handle Ctrl+A directly, ensuring selection works even without command activation.
- Registered a IPartListener2 to activate the EDIT_SELECT_ALL command handler when the Project Explorer view becomes active, enabling the menu item.
- Deactivated the handler when the view is no longer active to avoid stale references.

Note : No-ops - These methods are required by the IPartListener2 interface though unused but must be implemented. Yeah - i just tried even if removed it works(not sure if it added some warnings).

Open eclipse freshly, open Project Explorer view. Select a project and ctrl+A to select all the projects.
Before fix(unable to select, next click on 2nd project then ctrl+A will be enabled)
<img width="658" height="348" alt="image" src="https://github.com/user-attachments/assets/85fe502f-15b6-4ff6-b639-184694a7861a" />


After fix(able to select)
<img width="651" height="355" alt="image" src="https://github.com/user-attachments/assets/57cd884a-6cb8-4fe6-84bd-3be804eea30a" />
