### PR TITLE
Touch org.eclipse.ui.tests to fix comparator error

### DIFF
--- a/tests/org.eclipse.ui.tests/forceQualifierUpdate.txt
+++ b/tests/org.eclipse.ui.tests/forceQualifierUpdate.txt
@@ -15,3 +15,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/17
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3736


### PR DESCRIPTION
What happens is:

* Tycho moved to plexus-util 4.0.3 (https://github.com/eclipse-tycho/tycho/pull/5941) to resolve CVE https://github.com/eclipse-tycho/tycho/security/dependabot/15

* Plexus Util 4.0.1 (https://github.com/codehaus-plexus/plexus-utils/releases/tag/plexus-utils-4.0.1) contains -
https://github.com/codehaus-plexus/plexus-utils/releases/tag/plexus-utils-4.0.1)

The .gitignore in org.eclipse.ui.tests was added via 941c8bb03ed76cfda9d7d1978217f603d78888f4

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3736