### PR TITLE
Fix EditorSwitchTest opening external terminals

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/plugin.xml
+++ b/tests/org.eclipse.ui.tests.performance/plugin.xml
@@ -19,6 +19,13 @@
             name="Editor w/Outline"
             id="org.eclipse.ui.tests.perf_outline"
             extensions="perf_outline"/>
+      <editor
+            icon="icons/anything.gif"
+            class="org.eclipse.ui.tests.performance.parts.PerformanceEditorPart"
+            default="true"
+            name="Basic Performance Editor 2"
+            id="org.eclipse.ui.tests.perf_basic2"
+            extensions="perf_text"/>
    </extension>
    <extension
          point="org.eclipse.ui.perspectives">

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/EditorSwitchTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/EditorSwitchTest.java
@@ -54,7 +54,7 @@ public class EditorSwitchTest extends PerformanceTestCaseJunit4 {
 
 	@Parameters(name = "{index}: {0} - {1}")
 	public static Collection<Object[]> data() {
-		return Arrays.asList(new Object[][] { { "perf_outline", "java" }, { "perf_basic", "perf_outline" } });
+		return Arrays.asList(new Object[][] { { "perf_outline", "perf_text" }, { "perf_basic", "perf_outline" } });
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseEditorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenCloseEditorTest.java
@@ -52,7 +52,7 @@ public class OpenCloseEditorTest extends PerformanceTestCaseJunit4 {
 
 	@Parameters(name = "{index}: {0}")
 	public static Collection<Object[]> data() {
-		return Arrays.asList(new Object[][] { { "perf_basic" }, { "perf_outline" }, { "java" } });
+		return Arrays.asList(new Object[][] { { "perf_basic" }, { "perf_outline" }, { "perf_text" } });
 	}
 
 
@@ -85,7 +85,7 @@ public class OpenCloseEditorTest extends PerformanceTestCaseJunit4 {
 			stopMeasuring();
 		});
 
-		if (extension.equals("java")) {
+		if (extension.equals("perf_text")) {
 			tagAsSummary("UI - Open/Close Editor", Dimension.ELAPSED_PROCESS);
 		}
 		commitMeasurements();

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenMultipleEditorTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/OpenMultipleEditorTest.java
@@ -52,8 +52,8 @@ public class OpenMultipleEditorTest extends PerformanceTestCaseJunit4 {
 
 	@Parameters(name = "{index}: closeAll: {0} - closeEach: {1}")
 	public static Collection<Object[]> data() {
-		return Arrays.asList(new Object[][] { { "perf_basic", true }, { "perf_outline", true }, { "java", true },
-				{ "perf_basic", false }, { "perf_outline", false }, { "java", false } });
+		return Arrays.asList(new Object[][] { { "perf_basic", true }, { "perf_outline", true }, { "perf_text", true },
+				{ "perf_basic", false }, { "perf_outline", false }, { "perf_text", false } });
 	}
 
 	public OpenMultipleEditorTest(String extension, boolean closeAll) {

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/UIPerformanceTestRule.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/UIPerformanceTestRule.java
@@ -32,7 +32,7 @@ public class UIPerformanceTestRule extends ExternalResource {
 	public static final String PROJECT_NAME = "Performance Project";
 
 	private static final String INTRO_VIEW = "org.eclipse.ui.internal.introview";
-	public static final String[] EDITOR_FILE_EXTENSIONS = { "perf_basic", "perf_outline", "java" };
+	public static final String[] EDITOR_FILE_EXTENSIONS = { "perf_basic", "perf_outline", "perf_text" };
 
 	@Override
 	protected void before() throws Throwable {
@@ -67,7 +67,7 @@ public class UIPerformanceTestRule extends ExternalResource {
 	}
 
 	private static void setUpProject() throws CoreException {
-		// Create a java project.
+		// Create a performance project.
 		IProject testProject = getTestProject();
 		testProject.create(null);
 		testProject.open(null);


### PR DESCRIPTION
Replace the usage of ".java" extension with a custom ".perf_text" extension in performance tests.

The use of ".java" caused the OS to open external editors/terminals in environments where JDT is not installed or configured as the default editor.

This change ensures that an internal test editor is used, keeping the tests self-contained and preventing external side effects.