### PR TITLE
Ensure the last line is included in projection-based visible regions

### DIFF
--- a/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionViewer.java
+++ b/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -841,22 +841,18 @@ public class ProjectionViewer extends SourceViewer implements ITextViewerExtensi
 
 	private static int computeEndOfVisibleRegion(int start, int length, IDocument document) throws BadLocationException {
 		int documentLength= document.getLength();
-		int end= start + length + 1;
-		// ensure that trailing whitespace is included
-		// In this case, the line break needs to be included as well
-		boolean visibleRegionEndsWithTrailingWhitespace= end < documentLength && isWhitespaceButNotNewline(document.getChar(end - 1));
-		while (end < documentLength && isWhitespaceButNotNewline(document.getChar(end))) {
+		int end= start + length;
+		// ensure that the last line is fully included because projections cannot include partial lines
+		while (end < documentLength && !isLineBreak(document.getChar(end))) {
 			end++;
-			visibleRegionEndsWithTrailingWhitespace= true;
 		}
-		if (visibleRegionEndsWithTrailingWhitespace && end < documentLength && isLineBreak(document.getChar(end))) {
+		if (end < documentLength) {
+			end++;
+		}
+		if (end < documentLength && document.getChar(end) == '\n' && document.getChar(end - 1) == '\r') {
 			end++;
 		}
 		return end;
-	}
-
-	private static boolean isWhitespaceButNotNewline(char c) {
-		return Character.isWhitespace(c) && !isLineBreak(c);
 	}
 
 	private static boolean isLineBreak(char c) {


### PR DESCRIPTION
As noticed in https://github.com/eclipse-platform/eclipse.platform.ui/pull/3074#issuecomment-3638637269 by @totomomo18, there are situations where the projection-based folding introduced in #3074 hides the last line where it should be shown. In that example, it was due to Windows line endings (`\r\n`) where the last line was missing and it only moved past the `\r` but not the `\n` (it didn't account for the second character).

However, there is another situation where this can happen which is the case if there is additional (non-whitespace) text in the last line after the visible region. In the following example, assume that the visible region starts with `{` and ends with `}`:
```
{
    // ...
} // additional text here
```
Here, the `}` would be hidden.

An example where this could happen with JDT is enum constants (because of the `,` after the constants):
```java
enum ABC {
    SOME_CONSTANT,
    OTHER_CONSTANT
}
```

The problem with these situations is that projections/folding cannot hide partial lines at the end so it has to show the entire last line. When I implemented #3074, I was assuming that this was an issue with whitespace at the end but I didn't account for further text (it worked perfectly fine with comments and other things in JDT because comments at the end seem to be included in the visible regions set by JDT).

This change ensures that setting the visible region with projections enabled does not hide the last line in case there is additional text at the end of the line or the file is using Windows line endings by fixing the logic for computing the end of the visible region.