### PR TITLE
Migrate tests to JUnit 5 using CloseTestWindowsExtension

### DIFF
--- a/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/PreferenceMementoExtension.java
+++ b/tests/org.eclipse.ui.tests.harness/src/org/eclipse/ui/tests/harness/util/PreferenceMementoExtension.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vector Informatik and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ui.tests.harness.util;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferenceMemento;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Preference helper to restore changed preference values after test run.
+ */
+public class PreferenceMementoExtension implements BeforeEachCallback, AfterEachCallback {
+
+	private PreferenceMemento prefMemento;
+
+	@Override
+	public void beforeEach(ExtensionContext context) {
+		prefMemento = new PreferenceMemento();
+	}
+
+	@Override
+	public void afterEach(ExtensionContext context) {
+		if (prefMemento != null) {
+			prefMemento.resetPreferences();
+		}
+	}
+
+	/**
+	 * Change a preference value for the associated test run. The preference will
+	 * automatically be reset to the value it had before starting when executing
+	 * {@link #afterEach(ExtensionContext)}.
+	 *
+	 * @param <T>   preference value type. The type must have a corresponding
+	 *              {@link IPreferenceStore} setter.
+	 * @param store preference store to manipulate (must not be <code>null</code>)
+	 * @param name  preference to change
+	 * @param value new preference value
+	 * @throws IllegalArgumentException when setting a type which is not supported
+	 *                                  by {@link IPreferenceStore}
+	 *
+	 * @see IPreferenceStore#setValue(String, double)
+	 * @see IPreferenceStore#setValue(String, float)
+	 * @see IPreferenceStore#setValue(String, int)
+	 * @see IPreferenceStore#setValue(String, long)
+	 * @see IPreferenceStore#setValue(String, boolean)
+	 * @see IPreferenceStore#setValue(String, String)
+	 */
+	public <T> void setPreference(IPreferenceStore store, String name, T value) {
+		if (prefMemento == null) {
+			prefMemento = new PreferenceMemento();
+		}
+		prefMemento.setValue(store, name, value);
+	}
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/Bug41931Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/Bug41931Test.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.internal;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -30,21 +30,19 @@ import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.WorkbenchPage;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test for Bug 41931.
  *
  * @since 3.0
  */
-@Ignore
+@Disabled
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug41931Test {
-
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	/**
 	 * Tests that the <code>bringToTop(IWorkbenchPart)</code> correctly
@@ -83,8 +81,8 @@ public class Bug41931Test {
 		IEditorPart[] expectedResults = { editorA, editorB, editorC };
 		IWorkbenchPartReference[] actualResults = page.getSortedParts();
 		for (int i = 0; i < expectedResults.length; i++) {
-			assertEquals(
-					"Pre-test order is not correct.", expectedResults[i].getTitle(), actualResults[i].getPart(false).getTitle()); //$NON-NLS-1$
+			assertEquals(expectedResults[i].getTitle(), actualResults[i].getPart(false).getTitle(),
+					"Pre-test order is not correct."); //$NON-NLS-1$
 		}
 
 		// Bring editor B to the top.
@@ -94,8 +92,8 @@ public class Bug41931Test {
 		expectedResults = new IEditorPart[] { editorA, editorC, editorB };
 		actualResults = page.getSortedParts();
 		for (int i = 0; i < expectedResults.length; i++) {
-			assertEquals(
-					"bringToTop() does not change sorted part order.", expectedResults[i].getTitle(), actualResults[i].getPart(false).getTitle()); //$NON-NLS-1$
+			assertEquals(expectedResults[i].getTitle(), actualResults[i].getPart(false).getTitle(),
+					"bringToTop() does not change sorted part order."); //$NON-NLS-1$
 		}
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/PerspectiveSwitcherTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/PerspectiveSwitcherTest.java
@@ -15,25 +15,24 @@
 package org.eclipse.ui.tests.internal;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.IWorkbenchPreferenceConstants;
 import org.eclipse.ui.internal.WorkbenchWindow;
 import org.eclipse.ui.internal.util.PrefUtil;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.eclipse.ui.tests.harness.util.PreferenceMementoExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+@ExtendWith(CloseTestWindowsExtension.class)
 public class PerspectiveSwitcherTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
-
-	@Rule
-	public final PreferenceMementoRule preferenceMemento = new PreferenceMementoRule();
+	@RegisterExtension
+	public final PreferenceMementoExtension preferenceMemento = new PreferenceMementoExtension();
 
 	/**
 	 * This test ensures that our workbench window's perspective bar can opened if
@@ -44,14 +43,14 @@ public class PerspectiveSwitcherTest {
 		IPreferenceStore apiPreferenceStore = PrefUtil.getAPIPreferenceStore();
 
 		WorkbenchWindow window = (WorkbenchWindow) getWorkbench().getActiveWorkbenchWindow();
-		assertNotNull("We should have a perspective bar in the beginning", getPerspectiveSwitcher(window)); //$NON-NLS-1$
+		assertNotNull(getPerspectiveSwitcher(window), "We should have a perspective bar in the beginning"); //$NON-NLS-1$
 
 		// turn off the 'Open Perspective' item
 		preferenceMemento.setPreference(apiPreferenceStore, IWorkbenchPreferenceConstants.SHOW_OPEN_ON_PERSPECTIVE_BAR,
 				false);
 
 		// check that we still have a perspective bar
-		assertNotNull("The perspective bar should have been created successfully", getPerspectiveSwitcher(window)); //$NON-NLS-1$
+		assertNotNull(getPerspectiveSwitcher(window), "The perspective bar should have been created successfully"); //$NON-NLS-1$
 
 	}
 

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/StickyViewManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/StickyViewManagerTest.java
@@ -15,8 +15,8 @@
 package org.eclipse.ui.tests.internal;
 
 import static org.eclipse.ui.PlatformUI.getWorkbench;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IPerspectiveDescriptor;
@@ -26,27 +26,26 @@ import org.eclipse.ui.IViewReference;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPreferenceConstants;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.eclipse.ui.tests.harness.util.PreferenceMementoRule;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.eclipse.ui.tests.harness.util.PreferenceMementoExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @since 3.6
  */
-@Ignore
+@Disabled
+@ExtendWith(CloseTestWindowsExtension.class)
 public class StickyViewManagerTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
-
-	@Rule
-	public final PreferenceMementoRule preferenceMemento = new PreferenceMementoRule();
+	@RegisterExtension
+	public final PreferenceMementoExtension preferenceMemento = new PreferenceMementoExtension();
 
 
-	@Before
+	@BeforeEach
 	public final void setUp() throws Exception {
 		preferenceMemento.setPreference(PlatformUI.getPreferenceStore(),
 				IWorkbenchPreferenceConstants.ENABLE_32_STICKY_CLOSE_BEHAVIOR, false);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/TextHandlerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/internal/TextHandlerTest.java
@@ -16,9 +16,9 @@ package org.eclipse.ui.tests.internal;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.dnd.Clipboard;
@@ -27,23 +27,21 @@ import org.eclipse.swt.dnd.Transfer;
 import org.eclipse.swt.dnd.URLTransfer;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.actions.TextActionHandler;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test for {@link TextActionHandler}.
  *
  * @since 3.5
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class TextHandlerTest {
-
-	@Rule
-	public final CloseTestWindowsRule closeTestWindowsRule = new CloseTestWindowsRule();
 
 	@Test
 	public void testEditableText() throws Exception {
-		assumeFalse("Test fails on Mac: Bug 544675", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 544675");
 
 		IWorkbenchWindow window = openTestWindow();
 		TextControlView view = (TextControlView) window.getActivePage()


### PR DESCRIPTION
Migrates tests in `org.eclipse.ui.tests` from `CloseTestWindowsRule` (JUnit 4) to `CloseTestWindowsExtension` (JUnit 5).

Changes include:
- Replacing `CloseTestWindowsRule` with `CloseTestWindowsExtension`.
- Updating imports to JUnit 5.
- Converting annotations: `@Rule` -> `@ExtendWith`, `@Ignore` -> `@Disabled`, `@Before` -> `@BeforeEach`.
- Updating assertions to match JUnit 5 argument order (message last).

Tests migrated:
- `Bug43321Test`
- `Bug53489Test`
- `Bug44460Test`
- `Bug41931Test`
- `Bug40023Test`
- `Bug36537Test`
- `PerspectiveSwitcherTest`
- `TextHandlerTest`
- `StickyViewManagerTest`