### PR TITLE
[FIX] dispose code mining providers

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningManager.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningManager.java
@@ -118,6 +118,9 @@ public class CodeMiningManager implements Runnable {
 		if (fInlinedAnnotationSupport != null) {
 			fInlinedAnnotationSupport.updateAnnotations(Collections.emptySet());
 		}
+		if (fCodeMiningProviders != null) {
+			fCodeMiningProviders.forEach(ICodeMiningProvider::dispose);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2856

JDT does the same in JavaEditor.uninstallJavaCodeMining().

Seems that this was completely missing for e.g. text editors.