### PR TITLE
Replace Forms API with plain SWT in workspace dialogs

### DIFF
--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceDialog.java
@@ -40,6 +40,7 @@ import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.dialogs.TitleAreaDialog;
 import org.eclipse.jface.resource.JFaceColors;
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.util.Geometry;
 import org.eclipse.jface.window.Window;
 import org.eclipse.osgi.util.NLS;
@@ -71,11 +72,6 @@ import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Monitor;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.forms.events.ExpansionAdapter;
-import org.eclipse.ui.forms.events.ExpansionEvent;
-import org.eclipse.ui.forms.widgets.ExpandableComposite;
-import org.eclipse.ui.forms.widgets.Form;
-import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.osgi.framework.FrameworkUtil;
 
 /**
@@ -100,7 +96,7 @@ public class ChooseWorkspaceDialog extends TitleAreaDialog {
 
 	private Map<String, Link> recentWorkspacesLinks;
 
-	private Form recentWorkspacesForm;
+	private Composite recentWorkspacesForm;
 
 	private Button defaultButton;
 
@@ -313,38 +309,61 @@ public class ChooseWorkspaceDialog extends TitleAreaDialog {
 	 * Workspace
 	 */
 	private void createRecentWorkspacesComposite(final Composite composite) {
-		FormToolkit toolkit = new FormToolkit(composite.getDisplay());
-		composite.addDisposeListener(c -> toolkit.dispose());
-		recentWorkspacesForm = toolkit.createForm(composite);
+		recentWorkspacesForm = new Composite(composite, SWT.NONE);
 		recentWorkspacesForm.setBackground(composite.getBackground());
-		recentWorkspacesForm.getBody().setLayout(new GridLayout());
-		ExpandableComposite recentWorkspacesExpandable = toolkit.createExpandableComposite(recentWorkspacesForm.getBody(),
-				ExpandableComposite.TWISTIE);
-		recentWorkspacesExpandable.setTitleBarForeground(composite.getForeground());
-		recentWorkspacesExpandable.setForeground(composite.getForeground());
-		recentWorkspacesExpandable.setToggleColor(composite.getForeground());
-		recentWorkspacesExpandable.setActiveToggleColor(composite.getForeground());
+		recentWorkspacesForm.setLayout(new GridLayout());
 		recentWorkspacesForm.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
-		recentWorkspacesExpandable.setBackground(composite.getBackground());
-		recentWorkspacesExpandable.setText(IDEWorkbenchMessages.ChooseWorkspaceDialog_recentWorkspaces);
-		recentWorkspacesExpandable.setExpanded(launchData.isShowRecentWorkspaces());
-		recentWorkspacesExpandable.addExpansionListener(new ExpansionAdapter() {
-			@Override
-			public void expansionStateChanged(ExpansionEvent e) {
-				launchData.setShowRecentWorkspaces(((ExpandableComposite) e.getSource()).isExpanded());
-				Point size = getInitialSize();
-				Shell shell = getShell();
-				shell.setBounds(getConstrainedShellBounds(
-						new Rectangle(shell.getLocation().x, shell.getLocation().y, size.x, size.y)));
-			}
-		});
 
-		Composite panel = new Composite(recentWorkspacesExpandable, SWT.NONE);
-		recentWorkspacesExpandable.setClient(panel);
+		Composite header = new Composite(recentWorkspacesForm, SWT.NONE);
+		header.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+		GridLayout headerLayout = new GridLayout(2, false);
+		headerLayout.marginWidth = 0;
+		headerLayout.marginHeight = 0;
+		header.setLayout(headerLayout);
+		header.setBackground(composite.getBackground());
+
+		Label toggle = new Label(header, SWT.NONE);
+		toggle.setBackground(composite.getBackground());
+		toggle.setCursor(composite.getDisplay().getSystemCursor(SWT.CURSOR_HAND));
+
+		Label label = new Label(header, SWT.NONE);
+		label.setText(IDEWorkbenchMessages.ChooseWorkspaceDialog_recentWorkspaces);
+		label.setBackground(composite.getBackground());
+		label.setFont(JFaceResources.getFontRegistry().getBold(JFaceResources.DIALOG_FONT));
+		label.setCursor(composite.getDisplay().getSystemCursor(SWT.CURSOR_HAND));
+
+		Composite panel = new Composite(recentWorkspacesForm, SWT.NONE);
+		panel.setBackground(composite.getBackground());
+		GridData panelData = new GridData(SWT.FILL, SWT.FILL, true, false);
+		panel.setLayoutData(panelData);
+
 		RowLayout layout = new RowLayout(SWT.VERTICAL);
 		layout.marginLeft = 14;
 		layout.spacing = 6;
 		panel.setLayout(layout);
+
+		boolean expanded = launchData.isShowRecentWorkspaces();
+		panel.setVisible(expanded);
+		panelData.exclude = !expanded;
+		toggle.setText(expanded ? "\u25BE" : "\u25B8"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		Listener toggleListener = e -> {
+			boolean newState = !panel.getVisible();
+			panel.setVisible(newState);
+			((GridData) panel.getLayoutData()).exclude = !newState;
+			toggle.setText(newState ? "\u25BE" : "\u25B8"); //$NON-NLS-1$ //$NON-NLS-2$
+			launchData.setShowRecentWorkspaces(newState);
+			recentWorkspacesForm.requestLayout();
+
+			Point size = getInitialSize();
+			Shell shell = getShell();
+			shell.setBounds(getConstrainedShellBounds(
+					new Rectangle(shell.getLocation().x, shell.getLocation().y, size.x, size.y)));
+		};
+
+		toggle.addListener(SWT.MouseDown, toggleListener);
+		label.addListener(SWT.MouseDown, toggleListener);
+
 		List<String> recentWorkspaces = getRecentWorkspaces();
 		recentWorkspacesLinks = new HashMap<>(recentWorkspaces.size());
 		Map<String, String> uniqueWorkspaceNames = createUniqueWorkspaceNameMap();
@@ -532,7 +551,7 @@ public class ChooseWorkspaceDialog extends TitleAreaDialog {
 		new DirectoryProposalContentAssist().apply(combo);
 		combo.setTextDirection(SWT.AUTO_TEXT_DIRECTION);
 		combo.setFocus();
-		combo.setLayoutData(new GridData(400, SWT.DEFAULT));
+		combo.setLayoutData(new BorderData(SWT.CENTER));
 		combo.addModifyListener(e -> {
 			Button okButton = getButton(Window.OK);
 			if(okButton != null && !okButton.isDisposed()) {
@@ -711,9 +730,9 @@ public class ChooseWorkspaceDialog extends TitleAreaDialog {
 	/**
 	 * Get the "Recent Workspaces" form or null if not initialized.
 	 *
-	 * @return Form
+	 * @return Composite
 	 */
-	public Form getRecentWorkspacesForm() {
+	public Composite getRecentWorkspacesForm() {
 		return recentWorkspacesForm;
 	}
 

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceWithSettingsDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/ChooseWorkspaceWithSettingsDialog.java
@@ -33,8 +33,10 @@ import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.fieldassist.ControlDecoration;
 import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Image;
@@ -46,13 +48,10 @@ import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.forms.events.ExpansionEvent;
-import org.eclipse.ui.forms.events.IExpansionListener;
-import org.eclipse.ui.forms.widgets.ExpandableComposite;
-import org.eclipse.ui.forms.widgets.FormToolkit;
-import org.eclipse.ui.forms.widgets.ScrolledForm;
 import org.eclipse.ui.internal.WorkbenchPlugin;
 import org.eclipse.ui.preferences.SettingsTransfer;
 import org.osgi.framework.FrameworkUtil;
@@ -116,50 +115,64 @@ public class ChooseWorkspaceWithSettingsDialog extends ChooseWorkspaceDialog {
 	 * Create the controls for selecting the controls we are going to export.
 	 */
 	private void createSettingsControls(Composite workArea) {
-		final FormToolkit toolkit = new FormToolkit(workArea.getDisplay());
-		workArea.addDisposeListener(e -> toolkit.dispose());
-		final ScrolledForm form = toolkit.createScrolledForm(workArea);
-		form.getBody().setBackground(workArea.getBackground());
-		form.getBody().setLayout(new GridLayout());
-		form.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		final ScrolledComposite sc = new ScrolledComposite(workArea, SWT.V_SCROLL | SWT.H_SCROLL);
+		sc.setExpandHorizontal(true);
+		sc.setExpandVertical(true);
+		sc.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
-		final ExpandableComposite copySettingsExpandable =
-				toolkit.createExpandableComposite(form.getBody(), ExpandableComposite.TWISTIE);
+		Composite body = new Composite(sc, SWT.NONE);
+		body.setBackground(workArea.getBackground());
+		body.setLayout(new GridLayout());
+		sc.setContent(body);
 
-		copySettingsExpandable.setText(IDEWorkbenchMessages.ChooseWorkspaceWithSettingsDialog_SettingsGroupName);
-		copySettingsExpandable.setBackground(workArea.getBackground());
-		copySettingsExpandable.setTitleBarForeground(workArea.getForeground());
-		copySettingsExpandable.setToggleColor(workArea.getForeground());
-		copySettingsExpandable.setActiveToggleColor(workArea.getForeground());
-		copySettingsExpandable.setLayout(new GridLayout());
-		copySettingsExpandable.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
-		copySettingsExpandable.addExpansionListener(new IExpansionListener() {
+		Composite header = new Composite(body, SWT.NONE);
+		header.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+		GridLayout headerLayout = new GridLayout(2, false);
+		headerLayout.marginWidth = 0;
+		headerLayout.marginHeight = 0;
+		header.setLayout(headerLayout);
+		header.setBackground(workArea.getBackground());
 
-			@Override
-			public void expansionStateChanged(ExpansionEvent e) {
-				form.reflow(true);
-				Point size = getInitialSize();
-				Shell shell = getShell();
-				shell.setBounds(getConstrainedShellBounds(
-						new Rectangle(shell.getLocation().x, shell.getLocation().y, size.x, size.y)));
-			}
+		Label toggle = new Label(header, SWT.NONE);
+		toggle.setBackground(workArea.getBackground());
+		toggle.setCursor(workArea.getDisplay().getSystemCursor(SWT.CURSOR_HAND));
 
-			@Override
-			public void expansionStateChanging(ExpansionEvent e) {
-				// Nothing to do here
+		Label label = new Label(header, SWT.NONE);
+		label.setText(IDEWorkbenchMessages.ChooseWorkspaceWithSettingsDialog_SettingsGroupName);
+		label.setBackground(workArea.getBackground());
+		label.setFont(JFaceResources.getFontRegistry().getBold(JFaceResources.DIALOG_FONT));
+		label.setCursor(workArea.getDisplay().getSystemCursor(SWT.CURSOR_HAND));
 
-			}
-		});
-
-		Composite sectionClient = toolkit.createComposite(copySettingsExpandable);
+		Composite sectionClient = new Composite(body, SWT.NONE);
 		sectionClient.setBackground(workArea.getBackground());
+		GridData clientData = new GridData(SWT.FILL, SWT.FILL, true, false);
+		sectionClient.setLayoutData(clientData);
 
-		if (createButtons(toolkit, sectionClient)) {
-			copySettingsExpandable.setExpanded(true);
-		}
+		boolean expanded = createButtons(sectionClient);
+		sectionClient.setVisible(expanded);
+		clientData.exclude = !expanded;
+		toggle.setText(expanded ? "\u25BE" : "\u25B8"); //$NON-NLS-1$ //$NON-NLS-2$
 
-		copySettingsExpandable.setClient(sectionClient);
+		Listener toggleListener = e -> {
+			boolean newState = !sectionClient.getVisible();
+			sectionClient.setVisible(newState);
+			((GridData) sectionClient.getLayoutData()).exclude = !newState;
+			toggle.setText(newState ? "\u25BE" : "\u25B8"); //$NON-NLS-1$ //$NON-NLS-2$
 
+			body.layout(true);
+			sc.setMinSize(body.computeSize(SWT.DEFAULT, SWT.DEFAULT));
+
+			Point size = getInitialSize();
+			Shell shell = getShell();
+			shell.setBounds(getConstrainedShellBounds(
+					new Rectangle(shell.getLocation().x, shell.getLocation().y, size.x, size.y)));
+		};
+
+		toggle.addListener(SWT.MouseDown, toggleListener);
+		label.addListener(SWT.MouseDown, toggleListener);
+
+		body.layout(true);
+		sc.setMinSize(body.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 	}
 
 	/**
@@ -167,7 +180,7 @@ public class ChooseWorkspaceWithSettingsDialog extends ChooseWorkspaceDialog {
 	 *
 	 * @return boolean <code>true</code> if any were selected
 	 */
-	private boolean createButtons(FormToolkit toolkit, Composite sectionClient) {
+	private boolean createButtons(Composite sectionClient) {
 		String[] enabledSettings = getEnabledSettings(
 				PlatformUI.getDialogSettingsProvider(FrameworkUtil.getBundle(ChooseWorkspaceWithSettingsDialog.class))
 						.getDialogSettings()
@@ -179,8 +192,9 @@ public class ChooseWorkspaceWithSettingsDialog extends ChooseWorkspaceDialog {
 		sectionClient.setLayout(layout);
 
 		for (final IConfigurationElement settingsTransfer : SettingsTransfer.getSettingsTransfers()) {
-			final Button button = toolkit.createButton(sectionClient,
-					settingsTransfer.getAttribute(ATT_NAME), SWT.CHECK);
+			final Button button = new Button(sectionClient, SWT.CHECK);
+			button.setText(settingsTransfer.getAttribute(ATT_NAME));
+			button.setBackground(sectionClient.getBackground());
 
 			ControlDecoration deco = new ControlDecoration(button, SWT.TOP | SWT.RIGHT);
 			Image image = FieldDecorationRegistry.getDefault().getFieldDecoration(FieldDecorationRegistry.DEC_WARNING)
@@ -209,7 +223,6 @@ public class ChooseWorkspaceWithSettingsDialog extends ChooseWorkspaceDialog {
 				}
 			}
 
-			button.setBackground(sectionClient.getBackground());
 			button.addSelectionListener(new SelectionAdapter() {
 
 				@Override


### PR DESCRIPTION
Remove dependency on FormToolkit, ExpandableComposite, and ScrolledForm in ChooseWorkspaceDialog and ChooseWorkspaceWithSettingsDialog. Replace with plain SWT composites and Labels with Unicode triangle characters (▸/▾) for the expand/collapse toggle.

**Benefits:**
- Improves dialog startup performance by eliminating Forms overhead (extra decorated composites, global paint/focus listeners, color management, recursive ScrolledForm reflow)
- Unicode triangles (Geometric Shapes block, Unicode 1.0) render reliably on Windows, macOS, and Linux
- Also fixes layout data mismatch where the path Combo used GridData inside a BorderLayout container (now uses BorderData)