### PR TITLE
Remove ISharedImages.*HOVER

### DIFF
--- a/bundles/org.eclipse.ui.workbench/.settings/.api_filters
+++ b/bundles/org.eclipse.ui.workbench/.settings/.api_filters
@@ -102,6 +102,68 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="eclipseui/org/eclipse/ui/ISharedImages.java" type="org.eclipse.ui.ISharedImages">
+        <filter comment="https://github.com/eclipse-platform/eclipse.platform.ui/pull/3672" id="405864542">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.ISharedImages"/>
+                <message_argument value="IMG_TOOL_BACK_HOVER"/>
+            </message_arguments>
+        </filter>
+        <filter comment="https://github.com/eclipse-platform/eclipse.platform.ui/pull/3672" id="405864542">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.ISharedImages"/>
+                <message_argument value="IMG_TOOL_COPY_HOVER"/>
+            </message_arguments>
+        </filter>
+        <filter comment="https://github.com/eclipse-platform/eclipse.platform.ui/pull/3672" id="405864542">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.ISharedImages"/>
+                <message_argument value="IMG_TOOL_CUT_HOVER"/>
+            </message_arguments>
+        </filter>
+        <filter comment="https://github.com/eclipse-platform/eclipse.platform.ui/pull/3672" id="405864542">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.ISharedImages"/>
+                <message_argument value="IMG_TOOL_DELETE_HOVER"/>
+            </message_arguments>
+        </filter>
+        <filter comment="https://github.com/eclipse-platform/eclipse.platform.ui/pull/3672" id="405864542">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.ISharedImages"/>
+                <message_argument value="IMG_TOOL_FORWARD_HOVER"/>
+            </message_arguments>
+        </filter>
+        <filter comment="https://github.com/eclipse-platform/eclipse.platform.ui/pull/3672" id="405864542">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.ISharedImages"/>
+                <message_argument value="IMG_TOOL_NEW_WIZARD_HOVER"/>
+            </message_arguments>
+        </filter>
+        <filter comment="https://github.com/eclipse-platform/eclipse.platform.ui/pull/3672" id="405864542">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.ISharedImages"/>
+                <message_argument value="IMG_TOOL_PASTE_HOVER"/>
+            </message_arguments>
+        </filter>
+        <filter comment="https://github.com/eclipse-platform/eclipse.platform.ui/pull/3672" id="405864542">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.ISharedImages"/>
+                <message_argument value="IMG_TOOL_REDO_HOVER"/>
+            </message_arguments>
+        </filter>
+        <filter comment="https://github.com/eclipse-platform/eclipse.platform.ui/pull/3672" id="405864542">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.ISharedImages"/>
+                <message_argument value="IMG_TOOL_UNDO_HOVER"/>
+            </message_arguments>
+        </filter>
+        <filter comment="https://github.com/eclipse-platform/eclipse.platform.ui/pull/3672" id="405864542">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.ISharedImages"/>
+                <message_argument value="IMG_TOOL_UP_HOVER"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="eclipseui/org/eclipse/ui/dialogs/YesNoCancelListSelectionDialog.java" type="org.eclipse.ui.dialogs.YesNoCancelListSelectionDialog">
         <filter id="576778288">
             <message_arguments>

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/ISharedImages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/ISharedImages.java
@@ -342,18 +342,6 @@ public interface ISharedImages {
 	String IMG_TOOL_BACK_DISABLED = "IMG_TOOL_BACK_DISABLED"; //$NON-NLS-1$
 
 	/**
-	 * Identifies the back image in the hover (colored) state.
-	 *
-	 * @deprecated in 3.0. This image is now the same as <code>IMG_TOOL_BACK</code>.
-	 *             Enabled images are now in color. The workbench itself no longer
-	 *             uses the hover image variants.
-	 * @noreference Marked for deletion see
-	 *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=559593
-	 */
-	@Deprecated(forRemoval = true, since = "2024-03")
-	String IMG_TOOL_BACK_HOVER = "IMG_TOOL_BACK_HOVER"; //$NON-NLS-1$
-
-	/**
 	 * Identifies the copy image in the enabled state.
 	 */
 	String IMG_TOOL_COPY = "IMG_TOOL_COPY"; //$NON-NLS-1$
@@ -364,18 +352,6 @@ public interface ISharedImages {
 	String IMG_TOOL_COPY_DISABLED = "IMG_TOOL_COPY_DISABLED"; //$NON-NLS-1$
 
 	/**
-	 * Identifies the copy image in the hover (colored) state.
-	 *
-	 * @deprecated in 3.0. This image is now the same as <code>IMG_TOOL_COPY</code>.
-	 *             Enabled images are now in color. The workbench itself no longer
-	 *             uses the hover image variants.
-	 * @noreference Marked for deletion see
-	 *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=559593
-	 */
-	@Deprecated(forRemoval = true, since = "2024-03")
-	String IMG_TOOL_COPY_HOVER = "IMG_TOOL_COPY_HOVER"; //$NON-NLS-1$
-
-	/**
 	 * Identifies the cut image in the enabled state.
 	 */
 	String IMG_TOOL_CUT = "IMG_TOOL_CUT"; //$NON-NLS-1$
@@ -384,18 +360,6 @@ public interface ISharedImages {
 	 * Identifies the cut image in the disabled state.
 	 */
 	String IMG_TOOL_CUT_DISABLED = "IMG_TOOL_CUT_DISABLED"; //$NON-NLS-1$
-
-	/**
-	 * Identifies the cut image in the hover (colored) state.
-	 *
-	 * @deprecated in 3.0. This image is now the same as <code>IMG_TOOL_CUT</code>.
-	 *             Enabled images are now in color. The workbench itself no longer
-	 *             uses the hover image variants.
-	 * @noreference Marked for deletion see
-	 *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=559593
-	 */
-	@Deprecated(forRemoval = true, since = "2024-03")
-	String IMG_TOOL_CUT_HOVER = "IMG_TOOL_CUT_HOVER"; //$NON-NLS-1$
 
 	/**
 	 * Identifies the delete image in the enabled state.
@@ -412,18 +376,6 @@ public interface ISharedImages {
 	String IMG_TOOL_DELETE_DISABLED = "IMG_TOOL_DELETE_DISABLED"; //$NON-NLS-1$
 
 	/**
-	 * Identifies the delete image in the hover (colored) state.
-	 *
-	 * @deprecated in 3.0. This image is now the same as
-	 *             <code>IMG_TOOL_DELETE</code>. Enabled images are now in color.
-	 *             The workbench itself no longer uses the hover image variants.
-	 * @noreference Marked for deletion see
-	 *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=559593
-	 */
-	@Deprecated(forRemoval = true, since = "2024-03")
-	String IMG_TOOL_DELETE_HOVER = "IMG_TOOL_DELETE_HOVER"; //$NON-NLS-1$
-
-	/**
 	 * Identifies the forward image in the enabled state.
 	 */
 	String IMG_TOOL_FORWARD = "IMG_TOOL_FORWARD"; //$NON-NLS-1$
@@ -432,18 +384,6 @@ public interface ISharedImages {
 	 * Identifies the forward image in the disabled state.
 	 */
 	String IMG_TOOL_FORWARD_DISABLED = "IMG_TOOL_FORWARD_DISABLED"; //$NON-NLS-1$
-
-	/**
-	 * Identifies the forward image in the hover (colored) state.
-	 *
-	 * @deprecated in 3.0. This image is now the same as
-	 *             <code>IMG_TOOL_FORWARD</code>. Enabled images are now in color.
-	 *             The workbench itself no longer uses the hover image variants.
-	 * @noreference Marked for deletion see
-	 *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=559593
-	 */
-	@Deprecated(forRemoval = true, since = "2024-03")
-	String IMG_TOOL_FORWARD_HOVER = "IMG_TOOL_FORWARD_HOVER"; //$NON-NLS-1$
 
 	/**
 	 * Identifies the new wizard image in the enabled state.
@@ -456,19 +396,6 @@ public interface ISharedImages {
 	String IMG_TOOL_NEW_WIZARD_DISABLED = "IMG_TOOL_NEW_WIZARD_DISABLED"; //$NON-NLS-1$
 
 	/**
-	 * Identifies the new wizard image in the hover (colored) state.
-	 *
-	 * @deprecated in 3.0. This image is now the same as
-	 *             <code>IMG_TOOL_NEW_WIZARD</code>. Enabled images are now in
-	 *             color. The workbench itself no longer uses the hover image
-	 *             variants.
-	 * @noreference Marked for deletion see
-	 *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=559593
-	 */
-	@Deprecated(forRemoval = true, since = "2024-03")
-	String IMG_TOOL_NEW_WIZARD_HOVER = "IMG_TOOL_NEW_WIZARD_HOVER"; //$NON-NLS-1$
-
-	/**
 	 * Identifies the paste image in the enabled state.
 	 */
 	String IMG_TOOL_PASTE = "IMG_TOOL_PASTE"; //$NON-NLS-1$
@@ -477,18 +404,6 @@ public interface ISharedImages {
 	 * Identifies the paste image in the disabled state.
 	 */
 	String IMG_TOOL_PASTE_DISABLED = "IMG_TOOL_PASTE_DISABLED"; //$NON-NLS-1$
-
-	/**
-	 * Identifies the paste image in the hover (colored) state.
-	 *
-	 * @deprecated in 3.0. This image is now the same as
-	 *             <code>IMG_TOOL_PASTE</code>. Enabled images are now in color. The
-	 *             workbench itself no longer uses the hover image variants.
-	 * @noreference Marked for deletion see
-	 *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=559593
-	 */
-	@Deprecated(forRemoval = true, since = "2024-03")
-	String IMG_TOOL_PASTE_HOVER = "IMG_TOOL_PASTE_HOVER"; //$NON-NLS-1$
 
 	/**
 	 * Identifies the redo image in the enabled state.
@@ -501,19 +416,6 @@ public interface ISharedImages {
 	String IMG_TOOL_REDO_DISABLED = "IMG_TOOL_REDO_DISABLED"; //$NON-NLS-1$
 
 	/**
-	 * Identifies the redo image in the hover (colored) state.
-	 *
-	 * @deprecated in 3.0. This image is now the same as <code>IMG_TOOL_REDO</code>.
-	 *             Enabled images are now in color. The workbench itself no longer
-	 *             uses the hover image variants.
-	 *
-	 * @noreference Marked for deletion see
-	 *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=559593
-	 */
-	@Deprecated(forRemoval = true, since = "2024-03")
-	String IMG_TOOL_REDO_HOVER = "IMG_TOOL_REDO_HOVER"; //$NON-NLS-1$
-
-	/**
 	 * Identifies the undo image in the enabled state.
 	 */
 	String IMG_TOOL_UNDO = "IMG_TOOL_UNDO"; //$NON-NLS-1$
@@ -524,19 +426,6 @@ public interface ISharedImages {
 	String IMG_TOOL_UNDO_DISABLED = "IMG_TOOL_UNDO_DISABLED"; //$NON-NLS-1$
 
 	/**
-	 * Identifies the undo image in the hover (colored) state.
-	 *
-	 * @deprecated in 3.0. This image is now the same as <code>IMG_TOOL_UNDO</code>.
-	 *             Enabled images are now in color. The workbench itself no longer
-	 *             uses the hover image variants.
-	 *
-	 * @noreference Marked for deletion see
-	 *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=559593
-	 */
-	@Deprecated(forRemoval = true, since = "2024-03")
-	String IMG_TOOL_UNDO_HOVER = "IMG_TOOL_UNDO_HOVER"; //$NON-NLS-1$
-
-	/**
 	 * Identifies the up image in the enabled state.
 	 */
 	String IMG_TOOL_UP = "IMG_TOOL_UP"; //$NON-NLS-1$
@@ -545,18 +434,6 @@ public interface ISharedImages {
 	 * Identifies the up image in the disabled state.
 	 */
 	String IMG_TOOL_UP_DISABLED = "IMG_TOOL_UP_DISABLED"; //$NON-NLS-1$
-
-	/**
-	 * Identifies the up image in the hover (colored) state.
-	 *
-	 * @deprecated in 3.0. This image is now the same as <code>IMG_TOOL_UP</code>.
-	 *             Enabled images are now in color. The workbench itself no longer
-	 *             uses the hover image variants.
-	 * @noreference Marked for deletion see
-	 *              https://bugs.eclipse.org/bugs/show_bug.cgi?id=559593
-	 */
-	@Deprecated(forRemoval = true, since = "2024-03")
-	String IMG_TOOL_UP_HOVER = "IMG_TOOL_UP_HOVER"; //$NON-NLS-1$
 
 	// The following set of constants represent the image pairs that are used
 	// to construct cursors for drag and drop operations within the workbench

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchImages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchImages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -296,30 +296,6 @@ public/* final */class WorkbenchImages {
 		declareImage(IWorkbenchGraphicConstants.IMG_PREF_IMPORT, PATH_PREF + "import_wiz.svg", false); //$NON-NLS-1$
 		declareImage(IWorkbenchGraphicConstants.IMG_PREF_EXPORT, PATH_PREF + "export_wiz.svg", false); //$NON-NLS-1$
 
-		declareHoverImages();
-
-
-	}
-
-	/**
-	 * Declares all the workbench's deprecated hover images, including both "shared"
-	 * ones and internal ones.
-	 *
-	 * @deprecated As of 3.0, since the workbench itself no longer uses the hover
-	 *             image variants
-	 */
-	@Deprecated
-	private static final void declareHoverImages() {
-		declareImage(ISharedImages.IMG_TOOL_UNDO_HOVER, PATH_ETOOL + "undo_edit.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_REDO_HOVER, PATH_ETOOL + "redo_edit.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_CUT_HOVER, PATH_ETOOL + "cut_edit.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_COPY_HOVER, PATH_ETOOL + "copy_edit.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_PASTE_HOVER, PATH_ETOOL + "paste_edit.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_FORWARD_HOVER, PATH_ELOCALTOOL + "forward_nav.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_DELETE_HOVER, PATH_ETOOL + "delete_edit.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_NEW_WIZARD_HOVER, PATH_ETOOL + "new_wiz.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_BACK_HOVER, PATH_ELOCALTOOL + "backward_nav.svg", true); //$NON-NLS-1$
-		declareImage(ISharedImages.IMG_TOOL_UP_HOVER, PATH_ELOCALTOOL + "up_nav.svg", true); //$NON-NLS-1$
 	}
 
 	/**


### PR DESCRIPTION
They are deprecated since 3.0 and marked for removal since 2024-03.
Reduces needlessly created images by the workbench.