### PR TITLE
Remove redundant isCanceled checks in SaveablesList and SaveableHelper

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/SaveableHelper.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/SaveableHelper.java
@@ -193,9 +193,6 @@ public class SaveableHelper {
 						continue;
 					}
 					doSaveModel(model, subMonitor.split(1), window, confirm);
-					if (subMonitor.isCanceled()) {
-						break;
-					}
 				}
 			} finally {
 				monitorWrap.done();

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/SaveablesList.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/SaveablesList.java
@@ -796,9 +796,6 @@ public class SaveablesList implements ISaveablesLifecycleListener {
 					continue;
 				}
 				SaveableHelper.doSaveModel(model, subMonitor.split(1), shellProvider, blockUntilSaved);
-				if (subMonitor.isCanceled()) {
-					break;
-				}
 			}
 			monitorWrap.done();
 		};


### PR DESCRIPTION
This addresses the proposal by ptziegler in PR #3542 to split the removal of isCanceled checks.