### PR TITLE
Fix IllegalArgumentException in PartServiceImpl.addPart when editor area is missing

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench;singleton:=true
-Bundle-Version: 1.18.100.qualifier
+Bundle-Version: 1.18.200.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartServiceImpl.java
+++ b/bundles/org.eclipse.e4.ui.workbench/src/org/eclipse/e4/ui/internal/workbench/PartServiceImpl.java
@@ -1028,7 +1028,8 @@ public class PartServiceImpl implements EPartService {
 					activeStack.getChildren().add(providedPart);
 				} else {
 					// Find the first visible stack in the area
-					List<MPartStack> sharedStacks = modelService.findElements(area, null, MPartStack.class);
+					List<MPartStack> sharedStacks = area == null ? Collections.emptyList()
+							: modelService.findElements(area, null, MPartStack.class);
 					if (!sharedStacks.isEmpty()) {
 						for (MPartStack stack : sharedStacks) {
 							if (stack.isToBeRendered()) {


### PR DESCRIPTION
Fixes an IllegalArgumentException in PartServiceImpl.addPart that occurs when the shared editor area ('org.eclipse.ui.editorss') is not found.

The `modelService.findElements` method was called with a null `searchRoot` (area) when the editor area could not be located, triggering an assertion failure. This change adds a null check to handle this case gracefully.

Verified by running `OpenCloseTest` which now passes.