### PR TITLE
Fix regression in ProjectionViewer.setVisibleRegion for empty ranges

### DIFF
--- a/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionViewer.java
+++ b/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/ProjectionViewer.java
@@ -846,6 +846,9 @@ public class ProjectionViewer extends SourceViewer implements ITextViewerExtensi
 	private static int computeEndOfVisibleRegion(int start, int length, IDocument document) throws BadLocationException {
 		int documentLength= document.getLength();
 		int end= start + length;
+		if (length == 0 || isLineBreak(document.getChar(end - 1))) {
+			return end + 1;
+		}
 		// ensure that the last line is fully included because projections cannot include partial lines
 		while (end < documentLength && !isLineBreak(document.getChar(end))) {
 			end++;

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/ProjectionViewerTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/ProjectionViewerTest.java
@@ -437,6 +437,33 @@ public class ProjectionViewerTest {
 		}
 	}
 
+	@ParameterizedTest
+	@CsvSource({ "true", "false" })
+	void testRegionEndingWithStartOfLine(boolean enableProjections) {
+		Shell shell= new Shell();
+		shell.setLayout(new FillLayout());
+		TestProjectionViewer viewer= new TestProjectionViewer(shell, null, null, false, SWT.NONE);
+		String documentContent= """
+				Hello
+				World
+				123
+				456
+				""";
+		Document document= new Document(documentContent);
+		viewer.setDocument(document, new AnnotationModel());
+		if (enableProjections) {
+			viewer.enableProjection();
+		}
+
+		viewer.setVisibleRegion(documentContent.indexOf("World"), documentContent.indexOf("123") - documentContent.indexOf("World"));
+		shell.setVisible(true);
+		try {
+			assertEquals("World\n", viewer.getVisibleDocument().get());
+		} finally {
+			shell.dispose();
+		}
+	}
+
 	@Test
 	public void testImageLineStateAfterSettingVisibleRegionsWithProjectionsSetMethodAndClass() throws BadLocationException {
 		// https://github.com/eclipse-platform/eclipse.platform.ui/pull/3456


### PR DESCRIPTION
Commit 59dbd43a19dd introduced a regression where `setVisibleRegion(0, 0)` would expand to include the full line, causing `SegmentedModeTest.testShowNothing` to fail. This change ensures that empty ranges (length 0) are not expanded to the end of the line, restoring the previous behavior for this case while keeping the fix for partial lines (length > 0).

In addition to that, this PR prevents the last line from being included/shown when the end character is directly after the line break.


This is an extended version of #3670 (I also copied most of the description from there)
Fixes #3667