### PR TITLE
Bump dependency of org.eclipse.ui.workbench to SWT

### DIFF
--- a/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.workbench/META-INF/MANIFEST.MF
@@ -113,7 +113,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.33.0,4.0.0)",
  org.eclipse.e4.ui.workbench.addons.swt;bundle-version="0.10.0",
  org.eclipse.e4.ui.services;bundle-version="1.3.0",
  org.eclipse.emf.ecore.xmi;bundle-version="2.11.0",
- org.eclipse.e4.core.di.extensions;bundle-version="0.13.0"
+ org.eclipse.e4.core.di.extensions;bundle-version="0.13.0",
+ org.eclipse.swt;bundle-version="[3.133.0,4.0.0)"
 Import-Package: com.ibm.icu.util,
  jakarta.annotation;version="[2.1.0,3.0.0)",
  jakarta.inject;version="[2.0.0,3.0.0)",


### PR DESCRIPTION
With the consumption of latest functionality in SWT, the `Workbench` became incompatible with older versions of SWT. This is currently not reflected in the dependency bounds. This change adds an according lower bound for the dependency of `org.eclipse.ui.workbench` to SWT.

See:
- #3475