### PR TITLE
 Guard clipping to avoid resize artifacts in tree viewer

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StyledCellLabelProvider.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/StyledCellLabelProvider.java
@@ -389,7 +389,7 @@ public abstract class StyledCellLabelProvider extends OwnerDrawLabelProvider {
 			int y = textBounds.y
 					+ Math.max(0, (textBounds.height - layoutBounds.height) / 2);
 
-			if (gc.isClipped()) {
+			if (gc.isClipped() && ((style & SWT.RIGHT) != 0 || (style & SWT.CENTER) != 0)) {
 				Rectangle saveClipping = gc.getClipping();
 				gc.setClipping(textBounds);
 				textLayout.draw(gc, x, y);


### PR DESCRIPTION
 Setting the clipping region temporarily to the textBounds   was originally added (https://bugs.eclipse.org/bugs/show_bug.cgi?id=291245 comment 25) to prevent images  from being overdrawn when implementting  RIGHT or CENTER column alignment support in StyledCellLabelProvider. However, enabling  clipping causes artifact lines during tree resizing, as a temporary workaround the  clipping call is  now guarded and applied only in those alignment cases to avoid issues with resizing of columns.

**Steps to reproduce**
Step 0:Set monitor zoom to 175
1. Set monitor zoom to 175%.
2. Launch a runtime workspace.
3. In that runtime workspace, open the **Debug Configurations** dialog.
4. Go to the **Plug-ins** tab for another runtime workspace / Eclipse application.
5. Resize the **ID** column in the *Features* view. Artifact lines appear **without** this workaround.

### Behavior *without* the fix
https://github.com/user-attachments/assets/1525680f-e9e4-459a-a8e1-0860b62a5cd6

### Behavior *with* the fix

https://github.com/user-attachments/assets/99223cd7-545d-41f5-883e-25bcf854fe00


Additionally this issue can also be reproduced with the snippet provided in https://github.com/vi-eclipse/Eclipse-Platform/issues/548#issue-3674207659 
