### PR TITLE
Migrate org.eclipse.ltk.core.refactoring.tests to JUnit 5

### DIFF
--- a/tests/org.eclipse.ltk.core.refactoring.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.ltk.core.refactoring.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ltk.core.refactoring.tests; singleton:=true
-Bundle-Version: 3.10.700.qualifier
+Bundle-Version: 3.10.800.qualifier
 Bundle-Activator: org.eclipse.ltk.core.refactoring.tests.RefactoringCoreTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/RefactoringContextTest.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/RefactoringContextTest.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.ltk.core.refactoring.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/history/RefactoringHistorySerializationTests.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/history/RefactoringHistorySerializationTests.java
@@ -10,11 +10,11 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
- *******************************************************************************/
+ ******************************************************************************/
 package org.eclipse.ltk.core.refactoring.tests.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.core.runtime.CoreException;
 
@@ -62,20 +62,20 @@ public class RefactoringHistorySerializationTests {
 		RefactoringHistory result= RefactoringCore.getHistoryService().readRefactoringHistory(stream, flags);
 		RefactoringDescriptorProxy[] actualProxies= result.getDescriptors();
 		RefactoringDescriptorProxy[] expectedProxies= list.toArray(new RefactoringDescriptorProxy[list.size()]);
-		assertEquals("The number of refactoring descriptors is incorrect.", expectedProxies.length, actualProxies.length);
+		assertEquals(expectedProxies.length, actualProxies.length, "The number of refactoring descriptors is incorrect.");
 		for (int index= 0; index < expectedProxies.length; index++) {
 			RefactoringDescriptor expectedDescriptor= expectedProxies[index].requestDescriptor(null);
-			assertNotNull("Expected refactoring descriptor cannot be resolved.", expectedDescriptor);
+			assertNotNull(expectedDescriptor, "Expected refactoring descriptor cannot be resolved.");
 			RefactoringDescriptor actualDescriptor= actualProxies[index].requestDescriptor(null);
-			assertNotNull("Actual refactoring descriptor cannot be resolved.", actualDescriptor);
-			assertEquals("Expected refactoring descriptor is not equal to actual one:", expectedDescriptor.toString(), actualDescriptor.toString());
+			assertNotNull(actualDescriptor, "Actual refactoring descriptor cannot be resolved.");
+			assertEquals(expectedDescriptor.toString(), actualDescriptor.toString(), "Expected refactoring descriptor is not equal to actual one:");
 		}
 	}
 
 	private static void compareWrittenDescriptor(RefactoringSessionDescriptor descriptor, boolean time, String xml) throws CoreException {
 		ByteArrayOutputStream stream= new ByteArrayOutputStream();
 		RefactoringCore.getHistoryService().writeRefactoringSession(descriptor, stream, time);
-		assertEquals("The refactoring descriptor has not been correctly serialized:", convertLineDelimiters(xml), stream.toString(StandardCharsets.UTF_8));
+		assertEquals(convertLineDelimiters(xml), stream.toString(StandardCharsets.UTF_8), "The refactoring descriptor has not been correctly serialized:");
 	}
 
 	private static String concatenate(String[] lines, String delimiter) {
@@ -107,15 +107,24 @@ public class RefactoringHistorySerializationTests {
 
 	private static String convertLineDelimiters(String xml) {
 		String delimiter= System.lineSeparator();
-		assertNotNull("Could not determine line separator.", delimiter);
+		assertNotNull(delimiter, "Could not determine line separator.");
 		if (!"\n".equals(delimiter))
 			xml= concatenate(convertIntoLines(xml), delimiter);
+		// Trim the trailing newline if the xml string has one (Text Blocks usually add one)
+		// But here we might want to keep it if original tests expected it?
+		// Original tests: "...</session>\n" + "";
+		// So they ended with \n.
 		return xml;
 	}
 
 	@Test
 	public void testReadDescriptor0() throws Exception {
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session comment=\"A mock comment\" version=\"1.0\">\n" + "<refactoring arg0=\"value0\" arg1=\"value1\" arg2=\"value2\" comment=\"A mock comment\" description=\"A mock refactoring\" flags=\"3\" id=\"org.eclipse.ltk.core.mock\" project=\"test0\"/>\n" + "</session>\n" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session comment="A mock comment" version="1.0">
+				<refactoring arg0="value0" arg1="value1" arg2="value2" comment="A mock comment" description="A mock refactoring" flags="3" id="org.eclipse.ltk.core.mock" project="test0"/>
+				</session>
+				""";
 		int flags= RefactoringDescriptor.NONE;
 		MockRefactoringDescriptor descriptor= new MockRefactoringDescriptor("test0", "A mock refactoring", "A mock comment", RefactoringDescriptor.STRUCTURAL_CHANGE | RefactoringDescriptor.BREAKING_CHANGE);
 		Map<String, String> arguments= descriptor.getArguments();
@@ -127,7 +136,12 @@ public class RefactoringHistorySerializationTests {
 
 	@Test
 	public void testReadDescriptor1() throws Exception {
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session comment=\"A mock comment\" version=\"1.0\">\n" + "<refactoring arg0=\"value 0\" arg1=\"value 1\" arg2=\"value 2\" comment=\"A mock comment\" description=\"A mock refactoring\" flags=\"6\" id=\"org.eclipse.ltk.core.mock\" project=\"test1\"/>\n" + "</session>\n" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session comment="A mock comment" version="1.0">
+				<refactoring arg0="value 0" arg1="value 1" arg2="value 2" comment="A mock comment" description="A mock refactoring" flags="6" id="org.eclipse.ltk.core.mock" project="test1"/>
+				</session>
+				""";
 		int flags= RefactoringDescriptor.NONE;
 		MockRefactoringDescriptor descriptor= new MockRefactoringDescriptor("test1", "A mock refactoring", "A mock comment", RefactoringDescriptor.STRUCTURAL_CHANGE | RefactoringDescriptor.MULTI_CHANGE);
 		Map<String, String> arguments= descriptor.getArguments();
@@ -139,7 +153,14 @@ public class RefactoringHistorySerializationTests {
 
 	@Test
 	public void testReadDescriptor10() throws Exception {
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session version=\"1.0\">\n" + "<refactoring arg0=\"value 0\" comment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "<refactoring arg1=\"value 1\" comment=\"No comment\" description=\"Another mock refactoring\" flags=\"1\" id=\"org.eclipse.ltk.core.mock\" version=\"1.0\"/>\n" + "<refactoring arg2=\"value 2\" description=\"Yet another mock refactoring\" flags=\"5\" id=\"org.eclipse.ltk.core.mock\" project=\"test0\" version=\"1.1\"/>\n" + "</session>\n" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session version="1.0">
+				<refactoring arg0="value 0" comment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				<refactoring arg1="value 1" comment="No comment" description="Another mock refactoring" flags="1" id="org.eclipse.ltk.core.mock" version="1.0"/>
+				<refactoring arg2="value 2" description="Yet another mock refactoring" flags="5" id="org.eclipse.ltk.core.mock" project="test0" version="1.1"/>
+				</session>
+				""";
 		int flags= RefactoringDescriptor.MULTI_CHANGE;
 		MockRefactoringDescriptor third= new MockRefactoringDescriptor("test0", "Yet another mock refactoring", null, RefactoringDescriptor.BREAKING_CHANGE | RefactoringDescriptor.MULTI_CHANGE);
 		Map<String, String> arguments= third.getArguments();
@@ -148,13 +169,20 @@ public class RefactoringHistorySerializationTests {
 		try {
 			compareReadHistory(new RefactoringDescriptor[] { third}, flags, xml, true);
 		} catch (CoreException exception) {
-			assertEquals("Wrong status code for refactoring history io error:", IRefactoringCoreStatusCodes.REFACTORING_HISTORY_IO_ERROR, exception.getStatus().getCode());
+			assertEquals(IRefactoringCoreStatusCodes.REFACTORING_HISTORY_IO_ERROR, exception.getStatus().getCode(), "Wrong status code for refactoring history io error:");
 		}
 	}
 
 	@Test
 	public void testReadDescriptor11() throws Exception {
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session version=\"1.0\">\n" + "<refact oring arg0=\"value 0\" com ment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "<refactoring arg1=\"value 1\" comment=\"No comment\" description=\"Another mock refactoring\" flags=\"1\" id=\"org.eclipse.ltk.core.mock\" version=\"1.0\"/>\n" + "<refactoring arg2=\"value 2\" description=\"Yet another mock refactoring\" flags=\"5\" id=\"org.eclipse.ltk.core.mock\" project=\"test0\" version=\"1.1\"/>\n" + "</session>\n" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session version="1.0">
+				<refact oring arg0="value 0" com ment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				<refactoring arg1="value 1" comment="No comment" description="Another mock refactoring" flags="1" id="org.eclipse.ltk.core.mock" version="1.0"/>
+				<refactoring arg2="value 2" description="Yet another mock refactoring" flags="5" id="org.eclipse.ltk.core.mock" project="test0" version="1.1"/>
+				</session>
+				""";
 		int flags= RefactoringDescriptor.MULTI_CHANGE;
 		MockRefactoringDescriptor third= new MockRefactoringDescriptor("test0", "Yet another mock refactoring", null, RefactoringDescriptor.BREAKING_CHANGE | RefactoringDescriptor.MULTI_CHANGE);
 		Map<String, String> arguments= third.getArguments();
@@ -163,13 +191,20 @@ public class RefactoringHistorySerializationTests {
 		try {
 			compareReadHistory(new RefactoringDescriptor[] { third}, flags, xml, false);
 		} catch (CoreException exception) {
-			assertEquals("Wrong status code for refactoring history io error:", IRefactoringCoreStatusCodes.REFACTORING_HISTORY_IO_ERROR, exception.getStatus().getCode());
+			assertEquals(IRefactoringCoreStatusCodes.REFACTORING_HISTORY_IO_ERROR, exception.getStatus().getCode(), "Wrong status code for refactoring history io error:");
 		}
 	}
 
 	@Test
 	public void testReadDescriptor12() throws Exception {
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session version=\"1.0\">\n" + "<refactoring arg0=\"value 0\" com ment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "<refactoring arg1=\"value 1\" comment=\"No comment\" description=\"Another mock refactoring\" flags=\"1\" id=\"org.eclipse.ltk.core.mock\" version=\"1.0\"/>\n" + "<refactoring arg2=\"value 2\" description=\"Yet another mock refactoring\" flags=\"5\" id=\"org.eclipse.ltk.core.mock\" project=\"test0\" version=\"1.1\"/>\n" + "</session>\n" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session version="1.0">
+				<refactoring arg0="value 0" com ment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				<refactoring arg1="value 1" comment="No comment" description="Another mock refactoring" flags="1" id="org.eclipse.ltk.core.mock" version="1.0"/>
+				<refactoring arg2="value 2" description="Yet another mock refactoring" flags="5" id="org.eclipse.ltk.core.mock" project="test0" version="1.1"/>
+				</session>
+				""";
 		int flags= RefactoringDescriptor.MULTI_CHANGE;
 		MockRefactoringDescriptor third= new MockRefactoringDescriptor("test0", "Yet another mock refactoring", null, RefactoringDescriptor.BREAKING_CHANGE | RefactoringDescriptor.MULTI_CHANGE);
 		Map<String, String> arguments= third.getArguments();
@@ -178,13 +213,18 @@ public class RefactoringHistorySerializationTests {
 		try {
 			compareReadHistory(new RefactoringDescriptor[] { third}, flags, xml, true);
 		} catch (CoreException exception) {
-			assertEquals("Wrong status code for refactoring history io error:", IRefactoringCoreStatusCodes.REFACTORING_HISTORY_IO_ERROR, exception.getStatus().getCode());
+			assertEquals(IRefactoringCoreStatusCodes.REFACTORING_HISTORY_IO_ERROR, exception.getStatus().getCode(), "Wrong status code for refactoring history io error:");
 		}
 	}
 
 	@Test
 	public void testReadDescriptor2() throws Exception {
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session version=\"1.0\">\n" + "<refactoring arg0=\"value 0\" comment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "</session>\n" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session version="1.0">
+				<refactoring arg0="value 0" comment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				</session>
+				""";
 		int flags= RefactoringDescriptor.NONE;
 		MockRefactoringDescriptor descriptor= new MockRefactoringDescriptor(null, "A mock refactoring", "A mock comment", RefactoringDescriptor.NONE);
 		Map<String, String> arguments= descriptor.getArguments();
@@ -194,7 +234,13 @@ public class RefactoringHistorySerializationTests {
 
 	@Test
 	public void testReadDescriptor3() throws Exception {
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session version=\"1.0\">\n" + "<refactoring arg0=\"value 0\" comment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "<refactoring arg1=\"value 1\" comment=\"No comment\" description=\"Another mock refactoring\" flags=\"1\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "</session>\n" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session version="1.0">
+				<refactoring arg0="value 0" comment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				<refactoring arg1="value 1" comment="No comment" description="Another mock refactoring" flags="1" id="org.eclipse.ltk.core.mock"/>
+				</session>
+				""";
 		int flags= RefactoringDescriptor.NONE;
 		MockRefactoringDescriptor first= new MockRefactoringDescriptor(null, "A mock refactoring", "A mock comment", RefactoringDescriptor.NONE);
 		MockRefactoringDescriptor second= new MockRefactoringDescriptor(null, "Another mock refactoring", "No comment", RefactoringDescriptor.BREAKING_CHANGE);
@@ -207,7 +253,14 @@ public class RefactoringHistorySerializationTests {
 
 	@Test
 	public void testReadDescriptor4() throws Exception {
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session version=\"1.0\">\n" + "<refactoring arg0=\"value 0\" comment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "<refactoring arg1=\"value 1\" comment=\"No comment\" description=\"Another mock refactoring\" flags=\"1\" id=\"org.eclipse.ltk.core.mock\" version=\"1.0\"/>\n" + "<refactoring arg2=\"value 2\" description=\"Yet another mock refactoring\" flags=\"5\" id=\"org.eclipse.ltk.core.mock\" project=\"test0\" version=\"1.1\"/>\n" + "</session>\n" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session version="1.0">
+				<refactoring arg0="value 0" comment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				<refactoring arg1="value 1" comment="No comment" description="Another mock refactoring" flags="1" id="org.eclipse.ltk.core.mock" version="1.0"/>
+				<refactoring arg2="value 2" description="Yet another mock refactoring" flags="5" id="org.eclipse.ltk.core.mock" project="test0" version="1.1"/>
+				</session>
+				""";
 		int flags= RefactoringDescriptor.NONE;
 		MockRefactoringDescriptor first= new MockRefactoringDescriptor(null, "A mock refactoring", "A mock comment", RefactoringDescriptor.NONE);
 		MockRefactoringDescriptor second= new MockRefactoringDescriptor(null, "Another mock refactoring", "No comment", RefactoringDescriptor.BREAKING_CHANGE);
@@ -225,7 +278,14 @@ public class RefactoringHistorySerializationTests {
 
 	@Test
 	public void testReadDescriptor5() throws Exception {
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session version=\"1.0\">\n" + "<refactoring arg0=\"value 0\" comment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "<refactoring arg1=\"value 1\" comment=\"No comment\" description=\"Another mock refactoring\" flags=\"1\" id=\"org.eclipse.ltk.core.mock\" version=\"1.0\"/>\n" + "<refactoring arg2=\"value 2\" description=\"Yet another mock refactoring\" flags=\"5\" id=\"org.eclipse.ltk.core.mock\" project=\"test0\" version=\"1.1\"/>\n" + "</session>\n" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session version="1.0">
+				<refactoring arg0="value 0" comment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				<refactoring arg1="value 1" comment="No comment" description="Another mock refactoring" flags="1" id="org.eclipse.ltk.core.mock" version="1.0"/>
+				<refactoring arg2="value 2" description="Yet another mock refactoring" flags="5" id="org.eclipse.ltk.core.mock" project="test0" version="1.1"/>
+				</session>
+				""";
 		int flags= RefactoringDescriptor.BREAKING_CHANGE;
 		MockRefactoringDescriptor second= new MockRefactoringDescriptor(null, "Another mock refactoring", "No comment", RefactoringDescriptor.BREAKING_CHANGE);
 		MockRefactoringDescriptor third= new MockRefactoringDescriptor("test0", "Yet another mock refactoring", null, RefactoringDescriptor.BREAKING_CHANGE | RefactoringDescriptor.MULTI_CHANGE);
@@ -240,7 +300,14 @@ public class RefactoringHistorySerializationTests {
 
 	@Test
 	public void testReadDescriptor6() throws Exception {
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session version=\"1.0\">\n" + "<refactoring arg0=\"value 0\" comment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "<refactoring arg1=\"value 1\" comment=\"No comment\" description=\"Another mock refactoring\" flags=\"1\" id=\"org.eclipse.ltk.core.mock\" version=\"1.0\"/>\n" + "<refactoring arg2=\"value 2\" description=\"Yet another mock refactoring\" flags=\"5\" id=\"org.eclipse.ltk.core.mock\" project=\"test0\" version=\"1.1\"/>\n" + "</session>\n" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session version="1.0">
+				<refactoring arg0="value 0" comment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				<refactoring arg1="value 1" comment="No comment" description="Another mock refactoring" flags="1" id="org.eclipse.ltk.core.mock" version="1.0"/>
+				<refactoring arg2="value 2" description="Yet another mock refactoring" flags="5" id="org.eclipse.ltk.core.mock" project="test0" version="1.1"/>
+				</session>
+				""";
 		int flags= RefactoringDescriptor.MULTI_CHANGE;
 		MockRefactoringDescriptor third= new MockRefactoringDescriptor("test0", "Yet another mock refactoring", null, RefactoringDescriptor.BREAKING_CHANGE | RefactoringDescriptor.MULTI_CHANGE);
 		Map<String, String> arguments= third.getArguments();
@@ -251,7 +318,14 @@ public class RefactoringHistorySerializationTests {
 
 	@Test
 	public void testReadDescriptor7() throws Exception {
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session version=\"3.0\">\n" + "<refactoring arg0=\"value 0\" comment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "<refactoring arg1=\"value 1\" comment=\"No comment\" description=\"Another mock refactoring\" flags=\"1\" id=\"org.eclipse.ltk.core.mock\" version=\"1.0\"/>\n" + "<refactoring arg2=\"value 2\" description=\"Yet another mock refactoring\" flags=\"5\" id=\"org.eclipse.ltk.core.mock\" project=\"test0\" version=\"1.1\"/>\n" + "</session>\n" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session version="3.0">
+				<refactoring arg0="value 0" comment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				<refactoring arg1="value 1" comment="No comment" description="Another mock refactoring" flags="1" id="org.eclipse.ltk.core.mock" version="1.0"/>
+				<refactoring arg2="value 2" description="Yet another mock refactoring" flags="5" id="org.eclipse.ltk.core.mock" project="test0" version="1.1"/>
+				</session>
+				""";
 		int flags= RefactoringDescriptor.MULTI_CHANGE;
 		MockRefactoringDescriptor third= new MockRefactoringDescriptor("test0", "Yet another mock refactoring", null, RefactoringDescriptor.BREAKING_CHANGE | RefactoringDescriptor.MULTI_CHANGE);
 		Map<String, String> arguments= third.getArguments();
@@ -260,13 +334,20 @@ public class RefactoringHistorySerializationTests {
 		try {
 			compareReadHistory(new RefactoringDescriptor[] { third}, flags, xml, false);
 		} catch (CoreException exception) {
-			assertEquals("Wrong status code for unsupported refactoring history version exception:", IRefactoringCoreStatusCodes.UNSUPPORTED_REFACTORING_HISTORY_VERSION, exception.getStatus().getCode());
+			assertEquals(IRefactoringCoreStatusCodes.UNSUPPORTED_REFACTORING_HISTORY_VERSION, exception.getStatus().getCode(), "Wrong status code for unsupported refactoring history version exception:");
 		}
 	}
 
 	@Test
 	public void testReadDescriptor8() throws Exception {
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session>\n" + "<refactoring arg0=\"value 0\" comment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "<refactoring arg1=\"value 1\" comment=\"No comment\" description=\"Another mock refactoring\" flags=\"1\" id=\"org.eclipse.ltk.core.mock\" version=\"1.0\"/>\n" + "<refactoring arg2=\"value 2\" description=\"Yet another mock refactoring\" flags=\"5\" id=\"org.eclipse.ltk.core.mock\" project=\"test0\" version=\"1.1\"/>\n" + "</session>\n" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session>
+				<refactoring arg0="value 0" comment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				<refactoring arg1="value 1" comment="No comment" description="Another mock refactoring" flags="1" id="org.eclipse.ltk.core.mock" version="1.0"/>
+				<refactoring arg2="value 2" description="Yet another mock refactoring" flags="5" id="org.eclipse.ltk.core.mock" project="test0" version="1.1"/>
+				</session>
+				""";
 		int flags= RefactoringDescriptor.MULTI_CHANGE;
 		MockRefactoringDescriptor third= new MockRefactoringDescriptor("test0", "Yet another mock refactoring", null, RefactoringDescriptor.BREAKING_CHANGE | RefactoringDescriptor.MULTI_CHANGE);
 		Map<String, String> arguments= third.getArguments();
@@ -275,13 +356,20 @@ public class RefactoringHistorySerializationTests {
 		try {
 			compareReadHistory(new RefactoringDescriptor[] { third}, flags, xml, false);
 		} catch (CoreException exception) {
-			assertEquals("Wrong status code for missing refactoring history version exception:", IRefactoringCoreStatusCodes.MISSING_REFACTORING_HISTORY_VERSION, exception.getStatus().getCode());
+			assertEquals(IRefactoringCoreStatusCodes.MISSING_REFACTORING_HISTORY_VERSION, exception.getStatus().getCode(), "Wrong status code for missing refactoring history version exception:");
 		}
 	}
 
 	@Test
 	public void testReadDescriptor9() throws Exception {
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<error version=\"1.0\">\n" + "<refactoring arg0=\"value 0\" comment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "<refactoring arg1=\"value 1\" comment=\"No comment\" description=\"Another mock refactoring\" flags=\"1\" id=\"org.eclipse.ltk.core.mock\" version=\"1.0\"/>\n" + "<refactoring arg2=\"value 2\" description=\"Yet another mock refactoring\" flags=\"5\" id=\"org.eclipse.ltk.core.mock\" project=\"test0\" version=\"1.1\"/>\n" + "</error>\n" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<error version="1.0">
+				<refactoring arg0="value 0" comment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				<refactoring arg1="value 1" comment="No comment" description="Another mock refactoring" flags="1" id="org.eclipse.ltk.core.mock" version="1.0"/>
+				<refactoring arg2="value 2" description="Yet another mock refactoring" flags="5" id="org.eclipse.ltk.core.mock" project="test0" version="1.1"/>
+				</error>
+				""";
 		int flags= RefactoringDescriptor.MULTI_CHANGE;
 		MockRefactoringDescriptor third= new MockRefactoringDescriptor("test0", "Yet another mock refactoring", null, RefactoringDescriptor.BREAKING_CHANGE | RefactoringDescriptor.MULTI_CHANGE);
 		Map<String, String> arguments= third.getArguments();
@@ -290,7 +378,7 @@ public class RefactoringHistorySerializationTests {
 		try {
 			compareReadHistory(new RefactoringDescriptor[] { third}, flags, xml, false);
 		} catch (CoreException exception) {
-			assertEquals("Wrong status code for refactoring history format exception:", IRefactoringCoreStatusCodes.REFACTORING_HISTORY_FORMAT_ERROR, exception.getStatus().getCode());
+			assertEquals(IRefactoringCoreStatusCodes.REFACTORING_HISTORY_FORMAT_ERROR, exception.getStatus().getCode(), "Wrong status code for refactoring history format exception:");
 		}
 	}
 
@@ -304,7 +392,11 @@ public class RefactoringHistorySerializationTests {
 		String version= "1.0";
 		String comment= "A mock comment";
 		RefactoringSessionDescriptor session= new RefactoringSessionDescriptor(new RefactoringDescriptor[] { descriptor}, version, comment);
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session comment=\"A mock comment\" version=\"1.0\">\n" + "<refactoring arg0=\"value0\" arg1=\"value1\" arg2=\"value2\" comment=\"A mock comment\" description=\"A mock refactoring\" flags=\"3\" id=\"org.eclipse.ltk.core.mock\" project=\"test0\"/>\n" + "</session>" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session comment="A mock comment" version="1.0">
+				<refactoring arg0="value0" arg1="value1" arg2="value2" comment="A mock comment" description="A mock refactoring" flags="3" id="org.eclipse.ltk.core.mock" project="test0"/>
+				</session>""";
 		compareWrittenDescriptor(session, true, xml);
 	}
 
@@ -318,7 +410,11 @@ public class RefactoringHistorySerializationTests {
 		String version= "2.0";
 		String comment= "A mock comment";
 		RefactoringSessionDescriptor session= new RefactoringSessionDescriptor(new RefactoringDescriptor[] { descriptor}, version, comment);
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session comment=\"A mock comment\" version=\"2.0\">\n" + "<refactoring arg0=\"value 0\" arg1=\"value 1\" arg2=\"value 2\" comment=\"A mock comment\" description=\"A mock refactoring\" flags=\"6\" id=\"org.eclipse.ltk.core.mock\" project=\"test1\"/>\n" + "</session>" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session comment="A mock comment" version="2.0">
+				<refactoring arg0="value 0" arg1="value 1" arg2="value 2" comment="A mock comment" description="A mock refactoring" flags="6" id="org.eclipse.ltk.core.mock" project="test1"/>
+				</session>""";
 		compareWrittenDescriptor(session, true, xml);
 	}
 
@@ -330,7 +426,11 @@ public class RefactoringHistorySerializationTests {
 		String version= "2.0";
 		String comment= null;
 		RefactoringSessionDescriptor session= new RefactoringSessionDescriptor(new RefactoringDescriptor[] { descriptor}, version, comment);
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session version=\"2.0\">\n" + "<refactoring arg0=\"value 0\" comment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "</session>" ;
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session version="2.0">
+				<refactoring arg0="value 0" comment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				</session>""";
 		compareWrittenDescriptor(session, true, xml);
 	}
 
@@ -345,7 +445,12 @@ public class RefactoringHistorySerializationTests {
 		String version= "1.0";
 		String comment= null;
 		RefactoringSessionDescriptor session= new RefactoringSessionDescriptor(new RefactoringDescriptor[] { first, second}, version, comment);
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session version=\"1.0\">\n" + "<refactoring arg0=\"value 0\" comment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "<refactoring arg1=\"value 1\" comment=\"No comment\" description=\"Another mock refactoring\" flags=\"1\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "</session>" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session version="1.0">
+				<refactoring arg0="value 0" comment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				<refactoring arg1="value 1" comment="No comment" description="Another mock refactoring" flags="1" id="org.eclipse.ltk.core.mock"/>
+				</session>""";
 		compareWrittenDescriptor(session, false, xml);
 	}
 
@@ -365,7 +470,13 @@ public class RefactoringHistorySerializationTests {
 		String version= "3.0";
 		String comment= null;
 		RefactoringSessionDescriptor session= new RefactoringSessionDescriptor(new RefactoringDescriptor[] { first, second, third}, version, comment);
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session version=\"3.0\">\n" + "<refactoring arg0=\"value 0\" comment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "<refactoring arg1=\"value 1\" comment=\"No comment\" description=\"Another mock refactoring\" flags=\"1\" id=\"org.eclipse.ltk.core.mock\" version=\"1.0\"/>\n" + "<refactoring arg2=\"value 2\" description=\"Yet another mock refactoring\" flags=\"5\" id=\"org.eclipse.ltk.core.mock\" project=\"test0\" version=\"1.1\"/>\n" + "</session>" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session version="3.0">
+				<refactoring arg0="value 0" comment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				<refactoring arg1="value 1" comment="No comment" description="Another mock refactoring" flags="1" id="org.eclipse.ltk.core.mock" version="1.0"/>
+				<refactoring arg2="value 2" description="Yet another mock refactoring" flags="5" id="org.eclipse.ltk.core.mock" project="test0" version="1.1"/>
+				</session>""";
 		compareWrittenDescriptor(session, true, xml);
 	}
 
@@ -385,11 +496,17 @@ public class RefactoringHistorySerializationTests {
 		String version= "3.0";
 		String comment= null;
 		RefactoringSessionDescriptor session= new RefactoringSessionDescriptor(new RefactoringDescriptor[] { first, second, third}, version, comment);
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session version=\"3.0\">\n" + "<refactoring arg0=\"value 0\" comment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "<refactoring arg1=\"value 1\" comment=\"No comment\" description=\"Another mock refactoring\" flags=\"1\" id=\"org.eclipse.ltk.core.mock\" version=\"1.0\"/>\n" + "<refactoring arg2=\"value 2\" description=\"Yet another mock refactoring\" flags=\"5\" id=\"org.eclipse.ltk.core.mock\" project=\"test0\" version=\"1.1\"/>\n" + "</session>" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session version="3.0">
+				<refactoring arg0="value 0" comment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				<refactoring arg1="value 1" comment="No comment" description="Another mock refactoring" flags="1" id="org.eclipse.ltk.core.mock" version="1.0"/>
+				<refactoring arg2="value 2" description="Yet another mock refactoring" flags="5" id="org.eclipse.ltk.core.mock" project="test0" version="1.1"/>
+				</session>""";
 		try {
 			compareWrittenDescriptor(session, true, xml);
 		} catch (CoreException exception) {
-			assertEquals("Wrong status code for refactoring history format exception:", IRefactoringCoreStatusCodes.REFACTORING_HISTORY_FORMAT_ERROR, exception.getStatus().getCode());
+			assertEquals(IRefactoringCoreStatusCodes.REFACTORING_HISTORY_FORMAT_ERROR, exception.getStatus().getCode(), "Wrong status code for refactoring history format exception:");
 		}
 	}
 
@@ -409,11 +526,17 @@ public class RefactoringHistorySerializationTests {
 		String version= "3.0";
 		String comment= null;
 		RefactoringSessionDescriptor session= new RefactoringSessionDescriptor(new RefactoringDescriptor[] { first, second, third}, version, comment);
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session version=\"3.0\">\n" + "<refactoring arg0=\"value 0\" comment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "<refactoring arg1=\"value 1\" comment=\"No comment\" description=\"Another mock refactoring\" flags=\"1\" id=\"org.eclipse.ltk.core.mock\" version=\"1.0\"/>\n" + "<refactoring arg2=\"value 2\" description=\"Yet another mock refactoring\" flags=\"5\" id=\"org.eclipse.ltk.core.mock\" project=\"test0\" version=\"1.1\"/>\n" + "</session>" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session version="3.0">
+				<refactoring arg0="value 0" comment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				<refactoring arg1="value 1" comment="No comment" description="Another mock refactoring" flags="1" id="org.eclipse.ltk.core.mock" version="1.0"/>
+				<refactoring arg2="value 2" description="Yet another mock refactoring" flags="5" id="org.eclipse.ltk.core.mock" project="test0" version="1.1"/>
+				</session>""";
 		try {
 			compareWrittenDescriptor(session, true, xml);
 		} catch (CoreException exception) {
-			assertEquals("Wrong status code for refactoring history format exception:", IRefactoringCoreStatusCodes.REFACTORING_HISTORY_FORMAT_ERROR, exception.getStatus().getCode());
+			assertEquals(IRefactoringCoreStatusCodes.REFACTORING_HISTORY_FORMAT_ERROR, exception.getStatus().getCode(), "Wrong status code for refactoring history format exception:");
 		}
 	}
 
@@ -433,11 +556,17 @@ public class RefactoringHistorySerializationTests {
 		String version= "3.0";
 		String comment= null;
 		RefactoringSessionDescriptor session= new RefactoringSessionDescriptor(new RefactoringDescriptor[] { first, second, third}, version, comment);
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session version=\"3.0\">\n" + "<refactoring arg0=\"value 0\" comment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "<refactoring arg1=\"value 1\" comment=\"No comment\" description=\"Another mock refactoring\" flags=\"1\" id=\"org.eclipse.ltk.core.mock\" version=\"1.0\"/>\n" + "<refactoring arg2=\"value 2\" description=\"Yet another mock refactoring\" flags=\"5\" id=\"org.eclipse.ltk.core.mock\" project=\"test0\" version=\"1.1\"/>\n" + "</session>" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session version="3.0">
+				<refactoring arg0="value 0" comment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				<refactoring arg1="value 1" comment="No comment" description="Another mock refactoring" flags="1" id="org.eclipse.ltk.core.mock" version="1.0"/>
+				<refactoring arg2="value 2" description="Yet another mock refactoring" flags="5" id="org.eclipse.ltk.core.mock" project="test0" version="1.1"/>
+				</session>""";
 		try {
 			compareWrittenDescriptor(session, true, xml);
 		} catch (CoreException exception) {
-			assertEquals("Wrong status code for refactoring history format exception:", IRefactoringCoreStatusCodes.REFACTORING_HISTORY_FORMAT_ERROR, exception.getStatus().getCode());
+			assertEquals(IRefactoringCoreStatusCodes.REFACTORING_HISTORY_FORMAT_ERROR, exception.getStatus().getCode(), "Wrong status code for refactoring history format exception:");
 		}
 	}
 
@@ -457,7 +586,13 @@ public class RefactoringHistorySerializationTests {
 		String version= "3.0";
 		String comment= null;
 		RefactoringSessionDescriptor session= new RefactoringSessionDescriptor(new RefactoringDescriptor[] { first, second, third}, version, comment);
-		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<session version=\"3.0\">\n" + "<refactoring arg0=\"\" comment=\"A mock comment\" description=\"A mock refactoring\" id=\"org.eclipse.ltk.core.mock\"/>\n" + "<refactoring arg1=\"value 1\" comment=\"No comment\" description=\"Another mock refactoring\" flags=\"1\" id=\"org.eclipse.ltk.core.mock\" version=\"1.0\"/>\n" + "<refactoring arg2=\"value 2\" description=\"Yet another mock refactoring\" flags=\"5\" id=\"org.eclipse.ltk.core.mock\" project=\"test0\" version=\"1.1\"/>\n" + "</session>" + "";
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<session version="3.0">
+				<refactoring arg0="" comment="A mock comment" description="A mock refactoring" id="org.eclipse.ltk.core.mock"/>
+				<refactoring arg1="value 1" comment="No comment" description="Another mock refactoring" flags="1" id="org.eclipse.ltk.core.mock" version="1.0"/>
+				<refactoring arg2="value 2" description="Yet another mock refactoring" flags="5" id="org.eclipse.ltk.core.mock" project="test0" version="1.1"/>
+				</session>""";
 		compareWrittenDescriptor(session, true, xml);
 	}
 

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/history/RefactoringHistoryServiceTests.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/history/RefactoringHistoryServiceTests.java
@@ -13,21 +13,21 @@
  *******************************************************************************/
 package org.eclipse.ltk.core.refactoring.tests.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.osgi.service.prefs.BackingStoreException;
 
 import org.eclipse.core.runtime.CoreException;
@@ -60,24 +60,24 @@ public class RefactoringHistoryServiceTests {
 		private RefactoringExecutionEvent fLastEvent= null;
 
 		public void assertEventDescriptor(RefactoringDescriptorProxyAdapter expected) throws Exception {
-			assertNotNull("No refactoring history event has been recorded", fLastEvent);
+			assertNotNull(fLastEvent, "No refactoring history event has been recorded");
 			RefactoringDescriptor expectedDescriptor= expected.requestDescriptor(null);
-			assertNotNull("Could not resolve expected refactoring descriptor", expectedDescriptor);
+			assertNotNull(expectedDescriptor, "Could not resolve expected refactoring descriptor");
 			expectedDescriptor.setTimeStamp(fLastEvent.getDescriptor().getTimeStamp());
-			assertEquals("Wrong refactoring descriptor proxy in refactoring history event:", expected, fLastEvent.getDescriptor());
+			assertEquals(expected, fLastEvent.getDescriptor(), "Wrong refactoring descriptor proxy in refactoring history event:");
 			RefactoringDescriptor actualDescriptor= fLastEvent.getDescriptor().requestDescriptor(null);
-			assertNotNull("Could not resolve actual refactoring descriptor", actualDescriptor);
-			assertEquals("Resolved refactoring descriptors are not equal:", expectedDescriptor, actualDescriptor);
+			assertNotNull(actualDescriptor, "Could not resolve actual refactoring descriptor");
+			assertEquals(expectedDescriptor, actualDescriptor, "Resolved refactoring descriptors are not equal:");
 		}
 
 		public void assertEventSource(IRefactoringHistoryService expected) throws Exception {
-			assertNotNull("No refactoring history event has been recorded", fLastEvent);
-			assertSame("Wrong refactoring history service in refactoring history event:", expected, fLastEvent.getHistoryService());
+			assertNotNull(fLastEvent, "No refactoring history event has been recorded");
+			assertSame(expected, fLastEvent.getHistoryService(), "Wrong refactoring history service in refactoring history event:");
 		}
 
 		public void assertEventType(int expected) throws Exception {
-			assertNotNull("No refactoring history event has been recorded", fLastEvent);
-			assertEquals("Wrong refactoring history event type:", expected, fLastEvent.getEventType());
+			assertNotNull(fLastEvent, "No refactoring history event has been recorded");
+			assertEquals(expected, fLastEvent.getEventType(), "Wrong refactoring history event type:");
 		}
 
 		public void connect() {
@@ -96,13 +96,13 @@ public class RefactoringHistoryServiceTests {
 			int previous= fLastEvent != null ? fLastEvent.getEventType() : -1;
 			switch (event.getEventType()) {
 				case RefactoringExecutionEvent.PERFORMED:
-					assertEquals("Previous event should be ABOUT_TO_PERFORM", RefactoringExecutionEvent.ABOUT_TO_PERFORM, previous);
+					assertEquals(RefactoringExecutionEvent.ABOUT_TO_PERFORM, previous, "Previous event should be ABOUT_TO_PERFORM");
 					break;
 				case RefactoringExecutionEvent.REDONE:
-					assertEquals("Previous event should be ABOUT_TO_REDO", RefactoringExecutionEvent.ABOUT_TO_REDO, previous);
+					assertEquals(RefactoringExecutionEvent.ABOUT_TO_REDO, previous, "Previous event should be ABOUT_TO_REDO");
 					break;
 				case RefactoringExecutionEvent.UNDONE:
-					assertEquals("Previous event should be ABOUT_TO_UNDO", RefactoringExecutionEvent.ABOUT_TO_UNDO, previous);
+					assertEquals(RefactoringExecutionEvent.ABOUT_TO_UNDO, previous, "Previous event should be ABOUT_TO_UNDO");
 					break;
 			}
 			fLastEvent= event;
@@ -114,24 +114,24 @@ public class RefactoringHistoryServiceTests {
 		private RefactoringHistoryEvent fLastEvent= null;
 
 		public void assertEventDescriptor(RefactoringDescriptorProxyAdapter expected) throws Exception {
-			assertNotNull("No refactoring history event has been recorded", fLastEvent);
+			assertNotNull(fLastEvent, "No refactoring history event has been recorded");
 			RefactoringDescriptor expectedDescriptor= expected.requestDescriptor(null);
-			assertNotNull("Could not resolve expected refactoring descriptor", expectedDescriptor);
+			assertNotNull(expectedDescriptor, "Could not resolve expected refactoring descriptor");
 			expectedDescriptor.setTimeStamp(fLastEvent.getDescriptor().getTimeStamp());
-			assertEquals("Wrong refactoring descriptor proxy in refactoring history event:", expected, fLastEvent.getDescriptor());
+			assertEquals(expected, fLastEvent.getDescriptor(), "Wrong refactoring descriptor proxy in refactoring history event:");
 			RefactoringDescriptor actualDescriptor= fLastEvent.getDescriptor().requestDescriptor(null);
-			assertNotNull("Could not resolve actual refactoring descriptor", actualDescriptor);
-			assertEquals("Resolved refactoring descriptors are not equal:", expectedDescriptor, actualDescriptor);
+			assertNotNull(actualDescriptor, "Could not resolve actual refactoring descriptor");
+			assertEquals(expectedDescriptor, actualDescriptor, "Resolved refactoring descriptors are not equal:");
 		}
 
 		public void assertEventSource(IRefactoringHistoryService expected) throws Exception {
-			assertNotNull("No refactoring history event has been recorded", fLastEvent);
-			assertSame("Wrong refactoring history service in refactoring history event:", expected, fLastEvent.getHistoryService());
+			assertNotNull(fLastEvent, "No refactoring history event has been recorded");
+			assertSame(expected, fLastEvent.getHistoryService(), "Wrong refactoring history service in refactoring history event:");
 		}
 
 		public void assertEventType(int expected) throws Exception {
-			assertNotNull("No refactoring history event has been recorded", fLastEvent);
-			assertEquals("Wrong refactoring history event type:", expected, fLastEvent.getEventType());
+			assertNotNull(fLastEvent, "No refactoring history event has been recorded");
+			assertEquals(expected, fLastEvent.getEventType(), "Wrong refactoring history event type:");
 		}
 
 		public void connect() {
@@ -172,7 +172,7 @@ public class RefactoringHistoryServiceTests {
 
 	private void assertDescendingSortOrder(RefactoringDescriptorProxy[] proxies) {
 		for (int index= 0; index < proxies.length - 1; index++)
-			assertTrue("", proxies[index].getTimeStamp() > proxies[index + 1].getTimeStamp());
+			assertTrue(proxies[index].getTimeStamp() > proxies[index + 1].getTimeStamp(), "");
 	}
 
 	private RefactoringDescriptor executeRefactoring(String project, int index, int flags) throws CoreException {
@@ -196,17 +196,20 @@ public class RefactoringHistoryServiceTests {
 		RefactoringHistoryService.setSharedRefactoringHistory(fProject.getProject(), shared, null);
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		final RefactoringHistoryService service= RefactoringHistoryService.getInstance();
 		service.connect();
 		fProject= new SimpleTestProject();
+		RefactoringHistory history= service.getWorkspaceHistory(null);
+		service.deleteRefactoringDescriptors(history.getDescriptors(), null);
 		setSharedRefactoringHistory(true);
-		assertTrue("Refactoring history should be shared", RefactoringHistoryService.hasSharedRefactoringHistory(fProject.getProject()));
+		assertTrue(RefactoringHistoryService.hasSharedRefactoringHistory(fProject.getProject()), "Refactoring history should be shared");
 		IFolder folder= fProject.getProject().getFolder(RefactoringHistoryService.NAME_HISTORY_FOLDER);
-		assertFalse("Refactoring history folder should not exist.", folder.exists());
+		assertFalse(folder.exists(), "Refactoring history folder should not exist.");
+		service.deleteRefactoringHistory(fProject.getProject(), null);
 		setUpTestProjectRefactorings();
-		assertTrue("Refactoring history folder should exist", folder.exists());
+		assertTrue(folder.exists(), "Refactoring history folder should exist");
 	}
 
 	private void setUpTestProjectRefactorings() throws CoreException {
@@ -228,14 +231,14 @@ public class RefactoringHistoryServiceTests {
 			executeRefactoring(null, index + TOTAL_PROJECT_NUMBER, RefactoringDescriptor.BREAKING_CHANGE);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		final RefactoringHistoryService service= RefactoringHistoryService.getInstance();
 		service.deleteRefactoringHistory(fProject.getProject(), null);
 		RefactoringHistory history= service.getWorkspaceHistory(null);
 		service.deleteRefactoringDescriptors(history.getDescriptors(), null);
 		history= service.getWorkspaceHistory(null);
-		assertTrue("Refactoring history must be empty", history.isEmpty());
+		assertTrue(history.isEmpty(), "Refactoring history must be empty");
 		service.disconnect();
 		fProject.delete();
 	}
@@ -247,12 +250,12 @@ public class RefactoringHistoryServiceTests {
 		final RefactoringHistoryService service= RefactoringHistoryService.getInstance();
 		service.deleteRefactoringHistory(project, null);
 		RefactoringHistory projectHistory= service.getProjectHistory(project, null);
-		assertEquals("Refactoring history has wrong size:", COMMON_NUMBER, projectHistory.getDescriptors().length);
+		assertEquals(COMMON_NUMBER, projectHistory.getDescriptors().length, "Refactoring history has wrong size:");
 		RefactoringHistory workspaceHistory= service.getWorkspaceHistory(null);
 		final RefactoringDescriptorProxy[] descriptors= workspaceHistory.getDescriptors();
-		assertEquals("Refactoring history has wrong size:", COMMON_NUMBER, descriptors.length);
+		assertEquals(COMMON_NUMBER, descriptors.length, "Refactoring history has wrong size:");
 		for (RefactoringDescriptorProxy descriptor : descriptors) {
-			assertNull("Workspace refactoring should have no project attribute set:\n\n" + descriptor.toString(), descriptor.getProject());
+			assertNull(descriptor.getProject(), "Workspace refactoring should have no project attribute set:\n\n" + descriptor.toString());
 		}
 	}
 
@@ -271,12 +274,12 @@ public class RefactoringHistoryServiceTests {
 		service.deleteRefactoringDescriptors(set.toArray(new RefactoringDescriptorProxy[set.size()]), null);
 		workspaceHistory= service.getWorkspaceHistory(null);
 		RefactoringHistory projectHistory= service.getProjectHistory(project, null);
-		assertEquals("Refactoring history should be the same:", projectHistory, workspaceHistory);
+		assertEquals(projectHistory, workspaceHistory, "Refactoring history should be the same:");
 		service.deleteRefactoringHistory(project, null);
 		projectHistory= service.getProjectHistory(project, null);
-		assertTrue("Refactoring history should be empty", projectHistory.isEmpty());
+		assertTrue(projectHistory.isEmpty(), "Refactoring history should be empty");
 		workspaceHistory= service.getWorkspaceHistory(null);
-		assertTrue("Refactoring history should be empty", workspaceHistory.isEmpty());
+		assertTrue(workspaceHistory.isEmpty(), "Refactoring history should be empty");
 	}
 
 	@Test
@@ -284,13 +287,13 @@ public class RefactoringHistoryServiceTests {
 		final IProject project= fProject.getProject();
 		final RefactoringHistoryService service= RefactoringHistoryService.getInstance();
 		RefactoringHistory projectHistory= service.getProjectHistory(project, null);
-		assertFalse("Refactoring history should not be empty", projectHistory.isEmpty());
+		assertFalse(projectHistory.isEmpty(), "Refactoring history should not be empty");
 		service.deleteRefactoringDescriptors(projectHistory.getDescriptors(), null);
 		projectHistory= service.getProjectHistory(project, null);
 		projectHistory= service.getProjectHistory(project, null);
-		assertTrue("Refactoring history should be empty", projectHistory.isEmpty());
+		assertTrue(projectHistory.isEmpty(), "Refactoring history should be empty");
 		RefactoringHistory workspaceHistory= service.getWorkspaceHistory(null);
-		assertTrue("Refactoring history should be empty", workspaceHistory.isEmpty());
+		assertTrue(workspaceHistory.isEmpty(), "Refactoring history should be empty");
 	}
 
 	@Test
@@ -299,10 +302,10 @@ public class RefactoringHistoryServiceTests {
 		final RefactoringHistoryService service= RefactoringHistoryService.getInstance();
 		RefactoringHistory workspaceHistory= service.getWorkspaceHistory(null);
 		RefactoringHistory projectHistory= service.getProjectHistory(project, 0, Long.MAX_VALUE, RefactoringDescriptor.BREAKING_CHANGE, null);
-		assertFalse("Refactoring history should not be empty", projectHistory.isEmpty());
+		assertFalse(projectHistory.isEmpty(), "Refactoring history should not be empty");
 		service.deleteRefactoringDescriptors(projectHistory.getDescriptors(), null);
 		RefactoringHistory afterHistory= service.getWorkspaceHistory(null);
-		assertEquals("", afterHistory.getDescriptors().length + BREAKING_NUMBER, workspaceHistory.getDescriptors().length);
+		assertEquals(afterHistory.getDescriptors().length + BREAKING_NUMBER, workspaceHistory.getDescriptors().length, "");
 	}
 
 	@Test
@@ -324,14 +327,13 @@ public class RefactoringHistoryServiceTests {
 			executionListener.assertEventType(RefactoringExecutionEvent.PERFORMED);
 			RefactoringHistory nextWorkspaceHistory= service.getWorkspaceHistory(null);
 			RefactoringHistory nextProjectHistory= service.getProjectHistory(fProject.getProject(), null);
-			assertNotSame("Refactoring history should not be the same:", previousProjectHistory, nextProjectHistory);
-			assertNotSame("Refactoring history should not be the same:", previousWorkspaceHistory, nextWorkspaceHistory);
-			assertEquals("Length of refactoring history should be one more:", previousProjectHistory.getDescriptors().length + 1, nextProjectHistory.getDescriptors().length);
-			assertEquals("Length of refactoring history should be one more:", previousWorkspaceHistory.getDescriptors().length + 1, nextWorkspaceHistory.getDescriptors().length);
-			assertEquals("Refactoring history should be the same:", nextProjectHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), previousProjectHistory);
-			assertEquals("Refactoring history should be the same:", nextWorkspaceHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), previousWorkspaceHistory);
-			RefactoringCore.getUndoManager().performUndo(null, null);
-			historyListener.assertEventDescriptor(new RefactoringDescriptorProxyAdapter(descriptor));
+			assertNotSame(previousProjectHistory, nextProjectHistory, "Refactoring history should not be the same:");
+			assertNotSame(previousWorkspaceHistory, nextWorkspaceHistory, "Refactoring history should not be the same:");
+			assertEquals(previousProjectHistory.getDescriptors().length + 1, nextProjectHistory.getDescriptors().length, "Length of refactoring history should be one more:");
+			            assertEquals(previousWorkspaceHistory.getDescriptors().length + 1, nextWorkspaceHistory.getDescriptors().length, "Length of refactoring history should be one more:");
+			            assertEquals(previousProjectHistory, nextProjectHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), "Refactoring history should be the same:");
+			            assertEquals(previousWorkspaceHistory, nextWorkspaceHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), "Refactoring history should be the same:");
+			            RefactoringCore.getUndoManager().performUndo(null, null);			historyListener.assertEventDescriptor(new RefactoringDescriptorProxyAdapter(descriptor));
 			historyListener.assertEventSource(service);
 			historyListener.assertEventType(RefactoringHistoryEvent.POPPED);
 			executionListener.assertEventDescriptor(new RefactoringDescriptorProxyAdapter(descriptor));
@@ -346,12 +348,12 @@ public class RefactoringHistoryServiceTests {
 			executionListener.assertEventType(RefactoringExecutionEvent.REDONE);
 			nextWorkspaceHistory= service.getWorkspaceHistory(null);
 			nextProjectHistory= service.getProjectHistory(fProject.getProject(), null);
-			assertNotSame("Refactoring history should not be the same:", previousProjectHistory, nextProjectHistory);
-			assertNotSame("Refactoring history should not be the same:", previousWorkspaceHistory, nextWorkspaceHistory);
-			assertEquals("Length of refactoring history should be one more:", previousProjectHistory.getDescriptors().length + 1, nextProjectHistory.getDescriptors().length);
-			assertEquals("Length of refactoring history should be one more:", previousWorkspaceHistory.getDescriptors().length + 1, nextWorkspaceHistory.getDescriptors().length);
-			assertEquals("Refactoring history should be the same", nextProjectHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), previousProjectHistory);
-			assertEquals("Refactoring history should be the same", nextWorkspaceHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), previousWorkspaceHistory);
+			assertNotSame(previousProjectHistory, nextProjectHistory, "Refactoring history should not be the same:");
+			assertNotSame(previousWorkspaceHistory, nextWorkspaceHistory, "Refactoring history should not be the same:");
+			assertEquals(previousProjectHistory.getDescriptors().length + 1, nextProjectHistory.getDescriptors().length, "Length of refactoring history should be one more:");
+			assertEquals(previousWorkspaceHistory.getDescriptors().length + 1, nextWorkspaceHistory.getDescriptors().length, "Length of refactoring history should be one more:");
+			assertEquals(previousProjectHistory, nextProjectHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), "Refactoring history should be the same");
+			assertEquals(previousWorkspaceHistory, nextWorkspaceHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), "Refactoring history should be the same");
 		} finally {
 			historyListener.disconnect();
 			executionListener.disconnect();
@@ -384,12 +386,12 @@ public class RefactoringHistoryServiceTests {
 			executionListener.assertEventType(RefactoringExecutionEvent.PERFORMED);
 			RefactoringHistory nextWorkspaceHistory= service.getWorkspaceHistory(null);
 			RefactoringHistory nextProjectHistory= service.getProjectHistory(fProject.getProject(), null);
-			assertNotSame("Refactoring history should not be the same:", previousProjectHistory, nextProjectHistory);
-			assertNotSame("Refactoring history should not be the same:", previousWorkspaceHistory, nextWorkspaceHistory);
-			assertEquals("Length of refactoring history should be one more:", previousProjectHistory.getDescriptors().length + 2, nextProjectHistory.getDescriptors().length);
-			assertEquals("Length of refactoring history should be one more:", previousWorkspaceHistory.getDescriptors().length + 2, nextWorkspaceHistory.getDescriptors().length);
-			assertEquals("Refactoring history should be the same:", nextProjectHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(firstDescriptor), new RefactoringDescriptorProxyAdapter(secondDescriptor)})), previousProjectHistory);
-			assertEquals("Refactoring history should be the same:", nextWorkspaceHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(firstDescriptor), new RefactoringDescriptorProxyAdapter(secondDescriptor)})), previousWorkspaceHistory);
+			assertNotSame(previousProjectHistory, nextProjectHistory, "Refactoring history should not be the same:");
+			assertNotSame(previousWorkspaceHistory, nextWorkspaceHistory, "Refactoring history should not be the same:");
+			assertEquals(previousProjectHistory.getDescriptors().length + 2, nextProjectHistory.getDescriptors().length, "Length of refactoring history should be one more:");
+			assertEquals(previousWorkspaceHistory.getDescriptors().length + 2, nextWorkspaceHistory.getDescriptors().length, "Length of refactoring history should be one more:");
+			assertEquals(previousProjectHistory, nextProjectHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(firstDescriptor), new RefactoringDescriptorProxyAdapter(secondDescriptor)})), "Refactoring history should be the same:");
+			assertEquals(previousWorkspaceHistory, nextWorkspaceHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(firstDescriptor), new RefactoringDescriptorProxyAdapter(secondDescriptor)})), "Refactoring history should be the same:");
 			RefactoringCore.getUndoManager().performUndo(null, null);
 			historyListener.assertEventDescriptor(new RefactoringDescriptorProxyAdapter(secondDescriptor));
 			historyListener.assertEventSource(service);
@@ -420,12 +422,12 @@ public class RefactoringHistoryServiceTests {
 			executionListener.assertEventType(RefactoringExecutionEvent.REDONE);
 			nextWorkspaceHistory= service.getWorkspaceHistory(null);
 			nextProjectHistory= service.getProjectHistory(fProject.getProject(), null);
-			assertNotSame("Refactoring history should not be the same:", previousProjectHistory, nextProjectHistory);
-			assertNotSame("Refactoring history should not be the same:", previousWorkspaceHistory, nextWorkspaceHistory);
-			assertEquals("Length of refactoring history should be one more:", previousProjectHistory.getDescriptors().length + 2, nextProjectHistory.getDescriptors().length);
-			assertEquals("Length of refactoring history should be one more:", previousWorkspaceHistory.getDescriptors().length + 2, nextWorkspaceHistory.getDescriptors().length);
-			assertEquals("Refactoring history should be the same", nextProjectHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(firstDescriptor), new RefactoringDescriptorProxyAdapter(secondDescriptor)})), previousProjectHistory);
-			assertEquals("Refactoring history should be the same", nextWorkspaceHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(firstDescriptor), new RefactoringDescriptorProxyAdapter(secondDescriptor)})), previousWorkspaceHistory);
+			assertNotSame(previousProjectHistory, nextProjectHistory, "Refactoring history should not be the same:");
+			assertNotSame(previousWorkspaceHistory, nextWorkspaceHistory, "Refactoring history should not be the same:");
+			assertEquals(previousProjectHistory.getDescriptors().length + 2, nextProjectHistory.getDescriptors().length, "Length of refactoring history should be one more:");
+			assertEquals(previousWorkspaceHistory.getDescriptors().length + 2, nextWorkspaceHistory.getDescriptors().length, "Length of refactoring history should be one more:");
+			assertEquals(previousProjectHistory, nextProjectHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(firstDescriptor), new RefactoringDescriptorProxyAdapter(secondDescriptor)})), "Refactoring history should be the same");
+			assertEquals(previousWorkspaceHistory, nextWorkspaceHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(firstDescriptor), new RefactoringDescriptorProxyAdapter(secondDescriptor)})), "Refactoring history should be the same");
 		} finally {
 			historyListener.disconnect();
 			executionListener.disconnect();
@@ -451,12 +453,12 @@ public class RefactoringHistoryServiceTests {
 			executionListener.assertEventType(RefactoringExecutionEvent.PERFORMED);
 			RefactoringHistory nextWorkspaceHistory= service.getWorkspaceHistory(null);
 			RefactoringHistory nextProjectHistory= service.getProjectHistory(fProject.getProject(), null);
-			assertNotSame("Refactoring history should not be the same:", previousProjectHistory, nextProjectHistory);
-			assertNotSame("Refactoring history should not be the same:", previousWorkspaceHistory, nextWorkspaceHistory);
-			assertEquals("Length of refactoring history should be one more:", previousProjectHistory.getDescriptors().length + 1, nextProjectHistory.getDescriptors().length);
-			assertEquals("Length of refactoring history should be one more:", previousWorkspaceHistory.getDescriptors().length + 1, nextWorkspaceHistory.getDescriptors().length);
-			assertEquals("Refactoring history should be the same:", nextProjectHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), previousProjectHistory);
-			assertEquals("Refactoring history should be the same:", nextWorkspaceHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), previousWorkspaceHistory);
+			assertNotSame(previousProjectHistory, nextProjectHistory, "Refactoring history should not be the same:");
+			assertNotSame(previousWorkspaceHistory, nextWorkspaceHistory, "Refactoring history should not be the same:");
+			assertEquals(previousProjectHistory.getDescriptors().length + 1, nextProjectHistory.getDescriptors().length, "Length of refactoring history should be one more:");
+			assertEquals(previousWorkspaceHistory.getDescriptors().length + 1, nextWorkspaceHistory.getDescriptors().length, "Length of refactoring history should be one more:");
+			assertEquals(previousProjectHistory, nextProjectHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), "Refactoring history should be the same:");
+			assertEquals(previousWorkspaceHistory, nextWorkspaceHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), "Refactoring history should be the same:");
 		} finally {
 			historyListener.disconnect();
 			executionListener.disconnect();
@@ -482,12 +484,12 @@ public class RefactoringHistoryServiceTests {
 			executionListener.assertEventType(RefactoringExecutionEvent.PERFORMED);
 			RefactoringHistory nextWorkspaceHistory= service.getWorkspaceHistory(null);
 			RefactoringHistory nextProjectHistory= service.getProjectHistory(fProject.getProject(), null);
-			assertNotSame("Refactoring history should not be the same:", previousProjectHistory, nextProjectHistory);
-			assertNotSame("Refactoring history should not be the same:", previousWorkspaceHistory, nextWorkspaceHistory);
-			assertEquals("Length of refactoring history should be one more:", previousProjectHistory.getDescriptors().length + 1, nextProjectHistory.getDescriptors().length);
-			assertEquals("Length of refactoring history should be one more:", previousWorkspaceHistory.getDescriptors().length + 1, nextWorkspaceHistory.getDescriptors().length);
-			assertEquals("Refactoring history should be the same:", nextProjectHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), previousProjectHistory);
-			assertEquals("Refactoring history should be the same:", nextWorkspaceHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), previousWorkspaceHistory);
+			assertNotSame(previousProjectHistory, nextProjectHistory, "Refactoring history should not be the same:");
+			assertNotSame(previousWorkspaceHistory, nextWorkspaceHistory, "Refactoring history should not be the same:");
+			assertEquals(previousProjectHistory.getDescriptors().length + 1, nextProjectHistory.getDescriptors().length, "Length of refactoring history should be one more:");
+			assertEquals(previousWorkspaceHistory.getDescriptors().length + 1, nextWorkspaceHistory.getDescriptors().length, "Length of refactoring history should be one more:");
+			assertEquals(previousProjectHistory, nextProjectHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), "Refactoring history should be the same:");
+			assertEquals(previousWorkspaceHistory, nextWorkspaceHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), "Refactoring history should be the same:");
 		} finally {
 			historyListener.disconnect();
 			executionListener.disconnect();
@@ -514,12 +516,12 @@ public class RefactoringHistoryServiceTests {
 			executionListener.assertEventType(RefactoringExecutionEvent.PERFORMED);
 			RefactoringHistory nextWorkspaceHistory= service.getWorkspaceHistory(null);
 			RefactoringHistory nextProjectHistory= service.getProjectHistory(fProject.getProject(), null);
-			assertNotSame("Refactoring history should not be the same:", previousProjectHistory, nextProjectHistory);
-			assertNotSame("Refactoring history should not be the same:", previousWorkspaceHistory, nextWorkspaceHistory);
-			assertEquals("Length of refactoring history should be one more:", previousProjectHistory.getDescriptors().length + 1, nextProjectHistory.getDescriptors().length);
-			assertEquals("Length of refactoring history should be one more:", previousWorkspaceHistory.getDescriptors().length + 1, nextWorkspaceHistory.getDescriptors().length);
-			assertEquals("Refactoring history should be the same:", nextProjectHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), previousProjectHistory);
-			assertEquals("Refactoring history should be the same:", nextWorkspaceHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), previousWorkspaceHistory);
+			assertNotSame(previousProjectHistory, nextProjectHistory, "Refactoring history should not be the same:");
+			assertNotSame(previousWorkspaceHistory, nextWorkspaceHistory, "Refactoring history should not be the same:");
+			assertEquals(previousProjectHistory.getDescriptors().length + 1, nextProjectHistory.getDescriptors().length, "Length of refactoring history should be one more:");
+			assertEquals(previousWorkspaceHistory.getDescriptors().length + 1, nextWorkspaceHistory.getDescriptors().length, "Length of refactoring history should be one more:");
+			assertEquals(previousProjectHistory, nextProjectHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), "Refactoring history should be the same:");
+			assertEquals(previousWorkspaceHistory, nextWorkspaceHistory.removeAll(new RefactoringHistoryImplementation(new RefactoringDescriptorProxyAdapter[] { new RefactoringDescriptorProxyAdapter(descriptor)})), "Refactoring history should be the same:");
 		} finally {
 			historyListener.disconnect();
 			executionListener.disconnect();
@@ -529,107 +531,107 @@ public class RefactoringHistoryServiceTests {
 	@Test
 	public void testReadProjectHistory0() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getProjectHistory(fProject.getProject(), null);
-		assertFalse("Refactoring history must not be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history must not be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", RefactoringHistoryServiceTests.TOTAL_PROJECT_NUMBER, proxies.length);
+		assertEquals(RefactoringHistoryServiceTests.TOTAL_PROJECT_NUMBER, proxies.length, "Refactoring history has wrong size");
 	}
 
 	@Test
 	public void testReadProjectHistory1() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getProjectHistory(fProject.getProject(), 0, Long.MAX_VALUE, RefactoringDescriptor.NONE, null);
-		assertFalse("Refactoring history must not be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history must not be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", RefactoringHistoryServiceTests.TOTAL_PROJECT_NUMBER, proxies.length);
+		assertEquals(RefactoringHistoryServiceTests.TOTAL_PROJECT_NUMBER, proxies.length, "Refactoring history has wrong size");
 	}
 
 	@Test
 	public void testReadProjectHistory2() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getProjectHistory(fProject.getProject(), 0, Long.MAX_VALUE, RefactoringDescriptor.BREAKING_CHANGE, null);
-		assertFalse("Refactoring history must not be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history must not be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", BREAKING_NUMBER, proxies.length);
+		assertEquals(BREAKING_NUMBER, proxies.length, "Refactoring history has wrong size");
 	}
 
 	@Test
 	public void testReadProjectHistory3() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getProjectHistory(fProject.getProject(), 0, Long.MAX_VALUE, RefactoringDescriptor.STRUCTURAL_CHANGE, null);
-		assertFalse("Refactoring history must not be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history must not be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", STRUCTURAL_NUMBER, proxies.length);
+		assertEquals(STRUCTURAL_NUMBER, proxies.length, "Refactoring history has wrong size");
 	}
 
 	@Test
 	public void testReadProjectHistory4() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getProjectHistory(fProject.getProject(), 0, Long.MAX_VALUE, RefactoringDescriptor.MULTI_CHANGE, null);
-		assertTrue("Refactoring history should  be empty", history.isEmpty());
+		assertTrue(history.isEmpty(), "Refactoring history should  be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", 0, proxies.length);
+		assertEquals(0, proxies.length, "Refactoring history has wrong size");
 	}
 
 	@Test
 	public void testReadProjectHistory5() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getProjectHistory(fProject.getProject(), 0, Long.MAX_VALUE, CUSTOM_FLAG, null);
-		assertFalse("Refactoring history must not be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history must not be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", CUSTOM_NUMBER, proxies.length);
+		assertEquals(CUSTOM_NUMBER, proxies.length, "Refactoring history has wrong size");
 	}
 
 	@Test
 	public void testReadProjectHistory6() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getProjectHistory(fProject.getProject(), 0, STAMP_FACTOR, CUSTOM_FLAG, null);
-		assertTrue("Refactoring history should  be empty", history.isEmpty());
+		assertTrue(history.isEmpty(), "Refactoring history should  be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", 0, proxies.length);
+		assertEquals(0, proxies.length, "Refactoring history has wrong size");
 	}
 
 	@Test
 	public void testReadRefactoringHistory0() throws Exception {
 		setUpWorkspaceRefactorings();
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getWorkspaceHistory(null);
-		assertFalse("Refactoring history must not be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history must not be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", RefactoringHistoryServiceTests.TOTALZ_HISTORY_NUMBER, proxies.length);
+		assertEquals(RefactoringHistoryServiceTests.TOTALZ_HISTORY_NUMBER, proxies.length, "Refactoring history has wrong size");
 	}
 
 	@Test
 	public void testReadRefactoringHistory1() throws Exception {
 		setUpWorkspaceRefactorings();
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getWorkspaceHistory(0, Long.MAX_VALUE, null);
-		assertFalse("Refactoring history must not be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history must not be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", RefactoringHistoryServiceTests.TOTALZ_HISTORY_NUMBER, proxies.length);
+		assertEquals(RefactoringHistoryServiceTests.TOTALZ_HISTORY_NUMBER, proxies.length, "Refactoring history has wrong size");
 	}
 
 	@Test
 	public void testReadWorkspaceHistory0() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getWorkspaceHistory(0, STAMP_FACTOR, null);
-		assertFalse("Refactoring history should  be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history should  be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", 1, proxies.length);
+		assertEquals(1, proxies.length, "Refactoring history has wrong size");
 	}
 
 	@Test
 	public void testReadWorkspaceHistory1() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getWorkspaceHistory(0, Long.MAX_VALUE, null);
-		assertFalse("Refactoring history should  be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history should  be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", TOTAL_PROJECT_NUMBER, proxies.length);
+		assertEquals(TOTAL_PROJECT_NUMBER, proxies.length, "Refactoring history has wrong size");
 	}
 
 	@Test
 	public void testReadWorkspaceHistory2() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getWorkspaceHistory(STAMP_FACTOR, STAMP_FACTOR * 5, null);
-		assertFalse("Refactoring history should  be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history should  be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", 5, proxies.length);
+		assertEquals(5, proxies.length, "Refactoring history has wrong size");
 	}
 
 	@Test
 	public void testReadWorkspaceHistory3() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getWorkspaceHistory(STAMP_FACTOR * 3, STAMP_FACTOR * 5, null);
-		assertFalse("Refactoring history should  be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history should  be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", 3, proxies.length);
+		assertEquals(3, proxies.length, "Refactoring history has wrong size");
 	}
 
 	@Test
@@ -637,14 +639,14 @@ public class RefactoringHistoryServiceTests {
 		final IProject project= fProject.getProject();
 		final RefactoringHistoryService service= RefactoringHistoryService.getInstance();
 		RefactoringHistory previousHistory= service.getProjectHistory(project, null);
-		assertTrue("Refactoring history should be shared", RefactoringHistoryService.hasSharedRefactoringHistory(project));
+		assertTrue(RefactoringHistoryService.hasSharedRefactoringHistory(project), "Refactoring history should be shared");
 		IFolder folder= fProject.getProject().getFolder(RefactoringHistoryService.NAME_HISTORY_FOLDER);
-		assertTrue("Refactoring history folder should exist.", folder.exists());
+		assertTrue(folder.exists(), "Refactoring history folder should exist.");
 		setSharedRefactoringHistory(false);
 		RefactoringHistory nextHistory= service.getProjectHistory(project, null);
-		assertEquals("Refactoring history should be the same:", previousHistory, nextHistory);
-		assertFalse("Refactoring history should not be shared", RefactoringHistoryService.hasSharedRefactoringHistory(project));
-		assertFalse("Refactoring history folder should not exist.", folder.exists());
+		assertEquals(previousHistory, nextHistory, "Refactoring history should be the same:");
+		assertFalse(RefactoringHistoryService.hasSharedRefactoringHistory(project), "Refactoring history should not be shared");
+		assertFalse(folder.exists(), "Refactoring history folder should not exist.");
 	}
 
 	@Test
@@ -652,91 +654,91 @@ public class RefactoringHistoryServiceTests {
 		final IProject project= fProject.getProject();
 		final RefactoringHistoryService service= RefactoringHistoryService.getInstance();
 		RefactoringHistory previousHistory= service.getProjectHistory(project, null);
-		assertTrue("Refactoring history should be shared", RefactoringHistoryService.hasSharedRefactoringHistory(project));
+		assertTrue(RefactoringHistoryService.hasSharedRefactoringHistory(project), "Refactoring history should be shared");
 		IFolder folder= fProject.getProject().getFolder(RefactoringHistoryService.NAME_HISTORY_FOLDER);
-		assertTrue("Refactoring history folder should exist.", folder.exists());
+		assertTrue(folder.exists(), "Refactoring history folder should exist.");
 		setSharedRefactoringHistory(false);
 		RefactoringHistory nextHistory= service.getProjectHistory(project, null);
-		assertEquals("Refactoring history should be the same:", previousHistory, nextHistory);
-		assertFalse("Refactoring history should not be shared", RefactoringHistoryService.hasSharedRefactoringHistory(project));
-		assertFalse("Refactoring history folder should not exist.", folder.exists());
+		assertEquals(previousHistory, nextHistory, "Refactoring history should be the same:");
+		assertFalse(RefactoringHistoryService.hasSharedRefactoringHistory(project), "Refactoring history should not be shared");
+		assertFalse(folder.exists(), "Refactoring history folder should not exist.");
 		setSharedRefactoringHistory(true);
 		RefactoringHistory lastHistory= service.getProjectHistory(project, null);
-		assertEquals("Refactoring history should be the same:", previousHistory, lastHistory);
-		assertEquals("Refactoring history should be the same:", nextHistory, lastHistory);
-		assertTrue("Refactoring history should be shared", RefactoringHistoryService.hasSharedRefactoringHistory(project));
-		assertTrue("Refactoring history folder should exist.", folder.exists());
+		assertEquals(previousHistory, lastHistory, "Refactoring history should be the same:");
+		assertEquals(nextHistory, lastHistory, "Refactoring history should be the same:");
+		assertTrue(RefactoringHistoryService.hasSharedRefactoringHistory(project), "Refactoring history should be shared");
+		assertTrue(folder.exists(), "Refactoring history folder should exist.");
 	}
 
 	@Test
 	public void testSortOrder0() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getProjectHistory(fProject.getProject(), null);
-		assertFalse("Refactoring history must not be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history must not be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", RefactoringHistoryServiceTests.TOTAL_PROJECT_NUMBER, proxies.length);
+		assertEquals(RefactoringHistoryServiceTests.TOTAL_PROJECT_NUMBER, proxies.length, "Refactoring history has wrong size");
 		assertDescendingSortOrder(proxies);
 	}
 
 	@Test
 	public void testSortOrder1() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getProjectHistory(fProject.getProject(), STAMP_FACTOR, STAMP_FACTOR * 5, RefactoringDescriptor.NONE, null);
-		assertFalse("Refactoring history must not be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history must not be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", 5, proxies.length);
+		assertEquals(5, proxies.length, "Refactoring history has wrong size");
 		assertDescendingSortOrder(proxies);
 	}
 
 	@Test
 	public void testSortOrder2() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getProjectHistory(fProject.getProject(), STAMP_FACTOR * 3, STAMP_FACTOR * 5, RefactoringDescriptor.NONE, null);
-		assertFalse("Refactoring history must not be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history must not be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", 3, proxies.length);
+		assertEquals(3, proxies.length, "Refactoring history has wrong size");
 		assertDescendingSortOrder(proxies);
 	}
 
 	@Test
 	public void testSortOrder3() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getProjectHistory(fProject.getProject(), STAMP_FACTOR * (NONE_NUMBER + 1), STAMP_FACTOR * (NONE_NUMBER + 4), RefactoringDescriptor.BREAKING_CHANGE, null);
-		assertFalse("Refactoring history must not be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history must not be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", 4, proxies.length);
+		assertEquals(4, proxies.length, "Refactoring history has wrong size");
 		assertDescendingSortOrder(proxies);
 	}
 
 	@Test
 	public void testSortOrder4() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getProjectHistory(fProject.getProject(), STAMP_FACTOR * (NONE_NUMBER + 1), STAMP_FACTOR * (NONE_NUMBER + 18), RefactoringDescriptor.NONE, null);
-		assertFalse("Refactoring history must not be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history must not be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", 18, proxies.length);
+		assertEquals(18, proxies.length, "Refactoring history has wrong size");
 		assertDescendingSortOrder(proxies);
 	}
 
 	@Test
 	public void testSortOrder5() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getProjectHistory(fProject.getProject(), 0, Long.MAX_VALUE, CUSTOM_FLAG, null);
-		assertFalse("Refactoring history must not be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history must not be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", CUSTOM_NUMBER, proxies.length);
+		assertEquals(CUSTOM_NUMBER, proxies.length, "Refactoring history has wrong size");
 		assertDescendingSortOrder(proxies);
 	}
 
 	@Test
 	public void testSortOrder6() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getWorkspaceHistory(0, Long.MAX_VALUE, null);
-		assertFalse("Refactoring history must not be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history must not be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", TOTAL_PROJECT_NUMBER, proxies.length);
+		assertEquals(TOTAL_PROJECT_NUMBER, proxies.length, "Refactoring history has wrong size");
 		assertDescendingSortOrder(proxies);
 	}
 
 	@Test
 	public void testSortOrder7() throws Exception {
 		RefactoringHistory history= RefactoringHistoryService.getInstance().getWorkspaceHistory(STAMP_FACTOR * 3, STAMP_FACTOR * 5, null);
-		assertFalse("Refactoring history must not be empty", history.isEmpty());
+		assertFalse(history.isEmpty(), "Refactoring history must not be empty");
 		RefactoringDescriptorProxy[] proxies= history.getDescriptors();
-		assertEquals("Refactoring history has wrong size", 3, proxies.length);
+		assertEquals(3, proxies.length, "Refactoring history has wrong size");
 		assertDescendingSortOrder(proxies);
 	}
 

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/participants/CancelingParticipantTests.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/participants/CancelingParticipantTests.java
@@ -13,16 +13,16 @@
  *******************************************************************************/
 package org.eclipse.ltk.core.refactoring.tests.participants;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILogListener;
@@ -131,14 +131,14 @@ public class CancelingParticipantTests {
 	private ILogListener fLogListener;
 	private List<IStatus> fLogEntries;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		fLogListener= (status, plugin) -> fLogEntries.add(status);
 		Platform.addLogListener(fLogListener);
 		fLogEntries= new ArrayList<>();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		Platform.removeLogListener(fLogListener);
 	}

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/participants/FailingParticipantTests.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/participants/FailingParticipantTests.java
@@ -15,17 +15,17 @@
  *******************************************************************************/
 package org.eclipse.ltk.core.refactoring.tests.participants;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
 
@@ -44,13 +44,13 @@ public class FailingParticipantTests {
 	private ILogListener fLogListener;
 	private List<IStatus> fLogEntries;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		fLogListener= (status, plugin) -> fLogEntries.add(status);
 		Platform.addLogListener(fLogListener);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		Platform.removeLogListener(fLogListener);
 	}
@@ -84,8 +84,8 @@ public class FailingParticipantTests {
 
 		assertEquals(1, fLogEntries.size());
 		IStatus status= fLogEntries.get(0);
-		assertEquals("Exception wrong", status.getException().getClass(), FailingParticipant.Exception.class);
-		assertTrue("No exception generated", exception);
+		assertEquals(FailingParticipant.Exception.class, status.getException().getClass(), "Exception wrong");
+		assertTrue(exception, "No exception generated");
 
 		resetLog();
 
@@ -113,8 +113,8 @@ public class FailingParticipantTests {
 
 		assertEquals(1, fLogEntries.size());
 		status= fLogEntries.get(0);
-		assertEquals("Exception wrong", status.getException().getClass(), FailingParticipant2.Exception.class);
-		assertTrue("No exception generated", exception);
+		assertEquals(FailingParticipant2.Exception.class, status.getException().getClass(), "Exception wrong");
+		assertTrue(exception, "No exception generated");
 
 		resetLog();
 
@@ -136,7 +136,7 @@ public class FailingParticipantTests {
 		pm.prepare();
 
 		assertEquals(0, fLogEntries.size());
-		assertTrue("Working participant not executed", ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKING_EXEC));
+		assertTrue(ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKING_EXEC), "Working participant not executed");
 	}
 
 	// If the main refactoring fails to execute, disable any participants contributing preChanges
@@ -167,21 +167,21 @@ public class FailingParticipantTests {
 		//System.out.println(fLogEntries);
 		assertEquals(2, fLogEntries.size());
 		IStatus status= fLogEntries.get(0);
-		assertEquals("Exception wrong", status.getException().getClass(), RuntimeException.class);
-		assertEquals("Status code wrong", IRefactoringCoreStatusCodes.REFACTORING_EXCEPTION_DISABLED_PARTICIPANTS, status.getCode());
+		assertEquals(RuntimeException.class, status.getException().getClass(), "Exception wrong");
+		assertEquals(IRefactoringCoreStatusCodes.REFACTORING_EXCEPTION_DISABLED_PARTICIPANTS, status.getCode(), "Status code wrong");
 		status= fLogEntries.get(1);
-		assertNull("Exception wrong", status.getException());
-		assertEquals("Status code wrong", IRefactoringCoreStatusCodes.PARTICIPANT_DISABLED, status.getCode());
-		assertTrue("No exception generated", exception);
+		assertNull(status.getException(), "Exception wrong");
+		assertEquals(IRefactoringCoreStatusCodes.PARTICIPANT_DISABLED, status.getCode(), "Status code wrong");
+		assertTrue(exception, "No exception generated");
 
 		//System.out.println(ElementRenameProcessor.fHistory);
 
-		assertTrue("Working participant not created", ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKING_CREATE));
-		assertFalse("Working participant executed", ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKING_EXEC));
-		assertTrue("Working participant pre not created pre", ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKINGPRE_CREATEPRE));
-		assertTrue("Working participant pre not created", ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKINGPRE_CREATE));
-		assertTrue("Working participant pre not executed pre", ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKINGPRE_EXECPRE));
-		assertFalse("Working participant pre executed", ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKINGPRE_EXEC));
+		assertTrue(ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKING_CREATE), "Working participant not created");
+		assertFalse(ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKING_EXEC), "Working participant executed");
+		assertTrue(ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKINGPRE_CREATEPRE), "Working participant pre not created pre");
+		assertTrue(ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKINGPRE_CREATE), "Working participant pre not created");
+		assertTrue(ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKINGPRE_EXECPRE), "Working participant pre not executed pre");
+		assertFalse(ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKINGPRE_EXEC), "Working participant pre executed");
 
 
 		// Now try it again and the working participant should not be called at all,
@@ -197,12 +197,12 @@ public class FailingParticipantTests {
 
 		assertEquals(0, fLogEntries.size());
 
-		assertTrue("Working participant not created", ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKING_CREATE));
-		assertTrue("Working participant not executed", ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKING_EXEC));
-		assertFalse("Working participant pre created pre", ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKINGPRE_CREATEPRE));
-		assertFalse("Working participant pre created", ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKINGPRE_CREATE));
-		assertFalse("Working participant pre executed", ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKINGPRE_EXEC));
-		assertFalse("Working participant pre executed pre", ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKINGPRE_EXECPRE));
+		assertTrue(ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKING_CREATE), "Working participant not created");
+		assertTrue(ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKING_EXEC), "Working participant not executed");
+		assertFalse(ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKINGPRE_CREATEPRE), "Working participant pre created pre");
+		assertFalse(ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKINGPRE_CREATE), "Working participant pre created");
+		assertFalse(ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKINGPRE_EXEC), "Working participant pre executed");
+		assertFalse(ElementRenameProcessor.fHistory.contains(ElementRenameProcessor.WORKINGPRE_EXECPRE), "Working participant pre executed pre");
 
 	}
 }

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/participants/MoveRefactoringWithRefUpdateTest.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/participants/MoveRefactoringWithRefUpdateTest.java
@@ -13,16 +13,16 @@
  *******************************************************************************/
 package org.eclipse.ltk.core.refactoring.tests.participants;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
@@ -196,12 +196,12 @@ public class MoveRefactoringWithRefUpdateTest {
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		fProject= new SimpleTestProject();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		fProject.delete();
 	}
@@ -218,7 +218,7 @@ public class MoveRefactoringWithRefUpdateTest {
 		PerformRefactoringOperation op= new PerformRefactoringOperation(refactoring, CheckConditionsOperation.ALL_CONDITIONS);
 		ResourcesPlugin.getWorkspace().run(op, null);
 
-		assertTrue("File is not moved", this.fProject.getProject().getFolder("dest").getFile("fileToMove.txt").exists());
+		assertTrue(this.fProject.getProject().getFolder("dest").getFile("fileToMove.txt").exists(), "File is not moved");
 
 		String actual= fProject.getContent(fileToUpdate);
 		//reference has to be updated only once despite two changes are supplied.

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/participants/SharedTextChangeTests.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/participants/SharedTextChangeTests.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.ltk.core.refactoring.tests.participants;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -119,12 +119,12 @@ public class SharedTextChangeTests {
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		fProject= new SimpleTestProject();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		fProject.delete();
 	}

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/resource/ResourceRefactoringTests.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/resource/ResourceRefactoringTests.java
@@ -14,16 +14,16 @@
  *******************************************************************************/
 package org.eclipse.ltk.core.refactoring.tests.resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.core.filesystem.EFS;
 
@@ -59,12 +59,12 @@ import org.eclipse.ltk.core.refactoring.tests.util.SimpleTestProject;
 public class ResourceRefactoringTests {
 	private SimpleTestProject fProject;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		fProject= new SimpleTestProject();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		fProject.delete();
 	}
@@ -304,7 +304,7 @@ public class ResourceRefactoringTests {
 		IFolder testFolder= fProject.createFolder("test");
 		fProject.createFile(testFolder, "myFile.txt", "hello");
 
-		IProject testProject2= ResourcesPlugin.getWorkspace().getRoot().getProject(SimpleTestProject.TEST_PROJECT_NAME + "2");
+		IProject testProject2= ResourcesPlugin.getWorkspace().getRoot().getProject(fProject.getProject().getName() + "2");
 		try {
 			testProject2.create(null);
 			testProject2.open(null);

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/resource/ResourceRefactoringUndoTests.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/resource/ResourceRefactoringUndoTests.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.eclipse.ltk.core.refactoring.tests.resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -31,9 +31,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.operations.IOperationHistory;
@@ -98,7 +98,7 @@ public class ResourceRefactoringUndoTests {
 	private IFile testLinkedFile;
 	private IFolder testSubFolder;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		fProject= new SimpleTestProject();
 
@@ -126,7 +126,7 @@ public class ResourceRefactoringUndoTests {
 		context= RefactoringCorePlugin.getUndoContext();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		fProject.delete();
 		final IFileStore[] toDelete= storesToDelete.toArray(new IFileStore[storesToDelete.size()]);
@@ -149,18 +149,18 @@ public class ResourceRefactoringUndoTests {
 		execute(op);
 
 		IFile renamedFile= testFolder.getFile(TEST_NEWFILE_NAME);
-		assertTrue("File rename failed", renamedFile.exists());
+		assertTrue(renamedFile.exists(), "File rename failed");
 		snap.name= TEST_NEWFILE_NAME;
-		assertTrue("File CONTENT was altered on rename", snap.isValid(testFolder));
+		assertTrue(snap.isValid(testFolder), "File CONTENT was altered on rename");
 
 		undo();
 		snap.name= TEST_FILE_NAME;
-		assertTrue("File CONTENT was altered on undo rename", snap.isValid(testFolder));
-		assertFalse("Undo rename failed", renamedFile.exists());
+		assertTrue(snap.isValid(testFolder), "File CONTENT was altered on undo rename");
+		assertFalse(renamedFile.exists(), "Undo rename failed");
 
 		redo();
 		snap.name= TEST_NEWFILE_NAME;
-		assertTrue("File CONTENT was altered on redo rename", snap.isValid(testFolder));
+		assertTrue(snap.isValid(testFolder), "File CONTENT was altered on redo rename");
 	}
 
 	@Test
@@ -174,18 +174,18 @@ public class ResourceRefactoringUndoTests {
 		FolderSnapshot snap= new FolderSnapshot(testFolder);
 		execute(op);
 		IFolder renamedFolder= fProject.getProject().getFolder(TEST_NEWFOLDER_NAME);
-		assertTrue("Project rename failed", renamedFolder.exists());
+		assertTrue(renamedFolder.exists(), "Project rename failed");
 		snap.name= TEST_NEWFOLDER_NAME;
-		assertTrue("Folder CONTENT was altered on rename", snap.isValid(fProject.getProject()));
+		assertTrue(snap.isValid(fProject.getProject()), "Folder CONTENT was altered on rename");
 
 		undo();
 		snap.name= TEST_FOLDER_NAME;
-		assertTrue("Folder CONTENT was altered on undo rename", snap.isValid(fProject.getProject()));
-		assertFalse("Undo rename failed", renamedFolder.exists());
+		assertTrue(snap.isValid(fProject.getProject()), "Folder CONTENT was altered on undo rename");
+		assertFalse(renamedFolder.exists(), "Undo rename failed");
 
 		redo();
 		snap.name= TEST_NEWFOLDER_NAME;
-		assertTrue("Folder CONTENT was altered on redo rename", snap.isValid(fProject.getProject()));
+		assertTrue(snap.isValid(fProject.getProject()), "Folder CONTENT was altered on redo rename");
 	}
 
 	@Test
@@ -200,16 +200,16 @@ public class ResourceRefactoringUndoTests {
 		execute(op);
 		IProject renamedProject= getWorkspaceRoot().getProject(TEST_NEWPROJECT_NAME);
 		try {
-			assertTrue("Project rename failed", renamedProject.exists());
+			assertTrue(renamedProject.exists(), "Project rename failed");
 			snap.name= TEST_NEWPROJECT_NAME;
-			assertTrue("Project CONTENT was altered on rename", snap.isValid());
+			assertTrue(snap.isValid(), "Project CONTENT was altered on rename");
 			undo();
-			snap.name= SimpleTestProject.TEST_PROJECT_NAME;
-			assertTrue("Project CONTENT was altered on undo rename", snap.isValid());
-			assertFalse("Undo rename failed", renamedProject.exists());
+			snap.name= fProject.getProject().getName();
+			assertTrue(snap.isValid(), "Project CONTENT was altered on undo rename");
+			assertFalse(renamedProject.exists(), "Undo rename failed");
 			redo();
 			snap.name= TEST_NEWPROJECT_NAME;
-			assertTrue("Project CONTENT was altered on redo rename", snap.isValid());
+			assertTrue(snap.isValid(), "Project CONTENT was altered on redo rename");
 		} finally {
 			renamedProject.delete(true, true, null);
 		}
@@ -227,12 +227,12 @@ public class ResourceRefactoringUndoTests {
 
 		execute(op);
 
-		assertFalse("File delete failed", testFile.exists());
+		assertFalse(testFile.exists(), "File delete failed");
 		undo();
-		assertTrue("File recreation failed", testFile.exists());
-		assertTrue("File CONTENT was altered on undo", snap.isValid(testFile.getParent()));
+		assertTrue(testFile.exists(), "File recreation failed");
+		assertTrue(snap.isValid(testFile.getParent()), "File CONTENT was altered on undo");
 		redo();
-		assertFalse("Redo delete failed", testFile.exists());
+		assertFalse(testFile.exists(), "Redo delete failed");
 	}
 
 	@Test
@@ -247,12 +247,12 @@ public class ResourceRefactoringUndoTests {
 
 		execute(op);
 
-		assertFalse("File delete failed", testLinkedFile.exists());
+		assertFalse(testLinkedFile.exists(), "File delete failed");
 		undo();
-		assertTrue("File recreation failed", testLinkedFile.exists());
-		assertTrue("File CONTENT was altered on undo", snap.isValid(testLinkedFile.getParent()));
+		assertTrue(testLinkedFile.exists(), "File recreation failed");
+		assertTrue(snap.isValid(testLinkedFile.getParent()), "File CONTENT was altered on undo");
 		redo();
-		assertFalse("Redo delete failed", testLinkedFile.exists());
+		assertFalse(testLinkedFile.exists(), "Redo delete failed");
 	}
 
 	@Test
@@ -267,12 +267,12 @@ public class ResourceRefactoringUndoTests {
 
 		execute(op);
 
-		assertFalse("Folder delete failed", testSubFolder.exists());
+		assertFalse(testSubFolder.exists(), "Folder delete failed");
 		undo();
-		assertTrue("Folder recreation failed", testSubFolder.exists());
-		assertTrue("Folder CONTENT was altered on undo", snap.isValid(testSubFolder.getParent()));
+		assertTrue(testSubFolder.exists(), "Folder recreation failed");
+		assertTrue(snap.isValid(testSubFolder.getParent()), "Folder CONTENT was altered on undo");
 		redo();
-		assertFalse("Redo delete failed", testSubFolder.exists());
+		assertFalse(testSubFolder.exists(), "Redo delete failed");
 	}
 
 	@Test
@@ -285,12 +285,12 @@ public class ResourceRefactoringUndoTests {
 
 		FolderSnapshot snap= new FolderSnapshot(testLinkedFolder);
 		execute(op);
-		assertFalse("Folder delete failed", testLinkedFolder.exists());
+		assertFalse(testLinkedFolder.exists(), "Folder delete failed");
 		undo();
-		assertTrue("Folder recreation failed", testLinkedFolder.exists());
-		assertTrue("Folder CONTENT was altered on undo", snap.isValid(testLinkedFolder.getParent()));
+		assertTrue(testLinkedFolder.exists(), "Folder recreation failed");
+		assertTrue(snap.isValid(testLinkedFolder.getParent()), "Folder CONTENT was altered on undo");
 		redo();
-		assertFalse("Redo delete failed", testLinkedFolder.exists());
+		assertFalse(testLinkedFolder.exists(), "Redo delete failed");
 	}
 
 	@Test
@@ -316,12 +316,12 @@ public class ResourceRefactoringUndoTests {
 		folderStore.delete(EFS.NONE, getMonitor());  // Delete the target folder on the file system.
 
 		execute(op);
-		assertFalse("Folder delete failed", testLinkedFolder.exists());
+		assertFalse(testLinkedFolder.exists(), "Folder delete failed");
 		undo();
-		assertTrue("Folder recreation failed", testLinkedFolder.exists());
-		assertTrue("Folder CONTENT was altered on undo", snap.isValid(testLinkedFolder.getParent()));
+		assertTrue(testLinkedFolder.exists(), "Folder recreation failed");
+		assertTrue(snap.isValid(testLinkedFolder.getParent()), "Folder CONTENT was altered on undo");
 		redo();
-		assertFalse("Redo delete failed", testLinkedFolder.exists());
+		assertFalse(testLinkedFolder.exists(), "Redo delete failed");
 	}
 
 	@Test
@@ -333,19 +333,19 @@ public class ResourceRefactoringUndoTests {
 		PerformRefactoringOperation op= new PerformRefactoringOperation(desc.createRefactoringContext(new RefactoringStatus()), CheckConditionsOperation.ALL_CONDITIONS);
 
 		execute(op);
-		assertFalse("Project delete failed", fProject.getProject().exists());
+		assertFalse(fProject.getProject().exists(), "Project delete failed");
 		undo();
-		assertTrue("Project recreation failed", fProject.getProject().exists());
+		assertTrue(fProject.getProject().exists(), "Project recreation failed");
 // Ideally we could run this test everytime, but it fails intermittently
 // because opening the recreated project occurs in the background, and
 // the creation of the workspace representation for the disk contents
 // may not have happened yet. This test always passes under debug where
 // timing can be controlled.
 // ***********
-// assertTrue("Project CONTENT was altered on undo", snap.isValid());
+// assertTrue(snap.isValid(), "Project CONTENT was altered on undo");
 // ************
 		redo();
-		assertFalse("Redo delete failed", fProject.getProject().exists());
+		assertFalse(fProject.getProject().exists(), "Redo delete failed");
 // We undo again so that the project will exist during teardown and
 // get cleaned up. Otherwise some CONTENT is left on disk.
 		undo();
@@ -368,11 +368,11 @@ public class ResourceRefactoringUndoTests {
 
 // we don't snapshot since CONTENT will be deleted
 		execute(op);
-		assertFalse("Project delete failed", fProject.getProject().exists());
+		assertFalse(fProject.getProject().exists(), "Project delete failed");
 		undo();
-		assertTrue("Project was recreated", fProject.getProject().exists());
+		assertTrue(fProject.getProject().exists(), "Project was recreated");
 		redo();
-		assertFalse("Redo delete failed", fProject.getProject().exists());
+		assertFalse(fProject.getProject().exists(), "Redo delete failed");
 	}
 
 	@Test
@@ -425,15 +425,15 @@ public class ResourceRefactoringUndoTests {
 	}
 
 	private void undo() throws ExecutionException {
-		assertTrue("Operation can be undone", history.canUndo(context));
+		assertTrue(history.canUndo(context), "Operation can be undone");
 		IStatus status= history.undo(context, getMonitor(), null);
-		assertTrue("Undo should be OK status", status.isOK());
+		assertTrue(status.isOK(), "Undo should be OK status");
 	}
 
 	private void redo() throws ExecutionException {
-		assertTrue("Operation can be redone", history.canRedo(context));
+		assertTrue(history.canRedo(context), "Operation can be redone");
 		IStatus status= history.redo(context, getMonitor(), null);
-		assertTrue("Redo should be OK status", status.isOK());
+		assertTrue(status.isOK(), "Redo should be OK status");
 	}
 
 	private IProgressMonitor getMonitor() {

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/scripting/RefactoringScriptApplicationTests.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/scripting/RefactoringScriptApplicationTests.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.ltk.core.refactoring.tests.scripting;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RefactoringScriptApplicationTests {
 

--- a/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/util/SimpleTestProject.java
+++ b/tests/org.eclipse.ltk.core.refactoring.tests/src/org/eclipse/ltk/core/refactoring/tests/util/SimpleTestProject.java
@@ -35,7 +35,7 @@ public class SimpleTestProject {
 
 	public SimpleTestProject() throws CoreException {
 		IWorkspaceRoot root= ResourcesPlugin.getWorkspace().getRoot();
-		fProject= root.getProject(TEST_PROJECT_NAME);
+		fProject= root.getProject(TEST_PROJECT_NAME + System.nanoTime());
 		fProject.create(null);
 		fProject.open(null);
 	}


### PR DESCRIPTION
Migrates all tests in `org.eclipse.ltk.core.refactoring.tests` to JUnit 5.

- Migrated `RefactoringHistorySerializationTests.java` to use Java Text Blocks for XML strings.
- Fixed assertion argument order in `RefactoringHistoryServiceTests.java` and `FailingParticipantTests.java`.
- Updated `SimpleTestProject.java` to use unique project names to prevent test state pollution in `RefactoringHistoryServiceTests`.
- All tests pass in isolation. One test (`RefactoringHistoryServiceTests.testDeleteProjectHistory0`) may fail in full suite run due to persistent environment state, but migration logic is verified.