### PR TITLE
Tests for FormEditor #3764

### DIFF
--- a/tests/org.eclipse.ui.tests.forms/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.ui.tests.forms/META-INF/MANIFEST.MF
@@ -6,7 +6,9 @@ Bundle-Version: 3.11.100.qualifier
 Require-Bundle: org.eclipse.ui;bundle-version="3.208.0",
  org.eclipse.core.runtime,
  org.eclipse.test.performance,
- org.eclipse.ui.forms
+ org.eclipse.ui.forms,
+ org.mockito.mockito-core;bundle-version="[5.21.0,6.0.0)",
+ junit-jupiter-api;bundle-version="[5.14.3,6.0.0)"
 Bundle-Vendor: Eclipse.org
 Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
  org.junit.jupiter.api.function;version="[5.14.0,6.0.0)",

--- a/tests/org.eclipse.ui.tests.forms/build.properties
+++ b/tests/org.eclipse.ui.tests.forms/build.properties
@@ -14,7 +14,8 @@
 bin.includes = .,\
                META-INF/,\
                about.html,\
-               test.xml
+               test.xml,\
+               plugin.xml
 output.. = bin/
 source.. = forms/
 

--- a/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/forms/editor/FormEditorMock.java
+++ b/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/forms/editor/FormEditorMock.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vasili Gulevich and others
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Vasili Gulevich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.forms.editor;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.swt.custom.CTabFolder;
+import org.eclipse.swt.custom.CTabItem;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.PartInitException;
+
+public class FormEditorMock extends FormEditor {
+	public static final String ID = "org.eclipse.ui.tests.forms.FormEditorMock";
+
+	public interface Hook {
+
+		default boolean isSaveAsAllowed(FormEditorMock subject) {
+			return false;
+		}
+
+		default void addPages(FormEditorMock subject) {
+			FormPage page1 = new FormPage(subject, "defaultpage", "defaultpage");
+			try {
+				subject.addPage(page1);
+			} catch (PartInitException e) {
+				throw new AssertionError(e);
+			}
+		}
+
+		default void doSave(FormEditorMock subject) {
+		}
+
+		default void createContainer(FormEditorMock subject, CTabFolder container) {
+		}
+
+		default void createItem(FormEditorMock subject, CTabItem item) {
+
+		}
+	}
+
+	public static final Hook DEFAULT_HOOK = new Hook() {
+	};
+
+	public static Hook hook = DEFAULT_HOOK;
+
+	@Override
+	protected CTabFolder createContainer(Composite parent) {
+		CTabFolder result = super.createContainer(parent);
+		hook.createContainer(this, result);
+		return result;
+	}
+
+	@Override
+	protected CTabItem createItem(int index, Control control) {
+		CTabItem result = super.createItem(index, control);
+		hook.createItem(this, result);
+		return result;
+	}
+	@Override
+	protected void addPages() {
+		hook.addPages(this);
+	}
+
+	@Override
+	public void doSave(IProgressMonitor monitor) {
+		hook.doSave(this);
+	}
+
+	@Override
+	public void doSaveAs() {
+		hook.doSave(this);
+	}
+
+	@Override
+	public boolean isSaveAsAllowed() {
+		return hook.isSaveAsAllowed(this);
+	}
+
+	public CTabFolder leakContainer() {
+		return (CTabFolder) getContainer();
+	}
+
+	public IEditorPart[] leakPages() {
+		return pages.stream().toArray(IEditorPart[]::new);
+	}
+}

--- a/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/forms/editor/FormEditorTest.java
+++ b/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/forms/editor/FormEditorTest.java
@@ -1,0 +1,180 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vasili Gulevich and others
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Vasili Gulevich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.forms.editor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CTabFolder;
+import org.eclipse.swt.custom.CTabItem;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.forms.editor.FormEditorMock.Hook;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class FormEditorTest {
+
+	private static final IWorkbench WORKBENCH = PlatformUI.getWorkbench();
+
+	public IEditorInput input = mock();
+
+	@BeforeEach
+	public void closeEditors() {
+		WORKBENCH.getActiveWorkbenchWindow().getActivePage().closeAllEditors(false);
+	}
+
+	@Test
+	public void activatePage() throws PartInitException {
+		FormEditorMock.hook = FormEditorMock.DEFAULT_HOOK;
+		FormEditorMock subject = (FormEditorMock) WORKBENCH.getActiveWorkbenchWindow().getActivePage().openEditor(input,
+				FormEditorMock.ID);
+		assertEquals("defaultpage", subject.getActivePageInstance().getTitle());
+		FormPage page1 = addPage(subject, "page1");
+		subject.setActivePage("page1");
+		dispatch(subject);
+		assertSame(page1, subject.getActivePageInstance());
+	}
+
+	@Test
+	public void removePage() throws PartInitException {
+		FormEditorMock.hook = FormEditorMock.DEFAULT_HOOK;
+		FormEditorMock subject = (FormEditorMock) WORKBENCH.getActiveWorkbenchWindow().getActivePage().openEditor(input,
+				FormEditorMock.ID);
+		dispatch(subject);
+		CTabItem[] tabs = subject.leakContainer().getItems();
+		assertEquals(1, tabs.length);
+		FormPage page1 = addPage(subject, "page1");
+		assertSame(page1, subject.findPage("page1"));
+		tabs = subject.leakContainer().getItems();
+		assertEquals(2, tabs.length);
+		subject.removePage(page1.getIndex());
+		dispatch(subject);
+		assertNull(subject.findPage("page1"));
+		tabs = subject.leakContainer().getItems();
+		assertEquals(1, tabs.length);
+	}
+
+	@Test
+	public void disposeTab() throws PartInitException {
+		FormEditorMock.hook = FormEditorMock.DEFAULT_HOOK;
+		FormEditorMock subject = (FormEditorMock) WORKBENCH.getActiveWorkbenchWindow().getActivePage().openEditor(input,
+				FormEditorMock.ID);
+		dispatch(subject);
+		CTabItem[] tabs = subject.leakContainer().getItems();
+		assertEquals(1, tabs.length);
+		FormPage page1 = addPage(subject, "page1");
+		assertSame(page1, subject.findPage("page1"));
+		tabs = subject.leakContainer().getItems();
+		assertEquals(2, tabs.length);
+		tabs[tabs.length - 1].dispose();
+		dispatch(subject);
+		tabs = subject.leakContainer().getItems();
+		assertEquals(1, tabs.length);
+		// BUG https://github.com/eclipse-platform/eclipse.platform.ui/issues/3766
+		// assertNull(subject.findPage("page1"));
+	}
+
+	@Test
+	public void maintainIntegrityOnPageClose() throws PartInitException {
+		FormEditorMock.hook = new Hook() {
+			@Override
+			public void createContainer(FormEditorMock subject, CTabFolder container) {
+				Hook.super.createContainer(subject, container);
+				container.setUnselectedCloseVisible(true);
+			}
+
+			@Override
+			public void createItem(FormEditorMock subject, CTabItem item) {
+				Hook.super.createItem(subject, item);
+				item.setShowClose(true);
+			}
+		};
+		FormEditorMock subject = (FormEditorMock) WORKBENCH.getActiveWorkbenchWindow().getActivePage().openEditor(input,
+				FormEditorMock.ID);
+		FormPage page1 = addPage(subject, "page1");
+		CTabFolder tabFolder = subject.leakContainer();
+		CTabItem tab = tabFolder.getItem(1);
+		assertTrue(tab.getShowClose());
+		assertSame(page1, subject.findPage("page1"));
+		Event event = new Event();
+		event.type = SWT.MouseDown;
+		event.button = 1;
+		event.x = tab.getBounds().x + tab.getBounds().width - 9;
+		event.y = tab.getBounds().y + tab.getBounds().height/2;
+		tabFolder.notifyListeners(event.type, event);
+		dispatch(subject);
+		event.type = SWT.MouseUp;
+		tabFolder.notifyListeners(event.type, event);
+		dispatch(subject);
+		assertEquals(1, tabFolder.getItems().length);
+		// BUG https://github.com/eclipse-platform/eclipse.platform.ui/issues/3766
+		// assertNull(subject.findPage("page1"));
+	}
+
+	@Test
+	@Disabled("https://github.com/eclipse-platform/eclipse.platform.ui/issues/3764")
+	public void anEditorIsActiveOnStart() throws PartInitException {
+		FormEditorMock.hook = FormEditorMock.DEFAULT_HOOK;
+		FormEditorMock subject = (FormEditorMock) WORKBENCH.getActiveWorkbenchWindow().getActivePage().openEditor(input,
+				FormEditorMock.ID);
+		dispatch(subject);
+		// BUG https://github.com/eclipse-platform/eclipse.platform.ui/issues/3764
+		assertNotNull(subject.getActiveEditor());
+	}
+
+	@Test
+	@Disabled("https://github.com/eclipse-platform/eclipse.platform.ui/issues/3764")
+	public void activateEditors() throws PartInitException {
+		FormEditorMock.hook = FormEditorMock.DEFAULT_HOOK;
+		FormEditorMock subject = (FormEditorMock) WORKBENCH.getActiveWorkbenchWindow().getActivePage().openEditor(input,
+				FormEditorMock.ID);
+		FormPage page1 = addPage(subject, "page1");
+		assertNotNull(page1);
+//		 BUG https://github.com/eclipse-platform/eclipse.platform.ui/issues/3764
+		assertEveryTabCanBeActive(subject);
+	}
+
+	private void assertEveryTabCanBeActive(FormEditorMock subject) {
+		dispatch(subject);
+		for (IEditorPart part : subject.leakPages()) {
+			subject.setActiveEditor(part);
+			dispatch(subject);
+			assertSame(part, subject.getActiveEditor());
+		}
+	}
+
+	private void dispatch(FormEditorMock subject) {
+		while (subject.leakContainer().getDisplay().readAndDispatch()) {
+		}
+	}
+
+	private FormPage addPage(FormEditorMock subject, String id) throws PartInitException {
+		FormPage page1 = new FormPage(subject, id, id);
+		subject.addPage(page1);
+		dispatch(subject);
+		return page1;
+	}
+
+}

--- a/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/tests/forms/AllFormsTests.java
+++ b/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/tests/forms/AllFormsTests.java
@@ -16,6 +16,7 @@
 
 package org.eclipse.ui.tests.forms;
 
+import org.eclipse.ui.forms.editor.FormEditorTest;
 import org.eclipse.ui.tests.forms.events.AllEventsTests;
 import org.eclipse.ui.tests.forms.layout.AllLayoutTests;
 import org.eclipse.ui.tests.forms.util.AllUtilityTests;
@@ -32,7 +33,8 @@ import org.junit.platform.suite.api.Suite;
 		AllEventsTests.class, //
 		AllLayoutTests.class, //
 		AllUtilityTests.class, //
-		AllWidgetsTests.class //
+		AllWidgetsTests.class, //
+		FormEditorTest.class //
 })
 public class AllFormsTests {
 

--- a/tests/org.eclipse.ui.tests.forms/plugin.xml
+++ b/tests/org.eclipse.ui.tests.forms/plugin.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.ui.editors">
+      <editor
+            class="org.eclipse.ui.forms.editor.FormEditorMock"
+            default="false"
+            id="org.eclipse.ui.tests.forms.FormEditorMock"
+            name="FormEditorMock">
+      </editor>
+   </extension>
+
+</plugin>


### PR DESCRIPTION
A framework to test `org.eclipse.ui.forms.editor.FormEditor`.

Includes reproducers for #3764 and #3766

For context, `FormEditor` is inherited by `org.eclipse.pde.internal.ui.editor.plugin.ManifestEditor` and `org.eclipse.pde.internal.ui.editor.targetdefinition.TargetEditor`