### PR TITLE
Fix search result consistency in PositionTracker

### DIFF
--- a/bundles/org.eclipse.search/newsearch/org/eclipse/search/ui/text/AbstractTextSearchResult.java
+++ b/bundles/org.eclipse.search/newsearch/org/eclipse/search/ui/text/AbstractTextSearchResult.java
@@ -27,6 +27,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.eclipse.jface.text.Position;
+
 import org.eclipse.search.ui.ISearchResult;
 import org.eclipse.search.ui.ISearchResultListener;
 import org.eclipse.search.ui.SearchResultEvent;
@@ -42,7 +44,14 @@ public abstract class AbstractTextSearchResult implements ISearchResult {
 
 	private static final Match[] EMPTY_ARRAY= new Match[0];
 
-	private final ConcurrentMap<Object, Set<Match>> fElementsToMatches;
+	/**
+	 * Maps elements to their sets of matches. A {@link ConcurrentSkipListSet}
+	 * is used as the value type so that matches are kept in a stable sorted
+	 * order at all times, avoiding the need to sort on demand when
+	 * {@link #getMatches(Object)} is called. This is important to avoid
+	 * performance issues when a large number of matches are present.
+	 */
+	private final ConcurrentMap<Object, ConcurrentSkipListSet<Match>> fElementsToMatches;
 	private final List<ISearchResultListener> fListeners;
 	private final AtomicInteger matchCount;
 	private final ConcurrentHashMap<Match, Long> collisionOrder;
@@ -161,6 +170,40 @@ public abstract class AbstractTextSearchResult implements ISearchResult {
 		return fMatchEvent;
 	}
 
+	/**
+	 * Updates the given match with the offset and length of the given position.
+	 *
+	 * @param match
+	 *            the match to update
+	 * @param pos
+	 *            the new position (offset and length) for the match
+	 * @since 3.19
+	 */
+	public void updateMatch(Match match, Position pos) {
+		// The match is first removed from and then re-added to this search
+		// result. This is necessary because matches are stored in a
+		// ConcurrentSkipListSet ordered by offset and length: modifying
+		// a match's position while it is held in the set would corrupt the
+		// set's ordering invariants and cause incorrect lookup or removal
+		// behaviour. Removing the match before modification and re-adding it
+		// afterwards ensures the set remains consistent.
+		removeMatch(match);
+		match.setOffset(pos.getOffset());
+		match.setLength(pos.getLength());
+		addMatch(match);
+	}
+
+	/**
+	 * Adds a match to the internal data structures. Uses a
+	 * {@link ConcurrentSkipListSet} per element so that matches are always kept
+	 * in sorted order (by offset and length), avoiding the need to sort results
+	 * on demand each time {@link #getMatches(Object)} is called.
+	 *
+	 * @param match
+	 *            the match to add
+	 * @return {@code true} if the match was added, {@code false} if it was
+	 *         already present
+	 */
 	private boolean didAddMatch(Match match) {
 		matchCount.set(0);
 		updateFilterState(match);
@@ -168,6 +211,22 @@ public abstract class AbstractTextSearchResult implements ISearchResult {
 				k -> new ConcurrentSkipListSet<>(this::compare)).add(match);
 	}
 
+	/**
+	 * Comparator used by the {@link ConcurrentSkipListSet} to order matches by
+	 * offset and then by length. This method assumes that the {@link Match}
+	 * instances are <em>not</em> modified while being held in the set: changing
+	 * the offset or length of a match that is already in the set will corrupt
+	 * the set's ordering invariants and cause incorrect lookup or removal
+	 * behaviour.
+	 *
+	 * @param match2
+	 *            the first match
+	 * @param match1
+	 *            the second match
+	 * @return a negative integer, zero, or a positive integer as the first
+	 *         argument is less than, equal to, or greater than the second
+	 * @see #updateMatch(Match, Position)
+	 */
 	private int compare(Match match2, Match match1) {
 		if (match1 == match2) {
 			return 0;
@@ -353,7 +412,7 @@ public abstract class AbstractTextSearchResult implements ISearchResult {
 	 * @since 3.17
 	 */
 	public boolean hasMatches() {
-		for (Entry<Object, Set<Match>> entry : fElementsToMatches.entrySet()) {
+		for (Entry<Object, ConcurrentSkipListSet<Match>> entry : fElementsToMatches.entrySet()) {
 			if (!entry.getValue().isEmpty()) {
 				return true;
 			}

--- a/bundles/org.eclipse.search/newsearch/org/eclipse/search/ui/text/Match.java
+++ b/bundles/org.eclipse.search/newsearch/org/eclipse/search/ui/text/Match.java
@@ -15,6 +15,8 @@ package org.eclipse.search.ui.text;
 
 import org.eclipse.core.runtime.Assert;
 
+import org.eclipse.jface.text.Position;
+
 /**
  * A textual match in a given object. This class may be instantiated and also subclassed (to add
  * additional match state like accuracy, etc). The element a match is reported
@@ -91,6 +93,12 @@ public class Match {
 
 	/**
 	 * Sets the offset of this match.
+	 * <p>
+	 * <b>Warning:</b> This method should only be called from
+	 * {@link AbstractTextSearchResult#updateMatch(Match, Position)} to avoid
+	 * potential corruption of the result internal state if the match is already
+	 * tracked by a search result.
+	 * </p>
 	 *
 	 * @param offset
 	 *            the offset to set
@@ -110,6 +118,12 @@ public class Match {
 
 	/**
 	 * Sets the length.
+	 * <p>
+	 * <b>Warning:</b> This method should only be called from
+	 * {@link AbstractTextSearchResult#updateMatch(Match, Position)} to avoid
+	 * potential corruption of the result internal state if the match is already
+	 * tracked by a search result.
+	 * </p>
 	 *
 	 * @param length
 	 *            the length to set

--- a/bundles/org.eclipse.search/newsearch/org/eclipse/search2/internal/ui/text/PositionTracker.java
+++ b/bundles/org.eclipse.search/newsearch/org/eclipse/search2/internal/ui/text/PositionTracker.java
@@ -344,12 +344,7 @@ public class PositionTracker implements IQueryListener, ISearchResultListener, I
 					if (match.getOffset() != pos.getOffset() || match.getLength() != pos.getLength()) {
 						AbstractTextSearchResult result= fMatchesToSearchResults.get(match);
 						if (result != null) {
-							result.removeMatch(match);
-						}
-						match.setOffset(pos.getOffset());
-						match.setLength(pos.getLength());
-						if (result != null) {
-							result.addMatch(match);
+							result.updateMatch(match, pos);
 						}
 					}
 				}

--- a/bundles/org.eclipse.search/newsearch/org/eclipse/search2/internal/ui/text/PositionTracker.java
+++ b/bundles/org.eclipse.search/newsearch/org/eclipse/search2/internal/ui/text/PositionTracker.java
@@ -341,8 +341,17 @@ public class PositionTracker implements IQueryListener, ISearchResultListener, I
 							SearchPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, SearchPlugin.getID(), 0, e.getLocalizedMessage(), e));
 						}
 					}
-					match.setOffset(pos.getOffset());
-					match.setLength(pos.getLength());
+					if (match.getOffset() != pos.getOffset() || match.getLength() != pos.getLength()) {
+						AbstractTextSearchResult result= fMatchesToSearchResults.get(match);
+						if (result != null) {
+							result.removeMatch(match);
+						}
+						match.setOffset(pos.getOffset());
+						match.setLength(pos.getLength());
+						if (result != null) {
+							result.addMatch(match);
+						}
+					}
 				}
 			}
 		});

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/PositionTrackerTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/PositionTrackerTest.java
@@ -16,8 +16,14 @@ package org.eclipse.search.tests.filesearch;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -25,6 +31,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.eclipse.core.runtime.jobs.Job;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
 
 import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.filebuffers.ITextFileBuffer;
@@ -57,12 +66,38 @@ public class PositionTrackerTest {
 
 	public static JUnitSourceSetup junitSource= new JUnitSourceSetup();
 
+	private IFile fManyMatchesFile;
+
 	@BeforeEach
 	public void setUp() throws Exception {
 		String[] fileNamePatterns= { "*.java" };
 		FileTextSearchScope scope= FileTextSearchScope.newWorkspaceScope(fileNamePatterns, false);
 
 		fQuery1= new FileSearchQuery("Test", false, true, scope);
+		
+		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("JUnitTest");
+		if (!project.exists()) {
+			project.create(null);
+		}
+		if (!project.isOpen()) {
+			project.open(null);
+		}
+		fManyMatchesFile = project.getFile("ManyMatches.txt");
+		if (!fManyMatchesFile.exists()) {
+			List<String> lines = new ArrayList<>();
+			for (int i = 0; i < 100; i++) {
+				lines.add("Test Test Test Test Test Test Test Test Test Test");
+			}
+			Files.write(fManyMatchesFile.getLocation().toFile().toPath(), lines);
+			fManyMatchesFile.refreshLocal(IResource.DEPTH_ZERO, null);
+		}
+	}
+
+	@AfterEach
+	public void tearDown() throws Exception {
+		if (fManyMatchesFile != null && fManyMatchesFile.exists()) {
+			fManyMatchesFile.delete(true, null);
+		}
 	}
 
 
@@ -73,7 +108,8 @@ public class PositionTrackerTest {
 		Object[] elements= result.getElements();
 		try {
 			for (Object element : elements) {
-				checkInsertAtZero(result, (IFile) element);
+				if (element instanceof IFile)
+					checkInsertAtZero(result, (IFile) element);
 			}
 		} finally {
 			SearchPlugin.getActivePage().closeAllEditors(false);
@@ -88,7 +124,8 @@ public class PositionTrackerTest {
 		Object[] elements= result.getElements();
 		try {
 			for (Object element : elements) {
-				checkInsertInsideMatch(result, (IFile) element);
+				if (element instanceof IFile)
+					checkInsertInsideMatch(result, (IFile) element);
 			}
 		} finally {
 			SearchPlugin.getActivePage().closeAllEditors(false);
@@ -146,6 +183,45 @@ public class PositionTrackerTest {
 			}
 		} finally {
 			Job.getJobManager().endRule(file);
+			SearchPlugin.getActivePage().closeAllEditors(false);
+		}
+	}
+
+	@Test
+	public void testSearchResultConsistency() throws Exception {
+		String[] txtPatterns = { "*.txt" };
+		FileTextSearchScope txtScope = FileTextSearchScope.newWorkspaceScope(txtPatterns, false);
+		FileSearchQuery txtQuery = new FileSearchQuery("Test", false, true, txtScope);
+
+		NewSearchUI.runQueryInForeground(null, txtQuery);
+		AbstractTextSearchResult result = (AbstractTextSearchResult) txtQuery.getSearchResult();
+		Match[] matches = result.getMatches(fManyMatchesFile);
+		assertTrue(matches.length >= 10, "Expected many matches in ManyMatches.txt, got " + matches.length);
+
+		try {
+			SearchTestUtil.openTextEditor(SearchPlugin.getActivePage(), fManyMatchesFile);
+			ITextFileBuffer fb = FileBuffers.getTextFileBufferManager().getTextFileBuffer(fManyMatchesFile.getFullPath(), LocationKind.IFILE);
+			Job.getJobManager().beginRule(fManyMatchesFile, null);
+			try {
+				IDocument doc = fb.getDocument();
+
+				// Shift all matches
+				doc.replace(0, 0, "Shift all matches");
+
+				// Trigger dirtyStateChanged to update matches
+				InternalSearchUI.getInstance().getPositionTracker().dirtyStateChanged(fb, false);
+
+				// Verify we can still remove all matches.
+				for (Match match : matches) {
+					int countBefore = result.getMatchCount(fManyMatchesFile);
+					result.removeMatch(match);
+					assertEquals(countBefore - 1, result.getMatchCount(fManyMatchesFile), "Match " + match + " was NOT removed! ConcurrentSkipListSet might be corrupted.");
+				}
+				assertEquals(0, result.getMatchCount(fManyMatchesFile));
+			} finally {
+				Job.getJobManager().endRule(fManyMatchesFile);
+			}
+		} finally {
 			SearchPlugin.getActivePage().closeAllEditors(false);
 		}
 	}


### PR DESCRIPTION
This PR fixes ConcurrentSkipListSet corruption in AbstractTextSearchResult by ensuring matches are correctly re-indexed when mutated by PositionTracker. See https://github.com/eclipse-platform/eclipse.platform.ui/issues/3796