### PR TITLE
Use correct font for highlighting matches in "Open Resource" dialog

### DIFF
--- a/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.ide; singleton:=true
-Bundle-Version: 3.23.0.qualifier
+Bundle-Version: 3.23.100.qualifier
 Bundle-Activator: org.eclipse.ui.internal.ide.IDEWorkbenchPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/FilteredResourcesSelectionDialog.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/FilteredResourcesSelectionDialog.java
@@ -723,7 +723,7 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 			Styler boldStyler = new Styler() {
 				@Override
 				public void applyStyles(TextStyle textStyle) {
-					textStyle.font = JFaceResources.getFontRegistry().getBold(JFaceResources.DEFAULT_FONT);
+					textStyle.font = JFaceResources.getFontRegistry().getBold(JFaceResources.DIALOG_FONT);
 				}
 			};
 


### PR DESCRIPTION
# Summary

Fixes #3782 by using the dialog font as base for the highlighting style instead of the default font.

# Test Plan

(See also #3782)

* change dialog font to a bigger size
* open "Open Resource" dialog
* type in the filter box
* verify that the highlighting of matching substrings uses the dialog font size
