### PR TITLE
Add ConvertLineDelemiterTest to FileBuffersTestSuite

### DIFF
--- a/tests/org.eclipse.core.filebuffers.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.core.filebuffers.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.core.filebuffers.tests;singleton:=true
-Bundle-Version: 3.13.600.qualifier
+Bundle-Version: 3.13.700.qualifier
 Bundle-Activator: org.eclipse.core.filebuffers.tests.FileBuffersTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersTestSuite.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersTestSuite.java
@@ -37,7 +37,8 @@ import org.junit.platform.suite.api.SelectClasses;
 		FileStoreFileBuffersForNonExistingExternalFiles.class,
 		FileStoreFileBuffersForNonExistingWorkspaceFiles.class,
 		TextFileManagerDocCreationTests.class,
-		ResourceTextFileManagerDocCreationTests.class
+		ResourceTextFileManagerDocCreationTests.class,
+		ConvertLineDelemiterTest.class
 })
 public class FileBuffersTestSuite {
 	// see @SelectClasses


### PR DESCRIPTION
Adds `ConvertLineDelemiterTest` to `FileBuffersTestSuite` so it is run as part of the test suite.