### PR TITLE
Use IFile.isContentRestricted() when restricting file search

### DIFF
--- a/bundles/org.eclipse.search.core/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
+++ b/bundles/org.eclipse.search.core/search/org/eclipse/search/internal/core/text/TextSearchVisitor.java
@@ -38,7 +38,6 @@ import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.content.IContentType;
@@ -72,7 +71,7 @@ public class TextSearchVisitor {
 
 	public static final boolean TRACING= "true".equalsIgnoreCase(Platform.getDebugOption("org.eclipse.search/perf")); //$NON-NLS-1$ //$NON-NLS-2$
 	private static final int NUMBER_OF_LOGICAL_THREADS= Runtime.getRuntime().availableProcessors();
-	private static final String EXCLUSION_PREFERENCE_NAME = "search_exclusion_property"; //$NON-NLS-1$
+	private static final String DISABLE_RESTRICTED_FILE_SEARCH_PREFERENCE = "disableRestrictedFileSearch"; //$NON-NLS-1$
 
 	/**
 	 * Queue of files to be searched. IFile pointing to the same local file are
@@ -301,7 +300,7 @@ public class TextSearchVisitor {
 	private volatile boolean fIsLightweightAutoRefresh;
 	private final DirtyFileProvider fDirtyDiscovery;
 
-	private final QualifiedName fExclusionProperty;
+	private final boolean fDisableRestrictedFileSearch;
 
 	public TextSearchVisitor(TextSearchRequestor collector, Pattern searchPattern, DirtyFileProvider dirtyDiscovery) {
 		fCollector= collector;
@@ -315,8 +314,8 @@ public class TextSearchVisitor {
 		fileBatches = new ConcurrentLinkedQueue<>();
 
 		IPreferencesService prefs = Platform.getPreferencesService();
-		String exclusionPropertyName = prefs.getString(SearchCorePlugin.PLUGIN_ID, EXCLUSION_PREFERENCE_NAME, "", null); //$NON-NLS-1$
-		fExclusionProperty = exclusionPropertyName.isEmpty() ? null : new QualifiedName(null, exclusionPropertyName);
+		fDisableRestrictedFileSearch = prefs.getBoolean(SearchCorePlugin.PLUGIN_ID,
+				DISABLE_RESTRICTED_FILE_SEARCH_PREFERENCE, false, null);
 	}
 
 	public IStatus search(IFile[] files, IProgressMonitor monitor) {
@@ -557,16 +556,16 @@ public class TextSearchVisitor {
 	}
 
 	private boolean excluded(IFile file) {
-		if (fExclusionProperty != null) {
+		if (fDisableRestrictedFileSearch) {
 			try {
-				return file.getSessionProperty(fExclusionProperty) != null;
+				return file.isContentRestricted();
 			} catch (CoreException e) {
 				/*
-				 * The preference 'search_exclusion_property' indicates we
-				 * should skip files with the respective session property, but
-				 * we ran into an exception while reading the properties of the
-				 * file. Skip the file from the search, since we don't know if
-				 * the property is set or not.
+				 * The preference 'disableRestrictedFileSearch' indicates we
+				 * should skip restricted files, but we ran into an exception
+				 * while checking if the file is restricted. Skip the file from
+				 * the search, since we don't know if the file is restricted or
+				 * not.
 				 */
 				fStatus.add(errorStatusForFile(file, e));
 				return true;

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/AllFileSearchTests.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/AllFileSearchTests.java
@@ -28,7 +28,7 @@ import org.eclipse.search.tests.TextSearchResultTest;
 		SearchResultPageTest.class,
 		SortingTest.class,
 		TextSearchResultTest.class,
-		ExcludedFilesSearchTest.class,
+		RestrictedFilesSearchTest.class,
 })
 public class AllFileSearchTests {
 }

--- a/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/RestrictedFilesSearchTest.java
+++ b/tests/org.eclipse.search.tests/src/org/eclipse/search/tests/filesearch/RestrictedFilesSearchTest.java
@@ -30,7 +30,6 @@ import org.osgi.service.prefs.BackingStoreException;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 
@@ -54,13 +53,9 @@ import org.eclipse.search.ui.text.FileTextSearchScope;
  * property {@code search_excluded_file} on some test files and performs a search. Search matches
  * are not expected for the files with the session property.
  */
-public class ExcludedFilesSearchTest {
+public class RestrictedFilesSearchTest {
 
-	private static final String EXCLUSION_PREFERENCE_NAME= "search_exclusion_property";
-
-	private static final QualifiedName SESSION_PROPERTY_QN= new QualifiedName(null, "search_excluded_file");
-
-	private static final String SESSION_PROPERTY= "search_excluded_file";
+	private static final String DISABLE_PREFERENCE_NAME= "disableRestrictedFileSearch";
 
 	private static final String EXCLUDED_FILE_PREFIX= "excluded_";
 
@@ -69,7 +64,7 @@ public class ExcludedFilesSearchTest {
 	@AfterEach
 	public void cleanUp() throws Exception {
 		ResourceHelper.deleteProject(PROJECT_NAME);
-		setExcludedSearchEnabled(null);
+		setDisableRestrictedFileSearch(false);
 	}
 
 	@Test
@@ -102,10 +97,10 @@ public class ExcludedFilesSearchTest {
 			for (int i= 0; i < n; ++i) {
 				IFile link= ResourceHelper.createLinkedFile(project, new Path("link_file_" + i), file);
 				if (i == index) {
-					setExcludedSearchSessionProperty(link);
+					link.setContentRestricted(true);
 				}
 			}
-			setExcludedSearchEnabled(SESSION_PROPERTY);
+			setDisableRestrictedFileSearch(true);
 			TestResultCollector collector= new TestResultCollector(true);
 			doSearch(project, collector, searchString);
 			TestResult[] results= collector.getResults();
@@ -165,7 +160,7 @@ public class ExcludedFilesSearchTest {
 		String searchString= "hello";
 		IProject project= prepareProject(n, m, PROJECT_NAME, searchString);
 		if (sessionProperty) {
-			setExcludedSearchEnabled(SESSION_PROPERTY);
+			setDisableRestrictedFileSearch(true);
 			setSessionProperty(project);
 		}
 		TestResultCollector collector= new TestResultCollector(parallel);
@@ -177,8 +172,9 @@ public class ExcludedFilesSearchTest {
 		project.accept(new IResourceVisitor() {
 			@Override
 			public boolean visit(IResource resource) throws CoreException {
-				if (resource.getName().startsWith(EXCLUDED_FILE_PREFIX)) {
-					setExcludedSearchSessionProperty(resource);
+				if (resource.getType() == IResource.FILE && resource.getName().startsWith(EXCLUDED_FILE_PREFIX)) {
+					IFile file= (IFile) resource;
+					file.setContentRestricted(true);
 				}
 				return true;
 			}
@@ -234,16 +230,12 @@ public class ExcludedFilesSearchTest {
 		assertEquals(expectedCount, k, "Wrong number of results in file");
 	}
 
-	private static void setExcludedSearchSessionProperty(IResource resource) throws CoreException {
-		resource.setSessionProperty(SESSION_PROPERTY_QN, "true");
-	}
-
-	private static void setExcludedSearchEnabled(String value) throws BackingStoreException {
+	private static void setDisableRestrictedFileSearch(boolean enabled) throws BackingStoreException {
 		IEclipsePreferences node= InstanceScope.INSTANCE.getNode(SearchCorePlugin.PLUGIN_ID);
-		if (value != null) {
-			node.put(EXCLUSION_PREFERENCE_NAME, value);
+		if (enabled) {
+			node.putBoolean(DISABLE_PREFERENCE_NAME, true);
 		} else {
-			node.remove(EXCLUSION_PREFERENCE_NAME);
+			node.remove(DISABLE_PREFERENCE_NAME);
 		}
 		node.flush();
 	}


### PR DESCRIPTION
This change adjusts the initial change for file search restrictions, to use the newly added API: `IFile.isContentRestricted()`

Fixes: https://github.com/eclipse-platform/eclipse.platform.ui/issues/3815