### PR TITLE
Minor improvements to o.e.core.filebuffers.tests

### DIFF
--- a/tests/org.eclipse.core.filebuffers.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.core.filebuffers.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.core.filebuffers.tests;singleton:=true
-Bundle-Version: 3.14.0.qualifier
+Bundle-Version: 3.14.100.qualifier
 Bundle-Activator: org.eclipse.core.filebuffers.tests.FileBuffersTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName
@@ -15,6 +15,7 @@ Require-Bundle:
  org.eclipse.core.filebuffers;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.text;bundle-version="[3.5.0,4.0.0)"
 Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
+ org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",
  org.junit.jupiter.api.extension;version="[5.14.0,6.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/AbstractFileBufferDocCreationTests.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/AbstractFileBufferDocCreationTests.java
@@ -15,8 +15,6 @@ package org.eclipse.core.filebuffers.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -34,7 +32,6 @@ import org.eclipse.core.filebuffers.tests.MockDocumentSetupParticipants.TestDSP5
 import org.eclipse.core.filebuffers.tests.MockDocumentSetupParticipants.TestDSP6;
 
 import org.eclipse.jface.text.IDocument;
-
 
 /**
  * @since 3.4
@@ -124,8 +121,8 @@ public abstract class AbstractFileBufferDocCreationTests {
 		for (LocationKind lk : lks) {
 			IDocument document= fManager.createEmptyDocument(IPath.fromOSString(path), lk);
 			String content= document.get();
-			Set<String> expectedDSPs= new HashSet<>(Arrays.asList(toString(expectedDSPsArray)));
-			Set<String> actualDSPs= new HashSet<>(Arrays.asList(content.split("\n")));
+			Set<String> expectedDSPs= Set.of(toString(expectedDSPsArray));
+			Set<String> actualDSPs= Set.of(content.split("\n"));
 			assertEquals(expectedDSPs, actualDSPs);
 		}
 	}

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBufferCreation.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBufferCreation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2013 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -42,10 +42,7 @@ import org.eclipse.core.filebuffers.ITextFileBuffer;
 import org.eclipse.core.filebuffers.ITextFileBufferManager;
 import org.eclipse.core.filebuffers.LocationKind;
 
-import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
-
-
 
 public class FileBufferCreation {
 
@@ -54,9 +51,7 @@ public class FileBufferCreation {
 	private final static String CONTENT3= "This is the content of the external file.";
 	private final static String CONTENT4= "This is the content of a file in a linked folder.";
 
-
 	private IProject fProject;
-
 
 	@BeforeEach
 	public void setUp() throws Exception {
@@ -166,11 +161,7 @@ public class FileBufferCreation {
 		assertEquals(CONTENT1, document2.get());
 		assertSame(buffer2, manager.getTextFileBuffer(document2));
 
-		try {
-			document1.replace(0, document1.getLength(), CONTENT3);
-		} catch (BadLocationException x) {
-			assertTrue(false);
-		}
+		document1.replace(0, document1.getLength(), CONTENT3);
 
 		assertEquals(CONTENT3, document2.get());
 
@@ -198,7 +189,7 @@ public class FileBufferCreation {
 
 		IDocument document= buffer.getDocument();
 		assertNotNull(document);
-		assertTrue(CONTENT2.equals(document.get()));
+		assertEquals(CONTENT2, document.get());
 		assertSame(buffer, manager.getTextFileBuffer(document));
 
 		manager.disconnect(path, LocationKind.NORMALIZE, null);
@@ -221,7 +212,7 @@ public class FileBufferCreation {
 
 		IDocument document= buffer.getDocument();
 		assertNotNull(document);
-		assertTrue(CONTENT4.equals(document.get()));
+		assertEquals(CONTENT4, document.get());
 		assertSame(buffer, manager.getTextFileBuffer(document));
 
 		manager.disconnect(path, LocationKind.NORMALIZE, null);
@@ -259,11 +250,7 @@ public class FileBufferCreation {
 		assertEquals(document1.get(), document2.get());
 		assertEquals(CONTENT2, document1.get());
 
-		try {
-			document1.replace(0, document1.getLength(), CONTENT1);
-		} catch (BadLocationException x) {
-			assertFalse(false);
-		}
+		document1.replace(0, document1.getLength(), CONTENT1);
 
 		assertFalse(document1.get().equals(document2.get()));
 
@@ -290,7 +277,7 @@ public class FileBufferCreation {
 
 		IDocument document= buffer.getDocument();
 		assertNotNull(document);
-		assertTrue(CONTENT3.equals(document.get()));
+		assertEquals(CONTENT3, document.get());
 		assertSame(buffer, manager.getTextFileBuffer(document));
 
 		manager.disconnect(path, LocationKind.NORMALIZE, null);
@@ -330,11 +317,7 @@ public class FileBufferCreation {
 		assertEquals(document1.get(), document2.get());
 		assertEquals(CONTENT3, document1.get());
 
-		try {
-			document1.replace(0, document1.getLength(), CONTENT1);
-		} catch (BadLocationException x) {
-			assertFalse(false);
-		}
+		document1.replace(0, document1.getLength(), CONTENT1);
 
 		assertFalse(document1.get().equals(document2.get()));
 
@@ -359,7 +342,7 @@ public class FileBufferCreation {
 
 		IDocument document= buffer.getDocument();
 		assertNotNull(document);
-		assertTrue("".equals(document.get()));
+		assertTrue(document.get().isEmpty());
 		assertSame(buffer, manager.getTextFileBuffer(document));
 
 		manager.disconnect(path, LocationKind.NORMALIZE, null);
@@ -428,11 +411,7 @@ public class FileBufferCreation {
 		assertEquals(CONTENT1, document2.get());
 		assertSame(buffer2, manager.getTextFileBuffer(document2));
 
-		try {
-			document1.replace(0, document1.getLength(), CONTENT3);
-		} catch (BadLocationException x) {
-			assertTrue(false);
-		}
+		document1.replace(0, document1.getLength(), CONTENT3);
 
 		assertEquals(CONTENT3, document2.get());
 
@@ -460,7 +439,7 @@ public class FileBufferCreation {
 
 		IDocument document= buffer.getDocument();
 		assertNotNull(document);
-		assertTrue(CONTENT2.equals(document.get()));
+		assertEquals(CONTENT2, document.get());
 		assertSame(buffer, manager.getTextFileBuffer(document));
 
 		manager.disconnect(path, LocationKind.IFILE, null);
@@ -483,7 +462,7 @@ public class FileBufferCreation {
 
 		IDocument document= buffer.getDocument();
 		assertNotNull(document);
-		assertTrue(CONTENT4.equals(document.get()));
+		assertEquals(CONTENT4, document.get());
 		assertSame(buffer, manager.getTextFileBuffer(document));
 
 		manager.disconnect(path, LocationKind.IFILE, null);
@@ -521,11 +500,7 @@ public class FileBufferCreation {
 		assertEquals(document1.get(), document2.get());
 		assertEquals(CONTENT2, document1.get());
 
-		try {
-			document1.replace(0, document1.getLength(), CONTENT1);
-		} catch (BadLocationException x) {
-			assertFalse(false);
-		}
+		document1.replace(0, document1.getLength(), CONTENT1);
 
 		assertFalse(document1.get().equals(document2.get()));
 
@@ -552,7 +527,7 @@ public class FileBufferCreation {
 
 		IDocument document= buffer.getDocument();
 		assertNotNull(document);
-		assertTrue(CONTENT3.equals(document.get()));
+		assertEquals(CONTENT3, document.get());
 		assertSame(buffer, manager.getTextFileBuffer(document));
 
 		manager.disconnect(path, LocationKind.LOCATION, null);
@@ -574,7 +549,7 @@ public class FileBufferCreation {
 
 		IDocument document= buffer.getDocument();
 		assertNotNull(document);
-		assertTrue("".equals(document.get()));
+		assertTrue(document.get().isEmpty());
 		assertSame(buffer, manager.getTextFileBuffer(document));
 
 		manager.disconnect(path, LocationKind.LOCATION, null);
@@ -597,7 +572,7 @@ public class FileBufferCreation {
 
 		IDocument document= buffer.getDocument();
 		assertNotNull(document);
-		assertTrue("".equals(document.get()));
+		assertTrue(document.get().isEmpty());
 		assertSame(buffer, manager.getTextFileBuffer(document));
 
 		manager.disconnectFileStore(fileStore, null);

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBufferFunctions.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBufferFunctions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,9 +14,11 @@
  *******************************************************************************/
 package org.eclipse.core.filebuffers.tests;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -79,7 +81,7 @@ public abstract class FileBufferFunctions {
 		fProject= ResourceHelper.createProject("project");
 		fPath= createPath(fProject);
 		ITextFileBuffer buffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
-		assertTrue(buffer == null);
+		assertNull(buffer);
 	}
 
 	protected IProject getProject() {
@@ -89,7 +91,7 @@ public abstract class FileBufferFunctions {
 	@AfterEach
 	public void tearDown() {
 		ITextFileBuffer buffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
-		assertTrue(buffer == null);
+		assertNull(buffer);
 		ResourceHelper.deleteProject("project");
 	}
 
@@ -426,7 +428,7 @@ public abstract class FileBufferFunctions {
 		try {
 
 			ITextFileBuffer fileBuffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connect(fPath, LocationKind.NORMALIZE, null);
 			try {
@@ -477,7 +479,7 @@ public abstract class FileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connect(fPath, LocationKind.NORMALIZE, null);
 			try {
@@ -630,7 +632,7 @@ public abstract class FileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connect(fPath, LocationKind.NORMALIZE, null);
 			try {
@@ -676,7 +678,7 @@ public abstract class FileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connect(fPath, LocationKind.NORMALIZE, null);
 			try {
@@ -723,7 +725,7 @@ public abstract class FileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connect(fPath, LocationKind.NORMALIZE, null);
 			try {
@@ -770,7 +772,7 @@ public abstract class FileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connect(fPath, LocationKind.NORMALIZE, null);
 			try {
@@ -817,7 +819,7 @@ public abstract class FileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connect(fPath, LocationKind.NORMALIZE, null);
 			try {
@@ -860,7 +862,7 @@ public abstract class FileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connect(fPath, LocationKind.NORMALIZE, null);
 			try {
@@ -913,7 +915,7 @@ public abstract class FileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connect(fPath, LocationKind.NORMALIZE, null);
 			try {
@@ -954,7 +956,7 @@ public abstract class FileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connect(fPath, LocationKind.NORMALIZE, null);
 			try {
@@ -995,7 +997,7 @@ public abstract class FileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connect(fPath, LocationKind.NORMALIZE, null);
 			try {
@@ -1036,7 +1038,7 @@ public abstract class FileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connect(fPath, LocationKind.NORMALIZE, null);
 			try {
@@ -1078,7 +1080,7 @@ public abstract class FileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connect(fPath, LocationKind.NORMALIZE, null);
 			try {
@@ -1121,7 +1123,7 @@ public abstract class FileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connect(fPath, LocationKind.NORMALIZE, null);
 			try {

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForFilesInLinkedFolders.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForFilesInLinkedFolders.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,10 +14,8 @@
 package org.eclipse.core.filebuffers.tests;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.OutputStream;
 
 import org.junit.jupiter.api.AfterEach;
@@ -71,9 +69,6 @@ public class FileBuffersForFilesInLinkedFolders extends FileBufferFunctions {
 		return file.getFullPath();
 	}
 
-	/*
-	 * @see org.eclipse.core.filebuffers.tests.FileBufferFunctions#markReadOnly()
-	 */
 	@Override
 	protected void setReadOnly(boolean state) throws Exception {
 		IFile file= FileBuffers.getWorkspaceFileAtLocation(getPath());
@@ -115,8 +110,6 @@ public class FileBuffersForFilesInLinkedFolders extends FileBufferFunctions {
 		try (OutputStream out= fileStore.openOutputStream(EFS.NONE, null)) {
 			out.write("Changed content of file in linked folder".getBytes());
 			out.flush();
-		} catch (IOException x) {
-			fail();
 		}
 		IFileInfo fileInfo= fileStore.fetchInfo();
 		fileInfo.setLastModified(1000);

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForLinkedFiles.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForLinkedFiles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,8 @@
 package org.eclipse.core.filebuffers.tests;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.AfterEach;
 import org.osgi.framework.Bundle;
@@ -54,9 +56,6 @@ public class FileBuffersForLinkedFiles extends FileBufferFunctions {
 		return file.getFullPath();
 	}
 
-	/*
-	 * @see org.eclipse.core.filebuffers.tests.FileBufferFunctions#markReadOnly()
-	 */
 	@Override
 	protected void setReadOnly(boolean state) throws Exception {
 		IFile file= FileBuffers.getWorkspaceFileAtLocation(getPath());
@@ -93,7 +92,7 @@ public class FileBuffersForLinkedFiles extends FileBufferFunctions {
 
 	@Override
 	protected boolean modifyUnderlyingFile() throws Exception {
-		FileTool.write(fExternalFile.getAbsolutePath(), "Changed content of linked file");
+		Files.writeString(Path.of(fExternalFile.getAbsolutePath()), "Changed content of linked file");
 		fExternalFile.setLastModified(1000);
 		IFile iFile= FileBuffers.getWorkspaceFileAtLocation(getPath());
 		iFile.refreshLocal(IResource.DEPTH_INFINITE, null);

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForNonAccessibleWorkspaceFiles.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForNonAccessibleWorkspaceFiles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -59,9 +59,6 @@ public class FileBuffersForNonAccessibleWorkspaceFiles extends FileBufferFunctio
 		super.tearDown();
 	}
 
-	/*
-	 * @see org.eclipse.core.filebuffers.tests.FileBufferFunctions#markReadOnly()
-	 */
 	@Override
 	protected void setReadOnly(boolean state) throws Exception {
 		IFileStore fileStore= FileBuffers.getFileStoreAtLocation(getPath());

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForNonExistingExternalFiles.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForNonExistingExternalFiles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -47,9 +47,6 @@ public class FileBuffersForNonExistingExternalFiles extends FileBufferFunctions 
 		return IPath.fromOSString(path.toFile().getAbsolutePath());
 	}
 
-	/*
-	 * @see org.eclipse.core.filebuffers.tests.FileBufferFunctions#markReadOnly()
-	 */
 	@Override
 	protected void setReadOnly(boolean state) throws Exception {
 		IFileStore fileStore= FileBuffers.getFileStoreAtLocation(getPath());

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForNonExistingWorkspaceFiles.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForNonExistingWorkspaceFiles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -91,9 +91,6 @@ public class FileBuffersForNonExistingWorkspaceFiles extends FileBufferFunctions
 		assertTrue(file.exists());
 	}
 
-	/*
-	 * @see org.eclipse.core.filebuffers.tests.FileBufferFunctions#markReadOnly()
-	 */
 	@Override
 	protected void setReadOnly(boolean state) throws Exception {
 		IFileStore fileStore= FileBuffers.getFileStoreAtLocation(getPath());

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForWorkspaceFiles.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForWorkspaceFiles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,10 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.filebuffers.tests;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
-import java.io.IOException;
 import java.io.OutputStream;
 
 import org.osgi.framework.Bundle;
@@ -50,9 +49,6 @@ public class FileBuffersForWorkspaceFiles extends FileBufferFunctions {
 		return file.getFullPath();
 	}
 
-	/*
-	 * @see org.eclipse.core.filebuffers.tests.FileBufferFunctions#markReadOnly()
-	 */
 	@Override
 	protected void setReadOnly(boolean state) throws Exception {
 		IFile file= FileBuffers.getWorkspaceFileAtLocation(getPath());
@@ -94,14 +90,12 @@ public class FileBuffersForWorkspaceFiles extends FileBufferFunctions {
 		try (OutputStream out= fileStore.openOutputStream(EFS.NONE, null)) {
 			out.write("Changed content of workspace file".getBytes());
 			out.flush();
-		} catch (IOException x) {
-			fail();
 		}
 		IFileInfo fileInfo= fileStore.fetchInfo();
 		fileInfo.setLastModified(1000);
 		fileStore.putInfo(fileInfo, EFS.SET_LAST_MODIFIED, null);
 		IFile iFile= FileBuffers.getWorkspaceFileAtLocation(getPath());
-		assertTrue(iFile.exists() && iFile.getFullPath().equals(getPath()));
+		assertAll(() -> assertTrue(iFile.exists()), () -> assertTrue(iFile.getFullPath().equals(getPath())));
 		iFile.refreshLocal(IResource.DEPTH_INFINITE, null);
 		return true;
 	}

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileStoreFileBufferFunctions.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileStoreFileBufferFunctions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2015 IBM Corporation and others.
+ * Copyright (c) 2007, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,9 +13,11 @@
  *******************************************************************************/
 package org.eclipse.core.filebuffers.tests;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -75,7 +77,7 @@ public abstract class FileStoreFileBufferFunctions {
 		fProject= ResourceHelper.createProject("project");
 		fFileStore= EFS.getLocalFileSystem().getStore(createPath(fProject));
 		ITextFileBuffer buffer= fManager.getFileStoreTextFileBuffer(fFileStore);
-		assertTrue(buffer == null);
+		assertNull(buffer);
 	}
 
 	protected IProject getProject() {
@@ -85,7 +87,7 @@ public abstract class FileStoreFileBufferFunctions {
 	@AfterEach
 	public void tearDown() {
 		ITextFileBuffer buffer= fManager.getFileStoreTextFileBuffer(fFileStore);
-		assertTrue(buffer == null);
+		assertNull(buffer);
 		ResourceHelper.deleteProject("project");
 	}
 
@@ -375,13 +377,13 @@ public abstract class FileStoreFileBufferFunctions {
 
 			fManager.connectFileStore(fFileStore, null);
 
-			assertTrue(listener.count == 1);
+			assertEquals(1, listener.count);
 			assertNotNull(listener.buffer);
 			IFileBuffer fileBuffer= fManager.getFileStoreFileBuffer(fFileStore);
 			assertTrue(listener.buffer == fileBuffer);
 
 			fManager.disconnectFileStore(fFileStore, null);
-			assertTrue(listener.count == 0);
+			assertEquals(0, listener.count);
 			assertTrue(listener.buffer == fileBuffer);
 
 		} finally {
@@ -417,7 +419,7 @@ public abstract class FileStoreFileBufferFunctions {
 		try {
 
 			ITextFileBuffer fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connectFileStore(fFileStore, null);
 			try {
@@ -426,13 +428,13 @@ public abstract class FileStoreFileBufferFunctions {
 				IDocument document= fileBuffer.getDocument();
 				document.replace(0, 0, "prefix");
 
-				assertTrue(listener.count == 1);
+				assertEquals(1, listener.count);
 				assertTrue(listener.buffer == fileBuffer);
 				assertTrue(listener.isDirty);
 
 				fileBuffer.commit(null, true);
 
-				assertTrue(listener.count == 2);
+				assertEquals(2, listener.count);
 				assertTrue(listener.buffer == fileBuffer);
 				assertFalse(listener.isDirty);
 
@@ -468,7 +470,7 @@ public abstract class FileStoreFileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connectFileStore(fFileStore, null);
 			try {
@@ -477,13 +479,13 @@ public abstract class FileStoreFileBufferFunctions {
 				IDocument document= fileBuffer.getDocument();
 				document.replace(0, 0, "prefix");
 
-				assertTrue(listener.count == 1);
+				assertEquals(1, listener.count);
 				assertTrue(listener.buffer == fileBuffer);
 				assertTrue(listener.isDirty);
 
 				fileBuffer.revert(null);
 
-				assertTrue(listener.count == 2);
+				assertEquals(2, listener.count);
 				assertTrue(listener.buffer == fileBuffer);
 				assertFalse(listener.isDirty);
 
@@ -534,9 +536,9 @@ public abstract class FileStoreFileBufferFunctions {
 
 				fileBuffer.revert(null);
 
-				assertTrue(listener.preCount == 1);
+				assertEquals(1, listener.preCount);
 				assertTrue(listener.preBuffer == fileBuffer);
-				assertTrue(listener.postCount == 1);
+				assertEquals(1, listener.postCount);
 				assertTrue(listener.postBuffer == fileBuffer);
 
 			} finally {
@@ -583,9 +585,9 @@ public abstract class FileStoreFileBufferFunctions {
 				fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
 
 				if (modifyUnderlyingFile()) {
-					assertTrue(listener.preCount == 1);
+					assertEquals(1, listener.preCount);
 					assertTrue(listener.preBuffer == fileBuffer);
-					assertTrue(listener.postCount == 1);
+					assertEquals(1, listener.postCount);
 					assertTrue(listener.postBuffer == fileBuffer);
 				}
 
@@ -621,7 +623,7 @@ public abstract class FileStoreFileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connectFileStore(fFileStore, null);
 			try {
@@ -630,7 +632,7 @@ public abstract class FileStoreFileBufferFunctions {
 				fileBuffer.validateState(null, null);
 
 				if (isStateValidationSupported()) {
-					assertTrue(listener.count == 1);
+					assertEquals(1, listener.count);
 					assertTrue(listener.buffer == fileBuffer);
 					assertTrue(listener.isStateValidated);
 				}
@@ -667,7 +669,7 @@ public abstract class FileStoreFileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connectFileStore(fFileStore, null);
 			try {
@@ -677,7 +679,7 @@ public abstract class FileStoreFileBufferFunctions {
 				fileBuffer.validateState(null, null);
 
 				if (isStateValidationSupported()) {
-					assertTrue(listener.count == 1);
+					assertEquals(1, listener.count);
 					assertTrue(listener.buffer == fileBuffer);
 					assertTrue(listener.isStateValidated);
 				}
@@ -714,7 +716,7 @@ public abstract class FileStoreFileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connectFileStore(fFileStore, null);
 			try {
@@ -724,7 +726,7 @@ public abstract class FileStoreFileBufferFunctions {
 				fileBuffer.resetStateValidation();
 
 				if (isStateValidationSupported()) {
-					assertTrue(listener.count == 2);
+					assertEquals(2, listener.count);
 					assertTrue(listener.buffer == fileBuffer);
 					assertFalse(listener.isStateValidated);
 				}
@@ -761,7 +763,7 @@ public abstract class FileStoreFileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connectFileStore(fFileStore, null);
 			try {
@@ -772,7 +774,7 @@ public abstract class FileStoreFileBufferFunctions {
 				fileBuffer.resetStateValidation();
 
 				if (isStateValidationSupported()) {
-					assertTrue(listener.count == 2);
+					assertEquals(2, listener.count);
 					assertTrue(listener.buffer == fileBuffer);
 					assertFalse(listener.isStateValidated);
 				}
@@ -808,14 +810,14 @@ public abstract class FileStoreFileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connectFileStore(fFileStore, null);
 			try {
 
 				fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
 				if (deleteUnderlyingFile()) {
-					assertTrue(listener.count == 1);
+					assertEquals(1, listener.count);
 					assertTrue(listener.buffer == fileBuffer);
 				}
 
@@ -851,7 +853,7 @@ public abstract class FileStoreFileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connectFileStore(fFileStore, null);
 			try {
@@ -859,7 +861,7 @@ public abstract class FileStoreFileBufferFunctions {
 				fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
 				IPath newLocation= moveUnderlyingFile();
 				if (newLocation != null) {
-					assertTrue(listener.count == 1);
+					assertEquals(1, listener.count);
 					assertTrue(listener.buffer == fileBuffer);
 					assertEquals(listener.newLocation, newLocation);
 				}
@@ -894,7 +896,7 @@ public abstract class FileStoreFileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connectFileStore(fFileStore, null);
 			try {
@@ -935,14 +937,14 @@ public abstract class FileStoreFileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connectFileStore(fFileStore, null);
 			try {
 
 				fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
 				if (deleteUnderlyingFile()) {
-					assertTrue(listener.count == 1);
+					assertEquals(1, listener.count);
 					assertTrue(listener.buffer == fileBuffer);
 				}
 
@@ -976,14 +978,14 @@ public abstract class FileStoreFileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connectFileStore(fFileStore, null);
 			try {
 
 				fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
 				if (moveUnderlyingFile() != null) {
-					assertTrue(listener.count == 1);
+					assertEquals(1, listener.count);
 					assertTrue(listener.buffer == fileBuffer);
 				}
 
@@ -1017,7 +1019,7 @@ public abstract class FileStoreFileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connectFileStore(fFileStore, null);
 			try {
@@ -1026,7 +1028,7 @@ public abstract class FileStoreFileBufferFunctions {
 				fileBuffer.validateState(null, null);
 
 				if (isStateValidationSupported()) {
-					assertTrue(listener.count == 1);
+					assertEquals(1, listener.count);
 					assertTrue(listener.buffer == fileBuffer);
 				}
 
@@ -1059,7 +1061,7 @@ public abstract class FileStoreFileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connectFileStore(fFileStore, null);
 			try {
@@ -1069,7 +1071,7 @@ public abstract class FileStoreFileBufferFunctions {
 				document.replace(0, 0, "prefix");
 				fileBuffer.revert(null);
 
-				assertTrue(listener.count == 1);
+				assertEquals(1, listener.count);
 				assertTrue(listener.buffer == fileBuffer);
 
 			} finally {
@@ -1102,7 +1104,7 @@ public abstract class FileStoreFileBufferFunctions {
 		fManager.addFileBufferListener(listener);
 		try {
 			ITextFileBuffer fileBuffer= fManager.getFileStoreTextFileBuffer(fFileStore);
-			assertTrue(listener.count == 0 && listener.buffer == null);
+			assertAll(() -> assertEquals(0, listener.count), () -> assertNull(listener.buffer));
 
 			fManager.connectFileStore(fFileStore, null);
 			try {
@@ -1112,7 +1114,7 @@ public abstract class FileStoreFileBufferFunctions {
 				document.replace(0, 0, "prefix");
 				fileBuffer.commit(null, true);
 
-				assertTrue(listener.count == 1);
+				assertEquals(1, listener.count);
 				assertTrue(listener.buffer == fileBuffer);
 
 			} finally {

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileStoreFileBuffersForNonExistingExternalFiles.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileStoreFileBuffersForNonExistingExternalFiles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2015 IBM Corporation and others.
+ * Copyright (c) 2007, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -47,9 +47,6 @@ public class FileStoreFileBuffersForNonExistingExternalFiles extends FileStoreFi
 		return IPath.fromOSString(path.toFile().getAbsolutePath());
 	}
 
-	/*
-	 * @see org.eclipse.core.filebuffers.tests.FileBufferFunctions#markReadOnly()
-	 */
 	@Override
 	protected void setReadOnly(boolean state) throws Exception {
 		IFileStore fileStore= FileBuffers.getFileStoreAtLocation(getPath());

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileStoreFileBuffersForNonExistingWorkspaceFiles.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileStoreFileBuffersForNonExistingWorkspaceFiles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -89,9 +89,6 @@ public class FileStoreFileBuffersForNonExistingWorkspaceFiles extends FileStoreF
 		assertTrue(file.exists());
 	}
 
-	/*
-	 * @see org.eclipse.core.filebuffers.tests.FileBufferFunctions#markReadOnly()
-	 */
 	@Override
 	protected void setReadOnly(boolean state) throws Exception {
 		IFileStore fileStore= FileBuffers.getFileStoreAtLocation(getPath());

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileStoreFileBuffersForWorkspaceFiles.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileStoreFileBuffersForWorkspaceFiles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2018 IBM Corporation and others.
+ * Copyright (c) 2007, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,10 +13,9 @@
  *******************************************************************************/
 package org.eclipse.core.filebuffers.tests;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
-import java.io.IOException;
 import java.io.OutputStream;
 
 import org.osgi.framework.Bundle;
@@ -50,9 +49,6 @@ public class FileStoreFileBuffersForWorkspaceFiles extends FileBufferFunctions {
 		return file.getFullPath();
 	}
 
-	/*
-	 * @see org.eclipse.core.filebuffers.tests.FileBufferFunctions#markReadOnly()
-	 */
 	@Override
 	protected void setReadOnly(boolean state) throws Exception {
 		IFile file= FileBuffers.getWorkspaceFileAtLocation(getPath());
@@ -94,14 +90,12 @@ public class FileStoreFileBuffersForWorkspaceFiles extends FileBufferFunctions {
 		try (OutputStream out= fileStore.openOutputStream(EFS.NONE, null)) {
 			out.write("Changed content of workspace file".getBytes());
 			out.flush();
-		} catch (IOException x) {
-			fail();
 		}
 		IFileInfo fileInfo= fileStore.fetchInfo();
 		fileInfo.setLastModified(1000);
 		fileStore.putInfo(fileInfo, EFS.SET_LAST_MODIFIED, null);
 		IFile iFile= FileBuffers.getWorkspaceFileAtLocation(getPath());
-		assertTrue(iFile.exists() && iFile.getFullPath().equals(getPath()));
+		assertAll(() -> assertTrue(iFile.exists()), () -> assertTrue(iFile.getFullPath().equals(getPath())));
 		iFile.refreshLocal(IResource.DEPTH_INFINITE, null);
 		return true;
 	}

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileTool.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,15 +17,10 @@ package org.eclipse.core.filebuffers.tests;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.Writer;
 import java.net.URL;
-import java.util.Enumeration;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
@@ -39,64 +34,6 @@ public class FileTool {
 	private final static int MAX_RETRY= 5;
 
 	/**
-	 * A buffer.
-	 */
-	private static byte[] buffer= new byte[8192];
-
-	/**
-	 * Unzips the given zip file to the given destination directory
-	 * extracting only those entries the pass through the given
-	 * filter.
-	 *
-	 * @param zipFile the zip file to unzip
-	 * @param dstDir the destination directory
-	 * @throws IOException in case of problem
-	 */
-	public static void unzip(ZipFile zipFile, File dstDir) throws IOException {
-
-		Enumeration<? extends ZipEntry> entries = zipFile.entries();
-
-		try {
-			while(entries.hasMoreElements()){
-				ZipEntry entry = entries.nextElement();
-				if(entry.isDirectory()){
-					continue;
-				}
-				String entryName = entry.getName();
-				if (!new File(dstDir, entryName).toPath().normalize().startsWith(dstDir.toPath().normalize())) {
-					throw new RuntimeException("Bad zip entry: " + entryName); //$NON-NLS-1$
-				}
-				File file = new File(dstDir, changeSeparator(entryName, '/', File.separatorChar));
-				file.getParentFile().mkdirs();
-				try (InputStream src= zipFile.getInputStream(entry); OutputStream dst= new FileOutputStream(file)) {
-					transferData(src, dst);
-				}
-			}
-		} finally {
-			try {
-				zipFile.close();
-			} catch(IOException e){
-			}
-		}
-	}
-
-	/**
-	 * Returns the given file path with its separator
-	 * character changed from the given old separator to the
-	 * given new separator.
-	 *
-	 * @param path a file path
-	 * @param oldSeparator a path separator character
-	 * @param newSeparator a path separator character
-	 * @return the file path with its separator character
-	 * changed from the given old separator to the given new
-	 * separator
-	 */
-	public static String changeSeparator(String path, char oldSeparator, char newSeparator){
-		return path.replace(oldSeparator, newSeparator);
-	}
-
-	/**
 	 * Copies all bytes in the given source file to
 	 * the given destination file.
 	 *
@@ -108,26 +45,7 @@ public class FileTool {
 		destination.getParentFile().mkdirs();
 		try (InputStream is= new FileInputStream(source);
 				OutputStream os= new FileOutputStream(destination)) {
-			transferData(is, os);
-		}
-	}
-
-	/**
-	 * Copies all bytes in the given source stream to
-	 * the given destination stream. Neither streams
-	 * are closed.
-	 *
-	 * @param source the given source stream
-	 * @param destination the given destination stream
-	 * @throws IOException in case of error
-	 */
-	public static void transferData(InputStream source, OutputStream destination) throws IOException {
-		int bytesRead = 0;
-		while(bytesRead != -1){
-			bytesRead = source.read(buffer, 0, buffer.length);
-			if(bytesRead != -1){
-				destination.write(buffer, 0, bytesRead);
-			}
+			is.transferTo(os);
 		}
 	}
 
@@ -167,12 +85,6 @@ public class FileTool {
 		IPath stateLocation= plugin.getStateLocation();
 		stateLocation= stateLocation.append(path);
 		return stateLocation.toFile();
-	}
-
-	public static void write(String fileName, String content) throws IOException {
-		try (Writer writer= new FileWriter(fileName)) {
-			writer.write(content);
-		}
 	}
 
 	public static void delete(IPath path) {

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/MockDocumentSetupParticipants.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/MockDocumentSetupParticipants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 Symbian Software Systems, IBM Corporation and others.
+ * Copyright (c) 2008, 2026 Symbian Software Systems, IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/ResourceHelper.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/ResourceHelper.java
@@ -21,16 +21,13 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Plugin;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 
@@ -91,17 +88,13 @@ public class ResourceHelper {
 	public static IFolder createFolder(String portableFolderPath) throws CoreException {
 		ContainerCreator creator= new ContainerCreator(ResourcesPlugin.getWorkspace(), IPath.fromOSString(portableFolderPath));
 		IContainer container= creator.createContainer(NULL_MONITOR);
-		if (container instanceof IFolder)
-			return (IFolder) container;
+		if (container instanceof IFolder folder)
+			return folder;
 		return null;
 	}
 
 	public static IFile createFile(IFolder folder, String name, String contents) throws CoreException {
 		return createFile(folder.getFile(name), contents);
-	}
-
-	public static IFile createFile(IProject project, String name, String contents) throws CoreException {
-		return createFile(project.getFile(name), contents);
 	}
 
 	private static IFile createFile(IFile file, String contents) throws CoreException {
@@ -138,21 +131,4 @@ public class ResourceHelper {
 		return iFolder;
 	}
 
-	public static IProject createLinkedProject(String projectName, Plugin plugin, IPath linkPath) throws CoreException {
-		IWorkspace workspace= ResourcesPlugin.getWorkspace();
-		IProject project= workspace.getRoot().getProject(projectName);
-
-		IProjectDescription desc= workspace.newProjectDescription(projectName);
-		File file= FileTool.getFileInPlugin(plugin, linkPath);
-		IPath projectLocation= IPath.fromOSString(file.getAbsolutePath());
-		if (Platform.getLocation().equals(projectLocation))
-			projectLocation= null;
-		desc.setLocation(projectLocation);
-
-		project.create(desc, NULL_MONITOR);
-		if (!project.isOpen())
-			project.open(NULL_MONITOR);
-
-		return project;
-	}
 }

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/TestFailExtension.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/TestFailExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,14 +18,13 @@ import org.junit.jupiter.api.extension.TestWatcher;
 
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 
 public class TestFailExtension implements TestWatcher {
 
 	private static final String BUNDLE_ID= "org.eclipse.core.filebuffers.tests";
 
-	ILog log= ILog.of(Platform.getBundle(BUNDLE_ID));
+	ILog log= ILog.get();
 
 	@Override
 	public void testFailed(ExtensionContext context, Throwable e) {


### PR DESCRIPTION
Various cleanups and modernizations provoked by unstable test as can be seen at https://download.eclipse.org/eclipse/downloads/drops4/I20260306-1800/testresults/html/org.eclipse.core.filebuffers.tests_ep440I-unit-linux-x86_64-java25_linux.gtk.x86_64_25.html