### PR TITLE
Defer expensive project reference computation during selection changes

### DIFF
--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CloseUnrelatedProjectsAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CloseUnrelatedProjectsAction.java
@@ -133,7 +133,7 @@ public class CloseUnrelatedProjectsAction extends CloseResourceAction {
 
 	/**
 	 * Overrides to avoid calling the expensive
-	 * {@link #computeRelated(List)} during selection changes. Uses only
+	 * {@code computeRelated(List)} during selection changes. Uses only
 	 * the raw selection to determine enablement.
 	 */
 	@Override

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CloseUnrelatedProjectsAction.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/actions/CloseUnrelatedProjectsAction.java
@@ -30,6 +30,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialogWithToggle;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.window.IShellProvider;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Shell;
@@ -128,6 +129,25 @@ public class CloseUnrelatedProjectsAction extends CloseResourceAction {
 				IDEWorkbenchMessages.CloseUnrelatedProjectsAction_text_plural,
 				IDEWorkbenchMessages.CloseUnrelatedProjectsAction_toolTip_plural);
 		initAction();
+	}
+
+	/**
+	 * Overrides to avoid calling the expensive
+	 * {@link #computeRelated(List)} during selection changes. Uses only
+	 * the raw selection to determine enablement.
+	 */
+	@Override
+	protected boolean updateSelection(IStructuredSelection s) {
+		selectionDirty = true;
+		if (!selectionIsOfType(IResource.PROJECT)) {
+			return false;
+		}
+		for (IResource resource : super.getSelectedResources()) {
+			if (resource instanceof IProject project && project.isOpen()) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
CloseUnrelatedProjectsAction.getSelectedResources() calls computeRelated() which triggers buildConnectedComponents() and getReferencedProjects() for every project in the workspace. This is expensive because it can trigger classpath container resolution.

Previously, the inherited updateSelection() called getSelectedResources() on every selection change, causing this expensive computation to run on the UI thread during startup and navigation. This blocked the IDE.

Override updateSelection() to perform only a cheap enablement check: verify the selection contains at least one open IProject. The expensive computeRelated() call is deferred to getSelectedResources(), which is only invoked when the action is actually executed via run(). This is correct because getSelectedResources() already handles the selectionDirty flag and recomputes projectsToClose lazily when needed.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/2636