### PR TITLE
Eliminate includes of 3rd party bundles in features.

### DIFF
--- a/features/org.eclipse.e4.rcp/feature.xml
+++ b/features/org.eclipse.e4.rcp/feature.xml
@@ -170,10 +170,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.osgi.service.prefs"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.registry"
          version="0.0.0"/>
 


### PR DESCRIPTION
- We don't need org.osgi.service.prefs because it's required by org.eclipse.equinox.preferences.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3585