### PR TITLE
Use proper autoscale value for splash screen scaling

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/Workbench.java
@@ -3666,14 +3666,12 @@ public final class Workbench extends EventManager implements IWorkbench, org.ecl
 	}
 
 	private static class AutoscaleAdaptation {
-		private static final String SWT_AUTOSCALE = "swt.autoScale"; //$NON-NLS-1$
-
 		private boolean incompatibleMonitorSpecificScalingDisabled;
 
 		private final String initialAutoScaleValue;
 
 		public AutoscaleAdaptation() {
-			initialAutoScaleValue = System.getProperty(SWT_AUTOSCALE);
+			initialAutoScaleValue = DPIUtil.getEffectiveAutoScaleValue();
 		}
 
 		public void runWithInitialAutoScaleValue(Runnable runnable) {


### PR DESCRIPTION
The splash screen is initialized by the Equinox native launcher such that when the Workbench takes it over, the autoscaling settings used for processing it must fit to avoid a wrongly sized background image and controls.
Since the autoscaling default used to be "integer" and any other value was only defined by a system property, reading that system property was sufficient. With the adaptation of SWT and Equinox to default to autoscaling mode "quarter" on Windows when monitor-specific scaling is used, reading the system property is not sufficient anymore as it also depends on whether monitor-specific scaling is enabled.

This change adapts the identification of the proper autoscaling mode by just reading it from the SWT configuration. This also ensure that it will be resilient against potential future changes of default settings.

Without this change, starting an application based on the SWT and Equinox state of 2026-01-22 or newer and deactivating monitor-specific scaling via the Eclipse preference would result in unintended results on monitors with fractional scaling. The following shows the result on a 150% primary monitor:
<img width="382" height="266" alt="image" src="https://github.com/user-attachments/assets/ce9bc683-ba30-406b-ba6f-b227ad343103" />
