### PR TITLE
Deprecate for removal QuickMenuCreator#dispose

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/actions/QuickMenuAction.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/actions/QuickMenuAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2015 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -61,7 +61,6 @@ public abstract class QuickMenuAction extends Action {
 	 */
 	public void dispose() {
 		if (creator != null) {
-			creator.dispose();
 			creator = null;
 		}
 	}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/actions/QuickMenuCreator.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/actions/QuickMenuCreator.java
@@ -274,7 +274,7 @@ public abstract class QuickMenuCreator {
 	 *             {@link #createMenu()} will be disposed shortly after the SWT.Hide
 	 *             event.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2026-03")
 	public void dispose() {
 	}
 }

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/actions/ModifyWorkingSetDelegate.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/actions/ModifyWorkingSetDelegate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2015 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -164,7 +164,6 @@ public class ModifyWorkingSetDelegate extends AbstractWorkingSetPulldownDelegate
 	public void dispose() {
 		getWindow().getWorkbench().getWorkingSetManager().removePropertyChangeListener(listener);
 		super.dispose();
-		contextMenuCreator.dispose();
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/handlers/QuickMenuHandler.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/handlers/QuickMenuHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2015 IBM Corporation and others.
+ * Copyright (c) 2008, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -65,7 +65,6 @@ public class QuickMenuHandler extends AbstractHandler implements IMenuListener2 
 	@Override
 	public void dispose() {
 		if (creator != null) {
-			creator.dispose();
 			creator = null;
 		}
 	}


### PR DESCRIPTION
And stop calling it as it is a no-op anyway.