### PR TITLE
Migrate ConformanceTestSuite and dependencies to JUnit 5

### DIFF
--- a/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/MutableObservableCollectionContractTest.java
+++ b/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/MutableObservableCollectionContractTest.java
@@ -16,9 +16,9 @@
 
 package org.eclipse.jface.databinding.conformance;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,8 +30,8 @@ import org.eclipse.jface.databinding.conformance.delegate.IObservableCollectionC
 import org.eclipse.jface.databinding.conformance.util.ChangeEventTracker;
 import org.eclipse.jface.databinding.conformance.util.CurrentRealm;
 import org.eclipse.jface.databinding.conformance.util.RealmTester;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Mutability tests for IObservableCollection.
@@ -58,7 +58,7 @@ public class MutableObservableCollectionContractTest extends
 	}
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		super.setUp();
 		collection = (IObservableCollection) super.getObservable();
@@ -160,9 +160,8 @@ public class MutableObservableCollectionContractTest extends
 	public void testRemoveAll_NoChange() throws Exception {
 		ChangeEventTracker tracker = ChangeEventTracker.observe(collection);
 		collection.removeAll(Collections.EMPTY_LIST);
-		assertEquals(
-				"List.removeAll on an empty list should not fire a list change event",
-				0, tracker.count);
+		assertEquals(0, tracker.count,
+				"List.removeAll on an empty list should not fire a list change event");
 	}
 
 	@Test
@@ -205,20 +204,18 @@ public class MutableObservableCollectionContractTest extends
 		listener2.contains = true;
 
 		collection.retainAll(Arrays.asList(new Object[] { element1 }));
-		assertTrue(
-				formatFail("When Collection.retainAll(...) fires the change event the element should have been retained in the Collection."),
-				listener1.contains);
-		assertFalse(
-				formatFail("When Collection.retainAll(...) fires the change event the element should have been removed from the Collection."),
-				listener2.contains);
+		assertTrue(listener1.contains,
+				formatFail("When Collection.retainAll(...) fires the change event the element should have been retained in the Collection."));
+		assertFalse(listener2.contains,
+				formatFail("When Collection.retainAll(...) fires the change event the element should have been removed from the Collection."));
 	}
 
 	@Test
 	public void testRetainAll_NoChangeFiresNoChangeEvent() throws Exception {
 		ChangeEventTracker tracker = ChangeEventTracker.observe(collection);
 		collection.retainAll(Collections.EMPTY_LIST);
-		assertEquals("List.retainAll should not have fired a change event:", 0,
-				tracker.count);
+		assertEquals(0, tracker.count,
+				"List.retainAll should not have fired a change event:");
 	}
 
 	@Test
@@ -253,12 +250,11 @@ public class MutableObservableCollectionContractTest extends
 		ChangeEventTracker listener = ChangeEventTracker.observe(collection);
 		runnable.run();
 
-		assertEquals(formatFail(methodName + " should fire one ChangeEvent."),
-				1, listener.count);
-		assertEquals(
+		assertEquals(1, listener.count,
+				formatFail(methodName + " should fire one ChangeEvent."));
+		assertEquals(collection, listener.event.getObservable(),
 				formatFail(methodName
-						+ "'s change event observable should be the created Collection."),
-				collection, listener.event.getObservable());
+						+ "'s change event observable should be the created Collection."));
 	}
 
 	/**
@@ -277,11 +273,11 @@ public class MutableObservableCollectionContractTest extends
 				elementNotContained).init();
 		listener.contains = true;
 		collection.remove(elementNotContained);
-		assertFalse(
+		assertFalse(listener.contains,
 				formatFail(new StringBuilder("When ")
 						.append(methodName)
 						.append(" fires a change event the element should have been removed from the Collection.")
-						.toString()), listener.contains);
+						.toString()));
 	}
 
 	/**
@@ -299,11 +295,11 @@ public class MutableObservableCollectionContractTest extends
 		assertFalse(collection.contains(elementContained));
 		runnable.run();
 
-		assertTrue(
+		assertTrue(listener.contains,
 				formatFail(new StringBuilder("When ")
 						.append(methodName)
 						.append(" fires a change event the element should have been added to the Collection.")
-						.toString()), listener.contains);
+						.toString()));
 	}
 
 	/* package */static class ContainsListener implements IChangeListener {

--- a/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/MutableObservableListContractTest.java
+++ b/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/MutableObservableListContractTest.java
@@ -16,8 +16,8 @@
 
 package org.eclipse.jface.databinding.conformance;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,9 +30,8 @@ import org.eclipse.core.databinding.observable.list.ListDiff;
 import org.eclipse.jface.databinding.conformance.delegate.IObservableCollectionContractDelegate;
 import org.eclipse.jface.databinding.conformance.util.ChangeEventTracker;
 import org.eclipse.jface.databinding.conformance.util.ListChangeEventTracker;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Mutability tests for IObservableList.
@@ -60,7 +59,7 @@ public class MutableObservableListContractTest extends
 	}
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		super.setUp();
 		list = (IObservableList) getObservable();
@@ -186,7 +185,7 @@ public class MutableObservableListContractTest extends
 		list.add(element0);
 		final Object element1 = delegate.createElement(list);
 
-		assertListChangeEventFired(() -> assertSame(element0, list.set(0, element1)), "List.set(int, Object)", list,
+		assertListChangeEventFired(() -> assertSame(element0, list.set(0, element1), "List.set(int, Object)"), "List.set(int, Object)", list,
 				Arrays.asList(new Object[] { element1 }));
 	}
 
@@ -196,7 +195,7 @@ public class MutableObservableListContractTest extends
 		list.add(element1);
 		final Object element2 = delegate.createElement(list);
 
-		assertContainsDuringChangeEvent(() -> assertSame(element1, list.set(0, element2)), "List.set(int, Object)",
+		assertContainsDuringChangeEvent(() -> assertSame(element1, list.set(0, element2), "List.set(int, Object)"), "List.set(int, Object)",
 				list, element2);
 	}
 
@@ -229,13 +228,11 @@ public class MutableObservableListContractTest extends
 
 		final Object movedElement = list.move(0, 0);
 
-		assertEquals(
-				formatFail("IObservableList.move(int,int) should return the moved element"),
-				element, movedElement);
-		assertEquals(
+		assertEquals(element, movedElement,
+				formatFail("IObservableList.move(int,int) should return the moved element"));
+		assertEquals(0, tracker.count,
 				formatFail("IObservableLIst.move(int,int) should not fire a change event"
-						+ "when the old and new indices are the same"), 0,
-				tracker.count);
+						+ "when the old and new indices are the same"));
 	}
 
 	@Test
@@ -245,7 +242,7 @@ public class MutableObservableListContractTest extends
 		final Object element1 = delegate.createElement(list);
 		list.add(element1);
 
-		assertListChangeEventFired(() -> assertSame(element0, list.move(0, 1)), "IObservableList.move(int, int)", list,
+		assertListChangeEventFired(() -> assertSame(element0, list.move(0, 1), "IObservableList.move(int, int)"), "IObservableList.move(int, int)", list,
 				Arrays.asList(new Object[] { element1, element0 }));
 	}
 
@@ -398,9 +395,9 @@ public class MutableObservableListContractTest extends
 	public void testClear_ClearsList() {
 		Object element = delegate.createElement(list);
 		list.add(element);
-		Assert.assertEquals(Collections.singletonList(element), list);
+		assertEquals(Collections.singletonList(element), list);
 		list.clear();
-		Assert.assertEquals(Collections.EMPTY_LIST, list);
+		assertEquals(Collections.EMPTY_LIST, list);
 	}
 
 	private void assertListChangeEventFired(Runnable runnable,
@@ -416,32 +413,30 @@ public class MutableObservableListContractTest extends
 
 		runnable.run();
 
-		assertEquals(formatFail(methodName
-				+ " should fire one ListChangeEvent."), 1, listListener.count);
-		assertEquals(formatFail(methodName
-				+ "'s change event observable should be the created List."),
-				list, listListener.event.getObservable());
+		assertEquals(1, listListener.count, formatFail(methodName
+				+ " should fire one ListChangeEvent."));
+		assertEquals(list, listListener.event.getObservable(),
+				formatFail(methodName
+				+ "'s change event observable should be the created List."));
 
-		assertEquals(
-				formatFail("Two notifications should have been received."), 2,
-				queue.size());
-		assertEquals("ChangeEvent of " + methodName
-				+ " should have fired before the ListChangeEvent.",
-				changeListener, queue.get(0));
-		assertEquals("ListChangeEvent of " + methodName
-				+ " should have fired after the ChangeEvent.", listListener,
-				queue.get(1));
+		assertEquals(2, queue.size(),
+				formatFail("Two notifications should have been received."));
+		assertEquals(changeListener, queue.get(0),
+				"ChangeEvent of " + methodName
+				+ " should have fired before the ListChangeEvent.");
+		assertEquals(listListener, queue.get(1),
+				"ListChangeEvent of " + methodName
+				+ " should have fired after the ChangeEvent.");
 
-		assertEquals(formatFail(methodName
-				+ " did not leave observable list with the expected contents"),
-				newList, list);
+		assertEquals(newList, list,
+				formatFail(methodName
+				+ " did not leave observable list with the expected contents"));
 
 		ListDiff diff = listListener.event.diff;
 		diff.applyTo(oldList);
-		assertEquals(
+		assertEquals(newList, oldList,
 				formatFail(methodName
-						+ " fired a diff which does not represent the expected list change"),
-				newList, oldList);
+						+ " fired a diff which does not represent the expected list change"));
 
 	}
 }

--- a/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/MutableObservableSetContractTest.java
+++ b/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/MutableObservableSetContractTest.java
@@ -16,8 +16,8 @@
 
 package org.eclipse.jface.databinding.conformance;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,8 +30,8 @@ import org.eclipse.core.databinding.observable.set.IObservableSet;
 import org.eclipse.jface.databinding.conformance.delegate.IObservableCollectionContractDelegate;
 import org.eclipse.jface.databinding.conformance.util.ChangeEventTracker;
 import org.eclipse.jface.databinding.conformance.util.SetChangeEventTracker;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MutableObservableSetContractTest extends
 		MutableObservableCollectionContractTest {
@@ -46,7 +46,7 @@ public class MutableObservableSetContractTest extends
 	}
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		super.setUp();
 		set = (IObservableSet) getObservable();
@@ -206,22 +206,20 @@ public class MutableObservableSetContractTest extends
 
 		runnable.run();
 
-		assertEquals(
-				formatFail(methodName + " should fire one SetChangeEvent."), 1,
-				setListener.count);
-		assertEquals(formatFail(methodName
-				+ "'s change event observable should be the created Set."),
-				set, setListener.event.getObservable());
+		assertEquals(1, setListener.count,
+				formatFail(methodName + " should fire one SetChangeEvent."));
+		assertEquals(set, setListener.event.getObservable(),
+				formatFail(methodName
+				+ "'s change event observable should be the created Set."));
 
-		assertEquals(
-				formatFail("Two notifications should have been received."), 2,
-				queue.size());
-		assertEquals(formatFail("ChangeEvent of " + methodName
-				+ " should have fired before the SetChangeEvent."),
-				changeListener, queue.get(0));
-		assertEquals(formatFail("SetChangeEvent of " + methodName
-				+ " should have fired after the ChangeEvent."), setListener,
-				queue.get(1));
+		assertEquals(2, queue.size(),
+				formatFail("Two notifications should have been received."));
+		assertEquals(changeListener, queue.get(0),
+				formatFail("ChangeEvent of " + methodName
+				+ " should have fired before the SetChangeEvent."));
+		assertEquals(setListener, queue.get(1),
+				formatFail("SetChangeEvent of " + methodName
+				+ " should have fired after the ChangeEvent."));
 	}
 
 	/**
@@ -235,12 +233,12 @@ public class MutableObservableSetContractTest extends
 		runnable.run();
 
 		Set entries = listener.event.diff.getAdditions();
-		assertEquals(formatFail(methodName
-				+ " should result in one diff entry."), 1, entries.size());
+		assertEquals(1, entries.size(), formatFail(methodName
+				+ " should result in one diff entry."));
 
-		assertTrue(formatFail(methodName
-				+ " should result in a diff entry that is an addition."),
-				entries.contains(element));
+		assertTrue(entries.contains(element),
+				formatFail(methodName
+				+ " should result in a diff entry that is an addition."));
 	}
 
 	/**
@@ -254,11 +252,11 @@ public class MutableObservableSetContractTest extends
 		runnable.run();
 
 		Set entries = listener.event.diff.getRemovals();
-		assertEquals(formatFail(methodName
-				+ " should result in one diff entry."), 1, entries.size());
+		assertEquals(1, entries.size(), formatFail(methodName
+				+ " should result in one diff entry."));
 
-		assertTrue(formatFail(methodName
-				+ " should result in a diff entry that is a removal."),
-				entries.contains(element));
+		assertTrue(entries.contains(element),
+				formatFail(methodName
+				+ " should result in a diff entry that is a removal."));
 	}
 }

--- a/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/MutableObservableValueContractTest.java
+++ b/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/MutableObservableValueContractTest.java
@@ -16,7 +16,7 @@
 
 package org.eclipse.jface.databinding.conformance;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.jface.databinding.conformance.delegate.IObservableValueContractDelegate;
@@ -24,8 +24,8 @@ import org.eclipse.jface.databinding.conformance.util.ChangeEventTracker;
 import org.eclipse.jface.databinding.conformance.util.CurrentRealm;
 import org.eclipse.jface.databinding.conformance.util.RealmTester;
 import org.eclipse.jface.databinding.conformance.util.ValueChangeEventTracker;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Mutability tests for IObservableValue.
@@ -51,7 +51,7 @@ public class MutableObservableValueContractTest extends ObservableValueContractT
 	}
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		super.setUp();
 		this.observable = (IObservableValue) getObservable();
@@ -62,9 +62,8 @@ public class MutableObservableValueContractTest extends ObservableValueContractT
 		Object value = delegate.createValue(observable);
 
 		observable.setValue(value);
-		assertEquals(
-				formatFail("IObservableValue.setValue(Object) should set the value of the observable."),
-				value, observable.getValue());
+		assertEquals(value, observable.getValue(),
+				formatFail("IObservableValue.setValue(Object) should set the value of the observable."));
 	}
 
 	@Test
@@ -73,14 +72,11 @@ public class MutableObservableValueContractTest extends ObservableValueContractT
 
 		observable.setValue(delegate.createValue(observable));
 
-		assertEquals(formatFail("Change event listeners were not notified"), 1,
-				listener.count);
-		assertEquals(
-				formatFail("IObservableValue.setValue(Object) should fire one ChangeEvent."),
-				1, listener.count);
-		assertEquals(
-				formatFail("IObservableValue.setValue(Object)'s change event observable should be the created observable."),
-				observable, listener.event.getObservable());
+		assertEquals(1, listener.count, formatFail("Change event listeners were not notified"));
+		assertEquals(1, listener.count,
+				formatFail("IObservableValue.setValue(Object) should fire one ChangeEvent."));
+		assertEquals(observable, listener.event.getObservable(),
+				formatFail("IObservableValue.setValue(Object)'s change event observable should be the created observable."));
 	}
 
 	@Test
@@ -95,12 +91,10 @@ public class MutableObservableValueContractTest extends ObservableValueContractT
 		Object value = observable.getValue();
 		observable.setValue(value);
 
-		assertEquals(
-				formatFail("IObservableValue.setValue() should not fire a value change event when the value has not change."),
-				0, valueChangeListener.count);
-		assertEquals(
-				formatFail("IObservableValue.setValue() should not fire a change event when the value has not change."),
-				0, changeListener.count);
+		assertEquals(0, valueChangeListener.count,
+				formatFail("IObservableValue.setValue() should not fire a value change event when the value has not change."));
+		assertEquals(0, changeListener.count,
+				formatFail("IObservableValue.setValue() should not fire a change event when the value has not change."));
 	}
 
 	@Test

--- a/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/ObservableCollectionContractTest.java
+++ b/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/ObservableCollectionContractTest.java
@@ -16,8 +16,8 @@
 
 package org.eclipse.jface.databinding.conformance;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 
@@ -25,8 +25,8 @@ import org.eclipse.core.databinding.observable.IObservableCollection;
 import org.eclipse.jface.databinding.conformance.delegate.IObservableCollectionContractDelegate;
 import org.eclipse.jface.databinding.conformance.util.CurrentRealm;
 import org.eclipse.jface.databinding.conformance.util.RealmTester;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for IObservableCollection that don't mutate the collection.
@@ -52,7 +52,7 @@ public class ObservableCollectionContractTest extends ObservableContractTest {
 	}
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		super.setUp();
 		collection = (IObservableCollection) getObservable();
@@ -163,9 +163,7 @@ public class ObservableCollectionContractTest extends ObservableContractTest {
 
 	@Test
 	public void testGetElementType_ReturnsType() throws Exception {
-		assertEquals(
-				"Element type of the collection should be returned from IObservableCollection.getElementType()",
-				delegate.getElementType(collection),
-				collection.getElementType());
+		assertEquals(delegate.getElementType(collection), collection.getElementType(),
+				"Element type of the collection should be returned from IObservableCollection.getElementType()");
 	}
 }

--- a/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/ObservableContractTest.java
+++ b/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/ObservableContractTest.java
@@ -16,11 +16,11 @@
 
 package org.eclipse.jface.databinding.conformance;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.databinding.observable.ChangeEvent;
 import org.eclipse.core.databinding.observable.IChangeListener;
@@ -31,8 +31,8 @@ import org.eclipse.jface.databinding.conformance.delegate.IObservableContractDel
 import org.eclipse.jface.databinding.conformance.util.CurrentRealm;
 import org.eclipse.jface.databinding.conformance.util.DisposeEventTracker;
 import org.eclipse.jface.databinding.conformance.util.RealmTester;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for IObservable that don't require mutating the observable.
@@ -57,7 +57,7 @@ public class ObservableContractTest extends ObservableDelegateTest {
 	}
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		super.setUp();
 		observable = getObservable();
@@ -81,8 +81,8 @@ public class ObservableContractTest extends ObservableDelegateTest {
 
 	@Test
 	public void testGetRealm_NotNull() throws Exception {
-		assertNotNull(formatFail("The observable's realm should not be null."),
-				observable.getRealm());
+		assertNotNull(observable.getRealm(),
+				formatFail("The observable's realm should not be null."));
 	}
 
 	@Test
@@ -92,9 +92,8 @@ public class ObservableContractTest extends ObservableDelegateTest {
 		observable.addChangeListener(listener);
 		delegate.change(observable);
 
-		assertEquals(
-				formatFail("A change in the observable should notify change listeners."),
-				1, listener.count);
+		assertEquals(1, listener.count,
+				formatFail("A change in the observable should notify change listeners."));
 	}
 
 	@Test
@@ -105,11 +104,10 @@ public class ObservableContractTest extends ObservableDelegateTest {
 		delegate.change(observable);
 
 		ChangeEvent event = listener.event;
-		assertNotNull(formatFail("change event was null"), event);
+		assertNotNull(event, formatFail("change event was null"));
 
-		assertSame(
-				formatFail("In the change event the source of the change should be the observable."),
-				observable, event.getObservable());
+		assertSame(observable, event.getObservable(),
+				formatFail("In the change event the source of the change should be the observable."));
 	}
 
 	@Test
@@ -123,9 +121,8 @@ public class ObservableContractTest extends ObservableDelegateTest {
 		observable.addChangeListener(listener);
 
 		delegate.change(observable);
-		assertTrue(
-				formatFail("On change the current realm should be the realm of the observable."),
-				listener.isCurrentRealm);
+		assertTrue(listener.isCurrentRealm,
+				formatFail("On change the current realm should be the realm of the observable."));
 	}
 
 	@Test
@@ -136,23 +133,20 @@ public class ObservableContractTest extends ObservableDelegateTest {
 		delegate.change(observable);
 
 		// precondition check
-		assertEquals(formatFail("change did not notify listeners"), 1,
-				listener.count);
+		assertEquals(1, listener.count, formatFail("change did not notify listeners"));
 
 		observable.removeChangeListener(listener);
 		delegate.change(observable);
 
-		assertEquals(
-				formatFail("When a change listener is removed it should not still receive change events."),
-				1, listener.count);
+		assertEquals(1, listener.count,
+				formatFail("When a change listener is removed it should not still receive change events."));
 	}
 
 	@Test
 	public void testIsStale_NotStale() throws Exception {
 		delegate.setStale(observable, false);
-		assertFalse(
-				formatFail("When an observable is not stale isStale() should return false."),
-				observable.isStale());
+		assertFalse(observable.isStale(),
+				formatFail("When an observable is not stale isStale() should return false."));
 	}
 
 	@Test
@@ -201,9 +195,8 @@ public class ObservableContractTest extends ObservableDelegateTest {
 		observable = delegate.createObservable(realm);
 		delegate.change(observable);
 
-		assertEquals(
-				formatFail("After being disposed listeners should not receive change events."),
-				0, disposedObservableListener.count);
+		assertEquals(0, disposedObservableListener.count,
+				formatFail("After being disposed listeners should not receive change events."));
 	}
 
 	@Test

--- a/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/ObservableDelegateTest.java
+++ b/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/ObservableDelegateTest.java
@@ -16,7 +16,7 @@
 
 package org.eclipse.jface.databinding.conformance;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.core.databinding.observable.IObservable;
 import org.eclipse.core.databinding.observable.ObservableTracker;
@@ -24,8 +24,8 @@ import org.eclipse.core.databinding.observable.Realm;
 import org.eclipse.jface.databinding.conformance.delegate.IObservableContractDelegate;
 import org.eclipse.jface.databinding.conformance.util.CurrentRealm;
 import org.eclipse.jface.databinding.conformance.util.RealmTester;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * TestCase that provides the standard behavior expected for delegating test
@@ -45,7 +45,7 @@ public class ObservableDelegateTest {
 		this.delegate = delegate;
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		previousRealm = Realm.getDefault();
 
@@ -53,7 +53,7 @@ public class ObservableDelegateTest {
 		observable = doCreateObservable();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		delegate.tearDown();
 		observable.dispose();
@@ -130,8 +130,8 @@ public class ObservableDelegateTest {
 			}
 		}
 
-		assertEquals(formatFail(methodName
-				+ " should invoke ObservableTracker.getterCalled() once."), 1,
-				count);
+		assertEquals(1,
+				count, formatFail(methodName
+				+ " should invoke ObservableTracker.getterCalled() once."));
 	}
 }

--- a/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/ObservableListContractTest.java
+++ b/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/ObservableListContractTest.java
@@ -19,8 +19,8 @@ package org.eclipse.jface.databinding.conformance;
 import org.eclipse.core.databinding.observable.list.IObservableList;
 import org.eclipse.jface.databinding.conformance.delegate.IObservableCollectionContractDelegate;
 import org.eclipse.jface.databinding.conformance.util.CurrentRealm;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for IObservableList that don't require mutating the collection.
@@ -47,7 +47,7 @@ public class ObservableListContractTest extends
 	}
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		super.setUp();
 		list = (IObservableList) getObservable();

--- a/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/ObservableStaleContractTest.java
+++ b/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/ObservableStaleContractTest.java
@@ -16,17 +16,17 @@
 
 package org.eclipse.jface.databinding.conformance;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.databinding.observable.IObservable;
 import org.eclipse.core.databinding.observable.IStaleListener;
 import org.eclipse.core.databinding.observable.StaleEvent;
 import org.eclipse.jface.databinding.conformance.delegate.IObservableContractDelegate;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @since 3.3
@@ -41,7 +41,7 @@ public class ObservableStaleContractTest extends ObservableDelegateTest {
 	}
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		super.setUp();
 		observable = getObservable();
@@ -50,16 +50,15 @@ public class ObservableStaleContractTest extends ObservableDelegateTest {
 	@Test
 	public void testIsStale_TrueWhenStale() throws Exception {
 		delegate.setStale(observable, true);
-		assertTrue(formatFail("When stale isStale() should return true."),
-				observable.isStale());
+		assertTrue(observable.isStale(),
+				formatFail("When stale isStale() should return true."));
 	}
 
 	@Test
 	public void testIsStale_FalseWhenNotStale() throws Exception {
 		delegate.setStale(observable, false);
-		assertFalse(
-				formatFail("When not stale isStale() should return false."),
-				observable.isStale());
+		assertFalse(observable.isStale(),
+				formatFail("When not stale isStale() should return false."));
 	}
 
 	@Test
@@ -72,9 +71,8 @@ public class ObservableStaleContractTest extends ObservableDelegateTest {
 		observable.addStaleListener(listener);
 		delegate.setStale(observable, true);
 
-		assertEquals(
-				formatFail("When becoming stale listeners should be notified."),
-				1, listener.count);
+		assertEquals(1, listener.count,
+				formatFail("When becoming stale listeners should be notified."));
 	}
 
 	@Test
@@ -88,10 +86,9 @@ public class ObservableStaleContractTest extends ObservableDelegateTest {
 		delegate.setStale(observable, true);
 
 		StaleEvent event = listener.event;
-		assertNotNull(formatFail("stale event was null"), event);
-		assertEquals(
-				formatFail("When notifying listeners of becoming stale the observable should be the source of the event."),
-				observable, event.getObservable());
+		assertNotNull(event, formatFail("stale event was null"));
+		assertEquals(observable, event.getObservable(),
+				formatFail("When notifying listeners of becoming stale the observable should be the source of the event."));
 	}
 
 	@Test
@@ -103,16 +100,14 @@ public class ObservableStaleContractTest extends ObservableDelegateTest {
 		delegate.setStale(observable, true);
 
 		// precondition check
-		assertEquals(formatFail("set stale did not notify listeners"), 1,
-				listener.count);
+		assertEquals(1, listener.count, formatFail("set stale did not notify listeners"));
 
 		observable.removeStaleListener(listener);
 		ensureStale(observable, false);
 		delegate.setStale(observable, true);
 
-		assertEquals(
-				formatFail("Once removed stale listeners should not be notified of becoming stale."),
-				1, listener.count);
+		assertEquals(1, listener.count,
+				formatFail("Once removed stale listeners should not be notified of becoming stale."));
 	}
 
 	@Test
@@ -124,9 +119,8 @@ public class ObservableStaleContractTest extends ObservableDelegateTest {
 		observable.addStaleListener(listener);
 		delegate.setStale(observable, false);
 
-		assertEquals(
-				formatFail("Stale listeners should not be notified when the stale state changes from true to false."),
-				0, listener.count);
+		assertEquals(0, listener.count,
+				formatFail("Stale listeners should not be notified when the stale state changes from true to false."));
 	}
 
 	@Test
@@ -137,9 +131,8 @@ public class ObservableStaleContractTest extends ObservableDelegateTest {
 		observable.addStaleListener(listener);
 		delegate.setStale(observable, true);
 
-		assertTrue(
-				formatFail("When notifying listeners of becoming stale the observable's realm should be the current realm."),
-				listener.isCurrentRealm);
+		assertTrue(listener.isCurrentRealm,
+				formatFail("When notifying listeners of becoming stale the observable's realm should be the current realm."));
 	}
 
 	/**

--- a/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/ObservableValueContractTest.java
+++ b/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/ObservableValueContractTest.java
@@ -16,8 +16,8 @@
 
 package org.eclipse.jface.databinding.conformance;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,8 +32,8 @@ import org.eclipse.jface.databinding.conformance.delegate.IObservableValueContra
 import org.eclipse.jface.databinding.conformance.util.CurrentRealm;
 import org.eclipse.jface.databinding.conformance.util.RealmTester;
 import org.eclipse.jface.databinding.conformance.util.ValueChangeEventTracker;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @since 3.2
@@ -48,7 +48,7 @@ public class ObservableValueContractTest extends ObservableContractTest {
 	}
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		super.setUp();
 		observable = (IObservableValue) getObservable();
@@ -60,16 +60,14 @@ public class ObservableValueContractTest extends ObservableContractTest {
 				.observe(observable);
 
 		delegate.change(observable);
-		assertEquals(
-				formatFail("On change value change listeners should be notified."),
-				1, listener.count);
+		assertEquals(1, listener.count,
+				formatFail("On change value change listeners should be notified."));
 	}
 
 	@Test
 	public void testGetValueType_ExpectedType() throws Exception {
-		assertEquals(
-				formatFail("Type of the value should be returned from getType()."),
-				delegate.getValueType(observable), observable.getValueType());
+		assertEquals(delegate.getValueType(observable), observable.getValueType(),
+				formatFail("Type of the value should be returned from getType()."));
 	}
 
 	@Test
@@ -94,17 +92,15 @@ public class ObservableValueContractTest extends ObservableContractTest {
 
 		delegate.change(observable);
 
-		assertTrue(formatFail("Change Listeners were not notified on change."),
-				listeners.size() > 0);
+		assertTrue(listeners.size() > 0,
+				formatFail("Change Listeners were not notified on change."));
 
 		// not asserting the fact that both are notified as this is asserted in
 		// other tests
-		assertEquals(
-				formatFail("Change listeners should be notified before value change listeners."),
-				changeListener, listeners.get(0));
-		assertEquals(
-				formatFail("Value change listeners should be notified after change listeners."),
-				valueChangeListener, listeners.get(1));
+		assertEquals(changeListener, listeners.get(0),
+				formatFail("Change listeners should be notified before value change listeners."));
+		assertEquals(valueChangeListener, listeners.get(1),
+				formatFail("Value change listeners should be notified after change listeners."));
 	}
 
 	@Test
@@ -117,15 +113,13 @@ public class ObservableValueContractTest extends ObservableContractTest {
 
 		ValueChangeEvent event = listener.event;
 
-		assertTrue(formatFail("Change Listeners were not notified on change."),
-				listener.count > 0);
+		assertTrue(listener.count > 0,
+				formatFail("Change Listeners were not notified on change."));
 
-		assertEquals(
-				formatFail("When a value change event is fired the old value should be the previous value of the observable value."),
-				oldValue, event.diff.getOldValue());
-		assertEquals(
-				formatFail("When a value change event is fired the new value should be the same as the current value of the observable value."),
-				observable.getValue(), event.diff.getNewValue());
+		assertEquals(oldValue, event.diff.getOldValue(),
+				formatFail("When a value change event is fired the old value should be the previous value of the observable value."));
+		assertEquals(observable.getValue(), event.diff.getNewValue(),
+				formatFail("When a value change event is fired the new value should be the same as the current value of the observable value."));
 	}
 
 	@Test
@@ -143,9 +137,8 @@ public class ObservableValueContractTest extends ObservableContractTest {
 		ValueChangeListener listener = new ValueChangeListener();
 		observable.addValueChangeListener(listener);
 		delegate.change(observable);
-		assertEquals(
-				formatFail("When a value change event is fired the new value should be applied before firing the change event."),
-				listener.value, observable.getValue());
+		assertEquals(listener.value, observable.getValue(),
+				formatFail("When a value change event is fired the new value should be applied before firing the change event."));
 	}
 
 	@Test
@@ -156,16 +149,14 @@ public class ObservableValueContractTest extends ObservableContractTest {
 		delegate.change(observable);
 
 		// precondition
-		assertEquals(
-				formatFail("Value change listeners should be notified on change."),
-				1, listener.count);
+		assertEquals(1, listener.count,
+				formatFail("Value change listeners should be notified on change."));
 
 		observable.removeValueChangeListener(listener);
 		delegate.change(observable);
 
-		assertEquals(
-				formatFail("Value change listeners should not be notified after they've been removed from the observable."),
-				1, listener.count);
+		assertEquals(1, listener.count,
+				formatFail("Value change listeners should not be notified after they've been removed from the observable."));
 	}
 
 	@Test

--- a/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/util/RealmTester.java
+++ b/tests/org.eclipse.jface.tests.databinding.conformance/src/org/eclipse/jface/databinding/conformance/util/RealmTester.java
@@ -17,7 +17,7 @@ package org.eclipse.jface.databinding.conformance.util;
 
 import org.eclipse.core.databinding.observable.Realm;
 import org.eclipse.core.runtime.AssertionFailedException;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Aids in the testing of Realms.
@@ -56,7 +56,7 @@ public class RealmTester {
 			try {
 				runnable.run();
 			} catch (AssertionFailedException e) {
-				Assert.fail("Correct realm, exception should not have been thrown");
+				Assertions.fail("Correct realm, exception should not have been thrown");
 			}
 
 			realm.setCurrent(false);
@@ -66,7 +66,7 @@ public class RealmTester {
 
 			try {
 				runnable.run();
-				Assert.fail("Incorrect realm, exception should have been thrown");
+				Assertions.fail("Incorrect realm, exception should have been thrown");
 			} catch (AssertionFailedException e) {
 			}
 		} finally {
@@ -85,14 +85,14 @@ public class RealmTester {
 		try {
 			runnable.run();
 		} catch (AssertionFailedException e) {
-			Assert.fail("Correct realm, exception should not have been thrown");
+			Assertions.fail("Correct realm, exception should not have been thrown");
 		}
 
 		realm.setCurrent(false);
 
 		try {
 			runnable.run();
-			Assert.fail("Incorrect realm, exception should have been thrown");
+			Assertions.fail("Incorrect realm, exception should have been thrown");
 		} catch (AssertionFailedException e) {
 		}
 	}

--- a/tests/org.eclipse.jface.tests.databinding/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.tests.databinding/META-INF/MANIFEST.MF
@@ -16,6 +16,7 @@ Require-Bundle: org.eclipse.core.databinding;bundle-version="[1.3.0,2.0.0)",
  org.eclipse.jface.tests.databinding.conformance,
  org.eclipse.core.databinding.property
 Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Eclipse-BundleShape: dir


### PR DESCRIPTION
Migrate the `ConformanceTestSuite` and its dependent conformance test classes in `org.eclipse.jface.tests.databinding` to JUnit 5.
Verified with local tests.