### PR TITLE
Fix dark theme black toolbar background in inactive view stacks

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.ui.workbench.renderers.swt;singleton:=true
-Bundle-Version: 0.17.0.qualifier
+Bundle-Version: 0.17.100.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/StackRenderer.java
@@ -804,10 +804,11 @@ public class StackRenderer extends LazyStackRenderer {
 			tabFolder.setUnselectedCloseVisible(false);
 		}
 
-		bindWidget(element, tabFolder); // ?? Do we need this ?
-
-		// Add a composite to manage the view's TB and Menu
+		// Add a composite to manage the view's TB and Menu before bindWidget,
+		// so the CSS cascade triggered by bindWidget already reaches trComp
 		addTopRight(tabFolder);
+
+		bindWidget(element, tabFolder); // ?? Do we need this ?
 
 		return tabFolder;
 	}

--- a/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.themes;singleton:=true
-Bundle-Version: 1.2.2900.qualifier
+Bundle-Version: 1.2.3000.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.e4.ui.css.swt.theme

--- a/bundles/org.eclipse.ui.themes/css/dark/e4-dark_tabstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/dark/e4-dark_tabstyle.css
@@ -75,7 +75,7 @@ CTabItem:selected CLabel {
     color: '#org-eclipse-ui-workbench-ACTIVE_NOFOCUS_TAB_SELECTED_TEXT_COLOR';
 }
 
-CTabFolder > Composite#ToolbarComposite {
+CTabFolder > Composite.ToolbarComposite {
   background-color: '#org-eclipse-ui-workbench-ACTIVE_TAB_BG_END'; /* HACK for background of CTabFolder inner Toolbars */
 }
 


### PR DESCRIPTION
Two related bugs caused the toolbar composite (top-right area of a CTabFolder) to show a black background in the dark theme for any view stack that was never activated by the user:

1. CSS cascade timing (StackRenderer): bindWidget() was called before addTopRight(), so the initial CSS cascade triggered by bindWidget never reached trComp (it didn't exist yet). Only stacks later activated by the user got a subsequent cascade that corrected the background. Fix: call addTopRight() before bindWidget().

2. Wrong CSS selector type (e4-dark_tabstyle.css): the rule used "Composite#ToolbarComposite" (ID selector) but ToolBarManagerRenderer sets a CSS class, not a CSS ID, on the composite. The rule therefore never matched. Fix: change "#ToolbarComposite" to ".ToolbarComposite".