### PR TITLE
Fix regression in ProjectionViewer.setVisibleRegion for empty ranges

### DIFF
--- a/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionViewer.java
+++ b/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionViewer.java
@@ -846,6 +846,9 @@ public class ProjectionViewer extends SourceViewer implements ITextViewerExtensi
 	private static int computeEndOfVisibleRegion(int start, int length, IDocument document) throws BadLocationException {
 		int documentLength= document.getLength();
 		int end= start + length;
+		if (length == 0) {
+			return end + 1;
+		}
 		// ensure that the last line is fully included because projections cannot include partial lines
 		while (end < documentLength && !isLineBreak(document.getChar(end))) {
 			end++;


### PR DESCRIPTION
Commit 59dbd43a19dd introduced a regression where setVisibleRegion(0, 0) would expand to include the full line, causing SegmentedModeTest.testShowNothing to fail. This change ensures that empty ranges (length 0) are not expanded to the end of the line, restoring the previous behavior for this case while keeping the fix for partial lines (length > 0).