### PR TITLE
Migrate JFaceActionRule to JFaceActionExtension and migrated tests

### DIFF
--- a/tests/org.eclipse.jface.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.tests/META-INF/MANIFEST.MF
@@ -12,6 +12,7 @@ Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.ui,
  org.eclipse.ui.tests.harness
 Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.extension;version="[5.14.0,6.0.0)",
  org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
  org.junit.platform.commons.function;version="[1.14.0,2.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)",

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/ContributionItemTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/ContributionItemTest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.action;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.ActionContributionItem;
@@ -23,8 +23,8 @@ import org.eclipse.jface.action.IContributionManager;
 import org.eclipse.jface.resource.ResourceLocator;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Control;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests for the [I]ContributionItem API.
@@ -33,8 +33,8 @@ import org.junit.Test;
  */
 public class ContributionItemTest {
 
-	@Rule
-	public JFaceActionRule rule = new JFaceActionRule();
+	@RegisterExtension
+	public JFaceActionExtension rule = new JFaceActionExtension();
 
 	/**
 	 * Tests that a contribution item's parent link is set when added to a

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/CoolBarManagerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/CoolBarManagerTest.java
@@ -14,8 +14,8 @@
 
 package org.eclipse.jface.tests.action;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.CoolBarManager;
@@ -25,9 +25,9 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.CoolBar;
 import org.eclipse.swt.widgets.CoolItem;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @since 3.6
@@ -38,10 +38,10 @@ public class CoolBarManagerTest {
 
 	private CoolBar coolBar;
 
-	@Rule
-	public JFaceActionRule rule = new JFaceActionRule();
+	@RegisterExtension
+	public JFaceActionExtension rule = new JFaceActionExtension();
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		coolBarManager = new CoolBarManager(SWT.FLAT);
 		coolBar = coolBarManager.createControl(rule.getShell());

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/JFaceActionExtension.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/JFaceActionExtension.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2026 vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jface.tests.action;
+
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit 5 extension for all JFace action tests.
+ *
+ * @since 3.1
+ */
+public class JFaceActionExtension implements BeforeEachCallback, AfterEachCallback {
+
+	private Display display;
+	private Shell shell;
+
+	@Override
+	public void beforeEach(ExtensionContext context) throws Exception {
+		display = Display.getCurrent();
+		if (display == null) {
+			display = new Display();
+		}
+		shell = new Shell(display);
+		shell.setSize(500, 500);
+		shell.setLayout(new FillLayout());
+		shell.open();
+	}
+
+	@Override
+	public void afterEach(ExtensionContext context) throws Exception {
+		if (shell != null && !shell.isDisposed()) {
+			shell.dispose();
+		}
+	}
+
+	public Shell getShell() {
+		return shell;
+	}
+
+}

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/MenuManagerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/MenuManagerTest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.action;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.GroupMarker;
@@ -26,8 +26,8 @@ import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
 import org.eclipse.swt.widgets.Decorations;
 import org.eclipse.swt.widgets.Menu;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests for the MenuManager API.
@@ -35,8 +35,8 @@ import org.junit.Test;
  * @since 3.1
  */
 public class MenuManagerTest {
-	@Rule
-	public JFaceActionRule rule = new JFaceActionRule();
+	@RegisterExtension
+	public JFaceActionExtension rule = new JFaceActionExtension();
 
 	private int groupMarkerCount = 0;
 	private int separatorCount = 0;

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/ToolBarManagerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/ToolBarManagerTest.java
@@ -15,14 +15,14 @@
 
 package org.eclipse.jface.tests.action;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 
@@ -42,15 +42,15 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ToolBarManagerTest {
 
 	private static final int DEFAULT_STYLE = SWT.WRAP | SWT.FLAT | SWT.RIGHT;
 
-	@Rule
-	public JFaceActionRule rule = new JFaceActionRule();
+	@RegisterExtension
+	public JFaceActionExtension rule = new JFaceActionExtension();
 
 	public void testSetStyleWhenToolBarDoesNotExist() {
 		Composite parent = createComposite();
@@ -107,15 +107,15 @@ public class ToolBarManagerTest {
 		ObservableControlContribution item = new ObservableControlContribution("i want to be updated!");
 		manager.add(item);
 		manager.createControl(createComposite());
-		assertFalse("Update was called already", item.updateCalled);
-		assertTrue("computeWidth was not called", item.computeWidthCalled);
+		assertFalse(item.updateCalled, "Update was called already");
+		assertTrue(item.computeWidthCalled, "computeWidth was not called");
 		item.computeWidthCalled = false;
 		manager.update(false);
-		assertFalse("Item update should only be called when manager update is forced", item.updateCalled);
-		assertFalse("computeWidth should only be called when manager update is forced", item.computeWidthCalled);
+		assertFalse(item.updateCalled, "Item update should only be called when manager update is forced");
+		assertFalse(item.computeWidthCalled, "computeWidth should only be called when manager update is forced");
 		manager.update(true);
-		assertTrue("Update was not called", item.updateCalled);
-		assertTrue("computeWidth was not called", item.computeWidthCalled);
+		assertTrue(item.updateCalled, "Update was not called");
+		assertTrue(item.computeWidthCalled, "computeWidth was not called");
 	}
 
 	@Test
@@ -207,13 +207,13 @@ public class ToolBarManagerTest {
 	}
 
 	private static void assertImageDataEquals(ImageData im1, ImageData im2) {
-		assertNotNull("ImageData 1 is null", im1);
-		assertNotNull("ImageData 2 is null", im2);
-		assertEquals("ImageData width missmatch", im1.width, im2.width);
-		assertEquals("ImageData height missmatch", im1.height, im2.height);
+		assertNotNull(im1, "ImageData 1 is null");
+		assertNotNull(im2, "ImageData 2 is null");
+		assertEquals(im1.width, im2.width, "ImageData width missmatch");
+		assertEquals(im1.height, im2.height, "ImageData height missmatch");
 		for (int x = 0; x < im1.width; x++) {
 			for (int y = 0; y < im1.height; y++) {
-				assertEquals("pixel (" + x + "," + y + ") are not equal", im1.getPixel(x, y), im2.getPixel(x, y));
+				assertEquals(im1.getPixel(x, y), im2.getPixel(x, y), "pixel (" + x + "," + y + ") are not equal");
 			}
 		}
 	}


### PR DESCRIPTION
JUnit5

1. Created `JFaceActionExtension`: A new JUnit 5 extension that replaces JFaceActionRule.
2. Updated `MANIFEST.MF`: Added org.junit.jupiter.api.extension to Import-Package in org.eclipse.jface.tests.
3. Migrated Test Classes: Converted CoolBarManagerTest, MenuManagerTest, ContributionItemTest, and ToolBarManagerTest to JUnit 5 (using @Test, @BeforeEach, @RegisterExtension, and updated assertions).
4. Verification: Ran all 15 test methods via Maven Tycho, and all passed successfully.