### PR TITLE
Search filter showing only deepest match should't filter closed projects

### DIFF
--- a/bundles/org.eclipse.search/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.search; singleton:=true
-Bundle-Version: 3.18.0.qualifier
+Bundle-Version: 3.18.100.qualifier
 Bundle-Activator: org.eclipse.search.internal.ui.SearchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.properties
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/SearchMessages.properties
@@ -97,7 +97,7 @@ SearchPage_wholeWord= Who&le word
 
 TextSearchEngine_statusMessage= Problems encountered during text search.
 
-TextSearchInnermostProjectFilter_action_label=Show only most &nested match
+TextSearchInnermostProjectFilter_action_label=Show Only Most &Nested Match
 TextSearchInnermostProjectFilter_name=Duplicate match from outer project
 TextSearchInnermostProjectFilter_description= For files in nested projects, don't show matches for duplicate file references that are owned by projects that aren't the innermost project.
 TextSearchPage_searchIn_label=Search In

--- a/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/text/OuterProjectFileFilter.java
+++ b/bundles/org.eclipse.search/search/org/eclipse/search/internal/ui/text/OuterProjectFileFilter.java
@@ -28,10 +28,15 @@ public class OuterProjectFileFilter extends MatchFilter {
 	@Override
 	public boolean filters(Match match) {
 		if (match instanceof FileMatch) {
-			IFile file= ((FileMatch)match).getFile();
+			IFile file = ((FileMatch) match).getFile();
 			URI locationUri = file.getLocationURI();
+
 			IFile innermostFile = locationUri == null ? file : //
 					Arrays.stream(file.getWorkspace().getRoot().findFilesForLocationURI(locationUri)) //
+							// Don't consider the content of a closed project
+							// for filtering because the matches there cannot be
+							// shown
+							.filter(aFile -> aFile.getProject().isAccessible())
 							.min(Comparator.comparingInt(aFile -> aFile.getFullPath().segments().length))
 							// shortest workspace (project relative) full path
 							// means most nested project


### PR DESCRIPTION
- A closed project's content cannot be searched so matches attributed to a closed nested project should not filter the corresponding match from the outer project otherwise you can get very confusing results like `showing 0 of 1 matches`.
- Fix action label which is shown on a menu to be title case.