### PR TITLE
Use OfFloat Point values to create precise highlight brackets

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/MatchingCharacterPainter.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/MatchingCharacterPainter.java
@@ -257,17 +257,15 @@ public final class MatchingCharacterPainter implements IPainter, PaintListener {
 		if (gc != null) {
 			gc.setForeground(fColor);
 
-			final Rectangle bounds= fTextWidget.getTextBounds(offset, offset);
+			Point offsetLocation= fTextWidget.getLocationAtOffset(offset);
 
-			// determine the character width separately, because the getTextBounds above
-			// will also include any in-line annotations (e.g. codemining annotations) in the width
 			final String matchingCharacter= fTextWidget.getText(offset, offset);
-			final int width= gc.textExtent(matchingCharacter).x;
-
-			final int height= fTextWidget.getCaret().getSize().y;
+			Point characterBounds= gc.textExtent(matchingCharacter);
+			characterBounds.y-= 1;
+			Rectangle hightlightingArea= Rectangle.of(offsetLocation, characterBounds);
 
 			// draw box around line segment
-			gc.drawRectangle(bounds.x, bounds.y + bounds.height - height, width, height - 1);
+			gc.drawRectangle(hightlightingArea);
 		} else {
 			fTextWidget.redrawRange(offset, 1, true);
 		}


### PR DESCRIPTION
Because of rounding errors the bracket selection highlight is often inconsistent. Making use of residual values provides precise rectangle values and highlight is consistent across all zooms

Problem: At 250% (the problem is also there for all zooms, at 250 its just better visible), After every three line the fourth line x axis is bit too much on the left. (rounding error)

line 29: the width of highlight is 17px

<img width="836" height="157" alt="image" src="https://github.com/user-attachments/assets/297d2ce8-37af-457d-b881-9bfbed033c29" />

line 30: the width of highlight is 16px

<img width="721" height="108" alt="image" src="https://github.com/user-attachments/assets/48a1b155-3fff-4a3d-b342-7ab7ce41bdcc" />


### How to test

- Run the runtime workspace with monitor-specific scaling turned on
- Add some brackets in Java file { }
- Select the opening bracket, the closing bracket will be highlighted. 
- See if the rectangle around highlighted bracket is surrounded the bracket correctly (no-cutoffs)

### Result 

**Before Fix:**
<img width="388" height="1204" alt="image" src="https://github.com/user-attachments/assets/9f6f28ad-3136-47a6-9455-f98d963b7bd6" />


**After Fix:**
<img width="569" height="1314" alt="image" src="https://github.com/user-attachments/assets/b3b53899-b7dc-4b0d-9054-92eb559608d4" />

**Requires:**

- [x] https://github.com/eclipse-platform/eclipse.platform.swt/pull/2907
