### PR TITLE
Fix race condition in AbstractReconciler.reset() event ordering

### DIFF
--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/reconciler/AbstractReconciler.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/reconciler/AbstractReconciler.java
@@ -140,14 +140,13 @@ abstract public class AbstractReconciler implements IReconciler {
 		 */
 		public void reset() {
 
+			reconcilerReset();
+
 			if (fDelay > 0) {
 
 				synchronized (this) {
 					fIsDirty= true;
 					fReset= true;
-				}
-				synchronized (fDirtyRegionQueue) {
-					fDirtyRegionQueue.notifyAll(); // wake up wait(fDelay);
 				}
 
 			} else {
@@ -155,14 +154,13 @@ abstract public class AbstractReconciler implements IReconciler {
 				synchronized (this) {
 					fIsDirty= true;
 				}
-
-				synchronized (fDirtyRegionQueue) {
-					fDirtyRegionQueue.notifyAll();
-				}
 			}
 
 			informNotFinished();
-			reconcilerReset();
+
+			synchronized (fDirtyRegionQueue) {
+				fDirtyRegionQueue.notifyAll();
+			}
 		}
 
 		/**

--- a/tests/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.jface.text.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jface.text.tests
-Bundle-Version: 3.14.0.qualifier
+Bundle-Version: 3.14.100.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/JFaceTextTestSuite.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/JFaceTextTestSuite.java
@@ -26,6 +26,7 @@ import org.eclipse.jface.text.tests.contentassist.FilteringAsyncContentAssistTes
 import org.eclipse.jface.text.tests.contentassist.IncrementalAsyncContentAssistTests;
 import org.eclipse.jface.text.tests.reconciler.AbstractReconcilerTest;
 import org.eclipse.jface.text.tests.reconciler.FastAbstractReconcilerTest;
+import org.eclipse.jface.text.tests.reconciler.ReconcilerResetOrderingTest;
 import org.eclipse.jface.text.tests.rules.FastPartitionerTest;
 import org.eclipse.jface.text.tests.rules.FastPartitionerZeroLengthTest;
 import org.eclipse.jface.text.tests.rules.ScannerColumnTest;
@@ -61,6 +62,7 @@ import org.eclipse.jface.text.tests.templates.persistence.TemplatePersistenceDat
 
 		AbstractReconcilerTest.class,
 		FastAbstractReconcilerTest.class,
+		ReconcilerResetOrderingTest.class,
 
 		FastPartitionerZeroLengthTest.class,
 		FastPartitionerTest.class,

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/reconciler/AbstractReconcilerTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/reconciler/AbstractReconcilerTest.java
@@ -173,6 +173,7 @@ public class AbstractReconcilerTest {
 					}
 					@Override
 					protected void reconcilerReset() {
+						AbstractReconcilerTest.this.beforeReconcilerResetLogged();
 						fCallLog.add("reconcilerReset");
 					}
 					@Override
@@ -200,6 +201,10 @@ public class AbstractReconcilerTest {
 
 	void aboutToWork(@SuppressWarnings("unused") AbstractReconciler reconciler) {
 		// nothing
+	}
+
+	void beforeReconcilerResetLogged() {
+		// hook for subclasses to widen race window
 	}
 
 	@AfterEach

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/reconciler/ReconcilerResetOrderingTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/reconciler/ReconcilerResetOrderingTest.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jface.text.tests.reconciler;
+
+import org.eclipse.jface.text.reconciler.AbstractReconciler;
+
+/**
+ * Regression test for the race condition in
+ * {@link AbstractReconciler#install BackgroundWorker.reset()} where
+ * {@code reconcilerReset()} could be called after the background thread was
+ * already notified, allowing {@code process()} to run before the reset hook.
+ * <p>
+ * This test widens the race window by introducing a 50ms delay before logging
+ * {@code reconcilerReset}. Without the fix (reconcilerReset called before queue
+ * notification), the background thread is already awake during the delay and
+ * reaches {@code process()} first, causing {@code testReplacingDocumentWhenClean}
+ * to deterministically fail.
+ * </p>
+ *
+ * @see <a href="https://github.com/eclipse-platform/eclipse.platform.ui/issues/2708">Issue 2708</a>
+ */
+public class ReconcilerResetOrderingTest extends FastAbstractReconcilerTest {
+
+	@Override
+	void beforeReconcilerResetLogged() {
+		try {
+			Thread.sleep(50);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes flaky `FastAbstractReconcilerTest.testReplacingDocumentWhenClean` by reordering `BackgroundWorker.reset()` so that the `reconcilerReset()` hook executes before `fIsDirty` is set to true and before any queue notifications wake the background thread
- Adds `ReconcilerResetOrderingTest` that deterministically reproduces the race condition by widening the race window with a 50ms delay — this test always fails without the fix and always passes with it

## Root Cause

In `BackgroundWorker.reset()`, `reconcilerReset()` was called after `fIsDirty` was set and after `notifyAll()`/`informNotFinished()`. Two race windows existed:

1. `aboutToBeReconciledInternal()` (called before `reset()` in both `documentChanged` and `inputDocumentChanged`) triggers `signalWaitForFinish()` → `notifyAll()`, waking the background thread. It could then see `fIsDirty=true` (set at the start of `reset()`), consume the `fReset` flag, skip delay (`waitFinish=true`), and reach `process()` before `reconcilerReset()` ran.

2. Within `reset()` itself, `notifyAll()` and `informNotFinished()` were called before `reconcilerReset()`, providing additional wake-up points.

## Fix

Move `reconcilerReset()` to the very beginning of `reset()`, before `fIsDirty` is set. The background thread cannot find work (`isDirty()` returns false) and blocks in `delay()` until after the hook completes and state flags are set.

## User-visible impact

The `AbstractReconciler` drives background processing in text editors (syntax validation, spell checking, error/warning markers, code analysis). The race occurs when the document changes or is replaced (e.g., switching files, reverting). Without the reset hook firing first, `process()` can run with stale state, causing brief flickers of incorrect error markers or squiggles from a previous document. Being a race condition, this is intermittent and self-corrects on the next reconciling pass.

## Test plan

- [x] `AbstractReconcilerTest` (7 tests) — base reconciler tests, all pass
- [x] `FastAbstractReconcilerTest` (7 tests) — fast-mode tests including previously flaky `testReplacingDocumentWhenClean`, all pass
- [x] `ReconcilerResetOrderingTest` (7 tests) — new regression test with 50ms delay, deterministically fails without fix, passes with fix
- [x] Verified test fails without fix by temporarily reverting production code

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2708