### PR TITLE
AnnotationCodeMining should NP check the Annotation.getText() result

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/codemining/annotation/AnnotationCodeMining.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/codemining/annotation/AnnotationCodeMining.java
@@ -48,10 +48,13 @@ public class AnnotationCodeMining extends LineHeaderCodeMining {
 		super(lineNumber, document, provider, action);
 		this.annotationAccess= annotationAccess;
 
-		setLabel(sanitizeLabel(annotation.getText()));
-
+		String text = annotation.getText();
+		if (text != null) {
+			setLabel(sanitizeLabel(text));
+		}
 		this.annotation= annotation;
 	}
+
 
 	private static String sanitizeLabel(String label) {
 		return label.replace('\r', ' ').replace('\n', ' ');


### PR DESCRIPTION
Annotation.getText() allows to return null values.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3556