### PR TITLE
Increase the height of bracket selection by one point 

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/MatchingCharacterPainter.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/MatchingCharacterPainter.java
@@ -261,7 +261,6 @@ public final class MatchingCharacterPainter implements IPainter, PaintListener {
 
 			final String matchingCharacter= fTextWidget.getText(offset, offset);
 			Point characterBounds= gc.textExtent(matchingCharacter);
-			characterBounds.y-= 1;
 			Rectangle hightlightingArea= Rectangle.of(offsetLocation, characterBounds);
 
 			// draw box around line segment


### PR DESCRIPTION
In some zoom level the highlight is too close to the text and cutoff sometimes.

Example: 

Here with zoom 175% the bracket selection seems to cut off the text. 
<img width="201" height="145" alt="image" src="https://github.com/user-attachments/assets/4222f063-c2c2-4700-82f2-30ca02f02ed3" />

After increasing the size by 1 pt, we get something like this

<img width="200" height="119" alt="image" src="https://github.com/user-attachments/assets/63ea75fc-740c-4558-9775-1195d1fcb483" />

To me this looks much more cleaner than the current state.