### PR TITLE
Incorrect Colors in LTK Refactoring Preview Wizard

### DIFF
--- a/bundles/org.eclipse.ltk.ui.refactoring/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ltk.ui.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.ltk.ui.refactoring
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ltk.ui.refactoring; singleton:=true
-Bundle-Version: 3.14.0.qualifier
+Bundle-Version: 3.14.100.qualifier
 Bundle-Activator: org.eclipse.ltk.internal.ui.refactoring.RefactoringUIPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/TextEditChangePreviewViewer.java
+++ b/bundles/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/TextEditChangePreviewViewer.java
@@ -76,10 +76,10 @@ public class TextEditChangePreviewViewer implements IChangePreviewViewer {
 		public ComparePreviewer(Composite parent) {
 			super(parent, SWT.BORDER | SWT.FLAT, true);
 			fCompareConfiguration= new CompareConfiguration();
-			fCompareConfiguration.setLeftEditable(false);
-			fCompareConfiguration.setLeftLabel(RefactoringUIMessages.ComparePreviewer_original_source);
 			fCompareConfiguration.setRightEditable(false);
-			fCompareConfiguration.setRightLabel(RefactoringUIMessages.ComparePreviewer_refactored_source);
+			fCompareConfiguration.setRightLabel(RefactoringUIMessages.ComparePreviewer_original_source);
+			fCompareConfiguration.setLeftEditable(false);
+			fCompareConfiguration.setLeftLabel(RefactoringUIMessages.ComparePreviewer_refactored_source);
 			addDisposeListener(e -> {
 				if (fImage != null && !fImage.isDisposed()) {
 					fImage.dispose();
@@ -253,7 +253,7 @@ public class TextEditChangePreviewViewer implements IChangePreviewViewer {
 		}
 
 		fViewer.setInput(new DiffNode(
-			new CompareElement(left, type, resource),
-			new CompareElement(right, type, resource)));
+			new CompareElement(right, type, resource),
+			new CompareElement(left, type, resource)));
 	}
 }


### PR DESCRIPTION
Change left/right diff elements in refactoring wizard to get proper diff coloring.

This would make the "diff order" consistent with the **current** Eclipse diff order, which is, let say, "unusual" for a very long time (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=213780).  That is also the reason the refactoring wizard had always "swapped" the input sides, being inconsistent to provide expected usability. However the coloring can be consistent only if the diff order is default one, and since diff coloring was added, refactoring wizard "hack" became visible.

See also https://github.com/eclipse-platform/eclipse.platform.ui/issues/3776.

This PR depends on https://github.com/eclipse-platform/eclipse.platform/pull/2566 to avoid unexpected change of the "usual" diff order in the refactoring wizard.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3775