### PR TITLE
Fix flaky test QuickAccessComputerTest.testQuickAccessComputer

### DIFF
--- a/tests/org.eclipse.text.quicksearch.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.text.quicksearch.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.text.quicksearch.tests
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.text.quicksearch;bundle-version="1.0.300",
  org.eclipse.core.resources,

--- a/tests/org.eclipse.text.quicksearch.tests/src/org/eclipse/text/quicksearch/tests/QuickAccessComputerTest.java
+++ b/tests/org.eclipse.text.quicksearch.tests/src/org/eclipse/text/quicksearch/tests/QuickAccessComputerTest.java
@@ -55,7 +55,7 @@ class QuickAccessComputerTest {
 		dialog.setBlockOnOpen(false);
 		dialog.open();
 		var display = dialog.getShell().getDisplay();
-		assertTrue(DisplayHelper.waitForCondition(display, 2000, () -> dialog.getResult().length > 0));
+		assertTrue(DisplayHelper.waitForCondition(display, 5000, () -> dialog.getResult().length > 0), "QuickSearchDialog failed to find results within timeout");
 		dialog.close();
 
 		// Wait for the QuickAccessComputer to return results, as the search happens asynchronously.


### PR DESCRIPTION
Increased timeout from 2000ms to 5000ms to avoid intermittent failures on slower CI systems. Added assertion message for better debugging.