### PR TITLE
Fix random failing MMenuItemTest.testElementHierarchyInContext_HandledItem

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MMenuItemTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MMenuItemTest.java
@@ -764,7 +764,14 @@ public class MMenuItemTest {
 		inactivePart.getContext().set("key", "inactive");
 
 		// Ensure all pending UI events are processed before triggering the menu item
-		contextRule.spinEventLoop();
+		for (int i = 0; i < 10; i++) {
+			contextRule.spinEventLoop();
+			try {
+				Thread.sleep(5);
+			} catch (InterruptedException e) {
+				// ignore
+			}
+		}
 
 		assertFalse(executed[0]);
 
@@ -841,7 +848,17 @@ public class MMenuItemTest {
 
 		// Ensure all pending UI events are processed before triggering the menu item
 		// This prevents race conditions where the handler may not be fully registered yet
-		contextRule.spinEventLoop();
+		for (int i = 0; i < 50; i++) {
+			contextRule.spinEventLoop();
+			if (((MenuItem) menuItem.getWidget()).getEnabled()) {
+				break;
+			}
+			try {
+				Thread.sleep(5);
+			} catch (InterruptedException e) {
+				// ignore
+			}
+		}
 
 		assertFalse(executed[0]);
 		assertEquals(activePart, window.getContext().get(EPartService.class)


### PR DESCRIPTION
The test testElementHierarchyInContext_HandledItem was failing randomly because the handler registration is asynchronous and might not be complete when the menu item execution is triggered.

This change adds a wait loop that checks for the menu item enablement, which is a reliable indicator that the handler is registered and the command is ready. It also increases the robustness of testElementHierarchyInContext_DirectItem by spinning the event loop multiple times.

Fixes #1737