### PR TITLE
JDT Clean-up Use String.replace() instead of String.replaceAll() when

### DIFF
--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/FormTextModel.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/FormTextModel.java
@@ -122,11 +122,11 @@ public class FormTextModel {
 
 	private String processAmpersandEscapes(String pTaggedText) {
 		try {
-			String taggedText = pTaggedText.replaceAll("&quot;", "&#034;"); //$NON-NLS-1$//$NON-NLS-2$
-			taggedText = taggedText.replaceAll("&apos;", "&#039;"); //$NON-NLS-1$//$NON-NLS-2$
-			taggedText = taggedText.replaceAll("&lt;", "&#060;"); //$NON-NLS-1$//$NON-NLS-2$
-			taggedText = taggedText.replaceAll("&gt;", "&#062;"); //$NON-NLS-1$//$NON-NLS-2$
-			taggedText = taggedText.replaceAll("&amp;", "&#038;"); //$NON-NLS-1$//$NON-NLS-2$
+			String taggedText = pTaggedText.replace("&quot;", "&#034;"); //$NON-NLS-1$//$NON-NLS-2$
+			taggedText = taggedText.replace("&apos;", "&#039;"); //$NON-NLS-1$//$NON-NLS-2$
+			taggedText = taggedText.replace("&lt;", "&#060;"); //$NON-NLS-1$//$NON-NLS-2$
+			taggedText = taggedText.replace("&gt;", "&#062;"); //$NON-NLS-1$//$NON-NLS-2$
+			taggedText = taggedText.replace("&amp;", "&#038;"); //$NON-NLS-1$//$NON-NLS-2$
 			return taggedText.replaceAll("&([^#])", "&#038;$1"); //$NON-NLS-1$//$NON-NLS-2$
 		} catch (Exception e) {
 			return pTaggedText;

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/templates/AbstractTemplatesPage.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/templates/AbstractTemplatesPage.java
@@ -960,7 +960,7 @@ public abstract class AbstractTemplatesPage extends Page implements ITemplatesPa
 				try {
 					String pattern= ((String)clipboard.getContents(TextTransfer.getInstance()));
 					if (pattern != null) {
-						final Template template= new Template(createTemplateName(), TemplatesMessages.TemplatesPage_paste_description, getContextTypeId(), pattern.replaceAll("\\$", "\\$\\$"), true); //$NON-NLS-1$//$NON-NLS-2$
+						final Template template= new Template(createTemplateName(), TemplatesMessages.TemplatesPage_paste_description, getContextTypeId(), pattern.replace("$", "$$"), true); //$NON-NLS-1$//$NON-NLS-2$
 						getShell().getDisplay().asyncExec(() -> addTemplate(template));
 						return;
 					}
@@ -1556,7 +1556,7 @@ public abstract class AbstractTemplatesPage extends Page implements ITemplatesPa
 					contextId= ((TemplatePersistenceData) object).getTemplate().getContextTypeId();
 				}
 				if (textTransfer.isSupportedType(event.currentDataType)) {
-					String text= ((String) event.data).replaceAll("\\$", "\\$\\$"); //$NON-NLS-1$ //$NON-NLS-2$
+					String text= ((String) event.data).replace("$", "$$"); //$NON-NLS-1$ //$NON-NLS-2$
 					final Template template= new Template(createTemplateName(),
 							TemplatesMessages.TemplatesPage_paste_description, contextId, text,
 							true);

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/AbstractPairMatcherTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/AbstractPairMatcherTest.java
@@ -416,7 +416,7 @@ public abstract class AbstractPairMatcherTest {
 			pos2= pos1;
 		}
 
-		final String stripped= str.replaceAll("%", "").replaceAll("#", "");
+		final String stripped= str.replace("%", "").replace("#", "");
 
 		if (enclosingTest) {
 			return new TestCase(stripped, pos1, pos2, match1, match2);

--- a/tests/org.eclipse.tests.urischeme/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.tests.urischeme/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-Vendor: %Plugin.Providername
 Bundle-SymbolicName: org.eclipse.tests.urischeme
-Bundle-Version: 1.2.700.qualifier
+Bundle-Version: 1.2.800.qualifier
 Bundle-Localization: plugin
 Fragment-Host: org.eclipse.urischeme;bundle-version="1.1.100"
 Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",

--- a/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/ProcessSpy.java
+++ b/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/ProcessSpy.java
@@ -22,7 +22,7 @@ public class ProcessSpy implements IProcessExecutor {
 	@Override
 	public String execute(String process, String... args) throws IOException {
 		records.add(new Record(process, args));
-		return result == null ? null : result.replaceAll("\r\n", "\n");
+		return result == null ? null : result.replace("\r\n", "\n");
 	}
 
 	static class Record {

--- a/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitPlistFileWriter.java
+++ b/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitPlistFileWriter.java
@@ -234,7 +234,7 @@ public class TestUnitPlistFileWriter {
 	private void assertXml(String xml, PlistFileWriter writer) {
 		StringWriter stringWriters[] = new StringWriter[1];
 		writer.writeTo(() -> (stringWriters[0] = new StringWriter()));
-		assertEquals(xml, stringWriters[0].toString().replaceAll("\r\n", "\n"));
+		assertEquals(xml, stringWriters[0].toString().replace("\r\n", "\n"));
 	}
 
 	private PlistFileWriter getWriter() {

--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/contributions/ReconcilerStrategyFirst.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/contributions/ReconcilerStrategyFirst.java
@@ -54,7 +54,7 @@ public class ReconcilerStrategyFirst implements IReconcilingStrategy, IReconcili
 		String doc = document.get();
 		if(doc.contains(SEARCH_TERM)) {
 			Display.getDefault().asyncExec(() -> {
-				document.set(document.get().replaceAll(SEARCH_TERM, REPLACEMENT));
+				document.set(document.get().replace(SEARCH_TERM, REPLACEMENT));
 			});
 		}
 	}

--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/contributions/ReconcilerStrategySecond.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/contributions/ReconcilerStrategySecond.java
@@ -54,7 +54,7 @@ public class ReconcilerStrategySecond implements IReconcilingStrategy, IReconcil
 		String doc = document.get();
 		if(doc.contains(SEARCH_TERM)) {
 			Display.getDefault().asyncExec(() -> {
-				document.set(document.get().replaceAll(SEARCH_TERM, REPLACEMENT));
+				document.set(document.get().replace(SEARCH_TERM, REPLACEMENT));
 			});
 		}
 	}


### PR DESCRIPTION
possible

In https://github.com/eclipse-platform/eclipse.platform.ui/issues/3517 we discuss which automatic clean-ups we should add. This is the result of a manual run in eclipse-platform.ui to see if this clean-up has issues. Also by running it manually before enabling the clean-ups we avoid creating PR per bundle.