### PR TITLE
Add no-AI-attribution rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,10 @@ cat bundles/org.eclipse.jface/META-INF/MANIFEST.MF
 grep -r "pattern" bundles/org.eclipse.jface/src
 ```
 
+## Git Commits
+
+**Do NOT add `Co-Authored-By` or similar AI attribution trailers to commits.** This fails the Eclipse license check.
+
 ## Critical Development Rules
 
 ### 1. OSGi Dependencies


### PR DESCRIPTION
## Summary
- Instruct AI tools not to add `Co-Authored-By` or similar AI attribution trailers to commits, as this fails the Eclipse license check

## Test plan
- [x] Verified AGENTS.md renders correctly