### PR TITLE
Introduce AbstractInlinedAnnotation#getMinings() to expose ICodeMining list

### DIFF
--- a/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jface.text/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.text
-Bundle-Version: 3.30.100.qualifier
+Bundle-Version: 3.31.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningDocumentFooterAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningDocumentFooterAnnotation.java
@@ -15,6 +15,7 @@ import static org.eclipse.jface.internal.text.codemining.CodeMiningLineHeaderAnn
 import static org.eclipse.jface.internal.text.codemining.CodeMiningLineHeaderAnnotation.hasAtLeastOneResolvedMiningNotEmpty;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -143,5 +144,13 @@ public class CodeMiningDocumentFooterAnnotation extends LineFooterAnnotation imp
 	@Override
 	public boolean isInVisibleLines() {
 		return super.isInVisibleLines();
+	}
+
+	/**
+	 * @since 3.31
+	 */
+	@Override
+	public List<ICodeMining> getMinings() {
+		return Collections.unmodifiableList(fMinings);
 	}
 }

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineContentAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineContentAnnotation.java
@@ -14,6 +14,7 @@
 package org.eclipse.jface.internal.text.codemining;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -215,5 +216,13 @@ public class CodeMiningLineContentAnnotation extends LineContentAnnotation imple
 
 	public final boolean isAfterPosition() {
 		return afterPosition;
+	}
+
+	/**
+	 * @since 3.31
+	 */
+	@Override
+	public List<ICodeMining> getMinings() {
+		return Collections.unmodifiableList(fMinings);
 	}
 }

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineHeaderAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineHeaderAnnotation.java
@@ -14,6 +14,7 @@
 package org.eclipse.jface.internal.text.codemining;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -289,5 +290,13 @@ public class CodeMiningLineHeaderAnnotation extends LineHeaderAnnotation impleme
 	@Override
 	public boolean isInVisibleLines() {
 		return super.isInVisibleLines();
+	}
+
+	/**
+	 * @since 3.31
+	 */
+	@Override
+	public List<ICodeMining> getMinings() {
+		return Collections.unmodifiableList(fMinings);
 	}
 }

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/AbstractInlinedAnnotation.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/AbstractInlinedAnnotation.java
@@ -13,6 +13,8 @@
  */
 package org.eclipse.jface.text.source.inlined;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Consumer;
 
 import org.eclipse.swt.SWT;
@@ -26,6 +28,7 @@ import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.ITextViewerExtension5;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.Region;
+import org.eclipse.jface.text.codemining.ICodeMining;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.text.source.projection.ProjectionViewer;
@@ -298,6 +301,17 @@ public abstract class AbstractInlinedAnnotation extends Annotation {
 	void setLocation(int x, int y) {
 		this.fX= x;
 		this.fY= y;
+	}
+
+	/**
+	 * Returns the list of code minings associated with this annotation, or an empty list if this
+	 * annotation has no associated minings.
+	 *
+	 * @return an unmodifiable list of code minings, never <code>null</code>
+	 * @since 3.31
+	 */
+	public List<ICodeMining> getMinings() {
+		return Collections.emptyList();
 	}
 
 	/**


### PR DESCRIPTION
Adds a new public API method `getMinings()` to `AbstractInlinedAnnotation` that provides read-only access to the list of `ICodeMining` instances associated with an inlined annotation.

This API is needed to implement the unified diff feature via https://github.com/eclipse-platform/eclipse.platform/pull/2560