### PR TITLE
Bump o.e.ui.themes to 1.3.0

### DIFF
--- a/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.ui.themes/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.themes;singleton:=true
-Bundle-Version: 1.2.3000.qualifier
+Bundle-Version: 1.3.0.qualifier
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.e4.ui.css.swt.theme


### PR DESCRIPTION
To indicate removal of Classic theme in
https://github.com/eclipse-platform/eclipse.platform.ui/pull/3833