### PR TITLE
Migrate org.eclipse.ui.editors.tests to JUnit 5

### DIFF
--- a/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
@@ -10,7 +10,6 @@ Export-Package: org.eclipse.jface.text.tests.codemining,
  org.eclipse.ui.internal.texteditor.stickyscroll
 Require-Bundle: 
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
- org.junit;bundle-version="4.12.0",
  org.eclipse.jface;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.text;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui.workbench.texteditor;bundle-version="[3.16.500,4.0.0)",
@@ -27,7 +26,10 @@ Require-Bundle:
  org.eclipse.ui.tests.harness;bundle-version="1.8.0",
  org.mockito.mockito-core;bundle-version="5.12.0"
 Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
- org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
+ org.junit.jupiter.api.io;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
+ org.hamcrest;version="[3.0.0,4.0.0)",
+ org.hamcrest.core;version="[3.0.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Eclipse-BundleShape: dir
 Bundle-ActivationPolicy: lazy

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/jface/text/tests/codemining/CodeMiningTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.jface.text.tests.codemining;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.text.SimpleDateFormat;
@@ -18,11 +18,11 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.concurrent.Callable;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
@@ -65,20 +65,20 @@ public class CodeMiningTest {
 
 	private static IProject project;
 
-	@BeforeClass
-	public static void beforeClass() throws Exception {
+	@BeforeAll
+	static void beforeClass() throws Exception {
 		hideWelcomePage();
 		createProject(PROJECT_NAME);
 	}
 
-	@AfterClass
-	public static void afterClass() throws Exception {
+	@AfterAll
+	static void afterClass() throws Exception {
 		if (project != null)
 			project.delete(true, new NullProgressMonitor());
 	}
 
-	@After
-	public void after() {
+	@AfterEach
+	void after() {
 		closeAllEditors();
 		drainEventQueue();
 		CodeMiningTestProvider.provideContentMiningAtOffset = -1;
@@ -112,7 +112,7 @@ public class CodeMiningTest {
 	}
 
 	@Test
-	public void testClearCodeMiningTextEditorDecorationIfInInvisibleArea() throws Exception {
+	void testClearCodeMiningTextEditorDecorationIfInInvisibleArea() throws Exception {
 		IFile file = project.getFile("test.testprojectionviewer");
 		if (file.exists()) {
 			file.delete(true, new NullProgressMonitor());
@@ -144,7 +144,7 @@ public class CodeMiningTest {
 			}
 		});
 		StyleRange style = styledText.getStyleRangeAtOffset(offsetAtLine95 - 1);
-		assertTrue(style.metrics.width > 0);
+		assertTrue(style != null && style.metrics != null && style.metrics.width > 0);
 		// scroll to top so that code minings are not in visible area
 		viewer.setSelectedRange(0, 0);
 		viewer.revealRange(0, 1);
@@ -156,14 +156,14 @@ public class CodeMiningTest {
 		// assert that line vertical height and styleRange was removed after
 		// deleting the codeminings
 		for (int i = 0; i < 100; i++) {
-			assertTrue("line vertical indent not zeri at line index " + i, styledText.getLineVerticalIndent(i) == 0);
+			assertTrue(styledText.getLineVerticalIndent(i) == 0, "line vertical indent not zeri at line index " + i);
 		}
 		style = styledText.getStyleRangeAtOffset(offsetAtLine95 - 1);
 		assertTrue(style == null);
 	}
 
 	@Test
-	public void testInlinedAnnotationSupportIsInLinesReturnsValidResultAfterDocumentChange() throws Exception {
+	void testInlinedAnnotationSupportIsInLinesReturnsValidResultAfterDocumentChange() throws Exception {
 		IFile file = project.getFile("test.testprojectionviewer");
 		if (file.exists()) {
 			file.delete(true, new NullProgressMonitor());
@@ -185,8 +185,7 @@ public class CodeMiningTest {
 		additions.put(annot, new Position(0, source.length()));
 		annotationModel.modifyAnnotations(deletionsArray, additions, null);
 
-		Assert.assertTrue("Line header code mining above 3rd line not drawn",
-				waitForCondition(widget.getDisplay(), 2000, new Callable<Boolean>() {
+		Assertions.assertTrue(waitForCondition(widget.getDisplay(), 2000, new Callable<Boolean>() {
 					@Override
 					public Boolean call() throws Exception {
 						try {
@@ -196,14 +195,13 @@ public class CodeMiningTest {
 							return false;
 						}
 					}
-				}));
+				}), "Line header code mining above 3rd line not drawn");
 
 		IDocument doc = viewer.getDocument();
 		widget.setCaretOffset(offset);
 		doc.replace(offset, 0, "\n        insert text");
 		drainEventQueue();
-		Assert.assertTrue("Line header code mining above 4th line after inserting text not drawn",
-				waitForCondition(widget.getDisplay(), 2000, new Callable<Boolean>() {
+		Assertions.assertTrue(waitForCondition(widget.getDisplay(), 2000, new Callable<Boolean>() {
 					@Override
 					public Boolean call() throws Exception {
 						try {
@@ -213,11 +211,11 @@ public class CodeMiningTest {
 							return false;
 						}
 					}
-				}));
+				}), "Line header code mining above 4th line after inserting text not drawn");
 	}
 
 	@Test
-	public void testCodeMiningOnEmptyLine() throws Exception {
+	void testCodeMiningOnEmptyLine() throws Exception {
 		IFile file = project.getFile("test.txt");
 		if (file.exists()) {
 			file.delete(true, new NullProgressMonitor());
@@ -230,21 +228,19 @@ public class CodeMiningTest {
 		drainEventQueue();
 		ISourceViewer viewer = (ISourceViewer) editor.getAdapter(ITextViewer.class);
 		StyledText widget = viewer.getTextWidget();
-		Assert.assertTrue("line content mining not available",
-				waitForCondition(widget.getDisplay(), 1000, new Callable<Boolean>() {
+		Assertions.assertTrue(waitForCondition(widget.getDisplay(), 1000, new Callable<Boolean>() {
 					@Override
 					public Boolean call() throws Exception {
 						return widget.getStyleRangeAtOffset(0) != null
 								&& widget.getStyleRangeAtOffset(0).metrics != null;
 					}
-				}));
+				}), "line content mining not available");
 		drainEventQueue();
 
 		CodeMiningTestProvider.provideHeaderMiningAtLine = 1;
 		((ISourceViewerExtension5) viewer).updateCodeMinings();
 
-		Assert.assertTrue("Code mining not drawn at empty line after calling updateCodeMinings",
-				waitForCondition(widget.getDisplay(), 2000, new Callable<Boolean>() {
+		Assertions.assertTrue(waitForCondition(widget.getDisplay(), 2000, new Callable<Boolean>() {
 					@Override
 					public Boolean call() throws Exception {
 						try {
@@ -254,11 +250,11 @@ public class CodeMiningTest {
 							return false;
 						}
 					}
-				}));
+				}), "Code mining not drawn at empty line after calling updateCodeMinings");
 	}
 
 	@Test
-	public void testCodeMiningAtEndOfLine() throws Exception {
+	void testCodeMiningAtEndOfLine() throws Exception {
 		IFile file = project.getFile("test.txt");
 		if (file.exists()) {
 			file.delete(true, new NullProgressMonitor());
@@ -273,21 +269,19 @@ public class CodeMiningTest {
 		drainEventQueue();
 		ISourceViewer viewer = (ISourceViewer) editor.getAdapter(ITextViewer.class);
 		StyledText widget = viewer.getTextWidget();
-		Assert.assertTrue("line content mining not available",
-				waitForCondition(widget.getDisplay(), 1000, new Callable<Boolean>() {
+		Assertions.assertTrue(waitForCondition(widget.getDisplay(), 1000, new Callable<Boolean>() {
 					@Override
 					public Boolean call() throws Exception {
 						return widget.getStyleRangeAtOffset(0) != null
 								&& widget.getStyleRangeAtOffset(0).metrics != null;
 					}
-				}));
+				}), "line content mining not available");
 		drainEventQueue();
 
 		CodeMiningTestProvider.provideContentMiningAtOffset = firstPart.length();
 		((ISourceViewerExtension5) viewer).updateCodeMinings();
 
-		Assert.assertTrue("Code mining not drawn at the end of second line after calling updateCodeMinings",
-				waitForCondition(widget.getDisplay(), 2000, new Callable<Boolean>() {
+		Assertions.assertTrue(waitForCondition(widget.getDisplay(), 2000, new Callable<Boolean>() {
 					@Override
 					public Boolean call() throws Exception {
 						try {
@@ -297,7 +291,7 @@ public class CodeMiningTest {
 							return false;
 						}
 					}
-				}));
+				}), "Code mining not drawn at the end of second line after calling updateCodeMinings");
 	}
 
 	private void drainEventQueue() {

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/CaseActionTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/CaseActionTest.java
@@ -13,16 +13,16 @@
  *******************************************************************************/
 package org.eclipse.ui.editors.tests;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
 
@@ -44,14 +44,14 @@ import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
 import org.eclipse.ui.texteditor.ITextEditorActionConstants;
 
-public class CaseActionTest {
+class CaseActionTest {
 
 	private static IProject project;
 	private static IFile file;
 	private AbstractTextEditor editor;
 
-	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
+	@BeforeAll
+	static void setUpBeforeClass() throws Exception {
 		project = ResourcesPlugin.getWorkspace().getRoot().getProject("test");
 		project.create(new NullProgressMonitor());
 		project.open(new NullProgressMonitor());
@@ -59,15 +59,15 @@ public class CaseActionTest {
 		file.create(new ByteArrayInputStream("bar".getBytes()), true, new NullProgressMonitor());
 	}
 
-	@AfterClass
-	public static void tearDownAfterClass() throws Exception {
+	@AfterAll
+	static void tearDownAfterClass() throws Exception {
 		file.delete(true, new NullProgressMonitor());
 		project.delete(true, new NullProgressMonitor());
 		TestUtil.cleanUp();
 	}
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeEach
+	void setUp() throws Exception {
 		IIntroPart intro = PlatformUI.getWorkbench().getIntroManager().getIntro();
 		if (intro != null) {
 			PlatformUI.getWorkbench().getIntroManager().closeIntro(intro);
@@ -80,14 +80,14 @@ public class CaseActionTest {
 		// make sure we start from a clean state
 	}
 
-	@After
-	public void tearDown() throws Exception {
+	@AfterEach
+	void tearDown() throws Exception {
 		editor.close(false);
 		editor= null;
 	}
 
 	@Test
-	public void testMultiSelectionCase() {
+	void testMultiSelectionCase() {
 		IDocument doc = editor.getDocumentProvider().getDocument(editor.getEditorInput());
 		doc.set("foo bar foo");
 		IRegion[] initialSelection = { new Region(0,3), new Region(8, 3) };

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/ChainedPreferenceStoreTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/ChainedPreferenceStoreTest.java
@@ -14,13 +14,13 @@
 
 package org.eclipse.ui.editors.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceStore;
@@ -47,8 +47,8 @@ public class ChainedPreferenceStoreTest {
 	private static final String DEFAULT_VALUE= "4";
 	private static final String DEFAULT_DEFAULT_VALUE= "";
 
-	@After
-	public void tearDown() {
+	@AfterEach
+	void tearDown() {
 		TestUtil.cleanUp();
 	}
 
@@ -57,7 +57,7 @@ public class ChainedPreferenceStoreTest {
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=69419
 	 */
 	@Test
-	public void testChainedStore0() {
+	void testChainedStore0() {
 		IPreferenceStore store1= new PreferenceStore();
 		IPreferenceStore store2= new PreferenceStore();
 		IPreferenceStore chainedStore= new ChainedPreferenceStore(new IPreferenceStore[] { store1, store2 });
@@ -80,7 +80,7 @@ public class ChainedPreferenceStoreTest {
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=52827
 	 */
 	@Test
-	public void testChainedStore1() {
+	void testChainedStore1() {
 		IPreferenceStore store1= new PreferenceStore();
 		IPreferenceStore store2= new PreferenceStore();
 		IPreferenceStore chainedStore= new ChainedPreferenceStore(new IPreferenceStore[] { store1, store2 });
@@ -101,7 +101,7 @@ public class ChainedPreferenceStoreTest {
 	 * Third case where the initial implementation used to have an assertion which would fail in this case
 	 */
 	@Test
-	public void testChainedStore2() {
+	void testChainedStore2() {
 		IPreferenceStore store1= new PreferenceStore();
 		IPreferenceStore store2= new PreferenceStore();
 		IPreferenceStore chainedStore= new ChainedPreferenceStore(new IPreferenceStore[] { store1, store2 });
@@ -123,7 +123,7 @@ public class ChainedPreferenceStoreTest {
 	 * Case where the initial implementation used to throw an IAE
 	 */
 	@Test
-	public void testChainedStore3() {
+	void testChainedStore3() {
 		IPreferenceStore store1= new PreferenceStore();
 		IPreferenceStore store2= new PreferenceStore();
 		IPreferenceStore chainedStore= new ChainedPreferenceStore(new IPreferenceStore[] { store1, store2 });

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/DocumentProviderRegistryTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/DocumentProviderRegistryTest.java
@@ -10,15 +10,15 @@
  *******************************************************************************/
 package org.eclipse.ui.editors.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.nio.file.Path;
 
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
@@ -41,13 +41,13 @@ import org.eclipse.ui.editors.text.TextFileDocumentProvider;
 
 public class DocumentProviderRegistryTest {
 
-	@Rule
-	public TemporaryFolder tmp = new TemporaryFolder();
+	@TempDir
+	Path tmp;
 
 	private IFile file;
 
-	@After
-	public void tearDown() throws Exception {
+	@AfterEach
+	void tearDown() throws Exception {
 		if (file != null) {
 			ResourceHelper.delete(file.getProject());
 		}
@@ -55,24 +55,24 @@ public class DocumentProviderRegistryTest {
 	}
 
 	@Test
-	public void testFindByExtensionInWorkspace() throws Exception {
+	void testFindByExtensionInWorkspace() throws Exception {
 		IFolder folder = ResourceHelper.createFolder("DocumentProviderRegistryTestProject/test");
 		file = ResourceHelper.createFile(folder, "file.testfile", "");
-		assertTrue("File should exist: " + file.toString(), file.exists());
+		assertTrue(file.exists(), "File should exist: " + file.toString());
 		IEditorInput editorInput = new FileEditorInput(file);
 		IDocumentProvider provider = DocumentProviderRegistry.getDefault().getDocumentProvider(editorInput);
-		assertEquals("Unexpected document provider found : " + provider.getClass().getName(),
-				TestDocumentProvider.class, provider.getClass());
+		assertEquals(TestDocumentProvider.class, provider.getClass(),
+				"Unexpected document provider found : " + provider.getClass().getName());
 	}
 
 	@Test
-	public void testFindByExtensionNonWorkspace() throws Exception {
-		File external = tmp.newFile("external.testfile");
+	void testFindByExtensionNonWorkspace() throws Exception {
+		File external = tmp.resolve("external.testfile").toFile();
 		IFileStore store = EFS.getLocalFileSystem().getStore(IPath.fromOSString(external.getCanonicalPath()));
 		IEditorInput editorInput = new FileStoreEditorInput(store);
 		IDocumentProvider provider = DocumentProviderRegistry.getDefault().getDocumentProvider(editorInput);
-		assertEquals("Unexpected document provider found : " + provider.getClass().getName(),
-				TestDocumentProvider.class, provider.getClass());
+		assertEquals(TestDocumentProvider.class, provider.getClass(),
+				"Unexpected document provider found : " + provider.getClass().getName());
 	}
 
 	public static class TestDocumentProvider extends TextFileDocumentProvider {

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/EncodingChangeTests.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/EncodingChangeTests.java
@@ -14,13 +14,13 @@
 
 package org.eclipse.ui.editors.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.custom.StyledText;
@@ -80,16 +80,16 @@ public class EncodingChangeTests {
 		return ORIGINAL_CONTENT;
 	}
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeEach
+	void setUp() throws Exception {
 		IFolder folder= ResourceHelper.createFolder("EncodingChangeTestProject/EncodingChangeTests/");
 		fFile= ResourceHelper.createFile(folder, "file" + fCount + ".txt", getOriginalContent());
 		fFile.setCharset(null, null);
 		fCount++;
 	}
 
-	@After
-	public void tearDown() throws Exception {
+	@AfterEach
+	void tearDown() throws Exception {
 		closeEditor(fEditor);
 		fEditor= null;
 		fFile= null;
@@ -98,7 +98,7 @@ public class EncodingChangeTests {
 	}
 
 	@Test
-	public void testChangeEncodingViaFile() {
+	void testChangeEncodingViaFile() {
 		IWorkbench workbench= PlatformUI.getWorkbench();
 		IWorkbenchPage page= workbench.getActiveWorkbenchWindow().getActivePage();
 		try {
@@ -126,7 +126,7 @@ public class EncodingChangeTests {
 	}
 
 	@Test
-	public void testChangeEncodingViaEncodingSupport() {
+	void testChangeEncodingViaEncodingSupport() {
 		IWorkbench workbench= PlatformUI.getWorkbench();
 		IWorkbenchPage page= workbench.getActiveWorkbenchWindow().getActivePage();
 		try {
@@ -157,7 +157,7 @@ public class EncodingChangeTests {
 	}
 
 	@Test
-	public void testAInvalidEncoding() {
+	void testAInvalidEncoding() {
 		IWorkbench workbench= PlatformUI.getWorkbench();
 		IWorkbenchPage page= workbench.getActiveWorkbenchWindow().getActivePage();
 		try {

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/FileDocumentProviderTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/FileDocumentProviderTest.java
@@ -13,18 +13,18 @@
  *******************************************************************************/
 package org.eclipse.ui.editors.tests;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.widgets.Display;
 
@@ -83,8 +83,8 @@ public class FileDocumentProviderTest {
 	private IEditorPart editor;
 	private IWorkbenchPage page;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeEach
+	void setUp() throws Exception {
 		closeIntro(PlatformUI.getWorkbench());
 		IFolder folder = ResourceHelper.createFolder("FileDocumentProviderTestProject/test");
 		file = (File) ResourceHelper.createFile(folder, "file.txt", "");
@@ -127,8 +127,8 @@ public class FileDocumentProviderTest {
 		}
 	}
 
-	@After
-	public void tearDown() throws Exception {
+	@AfterEach
+	void tearDown() throws Exception {
 		stopLockingFlag.set(true);
 		lockJob.cancel();
 		lockJob2.cancel();
@@ -141,9 +141,9 @@ public class FileDocumentProviderTest {
 	}
 
 	@Test
-	public void testRefreshFileWhileWorkspaceIsLocked1() throws Exception {
+	void testRefreshFileWhileWorkspaceIsLocked1() throws Exception {
 		// See https://bugs.eclipse.org/bugs/show_bug.cgi?id=482354
-		assertNotNull("Test must run in UI thread", Display.getCurrent());
+		assertNotNull(Display.getCurrent(), "Test must run in UI thread");
 
 		// Start workspace job which will lock workspace operations on file via
 		// rule
@@ -165,14 +165,14 @@ public class FileDocumentProviderTest {
 		fileProvider.refreshFile(file);
 
 		System.out.println("Busy wait terminated, UI thread is operable again!");
-		assertFalse("Test deadlocked while waiting on resource lock", stoppedByTest.get());
+		assertFalse(stoppedByTest.get(), "Test deadlocked while waiting on resource lock");
 		assertTrue(stopLockingFlag.get());
 	}
 
 	@Test
-	public void testRefreshFileWhileWorkspaceIsLocked2() throws Exception {
+	void testRefreshFileWhileWorkspaceIsLocked2() throws Exception {
 		// See https://bugs.eclipse.org/bugs/show_bug.cgi?id=482354
-		assertNotNull("Test must run in UI thread", Display.getCurrent());
+		assertNotNull(Display.getCurrent(), "Test must run in UI thread");
 
 		// Start workspace job which will lock workspace operations on file via
 		// rule
@@ -195,13 +195,13 @@ public class FileDocumentProviderTest {
 
 		System.out.println("Busy wait terminated, UI thread is operable again!");
 
-		assertFalse("Test deadlocked while waiting on resource lock", stoppedByTest.get());
+		assertFalse(stoppedByTest.get(), "Test deadlocked while waiting on resource lock");
 		assertTrue(stopLockingFlag.get());
 	}
 
 	@Test
-	public void testValidateStateForFileWhileWorkspaceIsLocked() throws Exception {
-		assertNotNull("Test must run in UI thread", Display.getCurrent());
+	void testValidateStateForFileWhileWorkspaceIsLocked() throws Exception {
+		assertNotNull(Display.getCurrent(), "Test must run in UI thread");
 
 		// Start workspace job which will lock workspace operations on file
 		lockJob2.schedule();
@@ -220,7 +220,7 @@ public class FileDocumentProviderTest {
 		fileProvider.validateState(editor.getEditorInput(), editor.getSite().getShell());
 
 		System.out.println("Busy wait terminated, UI thread is operable again!");
-		assertFalse("Test deadlocked while waiting on resource lock", stoppedByTest.get());
+		assertFalse(stoppedByTest.get(), "Test deadlocked while waiting on resource lock");
 		assertTrue(stopLockingFlag.get());
 	}
 

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/FindNextActionTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/FindNextActionTest.java
@@ -15,14 +15,14 @@ package org.eclipse.ui.editors.tests;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ResourceBundle;
 
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.FrameworkUtil;
 
 import org.eclipse.core.runtime.CoreException;
@@ -54,32 +54,41 @@ import org.eclipse.ui.texteditor.FindReplaceAction;
 public class FindNextActionTest {
 	private static final String TEST_PROJECT_NAME = "TestProject";
 
+
 	private static final String BUNDLE_FOR_CONSTRUCTED_KEYS_NAME = "org.eclipse.ui.texteditor.ConstructedEditorMessages";//$NON-NLS-1$
+
 
 	private static ResourceBundle bundleForConstructedKeys = ResourceBundle.getBundle(BUNDLE_FOR_CONSTRUCTED_KEYS_NAME);
 
+
 	private AbstractTextEditor editor;
+
 
 	private IProject project;
 
+
 	private FindNextAction action;
+
 
 	private static enum Direction {
 		FORWARD, BACKWARD
 	}
 
-	@Before
-	public void createTestProject() throws CoreException {
+
+	@BeforeEach
+	void createTestProject() throws CoreException {
 		project = ResourcesPlugin.getWorkspace().getRoot().getProject(TEST_PROJECT_NAME);
 		project.create(null);
 		project.open(null);
 	}
 
-	public void openEditorAndFindNextAction(String content, Direction direction) throws CoreException {
+
+	void openEditorAndFindNextAction(String content, Direction direction) throws CoreException {
 		IFile file = createTestFile(content);
 		editor = openEditor(file);
 		action = new FindNextAction(bundleForConstructedKeys, "findNext", editor, direction == Direction.FORWARD);
 	}
+
 
 	private IFile createTestFile(String content) throws CoreException {
 		IFile file = project.getFile("file.txt");
@@ -87,6 +96,7 @@ public class FindNextActionTest {
 		file.setCharset(null, null);
 		return file;
 	}
+
 
 	private static AbstractTextEditor openEditor(IFile file) throws PartInitException {
 		IWorkbench workbench = PlatformUI.getWorkbench();
@@ -96,8 +106,9 @@ public class FindNextActionTest {
 		return (AbstractTextEditor) editorPart;
 	}
 
-	@After
-	public void tearDown() throws Exception {
+
+	@AfterEach
+	void tearDown() throws Exception {
 		resetInitialSearchSettings();
 		closeEditor(editor);
 		editor = null;
@@ -105,6 +116,7 @@ public class FindNextActionTest {
 		project = null;
 		TestUtil.cleanUp();
 	}
+
 
 	private void resetInitialSearchSettings() {
 		IDialogSettings settings = getActionSettings();
@@ -114,6 +126,7 @@ public class FindNextActionTest {
 		settings.put("wholeword", false);
 	}
 
+
 	private static void closeEditor(IEditorPart editor) {
 		IWorkbenchPartSite site;
 		IWorkbenchPage page;
@@ -122,6 +135,7 @@ public class FindNextActionTest {
 		}
 	}
 
+
 	private void setEditorSelection(int offset, int length) {
 		Document document = (Document) editor.getDocumentProvider().getDocument(editor.getEditorInput());
 		TextSelection selection = new TextSelection(document, offset, length);
@@ -129,10 +143,12 @@ public class FindNextActionTest {
 		selectionProvider.setSelection(selection);
 	}
 
+
 	private void assertSelectionIs(int offset, int length) {
 		assertEquals(offset, getEditorSelection().getRegions()[0].getOffset());
 		assertEquals(length, getEditorSelection().getRegions()[0].getLength());
 	}
+
 
 	private TextSelection getEditorSelection() {
 		ISelectionProvider selectionProvider = editor.getSelectionProvider();
@@ -141,6 +157,7 @@ public class FindNextActionTest {
 		}
 		return null;
 	}
+
 
 	private IDialogSettings getActionSettings() {
 		IDialogSettings settings = PlatformUI.getDialogSettingsProvider(FrameworkUtil.getBundle(FindNextAction.class))
@@ -151,8 +168,9 @@ public class FindNextActionTest {
 		return fDialogSettings;
 	}
 
+
 	@Test
-	public void testFindNextForward() throws CoreException {
+	void testFindNextForward() throws CoreException {
 		openEditorAndFindNextAction("testtesttest", Direction.FORWARD);
 		setEditorSelection(0, 4);
 		action.run();
@@ -163,8 +181,9 @@ public class FindNextActionTest {
 		assertSelectionIs(0, 4);
 	}
 
+
 	@Test
-	public void testFindNextBackwards() throws CoreException {
+	void testFindNextBackwards() throws CoreException {
 		openEditorAndFindNextAction("testtesttest", Direction.BACKWARD);
 		setEditorSelection(4, 4);
 		action.run();
@@ -173,8 +192,9 @@ public class FindNextActionTest {
 		assertSelectionIs(8, 4);
 	}
 
+
 	@Test
-	public void testFindNextFromHistory() throws CoreException {
+	void testFindNextFromHistory() throws CoreException {
 		openEditorAndFindNextAction("word-abcd-text", Direction.FORWARD);
 		IDialogSettings settings = getActionSettings();
 		HistoryStore historyStore = new HistoryStore(settings, "findhistory", 15);
@@ -187,8 +207,9 @@ public class FindNextActionTest {
 		assertSelectionIs(5, 4);
 	}
 
+
 	@Test
-	public void testFindNextStoresCorrectHistory() throws CoreException {
+	void testFindNextStoresCorrectHistory() throws CoreException {
 		openEditorAndFindNextAction("history", Direction.FORWARD);
 		setEditorSelection(0, "history".length());
 		action.run();
@@ -197,8 +218,9 @@ public class FindNextActionTest {
 		assertThat(historyStore.get(0), is("history"));
 	}
 
+
 	@Test
-	public void testFindNextWithRegExEscapedCorrectly() throws CoreException {
+	void testFindNextWithRegExEscapedCorrectly() throws CoreException {
 		openEditorAndFindNextAction("wo+rd-woord", Direction.FORWARD);
 		IDialogSettings settings = getActionSettings();
 		setEditorSelection(0, 5);
@@ -207,8 +229,9 @@ public class FindNextActionTest {
 		assertSelectionIs(0, 5);
 	}
 
+
 	@Test
-	public void testCaseSensitiveFindNext() throws CoreException {
+	void testCaseSensitiveFindNext() throws CoreException {
 		openEditorAndFindNextAction("wordWORD", Direction.FORWARD);
 		IDialogSettings settings = getActionSettings();
 		settings.put("casesensitive", true);
@@ -217,8 +240,9 @@ public class FindNextActionTest {
 		assertSelectionIs(0, 4);
 	}
 
+
 	@Test
-	public void testFindNextMultilineSelection() throws CoreException {
+	void testFindNextMultilineSelection() throws CoreException {
 		openEditorAndFindNextAction("line\n\rnext\n\rnext\r\nline", Direction.FORWARD);
 		// we expect the search string to only contain the first line
 		setEditorSelection(0, 10);
@@ -226,8 +250,9 @@ public class FindNextActionTest {
 		assertSelectionIs(18, 4);
 	}
 
+
 	@Test
-	public void testFindNextNoWrap() throws CoreException {
+	void testFindNextNoWrap() throws CoreException {
 		openEditorAndFindNextAction("wordword", Direction.FORWARD);
 		IDialogSettings settings = getActionSettings();
 		settings.put("wrap", false);
@@ -238,8 +263,9 @@ public class FindNextActionTest {
 		assertSelectionIs(4, 4);
 	}
 
+
 	@Test
-	public void testFindWholeWords() throws CoreException {
+	void testFindWholeWords() throws CoreException {
 		openEditorAndFindNextAction("word longerword word", Direction.FORWARD);
 		IDialogSettings settings = getActionSettings();
 		settings.put("wholeword", true);
@@ -248,8 +274,9 @@ public class FindNextActionTest {
 		assertSelectionIs(16, 4);
 	}
 
+
 	@Test
-	public void testFindWholeWordsIsNotWord() throws CoreException {
+	void testFindWholeWordsIsNotWord() throws CoreException {
 		openEditorAndFindNextAction("w ord longerw ordinner w ord", Direction.FORWARD);
 		IDialogSettings settings = getActionSettings();
 		settings.put("wholeword", true);

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/GotoLineTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/GotoLineTest.java
@@ -13,12 +13,12 @@
  *******************************************************************************/
 package org.eclipse.ui.editors.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.widgets.Control;
@@ -61,31 +61,31 @@ public class GotoLineTest {
 		return ORIGINAL_CONTENT;
 	}
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeEach
+	void setUp() throws Exception {
 		IFolder folder= ResourceHelper.createFolder("GoToLineTestProject/goToLineTests/");
 		fFile= ResourceHelper.createFile(folder, "file.txt", getOriginalContent());
 	}
 
-	@After
-	public void tearDown() throws Exception {
+	@AfterEach
+	void tearDown() throws Exception {
 		ResourceHelper.deleteProject("GoToLineTestProject");
 		fFile= null;
 		TestUtil.cleanUp();
 	}
 
 	@Test
-	public void testGoToFirstLine() {
+	void testGoToFirstLine() {
 		goToLine(0, 0);
 	}
 
 	@Test
-	public void testGoToLastLine() {
+	void testGoToLastLine() {
 		goToLine(2, 2);
 	}
 
 	@Test
-	public void testGoToInvalidLine() {
+	void testGoToInvalidLine() {
 		goToLine(1, 1);
 		goToLine(-1, 1);
 		goToLine(3, 1);

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/LargeFileTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/LargeFileTest.java
@@ -10,16 +10,16 @@
  *******************************************************************************/
 package org.eclipse.ui.editors.tests;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedWriter;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.widgets.Display;
 
@@ -57,8 +57,8 @@ public class LargeFileTest {
 
 	boolean initialWordWrap;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeEach
+	void setUp() throws Exception {
 		IIntroPart intro = PlatformUI.getWorkbench().getIntroManager().getIntro();
 		if (intro != null) {
 			PlatformUI.getWorkbench().getIntroManager().closeIntro(intro);
@@ -78,8 +78,8 @@ public class LargeFileTest {
 		initialWordWrap = preferenceStore.getBoolean(AbstractTextEditor.PREFERENCE_WORD_WRAP_ENABLED);
 	}
 
-	@After
-	public void tearDown() throws Exception {
+	@AfterEach
+	void tearDown() throws Exception {
 		fLargeFile.deleteMarkers(IMarker.BOOKMARK, true, IResource.DEPTH_INFINITE);
 		ResourceHelper.deleteProject("LargeFileTestProject");
 		fLargeFile= null;
@@ -88,7 +88,7 @@ public class LargeFileTest {
 	}
 
 	@Test
-	public void openLargeFileWithAnnotation() throws Exception {
+	void openLargeFileWithAnnotation() throws Exception {
 		IWorkbench workbench= PlatformUI.getWorkbench();
 		Display display = workbench.getDisplay();
 		IWorkbenchPage page= workbench.getActiveWorkbenchWindow().getActivePage();
@@ -104,7 +104,7 @@ public class LargeFileTest {
 				baseline[0] = System.nanoTime() - baseline[0];
 			});
 			TestUtil.runEventLoop();
-			assertTrue("Expected a text editor", part instanceof ITextEditor);
+			assertTrue(part instanceof ITextEditor, "Expected a text editor");
 			page.closeEditor(part, false);
 			TestUtil.runEventLoop();
 		}
@@ -126,14 +126,13 @@ public class LargeFileTest {
 			withMarker[0] = System.nanoTime() - withMarker[0];
 		});
 		TestUtil.runEventLoop();
-		assertTrue("Expected a text editor", part instanceof ITextEditor);
+		assertTrue(part instanceof ITextEditor, "Expected a text editor");
 		page.closeEditor(part, false);
 		TestUtil.runEventLoop();
 		// Be generous here; all this timing is approximate. Fail if the attempt
 		// with the marker takes more than twice as long. If the OverviewRuler
 		// is badly implemented, opening with the marker will take much longer.
-		assertTrue("Opening large file took too long: " + (withMarker[0] / 1000000.0f) + "ms with marker vs. "
-				+ (baseline[0] / 1000000.0f) + "ms without",
-				withMarker[0] / 2 <= baseline[0]);
+		assertTrue(withMarker[0] / 2 <= baseline[0], "Opening large file took too long: " + (withMarker[0] / 1000000.0f) + "ms with marker vs. "
+				+ (baseline[0] / 1000000.0f) + "ms without");
 	}
 }

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/MarkerAnnotationOrderTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/MarkerAnnotationOrderTest.java
@@ -13,16 +13,16 @@
  *******************************************************************************/
 package org.eclipse.ui.editors.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedInputStream;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.Bundle;
 
 import org.eclipse.core.runtime.ContributorFactorySimple;
@@ -50,8 +50,8 @@ public class MarkerAnnotationOrderTest {
 
 	Object masterToken= null;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeEach
+	void setUp() throws Exception {
 		//add the marker updater extension point
 		IExtensionRegistry registry= Platform.getExtensionRegistry();
 		pointContributor= ContributorFactorySimple.createContributor(this);
@@ -71,8 +71,8 @@ public class MarkerAnnotationOrderTest {
 		}
 	}
 
-	@After
-	public void tearDown() throws Exception {
+	@AfterEach
+	void tearDown() throws Exception {
 		// remove the marker updater extension point
 		IExtensionRegistry registry= Platform.getExtensionRegistry();
 		IExtension[] extensions = registry.getExtensions(pointContributor);
@@ -85,7 +85,7 @@ public class MarkerAnnotationOrderTest {
 	}
 
 	@Test
-	public void testDirectDependency() {
+	void testDirectDependency() {
 		final ArrayList<IStatus> list= new ArrayList<>(2);
 		Bundle bundle= Platform.getBundle(EditorsUI.PLUGIN_ID);
 		ILog log= ILog.of(bundle);
@@ -102,15 +102,13 @@ public class MarkerAnnotationOrderTest {
 			log(e);
 		}
 
-		assertEquals("Wrong number of messages", 2, list.size());
+		assertEquals(2, list.size(), "Wrong number of messages");
 		assertEquals(
-				"Wrong Message for first status",
 				"Marker Updater 'org.eclipse.ui.texteditor.BasicMarkerUpdaterTest2' and 'org.eclipse.ui.texteditor.BasicMarkerUpdaterTest1' depend on each other, 'org.eclipse.ui.texteditor.BasicMarkerUpdaterTest2' will run before 'org.eclipse.ui.texteditor.BasicMarkerUpdaterTest1'",
-				((Status)list.get(0)).getMessage());
+				((Status)list.get(0)).getMessage(), "Wrong Message for first status");
 		assertEquals(
-				"Wrong Message for second status",
 				"Marker Updater 'org.eclipse.ui.texteditor.BasicMarkerUpdaterTest4' and 'org.eclipse.ui.texteditor.BasicMarkerUpdaterTest1' depend on each other, 'org.eclipse.ui.texteditor.BasicMarkerUpdaterTest4' will run before 'org.eclipse.ui.texteditor.BasicMarkerUpdaterTest1'",
-				((Status)list.get(1)).getMessage());
+				((Status)list.get(1)).getMessage(), "Wrong Message for second status");
 
 	}
 

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/SegmentedModeTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/SegmentedModeTest.java
@@ -14,12 +14,12 @@
  *******************************************************************************/
 package org.eclipse.ui.editors.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.widgets.Control;
@@ -52,14 +52,14 @@ public class SegmentedModeTest {
 		return ORIGINAL_CONTENT;
 	}
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeEach
+	void setUp() throws Exception {
 		IFolder folder= ResourceHelper.createFolder("project/folderA/folderB/");
 		fFile= ResourceHelper.createFile(folder, "file.txt", getOriginalContent());
 	}
 
-	@After
-	public void tearDown() throws Exception {
+	@AfterEach
+	void tearDown() throws Exception {
 		ResourceHelper.deleteProject("project");
 		TestUtil.cleanUp();
 	}
@@ -68,7 +68,7 @@ public class SegmentedModeTest {
 	 * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=70934
 	 */
 	@Test
-	public void testSegmentation() {
+	void testSegmentation() {
 		IWorkbench workbench= PlatformUI.getWorkbench();
 		IWorkbenchPage page= workbench.getActiveWorkbenchWindow().getActivePage();
 		try {
@@ -98,7 +98,7 @@ public class SegmentedModeTest {
 			}
 
 		} catch (PartInitException e) {
-			assertTrue(false);
+			fail(e);
 		}
 	}
 
@@ -106,7 +106,7 @@ public class SegmentedModeTest {
 	 * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=465684
 	 */
 	@Test
-	public void testShowNothing() {
+	void testShowNothing() {
 		IWorkbench workbench= PlatformUI.getWorkbench();
 		IWorkbenchPage page= workbench.getActiveWorkbenchWindow().getActivePage();
 		try {
@@ -133,7 +133,7 @@ public class SegmentedModeTest {
 			}
 
 		} catch (PartInitException e) {
-			assertTrue(false);
+			fail(e);
 		}
 	}
 }

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/StatusEditorTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/StatusEditorTest.java
@@ -14,15 +14,16 @@
  *******************************************************************************/
 package org.eclipse.ui.editors.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.widgets.Display;
@@ -55,16 +56,16 @@ public class StatusEditorTest {
 	private Display display;
 	private IWorkbenchPage page;
 
-	@Before
-	public void before() throws WorkbenchException {
+	@BeforeEach
+	void before() throws WorkbenchException {
 		window = PlatformUI.getWorkbench().openWorkbenchWindow(null);
 		display = window.getShell().getDisplay();
 		page = window.getActivePage();
 		processEvents();
 	}
 
-	@After
-	public void after() {
+	@AfterEach
+	void after() {
 		window.close();
 		page = null;
 		processEvents();
@@ -77,7 +78,7 @@ public class StatusEditorTest {
 	 * No exceptions are thrown when a status editor displaying an erroneous status is activated with a mouse click.
 	 */
 	@Test
-	public void doNotThrowOnActivationInStale() throws Exception {
+	void doNotThrowOnActivationInStale() throws Exception {
 		IEditorPart editor1 = openNonExistentFile(page, new URI("file:/1.txt"));
 		openNonExistentFile(page, new URI("file:/2.txt"));
 		ILog log = ILog.of(Platform.getBundle("org.eclipse.e4.ui.workbench"));
@@ -96,7 +97,7 @@ public class StatusEditorTest {
 			log.removeLogListener(listener);
 		}
 		if(!logEvents.isEmpty()) {
-			Assert.assertEquals("Unexpected errors logged", "", logEvents.toString());
+			assertEquals("", logEvents.toString(), "Unexpected errors logged");
 		}
 	}
 

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/TestUtil.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/TestUtil.java
@@ -15,7 +15,7 @@ package org.eclipse.ui.editors.tests;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.eclipse.swt.widgets.Display;
 
@@ -28,15 +28,15 @@ public class TestUtil {
 	 */
 	public static void cleanUp() {
 		// Ensure that the Thread.interrupted() flag didn't leak.
-		Assert.assertFalse("The main thread should not be interrupted at the end of a test", Thread.interrupted());
+		Assertions.assertFalse(Thread.interrupted(), "The main thread should not be interrupted at the end of a test");
 		// Wait for any outstanding jobs to finish. Protect against deadlock by
 		// terminating the wait after a timeout.
 		boolean timedOut = waitForJobs(0, TimeUnit.MINUTES.toMillis(3));
-		Assert.assertFalse("Some Job did not terminate at the end of the test", timedOut);
+		Assertions.assertFalse(timedOut, "Some Job did not terminate at the end of the test");
 		// Wait for any pending *syncExec calls to finish
 		runEventLoop();
 		// Ensure that the Thread.interrupted() flag didn't leak.
-		Assert.assertFalse("The main thread should not be interrupted at the end of a test", Thread.interrupted());
+		Assertions.assertFalse(Thread.interrupted(), "The main thread should not be interrupted at the end of a test");
 	}
 
 	/**

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/TextFileDocumentProviderTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/TextFileDocumentProviderTest.java
@@ -14,18 +14,18 @@
 package org.eclipse.ui.editors.tests;
 
 import static org.eclipse.ui.editors.tests.FileDocumentProviderTest.closeIntro;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.widgets.Display;
 
@@ -67,8 +67,8 @@ public class TextFileDocumentProviderTest {
 	private IEditorPart editor;
 	private IWorkbenchPage page;
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeEach
+	void setUp() throws Exception {
 		closeIntro(PlatformUI.getWorkbench());
 		IFolder folder = ResourceHelper.createFolder("FileDocumentProviderTestProject/test");
 		file = (File) ResourceHelper.createFile(folder, "file.txt", "");
@@ -111,8 +111,8 @@ public class TextFileDocumentProviderTest {
 		}
 	}
 
-	@After
-	public void tearDown() throws Exception {
+	@AfterEach
+	void tearDown() throws Exception {
 		stopLockingFlag.set(true);
 		lockJob.cancel();
 		lockJob2.cancel();
@@ -125,9 +125,9 @@ public class TextFileDocumentProviderTest {
 	}
 
 	@Test
-	public void testSynchronizeInputWhileWorkspaceIsLocked1() throws Exception {
+	void testSynchronizeInputWhileWorkspaceIsLocked1() throws Exception {
 		// See https://bugs.eclipse.org/bugs/show_bug.cgi?id=482354
-		assertNotNull("Test must run in UI thread", Display.getCurrent());
+		assertNotNull(Display.getCurrent(), "Test must run in UI thread");
 		fileProvider.connect(editor.getEditorInput());
 
 		// Start workspace job which will lock workspace operations on file via
@@ -150,14 +150,14 @@ public class TextFileDocumentProviderTest {
 		fileProvider.synchronize(editor.getEditorInput());
 
 		System.out.println("Busy wait terminated, UI thread is operable again!");
-		assertFalse("Test deadlocked while waiting on resource lock", stoppedByTest.get());
+		assertFalse(stoppedByTest.get(), "Test deadlocked while waiting on resource lock");
 		assertTrue(stopLockingFlag.get());
 	}
 
 	@Test
-	public void testSynchronizeInputWhileWorkspaceIsLocked2() throws Exception {
+	void testSynchronizeInputWhileWorkspaceIsLocked2() throws Exception {
 		// See https://bugs.eclipse.org/bugs/show_bug.cgi?id=482354
-		assertNotNull("Test must run in UI thread", Display.getCurrent());
+		assertNotNull(Display.getCurrent(), "Test must run in UI thread");
 
 		fileProvider.connect(editor.getEditorInput());
 
@@ -181,13 +181,13 @@ public class TextFileDocumentProviderTest {
 		fileProvider.synchronize(editor.getEditorInput());
 
 		System.out.println("Busy wait terminated, UI thread is operable again!");
-		assertFalse("Test deadlocked while waiting on resource lock", stoppedByTest.get());
+		assertFalse(stoppedByTest.get(), "Test deadlocked while waiting on resource lock");
 		assertTrue(stopLockingFlag.get());
 	}
 
 	@Test
-	public void testValidateStateForFileWhileWorkspaceIsLocked() throws Exception {
-		assertNotNull("Test must run in UI thread", Display.getCurrent());
+	void testValidateStateForFileWhileWorkspaceIsLocked() throws Exception {
+		assertNotNull(Display.getCurrent(), "Test must run in UI thread");
 
 		fileProvider.connect(editor.getEditorInput());
 
@@ -208,7 +208,7 @@ public class TextFileDocumentProviderTest {
 		fileProvider.validateState(editor.getEditorInput(), editor.getSite().getShell());
 
 		System.out.println("Busy wait terminated, UI thread is operable again!");
-		assertFalse("Test deadlocked while waiting on resource lock", stoppedByTest.get());
+		assertFalse(stoppedByTest.get(), "Test deadlocked while waiting on resource lock");
 		assertTrue(stopLockingFlag.get());
 	}
 

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/TextMultiCaretNavigationTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/TextMultiCaretNavigationTest.java
@@ -10,16 +10,16 @@
  ********************************************************************************/
 package org.eclipse.ui.editors.tests;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.widgets.Control;
@@ -51,16 +51,16 @@ public class TextMultiCaretNavigationTest {
 	private static AbstractTextEditor editor;
 	private static StyledText widget;
 
-	@Before
-	public void setUpBeforeClass() throws IOException, PartInitException, CoreException {
+	@BeforeEach
+	void setUpBeforeClass() throws IOException, PartInitException, CoreException {
 		file = File.createTempFile(TextMultiCaretNavigationTest.class.getName(), ".txt");
 		Files.write(file.toPath(), "  abc\n    1234\nxyz".getBytes());
 		editor = (AbstractTextEditor)IDE.openEditorOnFileStore(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI()));
 		widget = (StyledText) editor.getAdapter(Control.class);
 	}
 
-	@After
-	public void tearDown() {
+	@AfterEach
+	void tearDown() {
 		editor.close(false);
 		file.delete();
 		TestUtil.cleanUp();
@@ -68,7 +68,7 @@ public class TextMultiCaretNavigationTest {
 
 
 	@Test
-	public void testShiftHome() {
+	void testShiftHome() {
 		IDocument document = editor.getDocumentProvider().getDocument(editor.getEditorInput());
 		editor.getSelectionProvider().setSelection(new MultiTextSelection(document,
 				new IRegion[] { new Region(5, 0), new Region(14, 0), new Region(18, 0), }));
@@ -88,7 +88,7 @@ public class TextMultiCaretNavigationTest {
 	}
 
 	@Test
-	public void testShiftEnd() {
+	void testShiftEnd() {
 		IDocument document = editor.getDocumentProvider().getDocument(editor.getEditorInput());
 		editor.getSelectionProvider().setSelection(new MultiTextSelection(document,
 				new IRegion[] { new Region(0, 0), new Region(6, 0), new Region(15, 0), }));
@@ -102,7 +102,7 @@ public class TextMultiCaretNavigationTest {
 	}
 
 	@Test
-	public void testShiftEndHomeHome() {
+	void testShiftEndHomeHome() {
 		IDocument document = editor.getDocumentProvider().getDocument(editor.getEditorInput());
 		editor.getSelectionProvider().setSelection(new MultiTextSelection(document,
 				new IRegion[] { new Region(0, 0), new Region(6, 0), new Region(15, 0), }));

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/TextMultiCaretSelectionCommandsTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/TextMultiCaretSelectionCommandsTest.java
@@ -10,20 +10,20 @@
  *
  * Contributors:
  *     Dirk Steinkamp <dirk.steinkamp@gmx.de> - initial API and implementation
- *******************************************************************************/
+ ******************************************************************************/
 package org.eclipse.ui.editors.tests;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collections;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.widgets.Control;
@@ -49,7 +49,7 @@ import org.eclipse.ui.texteditor.AbstractTextEditor;
 
 /*
  * Note: this test would better fit in the org.eclipse.ui.workbench.texteditor bundle, but initializing
- * an editor from this bundle is quite tricky without the IDE and EFS utils.
+ * and editor from this bundle is quite tricky without the IDE and EFS utils.
  */
 public class TextMultiCaretSelectionCommandsTest {
 	private static final String MULTI_SELECTION_DOWN = "org.eclipse.ui.edit.text.select.selectMultiSelectionDown";
@@ -73,8 +73,8 @@ public class TextMultiCaretSelectionCommandsTest {
 	private static AbstractTextEditor editor;
 	private static StyledText widget;
 
-	@Before
-	public void setUpBeforeClass() throws IOException, PartInitException, CoreException {
+	@BeforeEach
+	void setUpBeforeClass() throws IOException, PartInitException, CoreException {
 		file = File.createTempFile(TextMultiCaretSelectionCommandsTest.class.getName(), ".txt");
 		Files.write(file.toPath(), (LINE_1 + LINE_2 + LINE_3 + LINE_4) //
 				.getBytes());
@@ -83,15 +83,15 @@ public class TextMultiCaretSelectionCommandsTest {
 		widget = (StyledText) editor.getAdapter(Control.class);
 	}
 
-	@After
-	public void tearDown() {
+	@AfterEach
+	void tearDown() {
 		editor.close(false);
 		file.delete();
 		TestUtil.cleanUp();
 	}
 
 	@Test
-	public void testMultiSelectionDown_withFirstIdentifierSelected_addsIdenticalIdentifiersToSelection()
+	void testMultiSelectionDown_withFirstIdentifierSelected_addsIdenticalIdentifiersToSelection()
 			throws Exception {
 		setSelection(new IRegion[] { new Region(0, 7) });
 		assertEquals(7, widget.getCaretOffset());
@@ -113,7 +113,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiSelectionDown_withSecondIdentifierSelectedIdentifier_addsNextOccurenceToSelection()
+	void testMultiSelectionDown_withSecondIdentifierSelectedIdentifier_addsNextOccurenceToSelection()
 			throws Exception {
 		setSelection(new IRegion[] { new Region(8, 6) });
 		assertEquals(14, widget.getCaretOffset());
@@ -125,7 +125,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiSelectionDown_withSelectionInSecondRow_addsIdenticalIdentifierInThirdRowToSelection()
+	void testMultiSelectionDown_withSelectionInSecondRow_addsIdenticalIdentifierInThirdRowToSelection()
 			throws Exception {
 		setSelection(new IRegion[] { new Region(L1_LEN + 8, 6) });
 		assertEquals(L1_LEN + 14, widget.getCaretOffset());
@@ -138,7 +138,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiSelectionDown_withTwoSelectionsAndAnchorBelow_reducesSelection() throws Exception {
+	void testMultiSelectionDown_withTwoSelectionsAndAnchorBelow_reducesSelection() throws Exception {
 		setSelection(new IRegion[] { new Region(L1_LEN + 8, 6) });
 		// It is important here to build up the selection in steps, so the
 		// handler can determine an anchor region
@@ -151,7 +151,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiSelectionDown_withTwoSelectionsAndAnchorAbove_extendsSelection() throws Exception {
+	void testMultiSelectionDown_withTwoSelectionsAndAnchorAbove_extendsSelection() throws Exception {
 		setSelection(new IRegion[] { new Region(L1_LEN + 8, 6) });
 		// It is important here to build up the selection in steps, so the
 		// handler can determine an anchor region
@@ -169,7 +169,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	// that check how the selection is expanded
 
 	@Test
-	public void testMultiSelectionDown_withCaretInFirstIdentifier_selectsFullIdentifier() throws Exception {
+	void testMultiSelectionDown_withCaretInFirstIdentifier_selectsFullIdentifier() throws Exception {
 		setSelection(new IRegion[] { new Region(1, 0) });
 		assertEquals(1, widget.getCaretOffset());
 
@@ -180,7 +180,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiSelectionDown_withCaretInSecondIdentifier_selectsFullIdentifier() throws Exception {
+	void testMultiSelectionDown_withCaretInSecondIdentifier_selectsFullIdentifier() throws Exception {
 		setSelection(new IRegion[] { new Region(11, 0) });
 		assertEquals(11, widget.getCaretOffset());
 
@@ -191,7 +191,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiSelectionDown_withCaretBetweenIdentifierCharAndNonIdentifierChar_selectsFullIdentifier()
+	void testMultiSelectionDown_withCaretBetweenIdentifierCharAndNonIdentifierChar_selectsFullIdentifier()
 			throws Exception {
 		setSelection(new IRegion[] { new Region(23, 0) });
 		assertEquals(23, widget.getCaretOffset());
@@ -203,7 +203,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiSelectionDown_withCaretInSecondRow_selectsFullIdentifier() throws Exception {
+	void testMultiSelectionDown_withCaretInSecondRow_selectsFullIdentifier() throws Exception {
 		setSelection(new IRegion[] { new Region(L1_LEN + 11, 0) });
 		assertEquals(L1_LEN + 11, widget.getCaretOffset());
 
@@ -214,7 +214,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiSelectionDown_withCaretInIdentifierWithNoFollowingMatch_selectsFullIdentifier()
+	void testMultiSelectionDown_withCaretInIdentifierWithNoFollowingMatch_selectsFullIdentifier()
 			throws Exception {
 		setSelection(new IRegion[] { new Region(L1_LEN + L2_LEN + L3_LEN + 11, 0) });
 		assertEquals(L1_LEN + L2_LEN + L3_LEN + 11, widget.getCaretOffset());
@@ -226,7 +226,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiSelectionDown_withCaretAtEndOfDocument_selectsFullIdentifier() throws Exception {
+	void testMultiSelectionDown_withCaretAtEndOfDocument_selectsFullIdentifier() throws Exception {
 		setSelection(new IRegion[] { new Region(L1_LEN + L2_LEN + L3_LEN + L4_LEN, 0) });
 		assertEquals(L1_LEN + L2_LEN + L3_LEN + L4_LEN, widget.getCaretOffset());
 
@@ -237,7 +237,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testAddAllMatches_withSingleSelection_selectsAllOccurences() throws Exception {
+	void testAddAllMatches_withSingleSelection_selectsAllOccurences() throws Exception {
 		setSelection(new IRegion[] { new Region(0, 7) });
 		assertEquals(7, widget.getCaretOffset());
 
@@ -249,7 +249,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testAddAllMatches_withDoubleSelectionOfSameText_selectsAllOccurences() throws Exception {
+	void testAddAllMatches_withDoubleSelectionOfSameText_selectsAllOccurences() throws Exception {
 		setSelection(new IRegion[] { new Region(0, 7), new Region(L1_LEN, 7) });
 		assertEquals(7, widget.getCaretOffset());
 
@@ -261,7 +261,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testAddAllMatches_withDoubleSelectionOfDifferentTexts_doesNotChangeSelection() throws Exception {
+	void testAddAllMatches_withDoubleSelectionOfDifferentTexts_doesNotChangeSelection() throws Exception {
 		setSelection(new IRegion[] { new Region(0, 7), new Region(8, 7) });
 		assertEquals(7, widget.getCaretOffset());
 
@@ -272,7 +272,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testAddAllMatches_withCaretInIdentifier_selectsAllOccurencesOfIdentifier() throws Exception {
+	void testAddAllMatches_withCaretInIdentifier_selectsAllOccurencesOfIdentifier() throws Exception {
 		setSelection(new IRegion[] { new Region(2, 0) });
 		assertEquals(2, widget.getCaretOffset());
 
@@ -284,7 +284,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiSelectionUp_withCaretInIdentifier_selectsFullIdentifier() throws Exception {
+	void testMultiSelectionUp_withCaretInIdentifier_selectsFullIdentifier() throws Exception {
 		setSelection(new IRegion[] { new Region(L1_LEN + 11, 0) });
 		assertEquals(L1_LEN + 11, widget.getCaretOffset());
 
@@ -295,7 +295,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiSelectionUp_withSingleSelectionAndNoPreviousMatch_doesNothing() throws Exception {
+	void testMultiSelectionUp_withSingleSelectionAndNoPreviousMatch_doesNothing() throws Exception {
 		setSelection(new IRegion[] { new Region(8, 6) });
 		assertEquals(14, widget.getCaretOffset());
 
@@ -306,7 +306,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiSelectionUp_withTwoSelections_removesSecondSelection() throws Exception {
+	void testMultiSelectionUp_withTwoSelections_removesSecondSelection() throws Exception {
 		setSelection(new IRegion[] { new Region(8, 6), new Region(L1_LEN + 8, 6) });
 		assertEquals(14, widget.getCaretOffset());
 
@@ -317,7 +317,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiSelectionUp_withThreeSelections_removesThirdSelection() throws Exception {
+	void testMultiSelectionUp_withThreeSelections_removesThirdSelection() throws Exception {
 		setSelection(
 				new IRegion[] { new Region(8, 6), new Region(L1_LEN + 8, 6), new Region(L1_LEN + L2_LEN + 10, 6) });
 		assertEquals(14, widget.getCaretOffset());
@@ -329,7 +329,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiSelectionUp_withTwoSelectionsAndAnchorAbove_reducesSelection() throws Exception {
+	void testMultiSelectionUp_withTwoSelectionsAndAnchorAbove_reducesSelection() throws Exception {
 		setSelection(new IRegion[] { new Region(8, 6) });
 		// It is important here to build up the selection in steps, so the
 		// handler can determine an anchor region
@@ -342,7 +342,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiSelectionUp_withTwoSelectionsAndAnchorBelow_extendsSelection() throws Exception {
+	void testMultiSelectionUp_withTwoSelectionsAndAnchorBelow_extendsSelection() throws Exception {
 		setSelection(new IRegion[] { new Region(L1_LEN + L2_LEN + 10, 6) });
 		// It is important here to build up the selection in steps, so the
 		// handler can determine an anchor region
@@ -358,7 +358,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testStopMultiSelection_withSingleSelection_doesNotChangeSelectionOrCaretOffset() throws Exception {
+	void testStopMultiSelection_withSingleSelection_doesNotChangeSelectionOrCaretOffset() throws Exception {
 		setSelection(new IRegion[] { new Region(0, 7) });
 
 		assertEquals(7, widget.getCaretOffset());
@@ -369,7 +369,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testStopMultiSelection_withMultiSelection_revokesSelectionAndKeepsFirstCaretOffset() throws Exception {
+	void testStopMultiSelection_withMultiSelection_revokesSelectionAndKeepsFirstCaretOffset() throws Exception {
 		setSelection(new IRegion[] { new Region(0, 7), new Region(L1_LEN, 7) });
 
 		assertEquals(7, widget.getCaretOffset());
@@ -380,7 +380,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testStopMultiSelection_withMultiSelectionAndCaretAtBeginning_revokesSelectionAndKeepsFirstCaretOffset()
+	void testStopMultiSelection_withMultiSelectionAndCaretAtBeginning_revokesSelectionAndKeepsFirstCaretOffset()
 			throws Exception {
 		setSelection(new IRegion[] { new Region(0, 7), new Region(L1_LEN, 7) });
 		assertEquals(7, widget.getCaretOffset());
@@ -391,7 +391,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testStopMultiSelection_withMultiSelectionAndCaretAfterLastSelection_revokesSelectionAndKeepsCaretOffset()
+	void testStopMultiSelection_withMultiSelectionAndCaretAfterLastSelection_revokesSelectionAndKeepsCaretOffset()
 			throws Exception {
 		setSelection(new IRegion[] { new Region(0, 7), new Region(L1_LEN, 7), new Region(L1_LEN + L2_LEN, 7) });
 		assertEquals(7, widget.getCaretOffset());
@@ -409,7 +409,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiCaretDown_withCaret_addsCaretsInNextLines() throws Exception {
+	void testMultiCaretDown_withCaret_addsCaretsInNextLines() throws Exception {
 		setSelection(new IRegion[] { new Region(0, 0) });
 		assertEquals(0, widget.getCaretOffset());
 
@@ -431,7 +431,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiCaretDown_withTwoCaretsAndAnchorRegionBelow_removesFirstCaret() throws Exception {
+	void testMultiCaretDown_withTwoCaretsAndAnchorRegionBelow_removesFirstCaret() throws Exception {
 		setSelection(new IRegion[] { new Region(L1_LEN, 0) });
 		assertEquals(L1_LEN, widget.getCaretOffset());
 
@@ -452,7 +452,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiCaretDown_withSingleSelection_addsSelectionInNextLine() throws Exception {
+	void testMultiCaretDown_withSingleSelection_addsSelectionInNextLine() throws Exception {
 		setSelection(new IRegion[] { new Region(0, 3) });
 		assertEquals(3, widget.getCaretOffset());
 
@@ -467,7 +467,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiCaretDown_withSingleCaretAtEndOfLongerLine_addsCaretAtEndOfNextLine() throws Exception {
+	void testMultiCaretDown_withSingleCaretAtEndOfLongerLine_addsCaretAtEndOfNextLine() throws Exception {
 		setSelection(new IRegion[] { new Region(L1_LEN + L2_LEN, 0) });
 		assertEquals(L1_LEN + L2_LEN, widget.getCaretOffset());
 
@@ -484,7 +484,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiCaretDown_withSingleCaretInLineAboveLineWithTabs_addsCaretInNextLineRespectingTabs()
+	void testMultiCaretDown_withSingleCaretInLineAboveLineWithTabs_addsCaretInNextLineRespectingTabs()
 			throws Exception {
 		widget.setTabs(4); // Make default explicit
 		setSelection(new IRegion[] { new Region(L1_LEN + 8, 0) });
@@ -503,7 +503,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiCaretDown_withSingleCaretInLineWithTabs_addsCaretInNextLineRespectingTabs() throws Exception {
+	void testMultiCaretDown_withSingleCaretInLineWithTabs_addsCaretInNextLineRespectingTabs() throws Exception {
 		widget.setTabs(4); // Make default explicit
 		setSelection(new IRegion[] { new Region(L1_LEN + L2_LEN + 2, 0) });
 		assertEquals(L1_LEN + L2_LEN + 2, widget.getCaretOffset());
@@ -522,7 +522,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiCaretDown_withSingleCaretAtEndOfText_doesNotChangeCaret() throws Exception {
+	void testMultiCaretDown_withSingleCaretAtEndOfText_doesNotChangeCaret() throws Exception {
 		setSelection(new IRegion[] { new Region(L1_LEN + L2_LEN + L3_LEN + L4_LEN, 0) });
 		assertEquals(L1_LEN + L2_LEN + L3_LEN + L4_LEN, widget.getCaretOffset());
 
@@ -539,7 +539,7 @@ public class TextMultiCaretSelectionCommandsTest {
 
 	/////////////////////////////////////////////////////
 	@Test
-	public void testMultiCaretUp_withCaret_addsCaretsInPreviousLines() throws Exception {
+	void testMultiCaretUp_withCaret_addsCaretsInPreviousLines() throws Exception {
 		setSelection(new IRegion[] { new Region(L1_LEN + L2_LEN, 0) });
 		assertEquals(L1_LEN + L2_LEN, widget.getCaretOffset());
 
@@ -561,7 +561,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiCaretUp_withTwoCaretsAndAnchorRegionAbove_removesLastCaret() throws Exception {
+	void testMultiCaretUp_withTwoCaretsAndAnchorRegionAbove_removesLastCaret() throws Exception {
 		setSelection(new IRegion[] { new Region(0, 0) });
 		assertEquals(0, widget.getCaretOffset());
 
@@ -582,7 +582,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiCaretUp_withSingleSelection_addsSelectionInPreviousLine() throws Exception {
+	void testMultiCaretUp_withSingleSelection_addsSelectionInPreviousLine() throws Exception {
 		setSelection(new IRegion[] { new Region(L1_LEN, 3) });
 		assertEquals(L1_LEN + 3, widget.getCaretOffset());
 
@@ -597,7 +597,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiCaretUp_withSingleCaretAtEndOfLongerLine_addsCaretAtEndOfPreviousLine() throws Exception {
+	void testMultiCaretUp_withSingleCaretAtEndOfLongerLine_addsCaretAtEndOfPreviousLine() throws Exception {
 		setSelection(new IRegion[] { new Region(L1_LEN + L2_LEN, 0) });
 		assertEquals(L1_LEN + L2_LEN, widget.getCaretOffset());
 
@@ -613,7 +613,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiCaretUp_withSingleCaretInLineBelowLineWithTabs_addsCaretInPreviousLineRespectingTabs()
+	void testMultiCaretUp_withSingleCaretInLineBelowLineWithTabs_addsCaretInPreviousLineRespectingTabs()
 			throws Exception {
 		widget.setTabs(4); // Make default explicit
 		setSelection(new IRegion[] { new Region(L1_LEN + L2_LEN + L3_LEN + 8, 0) });
@@ -633,7 +633,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiCaretUp_withSingleCaretInLineWithTabs_addsCaretInPreviousLineRespectingTabs()
+	void testMultiCaretUp_withSingleCaretInLineWithTabs_addsCaretInPreviousLineRespectingTabs()
 			throws Exception {
 		widget.setTabs(4); // Make default explicit
 		setSelection(new IRegion[] { new Region(L1_LEN + L2_LEN + 2, 0) });
@@ -652,7 +652,7 @@ public class TextMultiCaretSelectionCommandsTest {
 	}
 
 	@Test
-	public void testMultiCaretUp_withSingleCaretAtBeginningOfText_doesNotChangeCaret() throws Exception {
+	void testMultiCaretUp_withSingleCaretAtBeginningOfText_doesNotChangeCaret() throws Exception {
 		setSelection(new IRegion[] { new Region(0, 0) });
 		assertEquals(0, widget.getCaretOffset());
 

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/TextNavigationTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/TextNavigationTest.java
@@ -10,8 +10,8 @@
  ********************************************************************************/
 package org.eclipse.ui.editors.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -19,9 +19,9 @@ import java.nio.file.Files;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.widgets.Control;
@@ -57,8 +57,8 @@ public class TextNavigationTest {
 	private StyledText widget;
 	private IDocument fDocument;
 
-	@Before
-	public void setUp() throws IOException, PartInitException, CoreException {
+	@BeforeEach
+	void setUp() throws IOException, PartInitException, CoreException {
 		file = File.createTempFile(TextNavigationTest.class.getName(), ".txt");
 		Files.write(file.toPath(), "  abc".getBytes());
 		editor = (AbstractTextEditor)IDE.openEditorOnFileStore(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI()));
@@ -66,15 +66,15 @@ public class TextNavigationTest {
 		widget = (StyledText) editor.getAdapter(Control.class);
 	}
 
-	@After
-	public void tearDown() {
+	@AfterEach
+	void tearDown() {
 		editor.close(false);
 		file.delete();
 		TestUtil.cleanUp();
 	}
 
 	@Test
-	public void testHome() {
+	void testHome() {
 		IPreferenceStore preferenceStore = EditorsPlugin.getDefault().getPreferenceStore();
 		boolean previousPrefValue = preferenceStore.getBoolean(AbstractTextEditor.PREFERENCE_NAVIGATION_SMART_HOME_END);
 		preferenceStore.setValue(AbstractTextEditor.PREFERENCE_NAVIGATION_SMART_HOME_END, false);
@@ -91,7 +91,7 @@ public class TextNavigationTest {
 	}
 
 	@Test
-	public void testShiftHome() {
+	void testShiftHome() {
 		editor.selectAndReveal(5, 0);
 		IAction action= editor.getAction(ITextEditorActionDefinitionIds.SELECT_LINE_START);
 		action.run();
@@ -107,7 +107,7 @@ public class TextNavigationTest {
 	}
 
 	@Test
-	public void testShiftEnd() {
+	void testShiftEnd() {
 		editor.getSelectionProvider().setSelection(new TextSelection(0, 0));
 		IAction action= editor.getAction(ITextEditorActionDefinitionIds.SELECT_LINE_END);
 		action.run();
@@ -118,7 +118,7 @@ public class TextNavigationTest {
 	}
 
 	@Test
-	public void testShiftEndMultipleLines() {
+	void testShiftEndMultipleLines() {
 		fDocument.set("LINE 1\nLINE 2\n");
 		editor.selectAndReveal(12, -7);
 		editor.getAction(ITextEditorActionDefinitionIds.SELECT_LINE_END).run();
@@ -129,7 +129,7 @@ public class TextNavigationTest {
 	}
 
 	@Test
-	public void testShiftEndHomeHome() {
+	void testShiftEndHomeHome() {
 		editor.getSelectionProvider().setSelection(new TextSelection(0, 0));
 		assertEquals(0, widget.getCaretOffset());
 
@@ -153,7 +153,7 @@ public class TextNavigationTest {
 	}
 
 	@Test
-	public void testEndHomeRevealCaret() {
+	void testEndHomeRevealCaret() {
 		editor.getSelectionProvider().setSelection(new TextSelection(0, 0));
 		fDocument.set(IntStream.range(0, 2000).mapToObj(i -> "a").collect(Collectors.joining()));
 		PlatformUI.getWorkbench().getIntroManager().closeIntro(PlatformUI.getWorkbench().getIntroManager().getIntro());

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/ZoomTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/editors/tests/ZoomTest.java
@@ -13,15 +13,16 @@
  *******************************************************************************/
 package org.eclipse.ui.editors.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.widgets.Control;
@@ -54,8 +55,8 @@ public class ZoomTest {
 	private AbstractTextEditor editor;
 	private int initialFontSize;
 
-	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
+	@BeforeAll
+	static void setUpBeforeClass() throws Exception {
 		project = ResourcesPlugin.getWorkspace().getRoot().getProject("test");
 		project.create(new NullProgressMonitor());
 		project.open(new NullProgressMonitor());
@@ -63,15 +64,15 @@ public class ZoomTest {
 		file.create(new ByteArrayInputStream("bar".getBytes()), true, new NullProgressMonitor());
 	}
 
-	@AfterClass
-	public static void tearDownAfterClass() throws Exception {
+	@AfterAll
+	static void tearDownAfterClass() throws Exception {
 		file.delete(true, new NullProgressMonitor());
 		project.delete(true, new NullProgressMonitor());
 		TestUtil.cleanUp();
 	}
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeEach
+	void setUp() throws Exception {
 		IIntroPart intro = PlatformUI.getWorkbench().getIntroManager().getIntro();
 		if (intro != null) {
 			PlatformUI.getWorkbench().getIntroManager().closeIntro(intro);
@@ -86,27 +87,27 @@ public class ZoomTest {
 		initialFontSize = text.getFont().getFontData()[0].getHeight();
 	}
 
-	@After
-	public void tearDown() throws Exception {
+	@AfterEach
+	void tearDown() throws Exception {
 		editor.close(false);
 		editor= null;
 	}
 
 	@Test
-	public void testZoomCommand() throws Exception {
+	void testZoomCommand() throws Exception {
 		int times = 6;
 		Command zoomInCommand = PlatformUI.getWorkbench().getService(ICommandService.class)
 				.getCommand("org.eclipse.ui.edit.text.zoomIn");
 		for (int i = 0; i < times; i++) {
 			zoomInCommand.executeWithChecks(new ExecutionEvent(zoomInCommand, Collections.EMPTY_MAP, null, null));
 		}
-		Assert.assertEquals(this.initialFontSize + 12, text.getFont().getFontData()[0].getHeight());
+		assertEquals(this.initialFontSize + 12, text.getFont().getFontData()[0].getHeight());
 		Command zoomOutCommand = PlatformUI.getWorkbench().getService(ICommandService.class)
 				.getCommand("org.eclipse.ui.edit.text.zoomOut");
 		for (int i = 0; i < times; i++) {
 			zoomOutCommand.executeWithChecks(new ExecutionEvent(zoomOutCommand, Collections.EMPTY_MAP, null, null));
 		}
-		Assert.assertEquals(this.initialFontSize, text.getFont().getFontData()[0].getHeight());
+		assertEquals(this.initialFontSize, text.getFont().getFontData()[0].getHeight());
 	}
 
 }

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/DefaultStickyLinesProviderTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/DefaultStickyLinesProviderTest.java
@@ -16,14 +16,14 @@ package org.eclipse.ui.internal.texteditor.stickyscroll;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyledText;
@@ -53,8 +53,8 @@ public class DefaultStickyLinesProviderTest {
 	private StickyLinesProperties stickyLinesProperties;
 	private IEditorPart editorPart;
 
-	@Before
-	public void setup() {
+	@BeforeEach
+	void setup() {
 		shell = new Shell(Display.getDefault());
 		sourceViewer = new SourceViewer(shell, null, SWT.None);
 		sourceViewer.setDocument(new Document());
@@ -64,20 +64,20 @@ public class DefaultStickyLinesProviderTest {
 		stickyLinesProperties = new StickyLinesProperties(4, editorPart);
 	}
 
-	@After
-	public void teardown() {
+	@AfterEach
+	void teardown() {
 		TestUtil.cleanUp();
 	}
 
 	@Test
-	public void testEmptySourceCode() {
+	void testEmptySourceCode() {
 		List<IStickyLine> stickyLines = stickyLinesProvider.getStickyLines(sourceViewer, 0, stickyLinesProperties);
 
 		assertThat(stickyLines, is(empty()));
 	}
 
 	@Test
-	public void testSingleStickyLine() {
+	void testSingleStickyLine() {
 		String text = """
 				line 1
 				 line 2<""";
@@ -91,7 +91,7 @@ public class DefaultStickyLinesProviderTest {
 	}
 
 	@Test
-	public void testLineUnderStickyLine() {
+	void testLineUnderStickyLine() {
 		String text = """
 				line 1
 				 line 2<
@@ -106,7 +106,7 @@ public class DefaultStickyLinesProviderTest {
 	}
 
 	@Test
-	public void testNewStickyRoot() {
+	void testNewStickyRoot() {
 		String text = """
 				line 1
 				 line 2
@@ -121,7 +121,7 @@ public class DefaultStickyLinesProviderTest {
 	}
 
 	@Test
-	public void testIgnoreEmptyLines() {
+	void testIgnoreEmptyLines() {
 		String text = """
 				line 1
 
@@ -138,7 +138,7 @@ public class DefaultStickyLinesProviderTest {
 	}
 
 	@Test
-	public void testIgnoreOtherBlankLines() {
+	void testIgnoreOtherBlankLines() {
 		String text = """
 				line 1
 				    \t
@@ -155,7 +155,7 @@ public class DefaultStickyLinesProviderTest {
 	}
 
 	@Test
-	public void testLinesWithTabs() {
+	void testLinesWithTabs() {
 		stickyLinesProperties = new StickyLinesProperties(2, editorPart);
 		String text = """
 				line 1
@@ -171,7 +171,7 @@ public class DefaultStickyLinesProviderTest {
 	}
 
 	@Test
-	public void testLinesWithTabsAndSpaces() {
+	void testLinesWithTabsAndSpaces() {
 		// tab witdh 4
 		String text = """
 				line 1
@@ -189,7 +189,7 @@ public class DefaultStickyLinesProviderTest {
 	}
 
 	@Test
-	public void testStartAtEmptyLineWithNext() {
+	void testStartAtEmptyLineWithNext() {
 		String text = """
 				line 1
 
@@ -207,7 +207,7 @@ public class DefaultStickyLinesProviderTest {
 	}
 
 	@Test
-	public void testStartAtEmptyLineWithPrevious() {
+	void testStartAtEmptyLineWithPrevious() {
 		String text = """
 				line 1
 				 line 2
@@ -224,7 +224,7 @@ public class DefaultStickyLinesProviderTest {
 	}
 
 	@Test
-	public void testStickyLineWithSourceViewerLineMapping() {
+	void testStickyLineWithSourceViewerLineMapping() {
 		sourceViewer = new SourceViewerWithLineMapping(shell, null, SWT.None);
 		sourceViewer.setDocument(new Document());
 		textWidget = sourceViewer.getTextWidget();

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyLinesProviderRegistryTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyLinesProviderRegistryTest.java
@@ -8,9 +8,9 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionRegistry;
@@ -29,8 +29,8 @@ public class StickyLinesProviderRegistryTest {
 	private ISourceViewer viewer;
 	private ITextEditor editor;
 
-	@Before
-	public void setup() {
+	@BeforeEach
+	void setup() {
 		IConfigurationElement[] configurationElement = { mock(IConfigurationElement.class) };
 		stickyLinesProviderDescriptor = mock(StickyLinesProviderDescriptor.class);
 		viewer = mock(ISourceViewer.class);
@@ -43,13 +43,13 @@ public class StickyLinesProviderRegistryTest {
 		cut = new StickyLinesProviderRegistry(extensionRegistry, e -> stickyLinesProviderDescriptor);
 	}
 
-	@After
-	public void teardown() {
+	@AfterEach
+	void teardown() {
 		TestUtil.cleanUp();
 	}
 
 	@Test
-	public void testGetDefaultProviderIfNoMatch() {
+	void testGetDefaultProviderIfNoMatch() {
 		when(stickyLinesProviderDescriptor.matches(viewer, editor)).thenReturn(false);
 
 		IStickyLinesProvider provider = cut.getProvider(viewer, editor);
@@ -58,7 +58,7 @@ public class StickyLinesProviderRegistryTest {
 	}
 
 	@Test
-	public void testGetProviderForMatch() {
+	void testGetProviderForMatch() {
 		IStickyLinesProvider expProvider = mock(IStickyLinesProvider.class);
 		when(stickyLinesProviderDescriptor.matches(viewer, editor)).thenReturn(true);
 		when(stickyLinesProviderDescriptor.createStickyLinesProvider()).thenReturn(expProvider);

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
@@ -10,21 +10,21 @@
  *
  * Contributors:
  *     SAP SE - initial API and implementation
- *******************************************************************************/
+ ******************************************************************************/
 package org.eclipse.ui.internal.texteditor.stickyscroll;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
@@ -62,8 +62,8 @@ public class StickyScrollingControlTest {
 	private IVerticalRuler ruler;
 	private StickyScrollingControlSettings settings;
 
-	@Before
-	public void setup() {
+	@BeforeEach
+	void setup() {
 		shell = new Shell(Display.getDefault());
 		shell.setSize(200, 200);
 		shell.setLayout(new FillLayout());
@@ -81,8 +81,8 @@ public class StickyScrollingControlTest {
 		stickyScrollingControl = new StickyScrollingControl(sourceViewer, ruler, settings, null);
 	}
 
-	@After
-	public void teardown() {
+	@AfterEach
+	void teardown() {
 		shell.dispose();
 		stickyScrollingControl.dispose();
 		lineNumberColor.dispose();
@@ -92,7 +92,7 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testShowStickyLineTexts() {
+	void testShowStickyLineTexts() {
 		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 10", 9), new StickyLineStub("line 20", 19));
 		stickyScrollingControl.setStickyLines(stickyLines);
 
@@ -105,7 +105,7 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testCorrectColorsApplied() {
+	void testCorrectColorsApplied() {
 		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 10", 9), new StickyLineStub("line 20", 19));
 		stickyScrollingControl.setStickyLines(stickyLines);
 
@@ -121,7 +121,7 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testLimitStickyLinesCount() {
+	void testLimitStickyLinesCount() {
 		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 10", 9), new StickyLineStub("line 20", 19));
 		stickyScrollingControl.setStickyLines(stickyLines);
 
@@ -138,7 +138,7 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testCopyStyleRanges() {
+	void testCopyStyleRanges() {
 		StyleRange styleRangeLine1 = new StyleRange(0, 1, lineNumberColor, backgroundColor);
 		StyleRange styleRangeLine2 = new StyleRange(0, 2, hoverColor, separatorColor);
 		List<IStickyLine> stickyLines = List.of(//
@@ -162,7 +162,7 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testCopyStyleRangesWithLimitedStickyLines() {
+	void testCopyStyleRangesWithLimitedStickyLines() {
 		settings = new StickyScrollingControlSettings(1, lineNumberColor, hoverColor, backgroundColor, separatorColor,
 				true);
 		stickyScrollingControl.applySettings(settings);
@@ -185,7 +185,7 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testWithoutVerticalRuler() {
+	void testWithoutVerticalRuler() {
 		SourceViewer sourceViewerWithoutRuler = new SourceViewer(shell, null, SWT.None);
 		StickyScrollingControl stickyScrollingControlWithoutRuler = new StickyScrollingControl(sourceViewerWithoutRuler,
 				new StickyScrollingControlSettings(5, lineNumberColor, hoverColor, backgroundColor, separatorColor,
@@ -200,7 +200,7 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testWithoutLineNumber() {
+	void testWithoutLineNumber() {
 		when(ruler.getWidth()).thenReturn(20);
 		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 10", 9), new StickyLineStub("line 20", 19));
 		stickyScrollingControl.setStickyLines(stickyLines);
@@ -217,7 +217,7 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testStyling() {
+	void testStyling() {
 		Font font = new Font(shell.getDisplay(), new FontData("Arial", 12, SWT.BOLD));
 		sourceViewer.getTextWidget().setLineSpacing(10);
 		sourceViewer.getTextWidget().setFont(font);
@@ -237,7 +237,7 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testLayoutStickyLinesCanvasOnResize() {
+	void testLayoutStickyLinesCanvasOnResize() {
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
 
 		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 1", 0));
@@ -262,7 +262,7 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testDontLayoutOutDatedStickyLinesOnResize() {
+	void testDontLayoutOutDatedStickyLinesOnResize() {
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
 
 		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 1", 1));
@@ -281,10 +281,8 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testNavigateToStickyLine() {
-		String text = """
-				line 1
-				line 2""";
+	void testNavigateToStickyLine() {
+		String text = "line 1\nline 2";
 		sourceViewer.setInput(new Document(text));
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
 
@@ -300,12 +298,10 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testVerticalScrollingIsDispatched() {
+	void testVerticalScrollingIsDispatched() {
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 0);
 		Canvas stickyControlCanvas = getStickyControlCanvas(shell);
-		String text = """
-				line 1
-				line 2""";
+		String text = "line 1\nline 2";
 		sourceViewer.setInput(new Document(text));
 		sourceViewer.getTextWidget().getVerticalBar().setIncrement(10);
 		assertEquals(0, sourceViewer.getTextWidget().getTopPixel());
@@ -318,12 +314,10 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testHorizontalScrollingIsDispatched() {
+	void testHorizontalScrollingIsDispatched() {
 		sourceViewer.getTextWidget().setBounds(0, 0, 0, 200);
 		Canvas stickyControlCanvas = getStickyControlCanvas(shell);
-		String text = """
-				line 1
-				line 2""";
+		String text = "line 1\nline 2";
 		sourceViewer.setInput(new Document(text));
 		sourceViewer.getTextWidget().getHorizontalBar().setIncrement(10);
 		assertEquals(0, sourceViewer.getTextWidget().getHorizontalPixel());
@@ -336,7 +330,7 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testLimitStickyLinesToTextWidgetHeight() {
+	void testLimitStickyLinesToTextWidgetHeight() {
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
 		sourceViewer.getTextWidget().setText("line1\nline2");
 		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 2", 1));
@@ -351,19 +345,10 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testListenForCaretAfterKeyDown() {
+	void testListenForCaretAfterKeyDown() {
 		// set height to 10 so that scrolling is needed
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 10);
-		String text = """
-				line 1
-				line 2
-				line 3
-				line 4
-				line 5
-				line 6
-				line 7
-				line 8
-				line 9""";
+		String text = "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9";
 		sourceViewer.setInput(new Document(text));
 		assertEquals(0, sourceViewer.getTextWidget().getTopPixel());
 
@@ -375,19 +360,10 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testDontListenForCaretWithoutKeyDown() {
+	void testDontListenForCaretWithoutKeyDown() {
 		// set height to 10 so that scrolling is needed
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 10);
-		String text = """
-				line 1
-				line 2
-				line 3
-				line 4
-				line 5
-				line 6
-				line 7
-				line 8
-				line 9""";
+		String text = "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9";
 		sourceViewer.setInput(new Document(text));
 		assertEquals(0, sourceViewer.getTextWidget().getTopPixel());
 
@@ -398,19 +374,10 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testDontScrollOnCaretAtDocumentEnd() {
+	void testDontScrollOnCaretAtDocumentEnd() {
 		// set height to 10 so that scrolling is needed
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 10);
-		String text = """
-				line 1
-				line 2
-				line 3
-				line 4
-				line 5
-				line 6
-				line 7
-				line 8
-				line 9""";
+		String text = "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9";
 		sourceViewer.setInput(new Document(text));
 		assertEquals(0, sourceViewer.getTextWidget().getTopPixel());
 
@@ -422,19 +389,10 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
-	public void testDontScrollOnCaretWhenDocumentChangedBeforeExecution() {
+	void testDontScrollOnCaretWhenDocumentChangedBeforeExecution() {
 		// set height to 10 so that scrolling is needed
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 10);
-		String text = """
-				line 1
-				line 2
-				line 3
-				line 4
-				line 5
-				line 6
-				line 7
-				line 8
-				line 9""";
+		String text = "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9";
 		sourceViewer.setInput(new Document(text));
 		assertEquals(0, sourceViewer.getTextWidget().getTopPixel());
 		sourceViewer.getTextWidget().notifyListeners(SWT.KeyDown, new Event());

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandlerTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingHandlerTest.java
@@ -18,8 +18,8 @@ import static org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceCon
 import static org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants.EDITOR_LINE_NUMBER_RULER_COLOR;
 import static org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants.EDITOR_STICKY_SCROLLING_MAXIMUM_COUNT;
 import static org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants.EDITOR_TAB_WIDTH;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.atLeastOnce;
@@ -32,9 +32,9 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.StringJoiner;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
@@ -75,8 +75,8 @@ public class StickyScrollingHandlerTest {
 	private StyledText textWidget;
 	private IEditorPart editorPart;
 
-	@Before
-	public void setup() {
+	@BeforeEach
+	void setup() {
 		shell = new Shell(Display.getDefault());
 		shell.setBounds(0, 0, 200, 80);
 		ruler = new CompositeRuler();
@@ -98,14 +98,14 @@ public class StickyScrollingHandlerTest {
 		stickyLinesProperties = new StickyLinesProperties(4, editorPart);
 	}
 
-	@After
-	public void teardown() {
+	@AfterEach
+	void teardown() {
 		shell.dispose();
 		TestUtil.cleanUp();
 	}
 
 	@Test
-	public void testShowStickyLines() {
+	void testShowStickyLines() {
 		when(linesProvider.getStickyLines(sourceViewer, 1, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 10", 9)));
 
@@ -120,7 +120,7 @@ public class StickyScrollingHandlerTest {
 	}
 
 	@Test
-	public void testDontCalculateStickyLinesForFirstLine() {
+	void testDontCalculateStickyLinesForFirstLine() {
 		textWidget.setTopIndex(0);
 
 		stickyScrollingHandler.viewportChanged(100);
@@ -133,7 +133,7 @@ public class StickyScrollingHandlerTest {
 	}
 
 	@Test
-	public void testUnistallStickyLines() {
+	void testUnistallStickyLines() {
 		Canvas stickyControlCanvas = getStickyControlCanvas(this.shell);
 
 		stickyScrollingHandler.uninstall();
@@ -142,7 +142,7 @@ public class StickyScrollingHandlerTest {
 	}
 
 	@Test
-	public void testPreferencesLoaded() {
+	void testPreferencesLoaded() {
 		when(linesProvider.getStickyLines(sourceViewer, 1, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 10", 9)));
 
@@ -153,7 +153,7 @@ public class StickyScrollingHandlerTest {
 	}
 
 	@Test
-	public void testPreferencesUpdated() {
+	void testPreferencesUpdated() {
 		when(linesProvider.getStickyLines(sourceViewer, 1, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 10", 9), new StickyLineStub("line 20", 19)));
 		when(linesProvider.getStickyLines(sourceViewer, 2, stickyLinesProperties))
@@ -173,7 +173,7 @@ public class StickyScrollingHandlerTest {
 	}
 
 	@Test
-	public void testThrottledExecution() throws InterruptedException {
+	void testThrottledExecution() throws InterruptedException {
 		when(linesProvider.getStickyLines(sourceViewer, 1, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 10", 9)));
 		when(linesProvider.getStickyLines(sourceViewer, 1, stickyLinesProperties))
@@ -200,7 +200,7 @@ public class StickyScrollingHandlerTest {
 	}
 
 	@Test
-	public void testRemoveStickyLines() {
+	void testRemoveStickyLines() {
 		when(linesProvider.getStickyLines(sourceViewer, 1, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 1", 0), new StickyLineStub("line 2", 1)));
 		when(linesProvider.getStickyLines(sourceViewer, 2, stickyLinesProperties))
@@ -214,7 +214,7 @@ public class StickyScrollingHandlerTest {
 	}
 
 	@Test
-	public void testLineUnderStickyLine() {
+	void testLineUnderStickyLine() {
 		when(linesProvider.getStickyLines(sourceViewer, 1, stickyLinesProperties))
 				.thenReturn(List.of(new StickyLineStub("line 1", 0)));
 		when(linesProvider.getStickyLines(sourceViewer, 2, stickyLinesProperties))

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/texteditor/stickyscroll/StickyLineTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/texteditor/stickyscroll/StickyLineTest.java
@@ -10,15 +10,15 @@
  *
  * Contributors:
  *     SAP SE - initial API and implementation
- *******************************************************************************/
+ ******************************************************************************/
 package org.eclipse.ui.texteditor.stickyscroll;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
@@ -41,8 +41,8 @@ public class StickyLineTest {
 	private Color color;
 	private ISourceViewer sourceViewer;
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	void setUp() {
 		shell = new Shell();
 		sourceViewer = new SourceViewer(shell, null, SWT.None);
 		sourceViewer.setDocument(new Document());
@@ -50,21 +50,21 @@ public class StickyLineTest {
 		color = new Color(0, 0, 0);
 	}
 
-	@After
-	public void tearDown() {
+	@AfterEach
+	void tearDown() {
 		shell.dispose();
 		color.dispose();
 	}
 
 	@Test
-	public void testGetLineNumber() {
+	void testGetLineNumber() {
 		StickyLine stickyLine = new StickyLine(1, sourceViewer);
 
 		assertEquals(1, stickyLine.getLineNumber());
 	}
 
 	@Test
-	public void testGetText() {
+	void testGetText() {
 		textWidget.setText("line1\nline2\nline3");
 		StickyLine stickyLine = new StickyLine(1, sourceViewer);
 
@@ -72,7 +72,7 @@ public class StickyLineTest {
 	}
 
 	@Test
-	public void testGetStyleRanges() {
+	void testGetStyleRanges() {
 		textWidget.setText("line1\nline2\nline3");
 
 		// line1
@@ -96,7 +96,7 @@ public class StickyLineTest {
 	}
 
 	@Test
-	public void testGetStyleRangesIgnoresOutOfBoundLines() {
+	void testGetStyleRangesIgnoresOutOfBoundLines() {
 		textWidget.setText("line1\nline2\nline3");
 
 		StickyLine stickyLineOutOfBound = new StickyLine(10, sourceViewer);
@@ -107,7 +107,7 @@ public class StickyLineTest {
 	}
 
 	@Test
-	public void WithSourceViewerLineMapping() {
+	void WithSourceViewerLineMapping() {
 		sourceViewer = new SourceViewerWithLineMapping(shell, null, SWT.None);
 		sourceViewer.setDocument(new Document());
 		textWidget = sourceViewer.getTextWidget();


### PR DESCRIPTION
This PR migrates the tests in `org.eclipse.ui.editors.tests` from JUnit 4 to JUnit 5.

Changes include:
- Updating `MANIFEST.MF` to remove `org.junit` (JUnit 4) dependency and add `org.junit.jupiter.api` (JUnit 5) and other necessary packages.
- Replacing JUnit 4 annotations and assertions with their JUnit 5 equivalents.
- Migrating `TemporaryFolder` rule to `@TempDir`.
- Ensuring all 131 tests pass with `mvn clean verify`.