### PR TITLE
Remove redundant GC.dispose() calls for Image objects

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/ColorSelector.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/ColorSelector.java
@@ -192,7 +192,6 @@ public class ColorSelector extends EventManager {
 		}
 		gc.setLineWidth(2);
 		gc.drawRectangle(image.getBounds());
-		gc.dispose();
 
 		ImageData data = image.getImageData(zoom);
 		image.dispose();


### PR DESCRIPTION
This minor refactoring removes unnecessary calls to GC.dispose(), as disposing an Image automatically disposes its associated GC.

The images affected by this change are the color-rectangle visuals used in the color selector and syntax coloring. I tested the behavior both before and after the change and observed no visual differences.