### PR TITLE
Fix flaky ensureCleanUpAddonCleansUp test

### DIFF
--- a/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
+++ b/tests/org.eclipse.e4.ui.tests/src/org/eclipse/e4/ui/tests/workbench/PartRenderingEngineTests.java
@@ -64,7 +64,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.Widget;
-import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -2446,13 +2445,13 @@ public class PartRenderingEngineTests {
 
 		assertTrue(partStackForPartBPartC.isToBeRendered(), " PartStack with children should be rendered");
 		partService.hidePart(partB);
+		// Drain pending events between hides so that the event queue is clean
+		// when the second hidePart queues CleanupAddon's asyncExec for visCount==0
+		contextRule.spinEventLoop();
 		partService.hidePart(partC);
-		// DisplayHelper.waitForCondition() handles event processing via Display.sleep()
-		// and retries. Calling spinEventLoop() here creates a race condition where
-		// events may be processed before CleanupAddon's asyncExec() is queued (line 352).
-		assertTrue(
-				DisplayHelper.waitForCondition(Display.getDefault(), 30_000,
-						() -> !partStackForPartBPartC.isToBeRendered()), "CleanupAddon should ensure that partStack is not rendered anymore, as all childs have been removed");
+		contextRule.spinEventLoop();
+		assertFalse(partStackForPartBPartC.isToBeRendered(),
+				"CleanupAddon should ensure that partStack is not rendered anymore, as all childs have been removed");
 		// PartStack with IPresentationEngine.NO_AUTO_COLLAPSE should not be removed
 		// even if children are removed
 		partService.hidePart(editor, true);


### PR DESCRIPTION
## Summary
- Adds `spinEventLoop()` between the two `hidePart()` calls to drain pending events before the second hide
- This ensures a clean event queue when CleanupAddon's `asyncExec` is queued for `visCount==0`
- Replaces the 30-second `DisplayHelper.waitForCondition` polling with a deterministic event drain
- Removes now-unused `DisplayHelper` import

Depends on #3785 (revert of the synchronous cleanup change)

## Test plan
- [ ] Verify `ensureCleanUpAddonCleansUp` passes consistently (no longer flaky)
- [ ] Verify closing the Welcome screen does not produce an empty area

Fixes #3581

🤖 Generated with [Claude Code](https://claude.com/claude-code)