### PR TITLE
Add scrollbars to wizard dialog via ScrolledComposite

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/WizardDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/WizardDialog.java
@@ -52,6 +52,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.accessibility.AccessibleAdapter;
 import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.eclipse.swt.custom.BusyIndicator;
+import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Point;
@@ -729,9 +730,18 @@ public class WizardDialog extends TitleAreaDialog implements IWizardContainer2, 
 	 * @return Composite
 	 */
 	private Composite createPageContainer(Composite parent) {
-		Composite result = new Composite(parent, SWT.NULL);
-		result.setLayout(pageContainerLayout);
-		return result;
+		ScrolledComposite scrolled = new ScrolledComposite(parent, SWT.V_SCROLL | SWT.H_SCROLL);
+		scrolled.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		scrolled.setExpandHorizontal(true);
+		scrolled.setExpandVertical(true);
+		Composite content = new Composite(scrolled, SWT.NULL);
+		content.setLayout(pageContainerLayout);
+		scrolled.setContent(content);
+		content.addListener(SWT.Resize, e -> {
+			scrolled.setMinSize(content.computeSize(SWT.DEFAULT, SWT.DEFAULT));
+		});
+
+		return content;
 	}
 
 	/**


### PR DESCRIPTION
Previously, JFace wizard dialogs could have their content cut off without any scrollbars. This occurred when users resized the dialog or moved it between monitors, where size adjustments caused by rounding could make the dialog smaller than its content. As a result, parts of the UI could become inaccessible without any visual indication.

This change wraps the content in a ScrolledComposite, with vertical and horizontal scrollbars so users can still access all content even when the dialog becomes smaller.


Steps to reproduce

1)Open a new class dialog in eclipse IDE
2)Resize it to make it smaller to see the scrollbars appear with this change