### PR TITLE
Add missing descriptions to Colours and Fonts theme entries in Preferences

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/themes/ColorsAndFontsPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/themes/ColorsAndFontsPreferencePage.java
@@ -1959,6 +1959,17 @@ public final class ColorsAndFontsPreferencePage extends PreferencePage implement
 		}
 	}
 
+	private ThemeElementCategory getCategory() {
+		IStructuredSelection item = (IStructuredSelection) tree.getViewer().getSelection();
+		if (item != null && !item.isEmpty()) {
+			Object object = item.getFirstElement();
+			if (object instanceof ThemeElementCategory) {
+				return (ThemeElementCategory) object;
+			}
+		}
+		return null;
+	}
+
 	protected void updateControls() {
 		FontDefinition fontDefinition = getSelectedFontDefinition();
 		if (fontDefinition != null) {
@@ -1982,6 +1993,18 @@ public final class ColorsAndFontsPreferencePage extends PreferencePage implement
 			editDefaultButton.setEnabled(hasEditableDefault && isSetToDefault);
 			goToDefaultButton.setEnabled(hasEditableDefault);
 			setCurrentColor(colorDefinition);
+			return;
+		}
+		ThemeElementCategory category = getCategory();
+		if (category != null) {
+			fontChangeButton.setEnabled(false);
+			fontSystemButton.setEnabled(false);
+			fontResetButton.setEnabled(false);
+			editDefaultButton.setEnabled(false);
+			goToDefaultButton.setEnabled(false);
+
+			String desc = category.getDescription() != null ? category.getDescription() : ""; //$NON-NLS-1$
+			descriptionText.setText(desc);
 			return;
 		}
 		// not a font or a color?

--- a/examples/org.eclipse.e4.demo.cssbridge/plugin.properties
+++ b/examples/org.eclipse.e4.demo.cssbridge/plugin.properties
@@ -19,6 +19,8 @@ org.eclipse.e4.demo.cssbridge.blue.theme=Blue theme
 org.eclipse.e4.demo.cssbridge.green.theme=Green theme
 org.eclipse.e4.demo.cssbridge.red.theme=Red theme
 
+org.eclipse.e4.demo.cssbridge.ui.views.Theme.description= Colors and fonts used to demonstrate CSS based UI styling.
+
 org.eclipse.e4.demo.cssbridge.ui.views.Theme=CSS bridge demo theme
 org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.background=Shell background
 org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.selection.foreground=Shell selection foreground

--- a/examples/org.eclipse.e4.demo.cssbridge/plugin.xml
+++ b/examples/org.eclipse.e4.demo.cssbridge/plugin.xml
@@ -109,10 +109,14 @@
 
    <!-- The 3.x theme definition -->
    <extension point="org.eclipse.ui.themes">
-      <themeElementCategory
-            id="org.eclipse.e4.demo.cssbridge.ui.views.Theme"
-            label="%org.eclipse.e4.demo.cssbridge.ui.views.Theme"/>
-
+   <themeElementCategory
+         id="org.eclipse.e4.demo.cssbridge.ui.views.Theme"
+         label="%org.eclipse.e4.demo.cssbridge.ui.views.Theme">
+      <description>
+         %org.eclipse.e4.demo.cssbridge.ui.views.Theme.description
+      </description>
+   </themeElementCategory>
+   
       <!-- for IDs see the class: org.eclipse.e4.demo.cssbridge.ui.views.Shell -->
       <colorDefinition
         	id="org.eclipse.e4.demo.cssbridge.ui.views.theme.shell.selection.foreground"


### PR DESCRIPTION
**Consistent use of descriptions in Colours and Fonts preferences**

Some entries in the Colours and Fonts preference page already provide descriptions, while others leave the description area empty. This change makes use of the existing descriptions and applies them to theme entries so that the description box is consistently populated and available descriptions are properly utilised.This improves clarity and aligns the presentation with the approach used with the subtree elements in Eclipse preference pages and gives more clarity on what each entity is used for.

The Colours and Fonts preference page shows a description panel which is empty now. There are already descriptions available for some and not available for rest and they are not being used so as to display in the box. This PR make use of the description. This change adds the existing description usage to theme entries so that users always see meaningful information when navigating these settings.

for eg: `CSS bridge demo` theme and `view and editor folders` have descriptions available but it isn't displayed in the box; This PR makes changes to utilise the description available

before : 
<img width="300" height="300" alt="Screenshot 2026-01-09 at 8 02 23 PM" src="https://github.com/user-attachments/assets/f75b0247-9ea0-4a45-bb9d-4e4c0cf0fd80" />


after : 
<img width="300" height="300" alt="Screenshot 2026-01-09 at 7 35 17 PM" src="https://github.com/user-attachments/assets/995cbebd-3fe0-48ce-831a-ad0a0839fa59" />

similarly, with entities `Basic` and `View and Editor folders`

<img width="313" height="300" alt="Screenshot 2026-01-09 at 7 35 08 PM" src="https://github.com/user-attachments/assets/c6855457-bcd8-46fb-be2d-ad4b619d062c" />
<img width="300" height="300" alt="Screenshot 2026-01-09 at 7 35 32 PM" src="https://github.com/user-attachments/assets/9481335a-2036-4645-9d07-1044c3289e07" />


There are few more entries coming from `eclipse.platform` that needs similar updates. Once this change goes in, I plan to follow up on those as well.
