### PR TITLE
Fix sticky scroll height calculation for variable line heights

### DIFF
--- a/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.editors/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.editors; singleton:=true
-Bundle-Version: 3.21.0.qualifier
+Bundle-Version: 3.21.100.qualifier
 Bundle-Activator: org.eclipse.ui.internal.editors.text.EditorsPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -331,7 +331,10 @@ public class StickyScrollingControl {
 		StyledText textWidget= sourceViewer.getTextWidget();
 
 		int numberStickyLines= getNumberStickyLines();
-		int lineHeight= stickyLineText.getLineHeight() * numberStickyLines;
+		int lineHeight= 0;
+		for (int i= 0; i < numberStickyLines; i++) {
+			lineHeight+= stickyLineText.getLineHeight(stickyLineText.getOffsetAtLine(i));
+		}
 		int spacingHeight= stickyLineText.getLineSpacing() * (numberStickyLines - 1);
 		int separatorHeight= bottomSeparator.getBounds().height;
 
@@ -450,7 +453,8 @@ public class StickyScrollingControl {
 	}
 
 	private void limitVisibleStickyLinesToTextWidgetHeight(StyledText textWidget) {
-		int lineHeight= textWidget.getLineHeight() + textWidget.getLineSpacing();
+		int topOffset= textWidget.getOffsetAtLine(textWidget.getTopIndex());
+		int lineHeight= textWidget.getLineHeight(topOffset) + textWidget.getLineSpacing();
 		int textWidgetHeight= textWidget.getBounds().height;
 
 		int visibleLinesInTextWidget= textWidgetHeight / lineHeight;

--- a/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.editors.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.editors.tests;singleton:=true
-Bundle-Version: 3.14.0.qualifier
+Bundle-Version: 3.14.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jface.text.tests.codemining,

--- a/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
+++ b/tests/org.eclipse.ui.editors.tests/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControlTest.java
@@ -237,6 +237,26 @@ public class StickyScrollingControlTest {
 	}
 
 	@Test
+	void testCanvasBoundsHeightMatchesPerLineHeights() {
+		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
+		List<IStickyLine> stickyLines = List.of(new StickyLineStub("line 1", 0), new StickyLineStub("line 2", 1));
+		stickyScrollingControl.setStickyLines(stickyLines);
+
+		Canvas stickyControlCanvas = getStickyControlCanvas(shell);
+		StyledText stickyLineText = getStickyLineText();
+		Composite stickyLineSeparator = getStickyLineSeparator();
+
+		int expectedHeight = 0;
+		for (int i = 0; i < 2; i++) {
+			expectedHeight += stickyLineText.getLineHeight(stickyLineText.getOffsetAtLine(i));
+		}
+		expectedHeight += stickyLineText.getLineSpacing(); // (2-1) * spacing
+		expectedHeight += stickyLineSeparator.getBounds().height;
+
+		assertEquals(expectedHeight, stickyControlCanvas.getBounds().height);
+	}
+
+	@Test
 	void testLayoutStickyLinesCanvasOnResize() {
 		sourceViewer.getTextWidget().setBounds(0, 0, 200, 200);
 


### PR DESCRIPTION
When emoji or other content affects line heights, sticky scroll was calculating the total height wrong by assuming all lines were the same. Now it gets the actual height for each line instead. Also fixes the height check for limiting visible lines.