### PR TITLE
Fix debug tracing typos in CopyOnWriteTextStore

### DIFF
--- a/bundles/org.eclipse.text/src/org/eclipse/jface/text/CopyOnWriteTextStore.java
+++ b/bundles/org.eclipse.text/src/org/eclipse/jface/text/CopyOnWriteTextStore.java
@@ -138,7 +138,7 @@ public class CopyOnWriteTextStore implements ITextStore {
 	@Override
 	public void replace(int offset, int length, String text) {
 		if (Activator.DEBUG) {
-			Activator.trace("CopyOnWriteTextStore.replace() offset={0}" + offset + ", length={1}" + length + ", text={2}" + text); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			Activator.trace("CopyOnWriteTextStore.replace() offset=" + offset + ", length=" + length + ", text=" + text); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		}
 		if (fTextStore != fModifiableTextStore) {
 			String content= fTextStore.get(0, fTextStore.getLength());


### PR DESCRIPTION
Removes unnecessary "{0}", "{1}" and "{2}" from debug traces in CopyOnWriteTextStore.

See: https://github.com/eclipse-platform/eclipse.platform.ui/issues/3800