### PR TITLE
Allow user to set default theme

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/ThemeEngine.java
+++ b/bundles/org.eclipse.e4.ui.css.swt.theme/src/org/eclipse/e4/ui/css/swt/internal/theme/ThemeEngine.java
@@ -41,6 +41,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.RegistryFactory;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.IPreferencesService;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.e4.ui.css.core.engine.CSSElementContext;
 import org.eclipse.e4.ui.css.core.engine.CSSEngine;
@@ -85,6 +86,8 @@ public class ThemeEngine implements IThemeEngine {
 	public static final String THEME_PLUGIN_ID = "org.eclipse.e4.ui.css.swt.theme";
 
 	public static final String E4_DARK_THEME_ID = "org.eclipse.e4.ui.css.theme.e4_dark";
+
+	public static final String E4_DEFAULT_THEME_ID = "org.eclipse.e4.ui.css.theme.e4_default";
 
 	public static final String DISABLE_OS_DARK_THEME_INHERIT = "org.eclipse.e4.ui.css.theme.disableOSDarkThemeInherit";
 
@@ -424,8 +427,14 @@ public class ThemeEngine implements IThemeEngine {
 		for (Theme t : themes) {
 			if (t.getId().equals(themeId)) {
 				setTheme(t, restore);
-				break;
+				return;
 			}
+		}
+		// Theme not found (e.g. it was uninstalled); fall back to default
+		Platform.getLog(ThemeEngine.class)
+				.warn("Theme '" + themeId + "' not found; falling back to default theme."); //$NON-NLS-1$ //$NON-NLS-2$
+		if (!E4_DEFAULT_THEME_ID.equals(themeId)) {
+			setTheme(E4_DEFAULT_THEME_ID, restore);
 		}
 	}
 
@@ -556,7 +565,8 @@ public class ThemeEngine implements IThemeEngine {
 	}
 
 	private String getPreferenceThemeId() {
-		return getPreferences().get(THEMEID_KEY, null);
+		IPreferencesService prefService = Platform.getPreferencesService();
+		return prefService.getString(THEME_PLUGIN_ID, THEMEID_KEY, null, null);
 	}
 
 	private IEclipsePreferences getPreferences() {

--- a/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/E4Application.java
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/E4Application.java
@@ -38,6 +38,8 @@ import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.IProduct;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.RegistryFactory;
+import org.eclipse.core.runtime.preferences.ConfigurationScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.e4.core.contexts.ContextFunction;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.EclipseContextFactory;
@@ -315,7 +317,10 @@ public class E4Application implements IApplication {
 				: getArgValue(E4Application.THEME_ID, applicationContext, false);
 
 		if (!themeId.isPresent() && !cssURI.isPresent()) {
-			context.set(E4Application.THEME_ID, DEFAULT_THEME_ID);
+			IEclipsePreferences configurationScopeNode = ConfigurationScope.INSTANCE
+					.getNode("org.eclipse.e4.ui.css.swt.theme");
+			String defaultThemeId = configurationScopeNode.get("themeid", DEFAULT_THEME_ID);
+			context.set(E4Application.THEME_ID, defaultThemeId);
 		} else {
 			context.set(E4Application.THEME_ID, themeId.orElseGet(() -> null));
 		}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchMessages.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/WorkbenchMessages.java
@@ -49,7 +49,7 @@ public class WorkbenchMessages extends NLS {
 	public static String RescaleAtRuntimeSettingChangeWarningText;
 
 	public static String ThemeChangeWarningText;
-
+	public static String ThemeChange_useAsDefault;
 	public static String ThemeChangeWarningTitle;
 
 	public static String BundleSigningTray_Cant_Find_Service;

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
@@ -20,6 +20,7 @@
 package org.eclipse.ui.internal.dialogs;
 
 import static org.eclipse.jface.viewers.LabelProvider.createTextProvider;
+import static org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter;
 import static org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants.ATT_COLOR_AND_FONT_ID;
 import static org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants.ATT_OS_VERSION;
 import static org.eclipse.ui.internal.registry.IWorkbenchRegistryConstants.ATT_THEME_ASSOCIATION;
@@ -61,7 +62,6 @@ import org.eclipse.jface.viewers.ComboViewer;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
-import org.eclipse.jface.window.Window;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
@@ -419,16 +419,49 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 		}
 
 		if (showRestartDialog) {
-			showRestartDialog(restartDialogTitle, restartDialogMessage);
+			String themeId = null;
+			if (isThemingPossible()) {
+				ITheme theme = getSelectedTheme();
+				if (theme != null) {
+					themeId = theme.getId();
+				}
+			}
+			showRestartDialog(restartDialogTitle, restartDialogMessage, themeId);
 		}
 
 		return super.performOk();
 	}
 
-	private void showRestartDialog(String title, String warningText) {
-		if (new MessageDialog(null, title, null, warningText, MessageDialog.NONE, 2,
-				WorkbenchMessages.Workbench_RestartButton, WorkbenchMessages.Workbench_DontRestartButton)
-						.open() == Window.OK) {
+	private void showRestartDialog(String title, String warningText, String themeId) {
+		boolean[] useAsDefault = { true };
+		MessageDialog dialog = new MessageDialog(null, title, null, warningText, MessageDialog.NONE, 2,
+				WorkbenchMessages.Workbench_RestartButton, WorkbenchMessages.Workbench_DontRestartButton) {
+			@Override
+			protected Control createCustomArea(Composite parent) {
+				if (themeId == null) {
+					return null;
+				}
+				Button checkbox = new Button(parent, SWT.CHECK);
+				checkbox.setText(WorkbenchMessages.ThemeChange_useAsDefault);
+				checkbox.setSelection(useAsDefault[0]);
+				checkbox.addSelectionListener(widgetSelectedAdapter(e -> useAsDefault[0] = checkbox.getSelection()));
+				return checkbox;
+			}
+		};
+		int result = dialog.open();
+		if (result == 0 || result == 1) { // 0: Restart, 1: Don't Restart
+			if (themeId != null && useAsDefault[0]) {
+				IEclipsePreferences configurationScopeNode = ConfigurationScope.INSTANCE
+						.getNode(E4_THEME_EXTENSION_POINT);
+				configurationScopeNode.put("themeid", themeId); //$NON-NLS-1$
+				try {
+					configurationScopeNode.flush();
+				} catch (BackingStoreException e) {
+					WorkbenchPlugin.log("Failed to set default theme in configuration scope", e); //$NON-NLS-1$
+				}
+			}
+		}
+		if (result == 0) {
 			Display.getDefault().asyncExec(() -> PlatformUI.getWorkbench().restart());
 		}
 	}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/messages.properties
@@ -498,6 +498,7 @@ PreferencePage_noDescription = (No description available)
 PreferencePageParameterValues_pageLabelSeparator = \ >\ 
 ThemingEnabled = E&nable theming
 ThemeChangeWarningText = Restart to fully apply theme changes
+ThemeChange_useAsDefault = &Use as default theme (only applies to workspaces without a configured theme)
 ThemeChangeWarningTitle = Theme Changed
 RescaleAtRuntimeSettingChangeWarningTitle = DPI Setting Changed
 RescaleAtRuntimeSettingChangeWarningText = Restart for the DPI setting changes to take effect


### PR DESCRIPTION
During theme switch the user can now set the selected theme as default This setting is saved as configuration scope and loaded for new workspaces unless the user has a theme set for this specific workspace. Add 'Use as default theme' checkbox to theme
restart dialog