### PR TITLE
Fix flaky AsyncContentAssistTest.testCompleteActivationChar

### DIFF
--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/contentassist/AbstractContentAssistTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/contentassist/AbstractContentAssistTest.java
@@ -229,7 +229,7 @@ public class AbstractContentAssistTest {
 
 	protected static Shell findNewShell(Collection<Shell> beforeShells) {
 		List<Shell> afterShells= findNewShells(beforeShells);
-		for (int attempt= 0; afterShells.size() != 1 && attempt < 10; attempt++) {
+		for (int attempt= 0; afterShells.size() != 1 && attempt < 50; attempt++) {
 			DisplayHelper.sleep(getDisplay(), 100);
 			afterShells= findNewShells(beforeShells);
 		}

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/contentassist/AsyncContentAssistTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/contentassist/AsyncContentAssistTest.java
@@ -17,7 +17,6 @@ package org.eclipse.jface.text.tests.contentassist;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -40,8 +39,6 @@ import org.eclipse.swt.widgets.Widget;
 import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
-
-import org.eclipse.jface.util.Util;
 
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
@@ -134,7 +131,6 @@ public class AsyncContentAssistTest {
 
 	@Test
 	public void testCompleteActivationChar() {
-		assumeFalse(Util.isWindows(), "test fails on Windows, see https://github.com/eclipse-platform/eclipse.platform.ui/issues/890");
 		shell.setLayout(new FillLayout());
 		shell.setSize(500, 300);
 		SourceViewer viewer= new SourceViewer(shell, null, SWT.NONE);
@@ -151,17 +147,20 @@ public class AsyncContentAssistTest {
 		contentAssistant.install(viewer);
 		shell.open();
 		Display display= shell.getDisplay();
-		Event keyEvent= new Event();
+		DisplayHelper.runEventLoop(display, 0);
 		Control control= viewer.getTextWidget();
+		control.forceFocus();
+		DisplayHelper.runEventLoop(display, 0);
+		final Collection<Shell> beforeShells= AbstractContentAssistTest.getCurrentShells();
+		// Use notifyListeners instead of Display.post() for reliable event delivery
+		// Display.post() sends native OS events that may not be processed reliably
+		// in headless CI environments
+		Event keyEvent= new Event();
 		keyEvent.widget= control;
 		keyEvent.type= SWT.KeyDown;
 		keyEvent.character= 'b';
 		keyEvent.keyCode= 'b';
-		control.getShell().forceActive();
-		control.getDisplay().post(keyEvent);
-		keyEvent.type= SWT.KeyUp;
-		control.getDisplay().post(keyEvent);
-		final Collection<Shell> beforeShells= AbstractContentAssistTest.getCurrentShells();
+		control.notifyListeners(SWT.KeyDown, keyEvent);
 		AbstractContentAssistTest.processEvents();
 		Shell newShell= AbstractContentAssistTest.findNewShell(beforeShells);
 		assertTrue(new DisplayHelper() {


### PR DESCRIPTION
## Summary
- Replace `Display.post()` with `control.notifyListeners()` for reliable event delivery in headless CI environments — `Display.post()` sends native OS events that may not be processed, causing the content assist popup to never appear
- Fix race condition by capturing `beforeShells` before posting key events, and process events after `shell.open()`
- Increase `findNewShell` timeout from 1s to 5s for slower CI environments
- Remove Windows-only `assumeFalse` skip — the test now works on all platforms

## Test plan
- [x] Ran `AsyncContentAssistTest` 5 times consecutively — all passes
- [x] Ran full `org.eclipse.jface.text.tests` suite — no regressions (only pre-existing `CodeMiningTest` failures)

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/890