### PR TITLE
Fix disabled wizard buttons appearing enabled in dark theme

### DIFF
--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/WizardDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/wizard/WizardDialog.java
@@ -973,7 +973,7 @@ public class WizardDialog extends TitleAreaDialog implements IWizardContainer2, 
 		if (control != null) {
 			Boolean b = (Boolean) saveState.get(key);
 			if (b != null) {
-				control.setEnabled(b.booleanValue());
+				setButtonEnabled(control, b.booleanValue());
 			}
 		}
 	}
@@ -1066,8 +1066,23 @@ public class WizardDialog extends TitleAreaDialog implements IWizardContainer2, 
 	private void saveEnableStateAndSet(Control control, Map<String, Object> saveState, String key, boolean enabled) {
 		if (control != null) {
 			saveState.put(key, control.getEnabled() ? Boolean.TRUE : Boolean.FALSE);
-			control.setEnabled(enabled);
+			setButtonEnabled(control, enabled);
 		}
+	}
+
+	/**
+	 * Sets the enabled state of a button and updates the CSS class name so that
+	 * the dark theme can style disabled buttons differently. The CSS class
+	 * "disabled" is set when the button is disabled, and cleared when enabled.
+	 * This triggers a reskin so that the CSS engine re-applies styles.
+	 *
+	 * @param control the button control
+	 * @param enabled whether the button should be enabled
+	 */
+	private static void setButtonEnabled(Control control, boolean enabled) {
+		control.setEnabled(enabled);
+		control.setData("org.eclipse.e4.ui.css.CssClassName", enabled ? null : "disabled"); //$NON-NLS-1$ //$NON-NLS-2$
+		control.reskin(SWT.NONE);
 	}
 
 	/**
@@ -1332,13 +1347,13 @@ public class WizardDialog extends TitleAreaDialog implements IWizardContainer2, 
 		boolean canFinish = wizard.canFinish();
 		if (backButton != null) {
 			boolean backEnabled = currentPage != null && currentPage.getPreviousPage() != null;
-			backButton.setEnabled(backEnabled);
+			setButtonEnabled(backButton, backEnabled);
 		}
 		if (nextButton != null) {
 			canFlipToNextPage = currentPage != null && currentPage.canFlipToNextPage();
-			nextButton.setEnabled(canFlipToNextPage);
+			setButtonEnabled(nextButton, canFlipToNextPage);
 		}
-		finishButton.setEnabled(canFinish);
+		setButtonEnabled(finishButton, canFinish);
 		// finish is default unless it is disabled and next is enabled
 		if (canFlipToNextPage && !canFinish) {
 			getShell().setDefaultButton(nextButton);

--- a/bundles/org.eclipse.ui.themes/css/dark/e4-dark_globalstyle.css
+++ b/bundles/org.eclipse.ui.themes/css/dark/e4-dark_globalstyle.css
@@ -45,6 +45,11 @@ Group > StyledText {
     color:'#org-eclipse-ui-workbench-DARK_FOREGROUND'; 
 }
 
+/* Disabled buttons should appear dimmed to distinguish them from enabled buttons */
+Button.disabled {
+    color: #777777;
+}
+
 /* ############################## Toolbar ############################## */
 /* Ensure that the labels in the tabfolder gets updated
    See Bug 552780


### PR DESCRIPTION
In the dark theme, the CSS sets a foreground color on all Button elements, which overrides the native OS disabled button rendering. This causes disabled buttons (like 'Finish') to look identical to enabled ones.

## Approach

Sets a `disabled` CSS class on wizard buttons when they are disabled via `setData("org.eclipse.e4.ui.css.CssClassName", "disabled")`. The dark theme CSS includes a new `Button.disabled` rule with a dimmed foreground color. A `reskin(SWT.NONE)` call triggers the CSS engine to re-apply styles.

This avoids enabling global dynamic CSS pseudo-class support (`org.eclipse.e4.ui.css.dynamic`), which is disabled for performance reasons.

## Changes

- **`WizardDialog.java`**: Added `setButtonEnabled()` helper used in all button state change paths (`updateButtons`, `saveEnableStateAndSet`, `restoreEnableState`)
- **`e4-dark_globalstyle.css`**: Added `Button.disabled { color: #777777; }` rule