### PR TITLE
[Demo] Remove Unwanted Single Quotes in Label #3751

### DIFF
--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2020 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -449,7 +449,7 @@ FileEditorPreference_default = De&fault
 FileEditorPreference_existsTitle = File Type Exists
 FileEditorPreference_existsMessage = An entry already exists for that file type
 FileEditorPreference_defaultLabel = (default)
-FileEditorPreference_contentTypesRelatedLink = See <a>''{0}''</a> for content-type based file associations.
+FileEditorPreference_contentTypesRelatedLink = See <a>{0}</a> for content-type based file associations.
 FileEditorPreference_isLocked = {0} (locked by ''{1}'' content type)
 
 FileExtension_extensionEmptyMessage = The file extension cannot be empty


### PR DESCRIPTION
This commit will remove unwanted single quotes displayed in Editors -> File Associations section label

Fixes : https://github.com/eclipse-platform/eclipse.platform.ui/issues/3751