### PR TITLE
Migrate org.eclipse.ui.tests.keys to JUnit5

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/BindingInteractionsTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/BindingInteractionsTest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.keys;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import java.util.Locale;
@@ -30,9 +30,9 @@ import org.eclipse.jface.bindings.BindingManager;
 import org.eclipse.jface.bindings.Scheme;
 import org.eclipse.jface.bindings.TriggerSequence;
 import org.eclipse.jface.util.Util;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases covering the various interaction between bindings. Bindings that
@@ -59,7 +59,7 @@ public final class BindingInteractionsTest {
 	 * Creates a new context manager and a binding manager for use in the test
 	 * cases.
 	 */
-	@Before
+	@BeforeEach
 	public void doSetUp() {
 		contextManager = new ContextManager();
 		bindingManager = new BindingManager(contextManager,
@@ -69,7 +69,7 @@ public final class BindingInteractionsTest {
 	/**
 	 * Releases the context manager and binding manager for garbage collection.
 	 */
-	@After
+	@AfterEach
 	public void doTearDown() {
 		contextManager = null;
 		bindingManager = null;
@@ -106,12 +106,10 @@ public final class BindingInteractionsTest {
 		TriggerSequence[] activeBindings = bindingManager
 				.getActiveBindingsFor(binding1.getParameterizedCommand());
 		assertFalse(binding1.equals(binding2));
-		assertTrue("Neither binding should be active",
-				activeBindings.length == 0);
+		assertTrue(activeBindings.length == 0, "Neither binding should be active");
 		activeBindings = bindingManager.getActiveBindingsFor(binding2
 				.getParameterizedCommand());
-		assertTrue("Neither binding should be active",
-				activeBindings.length == 0);
+		assertTrue(activeBindings.length == 0, "Neither binding should be active");
 	}
 
 	/**
@@ -147,27 +145,24 @@ public final class BindingInteractionsTest {
 		final Set<String> activeContextIds = new HashSet<>();
 		activeContextIds.add("parent");
 		contextManager.setActiveContextIds(activeContextIds);
-		assertEquals(
-				"When only the parent context is active, only the parent binding is active.",
-				binding1, bindingManager
-						.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(binding1,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE),
+				"When only the parent context is active, only the parent binding is active.");
 
 		// Only "child"
 		activeContextIds.clear();
 		activeContextIds.add("child");
 		contextManager.setActiveContextIds(activeContextIds);
-		assertEquals(
-				"When only the child context is active, only the child binding is active.",
-				binding2, bindingManager
-						.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(binding2,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE),
+				"When only the child context is active, only the child binding is active.");
 
 		// Both "parent" and "child"
 		activeContextIds.add("parent");
 		contextManager.setActiveContextIds(activeContextIds);
-		assertEquals(
-				"When both contexts are active, only the child binding is active.",
-				binding2, bindingManager
-						.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(binding2,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE),
+				"When both contexts are active, only the child binding is active.");
 	}
 
 	/**
@@ -197,8 +192,8 @@ public final class BindingInteractionsTest {
 		final Binding binding2 = new TestBinding("system", "na", "na", null,
 				null, Binding.SYSTEM, null);
 		bindingManager.addBinding(binding2);
-		assertEquals("The user should be able to remove bindings", null,
-				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(null,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE), "The user should be able to remove bindings");
 	}
 
 	/**
@@ -235,11 +230,9 @@ public final class BindingInteractionsTest {
 		final Binding parentBinding = new TestBinding("parentCommand", "na",
 				"parent", null, null, Binding.SYSTEM, null);
 		bindingManager.addBinding(parentBinding);
-		assertEquals(
-				"The user should be able to remove bindings to allow a parent binding",
-				"parentCommand", bindingManager.getPerfectMatch(
-						TestBinding.TRIGGER_SEQUENCE).getParameterizedCommand()
-						.getId());
+		assertEquals("parentCommand",
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE).getParameterizedCommand().getId(),
+				"The user should be able to remove bindings to allow a parent binding");
 	}
 
 	/**
@@ -276,10 +269,9 @@ public final class BindingInteractionsTest {
 		final Binding platformSpecific = new TestBinding("platformSpecific",
 				na, na, null, Util.getWS(), Binding.SYSTEM, null);
 		bindingManager.addBinding(platformSpecific);
-		assertEquals(
-				"We should be able to change a binding on a particular platform",
-				platformSpecific, bindingManager
-						.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(platformSpecific,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE),
+				"We should be able to change a binding on a particular platform");
 	}
 
 	/**
@@ -316,10 +308,9 @@ public final class BindingInteractionsTest {
 		bindings[1] = binding2;
 		bindings[2] = binding3;
 		bindingManager.setBindings(bindings);
-		assertEquals(
-				"A binding should not cause a deletion if its locale or platform doesn't match",
-				binding2, bindingManager
-						.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(binding2,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE),
+				"A binding should not cause a deletion if its locale or platform doesn't match");
 	}
 
 	/**
@@ -353,8 +344,8 @@ public final class BindingInteractionsTest {
 		final Binding binding3 = new TestBinding("user", "na", "na", null,
 				null, Binding.USER, null);
 		bindingManager.addBinding(binding3);
-		assertEquals("The user redefine a particular binding", binding3,
-				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(binding3,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE), "The user redefine a particular binding");
 	}
 
 	/**
@@ -388,9 +379,8 @@ public final class BindingInteractionsTest {
 				context.getId(), null, bindingManager.getPlatform(),
 				Binding.USER, null);
 		bindingManager.addBinding(userOverride);
-		assertEquals("The user redefine a binding deleted in the system",
-				userOverride, bindingManager
-						.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(userOverride,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE), "The user redefine a binding deleted in the system");
 
 	}
 
@@ -435,8 +425,8 @@ public final class BindingInteractionsTest {
 		bindingManager.addBinding(wrongDeletion);
 
 		// Test that the deletion worked.
-		assertEquals("The parent should not be active", null, bindingManager
-				.getPerfectMatch(binding.getTriggerSequence()));
+		assertEquals(null, bindingManager
+				.getPerfectMatch(binding.getTriggerSequence()), "The parent should not be active");
 	}
 
 	/**
@@ -478,12 +468,10 @@ public final class BindingInteractionsTest {
 		bindingManager.addBinding(childBinding);
 
 		// Test to see that only the child is active.
-		assertTrue("The parent should not be active",
-				bindingManager.getActiveBindingsFor(parentBinding
-						.getParameterizedCommand()).length == 0);
-		assertTrue("The child should be active",
-				bindingManager.getActiveBindingsFor(childBinding
-						.getParameterizedCommand()).length != 0);
+		assertTrue(bindingManager.getActiveBindingsFor(parentBinding
+						.getParameterizedCommand()).length == 0, "The parent should not be active");
+		assertTrue(bindingManager.getActiveBindingsFor(childBinding
+						.getParameterizedCommand()).length != 0, "The child should be active");
 	}
 
 	/**
@@ -517,10 +505,9 @@ public final class BindingInteractionsTest {
 		final Binding binding3 = new TestBinding("locale-specific", "na", "na",
 				Locale.getDefault().toString(), null, Binding.SYSTEM, null);
 		bindingManager.addBinding(binding3);
-		assertEquals(
-				"A plug-in developer should be able to change a binding for a locale",
-				binding3, bindingManager
-						.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(binding3,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE),
+				"A plug-in developer should be able to change a binding for a locale");
 	}
 
 	/**
@@ -554,10 +541,9 @@ public final class BindingInteractionsTest {
 		final Binding binding3 = new TestBinding("platform-specific", "na",
 				"na", null, Util.getWS(), Binding.SYSTEM, null);
 		bindingManager.addBinding(binding3);
-		assertEquals(
-				"A plug-in developer should be able to change a binding for a platform",
-				binding3, bindingManager
-						.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(binding3,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE),
+				"A plug-in developer should be able to change a binding for a platform");
 	}
 
 	/**
@@ -598,9 +584,8 @@ public final class BindingInteractionsTest {
 		final Binding binding2 = new TestBinding("parent", "parent", "na",
 				null, null, Binding.SYSTEM, null);
 		bindingManager.addBinding(binding2);
-		assertEquals("The binding from the child scheme should be active",
-				binding1, bindingManager
-						.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(binding1,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE), "The binding from the child scheme should be active");
 	}
 
 	/**
@@ -641,9 +626,8 @@ public final class BindingInteractionsTest {
 		final Binding binding2 = new TestBinding("child", childScheme.getId(),
 				parentContext.getId(), null, null, Binding.SYSTEM, null);
 		bindingManager.addBinding(binding2);
-		assertEquals("The binding from the child scheme should be active",
-				binding2, bindingManager
-						.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(binding2,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE), "The binding from the child scheme should be active");
 	}
 
 	/**
@@ -684,9 +668,8 @@ public final class BindingInteractionsTest {
 		final Binding binding2 = new TestBinding("parent", "parent", "na",
 				null, null, Binding.USER, null);
 		bindingManager.addBinding(binding2);
-		assertEquals("The binding from the child scheme should be active",
-				binding1, bindingManager
-						.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(binding1,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE), "The binding from the child scheme should be active");
 	}
 
 	/**
@@ -722,26 +705,23 @@ public final class BindingInteractionsTest {
 		final Set<String> activeContextIds = new HashSet<>();
 		activeContextIds.add("sibling1");
 		contextManager.setActiveContextIds(activeContextIds);
-		assertEquals(
-				"When only the first sibling is active, only the first binding is active",
-				binding1, bindingManager
-						.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(binding1,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE),
+				"When only the first sibling is active, only the first binding is active");
 
 		// Other sibling active
 		activeContextIds.clear();
 		activeContextIds.add("sibling2");
 		contextManager.setActiveContextIds(activeContextIds);
-		assertEquals(
-				"When only the second sibling is active, only the second binding is active",
-				binding2, bindingManager
-						.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(binding2,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE),
+				"When only the second sibling is active, only the second binding is active");
 
 		// Both siblings are active
 		activeContextIds.add("sibling1");
 		contextManager.setActiveContextIds(activeContextIds);
-		assertEquals("When both contexts are active, a conflict should occur",
-				null, bindingManager
-						.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(null,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE), "When both contexts are active, a conflict should occur");
 	}
 
 	/**
@@ -779,7 +759,7 @@ public final class BindingInteractionsTest {
 		final Binding binding2 = new TestBinding("system", "na", "na", null,
 				null, Binding.SYSTEM, null);
 		bindingManager.addBinding(binding2);
-		assertEquals("The user-defined binding should be active", binding1,
-				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertEquals(binding1,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE), "The user-defined binding should be active");
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/BindingManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/BindingManagerTest.java
@@ -14,13 +14,13 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.keys;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -44,9 +44,9 @@ import org.eclipse.jface.bindings.TriggerSequence;
 import org.eclipse.jface.bindings.keys.KeyBinding;
 import org.eclipse.jface.bindings.keys.KeySequence;
 import org.eclipse.jface.bindings.keys.ParseException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>
@@ -87,7 +87,7 @@ public final class BindingManagerTest {
 	 * Creates a new context manager and a binding manager for use in the test
 	 * cases.
 	 */
-	@Before
+	@BeforeEach
 	public void doSetUp() {
 		commandManager = new CommandManager();
 		contextManager = new ContextManager();
@@ -97,7 +97,7 @@ public final class BindingManagerTest {
 	/**
 	 * Releases the context manager and binding manager for garbage collection.
 	 */
-	@After
+	@AfterEach
 	public void doTearDown() {
 		bindingManager = null;
 		contextManager = null;
@@ -107,9 +107,9 @@ public final class BindingManagerTest {
 	/**
 	 * Tests that the constructor disallows a null context manager.
 	 */
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void testConstructor() {
-		new BindingManager(null, null);
+		assertThrows(NullPointerException.class, () -> new BindingManager(null, null));
 	}
 
 	/**
@@ -138,8 +138,8 @@ public final class BindingManagerTest {
 		final Binding binding = new TestBinding("conflict1", "na", "na", null,
 				null, Binding.SYSTEM, null);
 		bindingManager.addBinding(binding);
-		assertSame("The binding should be active", binding,
-				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE));
+		assertSame(binding,
+				bindingManager.getPerfectMatch(TestBinding.TRIGGER_SEQUENCE), "The binding should be active");
 	}
 
 	/**
@@ -153,10 +153,8 @@ public final class BindingManagerTest {
 	public void testGetActiveBindingsDisregardingContext() {
 		final Map<?, ?> activeBindings = bindingManager
 				.getActiveBindingsDisregardingContext();
-		assertNotNull("The active bindings should never be null",
-				activeBindings);
-		assertTrue("The active bindings should start empty",
-				activeBindings.isEmpty());
+		assertNotNull(activeBindings, "The active bindings should never be null");
+		assertTrue(activeBindings.isEmpty(), "The active bindings should start empty");
 	}
 
 	/**
@@ -170,10 +168,8 @@ public final class BindingManagerTest {
 	public void testGetActiveBindingsDisregardingContextFlat() {
 		final Collection<?> activeBindings = bindingManager
 				.getActiveBindingsDisregardingContextFlat();
-		assertNotNull("The active bindings should never be null",
-				activeBindings);
-		assertTrue("The active bindings should start empty",
-				activeBindings.isEmpty());
+		assertNotNull(activeBindings, "The active bindings should never be null");
+		assertTrue(activeBindings.isEmpty(), "The active bindings should start empty");
 	}
 
 	/**
@@ -188,11 +184,9 @@ public final class BindingManagerTest {
 		// Test with a null argument.
 		final TriggerSequence[] activeBindingsForNull = bindingManager
 				.getActiveBindingsFor((ParameterizedCommand) null);
-		assertNotNull("The active bindings for a command should never be null",
-				activeBindingsForNull);
+		assertNotNull(activeBindingsForNull, "The active bindings for a command should never be null");
 		assertTrue(
-				"The active binding for a null command should always be empty",
-				activeBindingsForNull.length == 0);
+				activeBindingsForNull.length == 0, "The active binding for a null command should always be empty");
 
 		// Test a simple case.
 		final Context context = contextManager.getContext("na");
@@ -213,9 +207,9 @@ public final class BindingManagerTest {
 
 		final TriggerSequence[] bindings = bindingManager
 				.getActiveBindingsFor(binding.getParameterizedCommand());
-		assertEquals("There should be one binding", 1, bindings.length);
-		assertSame("The binding should match", TestBinding.TRIGGER_SEQUENCE,
-				bindings[0]);
+		assertEquals(1, bindings.length, "There should be one binding");
+		assertSame(TestBinding.TRIGGER_SEQUENCE,
+				bindings[0], "The binding should match");
 	}
 
 	/**
@@ -226,8 +220,7 @@ public final class BindingManagerTest {
 	 */
 	@Test
 	public void testGetActiveScheme() {
-		assertNull("The active scheme should start null",
-				bindingManager.getActiveScheme());
+		assertNull(bindingManager.getActiveScheme(), "The active scheme should start null");
 	}
 
 	/**
@@ -237,24 +230,22 @@ public final class BindingManagerTest {
 	@Test
 	public void testGetBindings() {
 		// Check the starting condition.
-		assertNull("The bindings should start off null",
-				bindingManager.getBindings());
+		assertNull(bindingManager.getBindings(), "The bindings should start off null");
 
 		// Check that an added binding is included.
 		final Binding binding = new TestBinding(null, "schemeId", "contextId",
 				null, null, Binding.SYSTEM, null);
 		bindingManager.addBinding(binding);
 		final Binding[] bindings = bindingManager.getBindings();
-		assertEquals("There should be one binding", 1, bindings.length);
-		assertSame("The binding should be the same", binding, bindings[0]);
+		assertEquals(1, bindings.length, "There should be one binding");
+		assertSame(binding, bindings[0], "The binding should be the same");
 
 		/*
 		 * Check that modifying this set does not modify the internal data
 		 * structures.
 		 */
 		bindings[0] = null;
-		assertNotNull("There should be no change",
-				bindingManager.getBindings()[0]);
+		assertNotNull(bindingManager.getBindings()[0], "There should be no change");
 	}
 
 	/**
@@ -263,33 +254,30 @@ public final class BindingManagerTest {
 	@Test
 	public void testGetDefinedSchemeIds() {
 		// Starting condition.
-		assertTrue("The set of defined schemes should start empty",
-				bindingManager.getDefinedSchemes().length == 0);
+		assertTrue(bindingManager.getDefinedSchemes().length == 0, "The set of defined schemes should start empty");
 
 		// Retrieving a scheme shouldn't change anything.
 		final Scheme scheme = bindingManager.getScheme("schemeId");
 		assertTrue(
-				"The set of defined schemes should still be empty after a get",
-				bindingManager.getDefinedSchemes().length == 0);
+				bindingManager.getDefinedSchemes().length == 0, "The set of defined schemes should still be empty after a get");
 
 		// Defining the scheme should change things.
 		scheme.define("name", "description", null);
 		Scheme[] definedSchemes = bindingManager.getDefinedSchemes();
-		assertEquals("There should be one defined scheme id", 1,
-				definedSchemes.length);
-		assertSame("The defined scheme id should match", scheme,
-				definedSchemes[0]);
+		assertEquals(1,
+				definedSchemes.length, "There should be one defined scheme id");
+		assertSame(scheme,
+				definedSchemes[0], "The defined scheme id should match");
 
 		definedSchemes[0] = null;
 		definedSchemes = bindingManager.getDefinedSchemes();
-		assertSame("The API should not expose internal collections", scheme,
-				definedSchemes[0]);
+		assertSame(scheme,
+				definedSchemes[0], "The API should not expose internal collections");
 
 		// Undefining the scheme should also change things.
 		scheme.undefine();
 		assertTrue(
-				"The set of defined schemes should be empty after an undefine",
-				bindingManager.getDefinedSchemes().length == 0);
+				bindingManager.getDefinedSchemes().length == 0, "The set of defined schemes should be empty after an undefine");
 	}
 
 	/**
@@ -297,8 +285,7 @@ public final class BindingManagerTest {
 	 */
 	@Test
 	public void testGetLocale() {
-		assertNotNull("The locale should never be null",
-				bindingManager.getLocale());
+		assertNotNull(bindingManager.getLocale(), "The locale should never be null");
 	}
 
 	/**
@@ -347,10 +334,8 @@ public final class BindingManagerTest {
 		bindings[1] = partialMatchBinding1;
 		bindingManager.setBindings(bindings);
 		Map<?, ?> partialMatches = bindingManager.getPartialMatches(perfectMatch);
-		assertTrue("A partial match should override a perfect match",
-				!partialMatches.isEmpty());
-		assertTrue("A partial match should override a perfect match",
-				partialMatches.containsKey(partialMatch1));
+		assertTrue(!partialMatches.isEmpty(), "A partial match should override a perfect match");
+		assertTrue(partialMatches.containsKey(partialMatch1), "A partial match should override a perfect match");
 
 		// SCENARIO 2
 		final KeySequence partialMatch2 = KeySequence
@@ -365,25 +350,20 @@ public final class BindingManagerTest {
 		bindings[1] = partialMatchBinding2;
 		bindingManager.setBindings(bindings);
 		partialMatches = bindingManager.getPartialMatches(perfectMatch);
-		assertEquals("There should be two partial matches", 2,
-				partialMatches.size());
-		assertSame("The partial match should be the one defined",
-				partialMatchBinding1, partialMatches.get(partialMatch1));
-		assertSame("The partial match should be the one defined",
-				partialMatchBinding2, partialMatches.get(partialMatch2));
+		assertEquals(2,
+				partialMatches.size(), "There should be two partial matches");
+		assertSame(partialMatchBinding1, partialMatches.get(partialMatch1), "The partial match should be the one defined");
+		assertSame(partialMatchBinding2, partialMatches.get(partialMatch2), "The partial match should be the one defined");
 
 		// SCENARIO 3
 		bindingManager.addBinding(perfectMatchBinding);
 		partialMatches = bindingManager.getPartialMatches(KeySequence
 				.getInstance());
-		assertEquals("There should be three partial matches", 3,
-				partialMatches.size());
-		assertSame("The partial match should be the one defined",
-				perfectMatchBinding, partialMatches.get(perfectMatch));
-		assertSame("The partial match should be the one defined",
-				partialMatchBinding1, partialMatches.get(partialMatch1));
-		assertSame("The partial match should be the one defined",
-				partialMatchBinding2, partialMatches.get(partialMatch2));
+		assertEquals(3,
+				partialMatches.size(), "There should be three partial matches");
+		assertSame(perfectMatchBinding, partialMatches.get(perfectMatch), "The partial match should be the one defined");
+		assertSame(partialMatchBinding1, partialMatches.get(partialMatch1), "The partial match should be the one defined");
+		assertSame(partialMatchBinding2, partialMatches.get(partialMatch2), "The partial match should be the one defined");
 	}
 
 	/**
@@ -432,8 +412,8 @@ public final class BindingManagerTest {
 		bindings[1] = partialMatchBinding1;
 		bindingManager.setBindings(bindings);
 		Binding actualBinding = bindingManager.getPerfectMatch(perfectMatch);
-		assertSame("This should be a perfect match", perfectMatchBinding,
-				actualBinding);
+		assertSame(perfectMatchBinding,
+				actualBinding, "This should be a perfect match");
 
 		// SCENARIO 2
 		final KeySequence partialMatch2 = KeySequence
@@ -448,14 +428,13 @@ public final class BindingManagerTest {
 		bindings[1] = partialMatchBinding2;
 		bindingManager.setBindings(bindings);
 		actualBinding = bindingManager.getPerfectMatch(perfectMatch);
-		assertNull("There should be no perfect matches", actualBinding);
+		assertNull(actualBinding, "There should be no perfect matches");
 
 		// SCENARIO 3
 		bindingManager.addBinding(perfectMatchBinding);
 		actualBinding = bindingManager.getPerfectMatch(KeySequence
 				.getInstance());
-		assertNull("This should be no perfect matches for an empty sequence",
-				actualBinding);
+		assertNull(actualBinding, "This should be no perfect matches for an empty sequence");
 	}
 
 	/**
@@ -463,8 +442,7 @@ public final class BindingManagerTest {
 	 */
 	@Test
 	public void testGetPlatform() {
-		assertNotNull("The platform can never be null",
-				bindingManager.getPlatform());
+		assertNotNull(bindingManager.getPlatform(), "The platform can never be null");
 	}
 
 	/**
@@ -475,10 +453,10 @@ public final class BindingManagerTest {
 	public void testGetScheme() {
 		final String schemeId = "schemeId";
 		final Scheme firstScheme = bindingManager.getScheme(schemeId);
-		assertTrue("A scheme should start undefined", !firstScheme.isDefined());
+		assertTrue(!firstScheme.isDefined(), "A scheme should start undefined");
 		final Scheme secondScheme = bindingManager.getScheme(schemeId);
-		assertSame("The two scheme should be the same", firstScheme,
-				secondScheme);
+		assertSame(firstScheme,
+				secondScheme, "The two scheme should be the same");
 	}
 
 	/**
@@ -526,8 +504,7 @@ public final class BindingManagerTest {
 		bindings[0] = perfectMatchBinding;
 		bindings[1] = partialMatchBinding1;
 		bindingManager.setBindings(bindings);
-		assertTrue("A perfect match should be overridden by a partial",
-				bindingManager.isPartialMatch(perfectMatch));
+		assertTrue(bindingManager.isPartialMatch(perfectMatch), "A perfect match should be overridden by a partial");
 
 		// SCENARIO 2
 		final KeySequence partialMatch2 = KeySequence
@@ -541,14 +518,12 @@ public final class BindingManagerTest {
 		bindings[0] = partialMatchBinding1;
 		bindings[1] = partialMatchBinding2;
 		bindingManager.setBindings(bindings);
-		assertTrue("Two partial matches should count as a partial",
-				bindingManager.isPartialMatch(perfectMatch));
+		assertTrue(bindingManager.isPartialMatch(perfectMatch), "Two partial matches should count as a partial");
 
 		// SCENARIO 3
 		bindingManager.addBinding(perfectMatchBinding);
 		bindingManager.setBindings(bindings);
-		assertTrue("An empty sequence matches everything partially",
-				bindingManager.isPartialMatch(KeySequence.getInstance()));
+		assertTrue(bindingManager.isPartialMatch(KeySequence.getInstance()), "An empty sequence matches everything partially");
 	}
 
 	/**
@@ -596,8 +571,7 @@ public final class BindingManagerTest {
 		bindings[0] = perfectMatchBinding;
 		bindings[1] = partialMatchBinding1;
 		bindingManager.setBindings(bindings);
-		assertTrue("This should be a perfect match",
-				bindingManager.isPerfectMatch(perfectMatch));
+		assertTrue(bindingManager.isPerfectMatch(perfectMatch), "This should be a perfect match");
 
 		// SCENARIO 2
 		final KeySequence partialMatch2 = KeySequence
@@ -611,13 +585,11 @@ public final class BindingManagerTest {
 		bindings[0] = partialMatchBinding1;
 		bindings[1] = partialMatchBinding2;
 		bindingManager.setBindings(bindings);
-		assertTrue("This should be no perfect matches",
-				!bindingManager.isPerfectMatch(perfectMatch));
+		assertTrue(!bindingManager.isPerfectMatch(perfectMatch), "This should be no perfect matches");
 
 		// SCENARIO 3
 		bindingManager.addBinding(perfectMatchBinding);
-		assertTrue("This should be no perfect matches",
-				!bindingManager.isPerfectMatch(KeySequence.getInstance()));
+		assertTrue(!bindingManager.isPerfectMatch(KeySequence.getInstance()), "This should be no perfect matches");
 	}
 
 	/**
@@ -655,33 +627,26 @@ public final class BindingManagerTest {
 		final Binding binding5 = new TestBinding("command5", "na", "na", "zh",
 				"gtk", Binding.USER, null);
 		bindingManager.addBinding(binding5);
-		assertNotNull("There should be three active bindings",
-				bindingManager.getActiveBindingsFor(binding1
-						.getParameterizedCommand()));
-		assertNotNull("There should be three active bindings",
-				bindingManager.getActiveBindingsFor(binding2
-						.getParameterizedCommand()));
-		assertNotNull("There should be three active bindings",
-				bindingManager.getActiveBindingsFor(binding4
-						.getParameterizedCommand()));
+		assertNotNull(bindingManager.getActiveBindingsFor(binding1
+						.getParameterizedCommand()), "There should be three active bindings");
+		assertNotNull(bindingManager.getActiveBindingsFor(binding2
+						.getParameterizedCommand()), "There should be three active bindings");
+		assertNotNull(bindingManager.getActiveBindingsFor(binding4
+						.getParameterizedCommand()), "There should be three active bindings");
 
 		// REMOVE SOME BINDINGS
 		bindingManager.removeBindings(TestBinding.TRIGGER_SEQUENCE, "na", "na",
 				"zh", "gtk", null, Binding.USER);
-		assertEquals("There should be four bindings left", 4,
-				bindingManager.getBindings().length);
-		assertNotNull("There should be four active bindings",
-				bindingManager.getActiveBindingsFor(binding1
-						.getParameterizedCommand()));
-		assertNotNull("There should be four active bindings",
-				bindingManager.getActiveBindingsFor(binding2
-						.getParameterizedCommand()));
-		assertNotNull("There should be four active bindings",
-				bindingManager.getActiveBindingsFor(binding3
-						.getParameterizedCommand()));
-		assertNotNull("There should be four active bindings",
-				bindingManager.getActiveBindingsFor(binding4
-						.getParameterizedCommand()));
+		assertEquals(4,
+				bindingManager.getBindings().length, "There should be four bindings left");
+		assertNotNull(bindingManager.getActiveBindingsFor(binding1
+						.getParameterizedCommand()), "There should be four active bindings");
+		assertNotNull(bindingManager.getActiveBindingsFor(binding2
+						.getParameterizedCommand()), "There should be four active bindings");
+		assertNotNull(bindingManager.getActiveBindingsFor(binding3
+						.getParameterizedCommand()), "There should be four active bindings");
+		assertNotNull(bindingManager.getActiveBindingsFor(binding4
+						.getParameterizedCommand()), "There should be four active bindings");
 	}
 
 	/**
@@ -701,13 +666,12 @@ public final class BindingManagerTest {
 		// SELECT DEFINED
 		scheme.define("name", "description", null);
 		bindingManager.setActiveScheme(scheme);
-		assertSame("The schemes should match", scheme,
-					bindingManager.getActiveScheme());
+		assertSame(scheme,
+					bindingManager.getActiveScheme(), "The schemes should match");
 
 		// UNDEFINE SELECTED
 		scheme.undefine();
-		assertNull("The scheme should have become unselected",
-				bindingManager.getActiveScheme());
+		assertNull(bindingManager.getActiveScheme(), "The scheme should have become unselected");
 	}
 
 	@Test
@@ -785,9 +749,8 @@ public final class BindingManagerTest {
 		// SET NULL
 		bindingManager.setBindings(null);
 		assertTrue(
-				"There should be no active bindings",
 				bindingManager
-						.getActiveBindingsFor((ParameterizedCommand) null).length == 0);
+						.getActiveBindingsFor((ParameterizedCommand) null).length == 0, "There should be no active bindings");
 
 		// ADD BINDING
 		final String commandId = "commandId";
@@ -798,10 +761,9 @@ public final class BindingManagerTest {
 		bindingManager.setBindings(bindings);
 		final TriggerSequence[] activeBindings = bindingManager
 				.getActiveBindingsFor(binding.getParameterizedCommand());
-		assertEquals("There should be one active binding", 1,
-				activeBindings.length);
-		assertSame("The binding should be the one we set",
-				TestBinding.TRIGGER_SEQUENCE, activeBindings[0]);
+		assertEquals(1,
+				activeBindings.length, "There should be one active binding");
+		assertSame(TestBinding.TRIGGER_SEQUENCE, activeBindings[0], "The binding should be the one we set");
 	}
 
 	/**
@@ -831,16 +793,14 @@ public final class BindingManagerTest {
 		final Binding binding = new TestBinding(commandId, "na", "na", "xx",
 				null, Binding.SYSTEM, null);
 		bindingManager.addBinding(binding);
-		assertTrue("The binding shouldn't be active",
-				bindingManager.getActiveBindingsFor(binding
-						.getParameterizedCommand()).length == 0);
+		assertTrue(bindingManager.getActiveBindingsFor(binding
+						.getParameterizedCommand()).length == 0, "The binding shouldn't be active");
 		bindingManager.setLocale("xx_XX");
 		final TriggerSequence[] activeBindings = bindingManager
 				.getActiveBindingsFor(binding.getParameterizedCommand());
-		assertEquals("The binding should become active", 1,
-				activeBindings.length);
-		assertSame("The binding should be the same",
-				TestBinding.TRIGGER_SEQUENCE, activeBindings[0]);
+		assertEquals(1,
+				activeBindings.length, "The binding should become active");
+		assertSame(TestBinding.TRIGGER_SEQUENCE, activeBindings[0], "The binding should be the same");
 	}
 
 	/**
@@ -870,16 +830,14 @@ public final class BindingManagerTest {
 		final Binding binding = new TestBinding(commandId, "na", "na", null,
 				"atari", Binding.SYSTEM, null);
 		bindingManager.addBinding(binding);
-		assertTrue("The binding shouldn't be active",
-				bindingManager.getActiveBindingsFor(binding
-						.getParameterizedCommand()).length == 0);
+		assertTrue(bindingManager.getActiveBindingsFor(binding
+						.getParameterizedCommand()).length == 0, "The binding shouldn't be active");
 		bindingManager.setPlatform("atari");
 		final TriggerSequence[] activeBindings = bindingManager
 				.getActiveBindingsFor(binding.getParameterizedCommand());
-		assertEquals("The binding should become active", 1,
-				activeBindings.length);
-		assertSame("The binding should be the same",
-				TestBinding.TRIGGER_SEQUENCE, activeBindings[0]);
+		assertEquals(1,
+				activeBindings.length, "The binding should become active");
+		assertSame(TestBinding.TRIGGER_SEQUENCE, activeBindings[0], "The binding should be the same");
 	}
 
 	/**
@@ -894,11 +852,9 @@ public final class BindingManagerTest {
 		// Test with a null argument.
 		final TriggerSequence[] activeBindingsForNull = bindingManager
 				.getActiveBindingsFor((ParameterizedCommand) null);
-		assertNotNull("The active bindings for a command should never be null",
-				activeBindingsForNull);
+		assertNotNull(activeBindingsForNull, "The active bindings for a command should never be null");
 		assertTrue(
-				"The active binding for a null command should always be empty",
-				activeBindingsForNull.length == 0);
+				activeBindingsForNull.length == 0, "The active binding for a null command should always be empty");
 
 		// Test a simple case.
 		final Context context = contextManager.getContext("na");

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/BindingPersistenceTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/BindingPersistenceTest.java
@@ -14,11 +14,11 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.keys;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 
@@ -40,10 +40,10 @@ import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.keys.IBindingService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases covering the various interaction between bindings. Bindings that
@@ -62,7 +62,7 @@ public final class BindingPersistenceTest {
 	 * Creates a new workbench and retrieves its context manager and a binding
 	 * manager for use in the test cases.
 	 */
-	@Before
+	@BeforeEach
 	public void doSetUp() throws Exception {
 		IWorkbench workbench = PlatformUI.getWorkbench();
 		commandService = workbench.getAdapter(ICommandService.class);
@@ -84,8 +84,8 @@ public final class BindingPersistenceTest {
 
 		// Check the pre-conditions.
 		final String emacsSchemeId = EMACS_SCHEME_ID;
-		assertFalse("The active scheme should be Emacs yet", emacsSchemeId
-				.equals(bindingService.getActiveScheme().getId()));
+		assertFalse(emacsSchemeId
+				.equals(bindingService.getActiveScheme().getId()), "The active scheme should be Emacs yet");
 		final KeySequence formalKeySequence = KeySequence
 				.getInstance("ALT+SHIFT+Q A");
 		final String commandId = "org.eclipse.ui.views.showView";
@@ -99,13 +99,12 @@ public final class BindingPersistenceTest {
 						.getParameterizedCommand();
 				final String actualCommandId = (command == null) ? null
 						: command.getCommand().getId();
-				assertFalse("The command should not yet be bound", commandId
-						.equals(actualCommandId));
+				assertFalse(commandId
+						.equals(actualCommandId), "The command should not yet be bound");
 				break;
 			}
 		}
-		assertEquals("There shouldn't be a matching command yet",
-				bindings.length, i);
+		assertEquals(bindings.length, i, "There shouldn't be a matching command yet");
 
 		// Modify the preference store.
 		final IPreferenceStore store = WorkbenchPlugin.getDefault()
@@ -122,8 +121,8 @@ public final class BindingPersistenceTest {
 								+ "\"/></org.eclipse.ui.commands>");
 
 		// Check that the values have changed.
-		assertEquals("The active scheme should now be Emacs", emacsSchemeId,
-				bindingService.getActiveScheme().getId());
+		assertEquals(emacsSchemeId,
+				bindingService.getActiveScheme().getId(), "The active scheme should now be Emacs");
 		bindings = bindingService.getBindings();
 		for (i = 0; i < bindings.length; i++) {
 			final Binding binding = bindings[i];
@@ -133,13 +132,11 @@ public final class BindingPersistenceTest {
 						.getParameterizedCommand();
 				final String actualCommandId = (command == null) ? null
 						: command.getCommand().getId();
-				assertEquals("The command should be bound to 'ALT+SHIFT+Q A'",
-						commandId, actualCommandId);
+				assertEquals(commandId, actualCommandId, "The command should be bound to 'ALT+SHIFT+Q A'");
 				break;
 			}
 		}
-		assertFalse("There should be a matching command now",
-				(bindings.length == i));
+		assertFalse((bindings.length == i), "There should be a matching command now");
 	}
 
 	@Test
@@ -156,19 +153,19 @@ public final class BindingPersistenceTest {
 			if (binding.getType() == Binding.SYSTEM) {
 				String platform = binding.getPlatform();
 				int idx = (platform == null ? -1 : platform.indexOf(','));
-				assertEquals(binding.toString(), -1, idx);
+				assertEquals(-1, idx, binding.toString());
 				if (about.equals(binding.getParameterizedCommand())) {
 					if (m18A.equals(binding.getTriggerSequence())) {
 						numAboutBindings++;
-						assertNull("M+8 A", binding.getPlatform());
+						assertNull(binding.getPlatform(), "M+8 A");
 					} else if (m18B.equals(binding.getTriggerSequence())) {
 						numAboutBindings++;
 						// assertEquals(Util.WS_CARBON, binding.getPlatform());
 						// temp work around for honouring carbon bindings
-						assertTrue("failure for platform: "
-								+ binding.getPlatform(), Util.WS_CARBON
+						assertTrue(Util.WS_CARBON
 								.equals(binding.getPlatform())
-								|| Util.WS_COCOA.equals(binding.getPlatform()));
+								|| Util.WS_COCOA.equals(binding.getPlatform()), "failure for platform: "
+								+ binding.getPlatform());
 					}
 				}
 			}
@@ -181,7 +178,7 @@ public final class BindingPersistenceTest {
 		}
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	@SuppressWarnings("removal")
 	public final void TODOtestBindingTransform() throws Exception {
@@ -196,31 +193,31 @@ public final class BindingPersistenceTest {
 			if (binding.getType() == Binding.SYSTEM) {
 				String platform = binding.getPlatform();
 				int idx = (platform == null ? -1 : platform.indexOf(','));
-				assertEquals(binding.toString(), -1, idx);
+				assertEquals(-1, idx, binding.toString());
 				if (addWS.equals(binding.getParameterizedCommand())) {
 					if (m18w.equals(binding.getTriggerSequence())) {
 						numOfMarkers++;
-						assertNull(m18w.format(), binding.getPlatform());
+						assertNull(binding.getPlatform(), m18w.format());
 					} else if (m28w.equals(binding.getTriggerSequence())) {
 						numOfMarkers++;
-						assertTrue(platform, Util.WS_CARBON.equals(platform)
+						assertTrue(Util.WS_CARBON.equals(platform)
 								|| Util.WS_COCOA.equals(platform)
 								|| Util.WS_GTK.equals(platform)
-								|| Util.WS_WIN32.equals(platform));
+								|| Util.WS_WIN32.equals(platform), platform);
 					}
 				} else if (binding.getParameterizedCommand() == null
 						&& m18w.equals(binding.getTriggerSequence())) {
-					assertTrue(platform, Util.WS_CARBON.equals(platform)
+					assertTrue(Util.WS_CARBON.equals(platform)
 							|| Util.WS_COCOA.equals(platform)
 							|| Util.WS_GTK.equals(platform)
-							|| Util.WS_WIN32.equals(platform));
+							|| Util.WS_WIN32.equals(platform), platform);
 					numOfMarkers++;
 					foundDeleteMarker = true;
 				}
 			}
 		}
 		assertEquals(3, numOfMarkers);
-		assertTrue("Unable to find delete marker", foundDeleteMarker);
+		assertTrue(foundDeleteMarker, "Unable to find delete marker");
 
 		// make sure that the proper contexts are currently active
 		IContextService contextService = PlatformUI.getWorkbench()
@@ -570,7 +567,7 @@ public final class BindingPersistenceTest {
 		assertEquals(EMACS_SCHEME_ID, pasteBinding.getSchemeId());
 	}
 
-	@After
+	@AfterEach
 	public void doTearDown() throws Exception {
 		WorkbenchPlugin.getDefault().getPreferenceStore().setValue(
 						"org.eclipse.ui.commands",

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug189167Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug189167Test.java
@@ -14,11 +14,11 @@
 
 package org.eclipse.ui.tests.keys;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.jface.bindings.Binding;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests Bug 189167

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug36537Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug36537Test.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.keys;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,19 +29,17 @@ import org.eclipse.jface.bindings.TriggerSequence;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.keys.IBindingService;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests Bug 36537
  *
  * @since 3.0
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug36537Test {
-
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	/**
 	 * Tests that there are no redundant key bindings defined in the
@@ -115,8 +113,8 @@ public class Bug36537Test {
 					nullMatches++;
 				}
 
-				assertFalse(
-						"Redundant key bindings: " + binding + ", " + matchedBinding, same && (nullMatches < 1)); //$NON-NLS-1$ //$NON-NLS-2$
+				assertFalse(same && (nullMatches < 1),
+						"Redundant key bindings: " + binding + ", " + matchedBinding); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 
 			// Add the key binding.

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug40023Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug40023Test.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.keys;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -33,21 +33,19 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.internal.Workbench;
 import org.eclipse.ui.internal.keys.BindingService;
 import org.eclipse.ui.keys.IBindingService;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests Bug 40023
  *
  * @since 3.0
  */
-@Ignore("Intermittent failure.  SWT Bug 44344.  XGrabPointer?")
+@Disabled("Intermittent failure.  SWT Bug 44344.  XGrabPointer?")
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug40023Test {
-
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	/**
 	 * Retrieves a menu item matching or starting with the given name from an
@@ -112,7 +110,7 @@ public class Bug40023Test {
 				"&Window"); //$NON-NLS-1$
 		MenuItem lockToolBarsMenuItem = getMenuItem(windowMenu.getMenu()
 				.getItems(), "Lock the &Toolbars"); //$NON-NLS-1$
-		assertTrue("Checkbox menu item is not checked.", lockToolBarsMenuItem //$NON-NLS-1$
-				.getSelection());
+		assertTrue(lockToolBarsMenuItem //$NON-NLS-1$
+				.getSelection(), "Checkbox menu item is not checked.");
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug42024Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug42024Test.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.ui.tests.keys;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jface.bindings.keys.KeySequence;
 import org.eclipse.jface.bindings.keys.KeySequenceText;
@@ -24,9 +24,9 @@ import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests Bug 42024
@@ -41,7 +41,7 @@ public class Bug42024Test {
 	/** The instance of <code>KeySequenceText</code> we should tinker with. */
 	private KeySequenceText text = null;
 
-	@Before
+	@BeforeEach
 	public void doSetUp() throws Exception {
 		// Create a window with a KeySequenceText
 		Display display = Display.getCurrent();
@@ -54,7 +54,7 @@ public class Bug42024Test {
 		shell.open();
 	}
 
-	@After
+	@AfterEach
 	public void doTearDown() throws Exception {
 		// Close and destroy the window
 		shell.close();
@@ -79,8 +79,8 @@ public class Bug42024Test {
 		KeySequence keySequence = KeySequence.getInstance(keySequenceText);
 		text.setKeyStrokeLimit(KeySequenceText.INFINITE);
 		text.setKeySequence(keySequence);
-		assertEquals(
-				"Infinite limit but sequence changed.", keySequence, text.getKeySequence()); //$NON-NLS-1$
+		assertEquals(keySequence, text.getKeySequence(),
+				"Infinite limit but sequence changed."); //$NON-NLS-1$
 	}
 
 	/**
@@ -101,16 +101,16 @@ public class Bug42024Test {
 		KeySequence matchingKeySequence = KeySequence
 				.getInstance(matchingKeySequenceText);
 		text.setKeySequence(matchingKeySequence);
-		assertEquals(
-				"Limit of four change four stroke sequence.", matchingKeySequence, text.getKeySequence()); //$NON-NLS-1$
+		assertEquals(matchingKeySequence, text.getKeySequence(),
+				"Limit of four change four stroke sequence."); //$NON-NLS-1$
 
 		// Test one greater than length.
 		String longerKeySequenceText = "1 2 3 4 5"; //$NON-NLS-1$
 		KeySequence longerKeySequence = KeySequence
 				.getInstance(longerKeySequenceText);
 		text.setKeySequence(longerKeySequence);
-		assertEquals(
-				"Limit of four did not truncate to four.", length, text.getKeySequence().getKeyStrokes().length); //$NON-NLS-1$
+		assertEquals(length, text.getKeySequence().getKeyStrokes().length,
+				"Limit of four did not truncate to four."); //$NON-NLS-1$
 	}
 
 	/**
@@ -125,13 +125,13 @@ public class Bug42024Test {
 		// Test with a limit of four.
 		text.setKeyStrokeLimit(4);
 		text.setKeySequence(zeroStrokeSequence);
-		assertEquals(
-				"Limit of four changed zero stroke sequence.", zeroStrokeSequence, text.getKeySequence()); //$NON-NLS-1$
+		assertEquals(zeroStrokeSequence, text.getKeySequence(),
+				"Limit of four changed zero stroke sequence."); //$NON-NLS-1$
 
 		// Test with an infinite limit.
 		text.setKeyStrokeLimit(KeySequenceText.INFINITE);
 		text.setKeySequence(zeroStrokeSequence);
-		assertEquals(
-				"Infinite limit changed zero stroke sequence.", zeroStrokeSequence, text.getKeySequence()); //$NON-NLS-1$
+		assertEquals(zeroStrokeSequence, text.getKeySequence(),
+				"Infinite limit changed zero stroke sequence."); //$NON-NLS-1$
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug42627Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug42627Test.java
@@ -14,15 +14,15 @@
 
 package org.eclipse.ui.tests.keys;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests Bug 42627
  *
  * @since 3.0
  */
-@Ignore("Logging piece of fix did not go in M4.") // See commit 74a677140dd3fc6a09fa1c769c0af2cac3c1c08b
+@Disabled("Logging piece of fix did not go in M4.") // See commit 74a677140dd3fc6a09fa1c769c0af2cac3c1c08b
 public class Bug42627Test {
 
 	// TODO See if this is needed for anything.

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43168Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43168Test.java
@@ -22,7 +22,7 @@ import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests Bug 43168

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43321Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43321Test.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.keys;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
@@ -35,21 +35,19 @@ import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.Workbench;
 import org.eclipse.ui.internal.keys.BindingService;
 import org.eclipse.ui.keys.IBindingService;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests Bug 43321
  *
  * @since 3.0
  */
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug43321Test {
-
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	/**
 	 * Tests that non-check box items on the menu are not checked when activated
@@ -88,7 +86,7 @@ public class Bug43321Test {
 		// Get the menu item we've just selected.
 		IAction action = editor.getEditorSite().getActionBars()
 				.getGlobalActionHandler(ActionFactory.COPY.getId());
-		assertTrue("Non-checkbox menu item is checked.", !action.isChecked()); //$NON-NLS-1$
+		assertTrue(!action.isChecked(), "Non-checkbox menu item is checked."); //$NON-NLS-1$
 
 		FileUtil.deleteProject(testProject);
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43538Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43538Test.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.ui.tests.keys;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.swt.SWT;
@@ -24,7 +24,7 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.intro.IIntroManager;
 import org.eclipse.ui.tests.harness.util.AutomationUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for Bug 43538.
@@ -51,8 +51,8 @@ public class Bug43538Test {
 			@Override
 			public void handleEvent(Event event) {
 				if (event.stateMask == SWT.CTRL) {
-					assertEquals(
-							"Multiple key down events for 'Ctrl+Space'", 0, count++); //$NON-NLS-1$
+					assertEquals(0, count++,
+							"Multiple key down events for 'Ctrl+Space'"); //$NON-NLS-1$
 				}
 			}
 		};

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43597Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43597Test.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.ui.tests.keys;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
@@ -23,8 +23,8 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests Bug 43597
@@ -66,14 +66,14 @@ public class Bug43597Test {
 		Font fontAfter = text.getFont();
 
 		// Test.
-		assertEquals("Clearing text resets font.", fontBefore, fontAfter); //$NON-NLS-1$
+		assertEquals(fontBefore, fontAfter, "Clearing text resets font."); //$NON-NLS-1$
 
 		// Clean up after myself.
 		shell.close();
 		shell.dispose();
 	}
 
-	@After
+	@AfterEach
 	public void doTearDown() throws Exception {
 		if (textFont != null) {
 			textFont.dispose();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43610Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug43610Test.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.ui.tests.keys;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
@@ -22,7 +22,7 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.intro.IIntroManager;
 import org.eclipse.ui.tests.harness.util.AutomationUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for Bug 43610.
@@ -45,7 +45,7 @@ public class Bug43610Test {
 		Display display = Display.getCurrent();
 		Listener listener = event -> {
 			if (event.stateMask == SWT.SHIFT) {
-				assertEquals("Incorrect key code for 'Shift+Alt+'", SWT.ALT, event.keyCode); //$NON-NLS-1$
+				assertEquals(SWT.ALT, event.keyCode, "Incorrect key code for 'Shift+Alt+'"); //$NON-NLS-1$
 			}
 		};
 		display.addFilter(SWT.KeyDown, listener);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug44460Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug44460Test.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.keys;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.util.List;
@@ -43,21 +43,19 @@ import org.eclipse.ui.internal.WorkbenchPage;
 import org.eclipse.ui.internal.keys.BindingService;
 import org.eclipse.ui.internal.keys.WorkbenchKeyboard;
 import org.eclipse.ui.keys.IBindingService;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test for Bug 44460.
  *
  * @since 3.0
  */
-@Ignore("disabled since it refers to the Java builder and nature, which are not available in an RCP build")
+@Disabled("disabled since it refers to the Java builder and nature, which are not available in an RCP build")
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug44460Test {
-
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	/**
 	 * Test that pressing "Ctrl+Shift+T" in the Team Synchronizing perspective
@@ -116,7 +114,7 @@ public class Bug44460Test {
 		// Test that only two child shells are open (default).
 		Shell windowShell = window.getShell();
 		Shell[] childShells = windowShell.getShells();
-		assertTrue(
-				"Type hierarchy dialog opened inappropriately on 'Ctrl+Shift+T'", (childShells.length == 2)); //$NON-NLS-1$
+		assertTrue((childShells.length == 2),
+				"Type hierarchy dialog opened inappropriately on 'Ctrl+Shift+T'"); //$NON-NLS-1$
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug53489Test.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/Bug53489Test.java
@@ -15,7 +15,7 @@
 package org.eclipse.ui.tests.keys;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.openTestWindow;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
@@ -30,10 +30,10 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.tests.harness.util.AutomationUtil;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests that pressing delete in a styled text widget does not cause a double
@@ -41,12 +41,10 @@ import org.junit.Test;
  *
  * @since 3.0
  */
-@Ignore("disabled as it fails on the Mac.")
+@Disabled("disabled as it fails on the Mac.")
 // Ctrl+S doesn't save the editor, and posting MOD1+S also doesn't seem to work.
+@ExtendWith(CloseTestWindowsExtension.class)
 public class Bug53489Test {
-
-	@Rule
-	public CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
 
 	/**
 	 * Tests that pressing delete in a styled text widget (in a running Eclipse)
@@ -84,7 +82,7 @@ public class Bug53489Test {
 		// Test the text is only one character different.
 		LineNumberReader reader = new LineNumberReader(new InputStreamReader(textFile.getContents()));
 		String currentContents = reader.readLine();
-		assertTrue("'DEL' deleted more than one key.", (originalContents //$NON-NLS-1$
-				.length() == (currentContents.length() + 1)));
+		assertTrue((originalContents
+				.length() == (currentContents.length() + 1)), "'DEL' deleted more than one key."); //$NON-NLS-1$
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/DispatcherTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/DispatcherTest.java
@@ -29,17 +29,17 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.tests.commands.CheckInvokedHandler;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DispatcherTest {
 
 	private KeyBindingDispatcher dispatcher;
 	private IProject p;
 
-	@Before
+	@BeforeEach
 	public void doSetUp() throws CoreException {
 		this.dispatcher = PlatformUI.getWorkbench().getService(KeyBindingDispatcher.class);
 		CheckInvokedHandler.invoked = false;
@@ -48,7 +48,7 @@ public class DispatcherTest {
 		p.open(new NullProgressMonitor());
 	}
 
-	@After
+	@AfterEach
 	public void doTearDown() throws Exception {
 		p.delete(true, new NullProgressMonitor());
 	}
@@ -63,8 +63,8 @@ public class DispatcherTest {
 		try {
 			int shellCount = Display.getCurrent().getShells().length;
 			dispatcher.press(Arrays.asList(KeyStroke.getInstance(SWT.CTRL, 'O')), null);
-			Assert.assertFalse("No handler should have been invoked", CheckInvokedHandler.invoked);
-			Assert.assertEquals("No Shell should have been added", shellCount, Display.getCurrent().getShells().length);
+			Assertions.assertFalse(CheckInvokedHandler.invoked, "No handler should have been invoked");
+			Assertions.assertEquals(shellCount, Display.getCurrent().getShells().length, "No Shell should have been added");
 		} finally {
 			if (part != null) {
 				part.getEditorSite().getPage().closeEditor(part, false);
@@ -82,8 +82,8 @@ public class DispatcherTest {
 		try {
 			int shellCount = Display.getCurrent().getShells().length;
 			dispatcher.press(Arrays.asList(KeyStroke.getInstance(SWT.CTRL, 'O')), null);
-			Assert.assertTrue("Handler should have been invoked", CheckInvokedHandler.invoked);
-			Assert.assertEquals("No Shell should have been added", shellCount, Display.getCurrent().getShells().length);
+			Assertions.assertTrue(CheckInvokedHandler.invoked, "Handler should have been invoked");
+			Assertions.assertEquals(shellCount, Display.getCurrent().getShells().length, "No Shell should have been added");
 		} finally {
 			if (part != null) {
 				part.getEditorSite().getPage().closeEditor(part, false);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/KeysCsvTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/KeysCsvTest.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.ui.tests.keys;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.ui.internal.util.Util;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @since 3.3

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/KeysPreferenceModelTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/keys/KeysPreferenceModelTest.java
@@ -14,12 +14,12 @@
 
 package org.eclipse.ui.tests.keys;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -44,8 +44,8 @@ import org.eclipse.ui.internal.keys.model.ModelElement;
 import org.eclipse.ui.internal.keys.model.SchemeElement;
 import org.eclipse.ui.internal.keys.model.SchemeModel;
 import org.eclipse.ui.keys.IBindingService;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * @since 3.4
@@ -78,8 +78,8 @@ public class KeysPreferenceModelTest {
 				foundDialog = true;
 			}
 		}
-		assertTrue("No window context", foundWindow);
-		assertTrue("No dialog context", foundDialog);
+		assertTrue(foundWindow, "No window context");
+		assertTrue(foundDialog, "No dialog context");
 		assertNull(cm.getSelectedElement());
 		assertNotNull(cm.getContextIdToElement().get(
 				IContextService.CONTEXT_ID_DIALOG_AND_WINDOW));
@@ -92,12 +92,12 @@ public class KeysPreferenceModelTest {
 				foundDefault = true;
 			}
 		}
-		assertTrue("No default scheme", foundDefault);
+		assertTrue(foundDefault, "No default scheme");
 		assertEquals(IBindingService.DEFAULT_DEFAULT_ACTIVE_SCHEME_ID, sm
 				.getSelectedElement().getId());
 
 		ConflictModel cf = controller.getConflictModel();
-		assertNull("There should not be any conflicts", cf.getConflicts());
+		assertNull(cf.getConflicts(), "There should not be any conflicts");
 		assertNull(cf.getSelectedElement());
 
 		BindingModel bm = controller.getBindingModel();
@@ -287,7 +287,7 @@ public class KeysPreferenceModelTest {
 		assertChanges(expected, events);
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void failsOnCocoatestCreateConflict() throws Exception {
 		final KeyController controller = new KeyController();
@@ -324,7 +324,7 @@ public class KeysPreferenceModelTest {
 		assertNull(cf.getConflicts());
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void failsOnMacCocoatestConflictRemove() throws Exception {
 		final KeyController controller = new KeyController();
@@ -355,7 +355,7 @@ public class KeysPreferenceModelTest {
 		assertNull(cf.getConflicts());
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void failsOnMacCocoatestConflictRestore() throws Exception {
 		final KeyController controller = new KeyController();
@@ -435,7 +435,7 @@ public class KeysPreferenceModelTest {
 		assertChanges(expected, events);
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void failsOnWinAndLinuxWith16VMtestUpdateKeySequence() throws Exception {
 		final KeyController controller = new KeyController();
@@ -882,18 +882,14 @@ public class KeysPreferenceModelTest {
 
 	private void assertChangeEvent(int eventNum, PropertyChangeEvent expected,
 			PropertyChangeEvent event) {
-		assertEquals("source: " + eventNum, expected.getSource(), event
-				.getSource());
-		assertEquals("property: " + eventNum, expected.getProperty(), event
-				.getProperty());
-		assertEquals("old: " + eventNum, expected.getOldValue(), event
-				.getOldValue());
-		assertEquals("new: " + eventNum, expected.getNewValue(), event
-				.getNewValue());
+		assertEquals(expected.getSource(), event.getSource(), "source: " + eventNum);
+		assertEquals(expected.getProperty(), event.getProperty(), "property: " + eventNum);
+		assertEquals(expected.getOldValue(), event.getOldValue(), "old: " + eventNum);
+		assertEquals(expected.getNewValue(), event.getNewValue(), "new: " + eventNum);
 	}
 
 	private void assertChanges(PropertyChangeEvent[] expected, List<PropertyChangeEvent> events) {
-		assertEquals("events length", expected.length, events.size());
+		assertEquals(expected.length, events.size(), "events length");
 		for (int i = 0; i < expected.length; i++) {
 			assertChangeEvent(i, expected[i], events
 					.get(i));


### PR DESCRIPTION
* Updated imports to use org.junit.jupiter.api.*.
* Replaced @Before with @BeforeEach and @After with @AfterEach.
* Replaced @Ignore with @Disabled.
* Converted @Rule CloseTestWindowsRule to @ExtendWith(CloseTestWindowsExtension.class).
* Updated assertions to follow the JUnit 5 argument order (expected, actual, message).