### PR TITLE
Handle zero-width characters properly in code minings

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineContentAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineContentAnnotation.java
@@ -44,6 +44,8 @@ public class LineContentAnnotation extends AbstractInlinedAnnotation {
 
 	private int redrawnCharacterWidth;
 
+	private boolean isZeroWidthCharacter;
+
 	/**
 	 * Line content annotation constructor.
 	 *
@@ -113,8 +115,9 @@ public class LineContentAnnotation extends AbstractInlinedAnnotation {
 		return redrawnCharacterWidth;
 	}
 
-	void setRedrawnCharacterWidth(int redrawnCharacterWidth) {
+	void setRedrawnCharacterWidth(int redrawnCharacterWidth, boolean isZeroWidthCharacter) {
 		this.redrawnCharacterWidth= redrawnCharacterWidth;
+		this.isZeroWidthCharacter= isZeroWidthCharacter;
 	}
 
 	@Override
@@ -151,7 +154,7 @@ public class LineContentAnnotation extends AbstractInlinedAnnotation {
 		if (!afterPosition) {
 			usePreviousChar= drawRightToPreviousChar(widgetPosition.getOffset(), textWidget);
 		}
-		if (width == 0 || getRedrawnCharacterWidth() == 0) {
+		if (isZeroWidthCharacter == false && (width == 0 || getRedrawnCharacterWidth() == 0)) {
 			return null;
 		}
 		int fullWidth= width + getRedrawnCharacterWidth();


### PR DESCRIPTION
This change improves the rendering of code minings in the presence of zero-width Unicode characters (e.g., ZWSP, ZWNJ, ZWJ, and BOM). The `InlinedAnnotationDrawingStrategy` was updated to recognize these characters, adjust their width calculations, and properly place code mining annotations without causing layout issues.

This change is needed by https://github.com/eclipse-platform/eclipse.platform.ui/pull/1437