### PR TITLE
Fix warning in o.e.e4.ui.workbench

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Require-Bundle: org.eclipse.e4.ui.model.workbench;bundle-version="1.2.0",
  org.eclipse.core.expressions;bundle-version="[3.7.0,4.0.0)",
  org.eclipse.e4.ui.di;bundle-version="0.9.0",
  org.eclipse.emf.ecore.xmi;bundle-version="2.7.0",
- org.eclipse.e4.core.di.extensions,
+ org.eclipse.e4.core.di.extensions;bundle-version="0.18.300",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17


### PR DESCRIPTION
Add missing min version for required bundle, fixes pde warning.