### PR TITLE
CodeMining: reuse existing inlined annotations when minings are unchanged

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineContentAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineContentAnnotation.java
@@ -216,4 +216,8 @@ public class CodeMiningLineContentAnnotation extends LineContentAnnotation imple
 	public final boolean isAfterPosition() {
 		return afterPosition;
 	}
+
+	public List<ICodeMining> getMinings() {
+		return fMinings;
+	}
 }

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineHeaderAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineHeaderAnnotation.java
@@ -290,4 +290,8 @@ public class CodeMiningLineHeaderAnnotation extends LineHeaderAnnotation impleme
 	public boolean isInVisibleLines() {
 		return super.isInVisibleLines();
 	}
+
+	public List<ICodeMining> getMinings() {
+		return fMinings;
+	}
 }

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningManager.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningManager.java
@@ -297,7 +297,7 @@ public class CodeMiningManager implements Runnable {
 			CodeMiningMode mode= CodeMiningMode.createFor(minings);
 
 			// Try to find existing annotation
-			AbstractInlinedAnnotation ann= fInlinedAnnotationSupport.findExistingAnnotation(pos);
+			AbstractInlinedAnnotation ann= fInlinedAnnotationSupport.findExistingAnnotation(pos, minings);
 			if (ann == null || !mode.annotationType.isInstance(ann)) {
 				// The annotation doesn't exists or has wrong type => create a new one.
 				boolean afterPosition= false;


### PR DESCRIPTION
Add getMinings() accessor methods to CodeMiningLineContentAnnotation and CodeMiningLineHeaderAnnotation to expose their mining lists. Enhance findExistingAnnotation() in InlinedAnnotationSupport to accept an optional
minings parameter and compare existing annotations' minings with new ones.
This allows reusing existing annotation instances when the mining content
hasn't changed, avoiding unnecessary annotation recreation and improving performance.

The change prevents flickering and reduces overhead by preserving annotation
objects when only their position is being updated during reconciliation, but
their actual mining data remains identical.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2786#issuecomment-3642875815