### PR TITLE
Add null-check to AbstractTableViewer and AbstractTreeViewer

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTableViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTableViewer.java
@@ -387,9 +387,11 @@ public abstract class AbstractTableViewer extends ColumnViewer {
 					}
 
 					ViewerColumn columnViewer = getViewerColumn(column);
-					ViewerCell cellToUpdate = new ViewerCell(viewerRowFromItem, column, element);
 
-					columnViewer.refresh(cellToUpdate);
+					if (columnViewer != null) {
+						ViewerCell cellToUpdate = new ViewerCell(viewerRowFromItem, column, element);
+						columnViewer.refresh(cellToUpdate);
+					}
 
 					// As it is possible for user code to run the event
 					// loop check here.

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/viewers/AbstractTreeViewer.java
@@ -994,9 +994,11 @@ public abstract class AbstractTreeViewer extends ColumnViewer {
 			}
 
 			ViewerColumn columnViewer = getViewerColumn(column);
-			ViewerCell cellToUpdate = new ViewerCell(viewerRowFromItem, column, element);
 
-			columnViewer.refresh(cellToUpdate);
+			if (columnViewer != null) {
+				ViewerCell cellToUpdate = new ViewerCell(viewerRowFromItem, column, element);
+				columnViewer.refresh(cellToUpdate);
+			}
 
 			// As it is possible for user code to run the event
 			// loop check here.


### PR DESCRIPTION
Check for null before using the result of getViewerColumn(int). The JavaDoc explicitly says that the method may return null and other places in the code are already checking for null.