### PR TITLE
Remove beep from content assist when no proposals found

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/CompletionProposalPopup.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/contentassist/CompletionProposalPopup.java
@@ -550,12 +550,6 @@ class CompletionProposalPopup implements IContentAssistListener {
 	 */
 	boolean hideWhenNoProposals(boolean autoActivated) {
 		if (autoActivated || !fContentAssistant.isShowEmptyList()) {
-			if (!autoActivated) {
-				Control control= fContentAssistSubjectControlAdapter.getControl();
-				if (control != null && !control.isDisposed()) {
-					control.getDisplay().beep();
-				}
-			}
 			hide();
 			return true;
 		}


### PR DESCRIPTION
## Summary
- Remove `Display.beep()` call in `CompletionProposalPopup.hideWhenNoProposals()` that fires every time content assist is manually invoked but has no proposals to show

## Test plan
- [x] Manually verified content assist no longer beeps when no proposals are available