### PR TITLE
Use Generic Editor in performance tests

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.performance/META-INF/MANIFEST.MF
@@ -18,7 +18,8 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.208.0",
  org.eclipse.ui.views,
  org.eclipse.e4.core.contexts,
  org.eclipse.ui.navigator,
- org.eclipse.ui.navigator.resources
+ org.eclipse.ui.navigator.resources,
+ org.eclipse.ui.genericeditor
 Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-ActivationPolicy: lazy

--- a/tests/org.eclipse.ui.tests.performance/plugin.xml
+++ b/tests/org.eclipse.ui.tests.performance/plugin.xml
@@ -6,7 +6,7 @@
          point="org.eclipse.ui.editors">
       <editor
             icon="icons/anything.gif"
-            class="org.eclipse.ui.tests.performance.parts.PerformanceEditorPart"
+            class="org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor"
             default="true"
             name="Basic Performance Editor"
             id="org.eclipse.ui.tests.perf_basic"
@@ -14,14 +14,14 @@
             
       <editor
             icon="icons/anything.gif"
-            class="org.eclipse.ui.tests.performance.parts.PerformanceEditorPart:outline"
+            class="org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor"
             default="true"
             name="Editor w/Outline"
             id="org.eclipse.ui.tests.perf_outline"
             extensions="perf_outline"/>
       <editor
             icon="icons/anything.gif"
-            class="org.eclipse.ui.tests.performance.parts.PerformanceEditorPart"
+            class="org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor"
             default="true"
             name="Basic Performance Editor 2"
             id="org.eclipse.ui.tests.perf_basic2"


### PR DESCRIPTION
Replace the custom PerformanceEditorPart with the Generic Editor (ExtensionBasedTextEditor) for performance tests. This provides a more realistic test environment by using a real editor implementation. The plugin.xml configuration is updated to map the performance test extensions to the Generic Editor.