### PR TITLE
Migrate HeadlessApplicationRule to JUnit 5 Extension

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/HeadlessApplicationElementTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/HeadlessApplicationElementTest.java
@@ -17,23 +17,23 @@ package org.eclipse.e4.ui.tests.application;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.internal.workbench.UIEventPublisher;
 import org.eclipse.e4.ui.model.application.MApplicationElement;
-import org.eclipse.e4.ui.tests.rules.HeadlessApplicationRule;
+import org.eclipse.e4.ui.tests.rules.HeadlessApplicationExtension;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.emf.common.notify.Notifier;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public abstract class HeadlessApplicationElementTest {
 
 	protected MApplicationElement applicationElement;
 	protected EModelService ems;
 
-	@Rule
-	public HeadlessApplicationRule rule = new HeadlessApplicationRule();
+	@RegisterExtension
+	public HeadlessApplicationExtension extension = new HeadlessApplicationExtension();
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-		IEclipseContext applicationContext = rule.getApplicationContext();
+		IEclipseContext applicationContext = extension.getApplicationContext();
 		applicationElement = createApplicationElement(applicationContext);
 		ems = applicationContext.get(EModelService.class);
 

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/HeadlessApplicationTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/HeadlessApplicationTest.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.HashSet;
 import java.util.List;
@@ -49,9 +49,9 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class HeadlessApplicationTest extends HeadlessApplicationElementTest {
 
@@ -59,7 +59,7 @@ public abstract class HeadlessApplicationTest extends HeadlessApplicationElement
 
 	protected IPresentationEngine renderer;
 
-	@Before
+	@BeforeEach
 	@Override
 
 	public void setUp() throws Exception {
@@ -76,7 +76,7 @@ public abstract class HeadlessApplicationTest extends HeadlessApplicationElement
 		}
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		for (MWindow window : application.getChildren()) {
 			renderer.removeGui(window);
@@ -233,10 +233,10 @@ public abstract class HeadlessApplicationTest extends HeadlessApplicationElement
 	protected abstract String getURI();
 
 	protected IPresentationEngine createPresentationEngine(String renderingEngineURI) throws Exception {
-		IContributionFactory contributionFactory = rule.getApplicationContext()
+		IContributionFactory contributionFactory = extension.getApplicationContext()
 				.get(IContributionFactory.class);
 		Object newEngine = contributionFactory.create(renderingEngineURI,
-				rule.getApplicationContext());
+				extension.getApplicationContext());
 		return (IPresentationEngine) newEngine;
 	}
 

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/UIEventTypesTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/UIEventTypesTest.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import org.eclipse.e4.core.contexts.IEclipseContext;
@@ -25,8 +25,8 @@ import org.eclipse.e4.ui.model.application.MApplicationElement;
 import org.eclipse.e4.ui.model.application.MApplicationFactory;
 import org.eclipse.e4.ui.workbench.UIEvents;
 import org.eclipse.emf.common.util.EList;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.osgi.service.event.Event;
 
 /**
@@ -42,11 +42,11 @@ public class UIEventTypesTest extends HeadlessApplicationElementTest {
 		return MApplicationFactory.INSTANCE.createApplication();
 	}
 
-	@Before
+	@BeforeEach
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		IEventBroker appEB = rule.getApplicationContext().get(IEventBroker.class);
+		IEventBroker appEB = extension.getApplicationContext().get(IEventBroker.class);
 
 		eventCount = 0;
 		appEB.subscribe(UIEvents.ApplicationElement.TOPIC_TAGS, event -> {
@@ -174,8 +174,8 @@ public class UIEventTypesTest extends HeadlessApplicationElementTest {
 		assertEquals(UIEvents.ApplicationElement.TAGS, event.getProperty(UIEvents.EventTags.ATTNAME));
 		assertEquals(UIEvents.EventTypes.MOVE, event.getProperty(UIEvents.EventTags.TYPE));
 		assertEquals("2", event.getProperty(UIEvents.EventTags.NEW_VALUE));
-		assertEquals("former position", 2, event.getProperty(UIEvents.EventTags.OLD_VALUE));
-		assertEquals("new position", 0, event.getProperty(UIEvents.EventTags.POSITION));
+		assertEquals(2, event.getProperty(UIEvents.EventTags.OLD_VALUE), "former position");
+		assertEquals(0, event.getProperty(UIEvents.EventTags.POSITION), "new position");
 	}
 
 	@Test

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/UIEventsTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/UIEventsTest.java
@@ -14,11 +14,11 @@
 
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,7 +47,7 @@ import org.eclipse.e4.ui.workbench.UIEvents.UIElement;
 import org.eclipse.e4.ui.workbench.UIEvents.UILabel;
 import org.eclipse.e4.ui.workbench.UIEvents.Window;
 import org.eclipse.emf.common.notify.Notifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.service.event.EventHandler;
 
 public class UIEventsTest extends HeadlessApplicationElementTest {
@@ -62,14 +62,14 @@ public class UIEventsTest extends HeadlessApplicationElementTest {
 		EventHandler attListener = event -> {
 			// In case of * topic check that that event topic starts with the same prefix
 			if (topic.endsWith("*")) {
-				assertTrue("Incorrect Topic.", event.getTopic().startsWith(topic.substring(0, topic.length() - 2)));
+				assertTrue(event.getTopic().startsWith(topic.substring(0, topic.length() - 2)), "Incorrect Topic.");
 			} else {
-				assertEquals("Incorrect Topic.", topic, event.getTopic());
+				assertEquals(topic, event.getTopic(), "Incorrect Topic.");
 			}
 
 			String attId = (String) event.getProperty(EventTags.ATTNAME);
 			int attIndex = getAttIndex(attId);
-			assertTrue("Unknown Attribite: " + attId, attIndex >= 0); //$NON-NLS-1$
+			assertTrue(attIndex >= 0, "Unknown Attribite: " + attId); //$NON-NLS-1$
 			hasFired[attIndex] = true;
 		};
 
@@ -201,7 +201,7 @@ public class UIEventsTest extends HeadlessApplicationElementTest {
 
 	@Test
 	public void testAllTopics() {
-		IEventBroker eventBroker = rule.getApplicationContext().get(IEventBroker.class);
+		IEventBroker eventBroker = extension.getApplicationContext().get(IEventBroker.class);
 
 		// Create a tester for each topic
 		AppElementTester appTester = new AppElementTester(eventBroker);
@@ -225,9 +225,9 @@ public class UIEventsTest extends HeadlessApplicationElementTest {
 
 		// Create the test harness and hook up the event publisher
 		MTestHarness allData = MTestFactory.eINSTANCE.createTestHarness();
-		final UIEventPublisher ep = new UIEventPublisher(rule.getApplicationContext());
+		final UIEventPublisher ep = new UIEventPublisher(extension.getApplicationContext());
 		((Notifier) allData).eAdapters().add(ep);
-		rule.getApplicationContext().set(UIEventPublisher.class, ep);
+		extension.getApplicationContext().set(UIEventPublisher.class, ep);
 
 		// AppElement
 		reset(allTesters);
@@ -241,8 +241,7 @@ public class UIEventsTest extends HeadlessApplicationElementTest {
 		// Test that no-ops don't throw events
 		appTester.reset();
 		allData.setElementId(newId);
-		assertTrue("event thrown on No-Op",
-				appTester.getAttIds(true).length == 0);
+		assertTrue(appTester.getAttIds(true).length == 0, "event thrown on No-Op");
 
 		// Command
 		reset(allTesters);
@@ -318,11 +317,11 @@ public class UIEventsTest extends HeadlessApplicationElementTest {
 	@Test
 	public void testBrokerCleanup() {
 		final String testTopic = "test/374534";
-		IEventBroker appEB = rule.getApplicationContext().get(IEventBroker.class);
+		IEventBroker appEB = extension.getApplicationContext().get(IEventBroker.class);
 
-		IEclipseContext childContext = rule.getApplicationContext().createChild();
+		IEclipseContext childContext = extension.getApplicationContext().createChild();
 		IEventBroker childEB = childContext.get(IEventBroker.class);
-		assertNotEquals("child context has same IEventBroker", appEB, childEB);
+		assertNotEquals(appEB, childEB, "child context has same IEventBroker");
 
 		final boolean[] seen = { false };
 		childEB.subscribe(testTopic, event -> seen[0] = true);

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/UIStartupTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/UIStartupTest.java
@@ -14,8 +14,8 @@
 
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.core.databinding.observable.Realm;
 import org.eclipse.e4.core.contexts.IEclipseContext;
@@ -30,16 +30,16 @@ import org.eclipse.e4.ui.services.IStylingEngine;
 import org.eclipse.e4.ui.workbench.IResourceUtilities;
 import org.eclipse.jface.databinding.swt.DisplayRealm;
 import org.eclipse.swt.widgets.Display;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.css.CSSStyleDeclaration;
 
 public abstract class UIStartupTest extends HeadlessApplicationTest {
 
 	protected Display display;
 
-	@Before
+	@BeforeEach
 	@Override
 	public void setUp() throws Exception {
 		display = Display.getDefault();
@@ -48,7 +48,7 @@ public abstract class UIStartupTest extends HeadlessApplicationTest {
 		}
 	}
 
-	@After
+	@AfterEach
 	@Override
 	public void tearDown() throws Exception {
 		super.tearDown();
@@ -158,7 +158,7 @@ public abstract class UIStartupTest extends HeadlessApplicationTest {
 	protected IEclipseContext createApplicationContext() {
 		final IEclipseContext[] contexts = new IEclipseContext[1];
 		Realm.runWithDefault(DisplayRealm.getRealm(display), () -> {
-			contexts[0] = rule.getApplicationContext();
+			contexts[0] = extension.getApplicationContext();
 			contexts[0].set(IResourceUtilities.class.getName(), new ResourceUtility());
 			contexts[0].set(IStylingEngine.class, new IStylingEngine() {
 				@Override
@@ -195,5 +195,6 @@ public abstract class UIStartupTest extends HeadlessApplicationTest {
 	protected void createGUI(final MUIElement uiRoot) {
 		Realm.runWithDefault(DisplayRealm.getRealm(display), () -> UIStartupTest.super.createGUI(uiRoot));
 	}
+
 
 }

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/rules/HeadlessApplicationExtension.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/rules/HeadlessApplicationExtension.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2018 vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lars Vogel <Lars.Vogel@vogella.com> - initial API and implementation
+ ******************************************************************************/
+
+package org.eclipse.e4.ui.tests.rules;
+
+import org.eclipse.e4.core.commands.CommandServiceAddon;
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.ui.internal.workbench.swt.E4Application;
+import org.eclipse.e4.ui.services.ContextServiceAddon;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+
+public class HeadlessApplicationExtension implements BeforeEachCallback, AfterEachCallback {
+	private IEclipseContext applicationContext;
+
+	/**
+	 * @return the applicationContext
+	 */
+	public IEclipseContext getApplicationContext() {
+		return applicationContext;
+	}
+
+	@Override
+	public void beforeEach(ExtensionContext context) throws Exception {
+		applicationContext = createApplicationContext();
+	}
+
+	@Override
+	public void afterEach(ExtensionContext context) throws Exception {
+		if (applicationContext != null) {
+			applicationContext.dispose();
+		}
+	}
+
+	protected IEclipseContext createApplicationContext() {
+		final IEclipseContext appContext = E4Application.createDefaultContext();
+		ContextInjectionFactory.make(CommandServiceAddon.class, appContext);
+		ContextInjectionFactory.make(ContextServiceAddon.class, appContext);
+		return appContext;
+	}
+}


### PR DESCRIPTION
This PR migrates the usage of the JUnit 4 `HeadlessApplicationRule` to a new JUnit 5 `HeadlessApplicationExtension`.

Changes include:
- Created `HeadlessApplicationExtension` which implements `BeforeEachCallback` and `AfterEachCallback`.
- Updated `HeadlessApplicationElementTest` to use `@RegisterExtension` and JUnit 5 annotations.
- Updated `HeadlessApplicationTest` and its subclasses (`UIEventTypesTest`, `UIEventsTest`, `HeadlessContactsDemoTest`, `HeadlessPhotoDemoTest`, `UIStartupTest`) to use JUnit 5 imports, annotations, and assertions.
- Verified that no regressions were introduced by running the tests for `org.eclipse.e4.ui.tests`.