### PR TITLE
Skip dot-folders (e.g., .git) when scanning for projects to import

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/messages.properties
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/wizards/datatransfer/messages.properties
@@ -112,7 +112,7 @@ WizardProjectsImportPage_invalidProjectName=Invalid Project
 WizardProjectsImportPage_projectLabel={0} ({1})
 WizardProjectsImportPage_hideExistingProjects=H&ide projects that already exist in the workspace
 WizardProjectsImportPage_closeProjectsAfterImport=Cl&ose newly imported projects upon completion
-WizardProjectsImportPage_skipDotFolders=S&kip folders starting with '.' (e.g. .git)
+WizardProjectsImportPage_skipDotFolders=S&kip folders starting with '.' (e.g., .git)
 
 # --- Export Wizards ---
 DataTransfer_export = Export
@@ -215,4 +215,4 @@ SmartImportWizardPage_incompleteExpand_message=Archive expansion didn''t complet
 SmartImportWizardPage_selectAtLeastOneFolderToOpenAsProject=Select at least one folder to import as project.
 SmartImportWizardPage_showOtherSpecializedImportWizard=Show other specialized import wizards
 SmartImportWizardPage_closeProjectsAfterImport=Cl&ose newly imported projects upon completion
-SmartImportWizardPage_skipDotFolders=S&kip folders starting with '.' (e.g. .git)
+SmartImportWizardPage_skipDotFolders=S&kip folders starting with '.' (e.g., .git)


### PR DESCRIPTION
Adds a **Skip folders starting with '.'** checkbox (default: true) to both import wizards:

- **Smart Import** (SmartImportRootWizardPage / SmartImportJob)
- **Import Existing Projects** (WizardProjectsImportPage)

When enabled, directories like `.git`, `.svn`, `.hg` etc. are skipped during recursive project scanning, significantly improving import performance for repositories with large `.git` folders.

The setting is persisted in dialog settings and defaults to `true` for new installations.

Includes tests for both wizards covering skip-enabled and skip-disabled scenarios.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/3858