### PR TITLE
Skip gradient image for flat look in FormHeading and CSS handler

### DIFF
--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/Section.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/Section.java
@@ -464,6 +464,11 @@ public class Section extends ExpandableComposite {
 	}
 	private void updateHeaderImage(Color bg, Rectangle bounds, int theight, int realtheight) {
 		Color gradient = getTitleBarGradientBackground() != null ? getTitleBarGradientBackground() : getBackground();
+		if (gradient.equals(bg)) {
+			// Flat look: gradient and background are the same, no image needed
+			super.setBackgroundImage(null);
+			return;
+		}
 		Image image = FormImages.getInstance().getSectionGradientImage(gradient, bg, realtheight,
 				theight, marginHeight, getDisplay());
 		super.setBackgroundImage(image);

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/css/properties/css2/CSSPropertyFormHandler.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/css/properties/css2/CSSPropertyFormHandler.java
@@ -64,8 +64,6 @@ public class CSSPropertyFormHandler extends AbstractCSSPropertySWTHandler {
 		if (TEXT_BACKGROUND_COLOR.equals(property)) {
 			if (value.getCssValueType() == CSSValue.CSS_PRIMITIVE_VALUE) {
 				Color color = (Color) engine.convert(value, Color.class, form.getDisplay());
-				// When a single color is received, make it 100% with that
-				// single color.
 				form.setTextBackground(new Color[] { color }, new int[] { 100 }, true);
 
 			} else if (value.getCssValueType() == CSSValue.CSS_VALUE_LIST) {
@@ -83,12 +81,19 @@ public class CSSPropertyFormHandler extends AbstractCSSPropertySWTHandler {
 				}
 
 				if (colors.size() > 0) {
-					List<Integer> list = grad.getPercents();
-					int[] percents = new int[list.size()];
-					for (int i = 0; i < percents.length; i++) {
-						percents[i] = list.get(i).intValue();
+					Color[] colorArray = colors.toArray(new Color[0]);
+					if (allColorsIdentical(colorArray)) {
+						// All gradient colors are the same — pass a single
+						// color to avoid unnecessary gradient processing
+						form.setTextBackground(new Color[] { colorArray[0] }, new int[] { 100 }, true);
+					} else {
+						List<Integer> list = grad.getPercents();
+						int[] percents = new int[list.size()];
+						for (int i = 0; i < percents.length; i++) {
+							percents[i] = list.get(i).intValue();
+						}
+						form.setTextBackground(colorArray, percents, grad.getVerticalGradient());
 					}
-					form.setTextBackground(colors.toArray(new Color[0]), percents, grad.getVerticalGradient());
 				}
 			}
 
@@ -99,6 +104,19 @@ public class CSSPropertyFormHandler extends AbstractCSSPropertySWTHandler {
 				form.setHeadColor(headProperty, color);
 			}
 		}
+	}
+
+	private static boolean allColorsIdentical(Color[] colors) {
+		if (colors.length <= 1) {
+			return true;
+		}
+		Color first = colors[0];
+		for (int i = 1; i < colors.length; i++) {
+			if (!first.equals(colors[i])) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@Override

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/FormHeading.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/FormHeading.java
@@ -795,7 +795,17 @@ public class FormHeading extends Canvas {
 
 	public void setTextBackground(Color[] gradientColors, int[] percents,
 			boolean vertical) {
-		if (gradientColors != null) {
+		if (gradientColors != null && allColorsIdentical(gradientColors)) {
+			// Flat look: all gradient colors are the same, so use a solid
+			// background instead of generating a gradient image
+			gradientInfo = null;
+			if (gradientImage != null) {
+				FormImages.getInstance().markFinished(gradientImage, getDisplay());
+				gradientImage = null;
+				setBackgroundImage(null);
+			}
+			setBackground(gradientColors[0]);
+		} else if (gradientColors != null) {
 			gradientInfo = new GradientInfo();
 			gradientInfo.gradientColors = gradientColors;
 			gradientInfo.percents = percents;
@@ -811,6 +821,19 @@ public class FormHeading extends Canvas {
 				setBackgroundImage(null);
 			}
 		}
+	}
+
+	private static boolean allColorsIdentical(Color[] colors) {
+		if (colors.length <= 1) {
+			return true;
+		}
+		Color first = colors[0];
+		for (int i = 1; i < colors.length; i++) {
+			if (!first.equals(colors[i])) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	public void setHeadingBackgroundImage(Image image) {

--- a/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/tests/forms/util/FlatLookTest.java
+++ b/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/tests/forms/util/FlatLookTest.java
@@ -16,6 +16,7 @@ package org.eclipse.ui.tests.forms.util;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
@@ -81,6 +82,104 @@ public class FlatLookTest {
 			head.redraw();
 			head.update();
 		});
+	}
+
+	@Test
+	public void testFlatLookUsesSolidBackground() {
+		Form form = new Form(shell, SWT.NONE);
+		FormHeading head = (FormHeading) form.getHead();
+		head.setSize(100, 50);
+
+		Color color = new Color(display, 200, 100, 50);
+		head.setTextBackground(new Color[] { color, color }, new int[] { 100 }, true);
+
+		// Flat look: identical colors should use solid background, no gradient
+		// image
+		assertNull(head.getBackgroundImage(),
+				"No gradient image should be created for identical colors");
+		assertEquals(color.getRGB(), head.getBackground().getRGB(),
+				"Background should be the flat color");
+	}
+
+	@Test
+	public void testGradientLookUsesBackgroundImage() {
+		Form form = new Form(shell, SWT.NONE);
+		FormHeading head = (FormHeading) form.getHead();
+		head.setSize(100, 50);
+
+		Color color1 = new Color(display, 255, 0, 0);
+		Color color2 = new Color(display, 0, 0, 255);
+		head.setTextBackground(new Color[] { color1, color2 }, new int[] { 100 }, true);
+
+		// Gradient look: distinct colors should generate a background image
+		assertNotNull(head.getBackgroundImage(),
+				"A gradient image should be created for distinct colors");
+	}
+
+	@Test
+	public void testSwitchFromGradientToFlat() {
+		Form form = new Form(shell, SWT.NONE);
+		FormHeading head = (FormHeading) form.getHead();
+		head.setSize(100, 50);
+
+		// First set a real gradient
+		Color color1 = new Color(display, 255, 0, 0);
+		Color color2 = new Color(display, 0, 0, 255);
+		head.setTextBackground(new Color[] { color1, color2 }, new int[] { 100 }, true);
+		assertNotNull(head.getBackgroundImage());
+
+		// Switch to flat look — gradient image should be cleaned up
+		Color flat = new Color(display, 128, 128, 128);
+		head.setTextBackground(new Color[] { flat, flat }, new int[] { 100 }, true);
+		assertNull(head.getBackgroundImage(),
+				"Gradient image should be removed when switching to flat look");
+		assertEquals(flat.getRGB(), head.getBackground().getRGB());
+	}
+
+	@Test
+	public void testSingleColorArrayIsFlatLook() {
+		Form form = new Form(shell, SWT.NONE);
+		FormHeading head = (FormHeading) form.getHead();
+		head.setSize(100, 50);
+
+		Color color = new Color(display, 42, 42, 42);
+		head.setTextBackground(new Color[] { color }, new int[] { 100 }, true);
+
+		assertNull(head.getBackgroundImage(),
+				"Single-color array should be treated as flat look");
+		assertEquals(color.getRGB(), head.getBackground().getRGB());
+	}
+
+	@Test
+	public void testFlatLookRendersWithoutErrors() {
+		Form form = new Form(shell, SWT.NONE);
+		FormHeading head = (FormHeading) form.getHead();
+		head.setSize(100, 50);
+
+		Color color = new Color(display, 200, 200, 200);
+		head.setTextBackground(new Color[] { color, color }, new int[] { 100 }, true);
+
+		assertDoesNotThrow(() -> {
+			head.redraw();
+			head.update();
+		});
+	}
+
+	@Test
+	public void testResetToNullClearsGradient() {
+		Form form = new Form(shell, SWT.NONE);
+		FormHeading head = (FormHeading) form.getHead();
+		head.setSize(100, 50);
+
+		Color color1 = new Color(display, 255, 0, 0);
+		Color color2 = new Color(display, 0, 0, 255);
+		head.setTextBackground(new Color[] { color1, color2 }, new int[] { 100 }, true);
+		assertNotNull(head.getBackgroundImage());
+
+		// Reset with null
+		head.setTextBackground(null, null, true);
+		assertNull(head.getBackgroundImage(),
+				"Background image should be cleared on reset");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- **FormHeading** (`setTextBackground`): Detect when all gradient colors are identical and use `setBackground(color)` instead of generating a gradient image via `FormImages`. This avoids unnecessary `Image` allocation and GC rendering for flat themes.
- **CSSPropertyFormHandler**: Simplify identical-color gradient lists from CSS into a single-color array before passing to the form widget, preventing unnecessary gradient processing downstream.

These changes implement Levels 1 and 4 from #3803, complementing the Level 2/3 changes in #3807.

Fixes #3803

## Test plan
- [ ] Verify flat theme renders correctly with solid background (no gradient image created)
- [ ] Verify gradient themes still render correctly with distinct colors
- [ ] Verify CSS `text-background-color` with identical gradient stops uses solid background
- [ ] Verify CSS `text-background-color` with distinct gradient stops still creates gradient

🤖 Generated with [Claude Code](https://claude.com/claude-code)