### PR TITLE
Migrate org.eclipse.jface.tests to JUnit 5

### DIFF
--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/AllActionTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/AllActionTests.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.action;
 
-
-
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
@@ -22,7 +20,5 @@ import org.junit.platform.suite.api.Suite;
 @SelectClasses({ ContributionItemTest.class, ToolBarManagerTest.class, CoolBarManagerTest.class,
 		MenuManagerTest.class })
 public class AllActionTests {
-
-	
 
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/ToolBarManagerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/action/ToolBarManagerTest.java
@@ -52,6 +52,7 @@ public class ToolBarManagerTest {
 	@RegisterExtension
 	public JFaceActionExtension rule = new JFaceActionExtension();
 
+	@Test
 	public void testSetStyleWhenToolBarDoesNotExist() {
 		Composite parent = createComposite();
 		ToolBarManager manager = new ToolBarManager(DEFAULT_STYLE | SWT.HORIZONTAL);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/AllDialogTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/dialogs/AllDialogTests.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.dialogs;
 
-
-
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
@@ -24,5 +22,4 @@ import org.junit.platform.suite.api.Suite;
 		ProgressMonitorDialogTest.class, PlainMessageDialogTest.class })
 public class AllDialogTests {
 
-	
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/fieldassist/AbstractFieldAssistTestCase.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/fieldassist/AbstractFieldAssistTestCase.java
@@ -24,13 +24,12 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-import org.eclipse.ui.tests.harness.util.TestRunLogUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestInfo;
 
 public abstract class AbstractFieldAssistTestCase {
-	
+
+
 	/**
 	 * The window that is being tested.
 	 */
@@ -47,8 +46,7 @@ public abstract class AbstractFieldAssistTestCase {
 	private int originalShellCount;
 
 	@BeforeEach
-	public final void setUp(TestInfo testInfo) throws Exception {
-		System.out.println(TestRunLogUtil.formatTestStartMessage(testInfo.getTestMethod().get().getName()));
+	public final void setUp() throws Exception {
 		Display display = getDisplay();
 		anotherShell = new Shell(display);
 		new Text(anotherShell, SWT.SINGLE);
@@ -60,13 +58,12 @@ public abstract class AbstractFieldAssistTestCase {
 	}
 
 	@AfterEach
-	public final void tearDown(TestInfo testInfo) throws Exception {
+	public final void tearDown() throws Exception {
 		if (window != null) {
 			spinEventLoop();
 		}
 		closeFieldAssistWindow();
 		anotherShell.close();
-		System.out.println(TestRunLogUtil.formatTestFinishedMessage(testInfo.getTestMethod().get().getName()));
 	}
 
 	protected Display getDisplay() {
@@ -194,8 +191,7 @@ public abstract class AbstractFieldAssistTestCase {
 	 */
 	protected void assertOneShellUp() {
 		spinEventLoop();
-		assertEquals(originalShellCount + 1,
-				window.getDisplay().getShells().length, "There should only be one shell up, the dialog");
+		assertEquals(originalShellCount + 1, window.getDisplay().getShells().length, "There should only be one shell up, the dialog");
 	}
 
 	/**
@@ -204,8 +200,7 @@ public abstract class AbstractFieldAssistTestCase {
 	 */
 	protected void assertTwoShellsUp() {
 		spinEventLoop();
-		assertEquals(originalShellCount + 2,
-				window.getDisplay().getShells().length, "There should two shells up, the dialog and the proposals dialog");
+		assertEquals(originalShellCount + 2, window.getDisplay().getShells().length, "There should two shells up, the dialog and the proposals dialog");
 	}
 
 	protected void setControlContent(String text) {

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/fieldassist/ContentProposalAdapterTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/fieldassist/ContentProposalAdapterTest.java
@@ -27,11 +27,9 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-import org.eclipse.ui.tests.harness.util.TestRunLogUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 public class ContentProposalAdapterTest {
 
@@ -119,8 +117,7 @@ public class ContentProposalAdapterTest {
 	// most of the following code is copied from AbstractFieldAssistTestCase
 
 	@BeforeEach
-	public final void setUp(TestInfo testInfo) throws Exception {
-		System.out.println(TestRunLogUtil.formatTestStartMessage(testInfo.getTestMethod().get().getName()));
+	public final void setUp() throws Exception {
 		Display display = getDisplay();
 		originalShellCount = display.getShells().length;
 		controlShell = new Shell(display);
@@ -132,7 +129,7 @@ public class ContentProposalAdapterTest {
 	}
 
 	@AfterEach
-	public final void tearDown(TestInfo testInfo) throws Exception {
+	public final void tearDown() throws Exception {
 		if (controlShell != null) {
 			spinEventLoop();
 			controlShell.close();
@@ -143,7 +140,6 @@ public class ContentProposalAdapterTest {
 			}
 			this.display = null;
 		}
-		System.out.println(TestRunLogUtil.formatTestFinishedMessage(testInfo.getTestMethod().get().getName()));
 	}
 
 	private Display getDisplay() {
@@ -232,7 +228,6 @@ public class ContentProposalAdapterTest {
 	 */
 	private void assertOneShellUp() {
 		spinEventLoop();
-		assertEquals(originalShellCount + 1,
-				text.getDisplay().getShells().length, "There should only be one shell up, the dialog");
+		assertEquals(originalShellCount + 1, text.getDisplay().getShells().length, "There should only be one shell up, the dialog");
 	}
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/fieldassist/ControlDecorationTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/fieldassist/ControlDecorationTests.java
@@ -54,10 +54,10 @@ public class ControlDecorationTests extends AbstractFieldAssistTestCase {
 		spinEventLoop();
 
 		/*
-		assertFalse("1.5", decoration.isVisible());
+		assertFalse(decoration.isVisible(), "1.5");
 		window.getFieldAssistControl().setFocus();
 		spinEventLoop();
-		assertTrue("1.6", decoration.isVisible());
+		assertTrue(decoration.isVisible(), "1.6");
 		decoration.setShowOnlyOnFocus(false);
 		*/
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/fieldassist/FieldAssistAPITests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/fieldassist/FieldAssistAPITests.java
@@ -65,6 +65,7 @@ public class FieldAssistAPITests extends AbstractFieldAssistTestCase {
 		assertEquals(content.length(), proposal.getCursorPosition(), "2.3");
 	}
 
+	@Test
 	public void testInitializationWithInvalidCursor() {
 		try {
 			proposal = new ContentProposal(content, label, description, 100);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/AllImagesTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/AllImagesTests.java
@@ -14,8 +14,6 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.images;
 
-
-
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
@@ -24,5 +22,4 @@ import org.junit.platform.suite.api.Suite;
 		UrlImageDescriptorTest.class, DecorationOverlayIconTest.class, DeferredImageDescriptorTest.class })
 public class AllImagesTests {
 
-	
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/UrlImageDescriptorTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/UrlImageDescriptorTest.java
@@ -21,9 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.IPath;
@@ -38,7 +39,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class UrlImageDescriptorTest {
 
 	@TempDir
-	public File tempFolder;
+	public Path tempFolder;
 
 	/**
 	 * Test that individually created images of a given descriptor are not equal
@@ -92,13 +93,13 @@ public class UrlImageDescriptorTest {
 		assertNotSame(fileNameProvider, fileNameProvider2nd, "URLImageDescriptor does return identical ImageFileNameProvider");
 		String imagePath100 = fileNameProvider.getImagePath(100);
 		assertNotNull(imagePath100, "URLImageDescriptor ImageFileNameProvider does not return the 100% path");
-		assertEquals(IPath.fromOSString(imagePath100).lastSegment(), "rectangular-57x16.png");
+		assertEquals("rectangular-57x16.png", IPath.fromOSString(imagePath100).lastSegment());
 		String imagePath200 = fileNameProvider.getImagePath(200);
 		assertNotNull(imagePath200, "URLImageDescriptor ImageFileNameProvider does not return the 200% path");
-		assertEquals(IPath.fromOSString(imagePath200).lastSegment(), "rectangular-114x32.png");
+		assertEquals("rectangular-114x32.png", IPath.fromOSString(imagePath200).lastSegment());
 		String imagePath150 = fileNameProvider.getImagePath(150);
 		assertNotNull(imagePath150, "URLImageDescriptor ImageFileNameProvider does not return the 150% path");
-		assertEquals(IPath.fromOSString(imagePath150).lastSegment(), "rectangular-86x24.png");
+		assertEquals("rectangular-86x24.png", IPath.fromOSString(imagePath150).lastSegment());
 		String imagePath250 = fileNameProvider.getImagePath(250);
 		assertNull(imagePath250, "URLImageDescriptor's ImageFileNameProvider does return a 250% path");
 	}
@@ -112,10 +113,10 @@ public class UrlImageDescriptorTest {
 		assertNotNull(fileNameProvider, "URLImageDescriptor does not adapt to ImageFileNameProvider");
 		String imagePath100 = fileNameProvider.getImagePath(100);
 		assertNotNull(imagePath100, "URLImageDescriptor ImageFileNameProvider does not return the 100% path");
-		assertEquals(IPath.fromOSString(imagePath100).lastSegment(), "zoomIn.png");
+		assertEquals("zoomIn.png", IPath.fromOSString(imagePath100).lastSegment());
 		String imagePath200 = fileNameProvider.getImagePath(200);
 		assertNotNull(imagePath200, "URLImageDescriptor ImageFileNameProvider does not return the @2x path");
-		assertEquals(IPath.fromOSString(imagePath200).lastSegment(), "zoomIn@2x.png");
+		assertEquals("zoomIn@2x.png", IPath.fromOSString(imagePath200).lastSegment());
 		String imagePath150 = fileNameProvider.getImagePath(150);
 		assertNull(imagePath150, "URLImageDescriptor's ImageFileNameProvider does return a @1.5x path");
 	}
@@ -134,20 +135,20 @@ public class UrlImageDescriptorTest {
 		boolean oldOsgiAvailable = InternalPolicy.OSGI_AVAILABLE;
 		InternalPolicy.OSGI_AVAILABLE = osgiAvailable;
 		try {
-			File file = new File(tempFolder, "image.png");
-			file.createNewFile();
-			URL imageFileURL = file.toURI().toURL();
-			new File(tempFolder, "image@2x.png").createNewFile();
+			Path imagePath = tempFolder.resolve("image.png");
+			Files.createFile(imagePath);
+			URL imageFileURL = imagePath.toUri().toURL();
+			Files.createFile(tempFolder.resolve("image@2x.png"));
 			ImageDescriptor descriptor = ImageDescriptor.createFromURL(imageFileURL);
 
 			ImageFileNameProvider fileNameProvider = Adapters.adapt(descriptor, ImageFileNameProvider.class);
 			assertNotNull(fileNameProvider, "URLImageDescriptor does not adapt to ImageFileNameProvider");
 			String imagePath100 = fileNameProvider.getImagePath(100);
 			assertNotNull(imagePath100, "URLImageDescriptor ImageFileNameProvider does not return the 100% path");
-			assertEquals(IPath.fromOSString(imagePath100).lastSegment(), "image.png");
+			assertEquals("image.png", IPath.fromOSString(imagePath100).lastSegment());
 			String imagePath200 = fileNameProvider.getImagePath(200);
 			assertNotNull(imagePath200, "URLImageDescriptor ImageFileNameProvider does not return the @2x path");
-			assertEquals(IPath.fromOSString(imagePath200).lastSegment(), "image@2x.png");
+			assertEquals("image@2x.png", IPath.fromOSString(imagePath200).lastSegment());
 			String imagePath150 = fileNameProvider.getImagePath(150);
 			assertNull(imagePath150, "URLImageDescriptor's ImageFileNameProvider does return a @1.5x path");
 		} finally {
@@ -157,15 +158,15 @@ public class UrlImageDescriptorTest {
 
 	@Test
 	public void testImageFileNameProviderGetxName_forFileURL_WhiteSpace() throws IOException {
-		File imageFolder = new File(tempFolder, "folder with spaces");
-		imageFolder.mkdir();
-		File imageFile = new File(imageFolder, "image with spaces.png");
-		imageFile.createNewFile();
+		Path imageFolder = tempFolder.resolve("folder with spaces");
+		Files.createDirectories(imageFolder);
+		Path imagePath = imageFolder.resolve("image with spaces.png");
+		Files.createFile(imagePath);
 
 		// This is an invalid URL because the whitespace characters are not properly
 		// encoded
 		@SuppressWarnings("deprecation")
-		URL imageFileURL = new URL("file", null, imageFile.getPath());
+		URL imageFileURL = new URL("file", null, imagePath.toString());
 		ImageDescriptor descriptor = ImageDescriptor.createFromURL(imageFileURL);
 
 		ImageFileNameProvider fileNameProvider = Adapters.adapt(descriptor, ImageFileNameProvider.class);

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/layout/AllLayoutTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/layout/AllLayoutTests.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.layout;
 
-
-
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
@@ -22,7 +20,5 @@ import org.junit.platform.suite.api.Suite;
 @SelectClasses({ GeometryTest.class, AbstractColumnLayoutTest.class, GridDataFactoryTest.class,
 		GridLayoutFactoryTest.class, TreeColumnLayoutTest.class })
 public class AllLayoutTests {
-
-	
 
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/preferences/AllPrefsTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/preferences/AllPrefsTests.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.preferences;
 
-
-
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
@@ -27,5 +25,4 @@ import org.junit.platform.suite.api.Suite;
 })
 public class AllPrefsTests {
 
-	
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/resources/AllResourcesTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/resources/AllResourcesTests.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.jface.tests.resources;
 
-
-
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
@@ -23,5 +21,4 @@ import org.junit.platform.suite.api.Suite;
 @SelectClasses({ FontRegistryTest.class, JFaceResourcesTest.class })
 public class AllResourcesTests {
 
-	
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/AllViewersTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/AllViewersTests.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.jface.tests.viewers;
 
-
-
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
@@ -35,7 +33,5 @@ import org.junit.platform.suite.api.Suite;
 		TreeViewerWithLimitTest.class, TreeViewerWithLimitCompatibilityTest.class, TableViewerWithLimitTest.class,
 		TableViewerWithLimitCompatibilityTest.class })
 public class AllViewersTests {
-
-	
 
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TestLazyModelContentProvider.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TestLazyModelContentProvider.java
@@ -18,8 +18,6 @@ import org.eclipse.jface.viewers.ILazyContentProvider;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.Viewer;
 
-import org.opentest4j.AssertionFailedError;
-
 /**
  * The TestLazyModelContentProvider is the lazy version
  * of the model content provider.
@@ -32,7 +30,7 @@ public class TestLazyModelContentProvider extends TestModelContentProvider imple
 	TestLazyModelContentProvider(TableViewerTest testObject){
 		test = testObject;
 		if(!(testObject instanceof VirtualLazyTableViewerTest)) {
-			throw new AssertionFailedError("TestLazyModelContentProvider only works with VirtualLazyTableViewerTest");
+			throw new IllegalStateException("TestLazyModelContentProvider only works with VirtualLazyTableViewerTest");
 		}
 	}
 

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TreeViewerWithLimitTest.java
@@ -277,15 +277,12 @@ public class TreeViewerWithLimitTest extends BaseLimitBasedViewerTest {
 		assertTrue(treeViewer.contains(rootModel, rootModel.get(0)), "element must be available on the viewer");
 
 		// last child of the root
-		assertTrue(
-				treeViewer.contains(rootModel, rootModel.get(rootModel.size() - 1)), "element must be available on the viewer");
+		assertTrue(treeViewer.contains(rootModel, rootModel.get(rootModel.size() - 1)), "element must be available on the viewer");
 		// child of first element is not expanded
-		assertFalse(
-				treeViewer.contains(rootModel, rootModel.get(0).children.get(0)), "element must not be available on the viewer");
+		assertFalse(treeViewer.contains(rootModel, rootModel.get(0).children.get(0)), "element must not be available on the viewer");
 		treeViewer.expandAll();
 		// child of first element when expanded.
-		assertTrue(
-				treeViewer.contains(rootModel, rootModel.get(0).children.get(0)), "element must be available on the viewer");
+		assertTrue(treeViewer.contains(rootModel, rootModel.get(0).children.get(0)), "element must be available on the viewer");
 	}
 
 	@Override

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/window/AllWindowTests.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/window/AllWindowTests.java
@@ -14,8 +14,6 @@
 
 package org.eclipse.jface.tests.window;
 
-
-
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
@@ -26,5 +24,4 @@ import org.junit.platform.suite.api.Suite;
 })
 public class AllWindowTests {
 
-	
 }

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/wizards/WizardTestSuite.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/wizards/WizardTestSuite.java
@@ -14,15 +14,11 @@
 
 package org.eclipse.jface.tests.wizards;
 
-
-
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
 @Suite
 @SelectClasses({ ButtonAlignmentTest.class, WizardTest.class, WizardProgressMonitorTest.class })
 public class WizardTestSuite {
-
-	
 
 }


### PR DESCRIPTION
- Migrated all tests in org.eclipse.jface.tests to JUnit 5.
- Updated MANIFEST.MF to use org.junit.jupiter.api and removed JUnit 4.
- Replaced JUnit 4 Rules with JUnit 5 Extensions or @TempDir.
- Fixed assertion and assumption parameter order for JUnit 5.
- Removed unused JFaceActionRule.
- Replaced JUnit 3 AssertionFailedError with IllegalStateException in TestLazyModelContentProvider.