### PR TITLE
Ensure code minings are rendered when editor is initially opened

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineHeaderAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineHeaderAnnotation.java
@@ -125,8 +125,8 @@ public class CodeMiningLineHeaderAnnotation extends LineHeaderAnnotation impleme
 		if (gc != null) {
 			return sumLineHeight;
 		} else {
-			int lineHeight= styledText.getLineHeight();
-			int result= numLinesOfAllMinings * (lineHeight + styledText.getLineSpacing());
+			int lineHeight= styledText != null ? styledText.getLineHeight() : 0;
+			int result= numLinesOfAllMinings * (lineHeight + (styledText != null ? styledText.getLineSpacing() : 0));
 			return result;
 		}
 	}
@@ -145,7 +145,7 @@ public class CodeMiningLineHeaderAnnotation extends LineHeaderAnnotation impleme
 				}
 			}
 			Point ext= gc.textExtent(line);
-			sumLineHeight+= ext.y + styledText.getLineSpacing();
+			sumLineHeight+= ext.y + (styledText != null ? styledText.getLineSpacing() : 0);
 		}
 		return sumLineHeight;
 	}

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningManager.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningManager.java
@@ -145,12 +145,16 @@ public class CodeMiningManager implements Runnable {
 		IProgressMonitor monitor= fMonitor;
 		// Collect the code minings for the viewer
 		getCodeMinings(fViewer, fCodeMiningProviders, monitor).thenAccept(symbols -> {
-			// check if request was canceled.
-			monitor.isCanceled();
-			// then group code minings by lines position
-			Map<Position, List<ICodeMining>> groups= groupByLines(symbols, fCodeMiningProviders);
-			// resolve and render code minings
-			renderCodeMinings(groups, fViewer, monitor);
+			try {
+				// check if request was canceled.
+				monitor.isCanceled();
+				// then group code minings by lines position
+				Map<Position, List<ICodeMining>> groups= groupByLines(symbols, fCodeMiningProviders);
+				// resolve and render code minings
+				renderCodeMinings(groups, fViewer, monitor);
+			} catch (Throwable e) {
+				logCodeMiningProviderException(e);
+			}
 		});
 	}
 

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/codemining/ICodeMining.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/codemining/ICodeMining.java
@@ -78,7 +78,7 @@ public interface ICodeMining {
 	 * {@link CompletableFuture#completedFuture(Object)} if no such resolution is necessary (in
 	 * which case {#isResolved()} is expected to return <code>true</code>).
 	 *
-	 * @param viewer the viewer.
+	 * @param viewer the viewer, can be null
 	 * @param monitor the monitor.
 	 * @return the future to resolve the content of mining, or
 	 *         {@link CompletableFuture#completedFuture(Object)} if no such resolution is necessary

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/AbstractInlinedAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/AbstractInlinedAnnotation.java
@@ -93,6 +93,7 @@ public abstract class AbstractInlinedAnnotation extends Annotation {
 	protected AbstractInlinedAnnotation(Position position, ISourceViewer viewer, Consumer<MouseEvent> onMouseHover, Consumer<MouseEvent> onMouseOut, Consumer<MouseEvent> onMouseMove) {
 		super(TYPE, false, ""); //$NON-NLS-1$
 		this.position= position;
+		this.fViewer= viewer;
 		this.onMouseHover= onMouseHover;
 		this.onMouseOut= onMouseOut;
 		this.onMouseMove= onMouseMove;
@@ -122,18 +123,25 @@ public abstract class AbstractInlinedAnnotation extends Annotation {
 	}
 
 	/**
-	 * Returns the {@link StyledText} widget where the annotation must be drawn.
+	 * Returns the {@link StyledText} widget where the annotation must be drawn or null if not
+	 * available.
 	 *
-	 * @return the {@link StyledText} widget where the annotation must be drawn.
+	 * @return the {@link StyledText} widget where the annotation must be drawn or null if not
+	 *         available.
 	 */
 	public StyledText getTextWidget() {
+		if (fViewer == null) {
+			return null;
+		}
 		return fViewer.getTextWidget();
 	}
 
 	/**
-	 * Returns the {@link ISourceViewer} where the annotation must be drawn.
+	 * Returns the {@link ISourceViewer} where the annotation must be drawn or null if not
+	 * available.
 	 *
-	 * @return the {@link ISourceViewer} where the annotation must be drawn.
+	 * @return the {@link ISourceViewer} where the annotation must be drawn or null if not
+	 *         available.
 	 */
 	public ISourceViewer getViewer() {
 		return fViewer;
@@ -155,9 +163,9 @@ public abstract class AbstractInlinedAnnotation extends Annotation {
 				Position pos= getPosition();
 				int offset= pos.getOffset();
 				ISourceViewer viewer= getViewer();
-				if (viewer instanceof ITextViewerExtension5) {
+				if (viewer instanceof ITextViewerExtension5 extViewer) {
 					// adjust offset according folded content
-					offset= ((ITextViewerExtension5) viewer).modelOffset2WidgetOffset(offset);
+					offset= extViewer.modelOffset2WidgetOffset(offset);
 				}
 				InlinedAnnotationDrawingStrategy.draw(this, null, text, offset, pos.getLength(), null);
 			} catch (RuntimeException e) {
@@ -248,6 +256,9 @@ public abstract class AbstractInlinedAnnotation extends Annotation {
 	 *         otherwise.
 	 */
 	protected boolean isInVisibleLines() {
+		if (support == null) {
+			return true; // support not yet available, we have to be optimistic
+		}
 		return support.isInVisibleLines(getPosition().getOffset());
 	}
 
@@ -272,6 +283,9 @@ public abstract class AbstractInlinedAnnotation extends Annotation {
 	 *         otherwise.
 	 */
 	protected boolean isInVisibleLines(int offset) {
+		if (support == null) {
+			return true; // support not yet available, we have to be optimistic
+		}
 		return support.isInVisibleLines(offset);
 	}
 
@@ -297,6 +311,9 @@ public abstract class AbstractInlinedAnnotation extends Annotation {
 	 */
 	boolean contains(int x, int y) {
 		StyledText styledText= getTextWidget();
+		if (styledText == null) {
+			return false;
+		}
 		GC gc= null;
 		try {
 			gc= new GC(styledText);

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineContentAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineContentAnnotation.java
@@ -119,7 +119,9 @@ public class LineContentAnnotation extends AbstractInlinedAnnotation {
 
 	@Override
 	boolean contains(int x, int y) {
-		return (x >= this.fX && x <= this.fX + width && y >= this.fY && y <= this.fY + getTextWidget().getLineHeight());
+		StyledText textWidget= getTextWidget();
+		int lineHeight= textWidget != null ? textWidget.getLineHeight() : 0;
+		return (x >= this.fX && x <= this.fX + width && y >= this.fY && y <= this.fY + lineHeight);
 	}
 
 	/**
@@ -137,6 +139,9 @@ public class LineContentAnnotation extends AbstractInlinedAnnotation {
 	 *         not model position.
 	 */
 	StyleRange updateStyle(StyleRange style, FontMetrics fontMetrics, ITextViewer viewer, boolean afterPosition) {
+		if (viewer == null) {
+			return null;
+		}
 		Position widgetPosition= computeWidgetPosition(viewer);
 		if (widgetPosition == null) {
 			return null;

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineFooterAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineFooterAnnotation.java
@@ -37,6 +37,9 @@ public class LineFooterAnnotation extends AbstractInlinedAnnotation {
 	 */
 	public int getHeight() {
 		StyledText styledText= super.getTextWidget();
+		if (styledText == null) {
+			return 0;
+		}
 		return styledText.getLineHeight();
 	}
 

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineHeaderAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineHeaderAnnotation.java
@@ -64,6 +64,9 @@ public class LineHeaderAnnotation extends AbstractInlinedAnnotation {
 	 */
 	public int getHeight() {
 		StyledText styledText= super.getTextWidget();
+		if (styledText == null) {
+			return 0;
+		}
 		return styledText.getLineHeight();
 	}
 


### PR DESCRIPTION
This PR fixes a NullPointerException that currently interrupts the code‑mining rendering pipeline. Due to this exception being thrown during editor initialization, no code minings are displayed when the editor is opened.

The problem is fixed by adding a null check for the `support` field in method call `AbstractInlinedAnnotation.isInVisibleLines()`.