### PR TITLE
Fix HiDPI progress icon clipping by relayouting only on image size change

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressAnimationItem.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/progress/ProgressAnimationItem.java
@@ -260,11 +260,21 @@ public class ProgressAnimationItem extends AnimationItem implements FinishedJobs
 		toolbar.setVisible(false);
 	}
 
+	boolean isImageSizeChanged(Image oldImage, Image image) {
+		boolean changed = true;
+		// check if image size really changed for old and new images
+		if (oldImage != null && !oldImage.isDisposed() && image != null && !image.isDisposed()) {
+			changed = !oldImage.getBounds().equals(image.getBounds());
+		}
+		return changed;
+	}
+
 	private void initButton(Image im, final String tt) {
+		boolean isLayoutRequired = isImageSizeChanged(im, toolButton.getImage());
 		toolButton.setImage(im);
 		toolButton.setToolTipText(tt);
 		toolbar.setVisible(true);
-		toolbar.getParent().requestLayout(); // must layout
+		toolbar.getParent().layout(isLayoutRequired);
 
 		if (currentAccessibleListener != null) {
 			toolbar.getAccessible().removeAccessibleListener(currentAccessibleListener);


### PR DESCRIPTION
On Windows HiDPI screens, the progress icon in the status bar could appear clipped because Toolbars are initially created  by windows with default button size (24×22). When larger images are set (e.g., 32×32 for 200% scaling), the toolbar resizes but the parent layout isn't updated due to deferred layout. 

This change replaces the deffered layout with a normal layout and adds a check to determine if the image size actually changed before requesting a relayout. The parent layout is now updated only when necessary, matching SWT's behavior for toolbar images and preventing unnecessary layouts while fixing the clipping issue. More information https://github.com/eclipse-platform/eclipse.platform.swt/issues/706#issuecomment-3611059369

**Steps to reproduce:** 

1)Set the monitors’ zoom to 200%. If using two monitors, make sure both have the same zoom just so that no DPI change occurs during startup. 
2)Open a runtime workspace.
3)In the runtime workspace, create a plugin project and run it as an Eclipse application. This will start the progress bar, which is visible only briefly for a second.
4)Once the Eclipse application launches, try to relaunch it with the same workspace. You’ll see an error saying the workspace is already in use by another application.
5)While this dialog is visible, the progress bar remains visible, and here you can observe the clipped/cut-off icon.

Without this change, the  progress bar does not relayout correctly on HiDPI screens, causing icon to be partially hidden.

**Before**
<img width="2317" height="1624" alt="image" src="https://github.com/user-attachments/assets/81e50c49-39dd-4584-af1e-27fea8c0350f" />


**After**

<img width="2270" height="1568" alt="image" src="https://github.com/user-attachments/assets/ecdc9835-af4e-433e-b35a-0cf2550c5366" />


Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/706