### PR TITLE
Fix test in response to SWT change in CTabFolder

### DIFF
--- a/tests/org.eclipse.e4.ui.tests.css.swt/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.e4.ui.tests.css.swt; singleton:=true
-Bundle-Version: 0.13.0.qualifier
+Bundle-Version: 0.13.100.qualifier
 Require-Bundle: org.eclipse.e4.ui.css.core,
  org.eclipse.e4.ui.css.swt,
  org.eclipse.e4.ui.css.swt.theme;bundle-version="0.15.0",

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CTabFolderTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/CTabFolderTest.java
@@ -185,8 +185,9 @@ public class CTabFolderTest extends CSSSWTTestCase {
 		assertEquals("true", engine.retrieveCSSProperty(folderToTest, "swt-simple", null));
 		folderToTest.getShell().close();
 		folderToTest = createTestCTabFolder("CTabFolder { swt-simple: false}");
-		assertEquals(false, folderToTest.getSimple());
-		assertEquals("false", engine.retrieveCSSProperty(folderToTest, "swt-simple", null));
+		// Curved tabs are no longer supported, so getSimple() always returns true
+		assertEquals(true, folderToTest.getSimple());
+		assertEquals("true", engine.retrieveCSSProperty(folderToTest, "swt-simple", null));
 	}
 
 	@Test


### PR DESCRIPTION
getSimple is now a no-opt

https://github.com/eclipse-platform/eclipse.platform.swt/pull/3168