### PR TITLE
Migrate StackRendererTest and others to JUnit 5

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests/META-INF/MANIFEST.MF
@@ -41,7 +41,8 @@ Import-Package: jakarta.annotation,
  org.osgi.service.event,
  org.junit.jupiter.api;version="[5.14.0,6.0.0)",
  org.junit.jupiter.api.extension;version="[5.14.0,6.0.0)",
- org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
+ org.opentest4j
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.e4.ui.tests
 Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MPartTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MPartTest.java
@@ -15,10 +15,10 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import jakarta.inject.Inject;
 import org.eclipse.e4.core.contexts.IEclipseContext;
@@ -27,18 +27,18 @@ import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartSashContainer;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartStack;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
-import org.eclipse.e4.ui.tests.rules.WorkbenchContextRule;
+import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
 import org.eclipse.e4.ui.workbench.IPresentationEngine;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class MPartTest {
 
-	@Rule
-	public WorkbenchContextRule contextRule = new WorkbenchContextRule();
+	@RegisterExtension
+	public WorkbenchContextExtension contextRule = new WorkbenchContextExtension();
 
 	@Inject
 	private IEclipseContext appContext;

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MWindowTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MWindowTest.java
@@ -15,14 +15,14 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import jakarta.inject.Inject;
 import org.eclipse.core.runtime.Platform;
@@ -37,7 +37,7 @@ import org.eclipse.e4.ui.model.application.ui.menu.MDirectMenuItem;
 import org.eclipse.e4.ui.model.application.ui.menu.MMenu;
 import org.eclipse.e4.ui.model.application.ui.menu.MMenuItem;
 import org.eclipse.e4.ui.services.IServiceConstants;
-import org.eclipse.e4.ui.tests.rules.WorkbenchContextRule;
+import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.swt.SWT;
@@ -51,14 +51,14 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.Widget;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class MWindowTest {
 
-	@Rule
-	public WorkbenchContextRule contextRule = new WorkbenchContextRule();
+	@RegisterExtension
+	public WorkbenchContextExtension contextRule = new WorkbenchContextExtension();
 
 	@Inject
 	private IEclipseContext appContext;
@@ -71,7 +71,7 @@ public class MWindowTest {
 
 	@Test
 	public void testCreateWindow() {
-		assumeFalse("Test fails on Mac: Bug 537639", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 537639");
 
 		final MWindow window = ems.createModelElement(MWindow.class);
 		window.setLabel("MyWindow");
@@ -147,7 +147,7 @@ public class MWindowTest {
 
 	@Test
 	public void testContextChildren() {
-		assumeFalse("Test fails on Mac: Bug 537639", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 537639");
 
 		final MWindow window = createWindowWithOneView();
 
@@ -250,7 +250,7 @@ public class MWindowTest {
 		assertEquals("windowName2", shell.getText());
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void TODOtestWindow_X() {
 		final MWindow window = ems.createModelElement(MWindow.class);
@@ -283,7 +283,7 @@ public class MWindowTest {
 		assertEquals(300, bounds.x);
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void TODOtestWindow_Y() {
 		final MWindow window = ems.createModelElement(MWindow.class);
@@ -387,22 +387,22 @@ public class MWindowTest {
 		Shell topShell = (Shell) window.getWidget();
 		Shell detachedShell = (Shell) detachedWindow.getWidget();
 		assertEquals(window, ems.getContainer(detachedWindow));
-		assertNull("Should have no shell image", topShell.getImage());
-		assertEquals("Detached should have same image", topShell.getImage(), detachedShell.getImage());
+		assertNull(topShell.getImage(), "Should have no shell image");
+		assertEquals(topShell.getImage(), detachedShell.getImage(), "Detached should have same image");
 
 		// now set icon on top-level window; detached window should inherit it
 		window.setIconURI("platform:/plugin/org.eclipse.e4.ui.tests/icons/filenav_nav.svg");
 		while (topShell.getDisplay().readAndDispatch()) {
 		}
-		assertNotNull("Should have shell image", topShell.getImage());
-		assertEquals("Detached should have same image", topShell.getImage(), detachedShell.getImage());
+		assertNotNull(topShell.getImage(), "Should have shell image");
+		assertEquals(topShell.getImage(), detachedShell.getImage(), "Detached should have same image");
 
 		// change top-level icon; detached window should inherit it
 		window.setIconURI(null);
 		while (topShell.getDisplay().readAndDispatch()) {
 		}
-		assertNull("Should have no shell image", topShell.getImage());
-		assertEquals("Detached should have same image", topShell.getImage(), detachedShell.getImage());
+		assertNull(topShell.getImage(), "Should have no shell image");
+		assertEquals(topShell.getImage(), detachedShell.getImage(), "Detached should have same image");
 
 		// turn detached into top-level window; inherited icon should be removed
 		window.setIconURI("platform:/plugin/org.eclipse.e4.ui.tests/icons/filenav_nav.svg");

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartOnTopManagerTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartOnTopManagerTest.java
@@ -15,8 +15,8 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.inject.Inject;
 import org.eclipse.e4.ui.internal.workbench.PartOnTopManager;
@@ -29,12 +29,12 @@ import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartSashContainer;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartStack;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
-import org.eclipse.e4.ui.tests.rules.WorkbenchContextRule;
+import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
 import org.eclipse.e4.ui.workbench.IWorkbench;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * This test class is used to validate the correctness of the
@@ -42,8 +42,8 @@ import org.junit.Test;
  */
 public class PartOnTopManagerTest {
 
-	@Rule
-	public WorkbenchContextRule contextRule = new WorkbenchContextRule();
+	@RegisterExtension
+	public WorkbenchContextExtension contextRule = new WorkbenchContextExtension();
 
 	@Inject
 	private EModelService ems;

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
@@ -16,13 +16,13 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import jakarta.inject.Inject;
 import java.util.function.Consumer;
@@ -48,7 +48,7 @@ import org.eclipse.e4.ui.model.application.ui.menu.MDirectToolItem;
 import org.eclipse.e4.ui.model.application.ui.menu.MMenu;
 import org.eclipse.e4.ui.model.application.ui.menu.MToolBar;
 import org.eclipse.e4.ui.model.application.ui.menu.MToolControl;
-import org.eclipse.e4.ui.tests.rules.WorkbenchContextRule;
+import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
 import org.eclipse.e4.ui.workbench.IPresentationEngine;
 import org.eclipse.e4.ui.workbench.addons.cleanupaddon.CleanupAddon;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
@@ -64,22 +64,20 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.Widget;
-import org.eclipse.test.Screenshots;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestWatcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.osgi.service.log.LogLevel;
 import org.osgi.service.log.LogListener;
 import org.osgi.service.log.LogReaderService;
 
 public class PartRenderingEngineTests {
 
-	@Rule
-	public WorkbenchContextRule contextRule = new WorkbenchContextRule();
+	@RegisterExtension
+	public WorkbenchContextExtension contextRule = new WorkbenchContextExtension();
 
 	@Inject
 	private IEclipseContext appContext;
@@ -98,7 +96,7 @@ public class PartRenderingEngineTests {
 	private boolean logged = false;
 	private Consumer<RuntimeException> runtimeExceptionHandler;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		logged = false;
 
@@ -106,7 +104,7 @@ public class PartRenderingEngineTests {
 		logReaderService.addLogListener(listener);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		LogReaderService logReaderService = appContext.get(LogReaderService.class);
 		logReaderService.removeLogListener(listener);
@@ -222,8 +220,7 @@ public class PartRenderingEngineTests {
 				EPartService.class);
 		service.activate(partB);
 		assertEquals(
-				"Activating another part should've altered the tab folder's selection",
-				1, tabFolder.getSelectionIndex());
+				1, tabFolder.getSelectionIndex(), "Activating another part should've altered the tab folder's selection");
 	}
 
 	@Test
@@ -254,8 +251,8 @@ public class PartRenderingEngineTests {
 		EPartService service = window.getContext().get(
 				EPartService.class);
 		service.showPart(partB.getElementId(), PartState.ACTIVATE);
-		assertEquals("Showing a part should alter the tab folder's selection",
-				1, tabFolder.getSelectionIndex());
+		assertEquals(
+				1, tabFolder.getSelectionIndex(), "Showing a part should alter the tab folder's selection");
 	}
 
 	@Test
@@ -285,8 +282,8 @@ public class PartRenderingEngineTests {
 
 		assertEquals(1, tabFolder.getItemCount());
 		assertEquals(0, tabFolder.getSelectionIndex());
-		assertEquals("The shown part should be the active part", shownPart,
-				stack.getSelectedElement());
+		assertEquals(shownPart,
+				stack.getSelectedElement(), "The shown part should be the active part");
 	}
 
 	@Test
@@ -315,8 +312,7 @@ public class PartRenderingEngineTests {
 
 		stack.setSelectedElement(partB);
 		assertEquals(
-				"Switching the active child should've changed the folder's selection",
-				1, tabFolder.getSelectionIndex());
+				1, tabFolder.getSelectionIndex(), "Switching the active child should've changed the folder's selection");
 	}
 
 	@Test
@@ -340,10 +336,9 @@ public class PartRenderingEngineTests {
 		stack.getChildren().add(partB);
 
 		assertEquals(
-				"Adding a part to a stack should not cause the stack's active child to change",
-				partA, stack.getSelectedElement());
-		assertNull("The object should not have been instantiated",
-				partB.getObject());
+				partA, stack.getSelectedElement(), "Adding a part to a stack should not cause the stack's active child to change");
+		assertNull(
+				partB.getObject(), "The object should not have been instantiated");
 	}
 
 	@Test
@@ -574,8 +569,7 @@ public class PartRenderingEngineTests {
 
 		partB.setToBeRendered(true);
 		assertEquals(
-				"Rendering another part in the stack should not change the selection",
-				0, tabFolder.getSelectionIndex());
+				0, tabFolder.getSelectionIndex(), "Rendering another part in the stack should not change the selection");
 		assertEquals(partA, stack.getSelectedElement());
 		assertEquals(2, tabFolder.getItemCount());
 		assertNotNull(partB.getObject());
@@ -628,8 +622,7 @@ public class PartRenderingEngineTests {
 		CTabFolder folder = (CTabFolder) stack.getWidget();
 		CTabItem itemA = folder.getItem(0);
 		assertEquals(
-				"The presentation engine should have created the part and set it",
-				partA.getWidget(), itemA.getControl());
+				partA.getWidget(), itemA.getControl(), "The presentation engine should have created the part and set it");
 
 		MPart partB = ems.createModelElement(MPart.class);
 		partB.setElementId("partB");
@@ -640,21 +633,19 @@ public class PartRenderingEngineTests {
 
 		CTabItem item2 = folder.getItem(1);
 		assertNull(
-				"For a stack, the object will not be rendered unless explicitly required",
-				item2.getControl());
+				item2.getControl(), "For a stack, the object will not be rendered unless explicitly required");
 
 		// ask the engine to render the part
 		engine.createGui(partB);
 
 		assertEquals(
-				"The presentation engine should have created the part and set it",
-				partB.getWidget(), item2.getControl());
+				partB.getWidget(), item2.getControl(), "The presentation engine should have created the part and set it");
 
 		// select the new part to display it to the user
 		stack.setSelectedElement(partB);
 
-		assertEquals("Selecting the element should not have changed anything",
-				partB.getWidget(), item2.getControl());
+		assertEquals(
+				partB.getWidget(), item2.getControl(), "Selecting the element should not have changed anything");
 	}
 
 	@Test
@@ -720,7 +711,7 @@ public class PartRenderingEngineTests {
 		} catch (IllegalArgumentException e) {
 			causedException = true;
 		}
-		assertFalse("Exception should not have been thrown", causedException);
+		assertFalse(causedException, "Exception should not have been thrown");
 
 		// You can *not* set the selected element to a non-child
 		causedException = false;
@@ -729,7 +720,7 @@ public class PartRenderingEngineTests {
 		} catch (IllegalArgumentException e) {
 			causedException = true;
 		}
-		assertTrue("Exception should have been thrown", causedException);
+		assertTrue(causedException, "Exception should have been thrown");
 	}
 
 	@Test
@@ -763,30 +754,28 @@ public class PartRenderingEngineTests {
 		container.setSelectedElement(partA);
 		partB.setToBeRendered(false);
 		assertEquals(
-				"Changing the TBR of a non-selected element should not change the value of the container's seletedElement",
-				partA, container.getSelectedElement());
+				partA, container.getSelectedElement(), "Changing the TBR of a non-selected element should not change the value of the container's seletedElement");
 
 
 		// Ensure that changing the TBR state of the selected element to false
 		// results in selecting moving to a TBR=true element
 		container.setSelectedElement(partA);
 		partA.setToBeRendered(false);
-		assertNotEquals("Changing the TBR of the selected element should have moved selection to a TBR item", partA,
-				container.getSelectedElement());
+		assertNotEquals(partA,
+				container.getSelectedElement(), "Changing the TBR of the selected element should have moved selection to a TBR item");
 
 		if ("gtk".equals(SWT.getPlatform())) {
 			assertTrue(
-					"Changing the TBR of the selected element should have moved selection to a TBR item",
-					container.getSelectedElement().isToBeRendered());
+					container.getSelectedElement().isToBeRendered(), "Changing the TBR of the selected element should have moved selection to a TBR item");
 
 			// Ensure that when all elements are TBR=false, selection is null
 			partC.setToBeRendered(false);
 			// Then there should be TBR item
-			assertNull("Changing the TBR of all elements to false should have set the field to null",
-					container.getSelectedElement());
+			assertNull(
+					container.getSelectedElement(), "Changing the TBR of all elements to false should have set the field to null");
 		} else {
-			assertNull("Changing the TBR of the selected element should have set the field to null",
-					container.getSelectedElement());
+			assertNull(
+					container.getSelectedElement(), "Changing the TBR of the selected element should have set the field to null");
 		}
 	}
 
@@ -821,15 +810,14 @@ public class PartRenderingEngineTests {
 		container.setSelectedElement(partA);
 		container.getChildren().remove(partB);
 		assertEquals(
-				"Changing the parent of a non-selected element should not change the value of the container's seletedElement",
-				partA, container.getSelectedElement());
+				partA, container.getSelectedElement(), "Changing the parent of a non-selected element should not change the value of the container's seletedElement");
 
 		// Ensure that changing the parent of the selected element
 		// results in it going null
 		container.setSelectedElement(partA);
 		container.getChildren().remove(partA);
-		assertNull("Changing the parent of the selected element should have set the field to null",
-				container.getSelectedElement());
+		assertNull(
+				container.getSelectedElement(), "Changing the parent of the selected element should have set the field to null");
 	}
 
 	@Test
@@ -968,7 +956,7 @@ public class PartRenderingEngineTests {
 		// if (checkMacBug466636())
 		// return;
 
-		assumeFalse("Test fails on Mac: Bug 537639", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 537639");
 
 		MWindow window = ems.createModelElement(MWindow.class);
 		application.getChildren().add(window);
@@ -1534,7 +1522,7 @@ public class PartRenderingEngineTests {
 		view.errorOnWidgetDisposal = true;
 
 		part.setToBeRendered(false);
-		assertTrue("The view should have been destroyed", view.isDestroyed());
+		assertTrue(view.isDestroyed(), "The view should have been destroyed");
 		assertNull(part.getObject());
 		assertNull(part.getContext());
 	}
@@ -1560,7 +1548,7 @@ public class PartRenderingEngineTests {
 		view.errorOnPreDestroy = true;
 
 		part.setToBeRendered(false);
-		assertTrue("The view should have been destroyed", view.isDestroyed());
+		assertTrue(view.isDestroyed(), "The view should have been destroyed");
 		assertNull(part.getObject());
 		assertNull(part.getContext());
 	}
@@ -1631,8 +1619,7 @@ public class PartRenderingEngineTests {
 		assertEquals(perspectiveContext1, partContext.getParent());
 		assertEquals(partContext, perspectiveContext1.getActiveChild());
 		assertNull(
-				"perspective2 doesn't have any parts, it should not have an active child context",
-				perspectiveContext2.getActiveChild());
+				perspectiveContext2.getActiveChild(), "perspective2 doesn't have any parts, it should not have an active child context");
 	}
 
 	@Test
@@ -1645,15 +1632,15 @@ public class PartRenderingEngineTests {
 
 		contextRule.createAndRunWorkbench(window);
 
-		assertNull("No widget for an unrendered window", window.getWidget());
-		assertNull("No context for an unrendered window", window.getContext());
+		assertNull(window.getWidget(), "No widget for an unrendered window");
+		assertNull(window.getContext(), "No context for an unrendered window");
 
 		window.setToBeRendered(true);
 
-		assertNotNull("Rendered window should have a widget",
-				window.getWidget());
-		assertNotNull("Rendered window should have a context",
-				window.getContext());
+		assertNotNull(
+				window.getWidget(), "Rendered window should have a widget");
+		assertNotNull(
+				window.getContext(), "Rendered window should have a context");
 	}
 
 	@Test
@@ -1666,15 +1653,15 @@ public class PartRenderingEngineTests {
 
 		contextRule.createAndRunWorkbench(window);
 
-		assertNotNull("Rendered window should have a widget",
-				window.getWidget());
-		assertNotNull("Rendered window should have a context",
-				window.getContext());
+		assertNotNull(
+				window.getWidget(), "Rendered window should have a widget");
+		assertNotNull(
+				window.getContext(), "Rendered window should have a context");
 
 		window.setToBeRendered(false);
 
-		assertNull("No widget for an unrendered window", window.getWidget());
-		assertNull("No context for an unrendered window", window.getContext());
+		assertNull(window.getWidget(), "No widget for an unrendered window");
+		assertNull(window.getContext(), "No context for an unrendered window");
 	}
 
 	@Test
@@ -1762,8 +1749,8 @@ public class PartRenderingEngineTests {
 		SampleToolControl impl = (SampleToolControl) toolControl.getObject();
 
 		appContext.get(IPresentationEngine.class).removeGui(window);
-		assertFalse("The shell should not have been disposed first",
-				impl.shellEagerlyDestroyed);
+		assertFalse(
+				impl.shellEagerlyDestroyed, "The shell should not have been disposed first");
 	}
 
 	@Test
@@ -1951,7 +1938,7 @@ public class PartRenderingEngineTests {
 		}
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void TODOtestBug326175_True() {
 		testBug326175(true);
@@ -1961,7 +1948,7 @@ public class PartRenderingEngineTests {
 	public void testBug326175_False() {
 		// if (checkMacBug466636())
 		// return;
-		assumeFalse("Test fails on Mac: Bug 537639", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 537639");
 
 		testBug326175(false);
 	}
@@ -2457,22 +2444,20 @@ public class PartRenderingEngineTests {
 		partService.hidePart(partA);
 		contextRule.spinEventLoop();
 
-		assertTrue(" PartStack with children should be rendered", partStackForPartBPartC.isToBeRendered());
+		assertTrue(partStackForPartBPartC.isToBeRendered(), " PartStack with children should be rendered");
 		partService.hidePart(partB);
 		partService.hidePart(partC);
 		// DisplayHelper.waitForCondition() handles event processing via Display.sleep()
 		// and retries. Calling spinEventLoop() here creates a race condition where
 		// events may be processed before CleanupAddon's asyncExec() is queued (line 352).
 		assertTrue(
-				"CleanupAddon should ensure that partStack is not rendered anymore, as all childs have been removed",
 				DisplayHelper.waitForCondition(Display.getDefault(), 5_000,
-						() -> !partStackForPartBPartC.isToBeRendered()));
+						() -> !partStackForPartBPartC.isToBeRendered()), "CleanupAddon should ensure that partStack is not rendered anymore, as all childs have been removed");
 		// PartStack with IPresentationEngine.NO_AUTO_COLLAPSE should not be removed
 		// even if children are removed
 		partService.hidePart(editor, true);
 		contextRule.spinEventLoop();
-		assertTrue("PartStack with IPresentationEngine.NO_AUTO_COLLAPSE should not be closed if children are removed",
-				partStackForEditor.isToBeRendered());
+		assertTrue(partStackForEditor.isToBeRendered(), "PartStack with IPresentationEngine.NO_AUTO_COLLAPSE should not be closed if children are removed");
 
 	}
 
@@ -2966,12 +2951,12 @@ public class PartRenderingEngineTests {
 		assertFalse(logged);
 	}
 
-	@Rule
-	public TestWatcher screenshotRule = Screenshots.onFailure(null);
+	// @Rule
+	// public TestWatcher screenshotRule = Screenshots.onFailure(null);
 
 	@Test
 	public void testBug372226() {
-		assumeFalse("Test fails on Mac: Bug 537639", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 537639");
 
 		MWindow window = ems.createModelElement(MWindow.class);
 
@@ -3126,8 +3111,7 @@ public class PartRenderingEngineTests {
 		view.errorOnWidgetDisposal = true;
 
 		part.setToBeRendered(false);
-		assertTrue("The view should have been destroyed",
-				view.isStatePersisted());
+		assertTrue(view.isStatePersisted(), "The view should have been destroyed");
 		assertNull(part.getObject());
 		assertNull(part.getContext());
 	}
@@ -3153,8 +3137,7 @@ public class PartRenderingEngineTests {
 		view.errorOnWidgetDisposal = true;
 
 		window.setToBeRendered(false);
-		assertTrue("The view should have been destroyed",
-				view.isStatePersisted());
+		assertTrue(view.isStatePersisted(), "The view should have been destroyed");
 		assertNull(part.getObject());
 		assertNull(part.getContext());
 	}

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/workbench/renderers/swt/MenuManagerRendererTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/workbench/renderers/swt/MenuManagerRendererTest.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.e4.ui.workbench.renderers.swt;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.inject.Inject;
 import org.eclipse.e4.ui.model.application.MApplication;
@@ -24,18 +24,18 @@ import org.eclipse.e4.ui.model.application.ui.basic.MTrimmedWindow;
 import org.eclipse.e4.ui.model.application.ui.menu.MDirectMenuItem;
 import org.eclipse.e4.ui.model.application.ui.menu.MMenu;
 import org.eclipse.e4.ui.model.application.ui.menu.MMenuItem;
-import org.eclipse.e4.ui.tests.rules.WorkbenchContextRule;
+import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.jface.action.MenuManager;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class MenuManagerRendererTest {
 
-	@Rule
-	public WorkbenchContextRule contextRule = new WorkbenchContextRule();
+	@RegisterExtension
+	public WorkbenchContextExtension contextRule = new WorkbenchContextExtension();
 
 	@Inject
 	private EModelService ems;
@@ -46,7 +46,7 @@ public class MenuManagerRendererTest {
 	private MMenu menu;
 	private MTrimmedWindow window;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		window = ems.createModelElement(MTrimmedWindow.class);
 		application.getChildren().add(window);
@@ -110,7 +110,7 @@ public class MenuManagerRendererTest {
 	}
 
 	@Test
-	@Ignore("Bug 560200")
+	@Disabled("Bug 560200")
 	public void testMMenu_ToBeRendered() {
 		MMenu submenu1 = ems.createModelElement(MMenu.class);
 		menu.getChildren().add(submenu1);

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRendererTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRendererTest.java
@@ -16,13 +16,13 @@
 
 package org.eclipse.e4.ui.workbench.renderers.swt;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.inject.Inject;
 import java.lang.reflect.InvocationHandler;
@@ -46,7 +46,7 @@ import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.model.application.ui.menu.MToolBar;
 import org.eclipse.e4.ui.services.IStylingEngine;
 import org.eclipse.e4.ui.services.internal.events.EventBroker;
-import org.eclipse.e4.ui.tests.rules.WorkbenchContextRule;
+import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
 import org.eclipse.e4.ui.workbench.UIEvents;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.swt.custom.CTabFolder;
@@ -57,17 +57,17 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Widget;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class StackRendererTest {
 
 	private static final String PART_DESC_ICON = "platform:/plugin/org.eclipse.e4.ui.tests/icons/pinned_ovr.svg";
 	private static final String PART_ICON = "platform:/plugin/org.eclipse.e4.ui.tests/icons/filenav_nav.svg";
 
-	@Rule
-	public WorkbenchContextRule contextRule = new WorkbenchContextRule();
+	@RegisterExtension
+	public WorkbenchContextExtension contextRule = new WorkbenchContextExtension();
 
 	@Inject
 	private IEclipseContext context;
@@ -81,7 +81,7 @@ public class StackRendererTest {
 	private MWindow window;
 	private MPartStack partStack;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		window = ems.createModelElement(MWindow.class);
 		application.getChildren().add(window);

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/workbench/renderers/swt/ToolBarManagerRendererTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/workbench/renderers/swt/ToolBarManagerRendererTest.java
@@ -14,11 +14,11 @@
 
 package org.eclipse.e4.ui.workbench.renderers.swt;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -38,7 +38,7 @@ import org.eclipse.e4.ui.model.application.ui.menu.MDirectToolItem;
 import org.eclipse.e4.ui.model.application.ui.menu.MToolBar;
 import org.eclipse.e4.ui.model.application.ui.menu.MToolBarContribution;
 import org.eclipse.e4.ui.model.application.ui.menu.MToolItem;
-import org.eclipse.e4.ui.tests.rules.WorkbenchContextRule;
+import org.eclipse.e4.ui.tests.rules.WorkbenchContextExtension;
 import org.eclipse.e4.ui.workbench.UIEvents;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.emf.common.util.ECollections;
@@ -46,15 +46,15 @@ import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.ToolBarManager;
 import org.eclipse.swt.SWTException;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.osgi.service.event.EventHandler;
 
 public class ToolBarManagerRendererTest {
 
-	@Rule
-	public WorkbenchContextRule contextRule = new WorkbenchContextRule();
+	@RegisterExtension
+	public WorkbenchContextExtension contextRule = new WorkbenchContextExtension();
 
 	@Inject
 	private EModelService ems;
@@ -69,7 +69,7 @@ public class ToolBarManagerRendererTest {
 	private MToolBar toolBar;
 	private MTrimmedWindow window;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		window = ems.createModelElement(MTrimmedWindow.class);
 		application.getChildren().add(window);
@@ -166,7 +166,7 @@ public class ToolBarManagerRendererTest {
 			contextRule.createAndRunWorkbench(window);
 
 			assertNull(toolBar.getRenderer());
-			assertTrue("Error(s) occurred while rendering toolbar: " + errors, errors.isEmpty());
+			assertTrue(errors.isEmpty(), "Error(s) occurred while rendering toolbar: " + errors);
 		} finally {
 			eventBroker.unsubscribe(eventHandler);
 			Platform.removeLogListener(logListener);
@@ -522,7 +522,7 @@ public class ToolBarManagerRendererTest {
 		// Create toolbar items with visibleWhen expressions
 		MToolItem toolItem1 = ems.createModelElement(MDirectToolItem.class);
 		toolItem1.setElementId("Item1");
-		
+
 		// Create an imperative expression that checks for a context variable
 		MImperativeExpression exp1 = ems.createModelElement(MImperativeExpression.class);
 		exp1.setTracking(true);
@@ -539,26 +539,26 @@ public class ToolBarManagerRendererTest {
 
 		// Initially, item1 should be hidden (expression returns false when showItem1 is not set)
 		assertEquals(2, tbm.getSize());
-		assertFalse("Item1 should be hidden initially", toolItem1.isVisible());
-		assertTrue("Item2 should be visible", toolItem2.isVisible());
+		assertFalse(toolItem1.isVisible(), "Item1 should be hidden initially");
+		assertTrue(toolItem2.isVisible(), "Item2 should be visible");
 
 		// Set context variable to show item1
 		window.getContext().set("showItem1", Boolean.TRUE);
-		
+
 		// Force context update by spinning the event loop
 		contextRule.spinEventLoop();
 
 		// Now item1 should be visible
-		assertTrue("Item1 should be visible after setting context variable", toolItem1.isVisible());
-		assertTrue("Item2 should still be visible", toolItem2.isVisible());
+		assertTrue(toolItem1.isVisible(), "Item1 should be visible after setting context variable");
+		assertTrue(toolItem2.isVisible(), "Item2 should still be visible");
 
 		// Hide item1 again
 		window.getContext().set("showItem1", Boolean.FALSE);
 		contextRule.spinEventLoop();
 
 		// Item1 should be hidden again
-		assertFalse("Item1 should be hidden after removing context variable", toolItem1.isVisible());
-		assertTrue("Item2 should still be visible", toolItem2.isVisible());
+		assertFalse(toolItem1.isVisible(), "Item1 should be hidden after removing context variable");
+		assertTrue(toolItem2.isVisible(), "Item2 should still be visible");
 	}
 
 	/**


### PR DESCRIPTION
This PR migrates the following tests to JUnit 5:
- StackRendererTest
- ToolBarManagerRendererTest
- MPartTest
- MWindowTest
- PartOnTopManagerTest
- MenuManagerRendererTest
- PartRenderingEngineTests

Key changes:
- Replaced WorkbenchContextRule with WorkbenchContextExtension
- Updated imports to org.junit.jupiter.api.*
- Updated annotations (@Before -> @BeforeEach, etc.)
- Swapped assertion arguments where necessary
- Updated assumptions
- Added org.opentest4j dependency for assumptions

Verified with Maven Tycho.