### PR TITLE
Fix traverse in multi page editors

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/handlers/TraversePageHandler.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/handlers/TraversePageHandler.java
@@ -41,6 +41,15 @@ public class TraversePageHandler extends WidgetMethodHandler {
 			int traversalDirection = translateToTraversalDirection(forward);
 			Control control = focusControl;
 			do {
+				if (control instanceof CTabFolder folder && !isRootCTabFolder(folder)) {
+					// For multi-page editors, we want to skip inner CTabFolders
+					// If not skipped there are two issues:
+					// 1. loopToFirstOrLastItem would change the selection of the inner CTabFolder
+					// 2. control.traverse itself would navigate up to the outer CTabFolder and
+					// navigate there
+					control = control.getParent();
+					continue;
+				}
 				if (control instanceof CTabFolder folder && isFinalItemInCTabFolder(folder, forward)
 						&& !hasHiddenItem(folder)) {
 					loopToFirstOrLastItem(folder, forward);
@@ -57,6 +66,15 @@ public class TraversePageHandler extends WidgetMethodHandler {
 			} while (control != null);
 		}
 		return null;
+	}
+
+	private boolean isRootCTabFolder(CTabFolder folder) {
+		for (var current = folder.getParent(); current != null; current = current.getParent()) {
+			if (current instanceof CTabFolder) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	private boolean hasHiddenItem(CTabFolder folder) {


### PR DESCRIPTION
control.traverse on a CTabFolder in the MultiPageEditor is navigation up the the outer CTabFolder itself.

This is causing several issues:
Setting the page for example to the second-to-last is changing the page in the multipage editor. Then the traverse direction is changed causing the outer tab to move in the wrong direction. Furthermore on the outer tab you cannot jump from the last tab to the very first tab.

### How to reproduce

1. Open two .java editor and one multi page editor, for example the manifest.
2. On the java editors, traverse to the next tab until you are in the manifest editor
3. In the manifest editor, traverse next tab will not work
4. Traverse to previous tab will jump to the `plugin.xml` inner tab
5. Traverse to previous again will jump to the java editor

See 

https://github.com/user-attachments/assets/3af76624-462c-40e6-85e3-bc5c8b9d56ea

