### PR TITLE
Revert workaround for unexpected text wrapping in ExpandableComposite

### DIFF
--- a/bundles/org.eclipse.ui.forms/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.forms/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %name
 Bundle-SymbolicName: org.eclipse.ui.forms;singleton:=true
-Bundle-Version: 3.13.700.qualifier
+Bundle-Version: 3.13.800.qualifier
 Bundle-Vendor: %provider-name
 Bundle-Localization: plugin
 Export-Package: org.eclipse.ui.forms,

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/ExpandableComposite.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/ExpandableComposite.java
@@ -22,7 +22,6 @@ package org.eclipse.ui.forms.widgets;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.ListenerList;
-import org.eclipse.core.runtime.Platform.OS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
@@ -289,13 +288,7 @@ public class ExpandableComposite extends Canvas {
 			Point labelDefault = this.textLabelCache.computeSize(SWT.DEFAULT, SWT.DEFAULT);
 
 			int tcWidthBeforeSplit = Math.min(width, tcDefault.x);
-
-			int additionalLabelWidthPadding = 0;
-			if (OS.isWindows()) {
-				/* compensate rounding issue in windows */
-				additionalLabelWidthPadding = 1;
-			}
-			int labelWidthBeforeSplit = Math.min(width, labelDefault.x + additionalLabelWidthPadding);
+			int labelWidthBeforeSplit = Math.min(width, labelDefault.x);
 
 			int tcWidthAfterSplit = tcWidthBeforeSplit;
 			int labelWidthAfterSplit = labelWidthBeforeSplit;


### PR DESCRIPTION
A workaround for unexpected text wrapping in ExpandableComposite had been introduced to deal with imprecise size calculation of controls for zooms like 125% and 175%. With recent changes to SWT, the size calculation for controls has been improved such that they always allocate sufficient space to fit their contents in. That makes the workaround in ExpandableComposite obsolete.

This change thus removes the obsolete, temporary workaround introduced with:
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/2986

