### PR TITLE
Fix alignment of onboarding area command labels

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
@@ -313,7 +313,7 @@ public class StackRenderer extends LazyStackRenderer {
 
 			String[] commandAndText = commands[i].split("\\$\\$\\$"); //$NON-NLS-1$
 
-			WidgetFactory.label(SWT.NONE).text(commandAndText[0]).foreground(color)
+			WidgetFactory.label(SWT.NONE).text(commandAndText[0]).foreground(color).align(SWT.RIGHT)
 					.supplyLayoutData(labelGridDataFactory::create).create(onboardingComposite);
 			WidgetFactory.label(SWT.NONE).text(commandAndText[1]).foreground(color)
 					.supplyLayoutData(commandGridDataFactory::create).create(onboardingComposite);


### PR DESCRIPTION
The command labels in a perspective's onboarding area are placed in a right-aligned layout but the labels themselves are not right-aligned, such that they are not perfectly right aligned as they can be up to 1 point off (which can sum up to multiple pixels with monitor zoom values).

This change adapts the labels to be right aligned such that they properly fit.

### Before
At 175%:
<img width="449" height="200" alt="image" src="https://github.com/user-attachments/assets/4ac97a70-addf-48a8-8e3a-0c69738714a4" />

### After
At 175%:
<img width="473" height="198" alt="image" src="https://github.com/user-attachments/assets/0bce4a41-dbe6-4a40-8437-a75a8d2f65c9" />
