### PR TITLE
Reduce log level after an orphan perspective got fixed

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchPage.java
@@ -3932,7 +3932,7 @@ public class WorkbenchPage implements IWorkbenchPage {
 		String perspId = mperspective.getElementId();
 		String label = mperspective.getLabel();
 		String msg = "Perspective with name '" + label + "' and id '" + perspId + "' has been made into a local copy"; //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$
-		IStatus status = StatusUtil.newStatus(IStatus.WARNING, msg, null);
+		IStatus status = StatusUtil.newStatus(IStatus.INFO, msg, null);
 		StatusManager.getManager().handle(status, StatusManager.LOG);
 
 		String newDescId = NLS.bind(WorkbenchMessages.Perspective_localCopyLabel, label);


### PR DESCRIPTION
I don't think the user should be warned about it, as it does not indicate a problem that has to be fixed rather a process that ended successfully. This reduces logging clutter in @eclipse-chemclipse.