### PR TITLE
Migrate Widget Factory Tests to JUnit 5

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/Bug299755Test.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/Bug299755Test.java
@@ -14,8 +14,8 @@
  ******************************************************************************/
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -25,7 +25,7 @@ import org.eclipse.e4.core.contexts.EclipseContextFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.ui.services.IServiceConstants;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Bug299755Test {
 

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/Bug308220Test.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/Bug308220Test.java
@@ -14,8 +14,8 @@
  ******************************************************************************/
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -26,7 +26,7 @@ import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.contexts.RunAndTrack;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.ui.services.IServiceConstants;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Bug308220Test {
 

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/Bug320857Test.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/Bug320857Test.java
@@ -13,9 +13,9 @@
  ******************************************************************************/
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -33,9 +33,9 @@ import org.eclipse.e4.ui.services.IServiceConstants;
 import org.eclipse.e4.ui.workbench.IPresentationEngine;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.emf.common.notify.Notifier;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class Bug320857Test {
 
@@ -45,7 +45,7 @@ public class Bug320857Test {
 
 	private EModelService ems;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		applicationContext = E4Application.createDefaultContext();
 		ems = applicationContext.get(EModelService.class);
@@ -55,7 +55,7 @@ public class Bug320857Test {
 		return "bundleclass://org.eclipse.e4.ui.tests/org.eclipse.e4.ui.tests.application.HeadlessContextPresentationEngine"; //$NON-NLS-1$
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		applicationContext.dispose();
 	}

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/E4ResourceTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/E4ResourceTest.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.Map;
 import java.util.Map.Entry;
@@ -27,7 +27,7 @@ import org.eclipse.e4.ui.model.application.MApplicationFactory;
 import org.eclipse.e4.ui.model.application.ui.basic.MBasicFactory;
 import org.eclipse.e4.ui.model.application.ui.basic.MTrimmedWindow;
 import org.eclipse.emf.ecore.EObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class E4ResourceTest {
 	@Test

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/EModelServiceFindTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/EModelServiceFindTest.java
@@ -14,11 +14,11 @@
  ******************************************************************************/
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,9 +46,9 @@ import org.eclipse.e4.ui.model.application.ui.menu.MToolBar;
 import org.eclipse.e4.ui.model.application.ui.menu.MToolBarElement;
 import org.eclipse.e4.ui.model.application.ui.menu.MToolControl;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class EModelServiceFindTest {
 
@@ -56,12 +56,12 @@ public class EModelServiceFindTest {
 
 	MApplication app = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		applicationContext = E4Application.createDefaultContext();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		applicationContext.dispose();
 	}

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/EModelServiceInsertTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/EModelServiceInsertTest.java
@@ -13,9 +13,9 @@
  ******************************************************************************/
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.internal.workbench.swt.E4Application;
@@ -28,9 +28,9 @@ import org.eclipse.e4.ui.model.application.ui.basic.MPartSashContainerElement;
 import org.eclipse.e4.ui.model.application.ui.basic.MPartStack;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class EModelServiceInsertTest {
 
@@ -40,13 +40,13 @@ public class EModelServiceInsertTest {
 
 	private EModelService ems;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		applicationContext = E4Application.createDefaultContext();
 		ems = applicationContext.get(EModelService.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		applicationContext.dispose();
 	}
@@ -113,20 +113,19 @@ public class EModelServiceInsertTest {
 				ratio);
 
 		MUIElement newPartParent = newPart.getParent();
-		assertTrue("parent must be a sash",
-				(newPartParent instanceof MPartSashContainer));
+		assertTrue((newPartParent instanceof MPartSashContainer), "parent must be a sash");
 		MPartSashContainer psc = (MPartSashContainer) newPartParent;
 
 		boolean horizontal = where == EModelService.LEFT_OF
 				|| where == EModelService.RIGHT_OF;
-		assertEquals("invalid sash orientation", horizontal, psc.isHorizontal());
+		assertEquals(horizontal, psc.isHorizontal(), "invalid sash orientation");
 
 		if (where == EModelService.LEFT_OF || where == EModelService.ABOVE) {
-			assertEquals("new part should be first", 0, psc.getChildren().indexOf(newPart));
-			assertEquals("old part should be second", 1, psc.getChildren().indexOf(relTo));
+			assertEquals(0, psc.getChildren().indexOf(newPart), "new part should be first");
+			assertEquals(1, psc.getChildren().indexOf(relTo), "old part should be second");
 		} else {
-			assertEquals("old part should be first", 0, psc.getChildren().indexOf(relTo));
-			assertEquals("new part should be second", 1, psc.getChildren().indexOf(newPart));
+			assertEquals(0, psc.getChildren().indexOf(relTo), "old part should be first");
+			assertEquals(1, psc.getChildren().indexOf(newPart), "new part should be second");
 		}
 	}
 

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/EModelServiceTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/EModelServiceTest.java
@@ -13,10 +13,10 @@
  ******************************************************************************/
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.e4.ui.model.application.descriptor.basic.MPartDescriptor;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
@@ -28,7 +28,7 @@ import org.eclipse.e4.ui.model.application.ui.basic.MPartStack;
 import org.eclipse.e4.ui.model.application.ui.basic.MTrimBar;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EModelServiceTest extends UITest {
 

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/EPartServiceTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/EPartServiceTest.java
@@ -13,12 +13,12 @@
  ******************************************************************************/
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -52,7 +52,7 @@ import org.eclipse.e4.ui.workbench.modeling.IPartListener;
 import org.eclipse.e4.ui.workbench.modeling.ISaveHandler;
 import org.eclipse.e4.ui.workbench.modeling.ISaveHandler.Save;
 import org.eclipse.emf.common.notify.Notifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EPartServiceTest extends UITest {
 
@@ -386,7 +386,7 @@ public class EPartServiceTest extends UITest {
 
 		EPartService partService = window.getContext().get(EPartService.class);
 		partService.bringToTop(partBack);
-		assertTrue("Bringing a part to the top should cause it to be rendered", partBack.isToBeRendered());
+		assertTrue(partBack.isToBeRendered(), "Bringing a part to the top should cause it to be rendered");
 	}
 
 	@Test
@@ -414,9 +414,7 @@ public class EPartServiceTest extends UITest {
 		assertEquals(partA, partService.getActivePart());
 
 		partService.bringToTop(partB);
-		assertEquals(
-				"Bringing a part to top that's not in the same container as the active part shouldn't change the active part",
-				partA, partService.getActivePart());
+		assertEquals(partA, partService.getActivePart(), "Bringing a part to top that's not in the same container as the active part shouldn't change the active part");
 	}
 
 	@Test
@@ -449,9 +447,7 @@ public class EPartServiceTest extends UITest {
 		assertEquals(partA, partService.getActivePart());
 
 		partService.bringToTop(partB);
-		assertEquals(
-				"Bringing a part to top that's not in the same container as the active part shouldn't change the active part",
-				partA, partService.getActivePart());
+		assertEquals(partA, partService.getActivePart(), "Bringing a part to top that's not in the same container as the active part shouldn't change the active part");
 	}
 
 	@Test
@@ -485,9 +481,7 @@ public class EPartServiceTest extends UITest {
 		assertEquals(partC, partService.getActivePart());
 
 		partService.bringToTop(partB);
-		assertEquals(
-				"Bringing a part to top that's not in the same container as the active part shouldn't change the active part",
-				partC, partService.getActivePart());
+		assertEquals(partC, partService.getActivePart(), "Bringing a part to top that's not in the same container as the active part shouldn't change the active part");
 	}
 
 	@Test
@@ -534,9 +528,7 @@ public class EPartServiceTest extends UITest {
 		assertEquals(partC, partService.getActivePart());
 
 		partService.bringToTop(partB);
-		assertEquals(
-				"Bringing a part to top that's not in the same container as the active part shouldn't change the active part",
-				partC, partService.getActivePart());
+		assertEquals(partC, partService.getActivePart(), "Bringing a part to top that's not in the same container as the active part shouldn't change the active part");
 	}
 
 	@Test
@@ -1098,7 +1090,7 @@ public class EPartServiceTest extends UITest {
 
 		EPartService partService = window.getContext().get(EPartService.class);
 		partService.activate(partBack);
-		assertTrue("Activating a part should cause it to be rendered", partBack.isToBeRendered());
+		assertTrue(partBack.isToBeRendered(), "Activating a part should cause it to be rendered");
 	}
 
 	@Test
@@ -1381,7 +1373,7 @@ public class EPartServiceTest extends UITest {
 		assertNotNull(part);
 		assertEquals("partId", part.getElementId());
 		assertEquals(part, partService.getActivePart());
-		assertTrue("Shown part should be visible", part.isVisible());
+		assertTrue(part.isVisible(), "Shown part should be visible");
 	}
 
 	@Test
@@ -1506,16 +1498,16 @@ public class EPartServiceTest extends UITest {
 		assertTrue(partService.isPartVisible(partB1));
 		assertEquals(partA1, partService.getActivePart());
 		assertEquals(shownPart, partA2);
-		assertNotNull("The part should have been created so it should have a context", partA2.getContext());
-		assertEquals("This part has not been instantiated yet, it should have no context", null, partB2.getContext());
+		assertNotNull(partA2.getContext(), "The part should have been created so it should have a context");
+		assertEquals(null, partB2.getContext(), "This part has not been instantiated yet, it should have no context");
 
 		shownPart = partService.showPart("partB2", EPartService.PartState.CREATE);
 		assertTrue(partService.isPartVisible(partA1));
 		assertTrue(partService.isPartVisible(partB1));
 		assertEquals(partA1, partService.getActivePart());
 		assertEquals(shownPart, partB2);
-		assertNotNull("The part should have been created so it should have a context", partA2.getContext());
-		assertNotNull("The part should have been created so it should have a context", partB2.getContext());
+		assertNotNull(partA2.getContext(), "The part should have been created so it should have a context");
+		assertNotNull(partB2.getContext(), "The part should have been created so it should have a context");
 	}
 
 	@Test
@@ -1551,9 +1543,8 @@ public class EPartServiceTest extends UITest {
 		MPart partB = partService.showPart("partB", EPartService.PartState.CREATE);
 
 		assertEquals(2, partStack.getChildren().size());
-		assertEquals("Only creating the part, the active part should not have changed", partA,
-				partService.getActivePart());
-		assertNotNull("The shown part should have a context", partB.getContext());
+		assertEquals(partA, partService.getActivePart(), "Only creating the part, the active part should not have changed");
+		assertNotNull(partB.getContext(), "The shown part should have a context");
 		assertFalse(partService.isPartVisible(partB));
 	}
 
@@ -1592,10 +1583,9 @@ public class EPartServiceTest extends UITest {
 		MPart partB = partService.showPart("partB", EPartService.PartState.CREATE);
 
 		assertEquals(1, partStackA.getChildren().size());
-		assertEquals("Only creating the part, the active part should not have changed", partA,
-				partService.getActivePart());
-		assertNotNull("The shown part should have a context", partB.getContext());
-		assertTrue("The part is the only one in the stack, it should be visible", partService.isPartVisible(partB));
+		assertEquals(partA, partService.getActivePart(), "Only creating the part, the active part should not have changed");
+		assertNotNull(partB.getContext(), "The shown part should have a context");
+		assertTrue(partService.isPartVisible(partB), "The part is the only one in the stack, it should be visible");
 	}
 
 	@Test
@@ -1707,9 +1697,8 @@ public class EPartServiceTest extends UITest {
 		MPart partB = partService.showPart("partB", EPartService.PartState.VISIBLE);
 
 		assertEquals(2, partStack.getChildren().size());
-		assertEquals("The part is in the same stack as the active part, so the active part should have changed", partB,
-				partService.getActivePart());
-		assertNotNull("The shown part should have a context", partB.getContext());
+		assertEquals(partB, partService.getActivePart(), "The part is in the same stack as the active part, so the active part should have changed");
+		assertNotNull(partB.getContext(), "The shown part should have a context");
 		assertFalse(partService.isPartVisible(partA));
 		assertTrue(partService.isPartVisible(partB));
 	}
@@ -1749,10 +1738,9 @@ public class EPartServiceTest extends UITest {
 		MPart partB = partService.showPart("partB", EPartService.PartState.VISIBLE);
 
 		assertEquals(1, partStackA.getChildren().size());
-		assertEquals("Only making a part visible, the active part should not have changed", partA,
-				partService.getActivePart());
-		assertNotNull("The shown part should have a context", partB.getContext());
-		assertTrue("The part is the only one in the stack, it should be visible", partService.isPartVisible(partB));
+		assertEquals(partA, partService.getActivePart(), "Only making a part visible, the active part should not have changed");
+		assertNotNull(partB.getContext(), "The shown part should have a context");
+		assertTrue(partService.isPartVisible(partB), "The part is the only one in the stack, it should be visible");
 	}
 
 	@Test
@@ -1820,9 +1808,8 @@ public class EPartServiceTest extends UITest {
 		MPart shownPart = partService.showPart("partB", EPartService.PartState.VISIBLE);
 
 		assertEquals(2, partStack.getChildren().size());
-		assertEquals("The part is in the same stack as the active part, so the active part should have changed", partB,
-				partService.getActivePart());
-		assertNotNull("The shown part should have a context", partB.getContext());
+		assertEquals(partB, partService.getActivePart(), "The part is in the same stack as the active part, so the active part should have changed");
+		assertNotNull(partB.getContext(), "The shown part should have a context");
 		assertFalse(partService.isPartVisible(partA));
 		assertTrue(partService.isPartVisible(partB));
 		assertEquals(partB, shownPart);
@@ -1849,8 +1836,8 @@ public class EPartServiceTest extends UITest {
 		assertEquals(1, window.getChildren().size());
 		assertEquals(part, window.getChildren().get(0));
 		assertEquals(part, shownPart);
-		assertTrue("A shown part should be rendered", part.isToBeRendered());
-		assertNotNull("A shown part should have a widget", part.getWidget());
+		assertTrue(part.isToBeRendered(), "A shown part should be rendered");
+		assertNotNull(part.getWidget(), "A shown part should have a widget");
 	}
 
 	@Test
@@ -1893,8 +1880,8 @@ public class EPartServiceTest extends UITest {
 		assertEquals(1, partStack.getChildren().size());
 		assertEquals(part, partStack.getChildren().get(0));
 		assertEquals(part, shownPart);
-		assertTrue("A shown part should be rendered", part.isToBeRendered());
-		assertNotNull("A shown part should have a widget", part.getWidget());
+		assertTrue(part.isToBeRendered(), "A shown part should be rendered");
+		assertNotNull(part.getWidget(), "A shown part should have a widget");
 	}
 
 	@Test
@@ -1941,8 +1928,8 @@ public class EPartServiceTest extends UITest {
 		assertEquals(1, partStack.getChildren().size());
 		assertEquals(part, partStack.getChildren().get(0));
 		assertEquals(part, shownPart);
-		assertTrue("A shown part should be rendered", part.isToBeRendered());
-		assertNotNull("A shown part should have a widget", part.getWidget());
+		assertTrue(part.isToBeRendered(), "A shown part should be rendered");
+		assertNotNull(part.getWidget(), "A shown part should have a widget");
 	}
 
 	@Test
@@ -1976,7 +1963,7 @@ public class EPartServiceTest extends UITest {
 		assertEquals(part, partService.getActivePart());
 
 		MPart part2 = partService.showPart("partId", partState);
-		assertEquals("Should not have instantiated a new MPart", part, part2);
+		assertEquals(part, part2, "Should not have instantiated a new MPart");
 		assertEquals(part, partService.getActivePart());
 	}
 
@@ -3058,13 +3045,13 @@ public class EPartServiceTest extends UITest {
 		initialize();
 		getEngine().createGui(window);
 
-		assertNull("The part shouldn't have been rendered", partB.getContext());
+		assertNull(partB.getContext(), "The part shouldn't have been rendered");
 		assertEquals(partB, placeholderB.getRef());
 		assertNull(partB.getCurSharedRef());
 
 		EPartService partService = window.getContext().get(EPartService.class);
 		partService.showPart(partB, partState);
-		assertNotNull("The part should have been rendered", partB.getContext());
+		assertNotNull(partB.getContext(), "The part should have been rendered");
 		assertEquals(partB, placeholderB.getRef());
 		assertEquals(placeholderB, partB.getCurSharedRef());
 	}
@@ -3598,8 +3585,7 @@ public class EPartServiceTest extends UITest {
 		if (beforeDirty) {
 			assertEquals(success, partService.savePart(saveablePart, confirm));
 		} else {
-			assertTrue("The part is not dirty, the save operation should complete successfully",
-					partService.savePart(saveablePart, confirm));
+			assertTrue(partService.savePart(saveablePart, confirm), "The part is not dirty, the save operation should complete successfully");
 		}
 
 		assertEquals(afterDirty, saveablePart.isDirty());
@@ -3826,8 +3812,7 @@ public class EPartServiceTest extends UITest {
 		if (beforeDirty) {
 			assertEquals(!throwException, partService.savePart(saveablePart, confirm));
 		} else {
-			assertTrue("The part is not dirty, the save operation should have complete successfully",
-					partService.savePart(saveablePart, confirm));
+			assertTrue(partService.savePart(saveablePart, confirm), "The part is not dirty, the save operation should have complete successfully");
 		}
 
 		assertEquals(beforeDirty && throwException, saveablePart.isDirty());
@@ -5578,8 +5563,7 @@ public class EPartServiceTest extends UITest {
 		if (beforeDirty) {
 			assertEquals(!throwException, partService.saveAll(confirm));
 		} else {
-			assertTrue("The part is not dirty, the save operation should have complete successfully",
-					partService.saveAll(confirm));
+			assertTrue(partService.saveAll(confirm), "The part is not dirty, the save operation should have complete successfully");
 		}
 
 		assertEquals(beforeDirty && throwException, saveablePart.isDirty());
@@ -5848,22 +5832,22 @@ public class EPartServiceTest extends UITest {
 		assertNotNull(windowService1);
 		assertNotNull(windowService2);
 
-		assertNotNull("The first part is active in the first window", windowService1.getActivePart());
-		assertNull("There should be nothing active in the second window", windowService2.getActivePart());
+		assertNotNull(windowService1.getActivePart(), "The first part is active in the first window");
+		assertNull(windowService2.getActivePart(), "There should be nothing active in the second window");
 
 		// activate the part
 		windowService1.activate(part);
 
-		assertEquals("The part should have been activated", part, windowService1.getActivePart());
-		assertNull("The second window has no parts, this should be null", windowService2.getActivePart());
+		assertEquals(part, windowService1.getActivePart(), "The part should have been activated");
+		assertNull(windowService2.getActivePart(), "The second window has no parts, this should be null");
 
 		// now move the part over from the first window to the second window
 		window2.getChildren().add(part);
 		// activate the part
 		windowService2.activate(part);
 
-		assertEquals("No parts in this window, this should be null", null, windowService1.getActivePart());
-		assertEquals("We activated it just now, this should be active", part, windowService2.getActivePart());
+		assertEquals(null, windowService1.getActivePart(), "No parts in this window, this should be null");
+		assertEquals(part, windowService2.getActivePart(), "We activated it just now, this should be active");
 	}
 
 	@Test
@@ -5927,7 +5911,7 @@ public class EPartServiceTest extends UITest {
 		MPart partB = partService.showPart("partId", partState);
 
 		// showPart should instantiate the part
-		assertNotNull("The part should have been rendered", partB.getContext());
+		assertNotNull(partB.getContext(), "The part should have been rendered");
 	}
 
 	@Test
@@ -6429,8 +6413,7 @@ public class EPartServiceTest extends UITest {
 
 		assertEquals(perspectiveContext1, partContext.getParent());
 		assertEquals(partContext, perspectiveContext1.getActiveChild());
-		assertNull("perspective2 doesn't have any parts, it should not have an active child context",
-				perspectiveContext2.getActiveChild());
+		assertNull(perspectiveContext2.getActiveChild(), "perspective2 doesn't have any parts, it should not have an active child context");
 	}
 
 	@Test
@@ -7257,23 +7240,19 @@ public class EPartServiceTest extends UITest {
 		partService.activate(partB);
 
 		partService.switchPerspective(perspectiveB);
-		assertEquals("partB is in both perspectives, active part should have been preserved", partB,
-				partService.getActivePart());
+		assertEquals(partB, partService.getActivePart(), "partB is in both perspectives, active part should have been preserved");
 
 		partService.hidePart(partB);
-		assertEquals("Hiding partB should have caused partA to be activated", partA, partService.getActivePart());
+		assertEquals(partA, partService.getActivePart(), "Hiding partB should have caused partA to be activated");
 
 		partService.switchPerspective(perspectiveA);
-		assertEquals("partA is in both perspectives, active part should have been preserved", partA,
-				partService.getActivePart());
+		assertEquals(partA, partService.getActivePart(), "partA is in both perspectives, active part should have been preserved");
 
 		partService.activate(partB);
-		assertEquals("partB should have been activated by activate(MPart)", partB, partService.getActivePart());
+		assertEquals(partB, partService.getActivePart(), "partB should have been activated by activate(MPart)");
 
 		partService.switchPerspective(perspectiveB);
-		assertEquals(
-				"partA should be the only part that's being shown in perspectiveB, thus, it should be the active part",
-				partA, partService.getActivePart());
+		assertEquals(partA, partService.getActivePart(), "partA should be the only part that's being shown in perspectiveB, thus, it should be the active part");
 	}
 
 	/**
@@ -7325,20 +7304,16 @@ public class EPartServiceTest extends UITest {
 		partService.activate(partB);
 
 		partService.switchPerspective(perspectiveB);
-		assertEquals("partB is in both perspectives, active part should have been preserved", partB,
-				partService.getActivePart());
+		assertEquals(partB, partService.getActivePart(), "partB is in both perspectives, active part should have been preserved");
 
 		partService.hidePart(partB);
-		assertEquals("Hiding partB should have caused partA to be activated", partA, partService.getActivePart());
+		assertEquals(partA, partService.getActivePart(), "Hiding partB should have caused partA to be activated");
 
 		partService.switchPerspective(perspectiveA);
-		assertEquals("partB is the only part in perspectiveA, thus, it should be the active part", partB,
-				partService.getActivePart());
+		assertEquals(partB, partService.getActivePart(), "partB is the only part in perspectiveA, thus, it should be the active part");
 
 		partService.switchPerspective(perspectiveB);
-		assertEquals(
-				"partA should be the only part that's being shown in perspectiveB, thus, it should be the active part",
-				partA, partService.getActivePart());
+		assertEquals(partA, partService.getActivePart(), "partA should be the only part that's being shown in perspectiveB, thus, it should be the active part");
 	}
 
 	/**
@@ -7401,7 +7376,7 @@ public class EPartServiceTest extends UITest {
 
 		EPartService partService = window.getContext().get(EPartService.class);
 		partService.activate(partB);
-		assertEquals("partB should be the active part", partB, partService.getActivePart());
+		assertEquals(partB, partService.getActivePart(), "partB should be the active part");
 
 		partService.switchPerspective(perspectiveB);
 		// assertEquals(
@@ -7410,20 +7385,16 @@ public class EPartServiceTest extends UITest {
 		// partA, partService.getActivePart());
 
 		partService.hidePart(partB);
-		assertEquals("partA should still be the active part", partA, partService.getActivePart());
+		assertEquals(partA, partService.getActivePart(), "partA should still be the active part");
 
 		partService.switchPerspective(perspectiveA);
-		assertEquals(
-				"partA is in both perspectives, but since partA is obscured by partB, partB should be the active part",
-				partB, partService.getActivePart());
+		assertEquals(partB, partService.getActivePart(), "partA is in both perspectives, but since partA is obscured by partB, partB should be the active part");
 
 		partService.activate(partB);
-		assertEquals("partB should have been activated by activate(MPart)", partB, partService.getActivePart());
+		assertEquals(partB, partService.getActivePart(), "partB should have been activated by activate(MPart)");
 
 		partService.switchPerspective(perspectiveB);
-		assertEquals(
-				"partA should be the only part that's being shown in perspectiveB, thus, it should be the active part",
-				partA, partService.getActivePart());
+		assertEquals(partA, partService.getActivePart(), "partA should be the only part that's being shown in perspectiveB, thus, it should be the active part");
 	}
 
 	/**
@@ -7483,21 +7454,16 @@ public class EPartServiceTest extends UITest {
 		partService.activate(partB);
 
 		partService.switchPerspective(perspectiveB);
-		assertEquals(
-				"partB is in both perspectives, but since partB is obscured by partA, partA should be the active part",
-				partA, partService.getActivePart());
+		assertEquals(partA, partService.getActivePart(), "partB is in both perspectives, but since partB is obscured by partA, partA should be the active part");
 
 		partService.hidePart(partB);
-		assertEquals("partA should still be the active part", partA, partService.getActivePart());
+		assertEquals(partA, partService.getActivePart(), "partA should still be the active part");
 
 		partService.switchPerspective(perspectiveA);
-		assertEquals("partB is the only part in perspectiveA, thus, it should be the active part", partB,
-				partService.getActivePart());
+		assertEquals(partB, partService.getActivePart(), "partB is the only part in perspectiveA, thus, it should be the active part");
 
 		partService.switchPerspective(perspectiveB);
-		assertEquals(
-				"partA should be the only part that's being shown in perspectiveB, thus, it should be the active part",
-				partA, partService.getActivePart());
+		assertEquals(partA, partService.getActivePart(), "partA should be the only part that's being shown in perspectiveB, thus, it should be the active part");
 	}
 
 	@Test
@@ -9033,7 +8999,7 @@ public class EPartServiceTest extends UITest {
 
 		partService.hidePart(partD);
 		assertEquals(partC, partStack.getSelectedElement());
-		assertEquals("The active part should have remained in the area", partC, partService.getActivePart());
+		assertEquals(partC, partService.getActivePart(), "The active part should have remained in the area");
 	}
 
 	@Test
@@ -9080,7 +9046,7 @@ public class EPartServiceTest extends UITest {
 
 		partService.hidePart(partD);
 		assertEquals(partC, partStack.getSelectedElement());
-		assertEquals("The active part should have remained in the area", partC, partService.getActivePart());
+		assertEquals(partC, partService.getActivePart(), "The active part should have remained in the area");
 	}
 
 	@Test
@@ -9150,7 +9116,7 @@ public class EPartServiceTest extends UITest {
 
 		partService.hidePart(partD);
 		assertEquals(partC, partStack.getSelectedElement());
-		assertEquals("The active part should have remained in the area", partC, partService.getActivePart());
+		assertEquals(partC, partService.getActivePart(), "The active part should have remained in the area");
 	}
 
 	@Test
@@ -9892,7 +9858,7 @@ public class EPartServiceTest extends UITest {
 		System.runFinalization();
 		System.gc();
 
-		assertNull("The part should no longer be reachable", ref.get());
+		assertNull(ref.get(), "The part should no longer be reachable");
 	}
 
 	@Test

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/ESelectionServiceTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/ESelectionServiceTest.java
@@ -13,9 +13,9 @@
  ******************************************************************************/
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -41,7 +41,7 @@ import org.eclipse.e4.ui.workbench.modeling.ISelectionListener;
 import org.eclipse.e4.ui.workbench.swt.DisplayUISynchronize;
 import org.eclipse.emf.common.notify.Notifier;
 import org.eclipse.swt.widgets.Display;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ESelectionServiceTest extends UITest {
 
@@ -929,7 +929,7 @@ public class ESelectionServiceTest extends UITest {
 		assertEquals(o, injectPart.selection);
 
 		partService.activate(partB);
-		assertEquals("Part B doesn't post a selection, no change", o, injectPart.selection);
+		assertEquals(o, injectPart.selection, "Part B doesn't post a selection, no change");
 
 		partService.activate(partA);
 		assertEquals(o, injectPart.selection);

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/EventBrokerTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/EventBrokerTest.java
@@ -14,15 +14,15 @@
 
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.services.events.IEventBroker;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.osgi.service.event.EventHandler;
 
 /**
@@ -34,7 +34,7 @@ public class EventBrokerTest extends UITest {
 	private AtomicInteger seen;
 	private IEclipseContext context;
 
-	@Before
+	@BeforeEach
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
@@ -42,7 +42,7 @@ public class EventBrokerTest extends UITest {
 		context = application.getContext().createChild(getClass().getName());
 	}
 
-	@After
+	@AfterEach
 	@Override
 	public void tearDown() throws Exception {
 		super.tearDown();
@@ -87,8 +87,7 @@ public class EventBrokerTest extends UITest {
 		child.dispose(); // subscriber should unsubscribe from notifications
 
 		publisher.send(TEST_TOPIC, new Object());
-		assertEquals("event broker did not properly unsubscribe on dispose", 1,
-				seen.get());
+		assertEquals(1, seen.get(), "event broker did not properly unsubscribe on dispose");
 	}
 
 	@Test
@@ -108,7 +107,7 @@ public class EventBrokerTest extends UITest {
 
 		eb.unsubscribe(handler);
 		eb.send(TEST_TOPIC, new Object());
-		assertEquals("subscription was not removed", 2, seen.get());
+		assertEquals(2, seen.get(), "subscription was not removed");
 	}
 
 }

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/ModelElementTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/ModelElementTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -28,7 +28,7 @@ import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EPackage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ModelElementTest {
 

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/ModelRobustnessTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/ModelRobustnessTest.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 import org.eclipse.e4.ui.internal.workbench.E4XMIResource;
@@ -29,7 +29,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ModelRobustnessTest {
 

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/ResourceHandlerTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/ResourceHandlerTest.java
@@ -15,9 +15,9 @@
 
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -45,8 +45,8 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.swt.widgets.Display;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Filter;
 import org.osgi.framework.FrameworkUtil;
@@ -92,7 +92,7 @@ public class ResourceHandlerTest {
 
 	}
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		URI uri = URI.createPlatformPluginURI("org.eclipse.e4.ui.tests/xmi/modelprocessor/base.e4xmi", true);
 

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/UITest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/application/UITest.java
@@ -13,7 +13,7 @@
  ******************************************************************************/
 package org.eclipse.e4.ui.tests.application;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.services.contributions.IContributionFactory;
@@ -22,8 +22,8 @@ import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.impl.ApplicationFactoryImpl;
 import org.eclipse.e4.ui.workbench.IPresentationEngine;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public class UITest {
 
@@ -36,7 +36,7 @@ public class UITest {
 
 	protected EModelService ems;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 
 		application = ApplicationFactoryImpl.eINSTANCE.createApplication();
@@ -47,7 +47,7 @@ public class UITest {
 		E4Application.initializeServices(application);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		applicationContext.dispose(); // used by the tests to dispose GUI?
 	}

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/AreaRendererTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/AreaRendererTest.java
@@ -14,8 +14,8 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.internal.workbench.E4Workbench;
@@ -30,23 +30,23 @@ import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.workbench.IWorkbench;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.swt.custom.CTabFolder;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class AreaRendererTest {
 	protected IEclipseContext appContext;
 	protected E4Workbench wb;
 	private EModelService ems;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		appContext = E4Application.createDefaultContext();
 		appContext.set(IWorkbench.PRESENTATION_URI_ARG, PartRenderingEngine.engineURI);
 		ems = appContext.get(EModelService.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		if (wb != null) {
 			wb.close();

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/Bug308317Test.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/Bug308317Test.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -28,9 +28,9 @@ import org.eclipse.e4.ui.model.application.ui.basic.MPartStack;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.services.IServiceConstants;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class Bug308317Test {
 
@@ -51,13 +51,13 @@ public class Bug308317Test {
 	protected IEclipseContext appContext;
 	private EModelService ems;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		appContext = E4Application.createDefaultContext();
 		ems = appContext.get(EModelService.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		appContext.dispose();
 	}

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/CompositePartClosingTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/CompositePartClosingTest.java
@@ -14,8 +14,8 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import jakarta.inject.Inject;
 import org.eclipse.e4.ui.model.application.MApplication;
@@ -76,8 +76,8 @@ public class CompositePartClosingTest {
 		partService.activate(part2);
 		partService.hidePart(part2);
 
-		assertNotEquals("Composite part got activated", compositePart, partStack1.getSelectedElement());
-		assertEquals("Wrong part got activated", part1, partStack1.getSelectedElement());
+		assertNotEquals(compositePart, partStack1.getSelectedElement(), "Composite part got activated");
+		assertEquals(part1, partStack1.getSelectedElement(), "Wrong part got activated");
 
 	}
 

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/ContextTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/ContextTest.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.commands.contexts.Context;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
@@ -24,9 +24,9 @@ import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.internal.workbench.swt.E4Application;
 import org.eclipse.e4.ui.services.ContextServiceAddon;
 import org.eclipse.e4.ui.services.EContextService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ContextTest {
 	private static final String WINDOW_ID = "org.eclipse.ui.contexts.window";
@@ -34,13 +34,13 @@ public class ContextTest {
 	private static final String DIALOG_AND_WINDOW_ID = "org.eclipse.ui.contexts.dialogAndWindow";
 	private IEclipseContext appContext;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		appContext = E4Application.createDefaultContext();
 		ContextInjectionFactory.make(ContextServiceAddon.class, appContext);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		appContext.dispose();
 	}

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/ContributionsAnalyzerTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/ContributionsAnalyzerTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.e4.core.commands.ExpressionContext;
 import org.eclipse.e4.core.contexts.IEclipseContext;
@@ -22,22 +22,22 @@ import org.eclipse.e4.ui.internal.workbench.ContributionsAnalyzer;
 import org.eclipse.e4.ui.internal.workbench.swt.E4Application;
 import org.eclipse.e4.ui.model.application.ui.MImperativeExpression;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ContributionsAnalyzerTest {
 
 	private IEclipseContext appContext;
 	private EModelService ems;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		appContext = E4Application.createDefaultContext();
 		ems = appContext.get(EModelService.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		appContext.dispose();
 	}

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/ExtensionsSortTests.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/ExtensionsSortTests.java
@@ -14,8 +14,8 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -27,9 +27,9 @@ import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.RegistryFactory;
 import org.eclipse.e4.ui.internal.workbench.ExtensionsSort;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
@@ -43,7 +43,7 @@ public class ExtensionsSortTests {
 	Bundle intermediate;
 	Bundle leaf;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		BundleContext context = FrameworkUtil.getBundle(getClass())
 				.getBundleContext();
@@ -104,7 +104,7 @@ public class ExtensionsSortTests {
 		return Integer.MIN_VALUE; // keep JDT happy
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		if (root != null) {
 			root.uninstall();

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/HandlerActivationTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/HandlerActivationTest.java
@@ -15,9 +15,9 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.core.runtime.Platform;
@@ -46,9 +46,9 @@ import org.eclipse.e4.ui.services.ContextServiceAddon;
 import org.eclipse.e4.ui.workbench.IWorkbench;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the activation of Handlers based on their Handler Container, e.g.
@@ -82,7 +82,7 @@ public class HandlerActivationTest {
 	private MPart partB1;
 	private EModelService ems;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		appContext = E4Application.createDefaultContext();
 		appContext.set(CommandServiceAddon.class, ContextInjectionFactory.make(CommandServiceAddon.class, appContext));
@@ -93,7 +93,7 @@ public class HandlerActivationTest {
 		createLayoutWithThreeContextLayers();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		if (wb != null) {
 			wb.close();
@@ -157,7 +157,7 @@ public class HandlerActivationTest {
 
 	@Test
 	public void testHandlerInWindowOnly() {
-		assumeFalse("Test fails on Mac: Bug 537639", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 537639");
 
 		TestHandler testHandler = createTestHandlerInHandlerContainer(window);
 		executeCommand();
@@ -166,7 +166,7 @@ public class HandlerActivationTest {
 
 	@Test
 	public void testHandlerInActivePerspectiveOnly() {
-		assumeFalse("Test fails on Mac: Bug 537639", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 537639");
 
 		TestHandler testHandler = createTestHandlerInHandlerContainer(perspectiveA);
 		executeCommand();
@@ -175,7 +175,7 @@ public class HandlerActivationTest {
 
 	@Test
 	public void testHandlerInActivePartOnly() {
-		assumeFalse("Test fails on Mac: Bug 537639", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 537639");
 
 		TestHandler testHandler = createTestHandlerInHandlerContainer(partA1);
 		executeCommand();
@@ -198,7 +198,7 @@ public class HandlerActivationTest {
 
 	@Test
 	public void testHandlerInActivePartAndPerspective() {
-		assumeFalse("Test fails on Mac: Bug 537639", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 537639");
 
 		TestHandler testHandler = createTestHandlerInHandlerContainer(partA1);
 		TestHandler testHandler2 = createTestHandlerInHandlerContainer(perspectiveA);
@@ -209,7 +209,7 @@ public class HandlerActivationTest {
 
 	@Test
 	public void testHandlerInActivePartAndWindow() {
-		assumeFalse("Test fails on Mac: Bug 537639", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 537639");
 
 		TestHandler testHandler = createTestHandlerInHandlerContainer(partA1);
 		TestHandler testHandler2 = createTestHandlerInHandlerContainer(window);
@@ -220,7 +220,7 @@ public class HandlerActivationTest {
 
 	@Test
 	public void testHandlerInActivePerspectiveAndWindow() {
-		assumeFalse("Test fails on Mac: Bug 537639", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 537639");
 
 		TestHandler testHandler = createTestHandlerInHandlerContainer(perspectiveA);
 		TestHandler testHandler2 = createTestHandlerInHandlerContainer(window);
@@ -231,7 +231,7 @@ public class HandlerActivationTest {
 
 	@Test
 	public void testHandlerInActivePartAndPerspectiveAndWindow() {
-		assumeFalse("Test fails on Mac: Bug 537639", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 537639");
 
 		TestHandler testHandler = createTestHandlerInHandlerContainer(partA1);
 		TestHandler testHandler2 = createTestHandlerInHandlerContainer(perspectiveA);
@@ -244,7 +244,7 @@ public class HandlerActivationTest {
 
 	@Test
 	public void testHandlerSwitchToInactivePart() {
-		assumeFalse("Test fails on Mac: Bug 537639", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 537639");
 
 		TestHandler testHandler = createTestHandlerInHandlerContainer(partA2);
 		executeCommand();
@@ -256,7 +256,7 @@ public class HandlerActivationTest {
 
 	@Test
 	public void testHandlerSwitchToInactivePerspective() {
-		assumeFalse("Test fails on Mac: Bug 537639", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 537639");
 
 		TestHandler testHandlerA = createTestHandlerInHandlerContainer(perspectiveA);
 		TestHandler testHandlerB = createTestHandlerInHandlerContainer(perspectiveB);
@@ -268,7 +268,7 @@ public class HandlerActivationTest {
 
 	@Test
 	public void testHandlerSwitchToInactivePartInOtherPerspectiveWithPerspectiveHandlers() {
-		assumeFalse("Test fails on Mac: Bug 537639", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 537639");
 
 		TestHandler testHandlerA = createTestHandlerInHandlerContainer(perspectiveA);
 		TestHandler testHandlerB = createTestHandlerInHandlerContainer(perspectiveB);
@@ -281,7 +281,7 @@ public class HandlerActivationTest {
 
 	@Test
 	public void testHandlerSwitchToInactivePartInOtherPerspectiveWithPartHandlers() {
-		assumeFalse("Test fails on Mac: Bug 537639", Platform.OS_MACOSX.equals(Platform.getOS()));
+		assumeFalse(Platform.OS_MACOSX.equals(Platform.getOS()), "Test fails on Mac: Bug 537639");
 
 		TestHandler testHandlerA = createTestHandlerInHandlerContainer(partA1);
 		TestHandler testHandlerB = createTestHandlerInHandlerContainer(partB1);

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/HandlerTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/HandlerTest.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.core.commands.Category;
 import org.eclipse.core.commands.Command;
@@ -30,9 +30,9 @@ import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.core.di.annotations.CanExecute;
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.ui.internal.workbench.swt.E4Application;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class HandlerTest {
 	private static final String HELP_COMMAND_ID = "org.eclipse.ui.commands.help";
@@ -61,13 +61,13 @@ public class HandlerTest {
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		appContext = E4Application.createDefaultContext();
 		ContextInjectionFactory.make(CommandServiceAddon.class, appContext);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		appContext.dispose();
 	}

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/InjectionEventTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/InjectionEventTest.java
@@ -15,10 +15,10 @@
  ******************************************************************************/
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -36,8 +36,8 @@ import org.eclipse.e4.ui.di.UIEventTopic;
 import org.eclipse.e4.ui.di.UISynchronize;
 import org.eclipse.e4.ui.workbench.swt.DisplayUISynchronize;
 import org.eclipse.swt.widgets.Display;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.service.event.EventAdmin;
@@ -123,7 +123,7 @@ public class InjectionEventTest {
 
 	private EventAdminHelper helper;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		BundleContext bundleContext = FrameworkUtil.getBundle(this.getClass()).getBundleContext();
 		IEclipseContext localContext = EclipseContextFactory.getServiceContext(bundleContext);

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MApplicationCommandAccessTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MApplicationCommandAccessTest.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.e4.core.commands.CommandServiceAddon;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
@@ -27,23 +27,23 @@ import org.eclipse.e4.ui.internal.workbench.swt.E4Application;
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.commands.MCommand;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MApplicationCommandAccessTest {
 	private static final int NUMBER_OF_COMMANDS = 1000;
 	protected IEclipseContext applicationContext;
 	protected E4Workbench wb;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		applicationContext = E4Application.createDefaultContext();
 
 		ContextInjectionFactory.make(CommandServiceAddon.class, applicationContext);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		applicationContext.dispose();
 	}

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MMenuItemTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MMenuItemTest.java
@@ -15,11 +15,11 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -367,7 +367,7 @@ public class MMenuItemTest {
 
 		MenuManagerRenderer renderer = getRenderer(appContext, mainMenu);
 		MenuManager manager = renderer.getManager(mainMenu);
-		assertNotNull("failed to create menu bar manager", manager);
+		assertNotNull(manager, "failed to create menu bar manager");
 
 		assertEquals(1, manager.getSize());
 
@@ -410,7 +410,7 @@ public class MMenuItemTest {
 
 		MenuManagerRenderer renderer = getRenderer(appContext, mainMenu);
 		MenuManager manager = renderer.getManager(mainMenu);
-		assertNotNull("failed to create menu bar manager", manager);
+		assertNotNull(manager, "failed to create menu bar manager");
 
 		assertEquals(1, manager.getSize());
 
@@ -453,7 +453,7 @@ public class MMenuItemTest {
 
 		MenuManagerRenderer renderer = getRenderer(appContext, mainMenu);
 		MenuManager manager = renderer.getManager(mainMenu);
-		assertNotNull("failed to create menu bar manager", manager);
+		assertNotNull(manager, "failed to create menu bar manager");
 
 		assertEquals(1, manager.getSize());
 
@@ -499,7 +499,7 @@ public class MMenuItemTest {
 		MenuManagerRenderer renderer = getRenderer(appContext, mainMenu);
 
 		MenuManager fileManager = renderer.getManager(fileMenu);
-		assertNotNull("No file menu?", fileManager);
+		assertNotNull(fileManager, "No file menu?");
 
 		assertEquals(4, fileManager.getSize());
 
@@ -539,13 +539,13 @@ public class MMenuItemTest {
 		MenuManagerRenderer renderer = getRenderer(appContext, mainMenu);
 
 		MenuManager fileManager = renderer.getManager(fileMenu);
-		assertNotNull("No file menu?", fileManager);
+		assertNotNull(fileManager, "No file menu?");
 
 		assertEquals(4, fileManager.getSize());
 
 		IContributionItem mmcItem = fileManager.getItems()[3];
 		assertEquals("mmc.item1", mmcItem.getId());
-		assertTrue("before the first show, we have no context to evaluate", mmcItem.isVisible());
+		assertTrue(mmcItem.isVisible(), "before the first show, we have no context to evaluate");
 
 		MenuManager manager = renderer.getManager(mainMenu);
 		manager.updateAll(true);
@@ -562,13 +562,13 @@ public class MMenuItemTest {
 
 		fileWidget.notifyListeners(SWT.Show, show);
 
-		assertFalse("after the first show, it should not be visible", mmcItem.isVisible());
+		assertFalse(mmcItem.isVisible(), "after the first show, it should not be visible");
 
 		fileWidget.notifyListeners(SWT.Hide, hide);
 
 		appContext.set("mmc1", Boolean.TRUE);
 
-		assertFalse("Change should not show up until next show", mmcItem.isVisible());
+		assertFalse(mmcItem.isVisible(), "Change should not show up until next show");
 
 		fileWidget.notifyListeners(SWT.Show, show);
 

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MPartSashContainerTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MPartSashContainerTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.internal.workbench.E4Workbench;
@@ -26,16 +26,16 @@ import org.eclipse.e4.ui.model.application.ui.basic.MPartSashContainer;
 import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.workbench.IWorkbench;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MPartSashContainerTest {
 	protected IEclipseContext appContext;
 	protected E4Workbench wb;
 	private EModelService ems;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		appContext = E4Application.createDefaultContext();
 		appContext.set(IWorkbench.PRESENTATION_URI_ARG,
@@ -43,7 +43,7 @@ public class MPartSashContainerTest {
 		ems = appContext.get(EModelService.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		if (wb != null) {
 			wb.close();

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MSashTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MSashTest.java
@@ -14,8 +14,8 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.internal.workbench.E4Workbench;
@@ -29,9 +29,9 @@ import org.eclipse.e4.ui.workbench.IWorkbench;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Widget;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test validates the UI Model &lt;-&gt; SWT Widget interactions specifically
@@ -62,7 +62,7 @@ public class MSashTest {
 	protected E4Workbench wb;
 	private EModelService ems;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		appContext = E4Application.createDefaultContext();
 		appContext.set(IWorkbench.PRESENTATION_URI_ARG,
@@ -70,7 +70,7 @@ public class MSashTest {
 		ems = appContext.get(EModelService.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		if (wb != null) {
 			wb.close();
@@ -103,16 +103,16 @@ public class MSashTest {
 			cdVal0 = Integer.parseInt(part0.getContainerData());
 		} catch (NumberFormatException e) {
 		}
-		assertNotEquals("Part0 data is not an integer", -1, cdVal0);
+		assertNotEquals(-1, cdVal0, "Part0 data is not an integer");
 
 		int cdVal1 = -1;
 		try {
 			cdVal1 = Integer.parseInt(part1.getContainerData());
 		} catch (NumberFormatException e) {
 		}
-		assertNotEquals("Part1 data is not an integer", -1, cdVal1);
+		assertNotEquals(-1, cdVal1, "Part1 data is not an integer");
 
-		assertEquals("Values should be equal", cdVal0, cdVal1);
+		assertEquals(cdVal0, cdVal1, "Values should be equal");
 	}
 
 	private MWindow createSashWithNViews(int n) {

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MSaveablePartTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MSaveablePartTest.java
@@ -15,8 +15,8 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import jakarta.inject.Inject;
 import org.eclipse.e4.ui.model.application.MApplication;

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MToolItemTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/MToolItemTest.java
@@ -15,10 +15,10 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.inject.Inject;
 import org.eclipse.e4.ui.model.application.MApplication;

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/ModelAssemblerFragmentOrderingTests.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/ModelAssemblerFragmentOrderingTests.java
@@ -15,8 +15,8 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.annotation.PostConstruct;
 import java.util.Arrays;
@@ -55,8 +55,8 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.swt.widgets.Display;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the ordering of fragment contributions based on their declared
@@ -75,7 +75,7 @@ public class ModelAssemblerFragmentOrderingTests {
 	private static final String MAIN_TOOLBAR_ID = "org.eclipse.e4.ui.tests.modelassembler.fragmentordering.mainWindow.mainToolBar";
 	private static final String MAIN_WINDOW_ID = "org.eclipse.e4.ui.tests.modelassembler.fragmentordering.mainWindow";
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		appContext = E4Application.createDefaultContext();
 		application = ApplicationFactoryImpl.eINSTANCE.createApplication();

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/ModelAssemblerTests.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/ModelAssemblerTests.java
@@ -16,8 +16,8 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
@@ -65,10 +65,10 @@ import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.equinox.log.ExtendedLogReaderService;
 import org.eclipse.equinox.log.LogFilter;
 import org.eclipse.swt.widgets.Display;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.osgi.service.log.LogEntry;
 import org.osgi.service.log.LogListener;
 
@@ -102,7 +102,7 @@ public class ModelAssemblerTests {
 
 	}
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		appContext = E4Application.createDefaultContext();
 		application = ApplicationFactoryImpl.eINSTANCE.createApplication();
@@ -135,7 +135,7 @@ public class ModelAssemblerTests {
 		modelService = application.getContext().get(EModelService.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		ExtendedLogReaderService log = appContext.get(ExtendedLogReaderService.class);
 		log.removeLogListener(logListener);
@@ -198,7 +198,7 @@ public class ModelAssemblerTests {
 	}
 
 	@Test
-	@Ignore // currently ignored due to bug 487748
+	@Disabled // currently ignored due to bug 487748
 	public void testFragments_existingXMIID_checkExists() throws Exception {
 		// create fragment
 		MStringModelFragment fragment = MFragmentFactory.INSTANCE.createStringModelFragment();
@@ -334,7 +334,7 @@ public class ModelAssemblerTests {
 		assertEquals(null, placeholder.getRef());
 
 		boolean completed = countDownLatch.await(COUNTDOWN_TIMEOUT, TimeUnit.MILLISECONDS);
-		assertTrue("Timeout - no event received", completed);
+		assertTrue(completed, "Timeout - no event received");
 
 		assertEquals(1, logMessages.size());
 		assertEquals("Could not resolve import for null", logMessages.poll());
@@ -491,7 +491,7 @@ public class ModelAssemblerTests {
 
 		testProcessor("org.eclipse.e4.ui.tests/data/ModelAssembler/processor_null.xml", true, false);
 		boolean completed = countDownLatch.await(COUNTDOWN_TIMEOUT, TimeUnit.MILLISECONDS);
-		assertTrue("Timeout - no event received", completed);
+		assertTrue(completed, "Timeout - no event received");
 
 		assertEquals(1, logMessages.size());
 		assertEquals("Unable to create processor null from org.eclipse.e4.ui.tests", logMessages.poll());
@@ -511,7 +511,7 @@ public class ModelAssemblerTests {
 
 		testProcessor("org.eclipse.e4.ui.tests/data/ModelAssembler/processor_wrongProcessorClass.xml", true, false);
 		boolean completed = countDownLatch.await(COUNTDOWN_TIMEOUT, TimeUnit.MILLISECONDS);
-		assertTrue("Timeout - no event received", completed);
+		assertTrue(completed, "Timeout - no event received");
 
 		assertEquals(1, logMessages.size());
 		assertEquals(
@@ -535,7 +535,7 @@ public class ModelAssemblerTests {
 		application.setElementId("newID");
 		testProcessor("org.eclipse.e4.ui.tests/data/ModelAssembler/processors_initial.xml", true, true);
 		boolean completed = countDownLatch.await(COUNTDOWN_TIMEOUT, TimeUnit.MILLISECONDS);
-		assertTrue("Timeout - no event received", completed);
+		assertTrue(completed, "Timeout - no event received");
 
 		assertEquals(1, logMessages.size());
 		assertEquals("Could not find element with id org.eclipse.e4.ui.tests.modelassembler.app", logMessages.poll());

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/ModelServiceImplTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/ModelServiceImplTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/NewMWindowTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/NewMWindowTest.java
@@ -14,11 +14,11 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.internal.workbench.E4Workbench;
@@ -45,16 +45,16 @@ import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.Widget;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class NewMWindowTest {
 	protected IEclipseContext appContext;
 	protected E4Workbench wb;
 	private EModelService ems;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		appContext = E4Application.createDefaultContext();
 		appContext.set(IWorkbench.PRESENTATION_URI_ARG,
@@ -62,7 +62,7 @@ public class NewMWindowTest {
 		ems = appContext.get(EModelService.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		if (wb != null) {
 			wb.close();

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartFocusTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartFocusTest.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -43,17 +43,17 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Text;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.osgi.framework.FrameworkUtil;
 
 /**
  * Ensure that setting focus to a widget within an non-active part causes the
  * part to be activated while not changing the focus.
  */
-@Ignore("See bug 505678")
+@Disabled("See bug 505678")
 public class PartFocusTest {
 
 	protected IEclipseContext appContext;
@@ -68,7 +68,7 @@ public class PartFocusTest {
 	protected MPart otherPart;
 	private EModelService ems;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		appContext = E4Application.createDefaultContext();
 		appContext.set(IWorkbench.PRESENTATION_URI_ARG,
@@ -139,7 +139,7 @@ public class PartFocusTest {
 		assertTrue(((PartBackend) otherPart.getObject()).text1.isFocusControl());
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		if (wb != null) {
 			wb.close();
@@ -170,7 +170,7 @@ public class PartFocusTest {
 		assertTrue(((PartBackend) part.getObject()).text1.isFocusControl());
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void XXXtestNoFocusChangeOnExplicitWidgetSelection() {
 		assertFalse(((PartBackend) part.getObject()).text1.isFocusControl());

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/SWTPartRendererTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/SWTPartRendererTest.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -33,11 +33,11 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-@Ignore
+@Disabled
 public class SWTPartRendererTest {
 	private SWTPartRenderer renderer;
 	private Shell shell;
@@ -45,7 +45,7 @@ public class SWTPartRendererTest {
 	private IEclipseContext context;
 	private Map<String, Object[]> stylingEngineExecutedMethods;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		renderer = new SWTPartRenderer() {
 			@Override

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/SashRendererTest.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/SashRendererTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.internal.workbench.E4Workbench;
@@ -28,9 +28,9 @@ import org.eclipse.e4.ui.model.application.ui.basic.MWindow;
 import org.eclipse.e4.ui.workbench.IWorkbench;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.swt.widgets.Display;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SashRendererTest {
 
@@ -38,14 +38,14 @@ public class SashRendererTest {
 	private E4Workbench wb;
 	private EModelService ems;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		appContext = E4Application.createDefaultContext();
 		appContext.set(IWorkbench.PRESENTATION_URI_ARG, PartRenderingEngine.engineURI);
 		ems = appContext.get(EModelService.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		if (wb != null) {
 			wb.close();

--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/TopoSortTests.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/TopoSortTests.java
@@ -14,15 +14,15 @@
 
 package org.eclipse.e4.ui.tests.workbench;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.eclipse.e4.ui.internal.workbench.TopologicalSort;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * A set of tests for the {@link TopologicalSort} class

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/AbstractFactoryTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/AbstractFactoryTest.java
@@ -16,32 +16,32 @@ package org.eclipse.jface.tests.widgets;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 public class AbstractFactoryTest {
 	protected static Shell shell;
 	protected static Image image;
 
-	@BeforeClass
+	@BeforeAll
 	public static void classSetup() {
 		final ImageGcDrawer noOp = (gc, width, height) -> {};
 		image = new Image(null, noOp, 1, 1);
 	}
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		shell = new Shell();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		shell.dispose();
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void classTearDown() {
 		image.dispose();
 		shell.dispose();

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitBrowserFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitBrowserFactory.java
@@ -13,13 +13,13 @@
  ******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.jface.widgets.BrowserFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitBrowserFactory extends AbstractFactoryTest {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitButtonFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitButtonFactory.java
@@ -13,15 +13,15 @@
 ******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.jface.widgets.ButtonFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Event;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitButtonFactory extends AbstractFactoryTest {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitCompositeFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitCompositeFactory.java
@@ -13,14 +13,14 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.widgets.CompositeFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitCompositeFactory extends AbstractFactoryTest {
 	@Test

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitControlFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitControlFactory.java
@@ -14,11 +14,11 @@
  ******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.widgets.LabelFactory;
@@ -28,7 +28,7 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Label;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test uses a LabelFactory to test the methods of AbstractControlFactory.

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitDateTimeFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitDateTimeFactory.java
@@ -13,15 +13,15 @@
 ******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.jface.widgets.DateTimeFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.DateTime;
 import org.eclipse.swt.widgets.Event;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitDateTimeFactory extends AbstractFactoryTest {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitGroupFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitGroupFactory.java
@@ -13,12 +13,12 @@
  ******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jface.widgets.GroupFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Group;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitGroupFactory extends AbstractFactoryTest {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitItemFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitItemFactory.java
@@ -20,7 +20,7 @@ import org.eclipse.jface.widgets.TableColumnFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -32,7 +32,7 @@ public class TestUnitItemFactory extends AbstractFactoryTest {
 	private Table table;
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setup() {
 		super.setup();
 		table = new Table(shell, SWT.NONE);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitItemFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitItemFactory.java
@@ -13,15 +13,15 @@
  ******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 import org.eclipse.jface.widgets.TableColumnFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test uses a TableColumnFactory to test the methods of

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitLabelFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitLabelFactory.java
@@ -13,12 +13,12 @@
  ******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jface.widgets.LabelFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Label;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitLabelFactory extends AbstractFactoryTest {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitLinkFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitLinkFactory.java
@@ -13,15 +13,15 @@
 ******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.jface.widgets.LinkFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Link;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitLinkFactory extends AbstractFactoryTest {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitSashFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitSashFactory.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.jface.widgets.SashFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Sash;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitSashFactory extends AbstractFactoryTest {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitSashFormFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitSashFormFactory.java
@@ -13,12 +13,12 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jface.widgets.SashFormFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.SashForm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitSashFormFactory extends AbstractFactoryTest {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitShellFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitShellFactory.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jface.widgets.ShellFactory;
 import org.eclipse.swt.SWT;
@@ -26,7 +26,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitShellFactory extends AbstractFactoryTest {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitSpinnerFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitSpinnerFactory.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.jface.widgets.SpinnerFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.TypedEvent;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Spinner;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitSpinnerFactory extends AbstractFactoryTest {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitTableColumnFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitTableColumnFactory.java
@@ -13,9 +13,9 @@
 ******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jface.widgets.TableColumnFactory;
 import org.eclipse.jface.widgets.WidgetFactory;
@@ -25,7 +25,7 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitTableColumnFactory extends AbstractFactoryTest {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitTableColumnFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitTableColumnFactory.java
@@ -24,7 +24,7 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class TestUnitTableColumnFactory extends AbstractFactoryTest {
@@ -32,7 +32,7 @@ public class TestUnitTableColumnFactory extends AbstractFactoryTest {
 	private Table table;
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setup() {
 		super.setup();
 		table = WidgetFactory.table(SWT.NONE).create(shell);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitTableFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitTableFactory.java
@@ -13,16 +13,16 @@
 ******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jface.widgets.TableFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Table;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitTableFactory extends AbstractFactoryTest {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitTextFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitTextFactory.java
@@ -13,15 +13,15 @@
  ******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.jface.widgets.TextFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.TypedEvent;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Text;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitTextFactory extends AbstractFactoryTest {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitTreeColumnFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitTreeColumnFactory.java
@@ -13,9 +13,9 @@
 ******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jface.widgets.TreeColumnFactory;
 import org.eclipse.jface.widgets.WidgetFactory;
@@ -25,7 +25,7 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
 import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitTreeColumnFactory extends AbstractFactoryTest {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitTreeColumnFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitTreeColumnFactory.java
@@ -24,7 +24,7 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class TestUnitTreeColumnFactory extends AbstractFactoryTest {
@@ -32,7 +32,7 @@ public class TestUnitTreeColumnFactory extends AbstractFactoryTest {
 	private Tree tree;
 
 	@Override
-	@Before
+	@BeforeEach
 	public void setup() {
 		super.setup();
 		tree = WidgetFactory.tree(SWT.NONE).create(shell);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitTreeFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitTreeFactory.java
@@ -13,16 +13,16 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.jface.widgets.TreeFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Tree;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUnitTreeFactory extends AbstractFactoryTest {
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitWidgetFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitWidgetFactory.java
@@ -13,14 +13,14 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.widgets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.jface.widgets.LabelFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Label;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test uses a LabelFactory to test the methods of AbstractWidgetFactory.


### PR DESCRIPTION
This PR migrates the Widget Factory Tests in `org.eclipse.jface.tests.widgets` from JUnit 4 to JUnit 5.

Changes:
* Updated `AbstractFactoryTest.java` to use JUnit 5 lifecycle annotations.
* Updated 19 `TestUnit*Factory.java` test classes to use JUnit 5 `@Test` and assertions.