### PR TITLE
Use UserScope instead of ConfigurationScope for default theme

### DIFF
--- a/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/E4Application.java
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/E4Application.java
@@ -38,8 +38,8 @@ import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.IProduct;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.RegistryFactory;
-import org.eclipse.core.runtime.preferences.ConfigurationScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.UserScope;
 import org.eclipse.e4.core.contexts.ContextFunction;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.EclipseContextFactory;
@@ -317,9 +317,9 @@ public class E4Application implements IApplication {
 				: getArgValue(E4Application.THEME_ID, applicationContext, false);
 
 		if (!themeId.isPresent() && !cssURI.isPresent()) {
-			IEclipsePreferences configurationScopeNode = ConfigurationScope.INSTANCE
+			IEclipsePreferences userScopeNode = UserScope.INSTANCE
 					.getNode("org.eclipse.e4.ui.css.swt.theme");
-			String defaultThemeId = configurationScopeNode.get("themeid", DEFAULT_THEME_ID);
+			String defaultThemeId = userScopeNode.get("themeid", DEFAULT_THEME_ID);
 			context.set(E4Application.THEME_ID, defaultThemeId);
 		} else {
 			context.set(E4Application.THEME_ID, themeId.orElseGet(() -> null));

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ViewsPreferencePage.java
@@ -42,6 +42,7 @@ import org.eclipse.core.runtime.preferences.ConfigurationScope;
 import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.core.runtime.preferences.UserScope;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.css.swt.theme.ITheme;
 import org.eclipse.e4.ui.css.swt.theme.IThemeEngine;
@@ -451,13 +452,13 @@ public class ViewsPreferencePage extends PreferencePage implements IWorkbenchPre
 		int result = dialog.open();
 		if (result == 0 || result == 1) { // 0: Restart, 1: Don't Restart
 			if (themeId != null && useAsDefault[0]) {
-				IEclipsePreferences configurationScopeNode = ConfigurationScope.INSTANCE
+				IEclipsePreferences userScopeNode = UserScope.INSTANCE
 						.getNode(E4_THEME_EXTENSION_POINT);
-				configurationScopeNode.put("themeid", themeId); //$NON-NLS-1$
+				userScopeNode.put("themeid", themeId); //$NON-NLS-1$
 				try {
-					configurationScopeNode.flush();
+					userScopeNode.flush();
 				} catch (BackingStoreException e) {
-					WorkbenchPlugin.log("Failed to set default theme in configuration scope", e); //$NON-NLS-1$
+					WorkbenchPlugin.log("Failed to set default theme in user scope", e); //$NON-NLS-1$
 				}
 			}
 		}


### PR DESCRIPTION
Changes the default theme preference storage from ConfigurationScope to UserScope.

UserScope is more appropriate as it represents a per-user setting that roams with the user across installations, while ConfigurationScope is shared across all users of an installation.

### Changes
- **E4Application.java**: Read default theme from UserScope instead of ConfigurationScope
- **ViewsPreferencePage.java**: Write default theme to UserScope instead of ConfigurationScope

Based on commit a7e91a0fe0cca3b15ab347ee380656242f42e823 which introduced the default theme feature.