### PR TITLE
Disposing and recreating menus  menus when parent changes

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/PartRenderingEngine.java
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/PartRenderingEngine.java
@@ -99,8 +99,10 @@ import org.eclipse.swt.events.ShellAdapter;
 import org.eclipse.swt.events.ShellEvent;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Decorations;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Widget;
 import org.eclipse.ui.testing.TestableObject;
@@ -581,6 +583,17 @@ public class PartRenderingEngine implements IPresentationEngine {
 						control.setParent((Composite) parentWidget);
 					}
 				}
+			}
+
+			if (currentWidget instanceof Menu menu) {
+				if (parentWidget instanceof Decorations) {
+					Decorations currentParent = menu.getParent();
+					if (currentParent != parentWidget) {
+						menu.dispose();
+						return safeCreateGui(element, parentWidget, parentContext);
+					}
+				}
+
 			}
 
 			// Reparent the context (or the kid's context)


### PR DESCRIPTION
When a part is moved to a different monitor if the part is a control we currently reparent the part As in the this [codeblock](https://github.com/vi-eclipse/eclipse.platform.ui/blob/9d11600da0250bbf7bd2abfaba4ddcf53bdcdbad/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/PartRenderingEngine.java#L583) .
However Menus, unlike controls, were not reparented when their associated part was moved (e.g., dragged to a different monitor). This caused menu icons and images to render at the wrong zoom due to the old parent's DPI. 

This change checks if a menu's parent has changed during rendering. If so, the menu is disposed and recreated under the correct parent, ensuring proper scaling and visual consistency across monitors.

### Steps to reproduce

1)Start the runtime workspace on secondary monitor (350%) 
2)Click on three dots on the right to open the menu here the icons would be rightly sized
2)Drag the Project Explorer tab to primary monitor (150%)
3)Click on three dots on the right

Before
<img width="356" height="303" alt="image" src="https://github.com/user-attachments/assets/9a2694b1-6fcb-4aa2-9d2f-860166df4905" />
After
<img width="311" height="298" alt="image" src="https://github.com/user-attachments/assets/dd7644d2-494b-4363-9b70-e9723e1dfe2b" />
