### PR TITLE
Use varargs in FilteredList and AbstractElementListSelectionDialog

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/dialogs/AbstractElementListSelectionDialog.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/dialogs/AbstractElementListSelectionDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -186,7 +186,7 @@ public abstract class AbstractElementListSelectionDialog extends SelectionStatus
 	 *
 	 * @param elements the elements of the list.
 	 */
-	protected void setListElements(Object[] elements) {
+	protected void setListElements(Object... elements) {
 		Assert.isNotNull(fFilteredList);
 		fFilteredList.setElements(elements);
 		handleElementsChanged();
@@ -263,7 +263,7 @@ public abstract class AbstractElementListSelectionDialog extends SelectionStatus
 	 *
 	 * @param selection the indices of the selection.
 	 */
-	protected void setSelection(Object[] selection) {
+	protected void setSelection(Object... selection) {
 		Assert.isNotNull(fFilteredList);
 		fFilteredList.setSelection(selection);
 	}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/dialogs/FilteredList.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/dialogs/FilteredList.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -246,7 +246,7 @@ public class FilteredList extends Composite {
 	 *
 	 * @param elements the elements to be shown in the list.
 	 */
-	public void setElements(Object[] elements) {
+	public void setElements(Object... elements) {
 		if (elements == null) {
 			fElements = new Object[0];
 		} else {
@@ -326,7 +326,7 @@ public class FilteredList extends Composite {
 	 *
 	 * @param selection an array of indices specifying the selection.
 	 */
-	public void setSelection(int[] selection) {
+	public void setSelection(int... selection) {
 		if (selection == null || selection.length == 0) {
 			fList.deselectAll();
 		} else // If there is no working update job, or the update job is ready to
@@ -365,7 +365,7 @@ public class FilteredList extends Composite {
 	 *
 	 * @param elements the array of elements to be selected.
 	 */
-	public void setSelection(Object[] elements) {
+	public void setSelection(Object... elements) {
 		if (elements == null || elements.length == 0) {
 			fList.deselectAll();
 			return;


### PR DESCRIPTION
This adapts the signature of the following methods to accept a vararg parameter instead of a plain array:

FilteredList:
- setElements(Object[]) -> setElements(Object...)
- setSelection(int[]) -> setSelection(int...)
- setSelection(Object[]) -> setSelection(Object...)

AbstractElementListSelectionDialog:
- setListElements(Object[]) -> setListElements(Object...)
- setSelection(Object[]) -> setSelection(Object...)

This stops callers from having to explicitly create an array when e.g. selecting a single element. For example `filteredList.setSelection(new int[]{0})` can be simplified to `filteredList.setSelection(0)`.