### PR TITLE
Don't do nested resize operations in TableResizeHelper

### DIFF
--- a/bundles/org.eclipse.text.quicksearch/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.text.quicksearch/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.text.quicksearch;singleton:=true
-Bundle-Version: 1.3.300.qualifier
+Bundle-Version: 1.3.400.qualifier
 Bundle-Activator: org.eclipse.text.quicksearch.internal.ui.QuickSearchActivator
 Require-Bundle: org.eclipse.ui;bundle-version="[3.113.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.13.0,4.0.0)",

--- a/bundles/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/ui/TableResizeHelper.java
+++ b/bundles/org.eclipse.text.quicksearch/src/org/eclipse/text/quicksearch/internal/ui/TableResizeHelper.java
@@ -28,6 +28,7 @@ import org.eclipse.swt.widgets.TableColumn;
 public class TableResizeHelper {
 
 	private final TableViewer tableViewer;
+	boolean resizeInProgress;
 
 	public TableResizeHelper(TableViewer tableViewer) {
 		this.tableViewer = tableViewer;
@@ -37,7 +38,9 @@ public class TableResizeHelper {
 		ControlListener resizeListener = new ControlListener() {
 			@Override
 			public void controlResized(ControlEvent e) {
-				resizeTable();
+				if (!resizeInProgress) {
+					resizeTable();
+				}
 			}
 			@Override
 			public void controlMoved(ControlEvent e) {
@@ -57,14 +60,19 @@ public class TableResizeHelper {
 	}
 
 	protected void resizeTable() {
-		Composite tableComposite = tableViewer.getTable();//.getParent();
-		Rectangle tableCompositeArea = tableComposite.getClientArea();
-		int width = tableCompositeArea.width;
+		try {
+			resizeInProgress = true;
+			Composite tableComposite = tableViewer.getTable();//.getParent();
+			Rectangle tableCompositeArea = tableComposite.getClientArea();
+			int width = tableCompositeArea.width;
 //		ScrollBar sb = tableViewer.getTable().getVerticalBar();
 //		if (sb!=null && sb.isVisible()) {
 //			width = width - sb.getSize().x;
 //		}
-		resizeTableColumns(width, tableViewer.getTable());
+			resizeTableColumns(width, tableViewer.getTable());
+		} finally {
+			resizeInProgress = false;
+		}
 	}
 
 	protected void resizeTableColumns(int tableWidth, Table table) {


### PR DESCRIPTION
Avoids endless resize operations & UI hangs in case resize listener/handler code itself triggers some OS specific resize events.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3676