### PR TITLE
Remove unwanted single quote from links

### DIFF
--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/TextEditorMessages.properties
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/TextEditorMessages.properties
@@ -76,10 +76,10 @@ TextEditorDefaultsPreferencePage_stickyScrollingMaximumCount_description=Limits 
 TextEditorDefaultsPreferencePage_tab=Tab ( \u00bb )
 TextEditorDefaultsPreferencePage_textDragAndDrop= Enable drag and dro&p of text
 TextEditorDefaultsPreferencePage_trailing=Trailing
-TextEditorPreferencePage_colorsAndFonts_link= More colors can be configured on the <a>'Colors and Fonts'</a> preference page.
+TextEditorPreferencePage_colorsAndFonts_link= More colors can be configured on the <a>Colors and Fonts</a> preference page.
 TextEditorPreferencePage_Font_link= Some editors may not honor all of these settings.\n\
 \n\
-See <a>'Colors and Fonts'</a> to configure the font.
+See <a>Colors and Fonts</a> to configure the font.
 
 TextEditorPreferencePage_selectionForegroundColor= Selection foreground color
 TextEditorPreferencePage_selectionBackgroundColor= Selection background color

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
@@ -172,7 +172,7 @@ ActionSetSelection_toolbarActions = &Toolbar details:
 ActionSetSelection_descriptionColumnHeader = Description
 ActionSetSelection_menuColumnHeader = Shortcut
 
-HideItems_itemInActionSet = Contributed by the <a>''{0}'' action set</a>.
+HideItems_itemInActionSet = Contributed by the <a>{0} action set</a>.
 HideItems_itemInUnavailableActionSet = This item cannot be made visible because the <a>action set ''{0}''</a> which contributes it is unavailable.
 HideItems_itemInUnavailableCommand = This command cannot be made visible in this dialog.
 HideItems_unavailableChildCommandGroup = This item cannot be made visible because all of its children are in the unavailable <a href="{0}">action set ''{1}''</a>.
@@ -448,7 +448,7 @@ FileEditorPreference_default = De&fault
 FileEditorPreference_existsTitle = File Type Exists
 FileEditorPreference_existsMessage = An entry already exists for that file type
 FileEditorPreference_defaultLabel = (default)
-FileEditorPreference_contentTypesRelatedLink = See <a>''{0}''</a> for content-type based file associations.
+FileEditorPreference_contentTypesRelatedLink = See <a>{0}</a> for content-type based file associations.
 FileEditorPreference_isLocked = {0} (locked by ''{1}'' content type)
 
 FileExtension_extensionEmptyMessage = The file extension cannot be empty


### PR DESCRIPTION
This pr removes unwanted single quotes from the label links shown in Preference pages and make links in preference page consistent

before : 
![before](https://github.com/user-attachments/assets/383c327f-1fdb-4a5a-8951-76bca0f44f7d)

after :
![after](https://github.com/user-attachments/assets/c09d1a1a-5edb-4d28-9a07-2e149db4b120)
