### PR TITLE
Fix deprecation warnings

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/application/CompatibilityWorkbenchWindowAdvisor.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/application/CompatibilityWorkbenchWindowAdvisor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2015 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -46,6 +46,7 @@ public class CompatibilityWorkbenchWindowAdvisor extends WorkbenchWindowAdvisor 
 	}
 
 	@Override
+	@Deprecated
 	public void preWindowOpen() {
 		wbAdvisor.preWindowOpen(getWindowConfigurer());
 	}
@@ -56,35 +57,42 @@ public class CompatibilityWorkbenchWindowAdvisor extends WorkbenchWindowAdvisor 
 	}
 
 	@Override
+	@Deprecated
 	public void postWindowRestore() throws WorkbenchException {
 		wbAdvisor.postWindowRestore(getWindowConfigurer());
 	}
 
 	@Override
+	@Deprecated
 	public void openIntro() {
 		wbAdvisor.openIntro(getWindowConfigurer());
 	}
 
 	@Override
+	@Deprecated
 	public void postWindowCreate() {
 		wbAdvisor.postWindowCreate(getWindowConfigurer());
 	}
 
 	@Override
+	@Deprecated
 	public void postWindowOpen() {
 		wbAdvisor.postWindowOpen(getWindowConfigurer());
 	}
 
 	@Override
+	@Deprecated
 	public boolean preWindowShellClose() {
 		return wbAdvisor.preWindowShellClose(getWindowConfigurer());
 	}
 
 	@Override
+	@Deprecated
 	public void postWindowClose() {
 		wbAdvisor.postWindowClose(getWindowConfigurer());
 	}
 
+	@Deprecated
 	public boolean isApplicationMenu(String menuId) {
 		return wbAdvisor.isApplicationMenu(getWindowConfigurer(), menuId);
 	}
@@ -94,6 +102,7 @@ public class CompatibilityWorkbenchWindowAdvisor extends WorkbenchWindowAdvisor 
 	}
 
 	@Override
+	@Deprecated
 	public void createWindowContents(Shell shell) {
 		wbAdvisor.createWindowContents(getWindowConfigurer(), shell);
 	}

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/ActionBarConfigurerTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/ActionBarConfigurerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2006,2014 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -53,6 +53,7 @@ public class ActionBarConfigurerTest {
 		WorkbenchAdvisor wa = new WorkbenchAdvisorObserver(1) {
 
 			@Override
+			@Deprecated
 			public void fillActionBars(IWorkbenchWindow window,
 					IActionBarConfigurer actionBarConfig, int flags) {
 				super.fillActionBars(window, actionBarConfig, flags);

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/IWorkbenchPageTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/IWorkbenchPageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2006, 2014 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -66,6 +66,7 @@ public class IWorkbenchPageTest {
 		WorkbenchAdvisor wa = new WorkbenchAdvisorObserver(1) {
 
 			@Override
+			@Deprecated
 			public void preWindowOpen(IWorkbenchWindowConfigurer configurer) {
 				super.preWindowOpen(configurer);
 				configurer.setShowPerspectiveBar(false);

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchAdvisorTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchAdvisorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2009, 2014 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -130,18 +130,21 @@ public class WorkbenchAdvisorTest {
 			}
 
 			@Override
+			@Deprecated
 			public void preWindowOpen(IWorkbenchWindowConfigurer c) {
 				assertFalse(windowOpenCalled);
 				super.preWindowOpen(c);
 			}
 
 			@Override
+			@Deprecated
 			public void postWindowOpen(IWorkbenchWindowConfigurer c) {
 				assertTrue(windowOpenCalled);
 				super.postWindowOpen(c);
 			}
 
 			@Override
+			@Deprecated
 			public boolean preWindowShellClose(IWorkbenchWindowConfigurer c) {
 				assertFalse(windowCloseCalled);
 				return super.preWindowShellClose(c);
@@ -265,6 +268,7 @@ public class WorkbenchAdvisorTest {
 		WorkbenchAdvisorObserver wa = new WorkbenchAdvisorObserver(1) {
 
 			@Override
+			@Deprecated
 			public void fillActionBars(IWorkbenchWindow window,
 					IActionBarConfigurer configurer, int flags) {
 				super.fillActionBars(window, configurer, flags);
@@ -284,6 +288,7 @@ public class WorkbenchAdvisorTest {
 	public void testEmptyProgressRegion() {
 		WorkbenchAdvisorObserver wa = new WorkbenchAdvisorObserver(1) {
 			@Override
+			@Deprecated
 			public void preWindowOpen(IWorkbenchWindowConfigurer configurer) {
 				super.preWindowOpen(configurer);
 				configurer.setShowProgressIndicator(false);

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchConfigurerTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchConfigurerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2009, 2014 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -143,6 +143,7 @@ public class WorkbenchConfigurerTest {
 		WorkbenchAdvisor advisor = new RCPTestWorkbenchAdvisor(1) {
 
 			@Override
+			@Deprecated
 			public void createWindowContents(
 					IWorkbenchWindowConfigurer configurer, Shell shell) {
 				ensureThread();
@@ -179,6 +180,7 @@ public class WorkbenchConfigurerTest {
 			}
 
 			@Override
+			@Deprecated
 			public void fillActionBars(IWorkbenchWindow window,
 					IActionBarConfigurer configurer, int flags) {
 				ensureThread();
@@ -210,6 +212,7 @@ public class WorkbenchConfigurerTest {
 			}
 
 			@Override
+			@Deprecated
 			public boolean isApplicationMenu(
 					IWorkbenchWindowConfigurer configurer, String menuId) {
 				ensureThread();
@@ -217,6 +220,7 @@ public class WorkbenchConfigurerTest {
 			}
 
 			@Override
+			@Deprecated
 			public void openIntro(IWorkbenchWindowConfigurer configurer) {
 				ensureThread();
 				super.openIntro(configurer);
@@ -241,24 +245,28 @@ public class WorkbenchConfigurerTest {
 			}
 
 			@Override
+			@Deprecated
 			public void postWindowClose(IWorkbenchWindowConfigurer configurer) {
 				ensureThread();
 				super.postWindowClose(configurer);
 			}
 
 			@Override
+			@Deprecated
 			public void postWindowCreate(IWorkbenchWindowConfigurer configurer) {
 				ensureThread();
 				super.postWindowCreate(configurer);
 			}
 
 			@Override
+			@Deprecated
 			public void postWindowOpen(IWorkbenchWindowConfigurer configurer) {
 				ensureThread();
 				super.postWindowOpen(configurer);
 			}
 
 			@Override
+			@Deprecated
 			public void postWindowRestore(IWorkbenchWindowConfigurer configurer)
 					throws WorkbenchException {
 				ensureThread();
@@ -278,12 +286,14 @@ public class WorkbenchConfigurerTest {
 			}
 
 			@Override
+			@Deprecated
 			public void preWindowOpen(IWorkbenchWindowConfigurer configurer) {
 				ensureThread();
 				super.preWindowOpen(configurer);
 			}
 
 			@Override
+			@Deprecated
 			public boolean preWindowShellClose(
 					IWorkbenchWindowConfigurer configurer) {
 				ensureThread();

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchSaveRestoreStateTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchSaveRestoreStateTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2006, 2016 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -380,11 +380,6 @@ public class WorkbenchSaveRestoreStateTest {
 				return true;
 			}
 
-			@Override
-			public void postWindowRestore(IWorkbenchWindowConfigurer configurer) throws WorkbenchException {
-				// TODO Auto-generated method stub
-				super.postWindowRestore(configurer);
-			}
 		};
 
 		int code2 = PlatformUI.createAndRunWorkbench(display, wa2);

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchWindowConfigurerTest.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/WorkbenchWindowConfigurerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2009, 2014 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -73,6 +73,7 @@ public class WorkbenchWindowConfigurerTest {
 		WorkbenchAdvisor wa = new WorkbenchAdvisorObserver(1) {
 
 			@Override
+			@Deprecated
 			public void fillActionBars(IWorkbenchWindow window,
 					IActionBarConfigurer actionBarConfig, int flags) {
 				super.fillActionBars(window, actionBarConfig, flags);

--- a/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/util/WorkbenchAdvisorObserver.java
+++ b/tests/org.eclipse.ui.tests.rcp/Eclipse RCP Tests/org/eclipse/ui/tests/rcp/util/WorkbenchAdvisorObserver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2009 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -110,12 +110,14 @@ public class WorkbenchAdvisorObserver extends RCPTestWorkbenchAdvisor {
 	}
 
 	@Override
+	@Deprecated
 	public void preWindowOpen(IWorkbenchWindowConfigurer configurer) {
 		super.preWindowOpen(configurer);
 		addOperation(PRE_WINDOW_OPEN);
 	}
 
 	@Override
+	@Deprecated
 	public void fillActionBars(IWorkbenchWindow window,
 			IActionBarConfigurer configurer, int flags) {
 		super.fillActionBars(window, configurer, flags);
@@ -123,6 +125,7 @@ public class WorkbenchAdvisorObserver extends RCPTestWorkbenchAdvisor {
 	}
 
 	@Override
+	@Deprecated
 	public void postWindowRestore(IWorkbenchWindowConfigurer configurer)
 			throws WorkbenchException {
 		super.postWindowRestore(configurer);
@@ -130,6 +133,7 @@ public class WorkbenchAdvisorObserver extends RCPTestWorkbenchAdvisor {
 	}
 
 	@Override
+	@Deprecated
 	public void postWindowOpen(IWorkbenchWindowConfigurer configurer) {
 		super.postWindowOpen(configurer);
 		addOperation(POST_WINDOW_OPEN);
@@ -142,6 +146,7 @@ public class WorkbenchAdvisorObserver extends RCPTestWorkbenchAdvisor {
 	}
 
 	@Override
+	@Deprecated
 	public boolean preWindowShellClose(IWorkbenchWindowConfigurer configurer) {
 		if (!super.preWindowShellClose(configurer)) {
 			return false;


### PR DESCRIPTION
* Mark overriding/implementing deprecated in parent methods as deprecated
* Drop deprecated methods that simply call super