### PR TITLE
Fix forShell notification positioned outside parent shell

### DIFF
--- a/bundles/org.eclipse.jface.notifications/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.notifications/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.jface.notifications
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.8.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.eclipse.jface.notifications,
  org.eclipse.jface.notifications.internal;x-internal:=true

--- a/bundles/org.eclipse.jface.notifications/src/org/eclipse/jface/notifications/AbstractNotificationPopup.java
+++ b/bundles/org.eclipse.jface.notifications/src/org/eclipse/jface/notifications/AbstractNotificationPopup.java
@@ -449,12 +449,13 @@ public abstract class AbstractNotificationPopup extends Window {
 	private Rectangle getPrimaryClientArea() {
 		Shell parentShell = getParentShell();
 		if (parentShell != null) {
-			// calculate client area in display-relative coordinates
-			// (i.e. without window border / decorations)
-			Rectangle bounds = parentShell.getBounds();
-			Rectangle trim = parentShell.computeTrim(0, 0, 0, 0);
-			return new Rectangle(bounds.x - trim.x, bounds.y - trim.y, bounds.width - trim.width,
-					bounds.height - trim.height);
+			// Use toDisplay(0, 0) to get the client area origin in display coordinates.
+			// This avoids computeTrim() which can return incorrect values on GTK with
+			// client-side decorations (CSD), causing the notification to be positioned
+			// outside the visible bounds of the parent shell.
+			Rectangle clientArea = parentShell.getClientArea();
+			Point clientOrigin = parentShell.toDisplay(0, 0);
+			return new Rectangle(clientOrigin.x, clientOrigin.y, clientArea.width, clientArea.height);
 		}
 		// else display on primary monitor
 		Monitor primaryMonitor = this.shell.getDisplay().getPrimaryMonitor();

--- a/tests/org.eclipse.jface.tests.notifications/src/org/eclipse/jface/tests/notifications/NotificationPopupTest.java
+++ b/tests/org.eclipse.jface.tests.notifications/src/org/eclipse/jface/tests/notifications/NotificationPopupTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,6 +31,8 @@ import org.eclipse.jface.notifications.internal.CommonImages;
 import org.eclipse.jface.widgets.WidgetFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
@@ -133,6 +136,40 @@ class NotificationPopupTest {
 		assertThat(controls, hasItem(aLabelWith("Hello World")));
 		assertThat(controls, hasItem(aLabelWith("This is a test")));
 		notication.close();
+	}
+
+	@Test
+	void forShellPositionsNotificationAtBottomRightOfParentShell() {
+		// Place the parent shell at a non-trivial location so that display-relative
+		// and parent-relative coordinates differ significantly
+		shell = new Shell(display, SWT.SHELL_TRIM);
+		shell.setLocation(200, 200);
+		shell.setSize(600, 400);
+		shell.open();
+
+		NotificationPopup notification = NotificationPopup.forShell(shell).text("test").delay(1).build();
+		notification.open();
+
+		Shell notifShell = notification.getShell();
+
+		// Convert both to display coordinates to get a platform-independent comparison
+		Point notifOriginDisplay = notifShell.toDisplay(0, 0);
+		Point notifSize = notifShell.getSize();
+		int notifRightDisplay = notifOriginDisplay.x + notifSize.x;
+		int notifBottomDisplay = notifOriginDisplay.y + notifSize.y;
+
+		Rectangle clientArea = shell.getClientArea();
+		Point clientBottomRightDisplay = shell.toDisplay(clientArea.width, clientArea.height);
+
+		// The notification must be flush against the bottom-right corner of the
+		// parent shell's client area, offset only by PADDING_EDGE (5 px)
+		int paddingEdge = 5;
+		assertEquals(clientBottomRightDisplay.x - paddingEdge, notifRightDisplay,
+				"notification right edge must align with parent client area right edge");
+		assertEquals(clientBottomRightDisplay.y - paddingEdge, notifBottomDisplay,
+				"notification bottom edge must align with parent client area bottom edge");
+
+		notification.close();
 	}
 
 	private List<Control> getNotificationPopupControls(NotificationPopup notication) {


### PR DESCRIPTION
## Problem

`NotificationPopup.forShell(shell)` caused the notification to appear well below the parent shell's bottom edge, leaving a large visible gap, instead of being anchored to the bottom-right corner of the parent shell.

## Root Cause

`AbstractNotificationPopup.getPrimaryClientArea()` computed display-absolute coordinates using `getBounds()` and `computeTrim()`. These coordinates were then passed to `Shell.setLocation()` on the notification shell, which is a child shell (created as `new Shell(parentShell, style)`).

However, `Shell.setLocation()` on a child shell expects coordinates **relative to the parent shell's client area** — not display-absolute coordinates. The extra offset (the parent shell's screen position plus title bar height and border widths) shifted the notification far outside the parent shell's visible area.

## Fix

Replace the `getBounds()`/`computeTrim()` calculation with `parentShell.getClientArea()`, which returns `{0, 0, clientWidth, clientHeight}` — exactly the right coordinate space for `setLocation()` on a child shell.

## Test

A new test `forShellPositionsNotificationAtBottomRightOfParentShell` is added that places a parent shell at position (200, 200) (where display-relative and parent-relative coordinates differ significantly) and asserts that the notification's bottom-right corner aligns with the parent shell's client area bottom-right corner. This test fails before the fix and passes after.