### PR TITLE
Remove swt-simple CSS property support (curved tabs removed in SWT)

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt/plugin.xml
+++ b/bundles/org.eclipse.e4.ui.css.swt/plugin.xml
@@ -285,14 +285,6 @@
       <handler
             adapter="org.eclipse.e4.ui.css.swt.dom.CTabFolderElement"
             composite="false"
-            handler="org.eclipse.e4.ui.css.swt.properties.custom.CSSPropertySimpleSWTHandler">
-         <property-name
-               name="swt-simple">
-         </property-name>
-      </handler>
-      <handler
-            adapter="org.eclipse.e4.ui.css.swt.dom.CTabFolderElement"
-            composite="false"
             handler="org.eclipse.e4.ui.css.swt.properties.custom.CSSPropertyMaximizeVisibleSWTHandler">
          <property-name
                name="swt-maximize-visible">

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
@@ -879,7 +879,7 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 
 		public Color[] getSelectionGradientColors() {
 			if (selectionGradientColorsField == null) {
-				selectionGradientColorsField = getField("selectionGradientColorsField"); //$NON-NLS-1$
+				selectionGradientColorsField = getField("selectionGradientColors"); //$NON-NLS-1$
 			}
 			return (Color[]) getFieldValue(selectionGradientColorsField);
 		}


### PR DESCRIPTION
## Summary

- Remove `swt-simple` CSS property handler registration from `plugin.xml` — `CTabFolder.setSimple()` is now deprecated and a no-op in SWT since curved tab support was removed
- Drop `swt-simple: false` from `e4_default_gtk.css` (dead configuration)
- Fix pre-existing reflection bug in `CTabRendering`: field lookup used wrong string `"selectionGradientColorsField"` instead of `"selectionGradientColors"`
- Update `CTabFolderTest` to reflect that `getSimple()` always returns `true`
- Update `docs/CSS.md` to document `swt-simple` as deprecated

## Related

Follows the SWT changes that removed curved tab support from `CTabFolder` and `CTabFolderRenderer`.

## Test plan

- [ ] Run `org.eclipse.e4.ui.tests.css.swt` — `CTabFolderTest#testCTabFolderSimple` should pass
- [ ] Verify no compilation errors in `org.eclipse.e4.ui.workbench.renderers.swt`