### PR TITLE
Wait for refresh job at FileBufferFunctions.tearDown()

### DIFF
--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBufferFunctions.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBufferFunctions.java
@@ -37,8 +37,10 @@ import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.jobs.Job;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
 
 import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.filebuffers.IFileBuffer;
@@ -89,10 +91,11 @@ public abstract class FileBufferFunctions {
 	}
 
 	@AfterEach
-	public void tearDown() {
+	public void tearDown() throws Exception {
 		ITextFileBuffer buffer= fManager.getTextFileBuffer(fPath, LocationKind.NORMALIZE);
 		assertNull(buffer);
 		ResourceHelper.deleteProject("project");
+		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, null);
 	}
 
 	protected IPath getPath() {

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForExternalFiles.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForExternalFiles.java
@@ -37,7 +37,7 @@ public class FileBuffersForExternalFiles extends FileBufferFunctions {
 
 	@Override
 	@AfterEach
-	public void tearDown() {
+	public void tearDown() throws Exception {
 		FileTool.delete(getPath());
 		FileTool.delete(FileBuffers.getSystemFileAtLocation(getPath()).getParentFile());
 		super.tearDown();

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForFilesInLinkedFolders.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForFilesInLinkedFolders.java
@@ -47,7 +47,7 @@ public class FileBuffersForFilesInLinkedFolders extends FileBufferFunctions {
 
 	@Override
 	@AfterEach
-	public void tearDown() {
+	public void tearDown() throws Exception {
 		FileTool.delete(getPath());
 		File file= fExternalFile;
 		FileTool.delete(file); // externalResources/linkedFolderTarget/FileInLinkedFolder

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForLinkedFiles.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForLinkedFiles.java
@@ -41,7 +41,7 @@ public class FileBuffersForLinkedFiles extends FileBufferFunctions {
 
 	@Override
 	@AfterEach
-	public void tearDown() {
+	public void tearDown() throws Exception {
 		FileTool.delete(fExternalFile);
 		FileTool.delete(fExternalFile.getParentFile());
 		super.tearDown();

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForNonAccessibleWorkspaceFiles.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForNonAccessibleWorkspaceFiles.java
@@ -54,7 +54,7 @@ public class FileBuffersForNonAccessibleWorkspaceFiles extends FileBufferFunctio
 
 	@Override
 	@AfterEach
-	public void tearDown() {
+	public void tearDown() throws Exception {
 		FileTool.delete(getPath());
 		super.tearDown();
 	}

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForNonExistingExternalFiles.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForNonExistingExternalFiles.java
@@ -35,7 +35,7 @@ public class FileBuffersForNonExistingExternalFiles extends FileBufferFunctions 
 
 	@Override
 	@AfterEach
-	public void tearDown() {
+	public void tearDown() throws Exception {
 		FileTool.delete(getPath());
 		super.tearDown();
 	}

--- a/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForNonExistingWorkspaceFiles.java
+++ b/tests/org.eclipse.core.filebuffers.tests/src/org/eclipse/core/filebuffers/tests/FileBuffersForNonExistingWorkspaceFiles.java
@@ -44,7 +44,7 @@ public class FileBuffersForNonExistingWorkspaceFiles extends FileBufferFunctions
 
 	@Override
 	@AfterEach
-	public void tearDown() {
+	public void tearDown() throws Exception {
 		FileTool.delete(getPath());
 		super.tearDown();
 	}


### PR DESCRIPTION
`FileBuffersForFilesInLinkedFolders.test16_3()` fails infrequently during CI jobs, the fail indicates a missing resource delta notification.

`RefreshJob` is triggered during file buffer operations in `test2` and `test6`, and can notify test listeners of deltas. To avoid this potential problem, this change adds a wait for the refresh family at: `tearDown()`

See: #2528