### PR TITLE
Migrate GenerateIdentifiersTest and LabelProviderTest to JUnit 5

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.performance/META-INF/MANIFEST.MF
@@ -21,6 +21,9 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.208.0",
  org.eclipse.ui.navigator.resources,
  org.eclipse.ui.genericeditor
 Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.extension;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.params;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.params.provider;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/UIPerformanceTestRule.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/UIPerformanceTestRule.java
@@ -23,9 +23,12 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.rules.ExternalResource;
 
-public class UIPerformanceTestRule extends ExternalResource {
+public class UIPerformanceTestRule extends ExternalResource implements BeforeAllCallback, AfterAllCallback {
 	public static final String PERSPECTIVE1 = "org.eclipse.ui.tests.performancePerspective1";
 	public static final String PERSPECTIVE2 = "org.eclipse.ui.tests.performancePerspective2";
 
@@ -33,6 +36,22 @@ public class UIPerformanceTestRule extends ExternalResource {
 
 	private static final String INTRO_VIEW = "org.eclipse.ui.internal.introview";
 	public static final String[] EDITOR_FILE_EXTENSIONS = { "perf_basic", "perf_outline", "perf_text" };
+
+	@Override
+	public void beforeAll(ExtensionContext context) throws Exception {
+		try {
+			before();
+		} catch (Exception e) {
+			throw e;
+		} catch (Throwable e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void afterAll(ExtensionContext context) throws Exception {
+		after();
+	}
 
 	@Override
 	protected void before() throws Throwable {


### PR DESCRIPTION
Migrate performance tests to JUnit 5 to avoid dependency on PerformanceTestCaseJunit4.

- Update UIPerformanceTestRule to implement BeforeAllCallback and AfterAllCallback.
- Migrate GenerateIdentifiersTest and LabelProviderTest to use PerformanceMeter directly.
- Use CloseTestWindowsExtension instead of CloseTestWindowsRule.
- Add necessary JUnit 5 imports to MANIFEST.MF.

This is part of the work for issue #3639.