### PR TITLE
Migrate org.eclipse.ui.tests.views.properties.tabbed to JUnit 5

### DIFF
--- a/tests/org.eclipse.ui.tests.views.properties.tabbed/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.views.properties.tabbed/META-INF/MANIFEST.MF
@@ -6,7 +6,6 @@ Bundle-Version: 3.9.0.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.208.0",
  org.eclipse.core.runtime,
- org.junit,
  org.eclipse.ui.ide,
  org.eclipse.ui.views.properties.tabbed,
  org.eclipse.jface.text

--- a/tests/org.eclipse.ui.tests.views.properties.tabbed/src/org/eclipse/ui/tests/views/properties/tabbed/TabbedPropertySheetPageDecorationsTest.java
+++ b/tests/org.eclipse.ui.tests.views.properties.tabbed/src/org/eclipse/ui/tests/views/properties/tabbed/TabbedPropertySheetPageDecorationsTest.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.ui.tests.views.properties.tabbed;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jface.viewers.IContentProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
@@ -33,9 +33,9 @@ import org.eclipse.ui.tests.views.properties.tabbed.decorations.views.Decoration
 import org.eclipse.ui.tests.views.properties.tabbed.views.TestsPerspective;
 import org.eclipse.ui.tests.views.properties.tabbed.views.TestsViewContentProvider;
 import org.eclipse.ui.views.properties.tabbed.ITabDescriptor;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TabbedPropertySheetPageDecorationsTest {
 
@@ -43,7 +43,7 @@ public class TabbedPropertySheetPageDecorationsTest {
 
 	private TreeNode[] treeNodes;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws WorkbenchException {
 		/**
 		 * Close the existing perspectives.
@@ -93,7 +93,7 @@ public class TabbedPropertySheetPageDecorationsTest {
 		}
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 
 		/**

--- a/tests/org.eclipse.ui.tests.views.properties.tabbed/src/org/eclipse/ui/tests/views/properties/tabbed/TabbedPropertySheetPageDynamicTest.java
+++ b/tests/org.eclipse.ui.tests.views.properties.tabbed/src/org/eclipse/ui/tests/views/properties/tabbed/TabbedPropertySheetPageDynamicTest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.views.properties.tabbed;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,9 +36,9 @@ import org.eclipse.ui.tests.views.properties.tabbed.dynamic.views.DynamicTestsVi
 import org.eclipse.ui.tests.views.properties.tabbed.dynamic.views.DynamicTestsViewContentProvider;
 import org.eclipse.ui.tests.views.properties.tabbed.views.TestsPerspective;
 import org.eclipse.ui.views.properties.tabbed.ITabDescriptor;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the dynamic tab and section support.
@@ -52,7 +52,7 @@ public class TabbedPropertySheetPageDynamicTest {
 
 	private DynamicTestsTreeNode[] treeNodes;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws WorkbenchException {
 
 		/**
@@ -92,7 +92,7 @@ public class TabbedPropertySheetPageDynamicTest {
 		assertEquals(11, treeNodes.length);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 
 		/**

--- a/tests/org.eclipse.ui.tests.views.properties.tabbed/src/org/eclipse/ui/tests/views/properties/tabbed/TabbedPropertySheetPageOverrideTest.java
+++ b/tests/org.eclipse.ui.tests.views.properties.tabbed/src/org/eclipse/ui/tests/views/properties/tabbed/TabbedPropertySheetPageOverrideTest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.views.properties.tabbed;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IViewPart;
@@ -31,9 +31,9 @@ import org.eclipse.ui.tests.views.properties.tabbed.model.Warning;
 import org.eclipse.ui.tests.views.properties.tabbed.override.OverrideTestsView;
 import org.eclipse.ui.tests.views.properties.tabbed.views.TestsPerspective;
 import org.eclipse.ui.views.properties.tabbed.ITabDescriptor;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the override tabs support.
@@ -45,7 +45,7 @@ public class TabbedPropertySheetPageOverrideTest {
 
 	private OverrideTestsView overrideTestsView;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws WorkbenchException {
 		/**
 		 * Close the existing perspectives.
@@ -73,7 +73,7 @@ public class TabbedPropertySheetPageOverrideTest {
 		overrideTestsView = (OverrideTestsView) view;
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		/**
 		 * Bug 175070: Make sure the views have finished painting.

--- a/tests/org.eclipse.ui.tests.views.properties.tabbed/src/org/eclipse/ui/tests/views/properties/tabbed/TabbedPropertySheetPageTest.java
+++ b/tests/org.eclipse.ui.tests.views.properties.tabbed/src/org/eclipse/ui/tests/views/properties/tabbed/TabbedPropertySheetPageTest.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.views.properties.tabbed;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jface.viewers.IContentProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
@@ -35,9 +35,9 @@ import org.eclipse.ui.tests.views.properties.tabbed.views.TestsViewContentProvid
 import org.eclipse.ui.views.properties.tabbed.ISection;
 import org.eclipse.ui.views.properties.tabbed.ITabDescriptor;
 import org.eclipse.ui.views.properties.tabbed.TabContents;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TabbedPropertySheetPageTest
 {
@@ -46,7 +46,7 @@ public class TabbedPropertySheetPageTest
 
 	private TreeNode[] treeNodes;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 
 		/**
@@ -84,7 +84,7 @@ public class TabbedPropertySheetPageTest
 		assertEquals(treeNodes.length, 8);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		/**
 		 * Bug 175070: Make sure the views have finished painting.

--- a/tests/org.eclipse.ui.tests.views.properties.tabbed/src/org/eclipse/ui/tests/views/properties/tabbed/TabbedPropertySheetPageTextTest.java
+++ b/tests/org.eclipse.ui.tests.views.properties.tabbed/src/org/eclipse/ui/tests/views/properties/tabbed/TabbedPropertySheetPageTextTest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.views.properties.tabbed;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.swt.widgets.Display;
@@ -30,9 +30,9 @@ import org.eclipse.ui.tests.views.properties.tabbed.views.TestsPerspective;
 import org.eclipse.ui.views.properties.tabbed.ISection;
 import org.eclipse.ui.views.properties.tabbed.ITabDescriptor;
 import org.eclipse.ui.views.properties.tabbed.TabContents;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the text tests view.
@@ -45,7 +45,7 @@ public class TabbedPropertySheetPageTextTest {
 
 	private TextTestsView textTestsView;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws WorkbenchException {
 
 		/**
@@ -74,7 +74,7 @@ public class TabbedPropertySheetPageTextTest {
 		textTestsView = (TextTestsView) view;
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		/**
 		 * Bug 175070: Make sure the views have finished painting.
@@ -164,7 +164,7 @@ public class TabbedPropertySheetPageTextTest {
 			textTestsView.getSite().getShell().getDisplay().readAndDispatch();
 			tabDescriptors= textTestsView.getTabbedPropertySheetPage().getActiveTabs();
 		} while (tabDescriptors.length == 0 && System.currentTimeMillis() < threshold);
-		assertTrue("No tab got activated", tabDescriptors.length > 0);
+		assertTrue(tabDescriptors.length > 0, "No tab got activated");
 		return tabDescriptors;
 	}
 


### PR DESCRIPTION
Migrate the org.eclipse.ui.tests.views.properties.tabbed bundle to JUnit 5 and remove the org.junit dependency.