### PR TITLE
Split table creation and configuration logic for QuickAccess to fix bold font

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessContents.java
@@ -725,8 +725,8 @@ public abstract class QuickAccessContents {
 
 	/**
 	 * Creates the table providing the contents for the quick access dialog. After
-	 * applying the dialog font, call {@link #installTableStyling(int)} to complete
-	 * the styling and layout for this table.
+	 * applying the dialog font, call {@link #configureTableStyling(int)} to
+	 * complete the styling and layout for this table.
 	 *
 	 * @param composite parent composite with {@link GridLayout}
 	 * @return the created table

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessDialog.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/quickaccess/QuickAccessDialog.java
@@ -13,6 +13,7 @@
  *     Tom Hochstein (Freescale) - Bug 393703 - NotHandledException selecting inactive command under 'Previous Choices' in Quick access
  *     René Brandstetter - Bug 433778
  *     Patrik Suzzi <psuzzi@gmail.com> - Bug 491410
+ *     Stefan Winkler <stefan@winklerweb.net> - Bug #3742
  *******************************************************************************/
 package org.eclipse.ui.internal.quickaccess;
 
@@ -246,10 +247,21 @@ public class QuickAccessDialog extends PopupDialog {
 		gridData.horizontalIndent = IDialogConstants.HORIZONTAL_MARGIN;
 		hintText.setLayoutData(gridData);
 
-		Table table = contents.createTable(composite, getDefaultOrientation());
+		Table table = contents.createTable(composite);
 		table.addKeyListener(getKeyAdapter());
 
 		return composite;
+	}
+
+	@Override
+	protected Control createContents(Composite parent) {
+		Control control = super.createContents(parent);
+
+		// after the complete contents (including dialog fonts) are configured, apply
+		// the table layout and styling
+		contents.configureTableStyling(getDefaultOrientation());
+
+		return control;
 	}
 
 	private TriggerSequence[] getInvokingCommandKeySequences() {
@@ -309,6 +321,7 @@ public class QuickAccessDialog extends PopupDialog {
 	@Override
 	protected Point getDefaultSize() {
 		GC gc = new GC(getContents());
+		gc.setFont(contents.getTable().getFont());
 		FontMetrics fontMetrics = gc.getFontMetrics();
 		gc.dispose();
 		int x = Dialog.convertHorizontalDLUsToPixels(fontMetrics, 300);


### PR DESCRIPTION
Fixes #3742 by splitting createTable() into the table creation logic and the table configuration logic. 
The former is executed as it was, but the latter is postponed until after the Dialog Font preferences have been applied, namely after PopupDialog.createContents() has completely been executed.

This PR contains three things, in detail:
* the fix to the bold font mentioned in #3742 
* a small fix to also adjust the default dialog size to the table font
* simplifying of three event adapters by replacing them with the more modern closure syntax
