### PR TITLE
Fix incorrect SubMonitor usage patterns

### DIFF
--- a/bundles/org.eclipse.ltk.core.refactoring/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ltk.core.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.ltk.core.refactoring
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ltk.core.refactoring; singleton:=true
-Bundle-Version: 3.15.100.qualifier
+Bundle-Version: 3.15.200.qualifier
 Bundle-Activator: org.eclipse.ltk.internal.core.refactoring.RefactoringCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/MultiStateTextFileChange.java
+++ b/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/MultiStateTextFileChange.java
@@ -435,7 +435,6 @@ public class MultiStateTextFileChange extends TextEditBasedChange {
 				releaseDocument(result, subMon.newChild(1));
 			}
 		}
-		subMon.done();
 		if (result == null) {
 			result= new Document();
 		}

--- a/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/PerformChangeOperation.java
+++ b/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/PerformChangeOperation.java
@@ -199,22 +199,18 @@ public class PerformChangeOperation implements IWorkspaceRunnable {
 	@Override
 	public void run(IProgressMonitor pm) throws CoreException {
 		SubMonitor subMon= SubMonitor.convert(pm, 4);
-		try {
-			fChangeExecuted= false;
-			if (createChange()) {
-				// Check for cancellation before executing the change, since canceling
-				// during change execution is not supported
-				// (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=187265 ):
-				fCreateChangeOperation.run(subMon.split(3));
-				fChange= fCreateChangeOperation.getChange();
-				if (fChange != null) {
-					executeChange(subMon.newChild(1));
-				}
-			} else {
-				executeChange(subMon.newChild(4));
+		fChangeExecuted= false;
+		if (createChange()) {
+			// Check for cancellation before executing the change, since canceling
+			// during change execution is not supported
+			// (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=187265 ):
+			fCreateChangeOperation.run(subMon.split(3));
+			fChange= fCreateChangeOperation.getChange();
+			if (fChange != null) {
+				executeChange(subMon.newChild(1));
 			}
-		} finally {
-			subMon.done();
+		} else {
+			executeChange(subMon.newChild(4));
 		}
 	}
 

--- a/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/PerformRefactoringOperation.java
+++ b/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/PerformRefactoringOperation.java
@@ -135,7 +135,6 @@ public class PerformRefactoringOperation implements IWorkspaceRunnable {
 				fUndo= perform.getUndoChange();
 			}
 		} finally {
-			subMon.done();
 			if (fRefactoringContext != null) {
 				fRefactoringContext.dispose();
 			}

--- a/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/Refactoring.java
+++ b/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/Refactoring.java
@@ -162,7 +162,6 @@ public abstract class Refactoring extends PlatformObject {
 		if (!result.hasFatalError()) {
 			result.merge(checkFinalConditions(subMon.split(refactoringTickProvider.getCheckFinalConditionsTicks())));
 		}
-		subMon.done();
 		return result;
 	}
 

--- a/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/TextChange.java
+++ b/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/TextChange.java
@@ -247,7 +247,6 @@ public abstract class TextChange extends TextEditBasedChange {
 			throw Changes.asCoreException(e);
 		} finally {
 			releaseDocument(document, subMon.newChild(1));
-			subMon.done();
 		}
 	}
 

--- a/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/participants/CheckConditionsContext.java
+++ b/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/participants/CheckConditionsContext.java
@@ -23,7 +23,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 
@@ -123,11 +122,7 @@ public class CheckConditionsContext {
 		SubMonitor sm= SubMonitor.convert(pm, "", values.size()); //$NON-NLS-1$
 		for (IConditionChecker checker : values) {
 			result.merge(checker.check(sm.split(1)));
-			if (pm.isCanceled()) {
-				throw new OperationCanceledException();
-			}
 		}
-		pm.done();
 		return result;
 	}
 

--- a/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/participants/ProcessorBasedRefactoring.java
+++ b/bundles/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/participants/ProcessorBasedRefactoring.java
@@ -232,9 +232,6 @@ public class ProcessorBasedRefactoring extends Refactoring {
 			if (result.hasFatalError()) {
 				return result;
 			}
-			if (sm.isCanceled()) {
-				throw new OperationCanceledException();
-			}
 
 			SharableParticipants sharableParticipants= new SharableParticipants(); // must not be shared when checkFinalConditions is called again
 			RefactoringParticipant[] loadedParticipants= getProcessor().loadParticipants(result, sharableParticipants);
@@ -270,9 +267,6 @@ public class ProcessorBasedRefactoring extends Refactoring {
 
 				stats.endRun();
 
-				if (sm2.isCanceled()) {
-					throw new OperationCanceledException();
-				}
 			}
 			if (result.hasFatalError()) {
 				return result;
@@ -292,9 +286,6 @@ public class ProcessorBasedRefactoring extends Refactoring {
 		try {
 			SubMonitor sm= SubMonitor.convert(pm, RefactoringCoreMessages.ProcessorBasedRefactoring_create_change, fParticipants.size() * 2 + 1);
 			Change processorChange= getProcessor().createChange(sm.split(1));
-			if (sm.isCanceled()) {
-				throw new OperationCanceledException();
-			}
 
 			fTextChangeMap= new HashMap<>();
 			addToTextChangeMap(processorChange);
@@ -333,9 +324,6 @@ public class ProcessorBasedRefactoring extends Refactoring {
 				} catch (CoreException | RuntimeException e) {
 					disableParticipant(participant, e);
 					throw e;
-				}
-				if (sm.isCanceled()) {
-					throw new OperationCanceledException();
 				}
 			}
 

--- a/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide; singleton:=true
-Bundle-Version: 3.22.800.qualifier
+Bundle-Version: 3.22.900.qualifier
 Bundle-Activator: org.eclipse.ui.internal.ide.IDEWorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportJob.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/SmartImportJob.java
@@ -383,7 +383,6 @@ public class SmartImportJob extends Job {
 		for (CrawlFolderJob job : jobs) {
 			job.join(0, subMonitor.split(1));
 		}
-		subMonitor.done();
 		return res;
 	}
 
@@ -512,7 +511,6 @@ public class SmartImportJob extends Job {
 			// make sure this folder isn't going to be processed again
 			excludedPaths.add(project.getLocation());
 		}
-		subMonitor.done();
 		return projectFromCurrentContainer;
 	}
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/SaveableHelper.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/SaveableHelper.java
@@ -184,21 +184,14 @@ public class SaveableHelper {
 		IRunnableWithProgress progressOp = monitor -> {
 			IProgressMonitor monitorWrap = new EventLoopProgressMonitor(monitor);
 			SubMonitor subMonitor = SubMonitor.convert(monitorWrap, WorkbenchMessages.Save, dirtyModels.size());
-			try {
-				for (Saveable model : dirtyModels) {
-					// handle case where this model got saved as a result of
-					// saving another
-					if (!model.isDirty()) {
-						subMonitor.worked(1);
-						continue;
-					}
-					doSaveModel(model, subMonitor.split(1), window, confirm);
-					if (subMonitor.isCanceled()) {
-						break;
-					}
+			for (Saveable model : dirtyModels) {
+				// handle case where this model got saved as a result of
+				// saving another
+				if (!model.isDirty()) {
+					subMonitor.worked(1);
+					continue;
 				}
-			} finally {
-				monitorWrap.done();
+				doSaveModel(model, subMonitor.split(1), window, confirm);
 			}
 		};
 

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/SaveablesList.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/SaveablesList.java
@@ -796,11 +796,7 @@ public class SaveablesList implements ISaveablesLifecycleListener {
 					continue;
 				}
 				SaveableHelper.doSaveModel(model, subMonitor.split(1), shellProvider, blockUntilSaved);
-				if (subMonitor.isCanceled()) {
-					break;
-				}
 			}
-			monitorWrap.done();
 		};
 
 		// Do the save.


### PR DESCRIPTION
This commit addresses SubMonitor anti-patterns as described in https://www.eclipse.org/articles/Article-Progress-Monitors/article.html

Changes:
1. Removed unnecessary done() calls on monitors after SubMonitor.convert()
   - SubMonitor automatically handles done() when work is complete
   - Affected files:
     * Refactoring.java
     * PerformChangeOperation.java * PerformRefactoringOperation.java * MultiStateTextFileChange.java * TextChange.java * SmartImportJob.java (2 instances) * SaveablesList.java * SaveableHelper.java * CheckConditionsContext.java

2. Removed redundant isCanceled() checks after split() calls
   - split() already includes implicit cancellation checks
   - Affected files:
     * ProcessorBasedRefactoring.java (4 instances)
     * CheckConditionsContext.java * SaveablesList.java * SaveableHelper.java

These changes improve code quality by following SubMonitor best practices and removing redundant code that could mask issues.