### PR TITLE
Migrate org.eclipse.ui.workbench.texteditor.tests to JUnit 5

### DIFF
--- a/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/META-INF/MANIFEST.MF
@@ -25,4 +25,6 @@ Automatic-Module-Name: org.eclipse.ui.workbench.texteditor.tests
 Import-Package: org.mockito,
  org.mockito.stubbing;version="5.5.0",
  org.junit.jupiter.api;version="[5.14.0,6.0.0)",
- org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
+ org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
+ org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
+ org.opentest4j;version="[1.3.0,2.0.0)"

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceLogicTest.java
@@ -20,9 +20,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -33,9 +33,9 @@ import static org.mockito.Mockito.withSettings;
 
 import java.util.function.Predicate;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.eclipse.swt.SWT;
@@ -86,14 +86,14 @@ public class FindReplaceLogicTest {
 		findReplaceLogic.setReplaceString(replaceString);
 	}
 
-	@After
+	@AfterEach
 	public void disposeShell() {
 		if (parentShell != null) {
 			parentShell.dispose();
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public void setupShell() {
 		parentShell= new Shell();
 	}
@@ -252,8 +252,8 @@ public class FindReplaceLogicTest {
 		expectStatusEmpty(findReplaceLogic);
 
 		status= findReplaceLogic.performSelectAndReplace();
-		assertEquals("Status wasn't correctly returned", false, status);
-		assertEquals("Text shouldn't have been changed", "Hello World !", textViewer.getDocument().get());
+		assertEquals(false, status, "Status wasn't correctly returned");
+		assertEquals("Hello World !", textViewer.getDocument().get(), "Text shouldn't have been changed");
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 	}
 
@@ -288,12 +288,12 @@ public class FindReplaceLogicTest {
 		expectStatusEmpty(findReplaceLogic);
 
 		setFindAndReplaceString(findReplaceLogic, """
-				""", " ");
+				 """, " ");
 		status= findReplaceLogic.performSelectAndReplace();
-		assertEquals("Status wasn't correctly returned", false, status);
-		assertEquals("Text shouldn't have been changed", """
+		assertEquals(false, status, "Status wasn't correctly returned");
+		assertEquals("""
 				Hello!
-				World!""", textViewer.getDocument().get());
+				World!""", textViewer.getDocument().get(), "Text shouldn't have been changed");
 	}
 
 	@Test
@@ -324,8 +324,8 @@ public class FindReplaceLogicTest {
 		expectStatusEmpty(findReplaceLogic);
 
 		status= findReplaceLogic.performSelectAndReplace();
-		assertEquals("Status wasn't correctly returned", false, status);
-		assertEquals("Text shouldn't have been changed", "Hello World ! !", textViewer.getDocument().get());
+		assertEquals(false, status, "Status wasn't correctly returned");
+		assertEquals("Hello World ! !", textViewer.getDocument().get(), "Text shouldn't have been changed");
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 	}
 
@@ -355,20 +355,20 @@ public class FindReplaceLogicTest {
 		setFindAndReplaceString(findReplaceLogic, "<Replace>", " ");
 
 		boolean status= findReplaceLogic.performReplaceAndFind();
-		assertTrue("replace should have been performed", status);
+		assertTrue(status, "replace should have been performed");
 		assertThat(textViewer.getDocument().get(), equalTo("Hello World<replace>!"));
 		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo("<replace>"));
 		expectStatusEmpty(findReplaceLogic);
 
 		setFindAndReplaceString(findReplaceLogic, "<replace>", " ");
 		status= findReplaceLogic.performReplaceAndFind();
-		assertTrue("replace should have been performed", status);
+		assertTrue(status, "replace should have been performed");
 		assertThat(textViewer.getDocument().get(), equalTo("Hello World !"));
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 
 		status= findReplaceLogic.performReplaceAndFind();
-		assertFalse("replace should not have been performed", status);
-		assertEquals("Text shouldn't have been changed", "Hello World !", textViewer.getDocument().get());
+		assertFalse(status, "replace should not have been performed");
+		assertEquals("Hello World !", textViewer.getDocument().get(), "Text shouldn't have been changed");
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 	}
 
@@ -381,12 +381,12 @@ public class FindReplaceLogicTest {
 		setFindAndReplaceString(findReplaceLogic, "<replace>", " ");
 
 		boolean status= findReplaceLogic.performReplaceAndFind();
-		assertTrue("replace should have been performed", status);
+		assertTrue(status, "replace should have been performed");
 		assertThat(textViewer.getDocument().get(), equalTo("Hello<Replace>World !"));
 		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo(" "));
 
 		status= findReplaceLogic.performReplaceAndFind();
-		assertFalse("replace should not have been performed", status);
+		assertFalse(status, "replace should not have been performed");
 		assertThat(textViewer.getDocument().get(), equalTo("Hello<Replace>World !"));
 		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo(" "));
 	}
@@ -400,20 +400,20 @@ public class FindReplaceLogicTest {
 		setFindAndReplaceString(findReplaceLogic, "<Replace>", " ");
 
 		boolean status= findReplaceLogic.performReplaceAndFind();
-		assertTrue("replace should have been performed", status);
+		assertTrue(status, "replace should have been performed");
 		assertThat(textViewer.getDocument().get(), equalTo("Hello World<replace>!"));
 		assertThat(findReplaceLogic.getTarget().getSelectionText(), equalTo("<replace>"));
 		expectStatusEmpty(findReplaceLogic);
 
 		setFindAndReplaceString(findReplaceLogic, "<replace>", " ");
 		status= findReplaceLogic.performReplaceAndFind();
-		assertTrue("replace should have been performed", status);
+		assertTrue(status, "replace should have been performed");
 		assertThat(textViewer.getDocument().get(), equalTo("Hello World !"));
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 
 		status= findReplaceLogic.performReplaceAndFind();
-		assertFalse("replace should not have been performed", status);
-		assertEquals("Text shouldn't have been changed", "Hello World !", textViewer.getDocument().get());
+		assertFalse(status, "replace should not have been performed");
+		assertEquals("Hello World !", textViewer.getDocument().get(), "Text shouldn't have been changed");
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 	}
 
@@ -484,8 +484,8 @@ public class FindReplaceLogicTest {
 
 		setFindAndReplaceString(findReplaceLogic, "<(\\w*)>", " ");
 		status= findReplaceLogic.performReplaceAndFind();
-		assertEquals("Status wasn't correctly returned", false, status);
-		assertEquals("Text shouldn't have been changed", "Hello World ! !", textViewer.getDocument().get());
+		assertEquals(false, status, "Status wasn't correctly returned");
+		assertEquals("Hello World ! !", textViewer.getDocument().get(), "Text shouldn't have been changed");
 		expectStatusIsCode(findReplaceLogic, FindStatus.StatusCode.NO_MATCH);
 	}
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceTestUtil.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceTestUtil.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ui.internal.findandreplace;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.function.Supplier;
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/FindReplaceUITest.java
@@ -10,20 +10,19 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
- *******************************************************************************/
+ ******************************************************************************/
 package org.eclipse.ui.internal.findandreplace;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ResourceBundle;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import org.eclipse.swt.SWT;
 
@@ -37,8 +36,8 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.texteditor.FindReplaceAction;
 
 public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess> {
-	@Rule
-	public TestName testName= new TestName();
+	
+	protected TestInfo testInfo;
 
 	private TextViewer fTextViewer;
 
@@ -46,8 +45,9 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 
 	private AccessType dialog;
 
-	@Before
-	public final void ensureWorkbenchWindowIsActive() {
+	@BeforeEach
+	public final void ensureWorkbenchWindowIsActive(TestInfo info) {
+		this.testInfo = info;
 		PlatformUI.getWorkbench().getWorkbenchWindows()[0].getShell().forceActive();
 	}
 
@@ -80,7 +80,7 @@ public abstract class FindReplaceUITest<AccessType extends IFindReplaceUIAccess>
 
 	protected abstract AccessType openUIFromTextViewer(TextViewer viewer);
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		if (dialog != null) {
 			dialog.closeAndRestore();

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/internal/findandreplace/overlay/FindReplaceOverlayTest.java
@@ -16,10 +16,10 @@ package org.eclipse.ui.internal.findandreplace.overlay;
 import static org.eclipse.ui.internal.findandreplace.FindReplaceTestUtil.waitForFocus;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.graphics.Point;
 
@@ -48,7 +48,7 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		actionAccessor.invoke("showOverlayInEditor");
 		FindReplaceOverlay overlay= (FindReplaceOverlay) actionAccessor.get("overlay");
 		OverlayAccess uiAccess= new OverlayAccess(getFindReplaceTarget(), overlay);
-		waitForFocus(uiAccess::hasFocus, testName.getMethodName());
+		waitForFocus(uiAccess::hasFocus, testInfo.getTestMethod().get().getName());
 		return uiAccess;
 	}
 
@@ -177,7 +177,7 @@ public class FindReplaceOverlayTest extends FindReplaceUITest<OverlayAccess> {
 		boolean useOverlayPreference= preferences.getBoolean(USE_FIND_REPLACE_OVERLAY, true);
 		try {
 			preferences.putBoolean(USE_FIND_REPLACE_OVERLAY, false);
-			assertFalse("dialog should be closed after changing preference", getDialog().isShown());
+			assertFalse(getDialog().isShown(), "dialog should be closed after changing preference");
 		} finally {
 			preferences.putBoolean(USE_FIND_REPLACE_OVERLAY, useOverlayPreference);
 			reopenFindReplaceUIForTextViewer();

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/AbstractTextZoomHandlerTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/AbstractTextZoomHandlerTest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.widgets.Composite;
 

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DocumentLineDifferTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/DocumentLineDifferTest.java
@@ -14,10 +14,10 @@
 package org.eclipse.ui.workbench.texteditor.tests;
 
 import static org.eclipse.jface.text.DocumentRewriteSessionType.SEQUENTIAL;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/FindReplaceDialogTest.java
@@ -17,11 +17,11 @@ import static org.eclipse.ui.internal.findandreplace.FindReplaceTestUtil.runEven
 import static org.eclipse.ui.internal.findandreplace.FindReplaceTestUtil.waitForFocus;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
@@ -54,13 +54,13 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 
 		Dialog dialog= (Dialog) fFindReplaceDialogStubAccessor.invoke("getDialog");
 		DialogAccess uiAccess= new DialogAccess(getFindReplaceTarget(), dialog);
-		waitForFocus(uiAccess::hasFocus, testName.getMethodName());
+		waitForFocus(uiAccess::hasFocus, testInfo.getTestMethod().get().getName());
 		return uiAccess;
 	}
 
 	@Test
 	public void testFocusNotChangedWhenEnterPressed() {
-		assumeFalse("On Mac, checkboxes only take focus if 'Full Keyboard Access' is enabled in the system preferences", Util.isMac());
+		assumeFalse(Util.isMac(), "On Mac, checkboxes only take focus if 'Full Keyboard Access' is enabled in the system preferences");
 
 		initializeTextViewerWithFindReplaceUI("line\nline\nline");
 		DialogAccess dialog= getDialog();
@@ -68,22 +68,22 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		dialog.getFindCombo().setFocus();
 		dialog.setFindText("line");
 		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
-		waitForFocus(dialog.getFindCombo()::isFocusControl, testName.getMethodName());
+		waitForFocus(dialog.getFindCombo()::isFocusControl, testInfo.getTestMethod().get().getName());
 
 		Button wrapCheckBox= dialog.getButtonForSearchOption(SearchOptions.WRAP);
 		Button globalRadioButton= dialog.getButtonForSearchOption(SearchOptions.GLOBAL);
 		wrapCheckBox.setFocus();
 		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
-		waitForFocus(wrapCheckBox::isFocusControl, testName.getMethodName());
+		waitForFocus(wrapCheckBox::isFocusControl, testInfo.getTestMethod().get().getName());
 
 		globalRadioButton.setFocus();
 		dialog.simulateKeyboardInteractionInFindInputField(SWT.CR, false);
-		waitForFocus(globalRadioButton::isFocusControl, testName.getMethodName());
+		waitForFocus(globalRadioButton::isFocusControl, testInfo.getTestMethod().get().getName());
 	}
 
 	@Test
 	public void testFocusNotChangedWhenButtonMnemonicPressed() {
-		assumeFalse("Mac does not support mnemonics", Util.isMac());
+		assumeFalse(Util.isMac(), "Mac does not support mnemonics");
 
 		initializeTextViewerWithFindReplaceUI("");
 		DialogAccess dialog= getDialog();
@@ -97,20 +97,20 @@ public class FindReplaceDialogTest extends FindReplaceUITest<DialogAccess> {
 		event.character= 'n';
 		event.doit= false;
 		wrapCheckBox.traverse(SWT.TRAVERSE_MNEMONIC, event);
-		waitForFocus(wrapCheckBox::isFocusControl, testName.getMethodName());
+		waitForFocus(wrapCheckBox::isFocusControl, testInfo.getTestMethod().get().getName());
 
 		Button globalRadioButton= dialog.getButtonForSearchOption(SearchOptions.GLOBAL);
 		globalRadioButton.setFocus();
 		event.detail= SWT.TRAVERSE_MNEMONIC;
 		event.doit= false;
 		globalRadioButton.traverse(SWT.TRAVERSE_MNEMONIC, event);
-		waitForFocus(globalRadioButton::isFocusControl, testName.getMethodName());
+		waitForFocus(globalRadioButton::isFocusControl, testInfo.getTestMethod().get().getName());
 
 		event.detail= SWT.TRAVERSE_MNEMONIC;
 		event.character= 'r';
 		event.doit= false;
 		globalRadioButton.traverse(SWT.TRAVERSE_MNEMONIC, event);
-		waitForFocus(globalRadioButton::isFocusControl, testName.getMethodName());
+		waitForFocus(globalRadioButton::isFocusControl, testInfo.getTestMethod().get().getName());
 	}
 
 	@Test

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/HippieCompletionTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/HippieCompletionTest.java
@@ -14,18 +14,18 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.core.runtime.AssertionFailedException;
 
@@ -47,7 +47,7 @@ public class HippieCompletionTest {
 	IDocument[] documents;
 	private HippieCompletionEngine fEngine;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		documents= new IDocument[5];
 		documents[0]= new Document("""
@@ -149,25 +149,25 @@ public class HippieCompletionTest {
 	public void testSearchBackwards1() throws BadLocationException {
 		List<String> list= fEngine.getCompletionsBackwards(documents[0],
 				"pri", documents[0].get().indexOf("println") + 10);
-		assertEquals(list.size(), 2);
-		assertEquals(list.get(0), "ntln");
-		assertEquals(list.get(1), "nt");
+		assertEquals(2, list.size());
+		assertEquals("ntln", list.get(0));
+		assertEquals("nt", list.get(1));
 
 		list= fEngine.getCompletionsBackwards(documents[0],
 				"pri", documents[0].getLength());
-		assertEquals(list.size(), 3);
-		assertEquals(list.get(0), "nting");
-		assertEquals(list.get(1), "ntln");
-		assertEquals(list.get(2), "nt");
+		assertEquals(3, list.size());
+		assertEquals("nting", list.get(0));
+		assertEquals("ntln", list.get(1));
+		assertEquals("nt", list.get(2));
 
 		list= fEngine.getCompletionsBackwards(documents[0],
 				"pri", documents[0].get().indexOf("println") + 1);
-		assertEquals(list.size(), 1);
-		assertEquals(list.get(0), "nt");
+		assertEquals(1, list.size());
+		assertEquals("nt", list.get(0));
 
 		list= fEngine.getCompletionsBackwards(documents[0],
 				"pa", 2);
-		assertEquals(list.size(), 0);
+		assertEquals(0, list.size());
 
 	}
 
@@ -190,54 +190,54 @@ public class HippieCompletionTest {
 	public void testSearchBackwards3() throws BadLocationException {
 		List<String> list= fEngine.getCompletionsBackwards(documents[1],
 				"test", documents[1].getLength());
-		assertEquals("Number of backwards suggestions does not match", 2, list.size());
+		assertEquals(2, list.size(), "Number of backwards suggestions does not match");
 		list= fEngine.getCompletionsBackwards(documents[1],
 				"tests", documents[1].getLength());
-		assertEquals("Number of backwards suggestions does not match", 1, list.size());
+		assertEquals(1, list.size(), "Number of backwards suggestions does not match");
 
 		list= fEngine.getCompletionsBackwards(documents[1],
 				"test", documents[1].getLength() - 1);
-		assertEquals("Number of backwards suggestions does not match", 1, list.size());
+		assertEquals(1, list.size(), "Number of backwards suggestions does not match");
 	}
 
 	@Test
 	public void testSearch() throws BadLocationException {
 		ArrayList<IDocument> docsList= new ArrayList<>(Arrays.asList(this.documents));
 		List<String> result= createSuggestions("te", docsList);
-		assertEquals("Number of completions does not match", 15, result.size());
+		assertEquals(15, result.size(), "Number of completions does not match");
 		result= fEngine.makeUnique(result);
-		assertEquals("Number of completions does not match", 7, result.size());
+		assertEquals(7, result.size(), "Number of completions does not match");
 
 		result= createSuggestions("Plug", docsList);
-		assertEquals("Number of completions does not match", 2, result.size());
+		assertEquals(2, result.size(), "Number of completions does not match");
 
 		result= createSuggestions("p", docsList);
-		assertEquals("Number of completions does not match", 23, result.size());
+		assertEquals(23, result.size(), "Number of completions does not match");
 		result= fEngine.makeUnique(result);
-		assertEquals("Number of completions does not match", 10, result.size());
-		assertEquals("Incorrect completion", "ackage", result.get(0));
-		assertEquals("Incorrect completion", "rint", result.get(1));
-		assertEquals("Incorrect completion", "ublic", result.get(2));
-		assertEquals("Incorrect completion", "rintln", result.get(3));
-		assertEquals("Incorrect completion", "rinting", result.get(4));
-		assertEquals("Incorrect completion", "lugin", result.get(5));
-		assertEquals("Incorrect completion", "rovider", result.get(6));
-		assertEquals("Incorrect completion", "roviderName", result.get(7));
-		assertEquals("Incorrect completion", "rogram", result.get(8));
-		assertEquals("Incorrect completion", "roperties", result.get(9));
+		assertEquals(10, result.size(), "Number of completions does not match");
+		assertEquals("ackage", result.get(0), "Incorrect completion");
+		assertEquals("rint", result.get(1), "Incorrect completion");
+		assertEquals("ublic", result.get(2), "Incorrect completion");
+		assertEquals("rintln", result.get(3), "Incorrect completion");
+		assertEquals("rinting", result.get(4), "Incorrect completion");
+		assertEquals("lugin", result.get(5), "Incorrect completion");
+		assertEquals("rovider", result.get(6), "Incorrect completion");
+		assertEquals("roviderName", result.get(7), "Incorrect completion");
+		assertEquals("rogram", result.get(8), "Incorrect completion");
+		assertEquals("roperties", result.get(9), "Incorrect completion");
 	}
 
 	@Test
 	public void testSearch2() throws BadLocationException {
 		ArrayList<IDocument> docsList= new ArrayList<>(Arrays.asList(this.documents));
 		List<String> result= createSuggestions("printe", docsList);
-		assertEquals("Number of completions does not match", 0, result.size());
+		assertEquals(0, result.size(), "Number of completions does not match");
 
 		result= createSuggestions("s", docsList);
-		assertEquals("Number of completions does not match", 8, result.size());
+		assertEquals(8, result.size(), "Number of completions does not match");
 
 		result= createSuggestions("pack", documents[0]);
-		assertEquals("Number of completions does not match", 1, result.size());
+		assertEquals(1, result.size(), "Number of completions does not match");
 	}
 
 	@Test
@@ -283,56 +283,56 @@ public class HippieCompletionTest {
 	public void testPrefix() throws BadLocationException {
 		String prefix= fEngine.getPrefixString(documents[0],
 				documents[0].get().indexOf("testing") + 3);
-		assertEquals(prefix, "tes");
+		assertEquals("tes", prefix);
 
 		prefix= fEngine.getPrefixString(documents[0],
 				documents[0].get().indexOf("public") + 4);
-		assertEquals(prefix, "publ");
+		assertEquals("publ", prefix);
 
 		prefix= fEngine.getPrefixString(documents[0],
 				documents[0].get().indexOf("println") + 7);
-		assertEquals(prefix, "println");
+		assertEquals("println", prefix);
 
 		prefix= fEngine.getPrefixString(documents[0],
 				documents[0].get().indexOf("println") + 8);
-		assertEquals(prefix, null);
+		assertEquals(null, prefix);
 
 		prefix= fEngine.getPrefixString(documents[1], 3);
-		assertEquals(prefix, "Thi");
+		assertEquals("Thi", prefix);
 
 		prefix= fEngine.getPrefixString(documents[1], 0);
-		assertEquals(prefix, null);
+		assertEquals(null, prefix);
 
 		prefix= fEngine.getPrefixString(documents[1], documents[1].getLength());
-		assertEquals(prefix, "tests");
+		assertEquals("tests", prefix);
 
 		prefix= fEngine.getPrefixString(documents[3],
 				documents[3].get().indexOf("Copyright") - 2);
-		assertEquals(prefix, null);
+		assertEquals(null, prefix);
 
 		prefix= fEngine.getPrefixString(documents[4],
 				documents[4].get().indexOf("IDE") + 2);
-		assertEquals(prefix, "ID");
+		assertEquals("ID", prefix);
 
 		prefix= fEngine.getPrefixString(documents[4],
 				documents[4].get().indexOf("$arabic\u20ACDigits") + 8);
-		assertEquals(prefix, "$arabic\u20AC");
+		assertEquals("$arabic\u20AC", prefix);
 
 		prefix= fEngine.getPrefixString(documents[4],
 				documents[4].get().indexOf("$arabic\u20AAWord") + 8);
-		assertEquals(prefix, "$arabic\u20AA");
+		assertEquals("$arabic\u20AA", prefix);
 
 		prefix= fEngine.getPrefixString(documents[4],
 				documents[4].get().indexOf("\u00A3\u0661\u0662\u0663") + 3);
-		assertEquals(prefix, "\u00A3\u0661\u0662");
+		assertEquals("\u00A3\u0661\u0662", prefix);
 
 		prefix= fEngine.getPrefixString(documents[4],
 				documents[4].get().indexOf("a\u0300\u0301b") + 3);
-		assertEquals(prefix, "a\u0300\u0301");
+		assertEquals("a\u0300\u0301", prefix);
 
 		prefix= fEngine.getPrefixString(documents[4],
 				documents[4].get().indexOf("\u0667\u0668\u0669\u0660") + 2);
-		assertEquals(prefix, "\u0667\u0668");
+		assertEquals("\u0667\u0668", prefix);
 	}
 
 	@Test
@@ -340,66 +340,66 @@ public class HippieCompletionTest {
 		IDocument intlDoc= documents[4];
 
 		List<String> result= createSuggestions("\u05D4", intlDoc); // hebrew letter heh
-		assertEquals("Number of completions does not match", 4, result.size());
-		assertEquals(result.get(0), "\u05DE\u05D7\u05DC\u05E7\u05D4");
-		assertEquals(result.get(1), "\u05D6\u05D5");
-		assertEquals(result.get(2), "\u05D4\u05E9\u05DC\u05DE\u05D5\u05EA");
-		assertEquals(result.get(3), "\u05D4\u05E9");
+		assertEquals(4, result.size(), "Number of completions does not match");
+		assertEquals("\u05DE\u05D7\u05DC\u05E7\u05D4", result.get(0));
+		assertEquals("\u05D6\u05D5", result.get(1));
+		assertEquals("\u05D4\u05E9\u05DC\u05DE\u05D5\u05EA", result.get(2));
+		assertEquals("\u05D4\u05E9", result.get(3));
 
 		result= createSuggestions("\u0661", intlDoc); // arabic digit "1"
-		assertEquals("Number of completions does not match", 1, result.size());
-		assertEquals(result.get(0), "\u0662\u0663\u0664\u0665\u0666");
+		assertEquals(1, result.size(), "Number of completions does not match");
+		assertEquals("\u0662\u0663\u0664\u0665\u0666", result.get(0));
 
 		result= createSuggestions("\u0628\u064E", intlDoc); // arabic letter bah and fatha
-		assertEquals("Number of completions does not match", 1, result.size());
-		assertEquals(result.get(0), "\u0627\u0628\u0650");
+		assertEquals(1, result.size(), "Number of completions does not match");
+		assertEquals("\u0627\u0628\u0650", result.get(0));
 		result= createSuggestions("\u0628", intlDoc); // arabic letter bah
-		assertEquals("Number of completions does not match", 2, result.size());
-		assertEquals(result.get(0), "\u064E\u0627\u0628\u0650");
-		assertEquals(result.get(1), "\u0627\u0628");
+		assertEquals(2, result.size(), "Number of completions does not match");
+		assertEquals("\u064E\u0627\u0628\u0650", result.get(0));
+		assertEquals("\u0627\u0628", result.get(1));
 
 		result= createSuggestions("$ara", intlDoc);
-		assertEquals("Number of completions does not match", 2, result.size());
-		assertEquals(result.get(0), "bic\u20ACDigits");
-		assertEquals(result.get(1), "bic\u20AAWord");
+		assertEquals(2, result.size(), "Number of completions does not match");
+		assertEquals("bic\u20ACDigits", result.get(0));
+		assertEquals("bic\u20AAWord", result.get(1));
 
 		result= createSuggestions("\u0441\u0430", intlDoc); // russian letters "s" and "a"
-		assertEquals("Number of completions does not match", 2, result.size());
-		assertEquals(result.get(0), "\u043C\u044B\u0439");
-		assertEquals(result.get(1), "\u043C");
+		assertEquals(2, result.size(), "Number of completions does not match");
+		assertEquals("\u043C\u044B\u0439", result.get(0));
+		assertEquals("\u043C", result.get(1));
 
 		result= createSuggestions("\u05D1\u05D5", intlDoc); // hebrew letters bet and vav
-		assertEquals("Number of completions does not match", 2, result.size());
-		assertEquals(result.get(0), "\u05D3\u05E7\u05EA");
-		assertEquals(result.get(1), "\u05D3\u05E7");
+		assertEquals(2, result.size(), "Number of completions does not match");
+		assertEquals("\u05D3\u05E7\u05EA", result.get(0));
+		assertEquals("\u05D3\u05E7", result.get(1));
 
 		result= createSuggestions("a", intlDoc);
-		assertEquals("Number of completions does not match", 4, result.size());
-		assertEquals(result.get(0), "n");
-		assertEquals(result.get(1), "rabic");
-		assertEquals(result.get(2), "rgs");
-		assertEquals(result.get(3), "\u0300\u0301b");
+		assertEquals(4, result.size(), "Number of completions does not match");
+		assertEquals("n", result.get(0));
+		assertEquals("rabic", result.get(1));
+		assertEquals("rgs", result.get(2));
+		assertEquals("\u0300\u0301b", result.get(3));
 
 		result= createSuggestions("\u20AA", intlDoc);  // israeli currency (shekel)
-		assertEquals("Number of completions does not match", 1, result.size());
-		assertEquals(result.get(0), "129");
+		assertEquals(1, result.size(), "Number of completions does not match");
+		assertEquals("129", result.get(0));
 
 		result= createSuggestions("\u20A3", intlDoc);  // french currency (frank)
-		assertEquals("Number of completions does not match", 2, result.size());
-		assertEquals(result.get(0), "1");
-		assertEquals(result.get(1), "1");
+		assertEquals(2, result.size(), "Number of completions does not match");
+		assertEquals("1", result.get(0));
+		assertEquals("1", result.get(1));
 
 		result= createSuggestions("\u044D", intlDoc);  // russial letter "hard e"
-		assertEquals("Number of completions does not match", 2, result.size());
-		assertEquals(result.get(0), "\u0442\u043E");
-		assertEquals(result.get(1), "\u0442");
+		assertEquals(2, result.size(), "Number of completions does not match");
+		assertEquals("\u0442\u043E", result.get(0));
+		assertEquals("\u0442", result.get(1));
 
 		result= createSuggestions("\u00A3", intlDoc);  // pound currency sign
-		assertEquals("Number of completions does not match", 1, result.size());
-		assertEquals(result.get(0), "\u0661\u0662\u0663");
+		assertEquals(1, result.size(), "Number of completions does not match");
+		assertEquals("\u0661\u0662\u0663", result.get(0));
 
 		result= createSuggestions("\u00A5", intlDoc);  // yen currency sign
-		assertEquals("Number of completions does not match", 0, result.size());
+		assertEquals(0, result.size(), "Number of completions does not match");
 	}
 
 	@Test
@@ -408,14 +408,14 @@ public class HippieCompletionTest {
 		List<String> list= fEngine.getCompletionsBackwards(intlDoc,
 				"\u043B\u0443", intlDoc.get().indexOf("129"));
 		assertEquals(2, list.size());
-		assertEquals(list.get(0), "\u0447\u0448");
-		assertEquals(list.get(1), "\u0447\u0448\u0438\u0439");
+		assertEquals("\u0447\u0448", list.get(0));
+		assertEquals("\u0447\u0448\u0438\u0439", list.get(1));
 
 		list= fEngine.getCompletionsBackwards(intlDoc,
 				"\u05DE", intlDoc.get().lastIndexOf('+'));
 		assertEquals(2, list.size());
-		assertEquals(list.get(0), "\u05D7");
-		assertEquals(list.get(1), "\u05E0\u05D2\u05E0\u05D5\u05DF");
+		assertEquals("\u05D7", list.get(0));
+		assertEquals("\u05E0\u05D2\u05E0\u05D5\u05DF", list.get(1));
 
 		list= fEngine.getCompletionsBackwards(intlDoc,
 				"\u0667", intlDoc.get().indexOf("\u2021\u0667") + 1);
@@ -424,7 +424,7 @@ public class HippieCompletionTest {
 		list= fEngine.getCompletionsBackwards(intlDoc,
 				"\u0628", intlDoc.get().lastIndexOf("\u0628"));
 		assertEquals(1, list.size());
-		assertEquals(list.get(0), "\u064E\u0627\u0628\u0650");
+		assertEquals("\u064E\u0627\u0628\u0650", list.get(0));
 
 	}
 
@@ -508,7 +508,7 @@ public class HippieCompletionTest {
 	@Test
 	public void testIteration() throws Exception {
 		//Check only with current document
-		IDocument openDocument= new Document("" +
+		IDocument openDocument= new Document ("" +
 				"bar\n" +
 				"bar1\n" +
 				"bar2\n" +
@@ -523,7 +523,7 @@ public class HippieCompletionTest {
 
 		//Check with 2 documents
 		List<IDocument> otherDocuments= new ArrayList<>();
-		otherDocuments.add(new Document("" +
+		otherDocuments.add(new Document ("" +
 				"bar3\n" +
 				"bar4\n" +
 				""));

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/ScreenshotTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/ScreenshotTest.java
@@ -16,9 +16,8 @@ package org.eclipse.ui.workbench.texteditor.tests;
 import java.io.File;
 import java.io.PrintStream;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.GC;
@@ -39,17 +38,14 @@ import org.eclipse.ui.PlatformUI;
 
 public class ScreenshotTest {
 
-	@Rule
-	public TestName testName = new TestName();
-
 	@Test
-	public void testScreenshot() throws Exception {
-		String screenshot= takeScreenshot(ScreenshotTest.class, testName.getMethodName(), System.out);
+	public void testScreenshot(TestInfo testInfo) throws Exception {
+		String screenshot= takeScreenshot(ScreenshotTest.class, testInfo.getTestMethod().get().getName(), System.out);
 		new File(screenshot).delete();
 	}
 
 	@Test
-	public void testWindowsTaskManagerScreenshots() throws Exception {
+	public void testWindowsTaskManagerScreenshots(TestInfo testInfo) throws Exception {
 		if (! Util.isWindows())
 			return;
 
@@ -74,7 +70,7 @@ public class ScreenshotTest {
 		System.out.println("* CTRL up " + display.post(event));
 
 		runEventQueue();
-		String screenshot1= takeScreenshot(ScreenshotTest.class, testName.getMethodName() + 2, System.out);
+		String screenshot1= takeScreenshot(ScreenshotTest.class, testInfo.getTestMethod().get().getName() + 2, System.out);
 
 		event.type= SWT.KeyDown;
 		event.character= SWT.ESC;
@@ -84,7 +80,7 @@ public class ScreenshotTest {
 		System.out.println("* ESC up " + display.post(event));
 
 		runEventQueue();
-		String screenshot2= takeScreenshot(ScreenshotTest.class, testName.getMethodName() + 3, System.out);
+		String screenshot2= takeScreenshot(ScreenshotTest.class, testInfo.getTestMethod().get().getName() + 3, System.out);
 		new File(screenshot1).delete();
 		new File(screenshot2).delete();
 	}

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/TextEditorPluginTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/TextEditorPluginTest.java
@@ -13,16 +13,16 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Random;
 
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import org.eclipse.ui.internal.texteditor.HistoryTracker;
 
@@ -31,7 +31,7 @@ import org.eclipse.ui.internal.texteditor.HistoryTracker;
  *
  * @since 3.1
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class TextEditorPluginTest {
 
 	Random rand = new Random(55); //pseudo-random for repeatability

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/TextViewerDeleteLineTargetTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/TextViewerDeleteLineTargetTest.java
@@ -10,15 +10,15 @@
  *
  * Contributors:
  *     Pierre-Yves Bigourdan - initial API and implementation
- *******************************************************************************/
+ ******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.Clipboard;
@@ -42,7 +42,7 @@ public class TextViewerDeleteLineTargetTest {
 	private Shell parentShell;
 	private TextViewerDeleteLineTarget underTest;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		document= new Document("first line\n" +
 				"\n" +
@@ -55,7 +55,7 @@ public class TextViewerDeleteLineTargetTest {
 		underTest= new TextViewerDeleteLineTarget(textViewer);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		if (parentShell != null) {
 			parentShell.dispose();

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/minimap/MinimapPageTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/minimap/MinimapPageTest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests.minimap;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
@@ -77,20 +77,20 @@ public class MinimapPageTest {
 	public void createNoneMinimapPage() {
 		ITextEditor textEditor= new MyTextEditor(TextVieverAdapterKind.None);
 		MinimapPage page= MinimapPage.createMinimapPage(textEditor);
-		Assert.assertNull(page);
+		Assertions.assertNull(page);
 	}
 
 	@Test
 	public void createMinimapPageWithITextViewerAdapter() {
 		ITextEditor textEditor= new MyTextEditor(TextVieverAdapterKind.ITextViewer);
 		MinimapPage page= MinimapPage.createMinimapPage(textEditor);
-		Assert.assertNotNull(page);
+		Assertions.assertNotNull(page);
 	}
 
 	@Test
 	public void createMinimapPageWithITextOperationTargetAdapter() {
 		ITextEditor textEditor= new MyTextEditor(TextVieverAdapterKind.ITextOperationTarget);
 		MinimapPage page= MinimapPage.createMinimapPage(textEditor);
-		Assert.assertNotNull(page);
+		Assertions.assertNotNull(page);
 	}
 }

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/minimap/MinimapWidgetTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/minimap/MinimapWidgetTest.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests.minimap;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
@@ -53,7 +53,7 @@ public class MinimapWidgetTest {
 
 	private StyledText minimapStyledText;
 
-	@Before
+	@BeforeEach
 	public void createMinimap() {
 		minimapParent= new Shell();
 		editorViewer= new TextViewer(minimapParent, SWT.NONE);
@@ -65,7 +65,7 @@ public class MinimapWidgetTest {
 
 	}
 
-	@After
+	@AfterEach
 	public void tearDownMinimap() {
 		if (minimapParent != null) {
 			minimapParent.dispose();
@@ -76,10 +76,10 @@ public class MinimapWidgetTest {
 	@Test
 	public void testMinimapContent() {
 		editorStyledText.setText("abcd");
-		Assert.assertEquals("abcd", minimapStyledText.getText());
+		Assertions.assertEquals("abcd", minimapStyledText.getText());
 
 		editorStyledText.replaceTextRange(1, 0, "ABCD");
-		Assert.assertEquals("aABCDbcd", minimapStyledText.getText());
+		Assertions.assertEquals("aABCDbcd", minimapStyledText.getText());
 	}
 
 	@Test
@@ -90,7 +90,7 @@ public class MinimapWidgetTest {
 		StyleRange[] ranges= new StyleRange[] { new StyleRange(0, 1, editorStyledText.getDisplay().getSystemColor(SWT.COLOR_BLACK), null) };
 		editorStyledText.setStyleRanges(ranges);
 		// Styles of minimap doesn't changed
-		Assert.assertArrayEquals(orginalMinimapStyles, minimapStyledText.getStyleRanges());
+		Assertions.assertArrayEquals(orginalMinimapStyles, minimapStyledText.getStyleRanges());
 	}
 
 	@Test
@@ -103,7 +103,7 @@ public class MinimapWidgetTest {
 		presentation.mergeStyleRanges(ranges);
 		editorViewer.changeTextPresentation(presentation, false);
 		StyleRange[] expectedRanges= new StyleRange[] { new StyleRange(0, 1, editorStyledText.getDisplay().getSystemColor(SWT.COLOR_BLACK), null) };
-		Assert.assertArrayEquals(expectedRanges, minimapStyledText.getStyleRanges());
+		Assertions.assertArrayEquals(expectedRanges, minimapStyledText.getStyleRanges());
 
 		ranges= new StyleRange[] { new StyleRange(1, 1, editorStyledText.getDisplay().getSystemColor(SWT.COLOR_RED), null) };
 		presentation= new TextPresentation();
@@ -111,6 +111,6 @@ public class MinimapWidgetTest {
 		editorViewer.changeTextPresentation(presentation, false);
 		expectedRanges= new StyleRange[] { new StyleRange(0, 1, editorStyledText.getDisplay().getSystemColor(SWT.COLOR_BLACK), null),
 				new StyleRange(1, 1, editorStyledText.getDisplay().getSystemColor(SWT.COLOR_RED), null) };
-		Assert.assertArrayEquals(expectedRanges, minimapStyledText.getStyleRanges());
+		Assertions.assertArrayEquals(expectedRanges, minimapStyledText.getStyleRanges());
 	}
 }

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/revisions/ChangeRegionTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/revisions/ChangeRegionTest.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests.revisions;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Date;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.graphics.RGB;
 
@@ -62,7 +62,7 @@ public class ChangeRegionTest {
 
 	private Revision fRevision;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		fRevision= new TestRevision();
 	}

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/revisions/HunkComputerTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/revisions/HunkComputerTest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests.revisions;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jface.internal.text.revisions.Hunk;
 import org.eclipse.jface.internal.text.revisions.HunkComputer;

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/revisions/RangeTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/revisions/RangeTest.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests.revisions;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jface.internal.text.revisions.LineIndexOutOfBoundsException;
 import org.eclipse.jface.internal.text.revisions.Range;

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/revisions/RangeUtil.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/revisions/RangeUtil.java
@@ -13,18 +13,18 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests.revisions;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
-import org.junit.Assert;
 
 import org.eclipse.jface.internal.text.revisions.Range;
 
 import org.eclipse.jface.text.source.ILineRange;
 
 
-class RangeUtil extends Assert {
+class RangeUtil {
 	private RangeUtil() {}
 
 	static void assertEqualRange(ILineRange expected, ILineRange actual) {

--- a/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/rulers/DAGTest.java
+++ b/tests/org.eclipse.ui.workbench.texteditor.tests/src/org/eclipse/ui/workbench/texteditor/tests/rulers/DAGTest.java
@@ -13,14 +13,17 @@
  *******************************************************************************/
 package org.eclipse.ui.workbench.texteditor.tests.rulers;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.ui.internal.texteditor.rulers.DAG;
 


### PR DESCRIPTION
Code Changes:
       * Replaced JUnit 4 imports (e.g., org.junit.Test,
org.junit.Assert) with JUnit 5 equivalents (org.junit.jupiter.api.Test, org.junit.jupiter.api.Assertions).
       * Updated lifecycle annotations (@Before -> @BeforeEach, @After
-> @AfterEach).
       * Updated assertEquals and assertFalse/assertTrue calls to match
JUnit 5's argument order (expected, actual, message / condition, message).
       * Replaced ExpectedException usage and try-catch-fail blocks with
Assertions.assertThrows.
       * Replaced @Rule public TestName with TestInfo injection in test
methods and setup methods.
       * Updated TextEditorPluginTest to use
@TestMethodOrder(MethodOrderer.MethodName.class) instead of @FixMethodOrder.