### PR TITLE
Migrate JFace Performance Tests to JUnit 5

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/CollatorPerformanceTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/CollatorPerformanceTest.java
@@ -19,18 +19,20 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 import org.eclipse.jface.util.Policy;
-import org.eclipse.test.performance.PerformanceTestCaseJunit4;
+import org.eclipse.test.performance.Performance;
+import org.eclipse.test.performance.PerformanceMeter;
 import org.eclipse.ui.tests.performance.UIPerformanceTestRule;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @since 3.5
  */
-public class CollatorPerformanceTest extends PerformanceTestCaseJunit4 {
+public class CollatorPerformanceTest {
 
-	@ClassRule
-	public static final UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
+	@RegisterExtension
+	static UIPerformanceTestRule uiPerformanceTestRule = new UIPerformanceTestRule();
 
 	private static final int ARRAYSIZE=100000;
 	private static String[] fArray;
@@ -43,16 +45,24 @@ public class CollatorPerformanceTest extends PerformanceTestCaseJunit4 {
 	 *  test Collator by sorting the array
 	 */
 	@Test
-	public void testCollator(){
+	public void testCollator(TestInfo testInfo) {
+		Performance perf = Performance.getDefault();
+		String scenarioId = this.getClass().getName() + "." + testInfo.getDisplayName();
+		PerformanceMeter meter = perf.createPerformanceMeter(scenarioId);
+
 		Comparator<Object> comparator=Policy.getComparator();
-		for (int i = 0; i < 15; i++) {
-			String[] array=fArray.clone();
-			startMeasuring();
-			Arrays.sort(array, comparator);
-			stopMeasuring();
+		try {
+			for (int i = 0; i < 15; i++) {
+				String[] array=fArray.clone();
+				meter.start();
+				Arrays.sort(array, comparator);
+				meter.stop();
+			}
+			meter.commit();
+			perf.assertPerformance(meter);
+		} finally {
+			meter.dispose();
 		}
-		commitMeasurements();
-		assertPerformance();
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListPopulationTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/ListPopulationTest.java
@@ -22,19 +22,21 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.List;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.test.performance.PerformanceTestCaseJunit4;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.test.performance.Performance;
+import org.eclipse.test.performance.PerformanceMeter;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * The ListPopulationTest is the test for simple
  * SWT lists.
  */
-public class ListPopulationTest extends PerformanceTestCaseJunit4 {
+public class ListPopulationTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	@RegisterExtension
+	CloseTestWindowsExtension closeTestWindows = new CloseTestWindowsExtension();
 
 	List list;
 
@@ -52,72 +54,89 @@ public class ListPopulationTest extends PerformanceTestCaseJunit4 {
 	}
 
 	@Test
-	public void testSmallAdd() throws Throwable {
-		addBench(100);
+	public void testSmallAdd(TestInfo testInfo) throws Throwable {
+		addBench(100, testInfo);
 	}
 
 	@Test
-	public void testSmallSetItems() throws Throwable {
-		setItemsBench(100);
+	public void testSmallSetItems(TestInfo testInfo) throws Throwable {
+		setItemsBench(100, testInfo);
 	}
 
 	@Test
-	public void testMediumAdd() throws Throwable {
-		addBench(5000);
+	public void testMediumAdd(TestInfo testInfo) throws Throwable {
+		addBench(5000, testInfo);
 	}
 
 	@Test
-	public void testMediumSetItems() throws Throwable {
-		setItemsBench(5000);
+	public void testMediumSetItems(TestInfo testInfo) throws Throwable {
+		setItemsBench(5000, testInfo);
 	}
 
 	@Test
-	public void testLargeAdd() throws Throwable {
-		addBench(50000);
+	public void testLargeAdd(TestInfo testInfo) throws Throwable {
+		addBench(50000, testInfo);
 	}
 
 	@Test
-	public void testLargeSetItems() throws Throwable {
-		setItemsBench(50000);
+	public void testLargeSetItems(TestInfo testInfo) throws Throwable {
+		setItemsBench(50000, testInfo);
 	}
 
 	/**
 	 * Test the time for adding elements using add.
 	 */
-	public void addBench(int count) throws Throwable {
+	public void addBench(int count, TestInfo testInfo) throws Throwable {
 		openBrowser();
 		final String [] items = getItems(count);
 
-		exercise(() -> {
-			list.removeAll();
-			startMeasuring();
-			for (String item : items) {
-				list.add(item);
-			}
-			processEvents();
-			stopMeasuring();
-		});
+		Performance perf = Performance.getDefault();
+		String scenarioId = this.getClass().getName() + "." + testInfo.getDisplayName();
+		PerformanceMeter meter = perf.createPerformanceMeter(scenarioId);
 
-		commitMeasurements();
-		assertPerformance();
+		try {
+			exercise(() -> {
+				list.removeAll();
+				meter.start();
+				for (String item : items) {
+					list.add(item);
+				}
+				processEvents();
+				meter.stop();
+			});
+
+			meter.commit();
+			perf.assertPerformance(meter);
+		} finally {
+			meter.dispose();
+		}
 	}
 
 	/**
 	 * Test the time for adding elements using setItem.
 	 */
-	public void setItemsBench(int count) throws Throwable {
+	public void setItemsBench(int count, TestInfo testInfo) throws Throwable {
 		openBrowser();
 		final String [] items = getItems(count);
-		exercise(() -> {
-			list.removeAll();
-			startMeasuring();
-			list.setItems(items);
-			processEvents();
-			stopMeasuring();
-		});
 
-		commitMeasurements();
-		assertPerformance();
+		Performance perf = Performance.getDefault();
+		String scenarioId = this.getClass().getName() + "." + testInfo.getDisplayName();
+		PerformanceMeter meter = perf.createPerformanceMeter(scenarioId);
+
+		try {
+			exercise(() -> {
+				list.removeAll();
+				meter.start();
+				list.setItems(items);
+				processEvents();
+				meter.stop();
+			});
+
+			meter.commit();
+			perf.assertPerformance(meter);
+		} finally {
+			meter.dispose();
+		}
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/SWTTreeTest.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/jface/tests/performance/SWTTreeTest.java
@@ -23,15 +23,17 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
-import org.eclipse.test.performance.PerformanceTestCaseJunit4;
-import org.eclipse.ui.tests.harness.util.CloseTestWindowsRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.eclipse.test.performance.Performance;
+import org.eclipse.test.performance.PerformanceMeter;
+import org.eclipse.ui.tests.harness.util.CloseTestWindowsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class SWTTreeTest extends PerformanceTestCaseJunit4 {
+public class SWTTreeTest {
 
-	@Rule
-	public final CloseTestWindowsRule closeTestWindows = new CloseTestWindowsRule();
+	@RegisterExtension
+	CloseTestWindowsExtension closeTestWindows = new CloseTestWindowsExtension();
 
 	Shell browserShell;
 
@@ -64,22 +66,30 @@ public class SWTTreeTest extends PerformanceTestCaseJunit4 {
 	 * Test the getItems API.
 	 */
 	@Test
-	public void testGetItems() throws CoreException {
+	public void testGetItems(TestInfo testInfo) throws CoreException {
 		openBrowser();
 
-		exercise(() -> {
-			processEvents();
-			startMeasuring();
-			for (int j = 0; j < TreeAddTest.TEST_COUNT; j++) {
-				tree.getItems();
-				processEvents();
-			}
-			stopMeasuring();
-		});
+		Performance perf = Performance.getDefault();
+		String scenarioId = this.getClass().getName() + "." + testInfo.getDisplayName();
+		PerformanceMeter meter = perf.createPerformanceMeter(scenarioId);
 
-		commitMeasurements();
-		assertPerformance();
-		browserShell.close();
+		try {
+			exercise(() -> {
+				processEvents();
+				meter.start();
+				for (int j = 0; j < TreeAddTest.TEST_COUNT; j++) {
+					tree.getItems();
+					processEvents();
+				}
+				meter.stop();
+			});
+
+			meter.commit();
+			perf.assertPerformance(meter);
+		} finally {
+			meter.dispose();
+			browserShell.close();
+		}
 	}
 
 	/**
@@ -87,22 +97,30 @@ public class SWTTreeTest extends PerformanceTestCaseJunit4 {
 	 * Test the getItem API.
 	 */
 	@Test
-	public void testGetItemAt() throws CoreException {
+	public void testGetItemAt(TestInfo testInfo) throws CoreException {
 		openBrowser();
 
-		exercise(() -> {
-			processEvents();
-			startMeasuring();
-			for (int j = 0; j < TreeAddTest.TEST_COUNT; j++) {
-				tree.getItem(j);
-				processEvents();
-			}
-			stopMeasuring();
-		});
+		Performance perf = Performance.getDefault();
+		String scenarioId = this.getClass().getName() + "." + testInfo.getDisplayName();
+		PerformanceMeter meter = perf.createPerformanceMeter(scenarioId);
 
-		commitMeasurements();
-		assertPerformance();
-		browserShell.close();
+		try {
+			exercise(() -> {
+				processEvents();
+				meter.start();
+				for (int j = 0; j < TreeAddTest.TEST_COUNT; j++) {
+					tree.getItem(j);
+					processEvents();
+				}
+				meter.stop();
+			});
+
+			meter.commit();
+			perf.assertPerformance(meter);
+		} finally {
+			meter.dispose();
+			browserShell.close();
+		}
 	}
 
 }


### PR DESCRIPTION
Migrate JFace performance tests to JUnit 5 to avoid dependency on PerformanceTestCaseJunit4.