### PR TITLE
Adapt placement test in StatusDialogManagerTest for fractional scaling

### DIFF
--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/StatusDialogManagerTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/statushandlers/StatusDialogManagerTest.java
@@ -774,7 +774,16 @@ public class StatusDialogManagerTest {
 		wsdm.addStatusAdapter(statusAdapter, false);
 		assertNotNull(StatusDialogUtil.getStatusShell());
 		Shell shell = StatusDialogUtil.getStatusShell();
-		assertEquals("Dialog is not centered correctly",getInitialLocation(shell), shell.getLocation());
+
+		Point expected = getInitialLocation(shell);
+		Point actual = shell.getLocation();
+		int tolerance = 1;
+		assertTrue("Dialog is not centered correctly" //
+				+ " (expected location: " + expected + " ± " + tolerance //
+				+ ", actual location: " + actual //
+				+ ", dialog bounds: " + shell.getBounds() //
+				+ ", parent bounds: " + shell.getParent().getBounds() + ")",
+				Math.abs(expected.x - actual.x) <= tolerance && Math.abs(expected.y - actual.y) <= tolerance);
 	}
 
 	//error link present


### PR DESCRIPTION
The StatusDialogManagerTest.testBug275867() sporadically fails on Windows because of off-by-one errors between the expected and actual location of the shell, probably caused by rounding on fractional monitor zooms.
To be more resilient against slight offsets in the position of the shell, this change adds a tolerance to the position validation. It also adds some more debug information to the failure description.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3717