### PR TITLE
Fix faulty selection update when bringing project explorer to top

### DIFF
--- a/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/actions/LinkEditorAction.java
+++ b/bundles/org.eclipse.ui.navigator/src/org/eclipse/ui/internal/navigator/actions/LinkEditorAction.java
@@ -149,9 +149,12 @@ public class LinkEditorAction extends Action implements ISelectionChangedListene
 
 			@Override
 			public void partBroughtToTop(IWorkbenchPart part) {
-				if (part instanceof IEditorPart && !ignoreEditorActivation) {
-					updateSelectionJob.schedule(NavigatorPlugin.LINK_HELPER_DELAY);
-				}
+				// Do not schedule a selection update here:
+				// 1. when the part is just brought to top (programmatically) but not activated,
+				// no link update is expected.
+				// 2. scheduling from both partActivated and partBroughtToTop can cause
+				// the job to run twice when the two events fire more than
+				// LINK_HELPER_DELAY apart (intermittent on slow machines).
 			}
 
 			@Override


### PR DESCRIPTION
## Summary

Fixes #1338 — intermittent failure of `LinkHelperTest.testLinkHelperEditorActivation` where `findSelectionCount` is 2 instead of the expected 1 by resolving the underlying issue in production code.

**Root cause:** `LinkEditorAction` registers an `IPartListener` that schedules `updateSelectionJob` from **both** `partActivated` and `partBroughtToTop`. First, this triggers selection updates just because the part is
(programmatically) brought to top, even if it is not activated, which is unintended. Second, both events fire for the same editor activation. Under normal timing they fire close together, so the second `schedule()` call resets the same job timer and the job runs once. But on slow machines (CI on Linux/GTK) the two events can fire more than `LINK_HELPER_DELAY` (120 ms) apart — the job runs once from the first event, completes, and is then rescheduled and run a second time from the second event, causing `findSelection()` to be called twice.

**Fix:** Remove the job scheduling from `partBroughtToTop`. The `partActivated` event is the correct signal for "an editor became active", which is exactly what the link-with-editor feature needs. Scheduling from `partBroughtToTop` is redundant (it fires for the same activation) and introduces the race.

## Test plan

- [ ] Existing `LinkHelperTest.testLinkHelperEditorActivation` and `testLinkHelperSelectionChange` cover this behaviour
- [ ] No new tests needed — this fixes an intermittent race in an existing test

---

🤖 Developed with [Claude Code](https://claude.ai/code) (claude-sonnet-4-6)