### PR TITLE
Backport : Avoid removal warning in AnimatorFactory due to java-doc

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/AnimatorFactory.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/AnimatorFactory.java
@@ -20,7 +20,7 @@ import org.eclipse.swt.widgets.Control;
 /**
  * Factory for control animators used by JFace to animate the display of an SWT
  * Control. Through the use of the method
- * {@link org.eclipse.jface.util.Policy#setAnimatorFactory(AnimatorFactory)}
+ * {@code org.eclipse.jface.util.Policy.setAnimatorFactory(AnimatorFactory)}
  * a new type of animator factory can be plugged into JFace.
  *
  * @since 3.2


### PR DESCRIPTION
Backport fix to 4.35 maintenance