### PR TITLE
Stop dealing with ThreadDeath

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/IEventLoopAdvisor.java
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/IEventLoopAdvisor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -39,27 +39,26 @@ public interface IEventLoopAdvisor {
 	public void eventLoopIdle(Display display);
 
 	/**
-	 * Performs arbitrary actions when the event loop crashes (the code that
-	 * handles a UI event throws an exception that is not caught).
+	 * Performs arbitrary actions when the event loop crashes (the code that handles
+	 * a UI event throws an exception that is not caught).
 	 * <p>
-	 * This method is called when the code handling a UI event throws an
-	 * exception. In a perfectly functioning application, this method would
-	 * never be called. In practice, it comes into play when there are bugs in
-	 * the code that trigger unchecked runtime exceptions. It is also activated
-	 * when the system runs short of memory, etc. Fatal errors (ThreadDeath) are
-	 * not passed on to this method, as there is nothing that could be done.
+	 * This method is called when the code handling a UI event throws an exception.
+	 * In a perfectly functioning application, this method would never be called. In
+	 * practice, it comes into play when there are bugs in the code that trigger
+	 * unchecked runtime exceptions. It is also activated when the system runs short
+	 * of memory, etc. Fatal errors are not passed on to this method, as there is
+	 * nothing that could be done.
 	 * </p>
 	 * <p>
-	 * Clients must not call this method directly (although super calls are
-	 * okay). The default implementation logs the problem so that it does not go
-	 * unnoticed. Subclasses may override or extend this method. It is generally
-	 * a bad idea to override with an empty method, and you should be especially
-	 * careful when handling Errors.
+	 * Clients must not call this method directly (although super calls are okay).
+	 * The default implementation logs the problem so that it does not go unnoticed.
+	 * Subclasses may override or extend this method. It is generally a bad idea to
+	 * override with an empty method, and you should be especially careful when
+	 * handling Errors.
 	 * </p>
 	 *
-	 * @param exception
-	 *            the uncaught exception that was thrown inside the UI event
-	 *            loop
+	 * @param exception the uncaught exception that was thrown inside the UI event
+	 *                  loop
 	 */
 	public void eventLoopException(Throwable exception);
 }

--- a/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/PartRenderingEngine.java
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/PartRenderingEngine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 IBM Corporation and others.
+ * Copyright (c) 2008, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1151,8 +1151,6 @@ public class PartRenderingEngine implements IPresentationEngine {
 							}
 							advisor.eventLoopIdle(display);
 						}
-					} catch (ThreadDeath th) {
-						throw th;
 					} catch (Exception | Error err) {
 						handle(err, advisor);
 					}
@@ -1166,10 +1164,6 @@ public class PartRenderingEngine implements IPresentationEngine {
 				try {
 					advisor.eventLoopException(ex);
 				} catch (Throwable t) {
-					if (t instanceof ThreadDeath) {
-						throw (ThreadDeath) t;
-					}
-
 					// couldn't handle the exception, print to console
 					t.printStackTrace();
 				}

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/operation/ModalContext.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/operation/ModalContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -122,10 +122,6 @@ public class ModalContext {
 				if (runnable != null) {
 					runnable.run(progressMonitor);
 				}
-			} catch (ThreadDeath e) {
-				// Make sure to propagate ThreadDeath, or threads will never
-				// fully terminate.
-				throw e;
 			} catch (InvocationTargetException | InterruptedException | RuntimeException | Error e) {
 				throwable = e;
 			} finally {
@@ -169,12 +165,6 @@ public class ModalContext {
 							display.sleep();
 						}
 						exceptionCount = 0;
-					}
-					// ThreadDeath is a normal error when the thread is dying.
-					// We must propagate it in order for it to properly
-					// terminate.
-					catch (ThreadDeath e) {
-						throw (e);
 					}
 					// For all other exceptions, log the problem.
 					catch (Throwable t) {
@@ -414,10 +404,6 @@ public class ModalContext {
 	static Throwable invokeThreadListener(IThreadListener listener, Thread switchingThread) {
 		try {
 			listener.threadChange(switchingThread);
-		} catch (ThreadDeath e) {
-			// Make sure to propagate ThreadDeath, or threads will never
-			// fully terminate
-			throw e;
 		} catch (RuntimeException | Error e) {
 			return e;
 		}
@@ -438,9 +424,7 @@ public class ModalContext {
 			InterruptedException interruptedException = new InterruptedException(e.getLocalizedMessage());
 			interruptedException.initCause(e);
 			throw interruptedException;
-		} catch (InvocationTargetException | InterruptedException | ThreadDeath e) {
-			// Make sure to propagate ThreadDeath, or threads will never fully
-			// terminate.
+		} catch (InvocationTargetException | InterruptedException e) {
 			throw e;
 		} catch (RuntimeException | Error e) {
 			throw new InvocationTargetException(e);

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/window/Window.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/window/Window.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -129,11 +129,6 @@ public abstract class Window implements IShellProvider {
 	private static class DefaultExceptionHandler implements IExceptionHandler {
 		@Override
 		public void handleException(Throwable t) {
-			if (t instanceof ThreadDeath) {
-				// Don't catch ThreadDeath as this is a normal occurrence when
-				// the thread dies
-				throw (ThreadDeath) t;
-			}
 			// Try to keep running.
 			t.printStackTrace();
 		}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/application/WorkbenchAdvisor.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/application/WorkbenchAdvisor.java
@@ -280,8 +280,8 @@ public abstract class WorkbenchAdvisor {
 	 * In a perfectly functioning application, this method would never be called. In
 	 * practice, it comes into play when there are bugs in the code that trigger
 	 * unchecked runtime exceptions. It is also activated when the system runs short
-	 * of memory, etc. Fatal errors (ThreadDeath) are not passed on to this method,
-	 * as there is nothing that could be done.
+	 * of memory, etc. Fatal errors are not passed on to this method, as there is
+	 * nothing that could be done.
 	 * </p>
 	 * <p>
 	 * Clients must not call this method directly (although super calls are okay).

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/ExceptionHandler.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/ExceptionHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,8 +17,7 @@ import org.eclipse.jface.window.Window;
 
 /**
  * This handler will pass along to the workbench advisor exceptions and errors
- * thrown while running the event loop. However, the <code>ThreadDeath</code>
- * error is simply thrown again, and is not passed along.
+ * thrown while running the event loop.
  */
 public final class ExceptionHandler implements Window.IExceptionHandler {
 
@@ -42,11 +41,6 @@ public final class ExceptionHandler implements Window.IExceptionHandler {
 	@Override
 	public void handleException(Throwable t) {
 		try {
-			// Ignore ThreadDeath error as its normal to get this when thread dies
-			if (t instanceof ThreadDeath) {
-				throw (ThreadDeath) t;
-			}
-
 			// Check to avoid recursive errors
 			exceptionCount++;
 			if (exceptionCount > 2) {

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
@@ -151,12 +151,6 @@ public class PartRenderingEngineTests {
 		try {
 			advisor.eventLoopException(ex);
 		} catch (Throwable t) {
-			// The type ThreadDeath has been deprecated since version 20
-			// and marked for removal
-			if ("ThreadDeath".equals(t.getClass().getSimpleName())) {
-				// don't catch ThreadDeath by accident
-				throw t;
-			}
 			// couldn't handle the exception, print to console
 			t.printStackTrace();
 		} finally {


### PR DESCRIPTION
Java 20+ Thread.stop throws UnsupportedOperationException and thus ThreadDeath is not thrown by anything anymore. Stop dealing with it. https://inside.java/2022/11/09/quality-heads-up/