### PR TITLE
Improve JFace notification snippets and documentation

### DIFF
--- a/docs/JFaceSnippets.md
+++ b/docs/JFaceSnippets.md
@@ -43,35 +43,28 @@ The JFace ColorSelector widget is a convenient composition of button and color s
 Notification
 ------------
 
+### [Snippet001 - Simple Notification Popup with Strings](https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/notifications/Snippet001NotificationPopupWithStrings.java)
+
+Demonstrates the simplest usage of the `NotificationPopup` builder API with `forShell()` and plain strings for title and content.
+
 ### [Snippet081 - Notification API](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/dialogs/Snippet081NotificationPopup.java)
 
-*   [Snippet081 - Notication API](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/dialogs/Snippet081NotificationPopup.java)
+Demonstrates usage of the non-blocking notification API with `forShell()`, showing notifications triggered by button clicks.
 
-  
-Demonstrates usage of the non-blocking notification API
-
-  
 ![Snippet081 Shell1.gif](images/Snippet081_Shell1.gif)
 
 ### [Snippet083 - Notification Popup with Functions](https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/notifications/Snippet083NotificationPopupWithFunctions.java)
 
-*   [Snippet083 - Notification Popup with Functions](https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/notifications/Snippet083NotificationPopupWithFunctions.java)
-
-Demonstrates the creation of notification popups that include function callbacks for user interactions.
+Demonstrates the creation of notification popups using `Function<Composite, Control>` for custom title and content creation.
 
 ### [Snippet084 - Notification Popup with Custom Delay and Fade](https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/notifications/Snippet084NotificationPopupWithCustomDelayAndFade.java)
 
-*   [Snippet084 - Notification Popup with Custom Delay and Fade](https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/notifications/Snippet084NotificationPopupWithCustomDelayAndFade.java)
+Shows how to create notification popups with custom delay and fade-in effects using the `delay()` and `fadeIn()` builder methods.
 
-Shows how to create notification popups with custom delay and fade effects for enhanced visual feedback.
+### [Snippet085 - Notification Popup with User Interaction](https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/notifications/Snippet085NotificationPopupWithUserInteraction.java)
 
-### [Snippet085 - Notification popup with user interaction](https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/notifications/Snippet085NotificationPopupWithUserInteraction.java)
+Demonstrates a `NotificationPopup` with interactive content — a label and a button that opens a confirmation dialog when clicked.
 
-This snippet demonstrates how to create a `NotificationPopup` that includes user interaction with a button. When the button is clicked, a confirmation dialog is shown.
-
-For the full code, please visit the [GitHub repository](https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/examples/org.eclipse.jface.snippets/Eclipse%20JFace%20Snippets/org/eclipse/jface/snippets/notifications/Snippet085NotificationPopupWithUserInteraction.java).
-
- 
 ![Snippet085.png](images/Snippet085NotificationPopupWithUserInteraction.png)
 
 

--- a/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/notifications/Snippet001NotificationPopupWithStrings.java
+++ b/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/notifications/Snippet001NotificationPopupWithStrings.java
@@ -4,13 +4,16 @@ import org.eclipse.jface.notifications.NotificationPopup;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
-public class Snippet001NotifcationPopupWithStrings {
+public class Snippet001NotificationPopupWithStrings {
 
 	public static void main(String[] args) {
 		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setSize(400, 200);
+		shell.open();
 
-		NotificationPopup.forDisplay(display).text("Just a notification").title("Test", true).open();
-		Shell shell = display.getShells()[0];
+		NotificationPopup.forShell(shell).text("Just a notification").title("Test", true).open();
+
 		while (!shell.isDisposed()) {
 			if (!display.readAndDispatch())
 				display.sleep();

--- a/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/notifications/Snippet083NotificationPopupWithFunctions.java
+++ b/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/notifications/Snippet083NotificationPopupWithFunctions.java
@@ -14,14 +14,16 @@ public class Snippet083NotificationPopupWithFunctions {
 
 	public static void main(String[] args) {
 		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setSize(400, 200);
+		shell.open();
 
 		Function<Composite, Control> contentCreator = WidgetFactory.label(SWT.NONE)
 				.text("Just a notification")::create;
 		Function<Composite, Control> titleCreator = WidgetFactory.label(SWT.NONE).text("Test")::create;
 
-		NotificationPopup.forDisplay(display).content(contentCreator).title(titleCreator, true).open();
+		NotificationPopup.forShell(shell).content(contentCreator).title(titleCreator, true).open();
 
-		Shell shell = display.getShells()[0];
 		while (!shell.isDisposed()) {
 			if (!display.readAndDispatch())
 				display.sleep();

--- a/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/notifications/Snippet084NotificationPopupWithCustomDelayAndFade.java
+++ b/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/notifications/Snippet084NotificationPopupWithCustomDelayAndFade.java
@@ -8,16 +8,18 @@ public class Snippet084NotificationPopupWithCustomDelayAndFade {
 
 	public static void main(String[] args) {
 		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setSize(400, 200);
+		shell.open();
 
-		 NotificationPopup.forDisplay(display).text("Just a notification").title("Test", false).delay(500)
-					.fadeIn(true).open();
+		NotificationPopup.forShell(shell).text("Just a notification").title("Test", false).delay(500).fadeIn(true)
+				.open();
 
-			Shell shell = display.getShells()[0];
-			while (!shell.isDisposed()) {
-				if (!display.readAndDispatch())
-					display.sleep();
-			}
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch())
+				display.sleep();
+		}
 
-			display.dispose();
+		display.dispose();
 	}
 }

--- a/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/notifications/Snippet085NotificationPopupWithUserInteraction.java
+++ b/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/notifications/Snippet085NotificationPopupWithUserInteraction.java
@@ -4,71 +4,34 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.notifications.NotificationPopup;
 import org.eclipse.jface.widgets.WidgetFactory;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Font;
-import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Button;
-import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 
 public class Snippet085NotificationPopupWithUserInteraction {
 
-    public static void main(String[] args) {
-        Display display = new Display();
-        Shell shell = new Shell(display); // Create the shell
+	public static void main(String[] args) {
+		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setSize(600, 400);
+		shell.open();
 
-        // Set the size of the shell
-        shell.setSize(400, 200);
-        
-        // Create content for the notification popup
-        Composite contentComposite = new Composite(shell, SWT.NONE);
-        GridLayout layout = new GridLayout();
-        layout.marginWidth = 10; // Margin width
-        layout.marginHeight = 10; // Margin height
-        contentComposite.setLayout(layout);
+		NotificationPopup.forShell(shell)
+				.content(parent -> {
+					WidgetFactory.label(SWT.WRAP).text("It is recommended that you\nupdate your configuration")
+							.create(parent);
+					WidgetFactory.button(SWT.PUSH).text("Confirm")
+							.onSelect(e -> MessageDialog.openConfirm(shell, "Confirmation", "Button was pressed!"))
+							.create(parent);
+					return parent;
+				})
+				.title("System update", true)
+				.open();
 
-        // Create a bold label with wrapped text
-        Label firstLine = new Label(contentComposite, SWT.WRAP);
-        firstLine.setText("It is recommended that you");
-        Font boldFont = new Font(display, "Arial", 10, SWT.BOLD);
-        firstLine.setFont(boldFont);
-        // Create a bold label with wrapped text
-        Label secondLine = new Label(contentComposite, SWT.WRAP);
-        secondLine.setText("update your configuration");
-        secondLine.setFont(boldFont);
-        
-        
-        // Create a button that will show the confirmation dialog when clicked
-        Button button = new Button(contentComposite, SWT.PUSH);
-        button.setText("Confirm");
-        
-        button.addListener(SWT.Selection, event -> {
-            MessageDialog.openConfirm(shell, "Confirmation", "Button was pressed!");
-        });
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch())
+				display.sleep();
+		}
 
-        // Set GridData for button to align properly in the layout
-        GridData gridData = new GridData(SWT.LEFT, SWT.CENTER, false, false);
-        button.setLayoutData(gridData);
-
-        // Create the notification popup
-        NotificationPopup.forDisplay(display)
-            .content(composite -> {
-                contentComposite.setParent(composite);
-                return composite;
-            })
-            .title(composite -> WidgetFactory.label(SWT.NONE).text("System update!!!").create(composite), true)
-            .open();
-
-        shell.open(); // Open the shell
-        
-        while (!shell.isDisposed()) {
-            if (!display.readAndDispatch())
-                display.sleep();
-        }
-
-        boldFont.dispose(); // Dispose of the font when done
-        display.dispose();
-    }
+		display.dispose();
+	}
 }


### PR DESCRIPTION
## Summary
- Fix typo in Snippet001 filename (`Notifcation` → `Notification`) and class name
- Fix inconsistent indentation in Snippet084
- Simplify Snippet085 to use the builder API idiomatically instead of creating widgets on a shell and reparenting them
- Add missing Snippet001 to JFaceSnippets.md
- Clean up Notification section in JFaceSnippets.md: remove duplicate links, fix typos, improve descriptions

See #1226

## Test plan
- [ ] Verify Snippet001, Snippet084, and Snippet085 compile and run correctly
- [ ] Verify JFaceSnippets.md renders correctly with new links