### PR TITLE
Migrate WorkbenchContextRule to WorkbenchContextExtension and update …

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
@@ -40,6 +40,7 @@ Import-Package: jakarta.annotation,
  jakarta.inject,
  org.osgi.service.event,
  org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.extension;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.e4.ui.tests

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/rules/WorkbenchContextExtension.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/rules/WorkbenchContextExtension.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2026 Rolf Theunissen and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Rolf Theunissen <rolf.theunissen@gmail.com> - initial API and implementation
+ *     Christoph Läubrich - adjust unit test
+ ******************************************************************************/
+
+package org.eclipse.e4.ui.tests.rules;
+
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.core.di.suppliers.ExtendedObjectSupplier;
+import org.eclipse.e4.core.internal.di.osgi.ProviderHelper;
+import org.eclipse.e4.ui.di.UIEventTopic;
+import org.eclipse.e4.ui.di.UISynchronize;
+import org.eclipse.e4.ui.internal.workbench.E4Workbench;
+import org.eclipse.e4.ui.internal.workbench.swt.E4Application;
+import org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine;
+import org.eclipse.e4.ui.model.application.MApplication;
+import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
+import org.eclipse.e4.ui.workbench.IWorkbench;
+import org.eclipse.e4.ui.workbench.modeling.EModelService;
+import org.eclipse.e4.ui.workbench.swt.DisplayUISynchronize;
+import org.eclipse.swt.widgets.Display;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class WorkbenchContextExtension implements BeforeEachCallback, AfterEachCallback {
+
+	private IEclipseContext context;
+	private E4Workbench wb;
+
+	public void createAndRunWorkbench(MWindow window) {
+		if (wb == null) {
+			wb = new E4Workbench(context.get(MApplication.class), context);
+		}
+		wb.createAndRunUI(window);
+	}
+
+	public void spinEventLoop() {
+		while (Display.getDefault().readAndDispatch()) {
+		}
+	}
+
+	@Override
+	public void beforeEach(ExtensionContext extensionContext) throws Exception {
+		try {
+			createContext();
+		} catch (Throwable e) {
+			throw new Exception(e);
+		}
+		ContextInjectionFactory.inject(extensionContext.getRequiredTestInstance(), context);
+	}
+
+	@Override
+	public void afterEach(ExtensionContext extensionContext) throws Exception {
+		dispose();
+	}
+
+	protected void createContext() throws Throwable {
+		context = E4Application.createDefaultContext();
+		context.set(IWorkbench.PRESENTATION_URI_ARG, PartRenderingEngine.engineURI);
+
+		final Display display = Display.getDefault();
+		context.set(UISynchronize.class, new DisplayUISynchronize(display));
+
+		ContextInjectionFactory.setDefault(context);
+
+		// Workaround, enforce injection on UIEventTopic provider with current context
+		ExtendedObjectSupplier supplier = ProviderHelper.findProvider(UIEventTopic.class.getName(), null);
+		ContextInjectionFactory.inject(supplier, context);
+
+		EModelService ems = context.get(EModelService.class);
+		MApplication application = ems.createModelElement(MApplication.class);
+		application.setContext(context);
+		context.set(MApplication.class, application);
+	}
+
+	protected void dispose() {
+		if (wb != null) {
+			wb.close();
+		}
+
+		ContextInjectionFactory.setDefault(null);
+
+		// Workaround, enforce uninjection on the UIEventTopic provider from context
+		ExtendedObjectSupplier supplier = ProviderHelper.findProvider(UIEventTopic.class.getName(), null);
+		ContextInjectionFactory.uninject(supplier, context);
+
+		context.dispose();
+	}
+
+}

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/CompositePartClosingTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/CompositePartClosingTest.java
@@ -25,16 +25,16 @@ import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartSashContainer;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartStack;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
-import org.eclipse.e4.ui.tests.rules.WorkbenchContextRule;
+import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class CompositePartClosingTest {
 
-	@Rule
-	public WorkbenchContextRule contextRule = new WorkbenchContextRule();
+	@RegisterExtension
+	public WorkbenchContextExtension contextRule = new WorkbenchContextExtension();
 
 	@Inject
 	private EModelService ems;

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MMenuItemTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MMenuItemTest.java
@@ -48,7 +48,7 @@ import org.eclipse.e4.ui.model.application.ui.menu.MMenuContribution;
 import org.eclipse.e4.ui.model.application.ui.menu.MMenuItem;
 import org.eclipse.e4.ui.model.application.ui.menu.MMenuSeparator;
 import org.eclipse.e4.ui.services.ContextServiceAddon;
-import org.eclipse.e4.ui.tests.rules.WorkbenchContextRule;
+import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
 import org.eclipse.e4.ui.workbench.renderers.swt.MenuManagerRenderer;
@@ -60,14 +60,14 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Widget;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class MMenuItemTest {
 
-	@Rule
-	public WorkbenchContextRule contextRule = new WorkbenchContextRule();
+	@RegisterExtension
+	public WorkbenchContextExtension contextRule = new WorkbenchContextExtension();
 
 	@Inject
 	private EModelService ems;
@@ -78,7 +78,7 @@ public class MMenuItemTest {
 	@Inject
 	private MApplication application;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		ContextInjectionFactory.make(CommandServiceAddon.class, appContext);
 		ContextInjectionFactory.make(ContextServiceAddon.class, appContext);

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MSaveablePartTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MSaveablePartTest.java
@@ -24,17 +24,17 @@ import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartSashContainer;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartStack;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
-import org.eclipse.e4.ui.tests.rules.WorkbenchContextRule;
+import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class MSaveablePartTest {
 
-	@Rule
-	public WorkbenchContextRule contextRule = new WorkbenchContextRule();
+	@RegisterExtension
+	public WorkbenchContextExtension contextRule = new WorkbenchContextExtension();
 
 	@Inject
 	private EModelService ems;

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MToolItemTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MToolItemTest.java
@@ -28,18 +28,18 @@ import org.eclipse.e4.ui.model.application.ui.menu.ItemType;
 import org.eclipse.e4.ui.model.application.ui.menu.MDirectToolItem;
 import org.eclipse.e4.ui.model.application.ui.menu.MToolBar;
 import org.eclipse.e4.ui.model.application.ui.menu.MToolItem;
-import org.eclipse.e4.ui.tests.rules.WorkbenchContextRule;
+import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.ToolItem;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class MToolItemTest {
 
-	@Rule
-	public WorkbenchContextRule contextRule = new WorkbenchContextRule();
+	@RegisterExtension
+	public WorkbenchContextExtension contextRule = new WorkbenchContextExtension();
 
 	@Inject
 	private EModelService ems;

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/ModelServiceImplTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/ModelServiceImplTest.java
@@ -29,25 +29,25 @@ import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartStack;
 import org.eclipse.e4.ui.model.application.ui.basic.MTrimmedWindow;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
-import org.eclipse.e4.ui.tests.rules.WorkbenchContextRule;
+import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 
 public class ModelServiceImplTest {
 	private static final String DUMMY_EDITOR_ID = "dummyEditor";
 
-	@Rule
-	public WorkbenchContextRule contextRule = new WorkbenchContextRule();
+	@RegisterExtension
+	public WorkbenchContextExtension contextRule = new WorkbenchContextExtension();
 
 	@Inject
 	private EModelService modelService;
 
 	private MPart editor;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		editor = modelService.createModelElement(MPart.class);
 		editor.setElementId(DUMMY_EDITOR_ID);


### PR DESCRIPTION
…tests

1. Created WorkbenchContextExtension as a JUnit 5 replacement for WorkbenchContextRule.
2. Updated MANIFEST.MF to include org.junit.jupiter.api.extension in Import-Package.
3. Migrated CompositePartClosingTest, MSaveablePartTest, ModelServiceImplTest, MMenuItemTest, and MToolItemTest to JUnit 5.
4. Verified all migrated tests pass via Maven Tycho.