### PR TITLE
Update Color constructors to modern signature

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTColorHelper.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTColorHelper.java
@@ -54,7 +54,7 @@ public class CSSSWTColorHelper {
 
 	public static Color getSWTColor(RGBColor rgbColor, Display display) {
 		RGBA rgb = getRGBA(rgbColor);
-		return new Color(display, rgb);
+		return new Color(rgb);
 	}
 
 	public static Color getSWTColor(CSSValue value, Display display) {
@@ -64,7 +64,7 @@ public class CSSSWTColorHelper {
 		Color color = display.getSystemColor(SWT.COLOR_BLACK);
 		RGBA rgba = getRGBA((CSSPrimitiveValue) value, display);
 		if (rgba != null) {
-			color = new Color(display, rgba.rgb.red, rgba.rgb.green, rgba.rgb.blue, rgba.alpha);
+			color = new Color(rgba.rgb.red, rgba.rgb.green, rgba.rgb.blue, rgba.alpha);
 		}
 		return color;
 	}

--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTColorHelper.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/helpers/CSSSWTColorHelper.java
@@ -52,7 +52,7 @@ public class CSSSWTColorHelper {
 
 	/*--------------- SWT Color Helper -----------------*/
 
-	public static Color getSWTColor(RGBColor rgbColor, Display display) {
+	public static Color getSWTColor(RGBColor rgbColor) {
 		RGBA rgb = getRGBA(rgbColor);
 		return new Color(rgb);
 	}

--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/properties/GradientBackgroundListener.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/properties/GradientBackgroundListener.java
@@ -157,10 +157,10 @@ public class GradientBackgroundListener implements Listener {
 				List<Color> colors = new ArrayList<>();
 				for (Object rgbObj : grad.getRGBs()) {
 					if (rgbObj instanceof RGBA rgba) {
-						Color color = new Color(control.getDisplay(), rgba);
+						Color color = new Color(rgba);
 						colors.add(color);
 					} else if (rgbObj instanceof RGB rgb) {
-						Color color = new Color(control.getDisplay(), rgb);
+						Color color = new Color(rgb);
 						colors.add(color);
 					}
 				}

--- a/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
+++ b/bundles/org.eclipse.e4.ui.workbench.renderers.swt/src/org/eclipse/e4/ui/workbench/renderers/swt/CTabRendering.java
@@ -411,7 +411,7 @@ public class CTabRendering extends CTabFolderRenderer implements ICTabRendering,
 		if (!active && !onBottom) {
 			RGB blendColor = gc.getDevice().getSystemColor(SWT.COLOR_WIDGET_LIGHT_SHADOW).getRGB();
 			RGB topGradient = blend(blendColor, tabOutlineColor.getRGB(), 40);
-			gradientLineTop = new Color(gc.getDevice(), topGradient);
+			gradientLineTop = new Color(topGradient);
 			foregroundPattern = new Pattern(gc.getDevice(), 0, 0, 0, bounds.height + 1, gradientLineTop,
 					gc.getDevice().getSystemColor(SWT.COLOR_WHITE));
 			gc.setForegroundPattern(foregroundPattern);

--- a/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/CSSRenderingUtils.java
+++ b/bundles/org.eclipse.e4.ui.workbench.swt/src/org/eclipse/e4/ui/internal/workbench/swt/CSSRenderingUtils.java
@@ -166,7 +166,7 @@ public class CSSRenderingUtils {
 		Image rotatedImage = new Image(display, imageData);
 		GC gc = new GC(rotatedImage);
 		RGB rgb = new RGB(0x7d, 0, 0);
-		Color offRed = new Color(display, rgb);
+		Color offRed = new Color(rgb);
 		gc.setBackground(offRed);
 		gc.fillRectangle(0, 0, bounds.height, bounds.width);
 		Transform t = new Transform(display);

--- a/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/SourceViewerInformationControl.java
+++ b/bundles/org.eclipse.jface.text/projection/org/eclipse/jface/text/source/projection/SourceViewerInformationControl.java
@@ -168,7 +168,7 @@ class SourceViewerInformationControl implements IInformationControl, IInformatio
 			GridData gd2= new GridData(GridData.FILL_VERTICAL | GridData.FILL_HORIZONTAL | GridData.HORIZONTAL_ALIGN_BEGINNING | GridData.VERTICAL_ALIGN_BEGINNING);
 			fStatusField.setLayoutData(gd2);
 
-			Color statusTextForegroundColor= new Color(fStatusField.getDisplay(),
+			Color statusTextForegroundColor= new Color(
 					blend(display.getSystemColor(SWT.COLOR_INFO_BACKGROUND).getRGB(), display.getSystemColor(SWT.COLOR_INFO_FOREGROUND).getRGB(), 0.56f));
 			fStatusField.setForeground(statusTextForegroundColor);
 

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/AbstractInformationControl.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/AbstractInformationControl.java
@@ -655,7 +655,7 @@ public abstract class AbstractInformationControl implements IInformationControl,
 		if (foreground == null || background == null) {
 			return;
 		}
-		Color statusLabelForeground= new Color(fStatusLabel.getDisplay(), Colors.blend(background.getRGB(), foreground.getRGB(), 0.56f));
+		Color statusLabelForeground= new Color(Colors.blend(background.getRGB(), foreground.getRGB(), 0.56f));
 		fStatusLabel.setForeground(statusLabelForeground);
 		fStatusLabel.setBackground(background);
 	}

--- a/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/hyperlink/DefaultHyperlinkPresenter.java
+++ b/bundles/org.eclipse.jface.text/src/org/eclipse/jface/text/hyperlink/DefaultHyperlinkPresenter.java
@@ -180,7 +180,7 @@ public class DefaultHyperlinkPresenter implements IHyperlinkPresenter, IHyperlin
 		} else if (fRGB != null) {
 			StyledText text= fTextViewer.getTextWidget();
 			if (text != null && !text.isDisposed()) {
-				fColor= new Color(text.getDisplay(), fRGB);
+				fColor= new Color(fRGB);
 			}
 		}
 	}
@@ -349,7 +349,7 @@ public class DefaultHyperlinkPresenter implements IHyperlinkPresenter, IHyperlin
 			}
 
 			if (rgb != null) {
-				return new Color(textWidget.getDisplay(), rgb);
+				return new Color(rgb);
 			}
 		}
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/PopupDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/PopupDialog.java
@@ -43,7 +43,6 @@ import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
@@ -876,7 +875,6 @@ public class PopupDialog extends Window {
 
 		GridDataFactory.fillDefaults().grab(true, false).align(SWT.FILL,
 				SWT.BEGINNING).applyTo(infoLabel);
-		Display display = parent.getDisplay();
 
 		Color backgroundColor = getBackground();
 		if (backgroundColor == null) {
@@ -886,7 +884,7 @@ public class PopupDialog extends Window {
 		if (foregroundColor == null) {
 			foregroundColor = getDefaultForeground();
 		}
-		Color infoColor = new Color(display, blend(
+		Color infoColor = new Color(blend(
 				backgroundColor.getRGB(), foregroundColor.getRGB(),
 				0.56f));
 

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/TitleAreaDialog.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/dialogs/TitleAreaDialog.java
@@ -222,7 +222,7 @@ public class TitleAreaDialog extends TrayDialog {
 		Color background;
 		Color foreground;
 		if (titleAreaRGB != null) {
-			titleAreaColor = new Color(display, titleAreaRGB);
+			titleAreaColor = new Color(titleAreaRGB);
 			background = titleAreaColor;
 			foreground = null;
 		} else {

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/fieldassist/FieldAssistColors.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/fieldassist/FieldAssistColors.java
@@ -141,7 +141,7 @@ public class FieldAssistColors {
 		destBlue += (src.getBlue() - destBlue) * alpha / 0xFF;
 
 		// create the color
-		Color color = new Color(display, destRed, destGreen, destBlue);
+		Color color = new Color(destRed, destGreen, destBlue);
 		// record the color in a map using the original color as the key
 		requiredFieldColorMap.put(dest, color);
 		// If we have never created a color on this display before, install

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/ColorSelector.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/preference/ColorSelector.java
@@ -187,7 +187,7 @@ public class ColorSelector extends EventManager {
 		RGB color = getColorValue();
 		gc.setForeground(display.getSystemColor(SWT.COLOR_WIDGET_BORDER));
 		if (color != null) {
-			gc.setBackground(new Color(display, color));
+			gc.setBackground(new Color(color));
 			gc.fillRectangle(image.getBounds());
 		}
 		gc.setLineWidth(2);

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ColorRegistry.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ColorRegistry.java
@@ -124,7 +124,7 @@ public class ColorRegistry extends ResourceRegistry {
 	}
 
 	/**
-	 * Create a new <code>Color</code> on the receivers <code>Display</code>.
+	 * Create a new <code>Color</code> for the given RGB value.
 	 *
 	 * @param rgb the <code>RGB</code> data for the color.
 	 * @return the new <code>Color</code> object.

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ColorRegistry.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/ColorRegistry.java
@@ -142,7 +142,7 @@ public class ColorRegistry extends ResourceRegistry {
 				hookDisplayDispose();
 			}
 		}
-		return new Color(display, rgb);
+		return new Color(rgb);
 	}
 
 	/**

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/RGBColorDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/RGBColorDescriptor.java
@@ -66,10 +66,8 @@ class RGBColorDescriptor extends ColorDescriptor {
 
 	@Override
 	public Color createColor(Device device) {
-		// If this descriptor is wrapping an existing color, then we can return the original color
-		// if this is the same device.
-		if (originalColor != null && originalColor.getDevice() == device) {
-			// If we're allocating on the same device as the original color, return the original.
+		// If this descriptor is wrapping an existing color, return the original.
+		if (originalColor != null) {
 			return originalColor;
 		}
 		return new Color(color);

--- a/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/RGBColorDescriptor.java
+++ b/bundles/org.eclipse.jface/src/org/eclipse/jface/resource/RGBColorDescriptor.java
@@ -72,6 +72,6 @@ class RGBColorDescriptor extends ColorDescriptor {
 			// If we're allocating on the same device as the original color, return the original.
 			return originalColor;
 		}
-		return new Color(device, color);
+		return new Color(color);
 	}
 }

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/SharedTextColors.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/SharedTextColors.java
@@ -58,7 +58,7 @@ class SharedTextColors implements ISharedTextColors {
 
 		Color color= colorTable.get(rgb);
 		if (color == null) {
-			color= new Color(display, rgb);
+			color= new Color(rgb);
 			colorTable.put(rgb, color);
 		}
 

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/TextEditorDefaultsPreferencePage.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/editors/text/TextEditorDefaultsPreferencePage.java
@@ -1147,14 +1147,14 @@ public class TextEditorDefaultsPreferencePage extends PreferencePage implements 
 					return null;
 				}
 				RGB rgb= colorEntry.isSystemDefault() ? colorEntry.systemColorRGB : colorEntry.getRGB();
-				Color color= new Color(tableComposite.getParent().getDisplay(), rgb.red, rgb.green, rgb.blue);
+				Color color= new Color(rgb.red, rgb.green, rgb.blue);
 				int dimensions= 10;
 				final ImageGcDrawer imageGcDrawer = (gc, width, height) -> {
 					// Draw color preview
 					gc.setBackground(color);
 					gc.fillRectangle(0, 0, width, height);
 					// Draw outline around color preview
-					gc.setBackground(new Color(tableComposite.getParent().getDisplay(), 0, 0, 0));
+					gc.setBackground(new Color(0, 0, 0));
 					gc.setLineWidth(2);
 					gc.drawRectangle(0, 0, width, height);
 				};

--- a/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/SourceViewerInformationControl.java
+++ b/bundles/org.eclipse.ui.editors/src/org/eclipse/ui/internal/texteditor/SourceViewerInformationControl.java
@@ -172,7 +172,7 @@ class SourceViewerInformationControl implements IInformationControl, IInformatio
 			GridData gd2= new GridData(GridData.FILL_VERTICAL | GridData.FILL_HORIZONTAL | GridData.HORIZONTAL_ALIGN_BEGINNING | GridData.VERTICAL_ALIGN_BEGINNING);
 			fStatusField.setLayoutData(gd2);
 
-			Color statusTextForegroundColor= new Color(fStatusField.getDisplay(),
+			Color statusTextForegroundColor= new Color(
 					blend(display.getSystemColor(SWT.COLOR_INFO_BACKGROUND).getRGB(), display.getSystemColor(SWT.COLOR_INFO_FOREGROUND).getRGB(), 0.56f));
 			fStatusField.setForeground(statusTextForegroundColor);
 

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/Hyperlink.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/forms/widgets/Hyperlink.java
@@ -246,7 +246,7 @@ public class Hyperlink extends AbstractHyperlink {
 	 */
 	protected void paintText(GC gc, Rectangle bounds) {
 		gc.setFont(getFont());
-		Color fg = isEnabled() ? getForeground() : new Color(gc.getDevice(),FormColors.blend(getBackground().getRGB(), getForeground().getRGB(), 70));
+		Color fg = isEnabled() ? getForeground() : new Color(FormColors.blend(getBackground().getRGB(), getForeground().getRGB(), 70));
 		gc.setForeground(fg);
 		if ((getStyle() & SWT.WRAP) != 0) {
 			FormUtil.paintWrapText(gc, text, bounds, underlined);

--- a/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/FormImages.java
+++ b/bundles/org.eclipse.ui.forms/src/org/eclipse/ui/internal/forms/widgets/FormImages.java
@@ -116,8 +116,8 @@ public class FormImages {
 		@Override
 		public Image createImage(boolean returnMissingImageOnError,	Device device) {
 			final ImageGcDrawer imageGcDrawer = (gc, width, height) -> {
-				Color color1 = new Color(device, fRGBs[0]);
-				Color color2 = new Color(device, fRGBs[1]);
+				Color color1 = new Color(fRGBs[0]);
+				Color color2 = new Color(fRGBs[1]);
 				try {
 					gc.setBackground(color1);
 					gc.fillRectangle(0, 0, width, height);
@@ -131,7 +131,7 @@ public class FormImages {
 					color2.dispose();
 				}
 			};
-			Color background = new Color(device, fRGBs[0]);
+			Color background = new Color(fRGBs[0]);
 			Image image = new Image(device, imageGcDrawer, 1, fLength);
 			image.setBackground(background);
 			background.dispose();
@@ -196,9 +196,9 @@ public class FormImages {
 			final ImageGcDrawer imageGcDrawer = (gc, iWidth, iHeight) -> {
 				Color[] colors = new Color[fRGBs.length];
 				for (int i = 0; i < colors.length; i++) {
-					colors[i] = fRGBs[i] == null ? null : new Color(device, fRGBs[i]);
+					colors[i] = fRGBs[i] == null ? null : new Color(fRGBs[i]);
 				}
-				Color bg = fBgRGB == null ? null : new Color(device, fBgRGB);
+				Color bg = fBgRGB == null ? null : new Color(fBgRGB);
 				try {
 					drawTextGradient(gc, iWidth, iHeight, colors, fPercents, fVertical, bg);
 				} finally {
@@ -212,7 +212,7 @@ public class FormImages {
 					}
 				}
 			};
-			Color background = fRGBs[0] == null ? null : new Color(device, fRGBs[0]);
+			Color background = fRGBs[0] == null ? null : new Color(fRGBs[0]);
 			Image gradient = new Image(device, imageGcDrawer, Math.max(width, 1), Math
 					.max(height, 1));
 			if (background != null) {
@@ -312,8 +312,8 @@ public class FormImages {
 
 		@Override
 		public Image createImage(boolean returnMissingImageOnError, Device device) {
-			Color originalBgColor = new Color(device, fRGBs[0]);
-			Color color1 = new Color(device, fRGBs[1]);
+			Color originalBgColor = new Color(fRGBs[0]);
+			Color color1 = new Color(fRGBs[1]);
 			final ImageGcDrawer imageGcDrawer = (gc, width, height) -> {
 				gc.setBackground(color1);
 				gc.fillRectangle(0, fMarginHeight + 2, width, fTheight - fMarginHeight - 3);
@@ -337,8 +337,8 @@ public class FormImages {
 		@Override
 		public Image createImage(boolean returnMissingImageOnError, Device device) {
 			final ImageGcDrawer imageGcDrawer = (gc, width, height) -> {
-				Color color1 = new Color(device, fRGBs[0]);
-				Color color2 = new Color(device, fRGBs[1]);
+				Color color1 = new Color(fRGBs[0]);
+				Color color2 = new Color(fRGBs[1]);
 				try {
 					gc.setBackground(color1);
 					gc.fillRectangle(0, 0, width, height);
@@ -352,7 +352,7 @@ public class FormImages {
 					color2.dispose();
 				}
 			};
-			Color background = new Color(device, fRGBs[0]);
+			Color background = new Color(fRGBs[0]);
 			Image image = new Image(device, imageGcDrawer, 1, fLength);
 			image.setBackground(background);
 			background.dispose();

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AbstractTextEditor.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AbstractTextEditor.java
@@ -4147,14 +4147,13 @@ public abstract class AbstractTextEditor extends EditorPart
 	 * Creates a color from the information stored in the given preference store.
 	 * Returns <code>null</code> if there is no such information available.
 	 *
-	 * @param store   the store to read from
-	 * @param key     the key used for the lookup in the preference store
-	 * @param display the display used create the color
+	 * @param store the store to read from
+	 * @param key   the key used for the lookup in the preference store
 	 * @return the created color according to the specification in the preference
 	 *         store
 	 * @since 2.0
 	 */
-	private Color createColor(IPreferenceStore store, String key, Display display) {
+	private Color createColor(IPreferenceStore store, String key) {
 
 		RGB rgb = null;
 
@@ -4167,7 +4166,7 @@ public abstract class AbstractTextEditor extends EditorPart
 			}
 
 			if (rgb != null) {
-				return new Color(display, rgb);
+				return new Color(rgb);
 			}
 		}
 
@@ -4190,22 +4189,22 @@ public abstract class AbstractTextEditor extends EditorPart
 
 			// ----------- foreground color --------------------
 			Color color = store.getBoolean(PREFERENCE_COLOR_FOREGROUND_SYSTEM_DEFAULT) ? null
-					: createColor(store, PREFERENCE_COLOR_FOREGROUND, styledText.getDisplay());
+					: createColor(store, PREFERENCE_COLOR_FOREGROUND);
 			styledText.setForeground(color);
 
 			// ---------- background color ----------------------
 			color = store.getBoolean(PREFERENCE_COLOR_BACKGROUND_SYSTEM_DEFAULT) ? null
-					: createColor(store, PREFERENCE_COLOR_BACKGROUND, styledText.getDisplay());
+					: createColor(store, PREFERENCE_COLOR_BACKGROUND);
 			styledText.setBackground(color);
 
 			// ----------- selection foreground color --------------------
 			color = store.getBoolean(PREFERENCE_COLOR_SELECTION_FOREGROUND_SYSTEM_DEFAULT) ? null
-					: createColor(store, PREFERENCE_COLOR_SELECTION_FOREGROUND, styledText.getDisplay());
+					: createColor(store, PREFERENCE_COLOR_SELECTION_FOREGROUND);
 			styledText.setSelectionForeground(color);
 
 			// ---------- selection background color ----------------------
 			color = store.getBoolean(PREFERENCE_COLOR_SELECTION_BACKGROUND_SYSTEM_DEFAULT) ? null
-					: createColor(store, PREFERENCE_COLOR_SELECTION_BACKGROUND, styledText.getDisplay());
+					: createColor(store, PREFERENCE_COLOR_SELECTION_BACKGROUND);
 			styledText.setSelectionBackground(color);
 
 		}
@@ -4225,7 +4224,7 @@ public abstract class AbstractTextEditor extends EditorPart
 
 			StyledText styledText = viewer.getTextWidget();
 
-			Color color = createColor(store, PREFERENCE_COLOR_FIND_SCOPE, styledText.getDisplay());
+			Color color = createColor(store, PREFERENCE_COLOR_FIND_SCOPE);
 
 			IFindReplaceTarget target = viewer.getFindReplaceTarget();
 			if (target instanceof IFindReplaceTargetExtension) {

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AbstractTextEditor.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/AbstractTextEditor.java
@@ -4222,8 +4222,6 @@ public abstract class AbstractTextEditor extends EditorPart
 		IPreferenceStore store = getPreferenceStore();
 		if (store != null) {
 
-			StyledText styledText = viewer.getTextWidget();
-
 			Color color = createColor(store, PREFERENCE_COLOR_FIND_SCOPE);
 
 			IFindReplaceTarget target = viewer.getFindReplaceTarget();

--- a/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/InfoForm.java
+++ b/bundles/org.eclipse.ui.workbench.texteditor/src/org/eclipse/ui/texteditor/InfoForm.java
@@ -69,7 +69,7 @@ public class InfoForm {
 		Display display= parent.getDisplay();
 		fBackgroundColor= display.getSystemColor(SWT.COLOR_LIST_BACKGROUND);
 		fForegroundColor= display.getSystemColor(SWT.COLOR_LIST_FOREGROUND);
-		fSeparatorColor= new Color(display, 152, 170, 203);
+		fSeparatorColor= new Color(152, 170, 203);
 
 		fPropertyChangeListener = this::handlePropertyChange;
 		JFaceResources.getFontRegistry().addListener(fPropertyChangeListener);

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/FilteredTableBaseHandler.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/FilteredTableBaseHandler.java
@@ -329,7 +329,7 @@ public abstract class FilteredTableBaseHandler extends AbstractHandler implement
 	 */
 	private Image createSeparatorBgImage() {
 		final ImageGcDrawer imageGcDrawer = (gc, width, height) -> {
-			gc.setBackground(new Color(dialog.getDisplay(), 127, 127, 127));
+			gc.setBackground(new Color(127, 127, 127));
 			gc.fillRectangle(0, 0, width, height);
 		};
 		return new Image(Display.getDefault(), imageGcDrawer, 1, 1);

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/HeapStatus.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/HeapStatus.java
@@ -137,9 +137,9 @@ public class HeapStatus extends Composite {
 			disabledGcImage = new Image(display, gcImage, SWT.IMAGE_DISABLE);
 		}
 
-		usedMemCol = new Color(display, 160, 160, 160); // gray
-		lowMemCol = new Color(display, 255, 70, 70); // medium red
-		freeMemCol = new Color(display, 255, 190, 125); // light orange
+		usedMemCol = new Color(160, 160, 160); // gray
+		lowMemCol = new Color(255, 70, 70); // medium red
+		freeMemCol = new Color(255, 190, 125); // light orange
 		sepCol = topLeftCol = armCol = usedMemCol;
 		bgCol = display.getSystemColor(SWT.COLOR_WIDGET_BACKGROUND);
 		bottomRightCol = display.getSystemColor(SWT.COLOR_WIDGET_HIGHLIGHT_SHADOW);

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ShowViewDialog.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/dialogs/ShowViewDialog.java
@@ -209,7 +209,7 @@ public class ShowViewDialog extends Dialog implements ISelectionChangedListener,
 		TreeViewer treeViewer = filteredTree.getViewer();
 		Control treeControl = treeViewer.getControl();
 		RGB dimmedRGB = blend(treeControl.getForeground().getRGB(), treeControl.getBackground().getRGB(), 60);
-		dimmedForeground = new Color(treeControl.getDisplay(), dimmedRGB);
+		dimmedForeground = new Color(dimmedRGB);
 
 		treeViewer
 				.setLabelProvider(new ViewLabelProvider(context, modelService, partService, window, dimmedForeground));

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/statushandlers/SupportTray.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/internal/statushandlers/SupportTray.java
@@ -149,7 +149,7 @@ public class SupportTray extends DialogTray implements ISelectionChangedListener
 
 		Color border = display.getSystemColor(SWT.COLOR_WIDGET_DARK_SHADOW);
 		Color background = display.getSystemColor(SWT.COLOR_LIST_BACKGROUND);
-		Color backgroundHot = new Color(display, new RGB(252, 160, 160));
+		Color backgroundHot = new Color(new RGB(252, 160, 160));
 		normal = new Image(display, createCloseButtonDrawer(background, border), 16, 16);
 		hover = new Image(display, createCloseButtonDrawer(backgroundHot, border), 16, 16);
 	}

--- a/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/splash/BasicSplashHandler.java
+++ b/bundles/org.eclipse.ui.workbench/eclipseui/org/eclipse/ui/splash/BasicSplashHandler.java
@@ -174,7 +174,7 @@ public abstract class BasicSplashHandler extends AbstractSplashHandler {
 		if (monitor != null) {
 			return;
 		}
-		this.foreground = new Color(getSplash().getShell().getDisplay(), foregroundRGB);
+		this.foreground = new Color(foregroundRGB);
 	}
 
 	/**

--- a/examples/org.eclipse.jface.examples.databinding/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.jface.examples.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jface.examples.databinding
-Bundle-Version: 1.5.0.qualifier
+Bundle-Version: 1.5.100.qualifier
 Eclipse-BundleShape: dir
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/examples/org.eclipse.jface.examples.databinding/src/org/eclipse/jface/examples/databinding/snippets/Snippet007ColorLabelProvider.java
+++ b/examples/org.eclipse.jface.examples.databinding/src/org/eclipse/jface/examples/databinding/snippets/Snippet007ColorLabelProvider.java
@@ -172,7 +172,7 @@ public class Snippet007ColorLabelProvider {
 		ColorLabelProvider(IObservableMap<?, ?>[] attributes, Display display, List<Person> persons) {
 			super(attributes);
 			this.persons = persons;
-			this.maleColor = new Color(display, 255, 192, 203);
+			this.maleColor = new Color(255, 192, 203);
 			this.femaleColor = display.getSystemColor(SWT.COLOR_BLUE);
 		}
 

--- a/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet003TableLabelProvider.java
+++ b/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet003TableLabelProvider.java
@@ -66,7 +66,7 @@ public class Snippet003TableLabelProvider {
 	}
 
 	private static Image createImage(Display display, int red, int green, int blue) {
-		Color color = new Color(display,red,green,blue);
+		Color color = new Color(red,green,blue);
 		Image image = new Image(display,10,10);
 		GC gc = new GC(image);
 		gc.setBackground(color);

--- a/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet046UpdateViewerFromBackgroundThread.java
+++ b/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet046UpdateViewerFromBackgroundThread.java
@@ -76,7 +76,7 @@ public class Snippet046UpdateViewerFromBackgroundThread {
 	}
 
 	private static Image createImage(Display display, int red, int green, int blue) {
-		Color color = new Color(display, red, green, blue);
+		Color color = new Color(red, green, blue);
 		Image image = new Image(display, 10, 10);
 		GC gc = new GC(image);
 		gc.setBackground(color);

--- a/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet051TableCenteredImage.java
+++ b/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet051TableCenteredImage.java
@@ -93,7 +93,7 @@ public class Snippet051TableCenteredImage {
 	}
 
 	private static Image createImage(Display display, int red, int green, int blue) {
-		Color color = new Color(display, red, green, blue);
+		Color color = new Color(red, green, blue);
 		Image image = new Image(display, 10, 10);
 		GC gc = new GC(image);
 		gc.setBackground(color);

--- a/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet061FakedNativeCellEditor.java
+++ b/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/viewers/Snippet061FakedNativeCellEditor.java
@@ -144,7 +144,7 @@ public class Snippet061FakedNativeCellEditor {
 		private Image makeShot(Control control, boolean type) {
 			// Hopefully no platform uses exactly this color because we'll make
 			// it transparent in the image.
-			Color greenScreen = new Color(control.getDisplay(), 222, 223, 224);
+			Color greenScreen = new Color(222, 223, 224);
 
 			Shell shell = new Shell(control.getShell(), SWT.NO_TRIM);
 

--- a/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/window/Snippet031TableStaticTooltip.java
+++ b/examples/org.eclipse.jface.snippets/Eclipse JFace Snippets/org/eclipse/jface/snippets/window/Snippet031TableStaticTooltip.java
@@ -117,7 +117,7 @@ public class Snippet031TableStaticTooltip {
 
 	private static Image createImage(Display display, int red, int green,
 			int blue) {
-		Color color = new Color(display, red, green, blue);
+		Color color = new Color(red, green, blue);
 		Image image = new Image(display, 10, 10);
 		GC gc = new GC(image);
 		gc.setBackground(color);

--- a/examples/org.eclipse.jface.text.examples/src/org/eclipse/jface/text/examples/sources/inlined/InlinedAnnotationDemo.java
+++ b/examples/org.eclipse.jface.text.examples/src/org/eclipse/jface/text/examples/sources/inlined/InlinedAnnotationDemo.java
@@ -287,7 +287,7 @@ public class InlinedAnnotationDemo {
 		Matcher m = c.matcher(input);
 		if (m.matches()) {
 			try {
-				return new Color(device, Integer.parseInt(m.group(1)), // r
+				return new Color(Integer.parseInt(m.group(1)), // r
 						Integer.parseInt(m.group(2)), // g
 						Integer.parseInt(m.group(3))); // b
 			} catch (Exception e) {

--- a/examples/org.eclipse.jface.text.examples/src/org/eclipse/jface/text/examples/sources/inlined/InlinedAnnotationDemo.java
+++ b/examples/org.eclipse.jface.text.examples/src/org/eclipse/jface/text/examples/sources/inlined/InlinedAnnotationDemo.java
@@ -41,7 +41,6 @@ import org.eclipse.jface.text.source.inlined.LineHeaderAnnotation;
 import org.eclipse.jface.text.source.inlined.Positions;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FillLayout;
@@ -195,7 +194,7 @@ public class InlinedAnnotationDemo {
 				String rgb = line.substring(index + "color:".length()).trim();
 				try {
 					String status = "OK!";
-					Color color = parse(rgb, viewer.getTextWidget().getDisplay());
+					Color color = parse(rgb);
 					if (color != null) {
 					} else {
 						status = "ERROR!";
@@ -282,7 +281,7 @@ public class InlinedAnnotationDemo {
 	 *            the rgb string color
 	 * @return the created color and null otherwise.
 	 */
-	private static Color parse(String input, Device device) {
+	private static Color parse(String input) {
 		Pattern c = Pattern.compile("rgb *\\( *([0-9]+), *([0-9]+), *([0-9]+) *\\)");
 		Matcher m = c.matcher(input);
 		if (m.matches()) {

--- a/examples/org.eclipse.ui.examples.javaeditor/Eclipse Java Editor Example/org/eclipse/ui/examples/javaeditor/util/JavaColorProvider.java
+++ b/examples/org.eclipse.ui.examples.javaeditor/Eclipse Java Editor Example/org/eclipse/ui/examples/javaeditor/util/JavaColorProvider.java
@@ -19,7 +19,6 @@ import java.util.Map;
 
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.widgets.Display;
 
 /**
  * Manager for colors used in the Java editor
@@ -49,7 +48,7 @@ public class JavaColorProvider {
 	public Color getColor(RGB rgb) {
 		Color color= fColorTable.get(rgb);
 		if (color == null) {
-			color= new Color(Display.getCurrent(), rgb);
+			color= new Color(rgb);
 			fColorTable.put(rgb, color);
 		}
 		return color;

--- a/examples/org.eclipse.ui.examples.javaeditor/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.ui.examples.javaeditor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.examples.javaeditor; singleton:=true
-Bundle-Version: 3.5.0.qualifier
+Bundle-Version: 3.5.100.qualifier
 Bundle-Activator: org.eclipse.ui.examples.javaeditor.JavaEditorExamplePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/examples/org.eclipse.ui.examples.javaeditor/Template Editor Example/org/eclipse/ui/examples/templateeditor/editors/ColorManager.java
+++ b/examples/org.eclipse.ui.examples.javaeditor/Template Editor Example/org/eclipse/ui/examples/templateeditor/editors/ColorManager.java
@@ -18,7 +18,6 @@ import java.util.Map;
 
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.widgets.Display;
 
 public class ColorManager {
 
@@ -27,7 +26,7 @@ public class ColorManager {
 	public Color getColor(RGB rgb) {
 		Color color = fColorTable.get(rgb);
 		if (color == null) {
-			color = new Color(Display.getCurrent(), rgb);
+			color = new Color(rgb);
 			fColorTable.put(rgb, color);
 		}
 		return color;

--- a/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/InheritTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/src/org/eclipse/e4/ui/tests/css/swt/InheritTest.java
@@ -41,7 +41,7 @@ public class InheritTest extends CSSSWTTestCase {
 		super.setUp();
 
 
-		redColor = new Color(display, RED);
+		redColor = new Color(RED);
 	}
 
 	/**

--- a/tests/org.eclipse.e4.ui.tests.css.swt/tkuiTestsToRefactor/swt/test/org/akrogen/tkui/css/swt/serializers/CSSSerializerSWTTest.java
+++ b/tests/org.eclipse.e4.ui.tests.css.swt/tkuiTestsToRefactor/swt/test/org/akrogen/tkui/css/swt/serializers/CSSSerializerSWTTest.java
@@ -122,7 +122,7 @@ public class CSSSerializerSWTTest {
 	}
 
 	private static void createResources(Display display) {
-		COLOR_GREEN = new Color(display, 0, 255, 0);
+		COLOR_GREEN = new Color(0, 255, 0);
 		CURSOR_HELP = new Cursor(display, SWT.CURSOR_HELP);
 
 		display.addListener(SWT.Dispose, event -> disposeResources());

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/ResourceManagerTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/images/ResourceManagerTest.java
@@ -103,8 +103,8 @@ public class ResourceManagerTest {
 		globalResourceManager = new DeviceResourceManager(display);
 		testImage = getImage("icons/anything.gif").createImage(display);
 		testImage2 = getImage("icons/binary_co.gif").createImage(display);
-		testColor = new Color(display, new RGB(10, 40, 20));
-		testColor2 = new Color(display, new RGB(230, 100, 26));
+		testColor = new Color(new RGB(10, 40, 20));
+		testColor2 = new Color(new RGB(230, 100, 26));
 
 		// Array of resource descriptors containing at least one duplicate of each type.
 		// If you modify this array, be sure to adjust numDupes as well. Note that some

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableColorProviderTest.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/viewers/TableColorProviderTest.java
@@ -29,7 +29,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
@@ -126,8 +125,8 @@ public class TableColorProviderTest extends StructuredViewerTest {
 	@Override
 	public void setUp() {
 		super.setUp();
-		red = new Color(Display.getCurrent(), 255, 0, 0);
-		green = new Color(Display.getCurrent(), 0, 255, 0);
+		red = new Color(255, 0, 0);
+		green = new Color(0, 255, 0);
 	}
 
 	@Override

--- a/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitControlFactory.java
+++ b/tests/org.eclipse.jface.tests/src/org/eclipse/jface/tests/widgets/TestUnitControlFactory.java
@@ -85,7 +85,7 @@ public class TestUnitControlFactory extends AbstractFactoryTest {
 
 	@Test
 	public void setsForeground() {
-		Color color = new Color(null, 255, 255, 255);
+		Color color = new Color(255, 255, 255);
 		Label label = LabelFactory.newLabel(SWT.NONE).foreground(color).create(shell);
 
 		assertEquals(color, label.getForeground());
@@ -93,7 +93,7 @@ public class TestUnitControlFactory extends AbstractFactoryTest {
 
 	@Test
 	public void setsBackground() {
-		Color color = new Color(null, 0, 0, 0);
+		Color color = new Color(0, 0, 0);
 		Label label = LabelFactory.newLabel(SWT.NONE).background(color).create(shell);
 
 		assertEquals(color, label.getBackground());

--- a/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/TextPresentationTest.java
+++ b/tests/org.eclipse.jface.text.tests/src/org/eclipse/jface/text/tests/TextPresentationTest.java
@@ -119,7 +119,7 @@ public class TextPresentationTest {
 	private Color createColor(int red, int green, int blue) {
 		if (red < 0 || red > 255 || green < 0 || green > 255 || blue < 0 || blue > 255)
 			return null;
-		Color c= new Color(fDisplay, red, green, blue);
+		Color c= new Color(red, green, blue);
 		fColors.add(c);
 		return c;
 	}

--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/contributions/ThePresentationReconcilerBlue.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/contributions/ThePresentationReconcilerBlue.java
@@ -15,7 +15,6 @@ package org.eclipse.ui.genericeditor.tests.contributions;
 
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.TextAttribute;
@@ -31,7 +30,7 @@ public class ThePresentationReconcilerBlue extends PresentationReconciler {
 	public ThePresentationReconcilerBlue() {
 		RuleBasedScanner scanner= new RuleBasedScanner();
 		IRule[] rules = new IRule[1];
-		rules[0]= new SingleLineRule("'", "'", new Token(new TextAttribute(new Color(Display.getCurrent(), new RGB(0, 0, 255))))); //$NON-NLS-1$ //$NON-NLS-2$
+		rules[0]= new SingleLineRule("'", "'", new Token(new TextAttribute(new Color(new RGB(0, 0, 255))))); //$NON-NLS-1$ //$NON-NLS-2$
 		scanner.setRules(rules);
 		DefaultDamagerRepairer dr= new DefaultDamagerRepairer(scanner);
 		this.setDamager(dr, IDocument.DEFAULT_CONTENT_TYPE);

--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/contributions/ThePresentationReconcilerGreen.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/contributions/ThePresentationReconcilerGreen.java
@@ -15,7 +15,6 @@ package org.eclipse.ui.genericeditor.tests.contributions;
 
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.TextAttribute;
@@ -35,7 +34,7 @@ public class ThePresentationReconcilerGreen extends PresentationReconciler {
 	public ThePresentationReconcilerGreen() {
 		RuleBasedScanner scanner= new RuleBasedScanner();
 		IRule[] rules = new IRule[1];
-		rules[0]= new SingleLineRule("'", "'", new Token(new TextAttribute(new Color(Display.getCurrent(), new RGB(0, 255, 0))))); //$NON-NLS-1$ //$NON-NLS-2$
+		rules[0]= new SingleLineRule("'", "'", new Token(new TextAttribute(new Color(new RGB(0, 255, 0))))); //$NON-NLS-1$ //$NON-NLS-2$
 		scanner.setRules(rules);
 		DefaultDamagerRepairer dr= new DefaultDamagerRepairer(scanner);
 		this.setDamager(dr, IDocument.DEFAULT_CONTENT_TYPE);

--- a/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/contributions/ThePresentationReconcilerRed.java
+++ b/tests/org.eclipse.ui.genericeditor.tests/src/org/eclipse/ui/genericeditor/tests/contributions/ThePresentationReconcilerRed.java
@@ -15,7 +15,6 @@ package org.eclipse.ui.genericeditor.tests.contributions;
 
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.TextAttribute;
@@ -31,7 +30,7 @@ public class ThePresentationReconcilerRed extends PresentationReconciler {
 	public ThePresentationReconcilerRed() {
 		RuleBasedScanner scanner= new RuleBasedScanner();
 		IRule[] rules = new IRule[1];
-		rules[0]= new SingleLineRule("'", "'", new Token(new TextAttribute(new Color(Display.getCurrent(), new RGB(255, 0, 0))))); //$NON-NLS-1$ //$NON-NLS-2$
+		rules[0]= new SingleLineRule("'", "'", new Token(new TextAttribute(new Color(new RGB(255, 0, 0))))); //$NON-NLS-1$ //$NON-NLS-2$
 		scanner.setRules(rules);
 		DefaultDamagerRepairer dr= new DefaultDamagerRepairer(scanner);
 		this.setDamager(dr, IDocument.DEFAULT_CONTENT_TYPE);

--- a/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/tests/forms/util/FlatLookTest.java
+++ b/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/tests/forms/util/FlatLookTest.java
@@ -60,7 +60,7 @@ public class FlatLookTest {
 		FormHeading head = (FormHeading) form.getHead();
 		head.setSize(100, 50);
 
-		Color color = new Color(display, 255, 0, 0);
+		Color color = new Color(255, 0, 0);
 		Color[] identicalColors = new Color[] { color, color };
 		int[] percents = new int[] { 100 };
 
@@ -74,7 +74,7 @@ public class FlatLookTest {
 		});
 
 		// Verify with distinct colors as well to ensure both paths work
-		Color color2 = new Color(display, 0, 0, 255);
+		Color color2 = new Color(0, 0, 255);
 		Color[] distinctColors = new Color[] { color, color2 };
 		head.setTextBackground(distinctColors, percents, true);
 
@@ -90,7 +90,7 @@ public class FlatLookTest {
 		FormHeading head = (FormHeading) form.getHead();
 		head.setSize(100, 50);
 
-		Color color = new Color(display, 200, 100, 50);
+		Color color = new Color(200, 100, 50);
 		head.setTextBackground(new Color[] { color, color }, new int[] { 100 }, true);
 
 		// Flat look: identical colors should use solid background, no gradient
@@ -107,8 +107,8 @@ public class FlatLookTest {
 		FormHeading head = (FormHeading) form.getHead();
 		head.setSize(100, 50);
 
-		Color color1 = new Color(display, 255, 0, 0);
-		Color color2 = new Color(display, 0, 0, 255);
+		Color color1 = new Color(255, 0, 0);
+		Color color2 = new Color(0, 0, 255);
 		head.setTextBackground(new Color[] { color1, color2 }, new int[] { 100 }, true);
 
 		// Gradient look: distinct colors should generate a background image
@@ -123,13 +123,13 @@ public class FlatLookTest {
 		head.setSize(100, 50);
 
 		// First set a real gradient
-		Color color1 = new Color(display, 255, 0, 0);
-		Color color2 = new Color(display, 0, 0, 255);
+		Color color1 = new Color(255, 0, 0);
+		Color color2 = new Color(0, 0, 255);
 		head.setTextBackground(new Color[] { color1, color2 }, new int[] { 100 }, true);
 		assertNotNull(head.getBackgroundImage());
 
 		// Switch to flat look — gradient image should be cleaned up
-		Color flat = new Color(display, 128, 128, 128);
+		Color flat = new Color(128, 128, 128);
 		head.setTextBackground(new Color[] { flat, flat }, new int[] { 100 }, true);
 		assertNull(head.getBackgroundImage(),
 				"Gradient image should be removed when switching to flat look");
@@ -142,7 +142,7 @@ public class FlatLookTest {
 		FormHeading head = (FormHeading) form.getHead();
 		head.setSize(100, 50);
 
-		Color color = new Color(display, 42, 42, 42);
+		Color color = new Color(42, 42, 42);
 		head.setTextBackground(new Color[] { color }, new int[] { 100 }, true);
 
 		assertNull(head.getBackgroundImage(),
@@ -156,7 +156,7 @@ public class FlatLookTest {
 		FormHeading head = (FormHeading) form.getHead();
 		head.setSize(100, 50);
 
-		Color color = new Color(display, 200, 200, 200);
+		Color color = new Color(200, 200, 200);
 		head.setTextBackground(new Color[] { color, color }, new int[] { 100 }, true);
 
 		assertDoesNotThrow(() -> {
@@ -171,8 +171,8 @@ public class FlatLookTest {
 		FormHeading head = (FormHeading) form.getHead();
 		head.setSize(100, 50);
 
-		Color color1 = new Color(display, 255, 0, 0);
-		Color color2 = new Color(display, 0, 0, 255);
+		Color color1 = new Color(255, 0, 0);
+		Color color2 = new Color(0, 0, 255);
 		head.setTextBackground(new Color[] { color1, color2 }, new int[] { 100 }, true);
 		assertNotNull(head.getBackgroundImage());
 
@@ -185,7 +185,7 @@ public class FlatLookTest {
 	@Test
 	public void testSectionFlatLook() {
 		Section section = new Section(shell, Section.TITLE_BAR);
-		Color bg = new Color(display, 240, 240, 240);
+		Color bg = new Color(240, 240, 240);
 		section.setTitleBarBackground(bg);
 		section.setTitleBarBorderColor(bg);
 
@@ -200,7 +200,7 @@ public class FlatLookTest {
 	@Test
 	public void testFormImagesFlatGradient() throws Exception {
 		FormImages instance = FormImages.getInstance();
-		Color color = new Color(display, 100, 100, 100);
+		Color color = new Color(100, 100, 100);
 
 		// test simple gradient with identical colors
 		org.eclipse.swt.graphics.Image img1 = instance.getGradient(color, color, 10, 10, 0, display);

--- a/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/tests/forms/util/FormImagesTest.java
+++ b/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/tests/forms/util/FormImagesTest.java
@@ -43,7 +43,7 @@ public class FormImagesTest {
 		FormImages instance = FormImages.getInstance();
 		// ensure the singleton is returning the same instance
 		assertEquals(instance, FormImages.getInstance(), "getInstance() returned a different FormImages instance");
-		Image gradient = instance.getGradient(new Color(display, 1, 1, 1), new Color(display, 7, 7, 7), 21, 21, 0, display);
+		Image gradient = instance.getGradient(new Color(1, 1, 1), new Color(7, 7, 7), 21, 21, 0, display);
 		instance.markFinished(gradient, display);
 		// ensure the singleton is returning the same instance after creating and disposing one gradient
 		assertEquals(instance, FormImages.getInstance(),
@@ -53,8 +53,8 @@ public class FormImagesTest {
 	@Test
 	public void testDisposeOne() throws Exception {
 		Display display = Display.getCurrent();
-		Image gradient = getFormImagesInstance().getGradient(new Color(display, 255, 255, 255),
-				new Color(display, 0, 0, 0), 21, 21, 0, display);
+		Image gradient = getFormImagesInstance().getGradient(new Color(255, 255, 255),
+				new Color(0, 0, 0), 21, 21, 0, display);
 		getFormImagesInstance().markFinished(gradient, display);
 		// ensure that getting a single gradient and marking it as finished disposed it
 		assertTrue(gradient.isDisposed(), "markFinished(...) did not dispose an image after a single getGradient()");
@@ -64,13 +64,13 @@ public class FormImagesTest {
 	@Test
 	public void testMultipleSimpleInstances() throws Exception {
 		Display display = Display.getCurrent();
-		Image gradient = getFormImagesInstance().getGradient(new Color(display, 200, 200, 200),
-				new Color(display, 0, 0, 0), 30, 16, 3, display);
+		Image gradient = getFormImagesInstance().getGradient(new Color(200, 200, 200),
+				new Color(0, 0, 0), 30, 16, 3, display);
 		int count;
 		// ensure that the same image is returned for many calls with the same parameter
 		for (count = 1; count < 20; count++)
-			assertEquals(gradient, getFormImagesInstance().getGradient(new Color(display, 200, 200, 200),
-					new Color(display, 0, 0, 0), 30, 16, 3, display),
+			assertEquals(gradient, getFormImagesInstance().getGradient(new Color(200, 200, 200),
+					new Color(0, 0, 0), 30, 16, 3, display),
 					"getGradient(...) returned a different image for the same params on iteration " + count);
 		for (; count > 0; count--) {
 			getFormImagesInstance().markFinished(gradient, display);
@@ -88,14 +88,14 @@ public class FormImagesTest {
 	@Test
 	public void testMultipleSectionGradientInstances() throws Exception {
 		Display display = Display.getCurrent();
-		Image gradient = getFormImagesInstance().getSectionGradientImage(new Color(display, 200, 200, 200),
-				new Color(display, 0, 0, 0), 30, 16, 3, display);
+		Image gradient = getFormImagesInstance().getSectionGradientImage(new Color(200, 200, 200),
+				new Color(0, 0, 0), 30, 16, 3, display);
 		int count;
 		// ensure that the same image is returned for many calls with the same
 		// parameter
 		for (count = 1; count < 20; count++)
-			assertEquals(gradient, getFormImagesInstance().getSectionGradientImage(new Color(display, 200, 200, 200),
-					new Color(display, 0, 0, 0), 30, 16, 3, display),
+			assertEquals(gradient, getFormImagesInstance().getSectionGradientImage(new Color(200, 200, 200),
+					new Color(0, 0, 0), 30, 16, 3, display),
 					"getSectionGradientImage(...) returned a different image for the same params on iteration "
 							+ count);
 		for (; count > 0; count--) {
@@ -115,14 +115,14 @@ public class FormImagesTest {
 	public void testMultipleComplexInstances() throws Exception {
 		Display display = Display.getCurrent();
 		Image gradient = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 200, 200, 200), new Color(display, 0, 0, 0) }, new int[] { 100 }, 31,
+				new Color[] { new Color(200, 200, 200), new Color(0, 0, 0) }, new int[] { 100 }, 31,
 				true, null, display);
 		int count;
 		// ensure that the same image is returned for many calls with the same parameter
 		for (count = 1; count < 20; count++)
 			assertEquals(gradient,
 					getFormImagesInstance().getGradient(
-							new Color[] { new Color(display, 200, 200, 200), new Color(display, 0, 0, 0) },
+							new Color[] { new Color(200, 200, 200), new Color(0, 0, 0) },
 							new int[] { 100 }, 31, true, null, display),
 					"getGradient(...) returned a different image for the same params on iteration " + count);
 		for (; count > 0; count--) {
@@ -142,67 +142,67 @@ public class FormImagesTest {
 	public void testMultipleUniqueInstances() throws Exception {
 		Display display = Display.getCurrent();
 		Image[] images = new Image[24];
-		images[0] = getFormImagesInstance().getGradient(new Color(display, 1, 0, 0), new Color(display, 100, 100, 100),
+		images[0] = getFormImagesInstance().getGradient(new Color(1, 0, 0), new Color(100, 100, 100),
 				25, 23, 1, display);
-		images[1] = getFormImagesInstance().getGradient(new Color(display, 0, 1, 0), new Color(display, 100, 100, 100),
+		images[1] = getFormImagesInstance().getGradient(new Color(0, 1, 0), new Color(100, 100, 100),
 				25, 23, 1, display);
-		images[2] = getFormImagesInstance().getGradient(new Color(display, 0, 0, 1), new Color(display, 100, 100, 100),
+		images[2] = getFormImagesInstance().getGradient(new Color(0, 0, 1), new Color(100, 100, 100),
 				25, 23, 1, display);
-		images[3] = getFormImagesInstance().getGradient(new Color(display, 0, 0, 0), new Color(display, 101, 100, 100),
+		images[3] = getFormImagesInstance().getGradient(new Color(0, 0, 0), new Color(101, 100, 100),
 				25, 23, 1, display);
-		images[4] = getFormImagesInstance().getGradient(new Color(display, 0, 0, 0), new Color(display, 100, 101, 100),
+		images[4] = getFormImagesInstance().getGradient(new Color(0, 0, 0), new Color(100, 101, 100),
 				25, 23, 1, display);
-		images[5] = getFormImagesInstance().getGradient(new Color(display, 0, 0, 0), new Color(display, 100, 100, 101),
+		images[5] = getFormImagesInstance().getGradient(new Color(0, 0, 0), new Color(100, 100, 101),
 				25, 23, 1, display);
-		images[6] = getFormImagesInstance().getGradient(new Color(display, 0, 0, 0), new Color(display, 100, 100, 100),
+		images[6] = getFormImagesInstance().getGradient(new Color(0, 0, 0), new Color(100, 100, 100),
 				20, 23, 1, display);
-		images[7] = getFormImagesInstance().getGradient(new Color(display, 0, 0, 0), new Color(display, 100, 100, 100),
+		images[7] = getFormImagesInstance().getGradient(new Color(0, 0, 0), new Color(100, 100, 100),
 				25, 10, 1, display);
-		images[8] = getFormImagesInstance().getGradient(new Color(display, 0, 0, 0), new Color(display, 100, 100, 100),
+		images[8] = getFormImagesInstance().getGradient(new Color(0, 0, 0), new Color(100, 100, 100),
 				25, 23, 2, display);
-		images[9] = getFormImagesInstance().getGradient(new Color(display, 1, 1, 1), new Color(display, 101, 101, 101),
+		images[9] = getFormImagesInstance().getGradient(new Color(1, 1, 1), new Color(101, 101, 101),
 				20, 10, 2, display);
-		images[10] = getFormImagesInstance().getGradient(new Color[] { new Color(display, 0, 0, 0) }, new int[] {}, 31,
+		images[10] = getFormImagesInstance().getGradient(new Color[] { new Color(0, 0, 0) }, new int[] {}, 31,
 				true, null, display);
 		images[11] = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 0, 0, 0), new Color(display, 1, 1, 1) }, new int[] { 80 }, 31, true,
-				new Color(display, 255, 255, 255), display);
+				new Color[] { new Color(0, 0, 0), new Color(1, 1, 1) }, new int[] { 80 }, 31, true,
+				new Color(255, 255, 255), display);
 		images[12] = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 0, 0, 0), new Color(display, 1, 1, 1) }, new int[] { 80 }, 31, true,
-				new Color(display, 0, 0, 0), display);
+				new Color[] { new Color(0, 0, 0), new Color(1, 1, 1) }, new int[] { 80 }, 31, true,
+				new Color(0, 0, 0), display);
 		images[13] = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 0, 0, 0), new Color(display, 100, 100, 100) }, new int[] { 100 }, 31,
+				new Color[] { new Color(0, 0, 0), new Color(100, 100, 100) }, new int[] { 100 }, 31,
 				true, null, display);
 		images[14] = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 1, 0, 0), new Color(display, 100, 100, 100) }, new int[] { 100 }, 31,
+				new Color[] { new Color(1, 0, 0), new Color(100, 100, 100) }, new int[] { 100 }, 31,
 				true, null, display);
 		images[15] = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 0, 1, 0), new Color(display, 100, 100, 100) }, new int[] { 100 }, 31,
+				new Color[] { new Color(0, 1, 0), new Color(100, 100, 100) }, new int[] { 100 }, 31,
 				true, null, display);
 		images[16] = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 0, 0, 1), new Color(display, 100, 100, 100) }, new int[] { 100 }, 31,
+				new Color[] { new Color(0, 0, 1), new Color(100, 100, 100) }, new int[] { 100 }, 31,
 				true, null, display);
 		images[17] = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 0, 0, 0), new Color(display, 101, 100, 100) }, new int[] { 100 }, 31,
+				new Color[] { new Color(0, 0, 0), new Color(101, 100, 100) }, new int[] { 100 }, 31,
 				true, null, display);
 		images[18] = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 0, 0, 0), new Color(display, 100, 101, 100) }, new int[] { 100 }, 31,
+				new Color[] { new Color(0, 0, 0), new Color(100, 101, 100) }, new int[] { 100 }, 31,
 				true, null, display);
 		images[19] = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 0, 0, 0), new Color(display, 100, 100, 101) }, new int[] { 100 }, 31,
+				new Color[] { new Color(0, 0, 0), new Color(100, 100, 101) }, new int[] { 100 }, 31,
 				true, null, display);
 		images[20] = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 0, 0, 0), new Color(display, 100, 100, 100) }, new int[] { 100 }, 20,
+				new Color[] { new Color(0, 0, 0), new Color(100, 100, 100) }, new int[] { 100 }, 20,
 				true, null, display);
 		images[21] = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 0, 0, 0), new Color(display, 100, 100, 100) }, new int[] { 100 }, 31,
+				new Color[] { new Color(0, 0, 0), new Color(100, 100, 100) }, new int[] { 100 }, 31,
 				false, null, display);
 		images[22] = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 0, 0, 0), new Color(display, 100, 100, 100) }, new int[] { 50 }, 31,
-				true, new Color(display, 1, 1, 1), display);
+				new Color[] { new Color(0, 0, 0), new Color(100, 100, 100) }, new int[] { 50 }, 31,
+				true, new Color(1, 1, 1), display);
 		images[23] = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 1, 1, 1), new Color(display, 101, 101, 101) }, new int[] { 50 }, 20,
-				false, new Color(display, 1, 1, 1), display);
+				new Color[] { new Color(1, 1, 1), new Color(101, 101, 101) }, new int[] { 50 }, 20,
+				false, new Color(1, 1, 1), display);
 		// ensure none of the images are the same
 		for (int i = 0; i < images.length - 1; i++) {
 			for (int j = i + 1; j < images.length; j++) {
@@ -224,21 +224,21 @@ public class FormImagesTest {
 	public void testComplexEquality() throws Exception {
 		Display display = Display.getCurrent();
 		Image image1 = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 0, 0, 0), new Color(display, 255, 255, 255) }, new int[] { 100 }, 20,
-				true, new Color(display, 100, 100, 100), display);
+				new Color[] { new Color(0, 0, 0), new Color(255, 255, 255) }, new int[] { 100 }, 20,
+				true, new Color(100, 100, 100), display);
 		Image image2 = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 0, 0, 0), new Color(display, 255, 255, 255) }, new int[] { 100 }, 20,
-				true, new Color(display, 0, 0, 0), display);
+				new Color[] { new Color(0, 0, 0), new Color(255, 255, 255) }, new int[] { 100 }, 20,
+				true, new Color(0, 0, 0), display);
 		assertEquals(image1, image2,
 				"different images were created with only the background color differing when that difference is irrelevant");
 		getFormImagesInstance().markFinished(image1, display);
 		getFormImagesInstance().markFinished(image2, display);
 		image1 = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 0, 0, 0), new Color(display, 255, 255, 255) }, new int[] { 80 }, 20,
-				true, new Color(display, 100, 100, 100), display);
+				new Color[] { new Color(0, 0, 0), new Color(255, 255, 255) }, new int[] { 80 }, 20,
+				true, new Color(100, 100, 100), display);
 		image2 = getFormImagesInstance().getGradient(
-				new Color[] { new Color(display, 0, 0, 0), new Color(display, 255, 255, 255) }, new int[] { 80 }, 20,
-				true, new Color(display, 0, 0, 0), display);
+				new Color[] { new Color(0, 0, 0), new Color(255, 255, 255) }, new int[] { 80 }, 20,
+				true, new Color(0, 0, 0), display);
 		assertNotSame(image1, image2, "the same image was used when different background colors were specified");
 		getFormImagesInstance().markFinished(image1, display);
 		getFormImagesInstance().markFinished(image2, display);
@@ -262,7 +262,7 @@ public class FormImagesTest {
 		Image image2 = getFormImagesInstance().getGradient(kit2.getColors().getColor(blueKey),
 				kit2.getColors().getColor(redKey), 21, 21, 0, display);
 		assertEquals(image1, image2, "different images were created for the same RGBs with different Color instances");
-		Image image3 = getFormImagesInstance().getGradient(new Color(display, 0, 0, 255), new Color(display, 255, 0, 0),
+		Image image3 = getFormImagesInstance().getGradient(new Color(0, 0, 255), new Color(255, 0, 0),
 				21, 21, 0, display);
 		assertEquals(image1, image3, "different images were created for the same RGBs with different Color instances");
 		kit1.dispose();

--- a/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/tests/forms/util/ImageHyperlinkTest.java
+++ b/tests/org.eclipse.ui.tests.forms/forms/org/eclipse/ui/tests/forms/util/ImageHyperlinkTest.java
@@ -144,7 +144,7 @@ public class ImageHyperlinkTest {
 	}
 
 	private Image createGradient() {
-		return FormImages.getInstance().getGradient(new Color(display, 0, 0, 0), new Color(display, 100, 100, 100), 1, 1,
+		return FormImages.getInstance().getGradient(new Color(0, 0, 0), new Color(100, 100, 100), 1, 1,
 				1, display);
 	}
 

--- a/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProvider.java
+++ b/tests/org.eclipse.ui.tests.navigator/src/org/eclipse/ui/tests/navigator/extension/TestLabelProvider.java
@@ -72,7 +72,7 @@ public abstract class TestLabelProvider extends LabelProvider implements
 	public static Color toForegroundColor(Color backColor) {
 		RGB rgb = backColor.getRGB();
 		RGB newRgb = new RGB(rgb.blue, rgb.red, rgb.green);
-		return new Color(Display.getCurrent(), newRgb);
+		return new Color(newRgb);
 	}
 
 	public Color getTestColor() {


### PR DESCRIPTION
Follows https://github.com/eclipse-platform/eclipse.platform.swt/issues/3232 by removing the Device/Display argument from Color constructors.