### PR TITLE
Fix invalid parameter name in BindingManager#getActiveBindingsFor1 Javadoc

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/bindings/BindingManager.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/bindings/BindingManager.java
@@ -1182,12 +1182,11 @@ public final class BindingManager extends HandleObjectManager<Scheme>
 
 	/**
 	 * A variation on {@link BindingManager#getActiveBindingsFor(String)} that
-	 * returns an array of bindings, rather than trigger sequences. This method
-	 * is needed for doing "best" calculations on the active bindings.
+	 * returns an array of bindings, rather than trigger sequences. This method is
+	 * needed for doing "best" calculations on the active bindings.
 	 *
-	 * @param commandId
-	 *            The identifier of the command for which the active bindings
-	 *            should be retrieved; must not be <code>null</code>.
+	 * @param command The command for which the active bindings should be retrieved;
+	 *                must not be <code>null</code>.
 	 * @return The active bindings for the given command; this value may be
 	 *         <code>null</code> if there are no active bindings.
 	 * @since 3.2


### PR DESCRIPTION
The `BindingManager#getActiveBindingsFor1` method has a parameter named `command` but the `@param` in the Javadoc comment references the name `commandId`. This slight inconsistency is there since https://github.com/eclipse-platform/eclipse.platform.ui/commit/82271bc612f6b4eee954d66d3434b5e1cb646a5a where the signature was updated without the Javadoc and causes an error/warning (I think it's shown as an error due to the project's properties) when trying to [compile Eclipse Platform with javac](https://github.com/eclipse-jdtls/eclipse.jdt.javac) (doing that also causes a few other warnings).