### PR TITLE
Migrate tests using JUnit 4 SwtLeakTestWatcher rule to JUni5

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/NestedSyncExecDeadlockTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/NestedSyncExecDeadlockTest.java
@@ -14,7 +14,7 @@
  **********************************************************************/
 package org.eclipse.ui.tests.concurrency;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -29,12 +29,11 @@ import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.actions.WorkspaceModifyOperation;
-import org.eclipse.ui.tests.SwtLeakTestWatcher;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestWatcher;
+import org.eclipse.ui.tests.SwtLeakExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * This is a regression test for a case where a recursive attempt to syncExec
@@ -42,8 +41,8 @@ import org.junit.rules.TestWatcher;
  */
 public class NestedSyncExecDeadlockTest {
 
-	@Rule
-	public TestWatcher swtLeakTestWatcher = new SwtLeakTestWatcher();
+	@RegisterExtension
+	public SwtLeakExtension swtLeakExtension = new SwtLeakExtension();
 
 	private static class ResourceListener implements IResourceChangeListener {
 		@Override
@@ -87,7 +86,7 @@ public class NestedSyncExecDeadlockTest {
 		shell.close();
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		project = workspace.getRoot().getProject("test-deadlock");
 
@@ -100,7 +99,7 @@ public class NestedSyncExecDeadlockTest {
 		workspace.addResourceChangeListener(listener, IResourceChangeEvent.POST_CHANGE);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		if (listener != null) {
 			workspace.removeResourceChangeListener(listener);

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/TestBug108162.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/TestBug108162.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.concurrency;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -26,10 +26,9 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.actions.WorkspaceModifyOperation;
-import org.eclipse.ui.tests.SwtLeakTestWatcher;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestWatcher;
+import org.eclipse.ui.tests.SwtLeakExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests the following sequence of events:
@@ -42,8 +41,8 @@ import org.junit.rules.TestWatcher;
  */
 public class TestBug108162 {
 
-	@Rule
-	public TestWatcher swtLeakTestWatcher = new SwtLeakTestWatcher();
+	@RegisterExtension
+	public SwtLeakExtension swtLeakExtension = new SwtLeakExtension();
 
 	static class LockAcquiringOperation extends WorkspaceModifyOperation {
 		@Override

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/TestBug269121.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/TestBug269121.java
@@ -13,7 +13,7 @@
  ******************************************************************************/
 package org.eclipse.ui.tests.concurrency;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.atomic.AtomicIntegerArray;
@@ -29,10 +29,9 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.actions.WorkspaceModifyOperation;
 import org.eclipse.ui.progress.UIJob;
-import org.eclipse.ui.tests.SwtLeakTestWatcher;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestWatcher;
+import org.eclipse.ui.tests.SwtLeakExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import junit.framework.AssertionFailedError;
 
@@ -59,8 +58,8 @@ import junit.framework.AssertionFailedError;
  */
 public class TestBug269121 {
 
-	@Rule
-	public TestWatcher swtLeakTestWatcher = new SwtLeakTestWatcher();
+	@RegisterExtension
+	public SwtLeakExtension swtLeakExtension = new SwtLeakExtension();
 
 	@Test
 	public void testBug() throws InterruptedException,
@@ -110,7 +109,7 @@ public class TestBug269121 {
 			Display.getCurrent().readAndDispatch();
 		}
 		job.join();
-		assertTrue("Timeout occurred - possible Deadlock. See logging!", statusJob.getResult().isOK());
+		assertTrue(statusJob.getResult().isOK(), "Timeout occurred - possible Deadlock. See logging!");
 		shell.close();
 	}
 }

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/TestBug98621.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/concurrency/TestBug98621.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.concurrency;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -28,10 +28,9 @@ import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.actions.WorkspaceModifyOperation;
-import org.eclipse.ui.tests.SwtLeakTestWatcher;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestWatcher;
+import org.eclipse.ui.tests.SwtLeakExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests the following sequence of events:
@@ -51,8 +50,8 @@ import org.junit.rules.TestWatcher;
  */
 public class TestBug98621 {
 
-	@Rule
-	public TestWatcher swtLeakTestWatcher = new SwtLeakTestWatcher();
+	@RegisterExtension
+	public SwtLeakExtension swtLeakExtension = new SwtLeakExtension();
 
 	class TransferTestOperation extends WorkspaceModifyOperation {
 		@Override

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/DeprecatedUIPreferencesAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/DeprecatedUIPreferencesAuto.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dialogs;
 
-import static org.junit.Assume.assumeNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.preference.IPreferenceNode;
@@ -23,16 +23,15 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.IWorkbenchHelpContextIds;
 import org.eclipse.ui.internal.WorkbenchPlugin;
-import org.eclipse.ui.tests.SwtLeakTestWatcher;
+import org.eclipse.ui.tests.SwtLeakExtension;
 import org.eclipse.ui.tests.harness.util.DialogCheck;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestWatcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class DeprecatedUIPreferencesAuto {
 
-	@Rule
-	public TestWatcher swtLeakTestWatcher = new SwtLeakTestWatcher();
+	@RegisterExtension
+	public SwtLeakExtension swtLeakExtension = new SwtLeakExtension();
 
 	protected Shell getShell() {
 		return DialogCheck.getShell();
@@ -131,7 +130,7 @@ public class DeprecatedUIPreferencesAuto {
 	public void testFieldEditorEnablePref() {
 
 		PreferenceManager manager = WorkbenchPlugin.getDefault().getPreferenceManager();
-		assumeNotNull(manager);
+		assumeTrue(manager != null);
 		PreferenceDialogWrapper dialog = new PreferenceDialogWrapper(
 				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), manager);
 		dialog.create();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIPreferencesAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIPreferencesAuto.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dialogs;
 
-import static org.junit.Assume.assumeNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.preference.IPreferenceNode;
@@ -23,16 +23,15 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.IWorkbenchHelpContextIds;
 import org.eclipse.ui.internal.WorkbenchPlugin;
-import org.eclipse.ui.tests.SwtLeakTestWatcher;
+import org.eclipse.ui.tests.SwtLeakExtension;
 import org.eclipse.ui.tests.harness.util.DialogCheck;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestWatcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class UIPreferencesAuto {
 
-	@Rule
-	public TestWatcher swtLeakTestWatcher = new SwtLeakTestWatcher();
+	@RegisterExtension
+	public SwtLeakExtension swtLeakExtension = new SwtLeakExtension();
 	protected Shell getShell() {
 		return DialogCheck.getShell();
 	}
@@ -133,7 +132,7 @@ public class UIPreferencesAuto {
 	public void testFieldEditorEnablePref() {
 		PreferenceManager manager = WorkbenchPlugin.getDefault()
 				.getPreferenceManager();
-		assumeNotNull(manager);
+		assumeTrue(manager != null);
 		PreferenceDialogWrapper dialog = new PreferenceDialogWrapper(
 				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), manager);
 		dialog.create();

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIWizardsAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIWizardsAuto.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.tests.dialogs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
@@ -39,21 +39,20 @@ import org.eclipse.ui.internal.dialogs.ImportWizard;
 import org.eclipse.ui.internal.dialogs.NewWizard;
 import org.eclipse.ui.internal.ide.IIDEHelpContextIds;
 import org.eclipse.ui.internal.wizards.newresource.ResourceMessages;
-import org.eclipse.ui.tests.SwtLeakTestWatcher;
+import org.eclipse.ui.tests.SwtLeakExtension;
 import org.eclipse.ui.tests.harness.util.DialogCheck;
 import org.eclipse.ui.tests.harness.util.FileUtil;
 import org.eclipse.ui.wizards.newresource.BasicNewFileResourceWizard;
 import org.eclipse.ui.wizards.newresource.BasicNewFolderResourceWizard;
 import org.eclipse.ui.wizards.newresource.BasicNewProjectResourceWizard;
-import org.junit.After;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestWatcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class UIWizardsAuto {
-	@Rule
-	public TestWatcher swtLeakTestWatcher = new SwtLeakTestWatcher();
+	@RegisterExtension
+	public SwtLeakExtension swtLeakExtension = new SwtLeakExtension();
 
 	private static final int SIZING_WIZARD_WIDTH = 470;
 
@@ -128,10 +127,7 @@ public class UIWizardsAuto {
 		return dialog;
 	}
 
-	/**
-	 * @see junit.framework.TestCase#tearDown()
-	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		if (project != null) {
 			project.delete(true, true, null);
@@ -149,14 +145,14 @@ public class UIWizardsAuto {
 	 * 1GJWD2E: ITPUI:ALL - Test classes should not be released in public packages.
 	 */
 	@Test
-	@Ignore("1GJWD2E: ITPUI:ALL")
+	@Disabled("1GJWD2E: ITPUI:ALL")
 	public void testFileSystemExport() {
 //		Dialog dialog = exportWizard(DataTransferTestStub.newFileSystemResourceExportPage1(null));
 //		DialogCheck.assertDialogTexts(dialog);
 	}
 
 	@Test
-	@Ignore("1GJWD2E: ITPUI:ALL")
+	@Disabled("1GJWD2E: ITPUI:ALL")
 	public void testZipFileExport() {
 //		Dialog dialog = exportWizard(DataTransferTestStub.newZipFileResourceExportPage1(null));
 //		DialogCheck.assertDialogTexts(dialog);
@@ -172,7 +168,7 @@ public class UIWizardsAuto {
 	 * 1GJWD2E: ITPUI:ALL - Test classes should not be released in public packages.
 	 */
 	@Test
-	@Ignore("1GJWD2E: ITPUI:ALL")
+	@Disabled("1GJWD2E: ITPUI:ALL")
 	public void testFileSystemImport() {
 //		Dialog dialog = importWizard(DataTransferTestStub.newFileSystemResourceImportPage1(
 //				WorkbenchPlugin.getDefault().getWorkbench(), StructuredSelection.EMPTY));
@@ -180,7 +176,7 @@ public class UIWizardsAuto {
 	}
 
 	@Test
-	@Ignore("1GJWD2E: ITPUI:ALL")
+	@Disabled("1GJWD2E: ITPUI:ALL")
 	public void testZipFileImport() {
 //		Dialog dialog = importWizard(DataTransferTestStub.newZipFileResourceImportPage1(null));
 //		DialogCheck.assertDialogTexts(dialog);
@@ -209,8 +205,7 @@ public class UIWizardsAuto {
 			public void addPages() {
 				super.addPages();
 				IWizardPage page = getPage("newFilePage1");
-				assertTrue("Expected newFilePage1",
-						page instanceof WizardNewFileCreationPage);
+				assertTrue(page instanceof WizardNewFileCreationPage, "Expected newFilePage1");
 				WizardNewFileCreationPage fileCreationPage = (WizardNewFileCreationPage) page;
 
 				try {

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/SupportTrayTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/SupportTrayTest.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.ui.tests.statushandlers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,18 +37,17 @@ import org.eclipse.ui.internal.statushandlers.IStatusDialogConstants;
 import org.eclipse.ui.internal.statushandlers.StackTraceSupportArea;
 import org.eclipse.ui.internal.statushandlers.SupportTray;
 import org.eclipse.ui.statushandlers.StatusAdapter;
-import org.eclipse.ui.tests.SwtLeakTestWatcher;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestWatcher;
+import org.eclipse.ui.tests.SwtLeakExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class SupportTrayTest {
 
-	@Rule
-	public TestWatcher swtLeakTestWatcher = new SwtLeakTestWatcher();
+	@RegisterExtension
+	public SwtLeakExtension swtLeakExtension = new SwtLeakExtension();
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		Policy.setErrorSupportProvider(null);
 	}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/WizardsStatusHandlingTestCase.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/WizardsStatusHandlingTestCase.java
@@ -14,8 +14,8 @@
 package org.eclipse.ui.tests.statushandlers;
 
 import static org.eclipse.ui.tests.harness.util.UITestUtil.processEvents;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.internal.registry.RegistryMessages;
 import org.eclipse.core.runtime.CoreException;
@@ -36,11 +36,10 @@ import org.eclipse.ui.internal.WorkbenchMessages;
 import org.eclipse.ui.internal.dialogs.ExportWizard;
 import org.eclipse.ui.statushandlers.StatusAdapter;
 import org.eclipse.ui.statushandlers.StatusManager;
-import org.eclipse.ui.tests.SwtLeakTestWatcher;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestWatcher;
+import org.eclipse.ui.tests.SwtLeakExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Tests whether the errors in wizards are handled properly
@@ -48,8 +47,8 @@ import org.junit.rules.TestWatcher;
  * @since 3.3
  */
 public class WizardsStatusHandlingTestCase {
-	@Rule
-	public TestWatcher swtLeakTestWatcher = new SwtLeakTestWatcher();
+	@RegisterExtension
+	public SwtLeakExtension swtLeakExtension = new SwtLeakExtension();
 
 	private static int SEVERITY = IStatus.ERROR;
 
@@ -73,7 +72,7 @@ public class WizardsStatusHandlingTestCase {
 
 	private static String FAULTY_WIZARD_NAME = "FaultyExportWizard";
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		TestStatusHandler.uninstall();
 	}
@@ -153,11 +152,9 @@ public class WizardsStatusHandlingTestCase {
 		assertEquals(PLUGIN_ID, status.getPlugin());
 		assertEquals(MESSAGE, status.getMessage());
 		assertEquals(EXCEPTION_CLASS, status.getException().getClass());
-		assertTrue(createIncorrectExceptionMessage(status.getException()
-				.getMessage()), EXCEPTION_MESSAGE.equals(status.getException()
-				.getMessage())
-				|| EXCEPTION_MESSAGE2
-						.equals(status.getException().getMessage()));
+		assertTrue(EXCEPTION_MESSAGE.equals(status.getException().getMessage())
+				|| EXCEPTION_MESSAGE2.equals(status.getException().getMessage()),
+				createIncorrectExceptionMessage(status.getException().getMessage()));
 	}
 
 	private String createIncorrectExceptionMessage(String exceptionMessage) {


### PR DESCRIPTION
Create SwtLeakExtension JUnit 5 extension and migrated all 10 identified test classes,