### PR TITLE
Migrate org.eclipse.tests.urischeme to JUnit 5

### DIFF
--- a/tests/org.eclipse.tests.urischeme/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.tests.urischeme/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Bundle-Version: 1.2.800.qualifier
 Bundle-Localization: plugin
 Fragment-Host: org.eclipse.urischeme;bundle-version="1.1.100"
 Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
- org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
+ org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
+ org.opentest4j;version="[1.2.0,2.0.0)"
 Automatic-Module-Name: org.eclipse.urischeme.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.junit;bundle-version="[4.12.0,5.0.0)"

--- a/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/TestUnitAutoRegisterSchemeHandlersJob.java
+++ b/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/TestUnitAutoRegisterSchemeHandlersJob.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.eclipse.urischeme;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +28,7 @@ import org.eclipse.core.internal.preferences.EclipsePreferences;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.urischeme.internal.registration.Scheme;
 import org.eclipse.urischeme.internal.registration.SchemeInformation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.osgi.service.prefs.BackingStoreException;
 
 @SuppressWarnings("restriction")
@@ -50,10 +50,10 @@ public class TestUnitAutoRegisterSchemeHandlersJob {
 
 		job.run(new NullProgressMonitor());
 
-		assertNull("Nothing should be written to preferences", preferenceNode.writtenValue);
-		assertFalse("Flush on preferences should not be called", preferenceNode.flushed);
-		assertNull("No schemes should be registered", osRegistration.addedSchemes);
-		assertNull("No schemes should be un-registered", osRegistration.removedSchemes);
+		assertNull(preferenceNode.writtenValue, "Nothing should be written to preferences");
+		assertFalse(preferenceNode.flushed, "Flush on preferences should not be called");
+		assertNull(osRegistration.addedSchemes, "No schemes should be registered");
+		assertNull(osRegistration.removedSchemes, "No schemes should be un-registered");
 
 	}
 
@@ -64,10 +64,10 @@ public class TestUnitAutoRegisterSchemeHandlersJob {
 
 		job.run(new NullProgressMonitor());
 
-		assertNull("Nothing should be written to preferences", preferenceNode.writtenValue);
-		assertFalse("Flush on preferences should not be called", preferenceNode.flushed);
-		assertNull("No schemes should be registered", osRegistration.addedSchemes);
-		assertNull("No schemes should be un-registered", osRegistration.removedSchemes);
+		assertNull(preferenceNode.writtenValue, "Nothing should be written to preferences");
+		assertFalse(preferenceNode.flushed, "Flush on preferences should not be called");
+		assertNull(osRegistration.addedSchemes, "No schemes should be registered");
+		assertNull(osRegistration.removedSchemes, "No schemes should be un-registered");
 
 	}
 
@@ -85,12 +85,12 @@ public class TestUnitAutoRegisterSchemeHandlersJob {
 
 		job.run(new NullProgressMonitor());
 
-		assertEquals("Wrong values written to preferences", helloScheme.getName() + "," + hello1Scheme.getName(),
-				preferenceNode.writtenValue);
-		assertTrue("Preferences not flushed", preferenceNode.flushed);
-		assertEquals("Wrong schemes have been registered", hello1SchemeInfo,
-				osRegistration.addedSchemes.iterator().next());
-		assertTrue("No schemes should be un-registered", osRegistration.removedSchemes.isEmpty());
+		assertEquals(helloScheme.getName() + "," + hello1Scheme.getName(),
+				preferenceNode.writtenValue, "Wrong values written to preferences");
+		assertTrue(preferenceNode.flushed, "Preferences not flushed");
+		assertEquals(hello1SchemeInfo,
+				osRegistration.addedSchemes.iterator().next(), "Wrong schemes have been registered");
+		assertTrue(osRegistration.removedSchemes.isEmpty(), "No schemes should be un-registered");
 	}
 
 	@Test
@@ -107,10 +107,10 @@ public class TestUnitAutoRegisterSchemeHandlersJob {
 
 		job.run(new NullProgressMonitor());
 
-		assertNull("Nothing should be written to preferences", preferenceNode.writtenValue);
-		assertFalse("Flush on preferences should not be called", preferenceNode.flushed);
-		assertNull("No schemes should be registered", osRegistration.addedSchemes);
-		assertNull("No schemes should be un-registered", osRegistration.removedSchemes);
+		assertNull(preferenceNode.writtenValue, "Nothing should be written to preferences");
+		assertFalse(preferenceNode.flushed, "Flush on preferences should not be called");
+		assertNull(osRegistration.addedSchemes, "No schemes should be registered");
+		assertNull(osRegistration.removedSchemes, "No schemes should be un-registered");
 	}
 
 	@Test
@@ -127,17 +127,17 @@ public class TestUnitAutoRegisterSchemeHandlersJob {
 
 		job.run(new NullProgressMonitor());
 
-		assertNull("Nothing should be written to preferences", preferenceNode.writtenValue);
-		assertFalse("Flush on preferences should not be called", preferenceNode.flushed);
-		assertNull("No schemes should be registered", osRegistration.addedSchemes);
-		assertNull("No schemes should be un-registered", osRegistration.removedSchemes);
+		assertNull(preferenceNode.writtenValue, "Nothing should be written to preferences");
+		assertFalse(preferenceNode.flushed, "Flush on preferences should not be called");
+		assertNull(osRegistration.addedSchemes, "No schemes should be registered");
+		assertNull(osRegistration.removedSchemes, "No schemes should be un-registered");
 	}
 
 	@Test
 	public void registrationOnUnsupportedRegistrationDoesNothing() throws Exception {
 		AutoRegisterSchemeHandlersJob job = createJob(new ArrayList<>(), "dontCare", new ArrayList<>(),
 				DOESNT_SUPPORT_REGISTRATION);
-		assertFalse("Job should not run on OSes that don't support registration", job.shouldSchedule());
+		assertFalse(job.shouldSchedule(), "Job should not run on OSes that don't support registration");
 	}
 
 	private AutoRegisterSchemeHandlersJob createJob(Collection<IScheme> installedSchemes,

--- a/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/UriSchemeExtensionReaderUnitTest.java
+++ b/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/UriSchemeExtensionReaderUnitTest.java
@@ -10,8 +10,9 @@
  *******************************************************************************/
 package org.eclipse.urischeme.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collection;
 
@@ -21,8 +22,8 @@ import org.eclipse.core.runtime.IContributor;
 import org.eclipse.core.runtime.IExtension;
 import org.eclipse.core.runtime.InvalidRegistryObjectException;
 import org.eclipse.urischeme.IScheme;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class UriSchemeExtensionReaderUnitTest {
 
@@ -30,7 +31,7 @@ public class UriSchemeExtensionReaderUnitTest {
 	private ConfigurationElementMock configElementForAbc;
 	private UriSchemeExtensionReader extensionReader;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		abcHandler = new UriSchemeHandlerSpy();
 		configElementForAbc = new ConfigurationElementMock("abc", "abc Scheme", abcHandler);
@@ -58,12 +59,12 @@ public class UriSchemeExtensionReaderUnitTest {
 		assertEquals(abcHandler, extensionReader.getHandlerFromExtensionPoint("abc"));
 	}
 
-	@Test(expected = CoreException.class)
+	@Test
 	public void throwExceptionOnWrongRegisteredType() throws Exception {
 		ConfigurationElementMock element = new ConfigurationElementMock("abc", "abc Scheme", new Object());
 		setExtensionsInReader(element);
 
-		extensionReader.getHandlerFromExtensionPoint("abc");
+		assertThrows(CoreException.class, () -> extensionReader.getHandlerFromExtensionPoint("abc"));
 	}
 
 	@Test

--- a/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/UriSchemeProcessorUnitTest.java
+++ b/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/UriSchemeProcessorUnitTest.java
@@ -13,8 +13,9 @@
  *******************************************************************************/
 package org.eclipse.urischeme.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -25,8 +26,8 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.urischeme.IScheme;
 import org.eclipse.urischeme.IUriSchemeExtensionReader;
 import org.eclipse.urischeme.IUriSchemeHandler;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class UriSchemeProcessorUnitTest {
 
@@ -34,7 +35,7 @@ public class UriSchemeProcessorUnitTest {
 	private UriSchemeProcessor schemeProcessor;
 	private UriSchemeExtensionReaderMock extensionReader;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		abcHandler = new UriSchemeHandlerSpy();
 		extensionReader = new UriSchemeExtensionReaderMock();
@@ -49,7 +50,7 @@ public class UriSchemeProcessorUnitTest {
 		schemeProcessor.handleUri("abc", "abc://test");
 
 		String errorMsg = "Registered handler was not called for '" + "abc://test" + "'";
-		assertTrue(errorMsg, abcHandler.uris.contains("abc://test"));
+		assertTrue(abcHandler.uris.contains("abc://test"), errorMsg);
 	}
 
 	@Test
@@ -65,13 +66,13 @@ public class UriSchemeProcessorUnitTest {
 		schemeProcessor.handleUri("abc", "abc://test");
 
 		assertEquals(2, abcHandler.uris.size());
-		assertEquals("Extension created more than once", 1, (int) extensionReader.readCount.get("abc"));
+		assertEquals(1, (int) extensionReader.readCount.get("abc"), "Extension created more than once");
 	}
 
-	@Test(expected = CoreException.class)
+	@Test
 	public void passesException() throws Exception {
 		extensionReader.exception = new CoreException(Status.CANCEL_STATUS);
-		schemeProcessor.handleUri("abc", "abc://test");
+		assertThrows(CoreException.class, () -> schemeProcessor.handleUri("abc", "abc://test"));
 	}
 
 	private static class UriSchemeExtensionReaderMock implements IUriSchemeExtensionReader {

--- a/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitDesktopFileWriter.java
+++ b/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitDesktopFileWriter.java
@@ -13,23 +13,17 @@
  *******************************************************************************/
 package org.eclipse.urischeme.internal.registration;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.hamcrest.Matcher;
-import org.hamcrest.core.AnyOf;
-import org.hamcrest.core.IsEqual;
-import org.hamcrest.core.IsNot;
-import org.hamcrest.core.StringContains;
-import org.hamcrest.core.StringEndsWith;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitDesktopFileWriter {
 
@@ -42,7 +36,7 @@ public class TestUnitDesktopFileWriter {
 
 		writer.addScheme("adt");
 
-		assertThat(new String(writer.getResult()), containsLine("MimeType=x-scheme-handler/adt;"));
+		assertContainsLine(new String(writer.getResult()), "MimeType=x-scheme-handler/adt;");
 	}
 
 	@Test
@@ -52,8 +46,8 @@ public class TestUnitDesktopFileWriter {
 		writer.addScheme("adt");
 		writer.addScheme("other");
 
-		assertThat(new String(writer.getResult()),
-				containsLine("MimeType=x-scheme-handler/adt;x-scheme-handler/other;"));
+		assertContainsLine(new String(writer.getResult()),
+				"MimeType=x-scheme-handler/adt;x-scheme-handler/other;");
 	}
 
 	@Test
@@ -63,8 +57,8 @@ public class TestUnitDesktopFileWriter {
 
 		writer.addScheme("other");
 
-		assertThat(new String(writer.getResult()),
-				containsLine("MimeType=x-scheme-handler/adt;x-scheme-handler/other;"));
+		assertContainsLine(new String(writer.getResult()),
+				"MimeType=x-scheme-handler/adt;x-scheme-handler/other;");
 	}
 
 	@Test
@@ -74,15 +68,15 @@ public class TestUnitDesktopFileWriter {
 
 		writer.addScheme("adt");
 
-		assertThat(new String(writer.getResult()), containsLine("MimeType=x-scheme-handler/adt;"));
+		assertContainsLine(new String(writer.getResult()), "MimeType=x-scheme-handler/adt;");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void addFailsOnIllegalScheme() {
 		DesktopFileWriter writer = getWriterFor(
 				fileContentWith("Exec=/usr/bin/eclipse %u", "MimeType=x-scheme-handler/adt;"));
 
-		writer.addScheme("&/%");
+		assertThrows(IllegalArgumentException.class, () -> writer.addScheme("&/%"));
 	}
 
 	@Test
@@ -92,7 +86,7 @@ public class TestUnitDesktopFileWriter {
 
 		writer.removeScheme("adt");
 
-		assertThat(new String(writer.getResult()), not(contains("MimeType")));
+		assertFalse(new String(writer.getResult()).contains("MimeType"));
 	}
 
 	@Test
@@ -102,7 +96,7 @@ public class TestUnitDesktopFileWriter {
 
 		writer.removeScheme("adt");
 
-		assertThat(new String(writer.getResult()), containsLine("MimeType=x-scheme-handler/other;"));
+		assertContainsLine(new String(writer.getResult()), "MimeType=x-scheme-handler/other;");
 	}
 
 	@Test
@@ -112,7 +106,7 @@ public class TestUnitDesktopFileWriter {
 
 		writer.removeScheme("other");
 
-		assertThat(new String(writer.getResult()), containsLine("MimeType=x-scheme-handler/adt;"));
+		assertContainsLine(new String(writer.getResult()), "MimeType=x-scheme-handler/adt;");
 	}
 
 	@Test
@@ -122,8 +116,8 @@ public class TestUnitDesktopFileWriter {
 
 		writer.removeScheme("other");
 
-		assertThat(new String(writer.getResult()),
-				containsLine("MimeType=x-scheme-handler/adt;x-scheme-handler/yetAnother;"));
+		assertContainsLine(new String(writer.getResult()),
+				"MimeType=x-scheme-handler/adt;x-scheme-handler/yetAnother;");
 	}
 
 	@Test
@@ -133,15 +127,15 @@ public class TestUnitDesktopFileWriter {
 
 		writer.removeScheme("other");
 
-		assertThat(new String(writer.getResult()), containsLine("MimeType=x-scheme-handler/adt;"));
+		assertContainsLine(new String(writer.getResult()), "MimeType=x-scheme-handler/adt;");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void removeFailsOnIllegalScheme() {
 		DesktopFileWriter writer = getWriterFor(
 				fileContentWith("Exec=/usr/bin/eclipse %u", "MimeType=x-scheme-handler/adt;"));
 
-		writer.removeScheme("&/%");
+		assertThrows(IllegalArgumentException.class, () -> writer.removeScheme("&/%"));
 	}
 
 	@Test
@@ -149,7 +143,7 @@ public class TestUnitDesktopFileWriter {
 		DesktopFileWriter writer = getWriterFor(
 				fileContentWith("Exec=/usr/bin/eclipse %u", "MimeType=x-scheme-handler/adt;"));
 
-		assertThat(new String(writer.getResult()), containsLine("MimeType=x-scheme-handler/adt;"));
+		assertContainsLine(new String(writer.getResult()), "MimeType=x-scheme-handler/adt;");
 	}
 
 	@Test
@@ -159,12 +153,12 @@ public class TestUnitDesktopFileWriter {
 
 		writer.removeScheme("adt");
 
-		assertThat(new String(writer.getResult()), not(contains("MimeType")));
+		assertFalse(new String(writer.getResult()).contains("MimeType"));
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void throwsExceptionOnEmptyDocument() {
-		getWriterFor(Collections.emptyList());
+		assertThrows(IllegalStateException.class, () -> getWriterFor(Collections.emptyList()));
 	}
 
 	@Test
@@ -175,12 +169,12 @@ public class TestUnitDesktopFileWriter {
 
 		DesktopFileWriter writer = getWriterFor(fileContent);
 
-		assertThat(new String(writer.getResult()), new StringEndsWith(comment));
+		assertTrue(new String(writer.getResult()).endsWith(comment));
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void throwsExceptionOnNonPropertiesFile() {
-		getWriterFor(Arrays.asList("foo=bar"));
+		assertThrows(IllegalStateException.class, () -> getWriterFor(Arrays.asList("foo=bar")));
 	}
 
 	@Test
@@ -189,14 +183,14 @@ public class TestUnitDesktopFileWriter {
 
 		writer.addScheme("adt");
 
-		assertThat(new String(writer.getResult()), containsLine("Exec=/usr/bin/eclipse %u"));
+		assertContainsLine(new String(writer.getResult()), "Exec=/usr/bin/eclipse %u");
 	}
 
 	@Test
 	public void addsAddUriPlaceholderToExecLineWhenJustGettingResult() {
 		DesktopFileWriter writer = getWriterFor(fileContentWith("Exec=/usr/bin/eclipse", NO_MIME));
 
-		assertThat(new String(writer.getResult()), containsLine("Exec=/usr/bin/eclipse %u"));
+		assertContainsLine(new String(writer.getResult()), "Exec=/usr/bin/eclipse %u");
 	}
 
 	@Test
@@ -206,7 +200,7 @@ public class TestUnitDesktopFileWriter {
 
 		writer.removeScheme("adt");
 
-		assertThat(new String(writer.getResult()), containsLine("Exec=/usr/bin/eclipse %u"));
+		assertContainsLine(new String(writer.getResult()), "Exec=/usr/bin/eclipse %u");
 	}
 
 	@Test
@@ -226,12 +220,12 @@ public class TestUnitDesktopFileWriter {
 		assertFalse(writer.isRegistered("other"));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void isRegisteredFailsOnIllegalScheme() {
 		DesktopFileWriter writer = getWriterFor(
 				fileContentWith("Exec=/usr/bin/eclipse %u", "MimeType=x-scheme-handler/adt;"));
 
-		writer.isRegistered("&/%");
+		assertThrows(IllegalArgumentException.class, () -> writer.isRegistered("&/%"));
 	}
 
 	@Test
@@ -241,7 +235,7 @@ public class TestUnitDesktopFileWriter {
 		DesktopFileWriter writer = getWriterFor(fileContent);
 
 		String expected = String.join(LINE_SEPARATOR, fileContent);
-		assertThat(new String(writer.getResult()), new IsEqual<>(expected));
+		assertEquals(expected, new String(writer.getResult()));
 	}
 
 	@Test
@@ -307,19 +301,9 @@ public class TestUnitDesktopFileWriter {
 		assertEquals("/usr/bin/eclipse  (copy)", writer.getExecutableLocation());
 	}
 
-	private Matcher<String> containsLine(String line) {
-		return AnyOf.anyOf( //
-				new StringContains(LINE_SEPARATOR + line + LINE_SEPARATOR), //
-				new StringContains(LINE_SEPARATOR + line) //
-		);
-	}
-
-	private Matcher<String> contains(String line) {
-		return new StringContains(line);
-	}
-
-	private Matcher<String> not(Matcher<String> not) {
-		return new IsNot<>(not);
+	private void assertContainsLine(String text, String line) {
+		assertTrue(text.contains(LINE_SEPARATOR + line),
+				"Text should contain line: " + line);
 	}
 
 	private DesktopFileWriter getWriterFor(List<String> fileContent) {

--- a/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitPlistFileWriter.java
+++ b/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitPlistFileWriter.java
@@ -13,14 +13,15 @@
  *******************************************************************************/
 package org.eclipse.urischeme.internal.registration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringReader;
 import java.io.StringWriter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitPlistFileWriter {
 
@@ -70,11 +71,11 @@ public class TestUnitPlistFileWriter {
 		assertSchemesInOrder(writer, "adt");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void addFailsOnIllegalScheme() {
 		PlistFileWriter writer = getWriterWithSchemes("adt");
 
-		writer.addScheme("&/%", "thisIsIllegal");
+		assertThrows(IllegalArgumentException.class, () -> writer.addScheme("&/%", "thisIsIllegal"));
 	}
 
 	@Test
@@ -155,11 +156,11 @@ public class TestUnitPlistFileWriter {
 		assertSchemesInOrder(writer, "adt");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void removeFailsOnIllegalScheme() {
 		PlistFileWriter writer = getWriterWithSchemes("adt");
 
-		writer.removeScheme("&/%");
+		assertThrows(IllegalArgumentException.class, () -> writer.removeScheme("&/%"));
 	}
 
 	@Test
@@ -181,27 +182,27 @@ public class TestUnitPlistFileWriter {
 		assertXml(expectedXml, writer);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void throwsExceptionOnEmptyDocument() {
-		new PlistFileWriter(() -> new StringReader(""));
+		assertThrows(IllegalArgumentException.class, () -> new PlistFileWriter(() -> new StringReader("")));
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void throwsExceptionOnWrongPlistFile() {
 		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" + "<plist version=\"1.0\"/>";
-		new PlistFileWriter(() -> new StringReader(xml));
+		assertThrows(IllegalStateException.class, () -> new PlistFileWriter(() -> new StringReader(xml)));
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void throwsExceptionOnWrongXmlFile() {
 		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" + "<foo/>";
-		new PlistFileWriter(() -> new StringReader(xml));
+		assertThrows(IllegalStateException.class, () -> new PlistFileWriter(() -> new StringReader(xml)));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void throwsExceptionOnNonXmlFile() {
 		String xml = "foo bar";
-		new PlistFileWriter(() -> new StringReader(xml));
+		assertThrows(IllegalArgumentException.class, () -> new PlistFileWriter(() -> new StringReader(xml)));
 	}
 
 	@Test
@@ -220,11 +221,11 @@ public class TestUnitPlistFileWriter {
 		assertFalse(writer.isRegisteredScheme("other"));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void getRegisteredFailsOnIllegalScheme() {
 		PlistFileWriter writer = getWriterWithSchemes("adt");
 
-		writer.isRegisteredScheme("&/%");
+		assertThrows(IllegalArgumentException.class, () -> writer.isRegisteredScheme("&/%"));
 	}
 
 	private void assertSchemesInOrder(PlistFileWriter writer, String... schemes) {

--- a/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitRegistrationLinux.java
+++ b/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitRegistrationLinux.java
@@ -10,11 +10,10 @@
  *******************************************************************************/
 package org.eclipse.urischeme.internal.registration;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -25,12 +24,10 @@ import java.util.stream.Collectors;
 import org.eclipse.urischeme.IOperatingSystemRegistration;
 import org.eclipse.urischeme.IScheme;
 import org.eclipse.urischeme.ISchemeInformation;
-import org.hamcrest.core.IsNot;
-import org.hamcrest.core.StringContains;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitRegistrationLinux {
 
@@ -60,7 +57,7 @@ public class TestUnitRegistrationLinux {
 	private FileProviderMock fileProvider;
 	private ProcessSpy processStub;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		fileProvider = new FileProviderMock();
 		processStub = new ProcessSpy();
@@ -71,13 +68,13 @@ public class TestUnitRegistrationLinux {
 		registration = new RegistrationLinux(fileProvider, processStub, PRODUCT_NAME);
 	}
 
-	@BeforeClass
+	@BeforeAll
 	public static void classSetup() {
 		originalEclipseHomeLocation = System.getProperty(ECLIPSE_HOME_LOCATION, "");
 		originalEclipseLauncher = System.getProperty(ECLIPSE_LAUNCHER, "");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void classTearDown() {
 		System.setProperty(ECLIPSE_HOME_LOCATION, originalEclipseHomeLocation);
 		System.setProperty(ECLIPSE_LAUNCHER, originalEclipseLauncher);
@@ -174,7 +171,7 @@ public class TestUnitRegistrationLinux {
 
 		assertEquals(1, registeredSchemes.size());
 		assertEquals("adt", registeredSchemes.get(0).getName());
-		assertTrue("Scheme should be handled", registeredSchemes.get(0).isHandled());
+		assertTrue(registeredSchemes.get(0).isHandled(), "Scheme should be handled");
 	}
 
 	@Test
@@ -294,20 +291,19 @@ public class TestUnitRegistrationLinux {
 	}
 
 	private void assertAppNameInFileIs(String name) {
-		assertThat(new String(fileProvider.writtenBytes), new StringContains("Name=" + name));
+		assertTrue(new String(fileProvider.writtenBytes).contains("Name=" + name));
 	}
 
 	private void assertMimeTypeInFileIs(String mimeType) {
-		assertThat(new String(fileProvider.writtenBytes), new StringContains("MimeType=" + mimeType));
+		assertTrue(new String(fileProvider.writtenBytes).contains("MimeType=" + mimeType));
 	}
 
 	private void assertExecInFileIs(String exec) {
-		assertThat(new String(fileProvider.writtenBytes), new StringContains("Exec=" + exec));
+		assertTrue(new String(fileProvider.writtenBytes).contains("Exec=" + exec));
 	}
 
 	private void assertNoMimeTypeInFile() {
-		assertThat(new String(fileProvider.writtenBytes),
-				new IsNot<>(new StringContains("MimeType=x-scheme-handler/adt;")));
+		assertFalse(new String(fileProvider.writtenBytes).contains("MimeType=x-scheme-handler/adt;"));
 	}
 
 	private void assertXdgMimeCalledFor(String... schemeHandler) {

--- a/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitRegistrationMacOsX.java
+++ b/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitRegistrationMacOsX.java
@@ -10,11 +10,10 @@
  *******************************************************************************/
 package org.eclipse.urischeme.internal.registration;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.io.Reader;
@@ -29,12 +28,10 @@ import java.util.Scanner;
 import org.eclipse.urischeme.IOperatingSystemRegistration;
 import org.eclipse.urischeme.IScheme;
 import org.eclipse.urischeme.ISchemeInformation;
-import org.hamcrest.core.IsNot;
-import org.hamcrest.core.StringContains;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitRegistrationMacOsX {
 
@@ -59,7 +56,7 @@ public class TestUnitRegistrationMacOsX {
 	private String lsregisterDumpForOwnAppPlus;
 	private String lsregisterDumpMacOS10_15_3;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		fileProvider = new FileProviderMock();
 		fileProvider.writer = new StringWriter();
@@ -84,14 +81,14 @@ public class TestUnitRegistrationMacOsX {
 
 	}
 
-	@BeforeClass
+	@BeforeAll
 	public static void classSetup() {
 		originalEclipseHomeLocation = System.getProperty("eclipse.home.location", "");
 		originalEclipseLauncher = System.getProperty("eclipse.launcher", "");
 
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void classTearDown() {
 		System.setProperty("eclipse.home.location", originalEclipseHomeLocation);
 		System.setProperty("eclipse.launcher", originalEclipseLauncher);
@@ -287,12 +284,12 @@ public class TestUnitRegistrationMacOsX {
 	}
 
 	private void assertSchemeInFile(String scheme) {
-		assertThat(fileProvider.writer.toString(), new StringContains("<string>" + scheme + "</string>"));
+		assertTrue(fileProvider.writer.toString().contains("<string>" + scheme + "</string>"));
 
 	}
 
 	private void assertSchemeNotInFile(String scheme) {
-		assertThat(fileProvider.writer.toString(), new IsNot<>(new StringContains("<string>" + scheme + "</string>")));
+		assertFalse(fileProvider.writer.toString().contains("<string>" + scheme + "</string>"));
 
 	}
 

--- a/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitRegistrationWindows.java
+++ b/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitRegistrationWindows.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.urischeme.internal.registration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -23,10 +23,10 @@ import java.util.List;
 
 import org.eclipse.urischeme.IScheme;
 import org.eclipse.urischeme.ISchemeInformation;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitRegistrationWindows {
 
@@ -46,13 +46,13 @@ public class TestUnitRegistrationWindows {
 	private static String originalEclipseHome;
 	private RegistrationWindows registrationWindows;
 
-	@BeforeClass
+	@BeforeAll
 	public static void classSetup() throws MalformedURLException {
 		originalEclipseLauncher = System.getProperty("eclipse.launcher", null);
 		originalEclipseHome = System.getProperty("eclipse.home.location", null);
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		System.setProperty("eclipse.launcher", PATH_TO_ECLIPSE_EXE);
 		registryWriter = new RegistryWriterMock();
@@ -63,7 +63,7 @@ public class TestUnitRegistrationWindows {
 		registrationWindows = new RegistrationWindows(registryWriter, fileProvider);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDown() throws Exception {
 		if (originalEclipseLauncher != null) {
 			System.setProperty("eclipse.launcher", originalEclipseLauncher);
@@ -81,22 +81,22 @@ public class TestUnitRegistrationWindows {
 	public void handlesAdd() throws Exception {
 		registrationWindows.handleSchemes(Arrays.asList(OTHER_SCHEME_INFO, ADT_SCHEME_INFO), Collections.emptyList());
 
-		assertEquals("Too many schemes added", 2, registryWriter.addedSchemes.size());
-		assertTrue("Scheme not added", registryWriter.addedSchemes.contains(OTHER_SCHEME_INFO.getName()));
-		assertTrue("Scheme not added", registryWriter.addedSchemes.contains(ADT_SCHEME_INFO.getName()));
+		assertEquals(2, registryWriter.addedSchemes.size(), "Too many schemes added");
+		assertTrue(registryWriter.addedSchemes.contains(OTHER_SCHEME_INFO.getName()), "Scheme not added");
+		assertTrue(registryWriter.addedSchemes.contains(ADT_SCHEME_INFO.getName()), "Scheme not added");
 
-		assertEquals("Too many schemes removed", 0, registryWriter.removedSchemes.size());
+		assertEquals(0, registryWriter.removedSchemes.size(), "Too many schemes removed");
 	}
 
 	@Test
 	public void handlesAddAndRemoveOfSameScheme() throws Exception {
 		registrationWindows.handleSchemes(Arrays.asList(OTHER_SCHEME_INFO), Arrays.asList(OTHER_SCHEME_INFO));
 
-		assertEquals("Too many schemes added", 1, registryWriter.addedSchemes.size());
-		assertTrue("Scheme not added", registryWriter.addedSchemes.contains(OTHER_SCHEME_INFO.getName()));
+		assertEquals(1, registryWriter.addedSchemes.size(), "Too many schemes added");
+		assertTrue(registryWriter.addedSchemes.contains(OTHER_SCHEME_INFO.getName()), "Scheme not added");
 
-		assertEquals("Too many schemes removed", 1, registryWriter.removedSchemes.size());
-		assertTrue("Scheme not removed", registryWriter.removedSchemes.contains(OTHER_SCHEME_INFO.getName()));
+		assertEquals(1, registryWriter.removedSchemes.size(), "Too many schemes removed");
+		assertTrue(registryWriter.removedSchemes.contains(OTHER_SCHEME_INFO.getName()), "Scheme not removed");
 	}
 
 	@Test
@@ -104,13 +104,13 @@ public class TestUnitRegistrationWindows {
 		registrationWindows.handleSchemes(Arrays.asList(OTHER_SCHEME_INFO, ADT_SCHEME_INFO),
 				Arrays.asList(ADT_SCHEME_INFO, OTHER_SCHEME_INFO));
 
-		assertEquals("Too many schemes added", 2, registryWriter.addedSchemes.size());
-		assertTrue("Scheme not added", registryWriter.addedSchemes.contains(OTHER_SCHEME_INFO.getName()));
-		assertTrue("Scheme not added", registryWriter.addedSchemes.contains(ADT_SCHEME_INFO.getName()));
+		assertEquals(2, registryWriter.addedSchemes.size(), "Too many schemes added");
+		assertTrue(registryWriter.addedSchemes.contains(OTHER_SCHEME_INFO.getName()), "Scheme not added");
+		assertTrue(registryWriter.addedSchemes.contains(ADT_SCHEME_INFO.getName()), "Scheme not added");
 
-		assertEquals("Too many schemes removed", 2, registryWriter.removedSchemes.size());
-		assertTrue("Scheme not removed", registryWriter.removedSchemes.contains(OTHER_SCHEME_INFO.getName()));
-		assertTrue("Scheme not removed", registryWriter.removedSchemes.contains(ADT_SCHEME_INFO.getName()));
+		assertEquals(2, registryWriter.removedSchemes.size(), "Too many schemes removed");
+		assertTrue(registryWriter.removedSchemes.contains(OTHER_SCHEME_INFO.getName()), "Scheme not removed");
+		assertTrue(registryWriter.removedSchemes.contains(ADT_SCHEME_INFO.getName()), "Scheme not removed");
 	}
 
 	@Test
@@ -197,11 +197,9 @@ public class TestUnitRegistrationWindows {
 
 	private void assertSchemeInformation(ISchemeInformation schemeInformation, IScheme scheme, String handlerlocation,
 			boolean isHandled) {
-		assertEquals("Scheme not set correctly", scheme.getName(), schemeInformation.getName());
-		assertEquals("Scheme description not set correctly", scheme.getDescription(),
-				schemeInformation.getDescription());
-		assertEquals("Handler location not set correctly", handlerlocation,
-				schemeInformation.getHandlerInstanceLocation());
-		assertEquals("isHandled not set correctly", isHandled, schemeInformation.isHandled());
+		assertEquals(scheme.getName(), schemeInformation.getName(), "Scheme not set correctly");
+		assertEquals(scheme.getDescription(), schemeInformation.getDescription(), "Scheme description not set correctly");
+		assertEquals(handlerlocation, schemeInformation.getHandlerInstanceLocation(), "Handler location not set correctly");
+		assertEquals(isHandled, schemeInformation.isHandled(), "isHandled not set correctly");
 	}
 }

--- a/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitRegistryWriter.java
+++ b/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitRegistryWriter.java
@@ -10,15 +10,16 @@
  *******************************************************************************/
 package org.eclipse.urischeme.internal.registration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.urischeme.internal.registration.WinRegistryMock.Entry;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitRegistryWriter {
 	private final static String QUOTE = "\"";
@@ -32,7 +33,7 @@ public class TestUnitRegistryWriter {
 	private WinRegistryMock registryMock;
 	private FileProviderMock fileProviderMock;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		registryMock = new WinRegistryMock();
 		launcher = "/path/to/eclipse/Eclips.exe";
@@ -48,13 +49,13 @@ public class TestUnitRegistryWriter {
 		writer = new RegistryWriter(registryMock, fileProviderMock);
 	}
 
-	@BeforeClass
+	@BeforeAll
 	public static void classSetup() {
 		originalEclipseLauncher = System.getProperty("eclipse.launcher", "");
 		originalEclipseHomeLocation = System.getProperty("eclipse.home.location", "");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void classTearDown() {
 		System.setProperty("eclipse.launcher", originalEclipseLauncher);
 		System.setProperty("eclipse.home.location", originalEclipseHomeLocation);
@@ -72,15 +73,15 @@ public class TestUnitRegistryWriter {
 				launcherWithArgs);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void throwsExceptionOnAddingInvalidScheme() throws Exception {
-		writer.addScheme("%&$", launcher);
+		assertThrows(IllegalArgumentException.class, () -> writer.addScheme("%&$", launcher));
 	}
 
-	@Test(expected = WinRegistryException.class)
+	@Test
 	public void throwsIllegalStateExceptionOnAddScheme() throws Exception {
 		registryMock.setValueForKeyException = new WinRegistryException("failed");
-		writer.addScheme("adt", launcher);
+		assertThrows(WinRegistryException.class, () -> writer.addScheme("adt", launcher));
 	}
 
 	@Test
@@ -100,12 +101,12 @@ public class TestUnitRegistryWriter {
 		assertEquals("Software\\Classes\\adt", registryMock.deletedKeys.get(3));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void throwsExceptionOnRemovingInvalidScheme() throws Exception {
-		writer.removeScheme("%&$");
+		assertThrows(IllegalArgumentException.class, () -> writer.removeScheme("%&$"));
 	}
 
-	@Test(expected = WinRegistryException.class)
+	@Test
 	public void throwsWinRegistryExceptionOnRemoveScheme() throws Exception {
 		registryMock.valuesForKeys.put("Software\\Classes\\adt-URL Protocol", "");
 		registryMock.valuesForKeys.put("Software\\Classes\\adt-null", "URL:adt");
@@ -115,7 +116,7 @@ public class TestUnitRegistryWriter {
 		fileProviderMock.fileExistsAnswers.put(launcher, true);
 
 		registryMock.deleteKeyException = new WinRegistryException("failed");
-		writer.removeScheme("adt");
+		assertThrows(WinRegistryException.class, () -> writer.removeScheme("adt"));
 	}
 
 	private void assertEntry(Entry entry, String key, String attribute, String value) {
@@ -203,10 +204,10 @@ public class TestUnitRegistryWriter {
 		assertEquals(null, writer.getRegisteredHandlerPath("adt"));
 	}
 
-	@Test(expected = WinRegistryException.class)
+	@Test
 	public void throwsWinRegistryExceptionOnGetRegisteredHandlerPath() throws Exception {
 		registryMock.getValueForKeyException = new WinRegistryException("failed");
-		writer.getRegisteredHandlerPath("adt");
+		assertThrows(WinRegistryException.class, () -> writer.getRegisteredHandlerPath("adt"));
 	}
 
 	@Test

--- a/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitWinRegistry.java
+++ b/tests/org.eclipse.tests.urischeme/src/org/eclipse/urischeme/internal/registration/TestUnitWinRegistry.java
@@ -1,20 +1,19 @@
 package org.eclipse.urischeme.internal.registration;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.UUID;
 
 import org.eclipse.core.runtime.Platform;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitWinRegistry {
 
 	@Test
 	public void testWinRegistry() throws Exception {
-		Assume.assumeThat("Requires Windows OS", Platform.getOS(), is(Platform.OS_WIN32));
+		Assumptions.assumeTrue(Platform.OS_WIN32.equals(Platform.getOS()), "Requires Windows OS");
 
 		WinRegistry winRegistry = new WinRegistry();
 		String randomKeyMain = UUID.randomUUID().toString();
@@ -24,13 +23,13 @@ public class TestUnitWinRegistry {
 
 		String actualVal = winRegistry.getValueForKey(randomKeyMain + "\\" + randomKeySub, "dummykey");
 
-		assertThat(actualVal, is("dummyval"));
+		assertEquals("dummyval", actualVal);
 
 		winRegistry.deleteKey(randomKeyMain + "\\" + randomKeySub);
 		winRegistry.deleteKey(randomKeyMain);
 
 		actualVal = winRegistry.getValueForKey(randomKeyMain + "\\" + randomKeySub, "dummykey");
 
-		assertThat(actualVal, is(nullValue()));
+		assertNull(actualVal);
 	}
 }


### PR DESCRIPTION
Migrates the org.eclipse.tests.urischeme test bundle from JUnit 4 to JUnit 5. Updates MANIFEST.MF to remove JUnit 4 dependency
     and import JUnit 5 packages.