### PR TITLE
Adapt HistoryTextWrapper#notifyListeners

### DIFF
--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/internal/findandreplace/overlay/HistoryTextWrapper.java
@@ -200,6 +200,7 @@ public class HistoryTextWrapper extends Composite {
 
 	@Override
 	public void notifyListeners(int eventType, Event event) {
+		super.notifyListeners(eventType, event);
 		textBar.notifyListeners(eventType, event);
 	}
 


### PR DESCRIPTION
This PR adapts the notifyListeners method in HistoryTextWrapper to call super#notifyListeners since not calling it changes the underlying default behaviour of its superclasses leading to faulty behavior, e.g. it breaks the chain of DPIChange processing leading to a broken drop down button in the HistoryTextWraper on DPIChange Event.


#### Bug Explained
When a file editor has the Ctrl+F search box open and the editor window is moved across screens with different DPI/scaling settings, the search box does not scale properly.

Steps to Reproduce:

1. Open a file in the editor.
2. Press Ctrl+F to open the search box.
3. Move the editor window from one monitor to another with a different zoom/DPI setting.
4. Observe that the search box remains the same size and does not adjust to the new DPI.


<img width="842" height="464" alt="Image" src="https://github.com/user-attachments/assets/2c7f83c4-0447-4748-8d79-b883401eb17a" />

#### Reason
The class `HistoryTextWrapper ` overrides the method `notifyListeners`:

```
@Override
public void notifyListeners(int eventType, Event event) {
	textBar.notifyListeners(eventType, event);
}
```

This method doesn't call `super.notifyListeners(eventType, event)`, hence, the chain of DPIChange processing is broken, leading to the toolbar under the `HistoryTextWrapper` never scaling.