### PR TITLE
Replace Image(Device, ImageData) with Image(Device, ImageDataProvider)

### DIFF
--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/FormUtil.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/FormUtil.java
@@ -25,6 +25,7 @@ import org.eclipse.swt.graphics.FontMetrics;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
@@ -485,25 +486,29 @@ public class FormUtil {
 	}
 
 	public static Image createAlphaMashImage(Device device, Image srcImage) {
-		Rectangle bounds = srcImage.getBounds();
-		int alpha = 0;
-		int calpha = 0;
-		ImageData data = srcImage.getImageData();
-		// Create a new image with alpha values alternating
-		// between fully transparent (0) and fully opaque (255).
-		// This image will show the background through the
-		// transparent pixels.
-		for (int i = 0; i < bounds.height; i++) {
-			// scan line
-			alpha = calpha;
-			for (int j = 0; j < bounds.width; j++) {
-				// column
-				data.setAlpha(j, i, alpha);
-				alpha = alpha == 255 ? 0 : 255;
+
+		ImageDataProvider imageDataProvider = zoom -> {
+			int alpha = 0;
+			int calpha = 0;
+			ImageData data = srcImage.getImageData(zoom);
+			// Create a new image with alpha values alternating
+			// between fully transparent (0) and fully opaque (255).
+			// This image will show the background through the
+			// transparent pixels.
+			for (int i = 0; i < data.height; i++) {
+				// scan line
+				alpha = calpha;
+				for (int j = 0; j < data.width; j++) {
+					// column
+					data.setAlpha(j, i, alpha);
+					alpha = alpha == 255 ? 0 : 255;
+				}
+				calpha = calpha == 255 ? 0 : 255;
 			}
-			calpha = calpha == 255 ? 0 : 255;
-		}
-		return new Image(device, data);
+
+			return data;
+		};
+		return new Image(device, imageDataProvider);
 	}
 
 	public static boolean mnemonicMatch(String text, char key) {


### PR DESCRIPTION
Description

This change is a refactoring that replaces the Image(Device, ImageData) constructor with Image(Device, ImageDataProvider) so that image scaling is handled correctly at higher zoom levels.

### Steps to Reproduce

1)On a monitor with display zoom set to 350%, open a **manifest.mf** file that contains extensions.

2)In the **Extensions** tab of manifest.mf, locate the Extension Details section.
There are three links as in screenshot: _Show extension point description , Open extension point schema, Find declaring extension point_
<img width="200" height="200" alt="image" src="https://github.com/user-attachments/assets/9fb8a7e1-48fa-47f6-bf35-a3668687e994" />

3)Use the mouse to select (highlight) the text of these links.

Without this change, the images to the left of the links appear blurry and incorrectly scaled, as shown in the screenshots.

| Before (ImageData constructor – blurry at 350% zoom) | After (ImageDataProvider – correctly scaled) |
|------------------------------------------------------|----------------------------------------------|
| ![Before](https://github.com/user-attachments/assets/9855f157-e7a2-43d5-b39a-de9104d43f20) | ![After](https://github.com/user-attachments/assets/7f06f27c-4e42-44cb-ac13-25a665fe6df9) |





