### PR TITLE
Add support for line background to sticky scrolling

### DIFF
--- a/bundles/org.eclipse.ui.editors/.settings/.api_filters
+++ b/bundles/org.eclipse.ui.editors/.settings/.api_filters
@@ -17,4 +17,12 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/ui/texteditor/stickyscroll/IStickyLine.java" type="org.eclipse.ui.texteditor.stickyscroll.IStickyLine">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.texteditor.stickyscroll.IStickyLine"/>
+                <message_argument value="getBackgroundColor()"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/stickyscroll/StickyScrollingControl.java
@@ -21,6 +21,7 @@ import java.util.StringJoiner;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CaretEvent;
 import org.eclipse.swt.custom.CaretListener;
+import org.eclipse.swt.custom.LineBackgroundEvent;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.events.ControlEvent;
@@ -185,6 +186,7 @@ public class StickyScrollingControl {
 		GridDataFactory.fillDefaults().grab(true, true).applyTo(stickyLineText);
 		stickyLineText.setEnabled(false);
 		stickyLineText.setBackground(settings.stickyLineBackgroundColor());
+		stickyLineText.addLineBackgroundListener(this::styleStickyLineBackground);
 
 		bottomSeparator= new Composite(stickyLinesCanvas, SWT.NONE);
 		GridDataFactory.fillDefaults().hint(0, 3).grab(true, false).span(2, 1).applyTo(bottomSeparator);
@@ -258,6 +260,12 @@ public class StickyScrollingControl {
 		stickyLineText.setForeground(textWidget.getForeground());
 		stickyLineText.setLineSpacing(textWidget.getLineSpacing());
 		stickyLineText.setLeftMargin(textWidget.getLeftMargin());
+	}
+
+	private void styleStickyLineBackground(LineBackgroundEvent event) {
+		int lineIndex = stickyLineText.getLineAtOffset(event.lineOffset);
+		IStickyLine line = stickyLines.get(lineIndex);
+		event.lineBackground = line.getBackgroundColor();
 	}
 
 	private void layoutStickyLines() {

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/texteditor/stickyscroll/IStickyLine.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/texteditor/stickyscroll/IStickyLine.java
@@ -14,6 +14,7 @@
 package org.eclipse.ui.texteditor.stickyscroll;
 
 import org.eclipse.swt.custom.StyleRange;
+import org.eclipse.swt.graphics.Color;
 
 /**
  * Representation of a sticky line.
@@ -42,5 +43,24 @@ public interface IStickyLine {
 	 * @return the style ranges of the sticky line
 	 */
 	StyleRange[] getStyleRanges();
+
+	/**
+	 * Returns the background color of the sticky line.
+	 * <p>
+	 * The background color is drawn for the full-width of the line. The text
+	 * background color if defined in a StyleRange ({@link #getStyleRanges()})
+	 * overlays the line background color.
+	 * </p>
+	 * <p>
+	 * {@code null} (the default), if the line has no special background color.
+	 * </p>
+	 * 
+	 * @return the background color of the sticky line or {@code null} for no
+	 *         special color
+	 * @since 3.22
+	 */
+	default Color getBackgroundColor() {
+		return null;
+	}
 
 }


### PR DESCRIPTION
Some text editors, like EGit's unified diff viewer, uses line background to style the editor's text. This change adds support to specify the line background of sticky lines too, so that they can be styled like in the editor.

<img width="733" height="328" alt="UnifiedDiffEditor-StickyLines" src="https://github.com/user-attachments/assets/36d479d7-ee3e-4c65-b990-50eb92695cfe" />
