### PR TITLE
Migrate org.eclipse.ltk.ui.refactoring.tests to JUnit 5

### DIFF
--- a/tests/org.eclipse.ltk.ui.refactoring.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ltk.ui.refactoring.tests/META-INF/MANIFEST.MF
@@ -14,7 +14,6 @@ Require-Bundle:
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.ltk.ui.refactoring;bundle-version="[3.14.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.208.0,4.0.0)",
- org.junit,
  org.eclipse.ltk.core.refactoring;bundle-version="[3.7.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.core.filebuffers;bundle-version="[3.5.0,4.0.0)",

--- a/tests/org.eclipse.ltk.ui.refactoring.tests/src/org/eclipse/ltk/ui/refactoring/tests/EmptySuite.java
+++ b/tests/org.eclipse.ltk.ui.refactoring.tests/src/org/eclipse/ltk/ui/refactoring/tests/EmptySuite.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ltk.ui.refactoring.tests;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EmptySuite {
 


### PR DESCRIPTION
Migrate the org.eclipse.ltk.ui.refactoring.tests bundle to JUnit 5 and remove the org.junit dependency.