### PR TITLE
Remove dead andFilters concept from Problems view filter

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ExtendedMarkersView.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/ExtendedMarkersView.java
@@ -1121,7 +1121,7 @@ public class ExtendedMarkersView extends ViewPart {
 	void openFiltersDialog() {
 		FiltersConfigurationDialog dialog = createFilterConfigurationDialog(generator);
 		if (dialog.open() == Window.OK) {
-			generator.updateFilters(dialog.getFilters(), dialog.andFilters());
+			generator.updateFilters(dialog.getFilters());
 		}
 	}
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/FiltersConfigurationDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/FiltersConfigurationDialog.java
@@ -86,8 +86,6 @@ public class FiltersConfigurationDialog extends TrayDialog {
 
 	private final MarkerContentGenerator generator;
 
-	private boolean andFilters = false;
-
 	private Button removeButton;
 	private Button renameButton;
 
@@ -113,17 +111,7 @@ public class FiltersConfigurationDialog extends TrayDialog {
 		super(parentShell);
 		filterGroups = makeWorkingCopy(generator.getAllFilters());
 		this.generator = generator;
-		andFilters = false;
 		setHelpAvailable(false);
-	}
-
-	/**
-	 * Return whether or not to AND the filters
-	 *
-	 * @return boolean
-	 */
-	boolean andFilters() {
-		return andFilters;
 	}
 
 	@Override
@@ -693,8 +681,6 @@ public class FiltersConfigurationDialog extends TrayDialog {
 	}
 
 	protected void performDefaults() {
-		andFilters = false;
-
 		filterGroups.clear();
 		List<MarkerFieldFilterGroup> declaredFilters = new ArrayList<>(generator.getDeclaredFilters());
 		filterGroups.addAll(declaredFilters);

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerContentGenerator.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerContentGenerator.java
@@ -67,7 +67,6 @@ public class MarkerContentGenerator {
 	private static final String TAG_COLUMN_VISIBILITY = "visible"; //$NON-NLS-1$
 	private static final String TAG_FILTERS_SECTION = "filterGroups"; //$NON-NLS-1$
 	private static final String TAG_GROUP_ENTRY = "filterGroup"; //$NON-NLS-1$
-	private static final String TAG_AND = "andFilters"; //$NON-NLS-1$
 	private static final String TAG_MARKER_LIMIT = "markerLimit"; //$NON-NLS-1$
 	private static final String TAG_MARKER_LIMIT_ENABLED = "markerLimitEnabled"; //$NON-NLS-1$
 
@@ -83,7 +82,6 @@ public class MarkerContentGenerator {
 	// filters
 	private Collection<MarkerFieldFilterGroup> enabledFilters;
 	private Collection<MarkerFieldFilterGroup> filters;
-	private boolean andFilters;
 	private int markerLimits = 100;
 	private boolean markerLimitsEnabled = true;
 
@@ -362,28 +360,11 @@ public class MarkerContentGenerator {
 	/**
 	 * Update the filters.
 	 */
-	void updateFilters(Collection<MarkerFieldFilterGroup> newFilters, boolean newAndFilters) {
-		setAndFilters(newAndFilters);
+	void updateFilters(Collection<MarkerFieldFilterGroup> newFilters) {
 		this.filters = newFilters;
 		enabledFilters = FILTERS_CHANGED;
 		writeFiltersPreference();
 		requestMarkerUpdate();
-	}
-
-	/**
-	 * Set whether the filters are being ANDed or ORed.
-	 */
-	void setAndFilters(boolean and) {
-		andFilters = and;
-	}
-
-	/**
-	 * Return whether the filters are being ANDed or ORed.
-	 *
-	 * @return boolean
-	 */
-	boolean andFilters() {
-		return andFilters;
 	}
 
 	/**
@@ -460,10 +441,6 @@ public class MarkerContentGenerator {
 			return;
 		}
 
-		Boolean andValue = memento.getBoolean(TAG_AND);
-		if (andValue != null) {
-			setAndFilters(andValue.booleanValue());
-		}
 		IMemento children[] = memento.getChildren(TAG_GROUP_ENTRY);
 
 		for (IMemento element : children) {
@@ -583,7 +560,6 @@ public class MarkerContentGenerator {
 	 * Write the settings for the filters to the memento.
 	 */
 	private void writeFiltersSettings(XMLMemento memento) {
-		memento.putBoolean(TAG_AND, andFilters());
 		Iterator<MarkerFieldFilterGroup> groups = getAllFilters().iterator();
 		while (groups.hasNext()) {
 			MarkerFieldFilterGroup group = groups.next();
@@ -699,28 +675,16 @@ public class MarkerContentGenerator {
 	 */
 	boolean select(MarkerEntry entry) {
 		try {
-			return select(entry, getSelectedResources(), getEnabledFilters(), andFilters());
+			return select(entry, getSelectedResources(), getEnabledFilters());
 		} finally {
 			entry.clearCache();
 		}
 	}
 
 	static boolean select(MarkerEntry entry, IResource[] selResources,
-			Collection<MarkerFieldFilterGroup> enabledFilters, boolean andFilters) {
+			Collection<MarkerFieldFilterGroup> enabledFilters) {
 		if (enabledFilters.size() > 0) {
-			Iterator<MarkerFieldFilterGroup> filtersIterator = enabledFilters.iterator();
-			if (andFilters) {
-				while (filtersIterator.hasNext()) {
-					MarkerFieldFilterGroup group = filtersIterator.next();
-					if (!group.selectByScope(entry, selResources) || !group.selectByFilters(entry)) {
-						return false;
-					}
-				}
-				return true;
-			}
-
-			while (filtersIterator.hasNext()) {
-				MarkerFieldFilterGroup group = filtersIterator.next();
+			for (MarkerFieldFilterGroup group : enabledFilters) {
 				if (group.selectByScope(entry, selResources) && group.selectByFilters(entry)) {
 					return true;
 				}
@@ -823,16 +787,14 @@ public class MarkerContentGenerator {
 	 * is a lot more time-consuming than collecting only once,filtering once and
 	 * adding to a list once.As a pre-filtering step, the
 	 * MarkerFieldFilterGroup#selectByScope uses IPath comparison for selection,
-	 * which happens real quickly.Also when filters are Anded we get a chance to
-	 * gather only on resources that actually matter.And we get a tool to check
-	 * at various places.
+	 * which happens real quickly.
 	 *
 	 * @return list of resource we want to collect markers for taking various
 	 *         enabled filters into account.
 	 */
 	Collection<IResource> getResourcesForBuild() {
 		currentResources = MarkerResourceUtil.computeResources(
-				getSelectedResources(), getEnabledFilters(), andFilters());
+				getSelectedResources(), getEnabledFilters());
 		return currentResources;
 	}
 
@@ -965,7 +927,6 @@ public class MarkerContentGenerator {
 		}
 		IResource[] selected = getSelectedResources();
 		Collection<MarkerFieldFilterGroup> enabled = getEnabledFilters();
-		boolean filtersAreANDed = andFilters();
 		Iterator<IResource> iterator = resources.iterator();
 		while (iterator.hasNext()) {
 			IMarker[] markers = null;
@@ -988,7 +949,7 @@ public class MarkerContentGenerator {
 			int lenght = markers.length;
 			for (int i = 0; i < lenght; i++) {
 				entry = new MarkerEntry(markers[i]);
-				if (select(entry, selected, enabled, filtersAreANDed)) {
+				if (select(entry, selected, enabled)) {
 					result.add(entry);
 				}
 				entry.clearCache();

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerResourceUtil.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/views/markers/MarkerResourceUtil.java
@@ -58,7 +58,7 @@ class MarkerResourceUtil {
 	 *         various enabled filters into account.
 	 */
 	static Set<IResource> computeResources(IResource[] selectedResources,
-			Collection<MarkerFieldFilterGroup> enabledFilters, boolean andFilters) {
+			Collection<MarkerFieldFilterGroup> enabledFilters) {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 
 		if (enabledFilters==null||enabledFilters.isEmpty()) {
@@ -66,8 +66,7 @@ class MarkerResourceUtil {
 			set.add(root);
 			return set;
 		}
-		Set<IResource> resourceSet = andFilters ? getResourcesFiltersAnded(enabledFilters,
-				selectedResources, root) : getResourcesFiltersOred(
+		Set<IResource> resourceSet = getResourcesFiltersOred(
 				enabledFilters, selectedResources, root);
 
 		//remove duplicates
@@ -136,89 +135,6 @@ class MarkerResourceUtil {
 				set = new HashSet<>(1);
 				set.add(root);
 				return set;
-			}
-		}
-		return resourceSet;
-	}
-
-	/**
-	 * The method may look long and a little time-consuming, but it actually
-	 * performs a short-circuit AND operation on the resources, and therefore
-	 * quick.
-	 *
-	 * Note: This is an optimization; we could have ORed the resources instead.
-	 * Let us say, for example, we had a filter of workspace-scope(ANY), and
-	 * others of scope on Selected element and maybe others.Now, if we computed
-	 * markers by ORing the resources, then we would compute markers for the
-	 * entire Workspace. The filters would anyways keep only the markers that
-	 * are an intersection of all resources (filter by scope) .In other words,
-	 * we spend more system-resources in both gathering and filtering.If we
-	 * ANDed the scopes(resources) we'd, save a good amount of system-resources
-	 * in both phases.
-	 *
-	 * @return set
-	 */
-	static Set<IResource> getResourcesFiltersAnded(Collection<MarkerFieldFilterGroup> enabledFilters,
-			IResource[] selectedResources, IWorkspaceRoot root) {
-		if (enabledFilters==null||enabledFilters.isEmpty()) {
-			HashSet<IResource> set = new HashSet<>(1);
-			set.add(root);
-			return set;
-		}
-		Set<IResource> resourceSet = new HashSet<>();
-
-		Iterator<MarkerFieldFilterGroup> filtersIterator = enabledFilters.iterator();
-		Set<IResource> removeMain = new HashSet<>();
-		while (filtersIterator.hasNext()) {
-			MarkerFieldFilterGroup group = filtersIterator.next();
-			Set<IResource> set = getResourcesForFilter(group, selectedResources, root);
-			if (resourceSet.isEmpty()) {
-				// first time
-				resourceSet.addAll(set);
-			} else {
-				Iterator<IResource> resIterator = resourceSet.iterator();
-				while (resIterator.hasNext()) {
-					boolean remove = true;
-					IResource mainRes = resIterator.next();
-					Iterator<IResource> iterator = set.iterator();
-					while (iterator.hasNext() && remove) {
-						IResource grpRes = iterator.next();
-						remove = !grpRes.equals(mainRes);
-						if (remove && grpRes.getFullPath().isPrefixOf(mainRes.getFullPath())) {
-							remove = false;
-						} else if (remove && mainRes.getFullPath().isPrefixOf(grpRes.getFullPath())) {
-							remove = false;
-							removeMain.add(mainRes);
-						}
-					}
-					if (remove) {
-						resIterator.remove();
-					}
-				}
-				Iterator<IResource> iterator = set.iterator();
-				while (iterator.hasNext()) {
-					boolean remove = true;
-					IResource grpRes = iterator.next();
-					resIterator = resourceSet.iterator();
-					while (resIterator.hasNext()&&remove) {
-						IResource mainRes = resIterator.next();
-						remove = !grpRes.equals(mainRes);
-						if (remove && mainRes.getFullPath().isPrefixOf(grpRes.getFullPath())) {
-							remove = false;
-						}
-					}
-					if (remove) {
-						iterator.remove();
-					}
-				}
-				resourceSet.addAll(set);
-				resourceSet.removeAll(removeMain);
-				removeMain.clear();
-				if (resourceSet.isEmpty()) {
-					// if the And between two is empty
-					// then its empty for all
-					return resourceSet;
-				}
 			}
 		}
 		return resourceSet;

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/MarkerSupportViewTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/markers/MarkerSupportViewTest.java
@@ -282,15 +282,10 @@ public class MarkerSupportViewTest {
 				getFilters.setAccessible(true);
 				Object filtersGot = getFilters.invoke(this);
 
-				Method andFilters = FiltersConfigurationDialog.class.getDeclaredMethod("andFilters");
-				andFilters.setAccessible(true);
-				Object filtersAnd = andFilters.invoke(this);
-
-				Method updateFilters = MarkerContentGenerator.class.getDeclaredMethod("updateFilters", Collection.class,
-						boolean.class);
+				Method updateFilters = MarkerContentGenerator.class.getDeclaredMethod("updateFilters", Collection.class);
 				updateFilters.setAccessible(true);
 
-				updateFilters.invoke(_generator, filtersGot, filtersAnd);
+				updateFilters.invoke(_generator, filtersGot);
 
 			} catch (Exception e) {
 				e.printStackTrace();


### PR DESCRIPTION
The `andFilters` boolean in `FiltersConfigurationDialog` was always hardcoded to `false` — no UI control ever set it to `true`. This removes the dead AND-filter logic that was never reachable.

## Changes

- Remove `andFilters` field, getter, and setter from `FiltersConfigurationDialog` and `MarkerContentGenerator`
- Remove `TAG_AND` persistence (read/write) from `MarkerContentGenerator`  
- Simplify `select()` method to always use OR logic (the only active code path)
- Remove unused `getResourcesFiltersAnded()` from `MarkerResourceUtil`
- Simplify `computeResources()` to always use OR resource computation
- Update `ExtendedMarkersView.openFiltersDialog()` call signature
- Update `MarkerSupportViewTest` reflection calls to match new signatures
- Clean up Javadoc referencing AND filter behavior

## Testing

- Verified compilation succeeds with `mvn clean compile -pl :org.eclipse.ui.ide -Pbuild-individual-bundles`
- Since `andFilters` was always `false`, this is a pure dead-code removal with no behavioral change