### PR TITLE
Fix flaky PartRenderingEngineTests.ensureCleanUpAddonCleansUp race condition

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
@@ -2466,12 +2466,11 @@ public class PartRenderingEngineTests {
 		assertTrue(" PartStack with children should be rendered", partStackForPartBPartC.isToBeRendered());
 		partService.hidePart(partB);
 		partService.hidePart(partC);
-		DisplayHelper.waitForCondition(Display.getDefault(), 5_000,
-				() -> partStackForPartBPartC.isToBeRendered() == false);
-		assertFalse(
+		contextRule.spinEventLoop();
+		assertTrue(
 				"CleanupAddon should ensure that partStack is not rendered anymore, as all childs have been removed",
-				partStackForPartBPartC.isToBeRendered());
-		assertFalse("Part stack should be removed", partStackForPartBPartC.isToBeRendered());
+				DisplayHelper.waitForCondition(Display.getDefault(), 5_000,
+						() -> partStackForPartBPartC.isToBeRendered() == false));
 		// PartStack with IPresentationEngine.NO_AUTO_COLLAPSE should not be removed
 		// even if children are removed
 		partService.hidePart(editor, true);


### PR DESCRIPTION
## Summary
Fixes the flaky `PartRenderingEngineTests.ensureCleanUpAddonCleansUp` test that was failing intermittently due to a race condition with async cleanup logic.

## Root Cause
- `CleanupAddon` performs cleanup asynchronously via `Display.asyncExec()` (CleanupAddon.java:352)
- The test was calling `waitForCondition()` immediately after hiding parts, before the async cleanup tasks were even posted to the event queue
- This created a race where the wait could timeout before cleanup had a chance to start

## Changes
- Add `contextRule.spinEventLoop()` after hiding partB and partC to ensure async cleanup tasks are processed before waiting
- Wrap `waitForCondition()` in `assertTrue()` for clearer error messages on timeout
- Remove redundant `assertFalse()` statements

This matches the pattern used in the adjacent `testBug332463` test.

## Testing
- Verified with 5 consecutive test runs - all passed consistently
- Test now completes in ~0.028-0.036s

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/751

🤖 Generated with [Claude Code](https://claude.com/claude-code)