### PR TITLE
Migrate Layout Performance Tests to JUnit 5

### DIFF
--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/UIPerformanceTestRule.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/UIPerformanceTestRule.java
@@ -34,7 +34,7 @@ public class UIPerformanceTestRule extends ExternalResource implements BeforeAll
 
 	public static final String PROJECT_NAME = "Performance Project";
 
-	private static final String INTRO_VIEW = "org.eclipse.ui.internal.introview";
+	public static final String INTRO_VIEW = "org.eclipse.ui.internal.introview";
 	public static final String[] EDITOR_FILE_EXTENSIONS = { "perf_basic", "perf_outline", "perf_text" };
 
 	@Override

--- a/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/LayoutPerformanceTestSuite.java
+++ b/tests/org.eclipse.ui.tests.performance/src/org/eclipse/ui/tests/performance/layout/LayoutPerformanceTestSuite.java
@@ -1,0 +1,24 @@
+package org.eclipse.ui.tests.performance.layout;
+
+import java.util.stream.Stream;
+
+import org.eclipse.ui.tests.performance.UIPerformanceTestRule;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({ //
+		ComputeSizeTest.class, //
+		LayoutTest.class, //
+		ResizeTest.class //
+})
+public class LayoutPerformanceTestSuite {
+
+	public static Stream<Arguments> data() {
+		return Stream.of(
+				Arguments.of(new ViewWidgetFactory(UIPerformanceTestRule.INTRO_VIEW), false),
+				Arguments.of(new EditorWidgetFactory("1.perf_basic"), false)
+		);
+	}
+}


### PR DESCRIPTION
Migrate ComputeSizeTest, LayoutTest, and ResizeTest to JUnit 5.
- Introduce LayoutPerformanceTestSuite for shared data providers.
- Remove inheritance from PerformanceTestCaseJunit4.
- Use CloseTestWindowsExtension.
- Use PerformanceMeter directly.
- Ensure INTRO_VIEW in UIPerformanceTestRule is visible.